### PR TITLE
[PyCDE] Allow multiple or no results from op create methods

### DIFF
--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -296,9 +296,10 @@ def wrap_opviews_with_values(dialect, module_name):
           if isinstance(created, support.NamedValueOpView):
             created = created.opview
 
-          # Return a Value.
-          assert len(created.results) == 1
-          return Value(created.results[0])
+          # Return the wrapped values, if any.
+          converted_results = tuple(Value(res) for res in created.results)
+          return converted_results[0] if len(
+              converted_results) == 1 else converted_results
 
         return create
 


### PR DESCRIPTION
Barring that I'm missing something obvious here, i don't see a reason for not allowing multiple or no result values from operations. One could argue why go through the trouble of wrapping return values if an op doesn't have any. However, `wrap_opviews_with_values` is doing double duty of both wrapping op results values, but also overriding the constructor of op classes such that construction is forwarded through their `create` methods. This cleans up the API in not having to say `OpClass.create(...)` for some (unwrapped) operations and `OpClass(...)`for wrapped operations.