### PR TITLE
[FIRRTL] Don't apply node bypass to node with droppable names

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1663,11 +1663,14 @@ struct NodeBypass : public mlir::RewritePattern {
     auto node = cast<NodeOp>(op);
     if (node.inner_sym() || !node.annotations().empty())
       return failure();
+
+    // If node has a droppable name, hand over to `FoldNodeName` to propagate
+    // `name` attribute.
+    if (node.hasDroppableName())
+      return failure();
     rewriter.startRootUpdate(node);
     node.replaceAllUsesWith(node.input());
     rewriter.finalizeRootUpdate(node);
-    if (node.hasDroppableName())
-      rewriter.eraseOp(node);
     return success();
   }
 };

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2362,8 +2362,14 @@ firrtl.module @NamePropagation(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, i
   // CHECK-NEXT: %e = firrtl.bits %c 1 to 0 {name = "e"}
   %1 = firrtl.bits %c 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   %e = firrtl.bits %1 1 to 0 {name = "e"}: (!firrtl.uint<3>) -> !firrtl.uint<2>
-  // CHECK-NEXT: firrtl.strictconnect %res2, %e
-  firrtl.strictconnect %res2, %e : !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.strictconnect %res1, %e
+  firrtl.strictconnect %res1, %e : !firrtl.uint<2>
+
+  // CHECK-NEXT: %name_node = firrtl.not %e {name = "name_node"} : (!firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.strictconnect %res2, %name_node
+  %2 = firrtl.not %e : (!firrtl.uint<2>) -> !firrtl.uint<2>
+  %name_node = firrtl.node droppable_name %2 : !firrtl.uint<2>
+  firrtl.strictconnect %res2, %name_node : !firrtl.uint<2>
 }
 
 // Issue 3319: https://github.com/llvm/circt/issues/3319


### PR DESCRIPTION
`NodeBypass` canonicalizer erases node ops without propagating name attributes. 
This eliminates almost all namehints on node op in firtool execution with -drop-names flag
so it is necessary not to apply node bypass to node with droppable names.