### PR TITLE
[PyCDE] Syntactic sugar to support new subdesign

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -39,13 +39,15 @@ def _obj_to_attribute(obj) -> ir.Attribute:
 
 __dir__ = os.path.dirname(__file__)
 _local_files = set([os.path.join(__dir__, x) for x in os.listdir(__dir__)])
+_hidden_filenames = set(["functools.py"])
 
 
 def get_user_loc() -> ir.Location:
   import traceback
   stack = reversed(traceback.extract_stack())
   for frame in stack:
-    if frame.filename in _local_files:
+    fn = os.path.split(frame.filename)[1]
+    if frame.filename in _local_files or fn in _hidden_filenames:
       continue
     return ir.Location.file(frame.filename, frame.lineno, 0)
   return ir.Location.unknown()

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -108,7 +108,7 @@ def _obj_to_value(x, type, result_type=None):
     with get_user_loc():
       return hw.ConstantOp(type, x)
 
-  if isinstance(x, list):
+  if isinstance(x, (list, tuple)):
     if not isinstance(type, ArrayType):
       raise ValueError(f"List is only convertable to hw array, not '{type}'")
     elemty = result_type.element_type
@@ -144,7 +144,7 @@ def _infer_type(x):
   if isinstance(x, Value):
     return x.type
 
-  if isinstance(x, list):
+  if isinstance(x, (list, tuple)):
     list_types = [_infer_type(i) for i in x]
     list_type = list_types[0]
     if not all([i == list_type for i in list_types]):

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -43,6 +43,10 @@ class Value:
   _reg_name = re.compile(r"^(.*)__reg(\d+)$")
 
   def reg(self, clk, rst=None, name=None, cycles=1):
+    """Register this value, returning the delayed value.
+    `clk`, `rst`: the clock and reset signals.
+    `name`: name this register explicitly.
+    `cycles`: number of registers to add."""
     from .dialects import seq
     if name is None:
       basename = None

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,6 +1,6 @@
 # RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
 
-from pycde import module, System, generator, dim, Input, Output, Value
+from pycde import module, System, generator, dim, Input, Output, Value, types
 import sys
 
 
@@ -17,6 +17,7 @@ class ComplexMux:
   Out = Output(dim(3, 4))
   OutArr = Output(dim(3, 4, 2))
   OutSlice = Output(dim(3, 4, 3))
+  OutInt = Output(types.i1)
 
   @generator
   def create(ports):
@@ -27,8 +28,10 @@ class ComplexMux:
     ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
     ports.OutSlice = ports.In[0:3]
 
+    ports.OutInt = ports.In[0][0][ports.Sel]
 
-# CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>, OutSlice: !hw.array<3xarray<4xi3>>)
+
+# CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>, OutInt: i1, OutSlice: !hw.array<3xarray<4xi3>>)
 # CHECK:         %c3_i3 = hw.constant 3 : i3
 # CHECK:         %0 = hw.array_get %In[%c3_i3] {sv.namehint = "In__3"} : !hw.array<5xarray<4xi3>>
 # CHECK:         %In__3__reg1 = seq.compreg sym @In__3__reg1 %0, %Clk : !hw.array<4xi3>
@@ -44,7 +47,12 @@ class ComplexMux:
 # CHECK:         [[R5:%.+]] = hw.array_get %In[%c1_i3_0] {sv.namehint = "In__1"} : !hw.array<5xarray<4xi3>>
 # CHECK:         [[R6:%.+]] = hw.array_create [[R5]], [[R4]] : !hw.array<4xi3>
 # CHECK:         [[R7:%.+]] = hw.array_slice %In[%c0_i3_1] {sv.namehint = "In_0upto3"} : (!hw.array<5xarray<4xi3>>) -> !hw.array<3xarray<4xi3>>
-# CHECK:         msft.output [[R3]], [[R6]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, !hw.array<3xarray<4xi3>>
+# CHECK:         [[R9:%.+]] = hw.array_get %8[%c0_i2] {sv.namehint = "In__0__0"} : !hw.array<4xi3>
+# CHECK:         %c0_i2_3 = hw.constant 0 : i2
+# CHECK:         [[R10:%.+]] = comb.concat %c0_i2_3, %Sel : i2, i1
+# CHECK:         [[R11:%.+]] = comb.shru [[R9]], [[R10]] : i3
+# CHECK:         [[R12:%.+]] = comb.extract [[R11]] from 0 : (i3) -> i1
+# CHECK:         msft.output [[R3]], [[R6]], [[R12]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, i1, !hw.array<3xarray<4xi3>>
 
 s = System([ComplexMux], name="Muxing", output_directory=sys.argv[1])
 s.generate()

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -54,7 +54,38 @@ class ComplexMux:
 # CHECK:         [[R12:%.+]] = comb.extract [[R11]] from 0 : (i3) -> i1
 # CHECK:         msft.output [[R3]], [[R6]], [[R12]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, i1, !hw.array<3xarray<4xi3>>
 
