### PR TITLE
[Python] Add support for SV attributes

### DIFF
--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -20,6 +20,17 @@ extern "C" {
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv);
 MLIR_CAPI_EXPORTED void registerSVPasses();
 
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool svAttrIsASVAttributeAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED MlirAttribute svSVAttributeAttrGet(MlirContext cCtxt,
+                                                      MlirStringRef name,
+                                                      MlirStringRef expression);
+MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetName(MlirAttribute);
+MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute);
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration_test/Bindings/Python/dialects/sv.py
+++ b/integration_test/Bindings/Python/dialects/sv.py
@@ -1,0 +1,33 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+from circt.dialects import hw, sv
+
+from mlir import ir
+
+with ir.Context() as ctx, ir.Location.unknown() as loc:
+  circt.register_dialects(ctx)
+  ctx.allow_unregistered_dialects = True
+
+  sv_attr = sv.SVAttributeAttr.get("fold", "false")
+  print(f"sv_attr: {sv_attr} {sv_attr.name} {sv_attr.expression}")
+  # CHECK: sv_attr: #sv.attribute<"fold" = "false"> fold false
+
+  sv_attr = sv.SVAttributeAttr.get("no_merge")
+  print(f"sv_attr: {sv_attr} {sv_attr.name} {sv_attr.expression}")
+  # CHECK: sv_attr: #sv.attribute<"no_merge"> no_merge None
+
+  i1 = ir.IntegerType.get_signless(1)
+  i1_inout = hw.InOutType.get(i1)
+
+  m = ir.Module.create()
+  with ir.InsertionPoint(m.body):
+
+    wire_op = sv.WireOp(i1_inout, "wire1", svAttributes=[sv_attr])
+    print(wire_op)
+    # CHECK: %wire1 = sv.wire  svattrs [#sv.attribute<"no_merge">] : !hw.inout<i1>
+
+    reg_op = sv.RegOp(i1_inout, "reg1", svAttributes=[sv_attr])
+    print(reg_op)
+    # CHECK: %reg1 = sv.reg  svattrs [#sv.attribute<"no_merge">] : !hw.inout<i1>

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -88,4 +88,6 @@ PYBIND11_MODULE(_circt, m) {
   circt::python::populateDialectMSFTSubmodule(msft);
   py::module hw = m.def_submodule("_hw", "HW API");
   circt::python::populateDialectHWSubmodule(hw);
+  py::module sv = m.def_submodule("_sv", "SV API");
+  circt::python::populateDialectSVSubmodule(sv);
 }

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -26,6 +26,7 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension.Core
     ESIModule.cpp
     HWModule.cpp
     MSFTModule.cpp
+    SVModule.cpp
   EMBED_CAPI_LINK_LIBS
     CIRCTCAPIComb
     CIRCTCAPIESI

--- a/lib/Bindings/Python/DialectModules.h
+++ b/lib/Bindings/Python/DialectModules.h
@@ -21,6 +21,7 @@ namespace python {
 void populateDialectESISubmodule(pybind11::module &m);
 void populateDialectHWSubmodule(pybind11::module &m);
 void populateDialectMSFTSubmodule(pybind11::module &m);
+void populateDialectSVSubmodule(pybind11::module &m);
 
 } // namespace python
 } // namespace circt

--- a/lib/Bindings/Python/SVModule.cpp
+++ b/lib/Bindings/Python/SVModule.cpp
@@ -1,0 +1,58 @@
+//===- SVModule.cpp - SV API pybind module --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DialectModules.h"
+
+#include "circt-c/Dialect/SV.h"
+#include "mlir-c/Bindings/Python/Interop.h"
+
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include "PybindUtils.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
+
+using namespace mlir::python::adaptors;
+
+void circt::python::populateDialectSVSubmodule(py::module &m) {
+  m.doc() = "SV Python Native Extension";
+
+  mlir_attribute_subclass(m, "SVAttributeAttr", svAttrIsASVAttributeAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, std::string name, py::object expressionObj,
+             MlirContext ctxt) {
+            MlirStringRef expression = {nullptr, 0};
+            if (!expressionObj.is_none())
+              expression = mlirStringRefCreateFromCString(
+                  expressionObj.cast<std::string>().c_str());
+            return cls(svSVAttributeAttrGet(
+                ctxt, mlirStringRefCreateFromCString(name.c_str()),
+                expression));
+          },
+          "Create a SystemVerilog attribute", py::arg(), py::arg("name"),
+          py::arg("expression") = py::none(), py::arg("ctxt") = py::none())
+      .def_property_readonly("name",
+                             [](MlirAttribute self) {
+                               MlirStringRef name =
+                                   svSVAttributeAttrGetName(self);
+                               return std::string(name.data, name.length);
+                             })
+      .def_property_readonly(
+          "expression", [](MlirAttribute self) -> py::object {
+            MlirStringRef name = svSVAttributeAttrGetExpression(self);
+            if (name.data == nullptr)
+              return py::none();
+            return py::str(std::string(name.data, name.length));
+          });
+}

--- a/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
@@ -1,6 +1,6 @@
 from circt.support import BackedgeBuilder, NamedValueOpView
 
-from mlir.ir import IntegerType, OpView, StringAttr
+from mlir.ir import ArrayAttr, IntegerType, OpView, StringAttr
 
 
 class CompRegBuilder(NamedValueOpView):
@@ -30,6 +30,7 @@ class CompRegOp:
                reset_value=None,
                name=None,
                sym_name=None,
+               svAttributes=None,
                loc=None,
                ip=None):
     operands = []
