### PR TITLE
[firtool] Rerun DropNamesPass after running middle-end passes

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -565,6 +565,12 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   pm.nest<firrtl::CircuitOp>().addPass(
       firrtl::createBlackBoxReaderPass(blackBoxRoot));
 
+  // Drop names introduced by middle-end passes (e.g. GrandCentral).
+  // TODO: Move this to the O1 pipeline.
+  if (dropName)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        firrtl::createDropNamesPass());
+
   // The above passes, IMConstProp in particular, introduce additional
   // canonicalization opportunities that we should pick up here before we
   // proceed to output-specific pipelines.


### PR DESCRIPTION
Middle-end passes might introduce operations with interesting names so this
commit adds another instance of DropNamesPass so that we can clean up them.