### PR TITLE
[ExportVerilog] Add explicit bitcast for sub expressions 

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -97,7 +97,7 @@ struct LoweringOptions {
   unsigned emittedLineLength = DEFAULT_LINE_LENGTH;
 
   /// Add an explicit bitcast for avoiding bitwidth mismatch LINT errors.
-  bool explicitBitcastAddMul = false;
+  bool explicitBitcast = false;
 
   /// If true, replicated ops are emitted to a header file.
   bool emitReplicatedOpsToHeader = false;

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -97,7 +97,6 @@ struct LoweringOptions {
   unsigned emittedLineLength = DEFAULT_LINE_LENGTH;
 
   /// Add an explicit bitcast for avoiding bitwidth mismatch LINT errors.
-  /// TODO: Change the name of option since it is not limit to add/mul anymore.
   bool explicitBitcastAddMul = false;
 
   /// If true, replicated ops are emitted to a header file.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1545,8 +1545,7 @@ public:
     // Emit the expression.
     emitSubExpr(exp, parenthesizeIfLooserThan,
                 /*signRequirement*/ NoRequirement,
-                /*isSelfDeterminedUnsignedValue*/ false,
-                /*isTopLevelExpression*/ true);
+                /*isSelfDeterminedUnsignedValue*/ false);
 
     // Emitted expression might break the line length constraint so align it
     // here.
@@ -1568,8 +1567,7 @@ private:
   /// known to be have "self determined" width, allowing us to omit extensions.
   SubExprInfo emitSubExpr(Value exp, VerilogPrecedence parenthesizeIfLooserThan,
                           SubExprSignRequirement signReq = NoRequirement,
-                          bool isSelfDeterminedUnsignedValue = false,
-                          bool isTopLevelExpression = false);
+                          bool isSelfDeterminedUnsignedValue = false);
 
   void formatOutBuffer();
 
@@ -1874,8 +1872,7 @@ static Value isZeroExtension(Value value) {
 SubExprInfo ExprEmitter::emitSubExpr(Value exp,
                                      VerilogPrecedence parenthesizeIfLooserThan,
                                      SubExprSignRequirement signRequirement,
-                                     bool isSelfDeterminedUnsignedValue,
-                                     bool isTopLevelExpression) {
+                                     bool isSelfDeterminedUnsignedValue) {
   // If this is a self-determined unsigned value, look through any inline zero
   // extensions.  This occurs on the RHS of a shift operation for example.
   if (isSelfDeterminedUnsignedValue && exp.hasOneUse()) {
@@ -1912,13 +1909,12 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
   signPreference = signRequirement;
 
   bool bitCastAdded = false;
-  if (state.options.explicitBitcastAddMul)
-    if (isa<AddOp, MulOp>(op) || (isTopLevelExpression && isa<SubOp>(op)))
-      if (auto inType =
-              (op->getResult(0).getType().dyn_cast_or_null<IntegerType>())) {
-        os << inType.getWidth() << "'(";
-        bitCastAdded = true;
-      }
+  if (state.options.explicitBitcastAddMul && isa<AddOp, MulOp>(op))
+    if (auto inType =
+            (op->getResult(0).getType().dyn_cast_or_null<IntegerType>())) {
+      os << inType.getWidth() << "'(";
+      bitCastAdded = true;
+    }
   // Okay, this is an expression we should emit inline.  Do this through our
   // visitor.
   auto expInfo = dispatchCombinationalVisitor(exp.getDefiningOp());

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1909,7 +1909,7 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
   signPreference = signRequirement;
 
   bool bitCastAdded = false;
-  if (state.options.explicitBitcastAddMul && isa<AddOp, MulOp, SubOp>(op))
+  if (state.options.explicitBitcast && isa<AddOp, MulOp, SubOp>(op))
     if (auto inType =
             (op->getResult(0).getType().dyn_cast_or_null<IntegerType>())) {
       os << inType.getWidth() << "'(";

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1909,7 +1909,7 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
   signPreference = signRequirement;
 
   bool bitCastAdded = false;
-  if (state.options.explicitBitcastAddMul && isa<AddOp, MulOp>(op))
+  if (state.options.explicitBitcastAddMul && isa<AddOp, MulOp, SubOp>(op))
     if (auto inType =
             (op->getResult(0).getType().dyn_cast_or_null<IntegerType>())) {
       os << inType.getWidth() << "'(";

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -63,8 +63,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
         errorHandler("expected integer source width");
         emittedLineLength = DEFAULT_LINE_LENGTH;
       }
-    } else if (option == "explicitBitcastAddMul") {
-      explicitBitcastAddMul = true;
+    } else if (option == "explicitBitcast") {
+      explicitBitcast = true;
     } else if (option == "emitReplicatedOpsToHeader") {
       emitReplicatedOpsToHeader = true;
     } else if (option.consume_front("maximumNumberOfTermsPerExpression=")) {
@@ -107,8 +107,8 @@ std::string LoweringOptions::toString() const {
     options += "disallowLocalVariables,";
   if (enforceVerifLabels)
     options += "verifLabels,";
-  if (explicitBitcastAddMul)
-    options += "explicitBitcastAddMul,";
+  if (explicitBitcast)
+    options += "explicitBitcast,";
   if (emitReplicatedOpsToHeader)
     options += "emitReplicatedOpsToHeader,";
   if (locationInfoStyle == LocationInfoStyle::WrapInAtSquareBracket)
@@ -179,7 +179,7 @@ struct LoweringCLOptions {
           "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
           "maximumNumberOfTermsPerExpression=<n>, "
-          "maximumNumberOfTermsInConcat=<n>, explicitBitcastAddMul, "
+          "maximumNumberOfTermsInConcat=<n>, explicitBitcast, "
           "emitReplicatedOpsToHeader, "
           "locationInfoStyle={plain,wrapInAtSquareBracket}, "
           "disallowPortDeclSharing, printDebugInfo"),

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -117,9 +117,11 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
     sv.if %cond {
       %c42 = hw.constant 42 : i8
       %add = comb.add %val, %c42 : i8
+      %sub_inner = comb.sub %val, %c42 : i8
+      %sub = comb.sub %sub_inner, %c42 : i8
 
-      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x\n", 8'(val + 8'h2A));
-      sv.fwrite %fd, "Inlined! %x\n"(%add) : i8
+      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(8'(val - 8'h2A) - 8'h2A));
+      sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
     }
 
     // begin/end required here to avoid else-confusion.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -117,11 +117,9 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
     sv.if %cond {
       %c42 = hw.constant 42 : i8
       %add = comb.add %val, %c42 : i8
-      %sub_inner = comb.sub %val, %c42 : i8
-      %sub = comb.sub %sub_inner, %c42 : i8
 
-      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(val - 8'h2A - 8'h2A));
-      sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
+      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x\n", 8'(val + 8'h2A));
+      sv.fwrite %fd, "Inlined! %x\n"(%add) : i8
     }
 
     // begin/end required here to avoid else-confusion.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -export-verilog -verify-diagnostics --lowering-options=exprInEventControl,explicitBitcastAddMul,maximumNumberOfTermsInConcat=10 | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s -export-verilog -verify-diagnostics --lowering-options=exprInEventControl,explicitBitcast,maximumNumberOfTermsInConcat=10 | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (


### PR DESCRIPTION
Unfortunately spyglass infers bitwidth of sub expression incorrectly even when they are not toplevel. This PR will surpass the lint warnings.  
This revert https://github.com/llvm/circt/pull/3094 and adds explicit bitcast for every sub expression when `explicitBitcastAddMul` option is true. 