### PR TITLE
[FIRRTL] Update GCT Taps to handle HierPathOp ending in Module

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -844,8 +844,17 @@ void GrandCentralTapsPass::runOnOperation() {
         for (auto inst : shortestPrefix.getValue())
           addSymbol(getInnerRefTo(inst));
         if (port.nla) {
-          for (auto sym : port.nla.namepath())
+          auto namepath = port.nla.namepath();
+          Attribute leaf = namepath.getValue().back();
+          if (!leaf.isa<InnerRefAttr>()) {
+            if (port.target.hasPort())
+              leaf = getInnerRefTo(port.target.getOp(), port.target.getPort());
+            else
+              leaf = getInnerRefTo(port.target.getOp());
+          }
+          for (auto sym : namepath.getValue().drop_back())
             addSymbol(sym);
+          addSymbol(leaf);
         } else if (port.target.getOp()) {
           if (port.target.hasPort())
             addSymbol(

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -333,9 +333,9 @@ firrtl.circuit "NLAGarbageCollection" {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
   // CHECK-NOT: @nla_3
-  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
-  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
-  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
+  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
+  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
   firrtl.module @Submodule(
     in %port: !firrtl.uint<1> sym @port [
       {circt.nonlocal = @nla_2,
@@ -419,8 +419,8 @@ firrtl.circuit "NLAGarbageCollection" {
 firrtl.circuit "NLAUsedInWiring"  {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
-  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo]
-  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo]
+  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
+  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
 
   // CHECK-LABEL: firrtl.module @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
@@ -495,8 +495,8 @@ firrtl.circuit "NLAUsedInWiring"  {
 // See https://github.com/llvm/circt/issues/2767.
 
 firrtl.circuit "Top" {
-  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule]
-  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule]
+  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
+  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule::@bar_0]
   firrtl.module @Submodule(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -554,3 +554,12 @@ firrtl.circuit "Top" {
     firrtl.instance dut @DUT()
   }
 }
+// ---
+// The HierpathOps that should be updated to end on a module:
+//  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+//  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+//  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+//  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo]
+//  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo]
+//  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule]
+//  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule]

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -333,9 +333,9 @@ firrtl.circuit "NLAGarbageCollection" {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
   // CHECK-NOT: @nla_3
-  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
-  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
-  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
+  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
   firrtl.module @Submodule(
     in %port: !firrtl.uint<1> sym @port [
       {circt.nonlocal = @nla_2,
@@ -419,8 +419,8 @@ firrtl.circuit "NLAGarbageCollection" {
 firrtl.circuit "NLAUsedInWiring"  {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
-  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
-  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
+  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo]
+  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo]
 
   // CHECK-LABEL: firrtl.module @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
@@ -495,8 +495,8 @@ firrtl.circuit "NLAUsedInWiring"  {
 // See https://github.com/llvm/circt/issues/2767.
 
 firrtl.circuit "Top" {
-  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
-  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule::@bar_0]
+  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule]
+  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule]
   firrtl.module @Submodule(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>


### PR DESCRIPTION
This commit updates the GrandCentralTaps to handle `HierPathOp` ending in modules.
TODO:

- [ ] Donot Garbage Collect the HierPathOp !