### PR TITLE
[FIRRTL] Fix doulbe free in FIRRTL node canonicalizer

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1650,7 +1650,6 @@ struct FoldNodeName : public mlir::RewritePattern {
     // Make sure we don't revisit this node.  This is redundant with NodeBypass,
     // but easier to do here.
     rewriter.replaceOp(node, node.input());
-    rewriter.eraseOp(node);
     return success();
   }
 };


### PR DESCRIPTION
This fixes operations being erased twice by `rewriter.replace` and
`rewriter.erase`.