### PR TITLE
[MSFT] Support for multiple top levels of same module

### DIFF
--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -30,13 +30,18 @@ public:
   LogicalResult emit(Operation *forMod, StringRef outputFile);
 
   Operation *getDefinition(FlatSymbolRefAttr);
+  const DenseSet<hw::GlobalRefOp> &getRefsUsed() { return refsUsed; }
+  void usedRef(hw::GlobalRefOp ref) { refsUsed.insert(ref); }
 
 private:
   mlir::ModuleOp topLevel;
 
   bool populated;
   hw::HWSymbolCache topLevelSymbols;
-  DenseMap<Operation *, SmallVector<DynInstDataOpInterface, 0>> tclOpsForMod;
+  DenseMap<Operation *,
+           DenseMap<StringAttr, SmallVector<DynInstDataOpInterface, 0>>>
+      tclOpsForModInstance;
+  DenseSet<hw::GlobalRefOp> refsUsed;
 
   LogicalResult populate();
 };

--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -16,6 +16,8 @@
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h"
 #include "circt/Support/LLVM.h"
+
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace circt {
@@ -38,8 +40,11 @@ private:
 
   bool populated;
   hw::HWSymbolCache topLevelSymbols;
+
+  /// Map Module operations to their top-level "instance" names. Map those
+  /// "instance" names to the lowered ops which get directly emitted as tcl.
   DenseMap<Operation *,
-           DenseMap<StringAttr, SmallVector<DynInstDataOpInterface, 0>>>
+           llvm::MapVector<StringAttr, SmallVector<DynInstDataOpInterface, 0>>>
       tclOpsForModInstance;
   DenseSet<hw::GlobalRefOp> refsUsed;
 

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
@@ -10,10 +10,12 @@
 #define CIRCT_DIALECT_MSFT_MSFTOPINTERFACES_H
 
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWSymCache.h"
 
 namespace circt {
 namespace msft {
 LogicalResult verifyDynInstData(Operation *);
+class InstanceHierarchyOp;
 } // namespace msft
 } // namespace circt
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h.inc"

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -68,21 +68,6 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
             ref.namepath()[0].cast<hw::InnerRefAttr>().getModule());
         return symCache.getDefinition(modSym);
       }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
-        Get the top level instance name, if specified.
-      }],
-      /*retTy=*/"StringAttr",
-      /*methodName=*/"getTopInstanceName",
-      /*args=*/(ins),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
-        auto hierOp = $_op->template getParentOfType<InstanceHierarchyOp>();
-        if (!hierOp)
-          return {};
-        return hierOp.instNameAttr();
-      }]
     >
   ];
 }

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -41,6 +41,48 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
       /*defaultImplementation=*/[{
         return $_op.refAttr();
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the top module op to which the GlobalRefOp which this op is referring.
+      }],
+      /*retTy=*/"Operation *",
+      /*methodName=*/"getTopModule",
+      /*args=*/(ins "circt::hw::HWSymbolCache &":$symCache),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        FlatSymbolRefAttr refSym = $_op.getGlobalRefSym();
+        if (!refSym) {
+          $_op->emitOpError("must run dynamic instance lowering first");
+          return nullptr;
+        }
+        auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
+            symCache.getDefinition(refSym));
+        if (!ref) {
+          $_op->emitOpError("could not find hw.globalRef ") << refSym;
+          return nullptr;
+        }
+        if (ref.namepath().empty())
+          return nullptr;
+        auto modSym = FlatSymbolRefAttr::get(
+            ref.namepath()[0].cast<hw::InnerRefAttr>().getModule());
+        return symCache.getDefinition(modSym);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the top level instance name, if specified.
+      }],
+      /*retTy=*/"StringAttr",
+      /*methodName=*/"getTopInstanceName",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        auto hierOp = $_op->template getParentOfType<InstanceHierarchyOp>();
+        if (!hierOp)
+          return {};
+        return hierOp.instNameAttr();
+      }]
     >
   ];
 }

