### PR TITLE
[LowerToHW] Add BackedgeBuilder, directly materialize inst inputs

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -30,6 +30,8 @@
 namespace circt {
 namespace firrtl {
 
+class StrictConnectOp;
+
 // is the name useless?
 bool isUselessName(circt::StringRef name);
 
@@ -101,6 +103,18 @@ bool hasDontTouch(Value value);
 /// Check whether an operation has a `DontTouch` annotation, or a symbol that
 /// should prevent certain types of canonicalizations.
 bool hasDontTouch(Operation *op);
+
+/// Scan all the uses of the specified value, checking to see if there is
+/// exactly one connect that has the value as its destination. This returns the
+/// operation if found and if all the other users are "reads" from the value.
+/// Returns null if there are no connects, or multiple connects to the value, or
+/// if the value is involved in an `AttachOp`.
+///
+/// Note that this will simply return the connect, which is located *anywhere*
+/// after the definition of the value. Users of this function are likely
+/// interested in the source side of the returned connect, the definition of
+/// which does likely not dominate the original value.
+StrictConnectOp getSingleConnectUserOf(Value value);
 
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1394,10 +1394,16 @@ LogicalResult MultibitMuxOp::canonicalize(MultibitMuxOp op,
 //===----------------------------------------------------------------------===//
 
 /// Scan all the uses of the specified value, checking to see if there is
-/// exactly one connect that sets the value as its destination.  This returns
-/// the operation if found and if all the other users are "reads" from the
-/// value.
-static StrictConnectOp getSingleConnectUserOf(Value value) {
+/// exactly one connect that has the value as its destination. This returns the
+/// operation if found and if all the other users are "reads" from the value.
+/// Returns null if there are no connects, or multiple connects to the value, or
+/// if the value is involved in an `AttachOp`.
+///
+/// Note that this will simply return the connect, which is located *anywhere*
+/// after the definition of the value. Users of this function are likely
+/// interested in the source side of the returned connect, the definition of
+/// which does likely not dominate the original value.
+StrictConnectOp firrtl::getSingleConnectUserOf(Value value) {
   StrictConnectOp connect;
   for (Operation *user : value.getUsers()) {
     // If we see an attach, just conservatively fail.


### PR DESCRIPTION
Add a `BackedgeBuilder` to `FIRRTLLowering` which can be used to directly materialize values that violate def-before-use ordering. To simplify usage, a new `setBackedgeLowering` function creates a backedge with the desired type and memorizes it as the lowering for the original value. A later call to `setLowering` for the original value will resolve the backedge.

As a first use of the backedge builder, materialize the input values for instances directly through a backedge if the port is trivially assigned by a single `StrictConnectOp`. This does away with temporary wires in most cases and is a useful preparation for handling non-FIRRTL types during lowering.

### Todo
- [x] Land #3322 