### PR TITLE
Improve documentation of attributes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -26,7 +26,7 @@ def AnnotationArrayAttr: ArrayAttrBase<
             "[&](::mlir::Attribute attr) { return attr.isa<"
             "::mlir::DictionaryAttr,"
             "::circt::firrtl::SubAnnotationAttr>();})">]>,
-    "all elements must be DictionaryAttr or SubAnnotationAttr"> {
+    "Annotation array attribute"> {
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
@@ -51,7 +51,7 @@ def PortAnnotationsAttr : ArrayAttrBase<
             "[&](::mlir::Attribute attr) { return attr.isa<"
             "::mlir::ArrayAttr,"
             "::mlir::DictionaryAttr>();})">]>,
-    ""> {
+    "Port annotations attribute"> {
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
@@ -77,6 +77,7 @@ def InvalidValueAttr : AttrDef<FIRRTLDialect, "InvalidValue"> {
 //===----------------------------------------------------------------------===//
 
 class AugmentedType<string name> : AttrDef<FIRRTLDialect, name> {
+  let description = "Used in the GrandCentralPass.";
   let parameters = (
     ins "DictionaryAttr":$underlying
   );
@@ -108,6 +109,7 @@ class AugmentedType<string name> : AttrDef<FIRRTLDialect, name> {
 }
 
 def AugmentedBundleType : AugmentedType<"AugmentedBundleType"> {
+  let summary = "GrandCentral AugmentedBundleType";
   let extraClassDeclaration =
     defaultClassDeclaration #
     hasID #
@@ -119,37 +121,47 @@ def AugmentedBundleType : AugmentedType<"AugmentedBundleType"> {
 }
 
 def AugmentedVectorType : AugmentedType<"AugmentedVectorType"> {
+  let summary = "GrandCentral AugmentedVectorType";
   let extraClassDeclaration = defaultClassDeclaration # hasElements;
 }
 
 def AugmentedGroundType : AugmentedType<"AugmentedGroundType"> {
+  let summary = "GrandCentral AugmentedGroundType";
   let extraClassDeclaration = hasID # hasName;
 }
 
 def AugmentedStringType : AugmentedType<"AugmentedStringType"> {
+  let summary = "GrandCentral AugmentedStringType";
   let extraClassDeclaration = hasName;
 }
 def AugmentedBooleanType : AugmentedType<"AugmentedBooleanType"> {
+  let summary = "GrandCentral AugmentedBooleanType";
   let extraClassDeclaration = hasName;
 }
 def AugmentedIntegerType : AugmentedType<"AugmentedIntegerType"> {
+  let summary = "GrandCentral AugmentedIntegerType";
   let extraClassDeclaration = hasName;
 }
 def AugmentedDoubleType : AugmentedType<"AugmentedDoubleType"> {
+  let summary = "GrandCentral AugmentedDoubleType";
   let extraClassDeclaration = hasName;
 }
 def AugmentedLiteralType : AugmentedType<"AugmentedLiteralType"> {
+  let summary = "GrandCentral AugmentedLiteralType";
   let extraClassDeclaration = hasName;
 }
 def AugmentedDeletedType : AugmentedType<"AugmentedDeletedType"> {
+  let summary = "GrandCentral AugmentedDeletedType";
   let extraClassDeclaration = hasName;
 }
 
 
-/// An attribute describing a module parameter, or instance parameter
-/// specification.
 def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl"> {
-  let summary = "module or instance parameter definition";
+  let summary = "Module or instance parameter definition";
+  let description = [{
+    An attribute describing a module parameter, or instance parameter
+    specification.
+  }];
 
   /// The value of the attribute - in a module, this is the default
   /// value (and may be missing).  In an instance, this is a required field that

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -125,10 +125,12 @@ def FileListAttr : AttrDef<HWDialect, "FileList"> {
 
 }
 
-/// An attribute describing a module parameter, or instance parameter
-/// specification.
 def ParamDeclAttr : AttrDef<HWDialect, "ParamDecl"> {
-  let summary = "module or instance parameter definition";
+  let summary = "Module or instance parameter definition";
+  let description = [{
+    An attribute describing a module parameter, or instance parameter
+    specification.
+  }];
 
   /// The value of the attribute - in a module, this is the default
   /// value (and may be missing).  In an instance, this is a required field that

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -11,7 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 def MacroIdentAttr : AttrDef<SVDialect, "MacroIdent"> {
-  let summary = "Represents a reference to a macro identifier";
+  let summary = "Macro identifier";
+  let description = [{
+    Represents a reference to a macro identifier.
+  }];
   let parameters = (ins "::mlir::StringAttr":$ident);
   let mnemonic = "macro.ident";
 


### PR DESCRIPTION
This PR aims to improve the generated documentation for some attribute
definitions and constraints. Some missing tablegen fields create empty
markdown headings with no content.  The focus of this change is just
getting anything in these fields, without much focus on creating high
quality content. Somewhat confusingly, the `summary` field of attribute
constraints is used as the "name" of the constraint in many locations.

See https://circt.llvm.org/docs/Dialects/FIRRTL/#attribute-constraint-definition for what the problem looks like.