### PR TITLE
[FIRRTL] Add a FIRRTL XMR Op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -214,3 +214,16 @@ def ProbeOp : FIRRTLOp<"probe"> {
   let assemblyFormat = "$inner_sym attr-dict ( `,` $operands^  `:` qualified(type($operands)))?";
 }
 
+def XMROp : FIRRTLOp<"xmr", []> {
+  let summary = "Encode a reference to a non-local net.";
+  let description = [{
+    This represents a non-local hierarchical name to a net, sometimes called a
+    cross-module reference. The hierarchical path is specified by a reference
+    to the symbol defined by a `HierPathOp`. The component within the module
+    is specified by a reference to an Inner Sym defined by the net.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$hierPathSym, HWInnerRefAttr:$componentSym);
+  let results = (outs FIRRTLType:$result);
+  let assemblyFormat = "$hierPathSym  $componentSym attr-dict `:` qualified(type($result))";
+}
+

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -219,11 +219,10 @@ def XMROp : FIRRTLOp<"xmr", []> {
   let description = [{
     This represents a non-local hierarchical name to a net, sometimes called a
     cross-module reference. The hierarchical path is specified by a reference
-    to the symbol defined by a `HierPathOp`. The component within the module
-    is specified by a reference to an Inner Sym defined by the net.
+    to the symbol defined by a `HierPathOp`.
   }];
-  let arguments = (ins FlatSymbolRefAttr:$hierPathSym, HWInnerRefAttr:$componentSym);
+  let arguments = (ins FlatSymbolRefAttr:$hierPathSym);
   let results = (outs FIRRTLType:$result);
-  let assemblyFormat = "$hierPathSym  $componentSym attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "$hierPathSym attr-dict `:` qualified(type($result))";
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -155,7 +155,7 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, StrictConnectOp, ForceOp, PrintFOp,
                        SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
-                       ProbeOp>([&](auto opNode) -> ResultType {
+                       ProbeOp, XMROp>([&](auto opNode) -> ResultType {
           return thisCast->visitStmt(opNode, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -192,6 +192,7 @@ public:
   HANDLE(AssumeOp);
   HANDLE(CoverOp);
   HANDLE(ProbeOp);
+  HANDLE(XMROp);
 
 #undef HANDLE
 };

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -81,21 +81,20 @@ def XMROp : SVOp<"xmr", []> {
   let summary = "Encode a reference to a non-local net.";
   let description = [{
     This represents a non-local hierarchical name to a net, sometimes called a
-    cross-module reference.  A hierarchical name may be absolute, when prefixed
-    with '$root', in which case it is resolved from the set of top-level modules
-    (any non-instantiated modules).  Non-absolute paths are resolved by
-    attempting resolution of the path locally, then recursively up the instance
-    graph. See SV Spec 23.6, pp721.
+    cross-module reference. This Op assumes an Upwards name referencing syntax,
+    (SV Spec 23.8, pp 727). The hierarchy is specified as a sequence of 
+    `InnerRefAttr`, that is the reference to the `InnerSym` defined by an
+    `InstanceOp`, and ends with a reference to either a Module or a component
+    within the module.
 
-    It is impossible to completely resolve a hierarchical name without making a
-    closed-world assumption in the compiler.  We therefore don't try to link
-    hierarchical names to what they resolve to at compile time.  A frontend
-    generating this op should ensure that any instance or object in the intended
-    path has public visibility so paths are not invalidated.
+    A frontend generating this op should ensure that any instance or object in
+    the intended path has public visibility so paths are not invalidated.
+    ExportVerilog prints this `XMR` starting with the module name specified
+    in the `namepath`.
   }];
-  let arguments = (ins UnitAttr:$isRooted, StrArrayAttr:$path, StrAttr:$terminal);
+  let arguments = (ins NameRefArrayAttr:$namepath);
   let results = (outs InOutType:$result);
-  let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "custom<XMRPath>($namepath) attr-dict `:` qualified(type($result))";
 }
 
 def ReadInOutOp

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2065,11 +2065,14 @@ SubExprInfo ExprEmitter::visitSV(ReadInterfaceSignalOp op) {
 }
 
 SubExprInfo ExprEmitter::visitSV(XMROp op) {
-  if (op.isRooted())
-    os << "$root.";
-  for (auto s : op.path())
-    os << s.cast<StringAttr>().getValue() << '.';
-  os << op.terminal();
+  os << op.namepath()[0].cast<hw::InnerRefAttr>().getModule().getValue() << ".";
+  for (unsigned i = 0, s = op.namepath().size() - 1; i < s; ++i)
+    if (auto innerRef = op.namepath()[i].dyn_cast<hw::InnerRefAttr>())
+      os << innerRef.getName().getValue() << ".";
+
+  auto leafRef = op.namepath()[op.namepath().size() - 1];
+  if (auto innerRef = leafRef.dyn_cast<hw::InnerRefAttr>())
+    os << innerRef.getName().getValue();
   return {Selection, IsUnsigned};
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3518,10 +3518,9 @@ LogicalResult FIRRTLLowering::visitStmt(XMROp op) {
   }
 
   SmallVector<Attribute, 4> namepath;
-  namepath.reserve(nla.namepath().size() + 1);
+  namepath.reserve(nla.namepath().size());
   for (auto attr : nla.namepath())
     namepath.push_back(attr);
-  namepath.push_back(op.componentSymAttr());
 
   auto xmrOp =
       builder.create<sv::XMROp>(sv::InOutType::get(op.getContext(), resultTy),

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -877,9 +877,8 @@ void GrandCentralTapsPass::runOnOperation() {
         Value hnameExpr = builder.create<VerbatimExprOp>(
             arg.getType().cast<FIRRTLType>(), hname, ValueRange{}, symbols);
         if (xmrNLA)
-          hnameExpr = builder.create<XMROp>(
-              arg.getType(), xmrNLA.sym_nameAttr(),
-              hw::InnerRefAttr::get(xmrNLA.leafMod(), xmrNLA.ref()));
+          hnameExpr =
+              builder.create<XMROp>(arg.getType(), xmrNLA.sym_nameAttr());
         builder.create<ConnectOp>(arg, hnameExpr);
       }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -874,11 +874,13 @@ void GrandCentralTapsPass::runOnOperation() {
 
         // Add a verbatim op that assigns this module port.
         auto arg = impl.getArgument(port.portNum);
-        Value hnameExpr = builder.create<VerbatimExprOp>(
-            arg.getType().cast<FIRRTLType>(), hname, ValueRange{}, symbols);
+        Value hnameExpr;
         if (xmrNLA)
           hnameExpr =
               builder.create<XMROp>(arg.getType(), xmrNLA.sym_nameAttr());
+        else
+          hnameExpr = builder.create<VerbatimExprOp>(
+              arg.getType().cast<FIRRTLType>(), hname, ValueRange{}, symbols);
         builder.create<ConnectOp>(arg, hnameExpr);
       }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1207,11 +1207,11 @@ hw.module @AggregateTemporay(%clock: i1, %foo: i1, %bar: i25) {
 }
 
 //CHECK-LABEL: module XMR_src
-//CHECK: assign $root.a.b.c = a;
-//CHECK-NEXT: assign aa = d.e.f;
+//CHECK: assign e1.e3 = a;
+//CHECK-NEXT: assign aa = e2.e4;
 hw.module @XMR_src(%a : i23) -> (aa: i3) {
-  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
-  %xmr2 = sv.xmr "d",e,f : !hw.inout<i3>
+  %xmr1 = sv.xmr [@Mod1::@e1, @Mod0::@e3]: !hw.inout<i23>
+  %xmr2 = sv.xmr [@Mod2::@e2, @Mod2::@e4]: !hw.inout<i3>
   %r = sv.read_inout %xmr2 : !hw.inout<i3>
   sv.assign %xmr1, %a : i23
   hw.output %r : i3

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1207,8 +1207,8 @@ hw.module @AggregateTemporay(%clock: i1, %foo: i1, %bar: i25) {
 }
 
 //CHECK-LABEL: module XMR_src
-//CHECK: assign e1.e3 = a;
-//CHECK-NEXT: assign aa = e2.e4;
+//CHECK: assign Mod1.e1.e3 = a;
+//CHECK-NEXT: assign aa = Mod2.e2.e4;
 hw.module @XMR_src(%a : i23) -> (aa: i3) {
   %xmr1 = sv.xmr [@Mod1::@e1, @Mod0::@e3]: !hw.inout<i23>
   %xmr2 = sv.xmr [@Mod2::@e2, @Mod2::@e4]: !hw.inout<i3>

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -330,9 +330,9 @@ firrtl.circuit "TestHarness" attributes {
 //
 // CHECK-LABEL: firrtl.circuit "NLAGarbageCollection"
 firrtl.circuit "NLAGarbageCollection" {
-  // CHECK-NOT: @nla_1
-  // CHECK-NOT: @nla_2
-  // CHECK-NOT: @nla_3
+  // CHECK: @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
+  // CHECK: @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
+  // CHECK: @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
   firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
   firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
   firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
@@ -417,10 +417,10 @@ firrtl.circuit "NLAGarbageCollection" {
 
 // CHECK-LABEL: firrtl.circuit "NLAUsedInWiring"
 firrtl.circuit "NLAUsedInWiring"  {
-  // CHECK-NOT: @nla_1
-  // CHECK-NOT: @nla_2
   firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
   firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
+  // CHECK: firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
+  // CHECK: firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
 
   // CHECK-LABEL: firrtl.module @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -408,6 +408,16 @@ firrtl.circuit "NLAGarbageCollection" {
         {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]
     } @DUT()
   }
+  // CHECK-LABEL:   firrtl.module @MemTap_impl_0(out %mem_0: !firrtl.uint<1>)
+  // CHECK:     %[[v1:.+]] = firrtl.xmr @nla_3 : !firrtl.uint<1>
+  // CHECK:     firrtl.connect %mem_0, %[[v1]] : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK-LABEL:   firrtl.module @DataTap_1_impl_0(out %_1: !firrtl.uint<1> sym @_1, out %_0: !firrtl.uint<1> sym @_0)
+  // CHECK:     %[[v11:.+]] = firrtl.xmr @nla_2 : !firrtl.uint<1>
+  // CHECK:     firrtl.connect %_1, %[[v11]] : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:     %[[v3:.+]] = firrtl.xmr @nla_1 : !firrtl.uint<1>
+  // CHECK:     firrtl.connect %_0, %[[v3]] : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   }
 }
 
 // -----
@@ -423,14 +433,11 @@ firrtl.circuit "NLAUsedInWiring"  {
   // CHECK: firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
 
   // CHECK-LABEL: firrtl.module @DataTap
-  // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
-  // CHECK-SAME:   symbols = [@NLAUsedInWiring, #hw.innerNameRef<@NLAUsedInWiring::@foo>, #hw.innerNameRef<@Foo::@f>]
+  // CHECK-NEXT: [[TMP:%.+]] = firrtl.xmr @nla_1 :
   // CHECK-NEXT: firrtl.connect %b, [[TMP]] : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
-  // CHECK-SAME:   symbols = [@NLAUsedInWiring, #hw.innerNameRef<@NLAUsedInWiring::@foo>, #hw.innerNameRef<@Foo::@g>]
+  // CHECK-NEXT: [[TMP:%.+]] = firrtl.xmr @nla_2 :
   // CHECK-NEXT: firrtl.connect %c, [[TMP]] : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
-  // CHECK-SAME:   symbols = [@NLAUsedInWiring, #hw.innerNameRef<@NLAUsedInWiring::@k>]
   // CHECK-NEXT: firrtl.connect %d, [[TMP]] : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.extmodule @DataTap(
     out b: !firrtl.uint<1> sym @b [{
@@ -529,12 +536,10 @@ firrtl.circuit "Top" {
   }
 
   // CHECK-LABEL: firrtl.module @MemTap_1_impl_0
-  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}"
-  // CHECK-SAME: symbols = [@Top, #hw.innerNameRef<@Top::@dut>, #hw.innerNameRef<@DUT::@submodule_1>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
+  // CHECK-NEXT: firrtl.xmr @nla_0 :
   firrtl.extmodule @MemTap_1(out mem_0: !firrtl.uint<1> [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.port", id = 0 : i64, portID = 0 : i64}]) attributes {defname = "MemTap"}
   // CHECK-LABEL: firrtl.module @MemTap_2_impl_0
-  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}"
-  // CHECK-SAME: symbols = [@Top, #hw.innerNameRef<@Top::@dut>, #hw.innerNameRef<@DUT::@submodule_2>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
+  // CHECK-NEXT: firrtl.xmr @nla :
   firrtl.extmodule @MemTap_2(out mem_0: !firrtl.uint<1> [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.port", id = 1 : i64, portID = 0 : i64}]) attributes {defname = "MemTap"}
 }
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -290,10 +290,10 @@ hw.module @AB(%a: i1, %b: i2) {
 
 //CHECK-LABEL: hw.module @XMR_src
 hw.module @XMR_src(%a : i23) {
-  //CHECK-NEXT:   sv.xmr isRooted "a", "b", "c" : !hw.inout<i23>
-  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
-  //CHECK-NEXT:   sv.xmr "a", "b", "c" : !hw.inout<i3>
-  %xmr2 = sv.xmr "a",b,c : !hw.inout<i3>
+  //CHECK-NEXT:   = sv.xmr [@Mod1::@e1, @Mod0::@e3] : !hw.inout<i23>
+  %xmr1 = sv.xmr [@Mod1::@e1, @Mod0::@e3]: !hw.inout<i23>
+  //CHECK-NEXT:   = sv.xmr [@Mod2::@e2, @Mod2::@e4] : !hw.inout<i3>
+  %xmr2 = sv.xmr [@Mod2::@e2, @Mod2::@e4]: !hw.inout<i3>
   %r = sv.read_inout %xmr1 : !hw.inout<i23>
   sv.assign %xmr1, %a : i23
 }


### PR DESCRIPTION
This is a Draft PR, proposing a new `XMROp` and showing its sample usage.
1. Add a FIRRTL XMR  Op that lowers to the SV XMR Op.
2. Update the SV XMR Op to align with the new usage.
3. Show how `GrandCentralTaps` can use this new Op for generating Taps, instead of `VerbatimExpr`.

This op is developed based on the proposal to update `HierPathOp` to end on a module (https://github.com/llvm/circt/pull/3250). 
If `HierPathOp` can only be used to specify hierarchichal paths that end on a module, then the `FIRRTL::XMROp` can be used to specify a component inside the path specified by `HierPathOp`. 
For example,  `firrtl.hierpath @nla_0 [@Top::@foo, @Foo]` specifies the path, and 
the `XMROp`  `%1 = firrtl.xmr @nla_0 <@Foo::@f> : !firrtl.uint<1>` 
uses the `InnerRefAttr` to specify the component `@f` in the module `@Foo`. 

We need a different `firrtl::XMROp` since the `sv::XMROp` has an `InOutType`.
Other followup tasks
1. How to merge `HW::GlobalRefOp` with this usage ?
2. How to generate the `FIRRTL::XMROp` directly during annotation lowering ?
3. Expose the IMCP to the `XMROp`.

The tests will fail, since this is based on the assumption that `HierPathOp` ends on a module, which is not yet merged.