### PR TITLE
[FIRRTL][FIRLexer] translateLocation: fix bug - incorrect getLineAndColumn argument 

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -168,8 +168,7 @@ FIRLexer::FIRLexer(const llvm::SourceMgr &sourceMgr, MLIRContext *context)
 /// Encode the specified source location information into a Location object
 /// for attachment to the IR or error reporting.
 Location FIRLexer::translateLocation(llvm::SMLoc loc) {
-  unsigned mainFileID = sourceMgr.getMainFileID();
-  auto lineAndColumn = sourceMgr.getLineAndColumn(loc, mainFileID);
+  auto lineAndColumn = sourceMgr.getLineAndColumn(loc);
   return FileLineColLoc::get(bufferNameIdentifier, lineAndColumn.first,
                              lineAndColumn.second);
 }


### PR DESCRIPTION
getLineAndColumn expects an optional bufferID. getMainFileID always returns 1, so in cases where the bufferID is not 1, this can cause a crash. Remove the unnecessary call to getMainFileID and leave out the bufferID argument (getLineAndColumn will find the buffer). mainFileID and bufferID are not the same.