### PR TITLE
[Scheduling] Add CPSAT scheduler (via OR-Tools) for `SharedOperatorsProblem`

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -74,6 +74,12 @@ LogicalResult scheduleLP(Problem &prob, Operation *lastOp);
 /// \p lastOp.
 LogicalResult scheduleLP(CyclicProblem &prob, Operation *lastOp);
 
+/// Solve the acyclic problem with shared operators using constraint programming
+/// and an external SAT solver. The objective is to minimize the start time of
+/// the given \p lastOp. Fails if the dependence graph contains cycles, or \p
+/// prob does not include \p lastOp.
+LogicalResult scheduleCPSAT(SharedOperatorsProblem &prob, Operation *lastOp);
+
 } // namespace scheduling
 } // namespace circt
 

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_OPTIONAL_SOURCES
   ASAPScheduler.cpp
   ChainingSupport.cpp
+  CPSATSchedulers.cpp
   LPSchedulers.cpp
   Problems.cpp
   SimplexSchedulers.cpp
@@ -27,7 +28,7 @@ if(ortools_FOUND)
 endif()
 
 if(SCHEDULING_OR_TOOLS)
-  list(APPEND SCHEDULING_SOURCES LPSchedulers.cpp)
+  list(APPEND SCHEDULING_SOURCES LPSchedulers.cpp CPSATSchedulers.cpp)
   list(APPEND SCHEDULING_LIBS ortools::ortools)
 endif()
 

--- a/lib/Scheduling/CPSATSchedulers.cpp
+++ b/lib/Scheduling/CPSATSchedulers.cpp
@@ -1,0 +1,151 @@
+//===- CPSATSchedulers.cpp - Schedulers using external CPSAT solvers
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of cp-sat programming-based schedulers using external solvers
+// via OR-Tools.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Scheduling/Algorithms.h"
+
+#include "mlir/IR/Operation.h"
+
+#include "ortools/sat/cp_model.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Format.h"
+
+#define DEBUG_TYPE "cpsat-schedulers"
+
+using namespace circt;
+using namespace circt::scheduling;
+using namespace operations_research;
+using namespace operations_research::sat;
+
+using llvm::dbgs;
+using llvm::format;
+
+/// Solve the shared operators problem by modeling it as a Resource
+/// Constrained Project Scheduling Problem (RCPSP), which in turn is formulated
+/// as a Constraint Programming (CP) Satisfiability (SAT) problem.
+///
+/// This is a high-fidelity translation of
+/// https://github.com/google/or-tools/blob/stable/examples/python/rcpsp_sat.py
+/// but a gentler introduction (though with differing formulation) is
+/// https://python-mip.readthedocs.io/en/latest/examples.html
+LogicalResult scheduling::scheduleCPSAT(SharedOperatorsProblem &prob,
+                                        Operation *lastOp) {
+  Operation *containingOp = prob.getContainingOp();
+  if (!prob.hasOperation(lastOp))
+    return containingOp->emitError("problem does not include last operation");
+
+  CpModelBuilder cpModel;
+  auto &tasks = prob.getOperations();
+  auto &resources = prob.getOperatorTypes();
+
+  DenseMap<Operation *, IntVar> taskStarts;
+  DenseMap<Operation *, IntVar> taskEnds;
+  DenseMap<Problem::OperatorType, SmallVector<IntervalVar, 4>>
+      resourcesToTaskIntervals;
+
+  // First get horizon, i.e., the time taken if all operations were executed
+  // sequentially.
+  unsigned horizon = 0;
+  for (auto *task : tasks) {
+    unsigned duration = *prob.getLatency(*prob.getLinkedOperatorType(task));
+    horizon += duration;
+  }
+
+  // Build task-interval decision variables, which effectively serve to
+  // constrain startVar and endVar to be duration apart. Then map them
+  // to the resources (operators) consumed during those intervals. Note,
+  // resources are in fact not constrained to be occupied for the whole of the
+  // task interval, but only during the first "tick". See comment below
+  // regarding cpModel.NewFixedSizeIntervalVar.
+  for (auto item : llvm::enumerate(tasks)) {
+    auto i = item.index();
+    auto *task = item.value();
+    IntVar startVar = cpModel.NewIntVar(Domain(0, horizon))
+                          .WithName((Twine("start_of_task_") + Twine(i)).str());
+    IntVar endVar = cpModel.NewIntVar(Domain(0, horizon))
+                        .WithName((Twine("end_of_task_") + Twine(i)).str());
+    taskStarts[task] = startVar;
+    taskEnds[task] = endVar;
+    auto resource = prob.getLinkedOperatorType(task);
+    unsigned duration = *prob.getLatency(*resource);
+    IntervalVar taskInterval =
+        cpModel.NewIntervalVar(startVar, duration, endVar)
+            .WithName((Twine("task_interval_") + Twine(i)).str());
+
+    if (prob.getLimit(*resource))
+      resourcesToTaskIntervals[resource.value()].emplace_back(taskInterval);
+  }
+
+  // Check for cycles and otherwise establish operation ordering
+  // constraints.
+  for (Operation *task : tasks) {
+    for (auto dep : prob.getDependences(task)) {
+      Operation *src = dep.getSource();
+      Operation *dst = dep.getDestination();
+      if (src == dst)
+        return containingOp->emitError() << "dependence cycle detected";
+      cpModel.AddLessOrEqual(taskEnds[src], taskStarts[dst]);
+    }
+  }
+
+  // Establish "cumulative" constraints in order to constrain maximum
+  // concurrent usage of operators.
+  for (auto resourceToTaskIntervals : resourcesToTaskIntervals) {
+    Problem::OperatorType &resource = resourceToTaskIntervals.getFirst();
+    auto capacity = prob.getLimit(resource);
+    SmallVector<IntervalVar, 4> &taskIntervals =
+        resourceToTaskIntervals.getSecond();
+    // The semantics of cumulative constraints in or-tools are such that
+    // for any integer point, the sum of the demands across all
+    // intervals containing that point does not exceed the capacity of the
+    // resource. Thus tasks, in 1-1 correspondence with their intervals, are
+    // constrained to satisfy maximum resource requirements.
+    // See https://or.stackexchange.com/a/3363 for more details.
+    CumulativeConstraint cumu = cpModel.AddCumulative(capacity.value());
+    for (auto &item : llvm::enumerate(taskIntervals)) {
+      auto i = item.index();
+      auto taskInterval = item.value();
+      IntVar demandVar = cpModel.NewIntVar(Domain(1)).WithName(
+          (Twine("demand_") + Twine(i) + Twine("_") + Twine(resource.strref()))
+              .str());
+      // Conventional formulation for SharedOperatorsProblem;
+      // interval during which the resource is occupied has size 1.
+      IntervalVar start =
+          cpModel.NewFixedSizeIntervalVar(taskInterval.StartExpr(), 1);
+      cumu.AddDemand(start, demandVar);
+    }
+  }
+
+  cpModel.Minimize(taskEnds[lastOp]);
+
+  Model model;
+
+  int numSolutions = 0;
+  model.Add(NewFeasibleSolutionObserver([&](const CpSolverResponse &r) {
+    LLVM_DEBUG(dbgs() << "Solution " << numSolutions << '\n');
+    LLVM_DEBUG(dbgs() << "Solution status" << r.status() << '\n');
+    ++numSolutions;
+  }));
+
+  LLVM_DEBUG(dbgs() << "Starting solver\n");
+  const CpSolverResponse response = SolveCpModel(cpModel.Build(), &model);
+
+  if (response.status() == CpSolverStatus::OPTIMAL ||
+      response.status() == CpSolverStatus::FEASIBLE) {
+    for (auto *task : tasks)
+      prob.setStartTime(task, SolutionIntegerValue(response, taskStarts[task]));
+
+    return success();
+  }
+  return containingOp->emitError() << "infeasible";
+}

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -628,6 +628,50 @@ void TestLPSchedulerPass::runOnOperation() {
   llvm_unreachable("Unsupported scheduling problem");
 }
 
