### PR TITLE
[FIRRTL] Make droppable_name default

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -59,7 +59,7 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
     /// Constructor when you have the target module in hand.
     OpBuilder<(ins "FModuleLike":$module,
                    "mlir::StringRef":$name,
-                   CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"bool","false">:$lowerToBind,
@@ -125,7 +125,7 @@ def MemOp : ReferableDeclOp<"mem"> {
                    "uint64_t":$depth, "RUWAttr":$ruw,
                    "ArrayRef<Attribute>":$portNames,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>
@@ -210,7 +210,7 @@ def NodeOp : ReferableDeclOp<"node",
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
                   CArg<"StringRef", "{}">:$name,
-                  CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                  CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, input, name, nameKind,
@@ -245,7 +245,7 @@ def RegOp : ReferableDeclOp<"reg"> {
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, name,
@@ -281,7 +281,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
@@ -316,7 +316,7 @@ def WireOp : ReferableDeclOp<"wire"> {
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                       CArg<"StringRef", "{}">:$name,
-                      CArg<"NameKindEnum", "NameKindEnum::InterestingName">:$nameKind,
+                      CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                       CArg<"ArrayRef<Attribute>","{}">:$annotations,
                       CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, name, nameKind,

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -94,7 +94,7 @@ static ParseResult parseNameKind(OpAsmParser &parser,
     return success();
   }
 
-  // Default is interesting name.
+  // Default is droppable name.
   result =
       NameKindEnumAttr::get(parser.getContext(), NameKindEnum::DroppableName);
   return success();

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -96,14 +96,14 @@ static ParseResult parseNameKind(OpAsmParser &parser,
 
   // Default is interesting name.
   result =
-      NameKindEnumAttr::get(parser.getContext(), NameKindEnum::InterestingName);
+      NameKindEnumAttr::get(parser.getContext(), NameKindEnum::DroppableName);
   return success();
 }
 
 static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
-  if (attr.getValue() != NameKindEnum::InterestingName)
+  if (attr.getValue() != NameKindEnum::DroppableName)
     p << stringifyNameKindEnum(attr.getValue()) << ' ';
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1479,7 +1479,7 @@ void InstanceOp::print(OpAsmPrinter &p) {
     p << " sym ";
     p.printSymbolName(attr.getValue());
   }
-  if (nameKindAttr().getValue() != NameKindEnum::InterestingName)
+  if (nameKindAttr().getValue() != NameKindEnum::DroppableName)
     p << ' ' << stringifyNameKindEnum(nameKindAttr().getValue());
   p << " ";
 
@@ -3318,16 +3318,16 @@ static ParseResult parseNameKind(OpAsmParser &parser,
     return success();
   }
 
-  // Default is interesting name.
+  // Default is droppable name.
   result =
-      NameKindEnumAttr::get(parser.getContext(), NameKindEnum::InterestingName);
+      NameKindEnumAttr::get(parser.getContext(), NameKindEnum::DroppableName);
   return success();
 }
 
 static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
-  if (attr.getValue() != NameKindEnum::InterestingName)
+  if (attr.getValue() != NameKindEnum::DroppableName)
     p << stringifyNameKindEnum(attr.getValue()) << ' ';
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -883,7 +883,7 @@ void ExtractInstancesPass::groupInstances() {
     // This will essentially disconnect the extracted instances.
     builder.setInsertionPointToStart(parent.getBody());
     auto wrapperInst = builder.create<InstanceOp>(
-        wrapper.getLoc(), wrapper, wrapperName, NameKindEnum::InterestingName,
+        wrapper.getLoc(), wrapper, wrapperName, NameKindEnum::DroppableName,
         ArrayRef<Attribute>{},
         /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/false,
         wrapperInstName);

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -189,7 +189,7 @@ void InjectDUTHierarchy::runOnOperation() {
   ModuleNamespace dutNS(dut);
   auto wrapperInst = b.create<InstanceOp>(
       b.getUnknownLoc(), wrapper, wrapper.moduleName(),
-      NameKindEnum::InterestingName, ArrayRef<Attribute>{},
+      NameKindEnum::DroppableName, ArrayRef<Attribute>{},
       ArrayRef<Attribute>{}, false,
       b.getStringAttr(dutNS.newName(wrapper.moduleName())));
   for (auto pair : llvm::enumerate(wrapperInst.getResults())) {

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -189,9 +189,8 @@ void InjectDUTHierarchy::runOnOperation() {
   ModuleNamespace dutNS(dut);
   auto wrapperInst = b.create<InstanceOp>(
       b.getUnknownLoc(), wrapper, wrapper.moduleName(),
-      NameKindEnum::DroppableName, ArrayRef<Attribute>{},
-      ArrayRef<Attribute>{}, false,
-      b.getStringAttr(dutNS.newName(wrapper.moduleName())));
+      NameKindEnum::DroppableName, ArrayRef<Attribute>{}, ArrayRef<Attribute>{},
+      false, b.getStringAttr(dutNS.newName(wrapper.moduleName())));
   for (auto pair : llvm::enumerate(wrapperInst.getResults())) {
     Value lhs = dut.getArgument(pair.index());
     Value rhs = pair.value();

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -387,7 +387,8 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
       // simpler to delete the memOp.
       auto wire = builder.create<WireOp>(
           result.getType(),
-          (memOp.name() + "_" + memOp.getPortName(index).getValue()).str());
+          (memOp.name() + "_" + memOp.getPortName(index).getValue()).str(),
+          memOp.nameKind());
       result.replaceAllUsesWith(wire.getResult());
       result = wire;
       // Create an access to all the common subfields.

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -628,7 +628,7 @@ Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b,
 
     auto wire = b.create<WireOp>(
         target.getLoc(), type, (prefix + portInfo[i].getName()).str(),
-        NameKindEnum::InterestingName, ArrayAttr::get(context, newAnnotations),
+        NameKindEnum::DroppableName, ArrayAttr::get(context, newAnnotations),
         newSym);
     wires.push_back(wire);
     mapper.map(arg, wire.getResult());

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -100,11 +100,11 @@ firrtl.circuit "Simple" {
                              out %outD: !firrtl.uint<4>,
                              in %inE: !firrtl.uint<3>,
                              out %outE: !firrtl.uint<4>) {
-    // CHECK: %.outB.output = sv.wire sym @__PortMadness__.outB.output : !hw.inout<i4>
+    // CHECK: %.outB.output = sv.wire : !hw.inout<i4>
     // CHECK: [[OUTBR:%.+]] = sv.read_inout %.outB.output
-    // CHECK: [[OUTC:%.+]] = sv.wire sym @__PortMadness__.outC.output : !hw.inout<i4>
+    // CHECK: [[OUTC:%.+]] = sv.wire  : !hw.inout<i4>
     // CHECK: [[OUTCR:%.+]] = sv.read_inout %.outC.output
-    // CHECK: [[OUTD:%.+]] = sv.wire sym @__PortMadness__.outD.output : !hw.inout<i4>
+    // CHECK: [[OUTD:%.+]] = sv.wire : !hw.inout<i4>
     // CHECK: [[OUTDR:%.+]] = sv.read_inout %.outD.output
 
     // Normal

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -166,12 +166,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %n1 = sv.wire
     // CHECK-NEXT: sv.assign %n1, %in2
     // CHECK-NEXT: sv.read_inout %n1
-    %n1 = firrtl.node %in2  {name = "n1"} : !firrtl.uint<2>
+    %n1 = firrtl.node interesting_name %in2 {name = "n1"} : !firrtl.uint<2>
     
     // CHECK-NEXT: [[WIRE:%n2]] = sv.wire sym @__Simple__n2 : !hw.inout<i2>
     // CHECK-NEXT: sv.assign [[WIRE]], %in2 : i2
     // CHECK-NEXT: sv.read_inout %n2
-    %n2 = firrtl.node %in2  {name = "n2", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
+    %n2 = firrtl.node interesting_name %in2  {name = "n2", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
 
     // Nodes with no names are just dropped.
     %22 = firrtl.node droppable_name %in2 {name = ""} : !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -14,10 +14,10 @@ circuit Foo:
     literal[1] <= UInt<1>("h00")
     literal[2] <= UInt<1>("h00")
     literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
-    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
-    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, literal))
     r <= x
     z <= r
@@ -40,10 +40,10 @@ circuit Foo:
     complex_literal[1] <= literal[1]
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -65,10 +65,10 @@ circuit Foo:
     complex_literal[1] <= bundle.b
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -83,11 +83,11 @@ circuit Foo:
     input x : SInt<4>
     output y : SInt<4>
     output z : SInt<4>
-    ; CHECK: %r = firrtl.regreset interesting_name %clock, %reset, %c0_si1
+    ; CHECK: %r = firrtl.regreset {{.+}} %clock, %reset, %c0_si1
     reg r : SInt<4>, clock with : (reset => (reset, asSInt(UInt(0))))
     r <= x
     wire w : SInt<4>
-    ; CHECK: %r2 = firrtl.regreset interesting_name %clock, %reset, %c-1_si4
+    ; CHECK: %r2 = firrtl.regreset {{.+}} %clock, %reset, %c-1_si4
     reg r2 : SInt<4>, clock with : (reset => (reset, w))
     r2 <= x
     node n = UInt("hf")

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -14,10 +14,10 @@ circuit Foo:
     literal[1] <= UInt<1>("h00")
     literal[2] <= UInt<1>("h00")
     literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c0_ui1
-    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c0_ui1
-    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, literal))
     r <= x
     z <= r
@@ -40,10 +40,10 @@ circuit Foo:
     complex_literal[1] <= literal[1]
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -65,10 +65,10 @@ circuit Foo:
     complex_literal[1] <= bundle.b
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset interesting_name %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset interesting_name %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -83,11 +83,11 @@ circuit Foo:
     input x : SInt<4>
     output y : SInt<4>
     output z : SInt<4>
-    ; CHECK: %r = firrtl.regreset %clock, %reset, %c0_si1
+    ; CHECK: %r = firrtl.regreset interesting_name %clock, %reset, %c0_si1
     reg r : SInt<4>, clock with : (reset => (reset, asSInt(UInt(0))))
     r <= x
     wire w : SInt<4>
-    ; CHECK: %r2 = firrtl.regreset %clock, %reset, %c-1_si4
+    ; CHECK: %r2 = firrtl.regreset interesting_name %clock, %reset, %c-1_si4
     reg r2 : SInt<4>, clock with : (reset => (reset, w))
     r2 <= x
     node n = UInt("hf")

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -18,7 +18,7 @@
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -37,13 +37,13 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
   ; CHECK: firrtl.module private @A
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.instance b @B(
+    ; CHECK: firrtl.instance b interesting_name @B(
     inst b of B
     x <= b.x
   module A_ :
@@ -67,8 +67,8 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK: firrtl.instance a1 @A(
-    ; CHECK: firrtl.instance a2 @A(
+    ; CHECK: firrtl.instance a1 interesting_name @A(
+    ; CHECK: firrtl.instance a2 interesting_name @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -96,7 +96,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -116,14 +116,14 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
   ; CHECK: firrtl.module private @A
   module A : @[yy 2:2]
     output x: UInt<1> @[yy 2:2]
-    ; CHECK-NEXT: firrtl.instance b @B(
+    ; CHECK-NEXT: firrtl.instance b interesting_name @B(
     inst b of B
     x <= b.u
   module A_ : @[xx 1:1]
@@ -150,8 +150,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 @A(
-    ; CHECK-NEXT: firrtl.instance a2 @A_(
+    ; CHECK-NEXT: firrtl.instance a1 interesting_name @A(
+    ; CHECK-NEXT: firrtl.instance a2 interesting_name @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -183,8 +183,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 @A(
-    ; CHECK-NEXT: firrtl.instance a2 @A_(
+    ; CHECK-NEXT: firrtl.instance a1 interesting_name @A(
+    ; CHECK-NEXT: firrtl.instance a2 interesting_name @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -228,8 +228,8 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip bar : UInt<1>, buzz : UInt<1>}}
-    ; CHECK: firrtl.instance foo @FooModule
-    ; CHECK: firrtl.instance bar @FooModule
+    ; CHECK: firrtl.instance foo interesting_name @FooModule
+    ; CHECK: firrtl.instance bar interesting_name @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <- foo.io
@@ -252,7 +252,7 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip foo : UInt<1>, fuzz : UInt<1>}}
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} @FooModule
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} interesting_name @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <= foo.io
@@ -265,7 +265,7 @@ circuit FooAndBarModule :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -293,7 +293,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -321,8 +321,8 @@ circuit Top : %[[
 ]]
   ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
-  ; CHECK-NEXT: firrtl.instance a2 @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] interesting_name @A(
+  ; CHECK-NEXT: firrtl.instance a2 interesting_name @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -357,8 +357,8 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
-  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] interesting_name @A(
+  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] interesting_name @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -456,9 +456,9 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
+    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] interesting_name @A()
     inst a of A
-    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] @A()
+    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] interesting_name @A()
     inst a_ of A_
   ; CHECK: firrtl.module private @A
   module A :

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -18,7 +18,7 @@
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -37,13 +37,13 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   ; CHECK: firrtl.module private @A
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.instance b interesting_name @B(
+    ; CHECK: firrtl.instance b {{.+}} @B(
     inst b of B
     x <= b.x
   module A_ :
@@ -67,8 +67,8 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK: firrtl.instance a1 interesting_name @A(
-    ; CHECK: firrtl.instance a2 interesting_name @A(
+    ; CHECK: firrtl.instance a1 {{.+}} @A(
+    ; CHECK: firrtl.instance a2 {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -96,7 +96,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -116,14 +116,14 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
   ; CHECK: firrtl.module private @A
   module A : @[yy 2:2]
     output x: UInt<1> @[yy 2:2]
-    ; CHECK-NEXT: firrtl.instance b interesting_name @B(
+    ; CHECK-NEXT: firrtl.instance b {{.+}} @B(
     inst b of B
     x <= b.u
   module A_ : @[xx 1:1]
@@ -150,8 +150,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 interesting_name @A(
-    ; CHECK-NEXT: firrtl.instance a2 interesting_name @A_(
+    ; CHECK-NEXT: firrtl.instance a1 {{.+}} @A(
+    ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -183,8 +183,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 interesting_name @A(
-    ; CHECK-NEXT: firrtl.instance a2 interesting_name @A_(
+    ; CHECK-NEXT: firrtl.instance a1 {{.+}} @A(
+    ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -228,8 +228,8 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip bar : UInt<1>, buzz : UInt<1>}}
-    ; CHECK: firrtl.instance foo interesting_name @FooModule
-    ; CHECK: firrtl.instance bar interesting_name @FooModule
+    ; CHECK: firrtl.instance foo {{.+}} @FooModule
+    ; CHECK: firrtl.instance bar {{.+}} @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <- foo.io
@@ -252,7 +252,7 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip foo : UInt<1>, fuzz : UInt<1>}}
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} interesting_name @FooModule
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} {{.+}} @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <= foo.io
@@ -265,7 +265,7 @@ circuit FooAndBarModule :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -293,7 +293,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} interesting_name @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -321,8 +321,8 @@ circuit Top : %[[
 ]]
   ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] interesting_name @A(
-  ; CHECK-NEXT: firrtl.instance a2 interesting_name @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
+  ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -357,8 +357,8 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] interesting_name @A(
-  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] interesting_name @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
+  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {{.+}} @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -456,9 +456,9 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] interesting_name @A()
+    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] {{.+}} @A()
     inst a of A
-    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] interesting_name @A()
+    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] {{.+}} @A()
     inst a_ of A_
   ; CHECK: firrtl.module private @A
   module A :

--- a/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
@@ -13,8 +13,8 @@ circuit Example :
     output out : UInt<1>[2]
     wire bar : UInt<1>
     bar is invalid
-    ; CHECK: %foo0 = firrtl.reg %clock :
-    ; CHECK: %foo1 = firrtl.reg %clock :
+    ; CHECK: %foo0 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo1 = firrtl.reg interesting_name %clock :
     reg foo0 : UInt<1>, clock with : (reset => (arst, bar))
     reg foo1 : UInt<1>, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -40,12 +40,12 @@ circuit Example :
     bar is invalid
     bar.a[1] <= UInt<1>(0)
 
-    ; CHECK: %foo0_a_0 = firrtl.reg %clock :
-    ; CHECK: %foo0_a_1 = firrtl.regreset %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg %clock :
-    ; CHECK: %foo1_a_0 = firrtl.reg %clock :
-    ; CHECK: %foo1_a_1 = firrtl.regreset %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg %clock :
+    ; CHECK: %foo0_a_0 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo0_a_1 = firrtl.regreset interesting_name %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo1_a_0 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo1_a_1 = firrtl.regreset interesting_name %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg interesting_name %clock :
     reg foo0 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (arst, bar))
     reg foo1 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -75,10 +75,10 @@ circuit Example :
     baz is invalid
     baz <= bar
 
-    ; CHECK: %foo0_a = firrtl.regreset %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg %clock :
-    ; CHECK: %foo1_a = firrtl.regreset %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg %clock :
+    ; CHECK: %foo0_a = firrtl.regreset interesting_name %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg interesting_name %clock
+    ; CHECK: %foo1_a = firrtl.regreset interesting_name %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg interesting_name %clock
     reg foo0 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (arst, baz))
     reg foo1 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (srst, baz))
     foo0 <= in
@@ -104,9 +104,9 @@ circuit Example :
     arst <= asAsyncReset(UInt<1>(0))
     srst <= UInt<1>(0)
 
-    ; CHECK: %foo0 = firrtl.reg %clock :
-    ; CHECK: %foo1 = firrtl.reg %clock :
-    ; CHECK: %foo2 = firrtl.reg %clock :
+    ; CHECK: %foo0 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo1 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo2 = firrtl.reg interesting_name %clock :
     reg foo0 : UInt<2>, clock with : (reset => (rst, UInt(3)))
     reg foo1 : UInt<2>, clock with : (reset => (arst, UInt(3)))
     reg foo2 : UInt<2>, clock with : (reset => (srst, UInt(3)))

--- a/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
@@ -13,8 +13,8 @@ circuit Example :
     output out : UInt<1>[2]
     wire bar : UInt<1>
     bar is invalid
-    ; CHECK: %foo0 = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo1 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo0 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo1 = firrtl.reg {{.+}} %clock :
     reg foo0 : UInt<1>, clock with : (reset => (arst, bar))
     reg foo1 : UInt<1>, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -40,12 +40,12 @@ circuit Example :
     bar is invalid
     bar.a[1] <= UInt<1>(0)
 
-    ; CHECK: %foo0_a_0 = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo0_a_1 = firrtl.regreset interesting_name %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo1_a_0 = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo1_a_1 = firrtl.regreset interesting_name %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo0_a_0 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo0_a_1 = firrtl.regreset {{.+}} %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo1_a_0 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo1_a_1 = firrtl.regreset {{.+}} %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg {{.+}} %clock :
     reg foo0 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (arst, bar))
     reg foo1 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -75,10 +75,10 @@ circuit Example :
     baz is invalid
     baz <= bar
 
-    ; CHECK: %foo0_a = firrtl.regreset interesting_name %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg interesting_name %clock
-    ; CHECK: %foo1_a = firrtl.regreset interesting_name %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg interesting_name %clock
+    ; CHECK: %foo0_a = firrtl.regreset {{.+}} %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg {{.+}} %clock
+    ; CHECK: %foo1_a = firrtl.regreset {{.+}} %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg {{.+}} %clock
     reg foo0 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (arst, baz))
     reg foo1 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (srst, baz))
     foo0 <= in
@@ -104,9 +104,9 @@ circuit Example :
     arst <= asAsyncReset(UInt<1>(0))
     srst <= UInt<1>(0)
 
-    ; CHECK: %foo0 = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo1 = firrtl.reg interesting_name %clock :
-    ; CHECK: %foo2 = firrtl.reg interesting_name %clock :
+    ; CHECK: %foo0 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo1 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo2 = firrtl.reg {{.+}} %clock :
     reg foo0 : UInt<2>, clock with : (reset => (rst, UInt(3)))
     reg foo1 : UInt<2>, clock with : (reset => (arst, UInt(3)))
     reg foo2 : UInt<2>, clock with : (reset => (srst, UInt(3)))

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -298,7 +298,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
     wire bar: {baz: UInt<1>, qux: UInt<1>}[2]
 
     ; CHECK-LABEL: module {
-    ; CHECK: %bar = firrtl.wire  {annotations =
+    ; CHECK: %bar = firrtl.wire interesting_name {annotations =
     ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
     ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
 
@@ -312,7 +312,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
     reg bar: {baz: UInt<1>, qux: UInt<1>}[2], clock
 
     ; CHECK-LABEL: module {
-    ; CHECK: %bar = firrtl.reg %clock  {annotations =
+    ; CHECK: %bar = firrtl.reg interesting_name %clock {annotations =
     ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
     ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
 
@@ -331,7 +331,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>w[9]"}]]
     b <= w
 
     ; CHECK-LABEL: module {
-    ; CHECK: %w = firrtl.wire {annotations =
+    ; CHECK: %w = firrtl.wire interesting_name {annotations =
     ; CHECK-SAME: #firrtl.subAnno<fieldID = 10, {a}
 
 ; // -----
@@ -352,24 +352,24 @@ circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "a": "a"},
     input reset : UInt<1>
     input clock : Clock
 
-    ; CHECK: %_T_0 = firrtl.wire droppable_name  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_0 = firrtl.wire  {annotations = [{a = "a"}]}
     wire _T_0 : UInt<1>
     ; CHECK: %_T_1 = firrtl.node
     node _T_1 = _T_0
-    ; CHECK: %_T_2 = firrtl.reg droppable_name %clock  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_2 = firrtl.reg %clock  {annotations = [{a = "a"}]}
     reg _T_2 : UInt<1>, clock
-    ; CHECK: %_T_3 = firrtl.regreset droppable_name {{.+}}  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_3 = firrtl.regreset {{.+}}  {annotations = [{a = "a"}]}
     reg _T_3 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0"))
-    ; CHECK: %_T_4 = chirrtl.seqmem droppable_name Undefined {annotations = [{a = "a"}]}
+    ; CHECK: %_T_4 = chirrtl.seqmem Undefined {annotations = [{a = "a"}]}
     smem _T_4 : UInt<1>[9] [256]
-    ; CHECK: %_T_5 = chirrtl.combmem droppable_name {annotations = [{a = "a"}]}
+    ; CHECK: %_T_5 = chirrtl.combmem {annotations = [{a = "a"}]}
     cmem _T_5 : UInt<1>[9] [256]
     ; CHECK: chirrtl.memoryport {{.+}} {annotations = [{a = "a"}]
     infer mport _T_6 = _T_5[reset], clock
-    ; CHECK: firrtl.instance _T_7 droppable_name {annotations = [{a = "a"}]}
+    ; CHECK: firrtl.instance _T_7 {annotations = [{a = "a"}]}
     inst _T_7 of Bar
-    ; CHECK: firrtl.mem droppable_name Undefined  {annotations = [{a = "a"}]
+    ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}]
     mem _T_8 :
         data-type => UInt<4>
         depth => 8
@@ -412,7 +412,7 @@ circuit Test : %[[
 ; CHECK: firrtl.module private @Example() attributes {
 ; CHECK-SAME: annotations = [{circt.nonlocal = @nla_1, class = "fake"}]
 ; CHECK: firrtl.module @Test()
-; CHECK:   firrtl.instance Test sym @Test @Example()
+; CHECK:   firrtl.instance Test sym @Test interesting_name @Example()
 
 ; // -----
 
@@ -431,9 +431,9 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
 ; CHECK: firrtl.module private @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
 ; CHECK: firrtl.module private @Bar()
-; CHECK: firrtl.instance baz sym @baz @Baz()
+; CHECK: firrtl.instance baz sym @baz interesting_name @Baz()
 ; CHECK: firrtl.module @Foo()
-; CHECK: firrtl.instance bar sym @bar @Bar()
+; CHECK: firrtl.instance bar sym @bar interesting_name @Bar()
 
 ; // -----
 
@@ -583,7 +583,7 @@ circuit memportAnno: %[[
       read-under-write => undefined
 ; CHECK-LABEL: firrtl.circuit "memportAnno"  {
 ; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo::@memory]
-; CHECK:        %memory_w = firrtl.mem sym @memory Undefined  {depth = 16 : i64, name = "memory", portAnnotations
+; CHECK:        %memory_w = firrtl.mem sym @memory interesting_name Undefined  {depth = 16 : i64, name = "memory", portAnnotations
 ; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]
 
 ; // -----

--- a/test/Dialect/FIRRTL/drop-name.mlir
+++ b/test/Dialect/FIRRTL/drop-name.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "Foo" {
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
-    // CHECK-NEXT:  %a = firrtl.wire droppable_name  : !firrtl.uint<1>
+    // CHECK-NEXT:  %a = firrtl.wire  : !firrtl.uint<1>
     %a = firrtl.wire : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
+++ b/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
@@ -31,8 +31,8 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
     // CHECK-NOT: firrtl.instance gate @EICG_wrapper
     %inst0_clock, %inst0_en = firrtl.instance inst0 @SomeModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
     %inst1_clock, %inst1_en = firrtl.instance inst1 @SomeModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
-    // CHECK: firrtl.instance ClockGatesGroup sym [[CLKGRP_SYM:@.+]] interesting_name @ClockGatesGroup
-    // CHECK: firrtl.instance InjectedSubmodule sym [[INJMOD_SYM:@.+]] interesting_name @InjectedSubmodule
+    // CHECK: firrtl.instance ClockGatesGroup sym [[CLKGRP_SYM:@.+]] @ClockGatesGroup
+    // CHECK: firrtl.instance InjectedSubmodule sym [[INJMOD_SYM:@.+]] @InjectedSubmodule
     firrtl.connect %inst0_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst1_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst0_en, %foo_en : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
+++ b/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
@@ -31,8 +31,8 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
     // CHECK-NOT: firrtl.instance gate @EICG_wrapper
     %inst0_clock, %inst0_en = firrtl.instance inst0 @SomeModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
     %inst1_clock, %inst1_en = firrtl.instance inst1 @SomeModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
-    // CHECK: firrtl.instance ClockGatesGroup sym [[CLKGRP_SYM:@.+]] @ClockGatesGroup
-    // CHECK: firrtl.instance InjectedSubmodule sym [[INJMOD_SYM:@.+]] @InjectedSubmodule
+    // CHECK: firrtl.instance ClockGatesGroup sym [[CLKGRP_SYM:@.+]] interesting_name @ClockGatesGroup
+    // CHECK: firrtl.instance InjectedSubmodule sym [[INJMOD_SYM:@.+]] interesting_name @InjectedSubmodule
     firrtl.connect %inst0_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst1_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst0_en, %foo_en : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -32,7 +32,7 @@ firrtl.circuit "Test" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
     // Trivial wire constant propagation.
-    %someWire = firrtl.wire : !firrtl.uint<1>
+    %someWire = firrtl.wire interesting_name : !firrtl.uint<1>
     firrtl.connect %someWire, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: %someWire = firrtl.wire
@@ -42,7 +42,7 @@ firrtl.circuit "Test" {
 
     // Trivial wire special constant propagation.
     %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
-    %clockWire = firrtl.wire : !firrtl.clock
+    %clockWire = firrtl.wire interesting_name : !firrtl.clock
     firrtl.connect %clockWire, %c0_clock : !firrtl.clock, !firrtl.clock
 
     // CHECK: %clockWire = firrtl.wire

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -206,14 +206,14 @@ firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4
 }
 }
 // CHECK-LABEL: firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>, out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>) {
-// CHECK-NEXT:   %b_in0 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_in1 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_out0 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_out1 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_in0 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_in1 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_out0 = firrtl.wire interesting_name : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_out1 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_in0 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_in1 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_out0 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_out1 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_in0 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_in1 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_out0 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_out1 = firrtl.wire  : !firrtl.uint<4>
 // CHECK-NEXT:   %0 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_out0, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   %1 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
@@ -241,8 +241,8 @@ firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: u
   %i_in0, %i_out0 = firrtl.instance i @InlineMe0(in in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>, out out0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>)
   firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
   firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
-// CHECK: %i_in0 = firrtl.wire interesting_name : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
-// CHECK: %i_out0 = firrtl.wire interesting_name : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+// CHECK: %i_in0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+// CHECK: %i_out0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %i_out0, %i_in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
@@ -508,7 +508,7 @@ firrtl.circuit "CollidingSymbolsPort" {
   ]} {}
   // CHECK-NEXT: firrtl.module private @Foo
   firrtl.module private @Foo() {
-    // CHECK-NEXT: firrtl.wire sym @[[BarbSym]] interesting_name {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]}
+    // CHECK-NEXT: firrtl.wire sym @[[BarbSym]] {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]}
     firrtl.instance bar sym @bar @Bar(in b: !firrtl.uint<1>)
     // CHECK-NEXT: firrtl.wire sym @b
     %colliding_b = firrtl.wire sym @b : !firrtl.uint<1>
@@ -574,7 +574,7 @@ firrtl.circuit "CollidingSymbolsNLAFixup" {
 
   // CHECK: firrtl.module @Bar()
   firrtl.module @Bar() {
-    // CHECK: %baz0_io = firrtl.wire sym @io interesting_name {annotations = [{circt.nonlocal = @nla0, class = "test"}]}
+    // CHECK: %baz0_io = firrtl.wire sym @io  {annotations = [{circt.nonlocal = @nla0, class = "test"}]}
     // CHECK: %baz0_w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla1, class = "test"}]}
     %0 = firrtl.instance baz0 sym @baz0 @Baz(out io : !firrtl.uint<1>)
 

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -206,14 +206,14 @@ firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4
 }
 }
 // CHECK-LABEL: firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>, out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>) {
-// CHECK-NEXT:   %b_in0 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_in1 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_out0 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_out1 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_in0 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_in1 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_out0 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %b_a_out1 = firrtl.wire  : !firrtl.uint<4>
+// CHECK-NEXT:   %b_in0 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_in1 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_out0 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_out1 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_in0 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_in1 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_out0 = firrtl.wire interesting_name : !firrtl.uint<4>
+// CHECK-NEXT:   %b_a_out1 = firrtl.wire interesting_name : !firrtl.uint<4>
 // CHECK-NEXT:   %0 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_out0, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   %1 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
@@ -241,8 +241,8 @@ firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: u
   %i_in0, %i_out0 = firrtl.instance i @InlineMe0(in in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>, out out0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>)
   firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
   firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
-// CHECK: %i_in0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
-// CHECK: %i_out0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+// CHECK: %i_in0 = firrtl.wire interesting_name : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+// CHECK: %i_out0 = firrtl.wire interesting_name : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %i_out0, %i_in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
@@ -508,7 +508,7 @@ firrtl.circuit "CollidingSymbolsPort" {
   ]} {}
   // CHECK-NEXT: firrtl.module private @Foo
   firrtl.module private @Foo() {
-    // CHECK-NEXT: firrtl.wire sym @[[BarbSym]] {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]}
+    // CHECK-NEXT: firrtl.wire sym @[[BarbSym]] interesting_name {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]}
     firrtl.instance bar sym @bar @Bar(in b: !firrtl.uint<1>)
     // CHECK-NEXT: firrtl.wire sym @b
     %colliding_b = firrtl.wire sym @b : !firrtl.uint<1>
@@ -574,7 +574,7 @@ firrtl.circuit "CollidingSymbolsNLAFixup" {
 
   // CHECK: firrtl.module @Bar()
   firrtl.module @Bar() {
-    // CHECK: %baz0_io = firrtl.wire sym @io  {annotations = [{circt.nonlocal = @nla0, class = "test"}]}
+    // CHECK: %baz0_io = firrtl.wire sym @io interesting_name {annotations = [{circt.nonlocal = @nla0, class = "test"}]}
     // CHECK: %baz0_w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla1, class = "test"}]}
     %0 = firrtl.instance baz0 sym @baz0 @Baz(out io : !firrtl.uint<1>)
 

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -202,7 +202,7 @@ firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>)
 
 // Check that annotations are preserved.
 firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>) {
-  // CHECK: firrtl.mem Undefined 
+  // CHECK: firrtl.mem Undefined
   // CHECK-SAME: annotations = [{a = "a"}]
   // CHECK-SAME: portAnnotations = [
   // CHECK-SAME:   [{b = "b"}],

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -87,10 +87,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input a8 : Analog<8>          ; CHECK: in %a8: !firrtl.analog<8>,
     input ab : {x : Analog<1>}    ; CHECK: in %ab: !firrtl.bundle<x: analog<1>>)
 
-    ; CHECK: %_t = firrtl.wire droppable_name : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t = firrtl.wire : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
 
-    ; CHECK: %_t_2 = firrtl.wire droppable_name : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     wire _t_2 : UInt<1>[12]
 
     ; CHECK: firrtl.strictconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
@@ -126,7 +126,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NOT: firrtl.strictconnect %reset
     reset is invalid
 
-    ; CHECK: %out_0 = firrtl.wire : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
+    ; CHECK: %out_0 = firrtl.wire interesting_name : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
 
     ; CHECK: [[A:%.+]] = firrtl.subfield %out_0(0) : (!firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>) -> !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
@@ -135,16 +135,16 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
-    ; CHECK: %_t_3 = firrtl.wire droppable_name : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_3 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[A:%.+]] = firrtl.subindex %_t_3[0] : !firrtl.vector<uint<1>, 12>
-    ; CHECK: %_t_4 = firrtl.wire droppable_name : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_4 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[B:%.+]] = firrtl.subindex %_t_4[0] : !firrtl.vector<uint<1>, 12>
     ; CHECK: firrtl.strictconnect [[A]], [[B]]
     wire _t_3 : UInt<1>[12] @[Nodes.scala 370:76]
     wire _t_4 : UInt<1>[12]
     _t_3[0] <= _t_4[0] @[Xbar.scala 21:44]
 
-    ; CHECK: %n1 = firrtl.node %i8 : !firrtl.uint<8>
+    ; CHECK: %n1 = firrtl.node interesting_name %i8 : !firrtl.uint<8>
     node n1 = i8
 
     ; CHECK: firrtl.add %reset, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -205,7 +205,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.asClock %reset_async : (!firrtl.asyncreset) -> !firrtl.clock
     node check_c5 = asClock(reset_async)
 
-    ; CHECK: firrtl.node %auto : !firrtl.uint<1>
+    ; CHECK: firrtl.node interesting_name %auto : !firrtl.uint<1>
     node check_output = auto
 
     ; CHECK: %c42_ui10 = firrtl.constant 42 : !firrtl.uint<10>
@@ -225,10 +225,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when reset : _t <= _t_2 else : _t <- _t_2
 
     ; CHECK: firrtl.when %reset {
-    ; CHECK:   [[N4A:%.+]] = firrtl.node %_t_2
+    ; CHECK:   [[N4A:%.+]] = firrtl.node interesting_name %_t_2
     ; CHECK:   firrtl.strictconnect %_t, [[N4A]]
     ; CHECK: } else {
-    ; CHECK:   [[N4B:%.+]] = firrtl.node %_t_2
+    ; CHECK:   [[N4B:%.+]] = firrtl.node interesting_name %_t_2
     ; CHECK:   firrtl.strictconnect %_t, [[N4B]]
     ; CHECK: }
     when reset :
@@ -307,11 +307,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint) -> !firrtl.uint
     node n8 = mux(reset, i8, UInt(4))
 
-    ; CHECK: %_t_2621 = firrtl.regreset droppable_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    ; CHECK: %_t_2621 = firrtl.regreset %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
     reg _t_2621 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0")) @[Edges.scala 230:27]
 
-    ; CHECK: %_t_1601 = firrtl.regreset droppable_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    ; CHECK: %_t_1601 = firrtl.regreset %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     reg _t_1601 : UInt<2>, clock with :
       (reset => (reset, UInt<2>("h00"))) @[Edges.scala 230:27]
 
@@ -329,24 +329,24 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; The Scala implementation of FIRRTL prints registers without a reset value
     ; using the register name as the reset.  Make sure we handle this for
     ; compatibility.
-    ; CHECK: %_t_2622 = firrtl.reg droppable_name %clock : !firrtl.uint<4>
+    ; CHECK: %_t_2622 = firrtl.reg %clock : !firrtl.uint<4>
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 
-    ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
+    ; CHECK: %xyz_in = firrtl.instance xyz interesting_name @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
     ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
     ; CHECK: firrtl.strictconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
     xyz.in <= i8
 
-    ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
+    ; CHECK: %myext_in, %myext_out = firrtl.instance myext interesting_name @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
     inst myext of MyExtModule
     myext.in <= i8
     printf(clock, reset, "Something interesting! %x", myext.out)
 
     ; CHECK: firrtl.when %reset  {
     when reset :
-      ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance reset_myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
+      ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance reset_myext interesting_name @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
       inst reset_myext of MyExtModule
       reset_myext.in <= i8
     ; CHECK: }
@@ -357,7 +357,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.subaccess %_t[%auto] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<1>
     auto <= _t[auto]
 
-    ; CHECK: %myMem = chirrtl.combmem : !chirrtl.cmemory<bundle<id: uint<4>, resp: uint<2>>, 8>
+    ; CHECK: %myMem = chirrtl.combmem interesting_name : !chirrtl.cmemory<bundle<id: uint<4>, resp: uint<2>>, 8>
     cmem myMem : { id : UInt<4>, resp : UInt<2>} [8] @[Decoupled.scala 209:24]
 
     ; CHECK: %memValue_data, %memValue_port = chirrtl.memoryport Infer %myMem {name = "memValue"} : (!chirrtl.cmemory<bundle<id: uint<4>, resp: uint<2>>, 8>) -> (!firrtl.bundle<id: uint<4>, resp: uint<2>>, !chirrtl.cmemoryport)
@@ -365,9 +365,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     infer mport memValue = myMem[i8], clock
     auto11 <= memValue.id
 
-    ; CHECK: %base_table_0 = chirrtl.seqmem Undefined : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
+    ; CHECK: %base_table_0 = chirrtl.seqmem interesting_name Undefined : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
     smem base_table_0 : UInt<1>[9] [256]
-    ; CHECK: %base_table_1 = chirrtl.seqmem Old : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
+    ; CHECK: %base_table_1 = chirrtl.seqmem interesting_name Old : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
     smem base_table_1 : UInt<1>[9] [256] old
 
     ; CHECK: %tableValue_data, %tableValue_port = chirrtl.memoryport Read %base_table_1 {name = "tableValue"} : (!chirrtl.cmemory<vector<uint<1>, 9>, 256>) -> (!firrtl.vector<uint<1>, 9>, !chirrtl.cmemoryport)
@@ -375,7 +375,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     read mport tableValue = base_table_1[i8], clock
 
     ; Check that we can handle large memory sizes.
-    ; CHECK: %testharness = chirrtl.seqmem Undefined : !chirrtl.cmemory<vector<uint<8>, 16>, 2147483648>
+    ; CHECK: %testharness = chirrtl.seqmem interesting_name Undefined : !chirrtl.cmemory<vector<uint<8>, 16>, 2147483648>
     smem testharness : UInt<8>[16][2147483648], undefined
 
     ; CHECK: firrtl.pad %i8, 10 : (!firrtl.uint<8>) -> !firrtl.uint<10>
@@ -388,7 +388,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node n13 = not(auto)
 
 
-    ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem droppable_name Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
+    ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
     ; CHECK-SAME: readLatency = 0 : i32, writeLatency = 1 : i32} :
     ; CHECK-SAME: !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>,
     ; CHECK-SAME: !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>,
@@ -435,19 +435,19 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire _t_6 : { flip b : { bits : { source : UInt<7> } } }
     node _t_8 = bits(_t_6.b.bits.source, 5, 0)
 
-    ; CHECK: %flip1 = firrtl.wire : !firrtl.bundle<x flip: bundle<a flip: uint>>
+    ; CHECK: %flip1 = firrtl.wire interesting_name : !firrtl.bundle<x flip: bundle<a flip: uint>>
     wire flip1 : { flip x : { flip a : UInt } }
-    ; CHECK: %flip2 = firrtl.wire : !firrtl.bundle<x flip: bundle<a flip: uint, b: analog>>
+    ; CHECK: %flip2 = firrtl.wire interesting_name : !firrtl.bundle<x flip: bundle<a flip: uint, b: analog>>
     wire flip2 : { flip x : { flip a : UInt, b: Analog } }
-    ; CHECK: %flip3 = firrtl.wire : !firrtl.bundle<x flip: bundle<a flip: uint, b flip: analog>>
+    ; CHECK: %flip3 = firrtl.wire interesting_name : !firrtl.bundle<x flip: bundle<a flip: uint, b flip: analog>>
     wire flip3 : { flip x : { flip a : UInt, flip b: Analog } }
-    ; CHECK: %flip4 = firrtl.wire : !firrtl.bundle<x flip: vector<bundle<a flip: uint>, 4>>
+    ; CHECK: %flip4 = firrtl.wire interesting_name : !firrtl.bundle<x flip: vector<bundle<a flip: uint>, 4>>
     wire flip4 : { flip x : { flip a : UInt }[4] }
 
 
   ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity(
   module expr_stmt_ambiguity :
-    ; CHECK: %reg = firrtl.wire : !firrtl.uint
+    ; CHECK: %reg = firrtl.wire interesting_name : !firrtl.uint
     wire reg : UInt
     ; CHECK: firrtl.connect %reg,
     reg <= UInt(42)
@@ -460,7 +460,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity2(
   module expr_stmt_ambiguity2 :
-    ; CHECK: firrtl.instance write @circuit
+    ; CHECK: firrtl.instance write interesting_name @circuit
     inst write of circuit
     ; CHECK: firrtl.connect %write_in
     write.in <= UInt(1)
@@ -501,7 +501,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Memory ports should be declared in the scope of the cmemory, but should
     ; be enabled at the location of the mport.
 
-    ; CHECK: %memory = chirrtl.seqmem Undefined  : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
+    ; CHECK: %memory = chirrtl.seqmem interesting_name Undefined  : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
     smem memory : UInt<1>[9] [256]
 
     ; CHECK: %xyz0_data, %xyz0_port = chirrtl.memoryport Read %memory {name = "xyz0"} : (!chirrtl.cmemory<vector<uint<1>, 9>, 256>) -> (!firrtl.vector<uint<1>, 9>, !chirrtl.cmemoryport)
@@ -512,12 +512,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       read mport xyz0 = memory[addr], clock
 
     ; CHECK: firrtl.when %cond  {
-    ; CHECK:    %n0 = firrtl.node %xyz0_data  : !firrtl.vector<uint<1>, 9>
+    ; CHECK:    %n0 = firrtl.node interesting_name %xyz0_data  : !firrtl.vector<uint<1>, 9>
     ; CHECK: }
     when cond :
       node n0 = xyz0
 
-    ; CHECK: %n1 = firrtl.node %xyz0_data  : !firrtl.vector<uint<1>, 9>
+    ; CHECK: %n1 = firrtl.node interesting_name %xyz0_data  : !firrtl.vector<uint<1>, 9>
     node n1 = xyz0
 
 
@@ -526,27 +526,27 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input cond : UInt<1>
 
     ; CHECK: [[CST15:%.+]] = firrtl.constant 15 : !firrtl.uint<4>
-    ; CHECK: %a = firrtl.node [[CST15]]
+    ; CHECK: %a = firrtl.node interesting_name [[CST15]]
     node a = UInt<4>(15)
-    ; CHECK: %b = firrtl.node [[CST15]]
+    ; CHECK: %b = firrtl.node interesting_name [[CST15]]
     node b = UInt<4>(15)
 
     ;; Constants always get emitted to the top level.
     ; CHECK: [[CST7:%.+]] = firrtl.constant 7 : !firrtl.uint<4>
     ; CHECK: firrtl.when %cond {
     when cond :
-      ; CHECK: %c = firrtl.node [[CST15]]
+      ; CHECK: %c = firrtl.node interesting_name [[CST15]]
       node c = UInt<4>(15)
-      ; CHECK: %d = firrtl.node [[CST7]]
+      ; CHECK: %d = firrtl.node interesting_name [[CST7]]
       node d = UInt<4>(7)
       ; CHECK: firrtl.when %cond {
       when cond :
-        ; CHECK:  %e = firrtl.node [[CST7]]
+        ; CHECK:  %e = firrtl.node interesting_name [[CST7]]
         node e = UInt<4>(7)
     ; CHECK: }
     ; CHECK: }
 
-    ; CHECK:  %f = firrtl.node [[CST15]]
+    ; CHECK:  %f = firrtl.node interesting_name [[CST15]]
     node f = UInt<4>(15)
     node g = UInt<4>(7)
 
@@ -559,12 +559,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Subfields always get emitted by their declarations.
     ; CHECK: [[SUB:%.+]] = firrtl.subfield %i(0)
 
-    ; CHECK: %n3 = firrtl.node [[SUB]]
+    ; CHECK: %n3 = firrtl.node interesting_name [[SUB]]
     node n3 = i.x
 
     ; CHECK: firrtl.when %cond {
     when cond:
-      ; CHECK: %n4 = firrtl.node [[SUB]]
+      ; CHECK: %n4 = firrtl.node interesting_name [[SUB]]
       node n4 = i.x
     ; CHECK: }
 
@@ -581,7 +581,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf(0)
-    ; CHECK: %_T = firrtl.node droppable_name %0
+    ; CHECK: %_T = firrtl.node %0
     node _T = bf.int_1
     ; CHECK: firrtl.when %_T {
     when _T :
@@ -600,7 +600,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       reader => io_deq_bits_MPORT
       writer => MPORT
       read-under-write => undefined
-      ; CHECK: %bar_MPORT, %bar_io_deq_bits_MPORT = firrtl.mem Undefined {depth = 1 : i64, name = "bar", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} :
+      ; CHECK: %bar_MPORT, %bar_io_deq_bits_MPORT = firrtl.mem interesting_name Undefined {depth = 1 : i64, name = "bar", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} :
       ; CHECK: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>,
       ; CHECK: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<3>>
 
@@ -637,7 +637,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module private @analog_in_aggregate_node
   module analog_in_aggregate_node:
     input a: { a: UInt<1>, b: Analog<1>}
-    ; CHECK: %b = firrtl.node %a : !firrtl.bundle<a: uint<1>, b: analog<1>>
+    ; CHECK: %b = firrtl.node interesting_name %a : !firrtl.bundle<a: uint<1>, b: analog<1>>
     node b = a
 
   ; Check that a register clock sink is converted to passive
@@ -646,7 +646,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input clkIn: Clock
     output clkOut: Clock
     clkOut <= clkIn
-    ; CHECK: firrtl.reg %clkOut
+    ; CHECK: firrtl.reg interesting_name %clkOut
     reg r: UInt<1>, clkOut
 
   ; Check that a register reset sink is converted to passive
@@ -655,7 +655,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input clk: Clock
     output rst: UInt<1>
     rst is invalid
-    ; CHECK: firrtl.regreset %clk, %rst
+    ; CHECK: firrtl.regreset interesting_name %clk, %rst
     reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))
 
   ; Check that a register init sink is converted to passive
@@ -665,7 +665,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input rst: UInt<1>
     output init: UInt<1>
     init is invalid
-    ; CHECK: firrtl.regreset %clk, %rst, %init
+    ; CHECK: firrtl.regreset interesting_name %clk, %rst, %init
     reg r: UInt<1>, clk with : (reset => (rst, init))
 
   ; https://github.com/llvm/circt/issues/492
@@ -783,7 +783,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire2 is invalid
 
     ; https://github.com/llvm/circt/issues/563
-    ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance U0 @mod_0_563
+    ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance U0 interesting_name @mod_0_563
     inst U0 of mod_0_563
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
@@ -819,7 +819,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input rEn: UInt<1>
     output rData: UInt<8>
 
-    ; CHECK: %mem_r = firrtl.mem Undefined {depth = 16 : i64, name = "mem", portNames = ["r"], readLatency = 2 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    ; CHECK: %mem_r = firrtl.mem interesting_name Undefined {depth = 16 : i64, name = "mem", portNames = ["r"], readLatency = 2 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
     mem mem:
       data-type => UInt<8>
       depth => 16
@@ -840,15 +840,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in2: UInt<42>
     input en: UInt<1>
 
-    ; CHECK: %out1 = firrtl.node %in1
+    ; CHECK: %out1 = firrtl.node interesting_name %in1
     node out1 = validif(en, in1)
 
-    ; CHECK: %out2 = firrtl.node %in2
+    ; CHECK: %out2 = firrtl.node interesting_name %in2
     node out2 = validif(en, in2)
 
     ; This is required for SFC compatibility.
     ; https://github.com/llvm/circt/issues/1186
-    ; CHECK: %out3 = firrtl.node %in1
+    ; CHECK: %out3 = firrtl.node interesting_name %in1
     node out3 = validif(UInt<1>(0), in1)
 
   ; Test that behavioral memory reads and writes both work and that flow checks

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -62,7 +62,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     ; Make sure the locator is applied to all the subexpressions.
     ; CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> loc("Misc.scala":210:20)
     ; CHECK:  %0 = firrtl.eq %mask_bit_2, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1> loc("Misc.scala":210:20)
-    ; CHECK:  %mask_nbit_2 = firrtl.node %0  : !firrtl.uint<1> loc("Misc.scala":210:20)
+    ; CHECK:  %mask_nbit_2 = firrtl.node interesting_name %0  : !firrtl.uint<1> loc("Misc.scala":210:20)
 
 
 

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -6,7 +6,7 @@ circuit Bar :
     ; Should create a "tap" node with the same type and a symbol when the type
     ; is passive.
     wire a: UInt<1>
-    ; CHECK: %a = firrtl.wire  : !firrtl.uint<1>
+    ; CHECK: %a = firrtl.wire interesting_name : !firrtl.uint<1>
 
     ; Should use the non-tap wire in expressions.
     a <= in
@@ -15,14 +15,14 @@ circuit Bar :
     ; When the type is not passive, the tap should be a wire with the passive
     ; type of the original wire.
     wire flip: {flip a: UInt<1>}
-    ; CHECK: %flip = firrtl.wire  : !firrtl.bundle<a flip: uint<1>>
+    ; CHECK: %flip = firrtl.wire interesting_name : !firrtl.bundle<a flip: uint<1>>
 
     ; Analog values should be tapped with a node.
     wire analog: Analog<1>
-    ; CHECK: %analog = firrtl.wire  : !firrtl.analog<1>
+    ; CHECK: %analog = firrtl.wire interesting_name : !firrtl.analog<1>
 
     ; Should create attaches for analog typed elements between the tap wire and
     ; the original wire.
     ; https://github.com/llvm/circt/issues/2718
     wire w: {flip a: UInt<1>, b: Analog<1>}[1]
-    ; CHECK: %w = firrtl.wire  : !firrtl.vector<bundle<a flip: uint<1>, b: analog<1>>, 1>
+    ; CHECK: %w = firrtl.wire interesting_name : !firrtl.vector<bundle<a flip: uint<1>, b: analog<1>>, 1>

--- a/test/circt-reduce/memory-stubber.mlir
+++ b/test/circt-reduce/memory-stubber.mlir
@@ -4,7 +4,7 @@ firrtl.circuit "Basic"   {
   // CHECK-LABEL: @Basic
   firrtl.module @Basic() {
     %memory_r = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    // CHECK: %memory_r = firrtl.wire droppable_name : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    // CHECK: %memory_r = firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
     // CHECK: [[MEM_ADDR:%.+]] = firrtl.subfield %memory_r(0)
     // CHECK: [[MEM_EN:%.+]] = firrtl.subfield %memory_r(1)
     // CHECK: [[XOR:%.+]] = firrtl.xor [[MEM_ADDR]], [[MEM_EN]]

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -94,32 +94,32 @@ circuit test_mod : %[[{"a": "a"}]]
 
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>, out %out_implicitTrunc: !firrtl.uint<1>, out %out_prettifyExample: !firrtl.uint<1>, out %out_multibitMux: !firrtl.uint<1>) {
-; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
+; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat interesting_name  @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
 ; MLIR-NEXT:    firrtl.strictconnect %cat_a, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.strictconnect %cat_b, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.strictconnect %cat_c, %b : !firrtl.uint<2>
-; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
+; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc interesting_name @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
 ; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
-; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
+; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample interesting_name @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
+; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop interesting_name @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_clock, %clock : !firrtl.clock
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_a_d, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %c, %flipFlop_a_q : !firrtl.uint<1>
-; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
+; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux interesting_name @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.instance unusedPortsMod @UnusedPortsMod()
+; MLIR-NEXT:    firrtl.instance unusedPortsMod interesting_name @UnusedPortsMod()
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod
 ; ANNOTATIONS-SAME: info = "a ModuleTarget Annotation"

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -112,9 +112,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:          firrtl.instance mem @prefix1_mem
+; CHECK:          firrtl.instance mem interesting_name @prefix1_mem
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:          firrtl.instance mem @prefix2_mem
+; CHECK:          firrtl.instance mem interesting_name @prefix2_mem
 ; CHECK:        firrtl.memmodule @prefix1_mem
 ; CHECK:        firrtl.memmodule @prefix2_mem
 


### PR DESCRIPTION
This commit changes a default value of namekind from interesting name to droppable name.

This is more comfortable in the situation where we want to create a dummy unnamed wire with for example
`builder.create<WireOp>(result.type())`. Previously a dummy wire created by this had `interesting_name` because default namekind was `interesting`. This commit also changes IR representation.