-s = System([ComplexMux], name="Muxing", output_directory=sys.argv[1])
+
+@module
+class Slicing:
+  In = Input(dim(8, 4, 5))
+  Sel8 = Input(types.i8)
+  Sel2 = Input(types.i2)
+
+  OutIntSlice = Output(types.i2)
+  OutArrSlice8 = Output(dim(8, 4, 2))
+  OutArrSlice2 = Output(dim(8, 4, 2))
+
+  @generator
+  def create(ports):
+    i = ports.In[0][0]
+    ports.OutIntSlice = i.slice(ports.Sel2, 2)
+    ports.OutArrSlice2 = ports.In.slice(ports.Sel2, 2)
+    ports.OutArrSlice8 = ports.In.slice(ports.Sel8, 2)
+
+
+# CHECK-LABEL:  msft.module @Slicing {} (%In: !hw.array<5xarray<4xi8>>, %Sel2: i2, %Sel8: i8) -> (OutArrSlice2: !hw.array<2xarray<4xi8>>, OutArrSlice8: !hw.array<2xarray<4xi8>>, OutIntSlice: i2)
+# CHECK:          [[R0:%.+]] = hw.array_get %In[%c0_i3] {sv.namehint = "In__0"} : !hw.array<5xarray<4xi8>>
+# CHECK:          [[R1:%.+]] = hw.array_get %0[%c0_i2] {sv.namehint = "In__0__0"} : !hw.array<4xi8>
+# CHECK:          [[R2:%.+]] = comb.concat %c0_i6, %Sel2 : i6, i2
+# CHECK:          [[R3:%.+]] = comb.shru [[R1]], [[R2]] : i8
+# CHECK:          [[R4:%.+]] = comb.extract [[R3]] from 0 : (i8) -> i2
+# CHECK:          [[R5:%.+]] = comb.concat %false, %Sel2 : i1, i2
+# CHECK:          [[R6:%.+]] = hw.array_slice %In[[[R5]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
+# CHECK:          [[R7:%.+]] = comb.extract %Sel8 from 0 : (i8) -> i3
+# CHECK:          [[R8:%.+]] = hw.array_slice %In[[[R7]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
+# CHECK:          msft.output [[R6]], [[R8]], [[R4]] : !hw.array<2xarray<4xi8>>, !hw.array<2xarray<4xi8>>, i2
+
+s = System([ComplexMux, Slicing], name="Muxing", output_directory=sys.argv[1])
 s.generate()
 s.print()
 

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,0 +1,50 @@
+# RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
+
+from pycde import module, System, generator, dim, Input, Output, Value, types
+import sys
+
+
+def array_from_tuple(*input):
+  return Value(input)
+
+
+@module
+class ComplexMux:
+
+  Clk = Input(dim(1))
+  In = Input(dim(3, 4, 5))
+  Sel = Input(dim(1))
+  Out = Output(dim(3, 4))
+  OutArr = Output(dim(3, 4, 2))
+
+  @generator
+  def create(ports):
+    clk = ports.Clk
+    select_from = Value([ports.In[3].reg(clk).reg(clk, cycles=2), ports.In[1]])
+    ports.Out = select_from[ports.Sel]
+
+    ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
+
+
+# CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>)
+# CHECK:         %c3_i3 = hw.constant 3 : i3
+# CHECK:         %0 = hw.array_get %In[%c3_i3] {sv.namehint = "In__3"} : !hw.array<5xarray<4xi3>>
+# CHECK:         %In__3__reg1 = seq.compreg sym @In__3__reg1 %0, %Clk : !hw.array<4xi3>
+# CHECK:         %In__3__reg2 = seq.compreg sym @In__3__reg2 %In__3__reg1, %Clk : !hw.array<4xi3>
+# CHECK:         %In__3__reg3 = seq.compreg sym @In__3__reg3 %In__3__reg2, %Clk : !hw.array<4xi3>
+# CHECK:         %c1_i3 = hw.constant 1 : i3
+# CHECK:         [[R1:%.+]] = hw.array_get %In[%c1_i3] {sv.namehint = "In__1"} : !hw.array<5xarray<4xi3>>
+# CHECK:         [[R2:%.+]] = hw.array_create [[R1]], %In__3__reg3 : !hw.array<4xi3>
+# CHECK:         [[R3:%.+]] = hw.array_get [[R2]][%Sel] : !hw.array<2xarray<4xi3>>
+# CHECK:         %c0_i3 = hw.constant 0 : i3
+# CHECK:         [[R4:%.+]] = hw.array_get %In[%c0_i3] {sv.namehint = "In__0"} : !hw.array<5xarray<4xi3>>
+# CHECK:         %c1_i3_0 = hw.constant 1 : i3
+# CHECK:         [[R5:%.+]] = hw.array_get %In[%c1_i3_0] {sv.namehint = "In__1"} : !hw.array<5xarray<4xi3>>
+# CHECK:         [[R6:%.+]] = hw.array_create [[R5]], [[R4]] : !hw.array<4xi3>
+# CHECK:         msft.output [[R3]], [[R6]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>
+
+s = System([ComplexMux], name="Muxing", output_directory=sys.argv[1])
+s.generate()
+s.print()
+
+s.emit_outputs()

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,6 +1,6 @@
 # RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
 