+namespace {
+struct TestCPSATSchedulerPass
+    : public PassWrapper<TestCPSATSchedulerPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestCPSATSchedulerPass)
+
+  TestCPSATSchedulerPass() = default;
+  TestCPSATSchedulerPass(const TestCPSATSchedulerPass &) {}
+  Option<std::string> problemToTest{*this, "with", llvm::cl::init("Problem")};
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-cpsat-scheduler"; }
+  StringRef getDescription() const override {
+    return "Emit a CPSAT scheduler's solution as attributes";
+  }
+};
+} // anonymous namespace
+
+void TestCPSATSchedulerPass::runOnOperation() {
+  auto func = getOperation();
+  Operation *lastOp = func.getBlocks().front().getTerminator();
+  OpBuilder builder(func.getContext());
+
+  if (problemToTest == "SharedOperatorsProblem") {
+    auto prob = SharedOperatorsProblem::get(func);
+    constructProblem(prob, func);
+    constructSharedOperatorsProblem(prob, func);
+    assert(succeeded(prob.check()));
+
+    if (failed(scheduleCPSAT(prob, lastOp))) {
+      func->emitError("scheduling failed");
+      return signalPassFailure();
+    }
+
+    if (failed(prob.verify())) {
+      func->emitError("schedule verification failed");
+      return signalPassFailure();
+    }
+
+    emitSchedule(prob, "cpSatStartTime", builder);
+    return;
+  }
+
+  llvm_unreachable("Unsupported scheduling problem");
+}
+
 #endif // SCHEDULING_OR_TOOLS
 
 //===----------------------------------------------------------------------===//
