### PR TITLE
[ExportVerilog] Verilog attribute support for sv.reg and sv.wire

### DIFF
--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -29,3 +29,30 @@ def MacroIdentAttr : AttrDef<SVDialect, "MacroIdent"> {
     ::llvm::StringRef getName() { return getIdent().getValue(); }
   }];
 }
+
+def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
+  let summary = "a Verilog Attribute";
+  let mnemonic = "attribute";
+  let description = [{
+    This attribute is used to encode a Verilog _attribute_.  A Verilog attribute
+    (not to be confused with an LLVM or MLIR attribute) is a syntactic mechanism
+    for adding metadata to specific declarations, statements, and expressions in
+    the Verilog language.  _There are no "standard" attributes_.  Specific tools
+    define and handle their own attributes.
+
+    Verilog attributes have a mandatory name and an optional constant
+    expression.  This is encoded as a key (name) value (expression) pair.
+    Multiple attributes may be specified, either with multiple separate
+    attributes or by comman-separating name--expression pairs.
+
+    For more information, refer to Section 5.12 of the SystemVerilog (1800-2017)
+    specification.
+  }];
+  let parameters = (ins "::mlir::StringAttr":$name,
+                        OptionalParameter<"::mlir::StringAttr">:$expression);
+
+  let assemblyFormat = [{ `<` $name ( `=` $expression^ )? `>` }];
+}
+
+def SVAttributeArrayAttr :
+  TypedArrayAttrBase<SVAttributeAttr, "sv.attribute array attribute">;

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -23,7 +23,8 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
      See SV Spec 6.7, pp97.
     }];
 
-  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym);
+  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym,
+                       OptionalAttr<StrArrayAttr>:$svAttributes);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
@@ -37,8 +38,10 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
     }]>
   ];
 
-  let assemblyFormat = [{ (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
-                          `:` qualified(type($result)) }];
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
+    (`svattrs` $svAttributes^)? `:` qualified(type($result))
+  }];
   let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
@@ -55,7 +58,8 @@ def RegOp : SVOp<"reg", [
      Declare a SystemVerilog Variable Declaration of 'reg' type.
      See SV Spec 6.8, pp100.
    }];
-  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym);
+  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym,
+                       OptionalAttr<StrArrayAttr>:$svAttributes);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
@@ -66,8 +70,10 @@ def RegOp : SVOp<"reg", [
   ];
 
   // We handle the name in a custom way, so we use a customer parser/printer.
-  let assemblyFormat = [{ (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
-                          `:` qualified(type($result)) }];
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
+    (`svattrs` $svAttributes^)? `:` qualified(type($result))
+  }];
   let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -24,7 +24,7 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
     }];
 
   let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym,
-                       OptionalAttr<StrArrayAttr>:$svAttributes);
+                       OptionalAttr<SVAttributeArrayAttr>:$svAttributes);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
@@ -59,7 +59,7 @@ def RegOp : SVOp<"reg", [
      See SV Spec 6.8, pp100.
    }];
   let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym,
-                       OptionalAttr<StrArrayAttr>:$svAttributes);
+                       OptionalAttr<SVAttributeArrayAttr>:$svAttributes);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -47,7 +47,8 @@ def CompRegOp : SeqOp<"compreg",
 
   let arguments = (ins AnyType:$input, I1:$clk, StrAttr:$name,
     Optional<I1>:$reset, Optional<AnyType>:$resetValue,
-    OptionalAttr<SymbolNameAttr>:$sym_name);
+    OptionalAttr<SymbolNameAttr>:$sym_name,
+    OptionalAttr<ArrayAttr>:$svAttributes);
   let results = (outs AnyType:$data);
   let hasCustomAssemblyFormat = 1;
 
