### PR TITLE
[FIRRTL] add dedup support for "Make all NLAs end in a Modules"

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -586,7 +586,8 @@ struct Deduper {
     for (auto pair : llvm::enumerate(module.getPortAnnotations()))
       for (auto anno : AnnotationSet(pair.value().cast<ArrayAttr>()))
         if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
-          targetMap[nlaRef.getAttr()] = PortAnnoTarget(module, pair.index());
+          targetMap[nlaRef.getAttr()].push_back(
+              PortAnnoTarget(module, pair.index()));
     // Record any annotations in the module body.
     module->walk([&](Operation *op) { recordAnnotations(op); });
   }
@@ -600,22 +601,23 @@ private:
 
   /// Record all targets which use an NLA.
   void recordAnnotations(Operation *op) {
-    for (auto anno : AnnotationSet(op)) {
-      if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
-        targetMap[nlaRef.getAttr()] = OpAnnoTarget(op);
-      }
-    }
+    // Record annotations.
+    for (auto anno : AnnotationSet(op))
+      if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
+        targetMap[nlaRef.getAttr()].push_back(OpAnnoTarget(op));
 
-    // Record port annotations if this is a mem operation.
+    // Record port annotations only if this is a mem operation.
     auto mem = dyn_cast<MemOp>(op);
     if (!mem)
       return;
-    // Breadcrumbs don't appear on port annotations, so we can skip the
-    // class check that we have above.
+
+    // Record port annotations. Breadcrumbs don't appear on port annotations, so
+    // we can skip the class check that we have above.
     for (auto pair : llvm::enumerate(mem.portAnnotations()))
       for (auto anno : AnnotationSet(pair.value().cast<ArrayAttr>()))
         if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
-          targetMap[nlaRef.getAttr()] = PortAnnoTarget(mem, pair.index());
+          targetMap[nlaRef.getAttr()].push_back(
+              PortAnnoTarget(mem, pair.index()));
   }
 
   /// This deletes and replaces all instances of the "fromModule" with instances
@@ -663,7 +665,7 @@ private:
       auto nlaRef = FlatSymbolRefAttr::get(nlaName);
       nlas.push_back(nlaRef);
       nlaTable->addNLA(nla);
-      targetMap[nlaName] = to;
+      targetMap[nlaName].push_back(to);
     }
     return nlas;
   }
@@ -679,9 +681,11 @@ private:
                       to.getNLAReference(getNamespace(toModule)));
   }
 
