### PR TITLE
[FIRRTL] Add cache to LowerAnnotations' annotation target resolution

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -69,6 +69,52 @@ struct AnnoPathValue {
   }
 };
 
+/// Cache AnnoTargets for a module's named things.
+struct AnnoTargetCache {
+  AnnoTargetCache() = delete;
+  AnnoTargetCache(const AnnoTargetCache &other) = default;
+  AnnoTargetCache(AnnoTargetCache &&other)
+      : targets(std::move(other.targets)){};
+
+  AnnoTargetCache(FModuleLike mod) { gatherTargets(mod); };
+
+  /// Lookup the target for 'name', empty if not found.
+  /// (check for validity using operator bool()).
+  AnnoTarget getTargetForName(StringRef name) const {
+    auto it = targets.find(name);
+    if (it == targets.end())
+      return {};
+    return it->second;
+  }
+
+private:
+  /// Walk the module and add named things to 'targets'.
+  void gatherTargets(FModuleLike mod);
+
+  llvm::StringMap<AnnoTarget> targets;
+};
+
+/// Cache AnnoTargets for a circuit's modules, walked as needed.
+struct CircuitTargetCache {
+  /// Get cache for specified module, creating it as needed.
+  /// Returned reference may become invalidated by future calls.
+  const AnnoTargetCache &getOrCreateCacheFor(FModuleLike module) {
+    auto it = targetCaches.find(module);
+    if (it == targetCaches.end()) {
+      it = targetCaches.try_emplace(module, module).first;
+    }
+    return it->second;
+  }
+
+  /// Lookup the target for 'name' in 'module'.
+  AnnoTarget lookup(FModuleLike module, StringRef name) {
+    return getOrCreateCacheFor(module).getTargetForName(name);
+  }
+
+private:
+  DenseMap<Operation *, AnnoTargetCache> targetCaches;
+};
+
 /// Return an input \p target string in canonical form.  This converts a Legacy
 /// Annotation (e.g., A.B.C) into a modern annotation (e.g., ~A|B>C).  Trailing
 /// subfield/subindex references are preserved.
@@ -80,11 +126,13 @@ Optional<TokenAnnoTarget> tokenizePath(StringRef origTarget);
 /// Convert a parsed target string to a resolved target structure.  This
 /// resolves all names and aggregates from a parsed target.
 Optional<AnnoPathValue> resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
-                                        SymbolTable &symTbl);
+                                        SymbolTable &symTbl,
+                                        CircuitTargetCache &cache);
 
 /// Resolve a string path to a named item inside a circuit.
 Optional<AnnoPathValue> resolvePath(StringRef rawPath, CircuitOp circuit,
-                                    SymbolTable &symTbl);
+                                    SymbolTable &symTbl,
+                                    CircuitTargetCache &cache);
 
 /// Return true if an Annotation's class name is handled by the LowerAnnotations
 /// pass.
@@ -99,6 +147,7 @@ struct ApplyState {
 
   CircuitOp circuit;
   SymbolTable &symTbl;
+  CircuitTargetCache targetCaches;
   AddToWorklistFn addToWorklistFn;
 
   ModuleNamespace &getNamespace(FModuleLike module) {

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -91,7 +91,7 @@ private:
   /// Walk the module and add named things to 'targets'.
   void gatherTargets(FModuleLike mod);
 
-  llvm::StringMap<AnnoTarget> targets;
+  llvm::DenseMap<StringRef, AnnoTarget> targets;
 };
 
 /// Cache AnnoTargets for a circuit's modules, walked as needed.

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -152,7 +152,8 @@ static Optional<AnnoPathValue> stdResolveImpl(StringRef rawPath,
     return {};
   }
 
-  return resolveEntities(*tokens, state.circuit, state.symTbl);
+  return resolveEntities(*tokens, state.circuit, state.symTbl,
+                         state.targetCaches);
 }
 
 /// (SFC) FIRRTL SingleTargetAnnotation resolver.  Uses the 'target' field of


### PR DESCRIPTION
Significantly improves performance by avoiding many walks of a module (for a different target, or for repeat lookups of same).
