### PR TITLE
[FIRRTL] Update EmitOMIR for New NLA Style

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -327,13 +327,6 @@ void EmitOMIRPass::runOnOperation() {
   if (anyFailures)
     return signalPassFailure();
 
-  // Delete the temporary NLAs.
-  for (auto nla : removeTempNLAs) {
-    LLVM_DEBUG(llvm::dbgs() << "Removing '" << nla << "'\n");
-    nlaTable->erase(nla);
-    nla.erase();
-  }
-
   removeTempNLAs.clear();
   // Remove the temp symbol from instances.
   for (auto *op : tempSymInstances)

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -327,40 +327,11 @@ void EmitOMIRPass::runOnOperation() {
   if (anyFailures)
     return signalPassFailure();
 
-  // Delete the temporary NLAs. This requires us to visit all the nodes along
-  // the NLA's path and remove `circt.nonlocal` annotations referring to the
-  // NLA.
-  DenseSet<InstanceOp> instsToModify;
-  DenseSet<StringAttr> nlaSymNamesToDrop;
-
+  // Delete the temporary NLAs.
   for (auto nla : removeTempNLAs) {
     LLVM_DEBUG(llvm::dbgs() << "Removing '" << nla << "'\n");
-    nlaSymNamesToDrop.insert(nla.sym_nameAttr());
-    for (auto nameRef : nla.namepath()) {
-      if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>()) {
-        auto it = instancesByName.find(innerRef);
-        if (it == instancesByName.end())
-          continue;
-        instsToModify.insert(it->second);
-      }
-    }
     nlaTable->erase(nla);
     nla.erase();
-  }
-
-  for (auto instOp : instsToModify) {
-    AnnotationSet::removeAnnotations(instOp, [&](Annotation anno) {
-      auto match =
-          anno.isClass("circt.nonlocal") &&
-          nlaSymNamesToDrop.contains(
-              anno.getMember<FlatSymbolRefAttr>("circt.nonlocal").getAttr());
-      if (match)
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Removing " << anno.getDict() << " from "
-                   << instOp->getParentOfType<FModuleOp>().getName() << "."
-                   << instOp.name() << "\n");
-      return match;
-    });
   }
 
   removeTempNLAs.clear();
@@ -386,20 +357,11 @@ void EmitOMIRPass::runOnOperation() {
 /// module of the circuit. Generates an error if any module along the path is
 /// instantiated multiple times.
 void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
-  auto *context = &getContext();
   auto builder = OpBuilder::atBlockBegin(getOperation().getBody());
 
   // Pick a name for the NLA that doesn't collide with anything.
   auto opName = tracker.op->getAttrOfType<StringAttr>("name");
   auto nlaName = circuitNamespace->newName("omir_nla_" + opName.getValue());
-
-  // Assemble the NLA annotation to be put on all the operations participating
-  // in the path.
-  auto nlaAttr = builder.getDictionaryAttr({
-      builder.getNamedAttr("circt.nonlocal",
-                           FlatSymbolRefAttr::get(context, nlaName)),
-      builder.getNamedAttr("class", StringAttr::get(context, "circt.nonlocal")),
-  });
 
   // Get all the paths instantiating this module. If there is an NLA already
   // attached to this tracker, we use it as a base to disambiguate the path to
@@ -433,9 +395,6 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   // annotation to each instance participating in the path.
   SmallVector<Attribute> namepath;
   auto addToPath = [&](Operation *op, StringAttr name) {
-    AnnotationSet annos(op);
-    annos.addAnnotations(nlaAttr);
-    annos.applyToOperation(op);
     namepath.push_back(hw::InnerRefAttr::getFromOperation(
         op, name, op->getParentOfType<FModuleOp>().getNameAttr()));
   };


### PR DESCRIPTION
Change the EmitOMIR pass to remove no hierpath ops.  It cannot safely do
this without computing the uses of a hierpath.  While the pass could be
updated to do this, it would be cleaner to handle hierpath removal with
a common DCE pass.

This change is made to support new NLA-style paths.  With this new
style, multiple NLAs may share the same hierpath ending at a module and
it is thereby unsafe for NLAs to decide to delete a hierpath without
checking for users.

Remove internal NLA breadcrumbs that are unnecessarily generated in
EmitOMIR.  These are entirely unused by internal EmitOMIR analyses and
serve no purpose other than to be removed by the pass later.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>