--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -82,12 +82,20 @@ def PDPhysRegionOp : MSFTOp<"pd.physregion",
 def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",
                                  [HasParent<"mlir::ModuleOp">, NoTerminator]> {
   let summary = "The root of an instance hierarchy";
+  let description = [{
+    Models the "root" / "top" of an instance hierarchy. `DynamicInstanceOp`s
+    must be contained by this op. Specifies the top module and (optionally) an
+    "instance" name in the case where there are multiple instances of a
+    particular module in a design. (As is often the case where one isn't
+    producing the design's "top" module but a subdesign.)
+  }];
 
-  let arguments = (ins FlatSymbolRefAttr:$topModuleRef);
+  let arguments = (ins FlatSymbolRefAttr:$topModuleRef,
+                       OptionalAttr<StrAttr>:$instName);
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
-    $topModuleRef $body attr-dict
+    $topModuleRef ($instName^)? $body attr-dict
   }];
 }
 

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -47,23 +47,24 @@ LogicalResult TclEmitter::populate() {
 
   // Bin any operations we may need to emit based on the root module in the
   // instance hierarchy path.
-  for (auto tclOp : topLevel.getOps<DynInstDataOpInterface>()) {
-    FlatSymbolRefAttr refSym = tclOp.getGlobalRefSym();
-    if (!refSym)
-      return tclOp->emitOpError("must run dynamic instance lowering first");
-    auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
-        topLevelSymbols.getDefinition(refSym));
-    if (!ref)
-      return tclOp->emitOpError("could not find hw.globalRef ") << refSym;
-    if (ref.namepath().empty())
-      continue;
-    auto modSym = FlatSymbolRefAttr::get(
-        ref.namepath()[0].cast<hw::InnerRefAttr>().getModule());
-    Operation *mod = topLevelSymbols.getDefinition(modSym);
-    assert(mod &&
-           "Invalid IR -- should have been caught by GlobalRef verifier");
-    tclOpsForMod[mod].push_back(tclOp);
+  for (auto hier : topLevel.getOps<InstanceHierarchyOp>()) {
+    Operation *mod = topLevelSymbols.getDefinition(hier.topModuleRefAttr());
+    auto &tclOps = tclOpsForModInstance[mod][hier.instNameAttr()];
+    for (auto tclOp : hier.getOps<DynInstDataOpInterface>()) {
+      assert(tclOp.getTopModule(topLevelSymbols) == mod &&
+             "Referenced mod does does not match");
+      tclOps.push_back(tclOp);
+    }
   }
+
+  // Locations at the global scope are assumed to refer to the module without an
+  // instance.
+  for (auto tclOp : topLevel.getOps<DynInstDataOpInterface>()) {
+    Operation *mod = tclOp.getTopModule(topLevelSymbols);
+    assert(mod && "Must be able to resolve top module");
+    tclOpsForModInstance[mod][{}].push_back(tclOp);
+  }
+
   return success();
 }
 
@@ -102,6 +103,17 @@ struct TclOutputState {
 
   void emitPath(hw::GlobalRefOp ref, Optional<StringRef> subpath);
   void emitInnerRefPart(hw::InnerRefAttr innerRef);
+
+  GlobalRefOp getRefOp(DynInstDataOpInterface refOp) {
+    auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
+        emitter.getDefinition(refOp.getGlobalRefSym()));
+    if (!ref)
+      refOp.emitOpError("could not find hw.globalRef named ")
+          << refOp.getGlobalRefSym();
+    else
+      emitter.usedRef(ref);
+    return ref;
+  }
 };
 } // anonymous namespace
 
@@ -162,18 +174,12 @@ LogicalResult
 TclOutputState::emitLocationAssignment(DynInstDataOpInterface refOp,
                                        PhysLocationAttr loc,
                                        Optional<StringRef> subpath) {
-  auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
-      emitter.getDefinition(refOp.getGlobalRefSym()));
-  if (!ref)
-    return refOp.emitOpError("could not find hw.globalRef named ")
-           << refOp.getGlobalRefSym();
-
   indent() << "set_location_assignment ";
   emit(loc);
 
   // To which entity does this apply?
   os << " -to $parent|";
-  emitPath(ref, subpath);
+  emitPath(getRefOp(refOp), subpath);
 
   return success();
 }