@@ -55,7 +56,7 @@ def CompRegOp : SeqOp<"compreg",
     OpBuilder<(ins "Value":$input, "Value":$clk, "StringRef":$sym_name), [{
       return build($_builder, $_state, input.getType(),
                    input, clk, sym_name, Value(), Value(),
-                   StringAttr::get($_builder.getContext(), sym_name));
+                   StringAttr::get($_builder.getContext(), sym_name), {});
     }]>,
   ];
 }

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -399,7 +399,7 @@ private:
     auto resetValue = b.create<hw::ConstantOp>(source.getType(), 0);
     auto regName = b.getStringAttr(name);
     return b.create<CompRegOp>(source.getType(), source, clock, regName, reset,
-                               resetValue, regName);
+                               resetValue, regName, ArrayAttr());
   }
 
   std::string createName(StringRef instanceName, StringRef portName) const {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2600,19 +2600,15 @@ void StmtEmitter::emitSVAttributes(ArrayAttr svAttrs, Operation *op) {
   // SystemVerilog 2017 Section 5.12.
   if (!svAttrs)
     return;
-  SmallVector<Attribute, 0> errorAttrs;
 
   indent() << "(* ";
   llvm::interleaveComma(svAttrs, os, [&](Attribute attr) {
-    if (auto strAttr = attr.dyn_cast<StringAttr>())
-      os << strAttr.getValue();
-    else
-      errorAttrs.push_back(attr);
+    auto svattr = attr.cast<SVAttributeAttr>();
+    os << svattr.getName().getValue();
+    if (svattr.getExpression())
+      os << " = " << svattr.getExpression().getValue();
   });
   os << " *)\n";
-
-  for (Attribute errorAttr : errorAttrs)
-    op->emitOpError("cannot emit SystemVerilog attribute: ") << errorAttr;
 }
 
 void StmtEmitter::emitStatementExpression(Operation *op) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -126,11 +126,13 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
   if (namesDisagree)
     p.printOptionalAttrDict(op->getAttrs(),
                             {SymbolTable::getSymbolAttrName(),
-                             hw::InnerName::getInnerNameAttrName()});
+                             hw::InnerName::getInnerNameAttrName(),
+                             "svAttributes"});
   else
     p.printOptionalAttrDict(op->getAttrs(),
                             {"name", SymbolTable::getSymbolAttrName(),
-                             hw::InnerName::getInnerNameAttrName()});
+                             hw::InnerName::getInnerNameAttrName(),
+                             "svAttributes"});
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -49,6 +49,12 @@ ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(loc, "too many operands");
   }
 
+  if (succeeded(parser.parseOptionalKeyword("svattrs"))) {
+    ArrayAttr svattrs;
+    if (parser.parseAttribute(svattrs, "svAttributes", result.attributes))
+      return failure();
+  }
+
   Type ty;
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
       parser.parseType(ty))
@@ -85,6 +91,11 @@ void CompRegOp::print(::mlir::OpAsmPrinter &p) {
   p << ' ' << input() << ", " << clk();
   if (reset())
     p << ", " << reset() << ", " << resetValue() << ' ';
+
+  if (svAttributes()) {
+    p << "svattrs " << svAttributesAttr();
+    elidedAttrs.push_back("svAttributes");
+  }
 
   // Determine if 'name' can be elided.
   if (name().empty()) {

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -49,6 +49,9 @@ public:
     if (reg.sym_name().hasValue())
       svReg.inner_symAttr(reg.sym_nameAttr());
 
+    if (reg.svAttributes())
+      svReg.svAttributesAttr(reg.svAttributesAttr());
+
     auto regVal = rewriter.create<sv::ReadInOutOp>(loc, svReg);
     if (reg.reset() && reg.resetValue()) {
       rewriter.create<sv::AlwaysFFOp>(

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -112,7 +112,6 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.bpassign %wire42, %param_y : i42
     }
 
-    // CHECK:   (* compiler_defined_attr *)
     // CHECK-NEXT:   if (cond)
     // CHECK-NOT: begin
     sv.if %cond {
@@ -123,7 +122,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
 
       // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(8'(val - 8'h2A) - 8'h2A));
       sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
-    } { "sv.attributes" = "compiler_defined_attr" }
+    }
 
     // begin/end required here to avoid else-confusion.
 
@@ -466,12 +465,11 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-EMPTY:
   // CHECK-NEXT: (* dont_merge *)
   // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg { "sv.attributes" = "dont_merge" } : !hw.inout<i8>
+  %myReg = sv.reg svattrs ["dont_merge"] : !hw.inout<i8>
 
-  // CHECK-NEXT: (* dont_merge *)
-  // CHECK-NEXT: (* dont_retime *)
+  // CHECK-NEXT: (* dont_merge, dont_retime *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg { "sv.attributes" = ["dont_merge", "dont_retime"] } : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg svattrs ["dont_merge", "dont_retime"] : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
   sv.assign %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -465,11 +465,11 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-EMPTY:
   // CHECK-NEXT: (* dont_merge *)
   // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg svattrs ["dont_merge"] : !hw.inout<i8>
+  %myReg = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i8>
 
-  // CHECK-NEXT: (* dont_merge, dont_retime *)
+  // CHECK-NEXT: (* dont_merge, dont_retime = true *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg svattrs ["dont_merge", "dont_retime"] : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg svattrs [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">] : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
   sv.assign %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;
@@ -1064,7 +1064,9 @@ hw.module @verbatim_M1(%clock : i1, %cond : i1, %val : i8) {
   %c42 = hw.constant 42 : i8
   %reg1 = sv.reg sym @verbatim_reg1: !hw.inout<i8>
   %reg2 = sv.reg sym @verbatim_reg2: !hw.inout<i8>
-  %wire25 = sv.wire sym @verbatim_wireSym1 : !hw.inout<i23>
+  // CHECK:      (* dont_merge *)
+  // CHECK-NEXT: wire [22:0] wire25
+  %wire25 = sv.wire sym @verbatim_wireSym1 svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i23>
   %add = comb.add %val, %c42 : i8
   %c42_2 = hw.constant 42 : i8
   %xor = comb.xor %val, %c42_2 : i8

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -112,6 +112,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.bpassign %wire42, %param_y : i42
     }
 
+    // CHECK:   (* compiler_defined_attr *)
     // CHECK-NEXT:   if (cond)
     // CHECK-NOT: begin
     sv.if %cond {
@@ -122,7 +123,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
 
       // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(8'(val - 8'h2A) - 8'h2A));
       sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
-    }
+    } { "sv.attributes" = "compiler_defined_attr" }
 
     // begin/end required here to avoid else-confusion.
 
@@ -463,11 +464,14 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-NEXT:                b);
 
   // CHECK-EMPTY:
