### PR TITLE
[FIRRTL] Add inter-module DCE

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -100,6 +100,8 @@ std::unique_ptr<mlir::Pass> createDropNamesPass();
 
 std::unique_ptr<mlir::Pass> createExtractInstancesPass();
 
+std::unique_ptr<mlir::Pass> createIMDCEPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -100,7 +100,7 @@ std::unique_ptr<mlir::Pass> createDropNamesPass();
 
 std::unique_ptr<mlir::Pass> createExtractInstancesPass();
 
-std::unique_ptr<mlir::Pass> createIMDCEPass();
+std::unique_ptr<mlir::Pass> createIMDeadCodeElimPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -81,6 +81,20 @@ def RemoveUnusedPorts : Pass<"firrtl-remove-unused-ports", "firrtl::CircuitOp"> 
   ];
 }
 
+def IMDCE : Pass<"firrtl-imdce", "firrtl::CircuitOp"> {
+  let summary = "Inter-module dce";
+  let description = [{
+    This pass performs inter-module liveness anaysis and delete dead code
+    aggressively. A value is considered as alive if it is connected to a port
+    of public modules or a value with a symbol. We first populate alive values
+    into a set, and then propagate the liveness by looking at their dataflow.
+  }];
+  let constructor = "circt::firrtl::createIMDCEPass()";
+  let statistics = [
+    Statistic<"numRemovedPorts", "num-removed-ports", "Number of ports erased">,
+  ];
+}
+
 def Inliner : Pass<"firrtl-inliner", "firrtl::CircuitOp"> {
   let summary = "Performs inlining, flattening, and dead module elimination";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -81,15 +81,15 @@ def RemoveUnusedPorts : Pass<"firrtl-remove-unused-ports", "firrtl::CircuitOp"> 
   ];
 }
 
