### PR TITLE
[SV] Replace StructAttrs with AttrDefs. NFC.

### DIFF
--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -13,11 +13,6 @@ mlir_tablegen(SVAttributes.cpp.inc -gen-attrdef-defs --attrdefs-dialect=sv)
 add_public_tablegen_target(MLIRSVAttributesIncGen)
 add_dependencies(circt-headers MLIRSVAttributesIncGen)
 
-mlir_tablegen(SVStructs.h.inc -gen-struct-attr-decls)
-mlir_tablegen(SVStructs.cpp.inc -gen-struct-attr-defs)
-add_public_tablegen_target(MLIRSVStructsIncGen)
-add_dependencies(circt-headers MLIRSVStructsIncGen)
-
 set(LLVM_TARGET_DEFINITIONS SVPasses.td)
 mlir_tablegen(SVPasses.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTSVTransformsIncGen)

--- a/include/circt/Dialect/SV/SVAttributes.h
+++ b/include/circt/Dialect/SV/SVAttributes.h
@@ -17,6 +17,4 @@
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/SV/SVAttributes.h.inc"
 
-#include "circt/Dialect/SV/SVStructs.h.inc"
-
 #endif // CIRCT_DIALECT_SV_SVATTRIBUTES_H

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -121,14 +121,20 @@ def ModportDirection : I32EnumAttr<"ModportDirection",
 def ModportDirectionAttr : EnumAttr<SVDialect, ModportDirection,
   "modport_direction">;
 
-def ModportDirectionField : StructFieldAttr<"direction", ModportDirectionAttr>;
+class SV_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<SVDialect, attrName, traits> {
+  let mnemonic = attrMnemonic;
+}
 
-def ModportSignalField : StructFieldAttr<"signal", FlatSymbolRefAttr>;
+def ModportStruct : SV_Attr<"ModportStruct", "mod_port"> {
+	let parameters = (ins
+                    ModportDirectionAttr:$direction,
+                    "mlir::FlatSymbolRefAttr":$signal);
 
-def ModportStructAttr : StructAttr<"ModportStructAttr", SVDialect,
-  [ModportDirectionField, ModportSignalField]>;
+  let assemblyFormat = "`<` struct(params) `>`";
+}
 
-def ModportStructArrayAttr : TypedArrayAttrBase<ModportStructAttr,
+def ModportStructArrayAttr : TypedArrayAttrBase<ModportStruct,
   "array of modport structs">;
 
 def InterfaceModportOp : SVOp<"interface.modport",

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3522,8 +3522,8 @@ LogicalResult StmtEmitter::visitSV(InterfaceModportOp op) {
 
   llvm::interleaveComma(op.ports(), os, [&](const Attribute &portAttr) {
     auto port = portAttr.cast<ModportStructAttr>();
-    os << stringifyEnum(port.direction().getValue()) << ' ';
-    auto signalDecl = state.symbolCache.getDefinition(port.signal());
+    os << stringifyEnum(port.getDirection().getValue()) << ' ';
+    auto signalDecl = state.symbolCache.getDefinition(port.getSignal());
     os << getSymOpName(signalDecl);
   });
 

--- a/lib/Dialect/SV/SVAttributes.cpp
+++ b/lib/Dialect/SV/SVAttributes.cpp
@@ -25,7 +25,6 @@ using namespace circt::sv;
 #include "circt/Dialect/SV/SVAttributes.cpp.inc"
 
 #include "circt/Dialect/SV/SVEnums.cpp.inc"
-#include "circt/Dialect/SV/SVStructs.cpp.inc"
 
 void SVDialect::registerAttributes() {
   addAttributes<

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -979,7 +979,7 @@ static ParseResult parseModportStructs(OpAsmParser &parser,
       return failure();
 
     ports.push_back(ModportStructAttr::get(
-        direction.cast<ModportDirectionAttr>(), signal, context));
+        context, direction.cast<ModportDirectionAttr>(), signal));
     return success();
   };
   if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren,
@@ -995,9 +995,9 @@ static void printModportStructs(OpAsmPrinter &p, Operation *,
   p << "(";
   llvm::interleaveComma(portsAttr, p, [&](Attribute attr) {
     auto port = attr.cast<ModportStructAttr>();
-    p << stringifyEnum(port.direction().getValue());
+    p << stringifyEnum(port.getDirection().getValue());
     p << ' ';
-    p.printSymbolName(port.signal().getRootReference().getValue());
+    p.printSymbolName(port.getSignal().getRootReference().getValue());
   });
   p << ')';
 }
@@ -1019,10 +1019,10 @@ void InterfaceModportOp::build(OpBuilder &builder, OperationState &state,
       ModportDirectionAttr::get(ctxt, ModportDirection::output);
   for (auto input : inputs)
     directions.push_back(ModportStructAttr::get(
-        inputDir, SymbolRefAttr::get(ctxt, input), ctxt));
+        ctxt, inputDir, SymbolRefAttr::get(ctxt, input)));
   for (auto output : outputs)
     directions.push_back(ModportStructAttr::get(
-        outputDir, SymbolRefAttr::get(ctxt, output), ctxt));
+        ctxt, outputDir, SymbolRefAttr::get(ctxt, output)));
   build(builder, state, name, ArrayAttr::get(ctxt, directions));
 }
 


### PR DESCRIPTION
`StructAttr` is being deprecated, replace it with `AttrDef` in `SVTypeDecl`. 
This change updates the `ModportStruct` type, and its members.