### PR TITLE
[PrepareForEmission] Use namehint for spilled expression

### DIFF
--- a/test/Conversion/ExportVerilog/max-terms.mlir
+++ b/test/Conversion/ExportVerilog/max-terms.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: module large_use_in_procedural
 hw.module @large_use_in_procedural(%clock: i1, %a: i1) {
-  // CHECK: wire [[GEN:.+]];
+  // CHECK: wire [[GEN:long_concat]];
   // CHECK: reg [[REG:.+]];
 
   // CHECK: assign [[GEN]] = a + a + a + a + a;
@@ -10,7 +10,8 @@ hw.module @large_use_in_procedural(%clock: i1, %a: i1) {
   sv.always {
     sv.ifdef.procedural "FOO" {
       // This expression should be hoisted and spilled.
-      %1 = comb.add %a, %a, %a, %a, %a : i1
+      // If there is a namehint, we should use the name.
+      %1 = comb.add %a, %a, %a, %a, %a {sv.namehint = "long_concat"}: i1
       // CHECK: if ([[GEN]])
       sv.if %1 {
         sv.exit


### PR DESCRIPTION
This is separated from https://github.com/llvm/circt/pull/3292.
If it is necessary to spill an expression at PrepareForEmission and the expression has
a namehint,  it would be better to use the name. 