### PR TITLE
[PrepareForEmission] Don't copy namehint to all sub expressions

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -213,6 +213,8 @@ static Value lowerFullyAssociativeOp(Operation &op, OperandRange operands,
                                      SmallVector<Operation *> &newOps) {
   // save the top level name
   auto name = op.getAttr("sv.namehint");
+  if (name)
+    op.removeAttr("sv.namehint");
   Value lhs, rhs;
   switch (operands.size()) {
   case 0:

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s -export-verilog -o %t.mlir && cat %t.mlir | FileCheck %s --check-prefix=IR
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)
@@ -705,6 +706,14 @@ hw.module @instance_result_reuse_wires() -> (b: i3) {
   hw.output %read : i3
 }
 
+// IR: @namehint_variadic
+hw.module @namehint_variadic(%a: i3) -> (b: i3) {
+  // IR-NEXT: %0 = comb.add %a, %a : i3
+  // IR-NEXT: %1 = comb.add %a, %0 {sv.namehint = "bar"} : i3
+  // IR-NEXT: hw.output %1
+  %0 = comb.add %a, %a, %a { sv.namehint = "bar" } : i3
+  hw.output %0 : i3
+}
 
 hw.module.extern @ExternDestMod(%a: i1, %b: i2) -> (c: i3, d: i4)
 hw.module @InternalDestMod(%a: i1, %b: i3) {}


### PR DESCRIPTION
This commit fixes a (potential) bug that namehints of variadic ops are copied to all lowered sub expressions. 

For example, 
```mlir
hw.module @namehint_variadic(%a: i3) -> (b: i3) {
  %0 = comb.add %a, %a, %a, %a, %a { sv.namehint = "bar" } : i3
  hw.output %0 : i3
}
```
`circt-opt -export-verilog`  currently transforms  IR above into:
```mlir
hw.module @namehint_variadic(%a: i3) -> (b: i3) {
    %0 = comb.add %a, %a {sv.namehint = "bar"} : i3
    %1 = comb.add %a, %a {sv.namehint = "bar"} : i3
    %2 = comb.add %a, %1 {sv.namehint = "bar"} : i3
    %3 = comb.add %0, %2 {sv.namehint = "bar"} : i3
    hw.output %3 : i3
}
```
Copying sv.namehint to all sub expression sounds weird even though it doesn't cause any bug (since namehints created here are not used at all). With this PR, the IR is transformed to:

```mlir
hw.module @namehint_variadic(%a: i3) -> (b: i3) {
    %0 = comb.add %a, %a : i3
    %1 = comb.add %a, %a : i3
    %2 = comb.add %a, %1 : i3
    %3 = comb.add %0, %2 {sv.namehint = "bar"} : i3
    hw.output %3 : i3
  }
```