@@ -201,12 +207,7 @@ LogicalResult TclOutputState::emit(PDRegPhysLocationOp locs) {
 /// Emit tcl in the form of:
 /// "set_global_assignment -name NAME VALUE -to $parent|fooInst|entityName"
 LogicalResult TclOutputState::emit(DynamicInstanceVerbatimAttrOp attr) {
-
-  auto ref =
-      dyn_cast_or_null<hw::GlobalRefOp>(emitter.getDefinition(attr.refAttr()));
-  if (!ref)
-    return attr.emitOpError("could not find hw.globalRef named ")
-           << attr.refAttr();
+  GlobalRefOp ref = getRefOp(attr);
   indent() << "set_instance_assignment -name " << attr.name() << " "
            << attr.value();
 
@@ -223,11 +224,7 @@ LogicalResult TclOutputState::emit(DynamicInstanceVerbatimAttrOp attr) {
 /// set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|a|b|c
 /// set_instance_assignment -name REGION_NAME test_region -to $parent|a|b|c
 LogicalResult TclOutputState::emit(PDPhysRegionOp region) {
-  auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
-      emitter.getDefinition(region.refAttr()));
-  if (!ref)
-    return region.emitOpError("could not find hw.globalRef named ")
-           << region.refAttr();
+  GlobalRefOp ref = getRefOp(region);
 
   auto physicalRegion = dyn_cast_or_null<DeclPhysicalRegionOp>(
       emitter.getDefinition(region.physRegionRefAttr()));
@@ -287,27 +284,34 @@ LogicalResult TclEmitter::emit(Operation *hwMod, StringRef outputFile) {
   std::string s;
   llvm::raw_string_ostream os(s);
   TclOutputState state(*this, os);
-  os << "proc {{" << state.symbolRefs.size() << "}}_config { parent } {\n";
-  state.symbolRefs.push_back(SymbolRefAttr::get(hwMod));
+  for (auto tclOpsForInstancesKV : tclOpsForModInstance[hwMod]) {
+    StringAttr instName = tclOpsForInstancesKV.getFirst();
+    os << "proc {{" << state.symbolRefs.size() << "}}";
+    if (instName)
+      os << '_' << instName.getValue();
+    os << "_config { parent } {\n";
+    state.symbolRefs.push_back(SymbolRefAttr::get(hwMod));
 
-  // Loop through the ops relevant to the specified root module.
-  LogicalResult ret = success();
-  for (Operation *tclOp : tclOpsForMod[hwMod]) {
-    LogicalResult rc =
-        TypeSwitch<Operation *, LogicalResult>(tclOp)
-            .Case([&](PDPhysLocationOp op) { return state.emit(op); })
-            .Case([&](PDRegPhysLocationOp op) { return state.emit(op); })
-            .Case([&](PDPhysRegionOp op) { return state.emit(op); })
-            .Case([&](DynamicInstanceVerbatimAttrOp op) {
-              return state.emit(op);
-            })
-            .Default([](Operation *op) {
-              return op->emitOpError("could not determine how to output tcl");
-            });
-    if (failed(rc))
-      ret = failure();
+    // Loop through the ops relevant to the specified root module.
+    LogicalResult ret = success();
+    auto &tclOpsForMod = tclOpsForInstancesKV.getSecond();
+    for (Operation *tclOp : tclOpsForMod) {
+      LogicalResult rc =
+          TypeSwitch<Operation *, LogicalResult>(tclOp)
+              .Case([&](PDPhysLocationOp op) { return state.emit(op); })
+              .Case([&](PDRegPhysLocationOp op) { return state.emit(op); })
+              .Case([&](PDPhysRegionOp op) { return state.emit(op); })
+              .Case([&](DynamicInstanceVerbatimAttrOp op) {
+                return state.emit(op);
+              })
+              .Default([](Operation *op) {
+                return op->emitOpError("could not determine how to output tcl");
+              });
+      if (failed(rc))
+        ret = failure();
+    }
+    os << "}\n\n";
   }
-  os << "}\n\n";
 
   // Create a verbatim op containing the Tcl and symbol references.
   OpBuilder builder = OpBuilder::atBlockEnd(hwMod->getBlock());


### PR DESCRIPTION
Some designs instantiate the same module more than once. Per-instance
data should be different, so we need a way to specify an "instance" of
the top level.