+  // CHECK-NEXT: (* dont_merge *)
   // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg : !hw.inout<i8>
+  %myReg = sv.reg { "sv.attributes" = "dont_merge" } : !hw.inout<i8>
 
+  // CHECK-NEXT: (* dont_merge *)
+  // CHECK-NEXT: (* dont_retime *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg { "sv.attributes" = ["dont_merge", "dont_retime"] } : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
   sv.assign %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -185,8 +185,8 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
     }
   }
 
-  // CHECK-NEXT: %combWire = sv.reg : !hw.inout<i1>
-  %combWire = sv.reg : !hw.inout<i1>
+  // CHECK-NEXT: %combWire = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i1>
+  %combWire = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i1>
   // CHECK-NEXT: %selReg = sv.reg : !hw.inout<i10>
   %selReg = sv.reg : !hw.inout<i10>
   // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1>

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -187,8 +187,8 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 
   // CHECK-NEXT: %combWire = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i1>
   %combWire = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<i1>
-  // CHECK-NEXT: %selReg = sv.reg : !hw.inout<i10>
-  %selReg = sv.reg : !hw.inout<i10>
+  // CHECK-NEXT: %selReg = sv.reg svattrs [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" = "true">] : !hw.inout<i10>
+  %selReg = sv.reg svattrs [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" ="true">] : !hw.inout<i10>
   // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1>
   %combWire2 = sv.wire : !hw.inout<i1>
   // CHECK-NEXT: %regForce = sv.reg : !hw.inout<i1>

--- a/test/Dialect/Seq/compreg.mlir
+++ b/test/Dialect/Seq/compreg.mlir
@@ -21,13 +21,13 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
 
   %sv = hw.struct_create (%r0) : !hw.struct<foo: i32>
 
-  %foo = seq.compreg %s, %clk, %rst, %sv : !hw.struct<foo: i32>
+  %foo = seq.compreg %s, %clk, %rst, %sv svattrs [#sv.attribute<"dont_merge">] : !hw.struct<foo: i32>
   seq.compreg %s, %clk : !hw.struct<foo: i32>
   // CHECK: %foo = seq.compreg %s, %clk, %rst, %{{.+}} : !hw.struct<foo: i32>
   // CHECK: %{{.+}} = seq.compreg %s, %clk : !hw.struct<foo: i32>
 
   // SV: [[REGST:%.+]] = hw.struct_create ([[REG5]]) : !hw.struct<foo: i32>
-  // SV: %foo = sv.reg  : !hw.inout<struct<foo: i32>>
+  // SV: %foo = sv.reg svattrs [#sv.attribute<"dont_merge">] : !hw.inout<struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign %foo, %s : !hw.struct<foo: i32>
   // SV: }(syncreset : posedge %rst)  {


### PR DESCRIPTION
Verilog attributes (SV 2017, section 5.12) support for regs and wires. Just like comments on modules, we're adding this support only where we need it since we'll have to reason about it in transformations.