@@ -48,6 +49,8 @@ class CompRegOp:
       attributes["name"] = StringAttr.get(name)
     if sym_name is not None:
       attributes["sym_name"] = StringAttr.get(sym_name)
+    if svAttributes is not None:
+      attributes["svAttributes"] = ArrayAttr.get(svAttributes)
 
     OpView.__init__(
         self,
@@ -67,6 +70,7 @@ class CompRegOp:
              reset_value=None,
              name=None,
              sym_name=None,
+             sv_attributes=None,
              **kwargs):
     return CompRegBuilder(cls,
                           result_type,
@@ -75,4 +79,5 @@ class CompRegOp:
                           reset_value=reset_value,
                           name=name,
                           sym_name=sym_name,
+                          svAttributes=sv_attributes,
                           needs_result_type=True)

--- a/lib/Bindings/Python/circt/dialects/_sv_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_sv_ops_ext.py
@@ -2,8 +2,8 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from mlir.ir import OpView, Attribute, StringAttr
-from circt.dialects import hw, sv
+from mlir.ir import ArrayAttr, Attribute, FlatSymbolRefAttr, OpView, StringAttr
+from circt.dialects import sv
 import circt.support as support
 
 
@@ -28,11 +28,22 @@ class IfDefOp:
 
 class WireOp:
 
-  def __init__(self, name, data_type, *, loc=None, ip=None):
-    name = "wire" if not name else name
+  def __init__(self,
+               data_type,
+               name,
+               *,
+               inner_sym=None,
+               svAttributes=None,
+               loc=None,
+               ip=None):
+    attributes = {"name": StringAttr.get(name)}
+    if inner_sym is not None:
+      attributes["inner_sym"] = FlatSymbolRefAttr.get(inner_sym)
+    if svAttributes is not None:
+      attributes["svAttributes"] = ArrayAttr.get(svAttributes)
     OpView.__init__(
         self,
-        self.build_generic(attributes={"name": StringAttr.get(name)},
+        self.build_generic(attributes=attributes,
                            results=[data_type],
                            operands=[],
                            successors=None,
@@ -40,12 +51,31 @@ class WireOp:
                            loc=loc,
                            ip=ip))
 
-  @staticmethod
-  def create(data_type, name=None):
-    if not isinstance(data_type, hw.InOutType):
-      data_type = hw.InOutType.get(data_type)
 
-    return sv.WireOp(name, data_type)
+class RegOp:
+
+  def __init__(self,
+               data_type,
+               name,
+               *,
+               inner_sym=None,
+               svAttributes=None,
+               loc=None,
+               ip=None):
+    attributes = {"name": StringAttr.get(name)}
+    if inner_sym is not None:
+      attributes["inner_sym"] = FlatSymbolRefAttr.get(inner_sym)
+    if svAttributes is not None:
+      attributes["svAttributes"] = ArrayAttr.get(svAttributes)
+    OpView.__init__(
+        self,
+        self.build_generic(attributes=attributes,
+                           results=[data_type],
+                           operands=[],
+                           successors=None,
+                           regions=0,
+                           loc=loc,
+                           ip=ip))
 
 
 class AssignOp:

--- a/lib/Bindings/Python/circt/dialects/sv.py
+++ b/lib/Bindings/Python/circt/dialects/sv.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._sv_ops_gen import *
+from mlir._mlir_libs._circt._sv import *

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -14,9 +14,8 @@
 
 using namespace circt::sv;
 
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, SVDialect)
-
 void registerSVPasses() { registerPasses(); }
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, SVDialect)
 
 bool svAttrIsASVAttributeAttr(MlirAttribute cAttr) {
   return unwrap(cAttr).isa<SVAttributeAttr>();

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -5,12 +5,40 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt-c/Dialect/SV.h"
+#include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
 
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, circt::sv::SVDialect)
+using namespace circt::sv;
 
-void registerSVPasses() { circt::sv::registerPasses(); }
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, SVDialect)
+
+void registerSVPasses() { registerPasses(); }
+
+bool svAttrIsASVAttributeAttr(MlirAttribute cAttr) {
+  return unwrap(cAttr).isa<SVAttributeAttr>();
+}
+
+MlirAttribute svSVAttributeAttrGet(MlirContext cCtxt, MlirStringRef cName,
+                                   MlirStringRef cExpression) {
+  mlir::MLIRContext *ctxt = unwrap(cCtxt);
+  mlir::StringAttr expr;
+  if (cExpression.data != nullptr)
+    expr = mlir::StringAttr::get(ctxt, unwrap(cExpression));
+  return wrap(SVAttributeAttr::get(
+      ctxt, mlir::StringAttr::get(ctxt, unwrap(cName)), expr));
+}
+
+MlirStringRef svSVAttributeAttrGetName(MlirAttribute cAttr) {
+  return wrap(unwrap(cAttr).cast<SVAttributeAttr>().getName().getValue());
+}
+
+MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute cAttr) {
+  auto expr = unwrap(cAttr).cast<SVAttributeAttr>().getExpression();
+  if (expr)
+    return wrap(expr.getValue());
+  return {nullptr, 0};
+}

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -93,7 +93,7 @@ void CompRegOp::print(::mlir::OpAsmPrinter &p) {
     p << ", " << reset() << ", " << resetValue() << ' ';
 
   if (svAttributes()) {
-    p << "svattrs " << svAttributesAttr();
+    p << " svattrs " << svAttributesAttr();
     elidedAttrs.push_back("svAttributes");
   }
 


### PR DESCRIPTION
Lots of boilerplate which should _really_ be autogenerated. Added support for SystemVerilog attributes to the python bindings for the SV and Seq dialects.