### PR TITLE
[FIRRTL] Add a new InnerSym Attribute

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -222,4 +222,26 @@ def NameKindEnumImpl: I32EnumAttr<"NameKindEnum", "name kind",
 
 def NameKindAttr: EnumAttr<FIRRTLDialect, NameKindEnumImpl, "name_kind">;
 
+def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
+  let summary = "Defines the properties of an inner_sym attribute.";
+  let description = [{
+    Defines the properties of an inner_sym attribute: the symbol name, the
+    fieldID and visibility.
+  }];
+  let mnemonic = "innerSym";
+  let parameters = (ins 
+         "::mlir::StringAttr":$symName,
+         DefaultValuedParameter<"int64_t", "0">:$fieldID,
+         DefaultValuedParameter<"::mlir::StringAttr", "public">:$sym_visibility
+         );
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
+      return get(sym.getContext(), sym, 0, 
+                 StringAttr::get(sym.getContext(), "public"));
+    }]>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -229,14 +229,14 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
     fieldID and visibility.
   }];
   let mnemonic = "innerSym";
-  let parameters = (ins 
+  let parameters = (ins
          "::mlir::StringAttr":$symName,
          DefaultValuedParameter<"int64_t", "0">:$fieldID,
          DefaultValuedParameter<"::mlir::StringAttr", "public">:$sym_visibility
          );
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
-      return get(sym.getContext(), sym, 0, 
+      return get(sym.getContext(), sym, 0,
                  StringAttr::get(sym.getContext(), "public"));
     }]>
   ];


### PR DESCRIPTION
Add a new attribute `InnerSymAttr` to replace the `SymbolNameAttr` for the `inner_sym` argument of `FIRRTL` Ops.
The attribute has three parameters
1. `StringAttr` Symbol name.
2. `int64_t` Field id, to refer to the field of an aggregate type, on which the symbol applies.
3. `StringAttr` Symbol visibility, which specifies if the symbol is `private` or `public` or `nested`.

A sample MLIR, once we update all the ops to use this attribute.
```mlir
 %wireName = firrtl.wire sym @wireSym<fieldID=1><sym_visibility="private">  : !firrtl.uint<42>
```