-  /// Clone the annotation for each NLA in a list.
-  void cloneAnnotation(SmallVector<FlatSymbolRefAttr> &nlas, Annotation anno,
-                       ArrayRef<NamedAttribute> attributes,
+  /// Clone the annotation for each NLA in a list. The attribute list should
+  /// have a placeholder for the "circt.nonlocal" field, and `nonLocalIndex`
+  /// should be the index of this field.
+  void cloneAnnotation(SmallVectorImpl<FlatSymbolRefAttr> &nlas,
+                       Annotation anno, ArrayRef<NamedAttribute> attributes,
                        unsigned nonLocalIndex,
                        SmallVector<Annotation> &newAnnotations) {
     SmallVector<NamedAttribute> mutableAttributes(attributes.begin(),
@@ -690,6 +694,7 @@ private:
       // Add the new annotation.
       mutableAttributes[nonLocalIndex].setValue(nla);
       auto dict = DictionaryAttr::getWithSorted(context, mutableAttributes);
+      // The original annotation records if its a subannotation.
       anno.setDict(dict);
       newAnnotations.push_back(anno);
     }
@@ -713,38 +718,42 @@ private:
     auto fromName = fromModule.getNameAttr();
     // Create a copy of the current NLAs. We will be pushing and removing
     // NLAs from this op as we go.
-    auto nlas = nlaTable->lookup(fromModule.getNameAttr()).vec();
+    auto moduleNLAs = nlaTable->lookup(fromModule.getNameAttr()).vec();
     // Change the NLA to target the toModule.
     nlaTable->renameModuleAndInnerRef(toName, fromName, renameMap);
-    for (auto nla : nlas) {
+    for (auto nla : moduleNLAs) {
       auto elements = nla.namepath().getValue();
       // If we don't need to add more context, we're done here.
       if (nla.root() != toName)
         continue;
-      // We need to clone the annotation for each new NLA.
-      auto target = targetMap[nla.sym_nameAttr()];
-      assert(target && "Target of NLA never encountered.  All modules should "
-                       "be reachable from the top module.");
-      SmallVector<Attribute> namepath(elements.begin(), elements.end());
-      SmallVector<Annotation> newAnnotations;
-      auto nlas = createNLAs(toName, target, fromModule, namepath);
-      for (auto anno : target.getAnnotations()) {
-        // Find the non-local field of the annotation.
-        auto [it, found] = mlir::impl::findAttrSorted(anno.begin(), anno.end(),
-                                                      nonLocalString);
-        if (!found || it->getValue().cast<FlatSymbolRefAttr>().getAttr() !=
-                          nla.sym_nameAttr()) {
-          newAnnotations.push_back(anno);
-          continue;
+      // Replace the uses of the old NLA with the new NLAs.
+      for (auto target : targetMap[nla.sym_nameAttr()]) {
+        // Create the replacement NLAs.
+        SmallVector<Attribute> namepath(elements.begin(), elements.end());
+        auto nlaRefs = createNLAs(toName, target, fromModule, namepath);
+        // We have to clone any annotation which uses the old NLA for each new
+        // NLA. This array collects the new set of annotations.
+        SmallVector<Annotation> newAnnotations;
+        for (auto anno : target.getAnnotations()) {
+          // Find the non-local field of the annotation.
+          auto [it, found] = mlir::impl::findAttrSorted(
+              anno.begin(), anno.end(), nonLocalString);
+          // If this annotation doesn't use the target NLA, copy it with no
+          // changes.
+          if (!found || it->getValue().cast<FlatSymbolRefAttr>().getAttr() !=
+                            nla.sym_nameAttr()) {
+            newAnnotations.push_back(anno);
+            continue;
+          }
+          auto nonLocalIndex = std::distance(anno.begin(), it);
+          // Clone the annotation and add it to the list of new annotations.
+          cloneAnnotation(nlaRefs, anno, ArrayRef(anno.begin(), anno.end()),
+                          nonLocalIndex, newAnnotations);
         }
-        auto nonLocalIndex = std::distance(anno.begin(), it);
-        // We have to clone all the annotations referencing this op
-        // SmallVector<NamedAttribute> attributes(anno.begin(), anno.end());
-        cloneAnnotation(nlas, anno, ArrayRef(anno.begin(), anno.end()),
-                        nonLocalIndex, newAnnotations);
+        // Apply the new annotations to the operation.
+        AnnotationSet annotations(newAnnotations, context);
+        target.setAnnotations(annotations);
       }
-      AnnotationSet annotations(newAnnotations, context);
-      target.setAnnotations(annotations);
 
       // Erase the old NLA and remove it from all breadcrumbs.
       eraseNLA(nla);
@@ -787,7 +796,7 @@ private:
         // This annotation is already a non-local annotation. Record that this
         // operation uses that NLA and stop processing this annotation.
         auto nlaName = attr.getValue().cast<FlatSymbolRefAttr>().getAttr();
-        targetMap[nlaName] = from;
+        targetMap[nlaName].push_back(from);
         newAnnotations.push_back(anno);
         return;
       }
@@ -1002,7 +1011,7 @@ private:
   // This maps an NLA to the operation or port that uses it. Since NLAs include
   // the name of the leaf element, its only possible for the NLA to be used by a
   // single op or port.
-  DenseMap<Attribute, AnnoTarget> targetMap;
+  DenseMap<Attribute, std::vector<AnnoTarget>> targetMap;
 
   // Cached attributes for faster comparisons and attribute building.
   StringAttr nonLocalString;

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
@@ -328,7 +328,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -354,8 +354,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
-  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
@@ -364,7 +364,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -752,11 +752,9 @@ circuit top : %[[
   }
 ]]
   ; CHECK:      firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK:      firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym]]
+  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
@@ -777,7 +775,7 @@ circuit top : %[[
     ob.z <= b.r.z
 
   ; CHECK:      firrtl.module private @a(
-  ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]
+  ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
   ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
   ; CHECK-SAME:      #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @[[nla_1]], class = "nla1"}>]

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -37,23 +37,6 @@ firrtl.circuit "Simple" {
   }
 }
 
-
-// Should pick a valid symbol when a wire has no name.
-// CHECK-LABEL: firrtl.circuit "Top"
-firrtl.circuit "Top"  {
-  firrtl.module @Top() {
-    %a1_x = firrtl.instance a1  @A(out x: !firrtl.uint<1>)
-    %a2_x = firrtl.instance a2  @A_(out x: !firrtl.uint<1>)
-  }
-  firrtl.module @A(out %x: !firrtl.uint<1>) {
-    // CHECK: %0 = firrtl.wire sym @inner_sym
-    %0 = firrtl.wire  {annotations = [{class = "hello"}]} : !firrtl.uint<1>
-  }
-  firrtl.module @A_(out %x: !firrtl.uint<1>) {
-    %0 = firrtl.wire  : !firrtl.uint<1>
-  }
-}
-
 // CHECK-LABEL: firrtl.circuit "PrimOps"
 firrtl.circuit "PrimOps" {
   // CHECK: firrtl.module @PrimOps0
@@ -82,29 +65,30 @@ firrtl.circuit "PrimOps" {
 
 // CHECK-LABEL: firrtl.circuit "Annotations"
 firrtl.circuit "Annotations" {
-  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Annotations::@annotations1, @Annotations0]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0::@f]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations0, @Annotations0::@c]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations1, @Annotations0::@b]
-  // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
-  // CHECK: firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
-  firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
-  firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations1, @Annotations0]
 
-  // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA3]], class = "one"}]}
+  // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
+  firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
+  // CHECK: firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
+  firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath @annos_nla3 [@Annotations::@annotations0, @Annotations0]
+  firrtl.hierpath @annos_nla3 [@Annotations::@annotations0, @Annotations0]
+
+  // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
   firrtl.module @Annotations0() {
     // Same annotation on both ops should stay local.
     // CHECK: %a = firrtl.wire  {annotations = [{class = "both"}]}
     %a = firrtl.wire {annotations = [{class = "both"}]} : !firrtl.uint<1>
 
     // Annotation from other module becomes non-local.
-    // CHECK: %b = firrtl.wire sym @b  {annotations = [{circt.nonlocal = [[NLA0]], class = "one"}]}
+    // CHECK: %b = firrtl.wire {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
     %b = firrtl.wire : !firrtl.uint<1>
 
     // Annotation from this module becomes non-local.
-    // CHECK: %c = firrtl.wire sym @c  {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
+    // CHECK: %c = firrtl.wire {annotations = [{circt.nonlocal = [[NLA0]], class = "one"}]}
     %c = firrtl.wire {annotations = [{class = "one"}]} : !firrtl.uint<1>
 
     // Two non-local annotations are unchanged, as they have enough context in the NLA already.
@@ -116,7 +100,7 @@ firrtl.circuit "Annotations" {
     %e = firrtl.wire {annotations = [{circt.nonlocal = @annos_nla2, class = "NonLocal"}]} : !firrtl.uint<1>
 
     // Subannotations should be handled correctly.
-    // CHECK: %f = firrtl.wire sym @f {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
+    // CHECK: %f = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA0]], class = "subanno"}>]}
     %f = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {class = "subanno"}>]} : !firrtl.bundle<a: uint<1>>
   }
   // CHECK-NOT: firrtl.module @Annotations1