-def IMDCE : Pass<"firrtl-imdce", "firrtl::CircuitOp"> {
-  let summary = "Inter-module dce";
+def IMDeadCodeElim : Pass<"firrtl-imdeadcodeelim", "firrtl::CircuitOp"> {
+  let summary = "Intermodule dead code elimination";
   let description = [{
-    This pass performs inter-module liveness anaysis and delete dead code
+    This pass performs inter-module liveness anaysis and deletes dead code
     aggressively. A value is considered as alive if it is connected to a port
     of public modules or a value with a symbol. We first populate alive values
     into a set, and then propagate the liveness by looking at their dataflow.
   }];
-  let constructor = "circt::firrtl::createIMDCEPass()";
+  let constructor = "circt::firrtl::createIMDeadCodeElimPass()";
   let statistics = [
     Statistic<"numRemovedPorts", "num-removed-ports", "Number of ports erased">,
   ];

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentralTaps.cpp
   GrandCentralSignalMappings.cpp
   IMConstProp.cpp
+  IMDCE.cpp
   InferResets.cpp
   InferReadWrite.cpp
   InferWidths.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -13,7 +13,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentralTaps.cpp
   GrandCentralSignalMappings.cpp
   IMConstProp.cpp
-  IMDCE.cpp
+  IMDeadCodeElim.cpp
   InferResets.cpp
   InferReadWrite.cpp
   InferWidths.cpp

--- a/lib/Dialect/FIRRTL/Transforms/IMDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDCE.cpp
@@ -1,0 +1,412 @@
+//===- IMDCE.cpp - Inter Module Dead Code Elimination -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Threading.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-imdce"
+
+using namespace circt;
+using namespace firrtl;
+
+/// Return true if this is a wire or a register or a node.
+static bool isWireOrRegOrNode(Operation *op) {
+  return isa<WireOp, RegResetOp, RegOp, NodeOp>(op);
+}
+
+/// Return true if this is a wire or register we're allowed to delete.
+static bool isDeletableWireOrRegOrNode(Operation *op) {
+  if (auto name = dyn_cast<FNamableOp>(op))
+    if (!name.hasDroppableName())
+      return false;
+  return !hasDontTouch(op);
+}
+
+namespace {
+struct IMDCEPass : public IMDCEBase<IMDCEPass> {
+  void runOnOperation() override;
+
+  void rewriteModuleSignature(FModuleOp module);
+  void rewriteModuleBody(FModuleOp module);
+
+  void markAlive(Value value) {
+    // If the value is already in `liveSet`, skip it.
+    if (liveSet.count(value))
+      return;
+    liveSet.insert(value);
+    worklist.push_back(value);
+  }
+
+  /// Return true if the value is known alive.
+  bool isKnownAlive(Value value) const {
+    assert(value && "null should not be used");
+    return liveSet.count(value);
+  }
+
+  /// Return true if the value is assumed dead.
+  bool isAssumedDead(Value value) const { return !isKnownAlive(value); }
+
+  bool isBlockExecutable(Block *block) const {
+    return executableBlocks.count(block);
+  }
+  void visitUser(Operation *op);
+  void visitValue(Value value);
+  void visitConnect(FConnectLike connect);
+  void visitSubelement(Operation *op);
+  void markBlockExecutable(Block *block);
+  void markWireOrRegOrNode(Operation *op);
+  void markMemOp(MemOp op);
+  void markInstanceOp(InstanceOp instanceOp);
+  void markUnknownSideEffectOp(Operation *op);
+
+private:
+  /// The set of blocks that are known to execute, or are intrinsically alive.
+  SmallPtrSet<Block *, 16> executableBlocks;
+
+  /// This keeps track of users the instance results that correspond to output
+  /// ports.
+  DenseMap<BlockArgument, llvm::TinyPtrVector<Value>>
+      resultPortToInstanceResultMapping;
+  InstanceGraph *instanceGraph;
+
+  /// A worklist of values whose liveness recently changed, indicating the
+  /// users need to be reprocessed.
+  SmallVector<Value, 64> worklist;
+  llvm::DenseSet<Value> liveSet;
+};
+} // namespace
+
+void IMDCEPass::markWireOrRegOrNode(Operation *op) {
+  assert(isWireOrRegOrNode(op) && "only a wire, a reg or a node is expected");
+  auto resultValue = op->getResult(0);
+
+  if (!isDeletableWireOrRegOrNode(op))
+    markAlive(resultValue);
+}
+
+void IMDCEPass::markMemOp(MemOp mem) {
+  for (auto result : mem.getResults())
+    markAlive(result);
+}
+
+void IMDCEPass::markUnknownSideEffectOp(Operation *op) {
+  // For operations with side effects, pessimistically mark results and
+  // operands as alive.
+  for (auto result : op->getResults())
+    markAlive(result);
+  for (auto operand : op->getOperands())
+    markAlive(operand);
+}
+
+void IMDCEPass::visitUser(Operation *op) {
+  LLVM_DEBUG(llvm::dbgs() << "Visit: " << *op << "\n");
+  if (auto connectOp = dyn_cast<FConnectLike>(op))
+    return visitConnect(connectOp);
+  if (isa<SubfieldOp, SubindexOp, SubaccessOp>(op))
+    return visitSubelement(op);
+}
+
+void IMDCEPass::markInstanceOp(InstanceOp instance) {
+  // Get the module being reference.
+  Operation *op = instanceGraph->getReferencedModule(instance);
+
+  // If this is an extmodule, just remember that any inputs and inouts are
+  // alive.
+  if (!isa<FModuleOp>(op)) {
+    auto module = dyn_cast<FModuleLike>(op);
+    for (size_t resultNo = 0, e = instance.getNumResults(); resultNo != e;
+         ++resultNo) {
+      auto portVal = instance.getResult(resultNo);
+      // If this is an output to the extmodule, we can ignore it.
+      if (module.getPortDirection(resultNo) == Direction::Out)
+        continue;
+
+      // Otherwise this is an inuput from it or an inout, mark it as alive.
+      markAlive(portVal);
+    }
+    return;
+  }
+
+  // Otherwise this is a defined module.
+  auto fModule = cast<FModuleOp>(op);
+  markBlockExecutable(fModule.getBody());
+
+  // Ok, it is a normal internal module reference so populate
+  // resultPortToInstanceResultMapping.
+  for (size_t resultNo = 0, e = instance.getNumResults(); resultNo != e;
+       ++resultNo) {
+    auto instancePortVal = instance.getResult(resultNo);
+
+    // Otherwise we have a result from the instance.  We need to forward results
+    // from the body to this instance result's SSA value, so remember it.
+    BlockArgument modulePortVal = fModule.getArgument(resultNo);
+
+    // Mark don't touch ports as alive.
+    if (hasDontTouch(modulePortVal)) {
+      markAlive(modulePortVal);
+      markAlive(instancePortVal);
+    }
+
+    resultPortToInstanceResultMapping[modulePortVal].push_back(instancePortVal);
+  }
+}
+
+void IMDCEPass::markBlockExecutable(Block *block) {
+  if (!executableBlocks.insert(block).second)
+    return; // Already executable.
+
+  for (auto &op : *block) {
+    if (isWireOrRegOrNode(&op))
+      markWireOrRegOrNode(&op);
+    else if (auto instance = dyn_cast<InstanceOp>(op))
+      markInstanceOp(instance);
+    else if (isa<FConnectLike>(op))
+      // Skip connect op.
+      continue;
+    else if (auto mem = dyn_cast<MemOp>(op))
+      markMemOp(mem);
+    else if (!mlir::MemoryEffectOpInterface::hasNoEffect(&op))
+      markUnknownSideEffectOp(&op);
+  }
+}
+
+void IMDCEPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----==="
+                          << "\n");
+  auto circuit = getOperation();
+  instanceGraph = &getAnalysis<InstanceGraph>();
+  for (auto module : circuit.getBody()->getOps<FModuleOp>()) {
+    if (module.isPublic()) {
+      markBlockExecutable(module.getBody());
+      // Mark the ports of public modules as alive.
+      for (auto port : module.getBody()->getArguments())
+        markAlive(port);
+    }
+  }
+
+  // If a value changed liveness then propagate liveness through its users and
+  // definition.
+  while (!worklist.empty()) {
+    Value changedVal = worklist.pop_back_val();
+    visitValue(changedVal);
+    for (Operation *user : changedVal.getUsers())
+      visitUser(user);
+  }
+
+  // Rewrite module signatures.
+  for (auto module : circuit.getBody()->getOps<FModuleOp>())
+    rewriteModuleSignature(module);
+
+  // Rewrite module bodies parallelly.
+  mlir::parallelForEach(circuit.getContext(),
+                        circuit.getBody()->getOps<FModuleOp>(),
+                        [&](auto op) { rewriteModuleBody(op); });
+}
+
+void IMDCEPass::visitValue(Value value) {
+  assert(isKnownAlive(value) && "only alive values reach here");
+
+  // Driving input ports propagates the liveness to each instance.
+  if (auto blockArg = value.dyn_cast<BlockArgument>()) {
+    auto module = cast<FModuleOp>(blockArg.getParentBlock()->getParentOp());
+    auto portDirection = module.getPortDirection(blockArg.getArgNumber());
+    // If the port is input, it's necessary to mark corresponding input ports of
+    // instances as alive. We don't have to propagate the liveness of output
+    // ports.
+    if (portDirection == Direction::In)
+      for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
+        markAlive(userOfResultPort);
+    return;
+  }
+
+  // Driving an instance argument port drives the corresponding argument of the
+  // referenced module.
+  if (auto instance = value.getDefiningOp<InstanceOp>()) {
+    auto instanceResult = value.cast<mlir::OpResult>();
+    // Update the src, when it's an instance op.
+    auto module =
+        dyn_cast<FModuleOp>(*instanceGraph->getReferencedModule(instance));
+    if (!module)
+      return;
+
+    BlockArgument modulePortVal =
+        module.getArgument(instanceResult.getResultNumber());
+    return markAlive(modulePortVal);
+  }
+
+  // If op is defined by an operation, mark its operands as alive.
+  if (auto op = value.getDefiningOp())
+    for (auto operand : op->getOperands())
+      markAlive(operand);
+}
+
+void IMDCEPass::visitConnect(FConnectLike connect) {
+  // If the dest is alive, mark the source value as alive.
+  if (isKnownAlive(connect.dest()))
+    markAlive(connect.src());
+}
+
+void IMDCEPass::visitSubelement(Operation *op) {
+  if (isKnownAlive(op->getOperand(0)))
+    markAlive(op->getResult(0));
+}
+
+void IMDCEPass::rewriteModuleBody(FModuleOp module) {
+  auto *body = module.getBody();
+  // If the module is unreachable, just ignore it.
+  // TODO: Erase this module from circuit op.
+  if (!executableBlocks.count(body))
+    return;
+
+  // Walk the IR bottom-up when deleting operations.
+  for (auto &op : llvm::make_early_inc_range(llvm::reverse(*body))) {
+    // Connects to values that we found to be dead can be dropped.
+    if (auto connect = dyn_cast<FConnectLike>(op)) {
+      if (isAssumedDead(connect.dest())) {
+        LLVM_DEBUG(llvm::dbgs() << "DEAD: " << connect << "\n";);
+        connect.erase();
+      }
+      continue;
+    }
+
+    // Delete dead wires, regs and nodes.
+    if (isWireOrRegOrNode(&op) && isAssumedDead(op.getResult(0))) {
+      LLVM_DEBUG(llvm::dbgs() << "DEAD: " << op << "\n";);
+      // Users should be already removed.
+      assert(op.use_empty() && "no user");
+      op.erase();
+      continue;
+    }
+
+    // Remove non-sideeffect op using `isOpTriviallyDead`.
+    if (mlir::isOpTriviallyDead(&op))
+      op.erase();
+  }
+}
+
+void IMDCEPass::rewriteModuleSignature(FModuleOp module) {
+  // If the module is unreachable, just ignore it.
+  // TODO: Erase this module from circuit op.
+  if (!executableBlocks.count(module.getBody()))
+    return;
+
+  // Ports of public modules cannot be modified.
+  if (module.isPublic())
+    return;
+
+  InstanceGraphNode *instanceGraphNode =
+      instanceGraph->lookup(module.moduleNameAttr());
+  LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
+                          << "\n");
+  SmallVector<unsigned> deadPortIndexes;
+  unsigned numOldPorts = module.getNumPorts();
+
+  ImplicitLocOpBuilder builder(module.getLoc(), module.getContext());
+  builder.setInsertionPointToStart(module.getBody());
+
+  for (auto index : llvm::seq(0u, numOldPorts)) {
+    auto argument = module.getArgument(index);
+    assert((!hasDontTouch(argument) || isKnownAlive(argument)) &&
+           "If the port has don't touch, it should be known alive");
+
+    // If the port has dontTouch, skip.
+    if (hasDontTouch(argument))
+      continue;
+
+    // If the port is known alive, then we can't delete it except for write-only
+    // output ports.
+    if (isKnownAlive(argument)) {
+      bool deadOutputPortAtAnyInstantiation =
+          module.getPortDirection(index) == Direction::Out &&
+          llvm::all_of(resultPortToInstanceResultMapping[argument],
+                       [&](Value result) { return isAssumedDead(result); });
+
+      if (!deadOutputPortAtAnyInstantiation)
+        continue;
+
+      // Ok, this port is used only within its defined module. So we can replace
+      // the port with a wire.
+      WireOp wire = builder.create<WireOp>(argument.getType());
+
+      // Since `liveSet` contains the port, we have to erase it from the set.
+      liveSet.erase(argument);
+      liveSet.insert(wire);
+      argument.replaceAllUsesWith(wire);
+      deadPortIndexes.push_back(index);
+      continue;
+    }
+
+    // Replace the port with a dummy wire. This wire should be erased within
+    // `rewriteModuleBody`.
+    WireOp wire = builder.create<WireOp>(argument.getType());
+    argument.replaceAllUsesWith(wire);
+    assert(isAssumedDead(wire) && "dummy wire must be dead");
+    deadPortIndexes.push_back(index);
+  }
+
+  // If there is nothing to remove, abort.
+  if (deadPortIndexes.empty())
+    return;
+
+  // Erase arguments of the old module from liveSet to prevent from creating
+  // dangling pointers.
+  for (auto arg : module.getArguments())
+    liveSet.erase(arg);
+
+  // Delete ports from the module.
+  module.erasePorts(deadPortIndexes);
+
+  // Add arguments of the new module to liveSet.
+  for (auto arg : module.getArguments())
+    liveSet.insert(arg);
+
+  // Rewrite all uses.
+  for (auto *use : instanceGraphNode->uses()) {
+    auto instance = cast<InstanceOp>(*use->getInstance());
+    ImplicitLocOpBuilder builder(instance.getLoc(), instance);
+    // Since we will rewrite instance op, it is necessary to remove old instance
+    // results from liveSet.
+    for (auto index : llvm::seq(0u, numOldPorts)) {
+      auto result = instance.getResult(index);
+      liveSet.erase(result);
+    }
+
+    // Replace old instance results with dummy wires.
+    for (auto index : deadPortIndexes) {
+      auto result = instance.getResult(index);
+      assert(isAssumedDead(result) &&
+             "instance results of dead ports must be dead");
+      WireOp wire = builder.create<WireOp>(result.getType());
+      result.replaceAllUsesWith(wire);
+    }
+
+    // Create a new instance op without dead ports.
+    auto newInstance = instance.erasePorts(builder, deadPortIndexes);
+
+    // Mark new results as alive.
+    for (auto newResult : newInstance.getResults())
+      liveSet.insert(newResult);
+
+    instanceGraph->replaceInstance(instance, newInstance);
+    // Remove old one.
+    instance.erase();
+  }
+
+  numRemovedPorts += deadPortIndexes.size();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createIMDCEPass() {
+  return std::make_unique<IMDCEPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -11,8 +11,6 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
-#include "llvm/ADT/APSInt.h"
-#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Debug.h"
 

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -140,8 +140,7 @@ void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
 
   // Ok, it is a normal internal module reference so populate
   // resultPortToInstanceResultMapping.
-  for (size_t resultNo = 0, e = instance.getNumResults(); resultNo != e;
-       ++resultNo) {
+  for (auto resultNo : llvm::seq(0u, instance.getNumResults())) {
     auto instancePortVal = instance.getResult(resultNo);
 
     // Otherwise we have a result from the instance.  We need to forward results
@@ -280,8 +279,7 @@ void IMDeadCodeElimPass::rewriteModuleBody(FModuleOp module) {
     // Delete dead wires, regs and nodes.
     if (isWireOrRegOrNode(&op) && isAssumedDead(op.getResult(0))) {
       LLVM_DEBUG(llvm::dbgs() << "DEAD: " << op << "\n";);
-      // Users should be already removed.
-      assert(op.use_empty() && "no user");
+      assert(op.use_empty() && "users should be already removed");
       op.erase();
       continue;
     }

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 -remove-unused-ports=0 %s | FileCheck %s
+; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 -imdce=0 %s | FileCheck %s
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 -imdce=0 %s | FileCheck %s
+; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 -imdeadcodeelim=0 %s | FileCheck %s
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -1,8 +1,8 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imdce)' --split-input-file  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imdeadcodeelim)' --split-input-file  %s | FileCheck %s
 firrtl.circuit "top" {
   // In `dead_module`, %source is connected to %dest through several dead operations such as
   // node, wire, reg or rgereset. %dest is also dead at any instantiation, so check that
-  // all operations are removed by IMDCE pass.
+  // all operations are removed by IMDeadCodeElim pass.
   // CHECK-LABEL: private @dead_module() {
   // CHECK-NEXT:  }
   firrtl.module private @dead_module(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
@@ -135,9 +135,9 @@ firrtl.circuit "UnusedOutput"  {
 
 // -----
 
-// Ensure that the "output_file" attribute isn't destroyed by IMDCE.
+// Ensure that the "output_file" attribute isn't destroyed by IMDeadCodeElim.
 // This matters for interactions between Grand Central (which sets these) and
-// IMDCE which may clone modules with stripped ports.
+// IMDeadCodeElim which may clone modules with stripped ports.
 //
 // CHECK-LABEL: "PreserveOutputFile"
 firrtl.circuit "PreserveOutputFile" {

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -1,0 +1,153 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imdce)' --split-input-file  %s | FileCheck %s
+firrtl.circuit "top" {
+  // In `dead_module`, %source is connected to %dest through several dead operations such as
+  // node, wire, reg or rgereset. %dest is also dead at any instantiation, so check that
+  // all operations are removed by IMDCE pass.
+  // CHECK-LABEL: private @dead_module() {
+  // CHECK-NEXT:  }
+  firrtl.module private @dead_module(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
+                                     in %clock:!firrtl.clock, in %reset:!firrtl.uint<1>) {
+    %dead_node = firrtl.node droppable_name %source: !firrtl.uint<1>
+
+    %dead_wire = firrtl.wire droppable_name : !firrtl.uint<1>
+    firrtl.strictconnect %dead_wire, %dead_node : !firrtl.uint<1>
+
+    %dead_reg = firrtl.reg droppable_name %clock  : !firrtl.uint<1>
+    firrtl.strictconnect %dead_reg, %dead_wire : !firrtl.uint<1>
+
+    %dead_reg_reset = firrtl.regreset droppable_name %clock, %reset, %dead_reg  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.strictconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
+
+    %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %dest, %not : !firrtl.uint<1>
+  }
+
+  // `%dontTouch` port has a symbol so it shouldn't be removed. `%sym_wire` also has a
+  // symbol so check  that `%source` is preserved too.
+  // CHECK-LABEL: firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>) {
+  firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>, in %dead: !firrtl.uint<1>) {
+    // CHECK-NEXT: %sym_wire = firrtl.wire sym @sym   : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
+    // CHECK-NEXT: }
+    %sym_wire = firrtl.wire sym @sym : !firrtl.uint<1>
+    firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
+
+  }
+
+  // CHECK-LABEL: firrtl.module private @mem(in %source: !firrtl.uint<1>) {
+  firrtl.module private @mem(in %source: !firrtl.uint<1>) {
+    // CHECK-NEXT: %ReadMemory_read0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+    %mem = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+    // CHECK-NEXT: %0 = firrtl.subfield %ReadMemory_read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
+    // CHECK-NEXT: firrtl.connect %0, %source : !firrtl.uint<4>, !firrtl.uint<1>
+    // CHECK-NEXT: }
+    %0 = firrtl.subfield %mem(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
+    firrtl.connect %0, %source : !firrtl.uint<4>, !firrtl.uint<1>
+  }
+
+  // Ports of public modules should not be modified.
+  // CHECK-LABEL: firrtl.module @top(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+  firrtl.module @top(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
+                     in %clock:!firrtl.clock, in %reset:!firrtl.uint<1>) {
+    // CHECK-NEXT: %tmp = firrtl.node droppable_name %source
+    // CHECK-NEXT: firrtl.strictconnect %dest, %tmp
+    %tmp = firrtl.node droppable_name %source: !firrtl.uint<1>
+    firrtl.strictconnect %dest, %tmp : !firrtl.uint<1>
+
+    // TODO: Remove instances of empty modules.
+    // CHECK-NEXT: firrtl.instance dead_module  @dead_module()
+    %source1, %dest1, %clock1, %reset1  = firrtl.instance dead_module @dead_module(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>, in clock:!firrtl.clock, in reset:!firrtl.uint<1>)
+    firrtl.strictconnect %source1, %source : !firrtl.uint<1>
+    firrtl.strictconnect %clock1, %clock : !firrtl.clock
+    firrtl.strictconnect %reset1, %reset : !firrtl.uint<1>
+
+    // Check that ports with dontTouch are not removed.
+    // CHECK-NEXT: %testDontTouch_dontTouch, %testDontTouch_source = firrtl.instance testDontTouch @dontTouch(in dontTouch: !firrtl.uint<1>, in source: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.strictconnect %testDontTouch_dontTouch, %source
+    // CHECK-NEXT: firrtl.strictconnect %testDontTouch_source, %source
+    %testDontTouch_dontTouch, %testDontTouch_source,  %dead = firrtl.instance testDontTouch @dontTouch(in dontTouch: !firrtl.uint<1>, in source: !firrtl.uint<1>, in dead:!firrtl.uint<1>)
+    firrtl.strictconnect %testDontTouch_dontTouch, %source : !firrtl.uint<1>
+    firrtl.strictconnect %testDontTouch_source, %source : !firrtl.uint<1>
+    firrtl.strictconnect %dead, %source : !firrtl.uint<1>
+
+    // CHECK-NEXT: %mem_source = firrtl.instance mem @mem(in source: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.strictconnect %mem_source, %source : !firrtl.uint<1>
+    %mem_source  = firrtl.instance mem @mem(in source: !firrtl.uint<1>)
+    firrtl.strictconnect %mem_source, %source : !firrtl.uint<1>
+    // CHECK-NEXT: }
+  }
+}
+
+// -----
+
+// Check that it's possible to analyze complex dependency across different modules.
+firrtl.circuit "top"  {
+  // CHECK-LABEL: firrtl.module private @Child1() {
+  // CHECK-NEXT:  }
+  firrtl.module private @Child1(in %input: !firrtl.uint<1>, out %output: !firrtl.uint<1>) {
+    firrtl.strictconnect %output, %input : !firrtl.uint<1>
+  }
+  // CHECK-LABEL: firrtl.module private @Child2() {
+  // CHECK-NEXT:  }
+  firrtl.module private @Child2(in %input: !firrtl.uint<1>, in %clock: !firrtl.clock, out %output: !firrtl.uint<1>) {
+    %r = firrtl.reg droppable_name %clock  : !firrtl.uint<1>
+    firrtl.strictconnect %r, %input : !firrtl.uint<1>
+    firrtl.strictconnect %output, %r : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
+  // CHECK-NEXT:    firrtl.instance tile  @Child1()
+  // CHECK-NEXT:    firrtl.instance bar  @Child2()
+  // CHECK-NEXT:  }
+  firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
+    %tile_input, %tile_output = firrtl.instance tile  @Child1(in input: !firrtl.uint<1>, out output: !firrtl.uint<1>)
+    firrtl.strictconnect %tile_input, %input : !firrtl.uint<1>
+    %named = firrtl.node droppable_name  %tile_output  : !firrtl.uint<1>
+    %bar_input, %bar_clock, %bar_output = firrtl.instance bar  @Child2(in input: !firrtl.uint<1>, in clock: !firrtl.clock, out output: !firrtl.uint<1>)
+    firrtl.strictconnect %bar_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %bar_input, %named : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: "UnusedOutput"
+firrtl.circuit "UnusedOutput"  {
+  // CHECK: firrtl.module {{.+}}@SingleDriver
+  // CHECK-NOT:     out %c
+  firrtl.module private @SingleDriver(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+    // CHECK-NEXT: %[[c_wire:.+]] = firrtl.wire
+    // CHECK-NEXT: firrtl.strictconnect %b, %[[c_wire]]
+    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    // CHECK-NEXT: %[[not_a:.+]] = firrtl.not %a
+    %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %[[c_wire]], %[[not_a]]
+    firrtl.strictconnect %c, %0 : !firrtl.uint<1>
+  }
+  // CHECK-LABEL: @UnusedOutput
+  firrtl.module @UnusedOutput(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    // CHECK: %singleDriver_a, %singleDriver_b = firrtl.instance singleDriver
+    %singleDriver_a, %singleDriver_b, %singleDriver_c = firrtl.instance singleDriver @SingleDriver(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    firrtl.strictconnect %singleDriver_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %b, %singleDriver_b : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Ensure that the "output_file" attribute isn't destroyed by IMDCE.
+// This matters for interactions between Grand Central (which sets these) and
+// IMDCE which may clone modules with stripped ports.
+//
+// CHECK-LABEL: "PreserveOutputFile"
+firrtl.circuit "PreserveOutputFile" {
+  // CHECK-NEXT: firrtl.module {{.+}}@Sub
+  // CHECK-SAME:   output_file
+  firrtl.module private @Sub(in %a: !firrtl.uint<1>) attributes {output_file = #hw.output_file<"hello">} {}
+  // CHECK: firrtl.module @PreserveOutputFile
+  firrtl.module @PreserveOutputFile() {
+    // CHECK-NEXT: firrtl.instance sub
+    // CHECK-SAME: output_file
+    firrtl.instance sub {output_file = #hw.output_file<"hello">} @Sub(in a: !firrtl.uint<1>)
+  }
+}

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -7,15 +7,15 @@ firrtl.circuit "top" {
   // CHECK-NEXT:  }
   firrtl.module private @dead_module(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
                                      in %clock:!firrtl.clock, in %reset:!firrtl.uint<1>) {
-    %dead_node = firrtl.node droppable_name %source: !firrtl.uint<1>
+    %dead_node = firrtl.node %source: !firrtl.uint<1>
 
-    %dead_wire = firrtl.wire droppable_name : !firrtl.uint<1>
+    %dead_wire = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %dead_wire, %dead_node : !firrtl.uint<1>
 
-    %dead_reg = firrtl.reg droppable_name %clock  : !firrtl.uint<1>
+    %dead_reg = firrtl.reg %clock : !firrtl.uint<1>
     firrtl.strictconnect %dead_reg, %dead_wire : !firrtl.uint<1>
 
-    %dead_reg_reset = firrtl.regreset droppable_name %clock, %reset, %dead_reg  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
 
     %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -49,9 +49,9 @@ firrtl.circuit "top" {
   // CHECK-LABEL: firrtl.module @top(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
   firrtl.module @top(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
                      in %clock:!firrtl.clock, in %reset:!firrtl.uint<1>) {
-    // CHECK-NEXT: %tmp = firrtl.node droppable_name %source
+    // CHECK-NEXT: %tmp = firrtl.node %source
     // CHECK-NEXT: firrtl.strictconnect %dest, %tmp
-    %tmp = firrtl.node droppable_name %source: !firrtl.uint<1>
+    %tmp = firrtl.node %source: !firrtl.uint<1>
     firrtl.strictconnect %dest, %tmp : !firrtl.uint<1>
 
     // TODO: Remove instances of empty modules.
@@ -90,7 +90,7 @@ firrtl.circuit "top"  {
   // CHECK-LABEL: firrtl.module private @Child2() {
   // CHECK-NEXT:  }
   firrtl.module private @Child2(in %input: !firrtl.uint<1>, in %clock: !firrtl.clock, out %output: !firrtl.uint<1>) {
-    %r = firrtl.reg droppable_name %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.uint<1>
     firrtl.strictconnect %r, %input : !firrtl.uint<1>
     firrtl.strictconnect %output, %r : !firrtl.uint<1>
   }
@@ -102,7 +102,7 @@ firrtl.circuit "top"  {
   firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
     %tile_input, %tile_output = firrtl.instance tile  @Child1(in input: !firrtl.uint<1>, out output: !firrtl.uint<1>)
     firrtl.strictconnect %tile_input, %input : !firrtl.uint<1>
-    %named = firrtl.node droppable_name  %tile_output  : !firrtl.uint<1>
+    %named = firrtl.node  %tile_output  : !firrtl.uint<1>
     %bar_input, %bar_clock, %bar_output = firrtl.instance bar  @Child2(in input: !firrtl.uint<1>, in clock: !firrtl.clock, out output: !firrtl.uint<1>)
     firrtl.strictconnect %bar_clock, %clock : !firrtl.clock
     firrtl.strictconnect %bar_input, %named : !firrtl.uint<1>

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -remove-unused-ports=false -verilog %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -imdce=false -verilog %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the
 ; no-op wires and nodes are not optimized away, then both ports should always

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -imdce=false -verilog %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -imdeadcodeelim=false -verilog %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the
 ; no-op wires and nodes are not optimized away, then both ports should always

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -118,7 +118,6 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
-; MLIR-NEXT:    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.instance unusedPortsMod @UnusedPortsMod()
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -67,7 +67,6 @@ circuit Qux: %[[{
 ;CHECK:    %[[memory_1:.+]] = sv.reg
 ;CHECK:    %[[memory_2:.+]] = sv.reg
 ;CHECK:    %[[memory_3:.+]] = sv.reg
-;CHECK:    %[[en:.+]] = sv.reg
 ;CHECK:    %[[addr:.+]] = sv.reg
 ;CHECK:    %[[v5:.+]] = sv.read_inout %[[addr]]
 ;CHECK:    %[[v6:.+]] = hw.array_create
@@ -78,7 +77,6 @@ circuit Qux: %[[{
 ;CHECK:    %[[v9:.+]] = hw.array_get %[[v6]][%rwAddr] : !hw.array<4xi8>
 ;CHECK:    sv.assign %[[memory_rw_rdata]], %[[v9]] : i8
 ;CHECK:    sv.always posedge %clock {
-;CHECK-NEXT:      sv.passign %[[en]], %rEn : i1
 ;CHECK-NEXT:      sv.passign %[[addr]], %rAddr : i2
 ;CHECK-NEXT:      sv.passign %[[memory_0]]
 ;CHECK-NEXT:      sv.passign %[[memory_1]]

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -115,7 +115,7 @@ circuit test:
     input clock: Clock
     input rAddr: UInt<4>
     input rEn: UInt<1>
-    output rData: UInt<8>
+    output rData: UInt<8>[3]
     input wMask: UInt<1>
     input wData: UInt<8>
 
@@ -124,7 +124,7 @@ circuit test:
     h1.clock <= clock
     h1.rAddr <= rAddr
     h1.rEn <= rEn
-    rData <= h1.rData
+    rData[0] <= h1.rData
     h1.wMask <= wMask
     h1.wData <= wData
 
@@ -132,7 +132,7 @@ circuit test:
     h2.clock <= clock
     h2.rAddr <= rAddr
     h2.rEn <= rEn
-    rData <= h2.rData
+    rData[1] <= h2.rData
     h2.wMask <= wMask
     h2.wData <= wData
 
@@ -140,7 +140,7 @@ circuit test:
     m2.clock <= clock
     m2.rAddr <= rAddr
     m2.rEn <= rEn
-    rData <= m2.rData
+    rData[2] <= m2.rData
     m2.wMask <= wMask
     m2.wData <= wData
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -241,9 +241,9 @@ static cl::opt<bool>
                     cl::desc("check combinational cycles on firrtl"),
                     cl::init(false), cl::cat(mainCategory));
 
-static cl::opt<bool> removeUnusedPorts("remove-unused-ports",
-                                       cl::desc("enable unused ports pruning"),
-                                       cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool> imdce("imdce",
+                           cl::desc("inter-module dead code elimination."),
+                           cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool> mergeConnections(
     "merge-connections",
@@ -577,9 +577,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
-    if (removeUnusedPorts)
-      pm.nest<firrtl::CircuitOp>().addPass(
-          firrtl::createRemoveUnusedPortsPass());
+    if (imdce)
+      pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMDCEPass());
   }
 
   if (emitOMIR)

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -241,9 +241,10 @@ static cl::opt<bool>
                     cl::desc("check combinational cycles on firrtl"),
                     cl::init(false), cl::cat(mainCategory));
 
-static cl::opt<bool> imdce("imdce",
-                           cl::desc("inter-module dead code elimination."),
-                           cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool>
+    imdeadcodeelim("imdeadcodeelim",
+                   cl::desc("inter-module dead code elimination."),
+                   cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool> mergeConnections(
     "merge-connections",
@@ -577,8 +578,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
-    if (imdce)
-      pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMDCEPass());
+    if (imdeadcodeelim)
+      pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMDeadCodeElimPass());
   }
 
   if (emitOMIR)


### PR DESCRIPTION
This pass performs inter-module liveness anaysis and delete dead code
 aggressively. A value is considered as alive if it is connected to a port
 of public modules or a value with a symbol. We first populate alive values
 into a set, and then propagate the liveness by looking at their dataflow.
The framework is almost same as IMCP except that lattice has two states 
(`knownAlive`, `assumedDead`) and direction of propagation is opposite.  