### PR TITLE
[FIRRTL] Make all NLAs end in a Module

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -137,15 +137,17 @@ buildNLA(CircuitOp circuit, size_t nlaSuffix,
   OpBuilder b(circuit.getBodyRegion());
   MLIRContext *ctxt = circuit.getContext();
   SmallVector<Attribute> insts;
-  for (auto &nla : nlas) {
+  for (size_t i = 0, e = nlas.size(); i < e; ++i) {
+    auto &nla = nlas[i];
     // Assumption: Symbol name = Operation name.
     auto module = std::get<1>(nla);
-    auto inst = std::get<2>(nla);
-    if (inst.empty())
+    if (i == e - 1)
       insts.push_back(FlatSymbolRefAttr::get(ctxt, module));
-    else
+    else {
+      auto inst = std::get<2>(nla);
       insts.push_back(hw::InnerRefAttr::get(StringAttr::get(ctxt, module),
                                             StringAttr::get(ctxt, inst)));
+    }
   }
   auto instAttr = ArrayAttr::get(ctxt, insts);
   auto nla = b.create<HierPathOp>(circuit.getLoc(),

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1521,8 +1521,6 @@ static bool needsSymbol(ArrayAttr &annotations) {
       // Ignore the annotation.
       continue;
     }
-    if (anno.getMember("circt.nonlocal"))
-      needsSymbol = true;
     filteredAnnos.push_back(attr);
   }
   if (needsSymbol)

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -103,14 +103,13 @@ static void addAnnotation(AnnoTarget ref, unsigned fieldIdx,
 static FlatSymbolRefAttr buildNLA(AnnoPathValue target, ApplyState &state) {
   OpBuilder b(state.circuit.getBodyRegion());
   SmallVector<Attribute> insts;
-  for (auto inst : target.instances)
+  for (auto inst : target.instances) {
     insts.push_back(OpAnnoTarget(inst).getNLAReference(
         state.getNamespace(inst->getParentOfType<FModuleLike>())));
+  }
 
-  auto module = dyn_cast<FModuleLike>(target.ref.getOp());
-  if (!module)
-    module = target.ref.getOp()->getParentOfType<FModuleLike>();
-  insts.push_back(target.ref.getNLAReference(state.getNamespace(module)));
+  insts.push_back(
+      FlatSymbolRefAttr::get(target.ref.getModule().moduleNameAttr()));
   auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
   state.symTbl.insert(nla);

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
   ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A(
@@ -328,7 +328,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -354,8 +354,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
-  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {{.+}} @A(
@@ -364,7 +364,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -450,9 +450,9 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
   ; CHECK: firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B::@[[fooSym]]]
+  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
@@ -472,7 +472,7 @@ circuit Top : %[[
   ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "B_"}
   ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "B"}
   module B :
-    ; CHECK: firrtl.node sym @[[fooSym]]
+    ; CHECK: firrtl.node
     ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "B_.bar"}
     ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "B.foo"}
     node foo = UInt<1>(0)
@@ -512,7 +512,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @D::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -524,7 +524,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
-  ; CHECK-SAME:      @D::@[[fooSym]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -752,11 +752,9 @@ circuit top : %[[
   }
 ]]
   ; CHECK:      firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK:      firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym]]
+  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
@@ -777,7 +775,7 @@ circuit top : %[[
     ob.z <= b.r.z
 
   ; CHECK:      firrtl.module private @a(
-  ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]
+  ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
   ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
   ; CHECK-SAME:      #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @[[nla_1]], class = "nla1"}>]

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -106,11 +106,14 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     inst bar of Bar
 
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar::@d]
-    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar::@b]
+    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar]
+    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar]
     ; CHECK: firrtl.module private @Bar
-    ; CHECK-SAME: sym @b [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
-    ; CHECK-NEXT:  %d = firrtl.wire sym @d
+    ; CHECK:      out %b
+    ; CHECK-NOT:  sym
+    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
+    ; CHECK-NEXT: %d = firrtl.wire
+    ; CHECK-NOT:  sym
     ; CHECK-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, five}>]}
     ; CHECK-SAME: : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
@@ -582,8 +585,8 @@ circuit memportAnno: %[[
       write-latency => 1
       read-under-write => undefined
 ; CHECK-LABEL: firrtl.circuit "memportAnno"  {
-; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo::@memory]
-; CHECK:        %memory_w = firrtl.mem sym @memory interesting_name Undefined  {depth = 16 : i64, name = "memory", portAnnotations
+; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo]
+; CHECK:        %memory_w = firrtl.mem {{.+}} Undefined {depth = 16 : i64, name = "memory", portAnnotations
 ; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]
 
 ; // -----
@@ -629,5 +632,5 @@ circuit instportAnno: %[[
     inst bar of Bar
 
 ; CHECK-LABEL: firrtl.circuit "instportAnno"
-; CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz]
-; CHECK:        %baz_a = firrtl.instance baz sym @baz interesting_name @Baz(out a: !firrtl.uint<1> [{circt.nonlocal = @[[HIER]], class = "hello"}])
+; CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar]
+; CHECK:        %baz_a = firrtl.instance baz interesting_name @Baz(out a: !firrtl.uint<1> [{circt.nonlocal = @[[HIER]], class = "hello"}])

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -21,8 +21,8 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
 // CHECK: firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL::@w]
-// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
@@ -57,9 +57,10 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child::@bar]
+// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child]
 // CHECK: firrtl.module @Child()
-// CHECK:   %bar_r = firrtl.mem sym @bar
+// CHECK:   %bar_r = firrtl.mem
+// CHECK-NOT: sym
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
 // CHECK: firrtl.module @MemPortsNL()
 // CHECK:   firrtl.instance child sym @child
@@ -120,8 +121,8 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest::@in]
-  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla, class = "circt.test"}])
+  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest]
+  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
   firrtl.module @Test() {
@@ -371,7 +372,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@w]
+// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 

--- a/test/Dialect/FIRRTL/print-nla-table.mlir
+++ b/test/Dialect/FIRRTL/print-nla-table.mlir
@@ -1,14 +1,14 @@
 // RUN: circt-opt -firrtl-print-nla-table %s  2>&1 | FileCheck %s
 
-// CHECK: BarNL: nla_1, nla, 
-// CHECK: BazNL: nla_1, nla_0, nla, 
-// CHECK: FooNL: nla_1, nla_0, nla, 
-// CHECK: FooL: 
+// CHECK: BarNL: nla_1, nla,
+// CHECK: BazNL: nla_1, nla_0, nla,
+// CHECK: FooNL: nla_1, nla_0, nla,
+// CHECK: FooL:
 
 firrtl.circuit "FooNL"  {
   firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@w]
-  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL]
+  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 
   firrtl.module @BarNL() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.test", nl = "nl"}]} {
     %w2 = firrtl.wire sym @w2  {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -154,8 +154,8 @@ firrtl.module @TestInvalidAttr() {
 }
 
 // Basic test for NLA operations.
-// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child::@w]
-firrtl.hierpath @nla [@Parent::@child, @Child::@w]
+// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child]
+firrtl.hierpath @nla [@Parent::@child, @Child]
 firrtl.module @Child() {
   %w = firrtl.wire sym @w : !firrtl.uint<1>
 }


### PR DESCRIPTION
This is the final piece of work towards making annotations not block
optimizations.  This PR switches annotation creation to stop attaching
symbols to non-local annotation targets. As much as possible, passes
have already been updated to handle the new style of HierPath used for
non-local annotations.