@@ -139,18 +123,16 @@ firrtl.circuit "Annotations" {
 // Check that module and memory port annotations are merged correctly.
 // CHECK-LABEL: firrtl.circuit "PortAnnotations"
 firrtl.circuit "PortAnnotations" {
-  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@a]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@a]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@bar]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@bar]
-  // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> sym @a [
-  // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "port1"},
-  // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "port0"}]) {
+  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
+  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
+  // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> [
+  // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "port1"},
+  // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"}]) {
   firrtl.module @PortAnnotations0(in %a : !firrtl.uint<1> [{class = "port0"}]) {
-    // CHECK: %bar_r = firrtl.mem sym @bar
+    // CHECK: %bar_r = firrtl.mem
     // CHECK-SAME: portAnnotations =
-    // CHECK-SAME:  {circt.nonlocal = [[NLA0]], class = "mem1"},
-    // CHECK-SAME:  {circt.nonlocal = [[NLA1]], class = "mem0"}
+    // CHECK-SAME:  {circt.nonlocal = [[NLA1]], class = "mem1"},
+    // CHECK-SAME:  {circt.nonlocal = [[NLA0]], class = "mem0"}
     %bar_r = firrtl.mem Undefined  {depth = 16 : i64, name = "bar", portAnnotations = [[{class = "mem0"}]], portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
   }
   // CHECK-NOT: firrtl.module @PortAnnotations1

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -83,13 +83,15 @@ firrtl.circuit "PrimOps" {
 // CHECK-LABEL: firrtl.circuit "Annotations"
 firrtl.circuit "Annotations" {
   // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Annotations::@annotations1, @Annotations0]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0::@e]
+  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0::@f]
   // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations0, @Annotations0::@c]
   // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations1, @Annotations0::@b]
   // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
   // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
+  // CHECK: firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
   firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
   firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
+  firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
 
   // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA3]], class = "one"}]}
   firrtl.module @Annotations0() {
@@ -109,9 +111,13 @@ firrtl.circuit "Annotations" {
     // CHECK: %d = firrtl.wire sym @d  {annotations = [{circt.nonlocal = @annos_nla1, class = "NonLocal"}, {circt.nonlocal = @annos_nla0, class = "NonLocal"}]}
     %d = firrtl.wire sym @d {annotations = [{circt.nonlocal = @annos_nla0, class = "NonLocal"}]} : !firrtl.uint<1>
 
+    // Same test as above but with the hiearchical path targeting the module.
+    // CHECK: %e = firrtl.wire {annotations = [{circt.nonlocal = @annos_nla3, class = "NonLocal"}, {circt.nonlocal = @annos_nla2, class = "NonLocal"}]}
+    %e = firrtl.wire {annotations = [{circt.nonlocal = @annos_nla2, class = "NonLocal"}]} : !firrtl.uint<1>
+
     // Subannotations should be handled correctly.
-    // CHECK: %e = firrtl.wire sym @e  {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
-    %e = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {class = "subanno"}>]} : !firrtl.bundle<a: uint<1>>
+    // CHECK: %f = firrtl.wire sym @f {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
+    %f = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {class = "subanno"}>]} : !firrtl.bundle<a: uint<1>>
   }
   // CHECK-NOT: firrtl.module @Annotations1
   firrtl.module @Annotations1() attributes {annotations = [{class = "one"}]} {
@@ -119,7 +125,8 @@ firrtl.circuit "Annotations" {
     %g = firrtl.wire {annotations = [{class = "one"}]} : !firrtl.uint<1>
     %h = firrtl.wire : !firrtl.uint<1>
     %i = firrtl.wire sym @i {annotations = [{circt.nonlocal = @annos_nla1, class = "NonLocal"}]} : !firrtl.uint<1>
-    %j = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %j = firrtl.wire {annotations = [{circt.nonlocal = @annos_nla3, class = "NonLocal"}]} : !firrtl.uint<1>
+    %k = firrtl.wire : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module @Annotations() {
     // CHECK: firrtl.instance annotations0 sym @annotations0  @Annotations0()


### PR DESCRIPTION
This is a PR to another open PR that depends on another PR ;).  Once #3309 is merged into `main`, I will merge this into #3300.

This commit changes the hierarchical paths produced by dedup to end at the module.  It is able to re-use the `hierpaths` created across all merged operations in a module.