### PR TITLE
[PrettifyVerilog] Stop duplicating unary op with namehint

### DIFF
--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -111,8 +111,9 @@ bool PrettifyVerilogPass::prettifyUnaryOperator(Operation *op) {
   //         = ^tmp2 + 42
   //
   // This is particularly helpful when the operand of the unary op has multiple
-  // uses as well.
-  if (op->use_empty() || op->hasOneUse())
+  // uses as well. If the op has a namehint, it is not necessary to duplicate
+  // the op because its temporary wire gets a good name anyway.
+  if (op->use_empty() || op->hasOneUse() || op->hasAttr("sv.namehint"))
     return false;
 
   // If this operation has any users that cannot inline the operation, then

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: hw.module @unary_ops
 hw.module @unary_ops(%arg0: i8, %arg1: i8, %arg2: i8, %arg3: i1)
-   -> (a: i8, b: i8, c: i1) {
+   -> (a: i8, b: i8, c: i1, d: i1) {
   %c-1_i8 = hw.constant -1 : i8
 
   // CHECK: [[XOR1:%.+]] = comb.xor %arg0
@@ -21,7 +21,12 @@ hw.module @unary_ops(%arg0: i8, %arg1: i8, %arg2: i8, %arg3: i1)
   %true = hw.constant true
   %c = comb.xor %arg3, %true : i1
 
+  // Expression with a namehint should not get duplicated.
   // CHECK: [[TRUE1:%.+]] = hw.constant true
+  // CHECK-NEXT: comb.xor %arg3, %true {sv.namehint = "foo"}
+  // CHECK-NOT: {sv.namehint = "foo"}
+  %d = comb.xor %arg3, %true {sv.namehint = "foo"}: i1
+
   sv.initial {
     // CHECK: [[TRUE2:%.+]] = hw.constant true
     // CHECK: [[XOR3:%.+]] = comb.xor %arg3, [[TRUE2]]
@@ -29,11 +34,14 @@ hw.module @unary_ops(%arg0: i8, %arg1: i8, %arg2: i8, %arg3: i1)
     sv.if %c {
       sv.fatal 1
     }
+    sv.if %d {
+      sv.fatal 1
+    }
   }
 
   // CHECK: [[XOR4:%.+]] = comb.xor %arg3, [[TRUE1]]
   // CHECK: hw.output %1, %3, [[XOR4]]
-  hw.output %a, %b, %c : i8, i8, i1
+  hw.output %a, %b, %c, %d : i8, i8, i1, i1
 }
 
 // VERILOG: assign a = ~arg0 + arg1;


### PR DESCRIPTION
This commit changes PrettifyVerilog to stop duplicating unary ops with namehints so that we can use namehints. This might be a bit controversial because namehint semantics is "best effort" but I'd like to stop cloning operations with namehints so that we can see more namehints.  

```mlir
hw.module @namehint(%a: i1) -> (b: i1, c: i1) {
  %true = hw.constant true
  %0 = comb.xor %a, %true {sv.namehint = "a_not"} : i1
  hw.output %0, %0 : i1, i1
}
```
before:
```verilog
  assign b = ~a;        // bar.mlir:4:8, :5:3
  assign c = ~a; 
```
after:
```verilog
  wire a_not = ~a;      // bar.mlir:4:8
  assign b = a_not;     // bar.mlir:5:3
  assign c = a_not;     // bar.mlir:5:3
```