-from pycde import module, System, generator, dim, Input, Output, Value, types
+from pycde import module, System, generator, dim, Input, Output, Value
 import sys
 
 
@@ -16,6 +16,7 @@ class ComplexMux:
   Sel = Input(dim(1))
   Out = Output(dim(3, 4))
   OutArr = Output(dim(3, 4, 2))
+  OutSlice = Output(dim(3, 4, 3))
 
   @generator
   def create(ports):
@@ -24,9 +25,10 @@ class ComplexMux:
     ports.Out = select_from[ports.Sel]
 
     ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
+    ports.OutSlice = ports.In[0:3]
 
 
-# CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>)
+# CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>, OutSlice: !hw.array<3xarray<4xi3>>)
 # CHECK:         %c3_i3 = hw.constant 3 : i3
 # CHECK:         %0 = hw.array_get %In[%c3_i3] {sv.namehint = "In__3"} : !hw.array<5xarray<4xi3>>
 # CHECK:         %In__3__reg1 = seq.compreg sym @In__3__reg1 %0, %Clk : !hw.array<4xi3>
@@ -41,7 +43,8 @@ class ComplexMux:
 # CHECK:         %c1_i3_0 = hw.constant 1 : i3
 # CHECK:         [[R5:%.+]] = hw.array_get %In[%c1_i3_0] {sv.namehint = "In__1"} : !hw.array<5xarray<4xi3>>
 # CHECK:         [[R6:%.+]] = hw.array_create [[R5]], [[R4]] : !hw.array<4xi3>
-# CHECK:         msft.output [[R3]], [[R6]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>
+# CHECK:         [[R7:%.+]] = hw.array_slice %In[%c0_i3_1] {sv.namehint = "In_0upto3"} : (!hw.array<5xarray<4xi3>>) -> !hw.array<3xarray<4xi3>>
+# CHECK:         msft.output [[R3]], [[R6]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, !hw.array<3xarray<4xi3>>
 
 s = System([ComplexMux], name="Muxing", output_directory=sys.argv[1])
 s.generate()

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -401,6 +401,21 @@ class ArrayGetOp:
     return hw.ArrayGetOp(array_type.element_type, array_value, idx_val)
 
 
+class ArraySliceOp:
+
+  @staticmethod
+  def create(array_value, low_index, ret_type):
+    array_value = support.get_value(array_value)
+    array_type = support.get_self_or_inner(array_value.type)
+    if isinstance(low_index, int):
+      idx_width = (array_type.size - 1).bit_length()
+      idx_width = max(1, idx_width)  # hw.constant cannot produce i0.
+      idx_val = ConstantOp.create(IntegerType.get_signless(idx_width),
+                                  low_index).result
+    else:
+      idx_val = support.get_value(low_index)
+    return hw.ArraySliceOp(ret_type, array_value, idx_val)
+
 class ArrayCreateOp:
 
   @staticmethod

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -416,6 +416,7 @@ class ArraySliceOp:
       idx_val = support.get_value(low_index)
     return hw.ArraySliceOp(ret_type, array_value, idx_val)
 
+
 class ArrayCreateOp:
 
   @staticmethod


### PR DESCRIPTION
- Add `cycles` argument to `reg` to add `cycles` registers of delay.
- Treat `tuple`s just like `list`s.
- Slice `ArrayValue`s.
- Get bit from `BitVectorValue` with `Value` in addition to python int or slices.
- Adds `slice` method to get constant-sized slices.
- Ignores `functools.py` when finding the user location.