@@ -661,6 +705,9 @@ void registerSchedulingTestPasses() {
 #ifdef SCHEDULING_OR_TOOLS
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestLPSchedulerPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestCPSATSchedulerPass>();
   });
 #endif
 }

--- a/test/Scheduling/or-tools/shared-operators-problems.mlir
+++ b/test/Scheduling/or-tools/shared-operators-problems.mlir
@@ -1,0 +1,54 @@
+// REQUIRES: or-tools
+// RUN: circt-opt %s -test-cpsat-scheduler=with=SharedOperatorsProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=CPSAT
+
+// CPSAT-LABEL: full_load
+func.func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "add", latency = 3, limit = 1 },
+    { name = "_0", latency = 0 }
+  ] } {
+  %0 = arith.addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
+  %1 = arith.addi %a1, %a1 { opr = "add", problemStartTime = 1 } : i32
+  %2 = arith.addi %a2, %a3 { opr = "add", problemStartTime = 2 } : i32
+  %3 = arith.addi %a3, %a4 { opr = "add", problemStartTime = 3 } : i32
+  %4 = arith.addi %a4, %a5 { opr = "add", problemStartTime = 4 } : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 7 } : (i32, i32, i32, i32, i32) -> i32
+  // CPSAT: return
+  // CPSAT-SAME: cpSatStartTime = 7
+  return { problemStartTime = 7 } %5 : i32
+}
+
+// CPSAT-LABEL: partial_load
+func.func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "add", latency = 3, limit = 3},
+    { name = "_0", latency = 0 }
+  ] } {
+  %0 = arith.addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
+  %1 = arith.addi %a1, %a1 { opr = "add", problemStartTime = 0 } : i32
+  %2 = arith.addi %a2, %a3 { opr = "add", problemStartTime = 0 } : i32
+  %3 = arith.addi %a3, %a4 { opr = "add", problemStartTime = 1 } : i32
+  %4 = arith.addi %a4, %a5 { opr = "add", problemStartTime = 1 } : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 4 } : (i32, i32, i32, i32, i32) -> i32
+  // CPSAT: return
+  // CPSAT-SAME: cpSatStartTime = 4
+  return { problemStartTime = 4 } %5 : i32
+}
+
+// CPSAT-LABEL: multiple
+func.func @multiple(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "slowAdd", latency = 3, limit = 2},
+    { name = "fastAdd", latency = 1, limit = 1},
+    { name = "_0", latency = 0 }
+  ] } {
+  %0 = arith.addi %a0, %a1 { opr = "slowAdd", problemStartTime = 0 } : i32
+  %1 = arith.addi %a1, %a1 { opr = "slowAdd", problemStartTime = 0 } : i32
+  %2 = arith.addi %a2, %a3 { opr = "fastAdd", problemStartTime = 0 } : i32
+  %3 = arith.addi %a3, %a4 { opr = "slowAdd", problemStartTime = 1 } : i32
+  %4 = arith.addi %a4, %a5 { opr = "fastAdd", problemStartTime = 1 } : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 4 } : (i32, i32, i32, i32, i32) -> i32
+  // CPSAT: return
+  // CPSAT-SAME: cpSatStartTime = 4
+  return { problemStartTime = 4 } %5 : i32
+}


### PR DESCRIPTION
This a WIP implementation of a scheduler for the `SharedOperatorsProblem` using a CP-SAT solver, through OR-Tools.
The formulation/model is the [Resource Constrained Project Scheduling Problem](https://python-mip.readthedocs.io/en/latest/examples.html#:~:text=The%20Resource%2DConstrained%20Project%20Scheduling,required%20amount%20of%20different%20resources.) (but I do not use the formulation from that link). 

The current implementation is closely modeled on the [OR-Tools example](https://github.com/google/or-tools/blob/stable/examples/python/rcpsp_sat.py). That example is slightly more general (I think) than applies to CIRCT, namely it allows for multiple "recipes" for satisfying a task/op. Thus, the implementation needed to differ non-trivially. Since I am not a CP/SAT/scheduling/optimization wizard, my approach was to first build a parallel python version of that example, sans recipe functionality, all the while comparing the result of my altered script to the original. Hence all the auxilliary artifacts in `test/Scheduling/or-tools/cpsat_scripts/`; what you find there are problem instances ([kindly provided OR-Tools as well](https://github.com/google/or-tools/tree/stable/examples/data/rcpsp/single_mode)) along with a `test.sh` that runs OR-Tools python implementation and my python implementation and diffs the results. Once the python version was done, I one for one ported to C++/CIRCT (including naming conventions, to make the porting process more brainless).

I plan to normalize the naming (i.e., switch to using the CIRCT naming schemes) and remove all of the supporting material after in-tree tests are robust (enough coverage) and pass (which they currently do not).

Any and all comments/questions/concerns welcome.

cc @jopperm 