### PR TITLE
[Docs] Fix a few typos

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -3,7 +3,7 @@
 The Scala FIRRTL Compiler (SFC) provides a mechanism to encode arbitrary
 metadata and associate it with zero or more "things" in a FIRRTL circuit.  This
 mechanism is an _Annotation_ and the association is described using one or more
-_Targets_.  Annotations should be viewed an extension to the FIRRTL IR
+_Targets_.  Annotations should be viewed as an extension to the FIRRTL IR
 specification, and can greatly affect the meaning and interpretation of the IR.
 
 Annotations are represented as a dictionary, with a "class" field which
@@ -192,13 +192,13 @@ to other MLIR operations, or dropped. A warning will be emitted if there are
 any unused annotations still in the circuit. For example, the `ModuleInliner`
 pass removes `firrtl.passes.InlineAnnotation` by inlining annotated modules or
 instances. JSON Annotations map to the builtin MLIR attributes. An annotation
-is implemented using a DictionaryAttr, which holds the class, target, any
+is implemented using a DictionaryAttr, which holds the class, target, and any
 annotation specific data.
 
 ## Annotations
 
 Annotations here are written in their JSON format. A "reference target"
-indicates that the annotation could target anything object in the hierarchy,
+indicates that the annotation could target any object in the hierarchy,
 although there may be further restrictions in the annotation.
 
 ### BlackBox
@@ -1416,7 +1416,7 @@ Example:
 
 ## Attributes in SV
 
-Some annotations transfrom into attributes consumed by non-FIRRTL passes.  This
+Some annotations transform into attributes consumed by non-FIRRTL passes.  This
 section describes well-defined attributes used by HW/SV passes.
 
 
@@ -1424,7 +1424,7 @@ section describes well-defined attributes used by HW/SV passes.
 
 Used by HWExportModuleHierarchy.  Signifies a root from which to dump the module
 hierarchy as a json file. This attribute is a list of files to output to, and
-has type `ArraAttr<OutputFileAttr>`.
+has type `ArrayAttr<OutputFileAttr>`.
 
 The exported JSON file encodes a recursive tree of module instances as JSON
 objects, with each object containing the following members:

--- a/docs/RationaleComb.md
+++ b/docs/RationaleComb.md
@@ -313,7 +313,7 @@ That said, it is a bad idea to *duplicate* operations to reduce widths: for
 example, it is better to have one large multiply with many users than to clone
 it because one user only needs some of the output bits.
 
-It is also beneficial to reduce widths, even if it adds a truncations or
+It is also beneficial to reduce widths, even if it adds truncations or
 extensions in the IR (because they are "just wires"). However, there are limits:
 any and-by-constant could be lowered to a concat of each bit principle,
 e.g. it is legal to turn `and(x, 9)` into `concat(x[3], 00, x[0])`.  Doing so is

--- a/docs/RationaleHW.md
+++ b/docs/RationaleHW.md
@@ -192,7 +192,7 @@ sv.verbatim "{{0}}" { symbols = [@glbl_B_M1] }
 An IR for Hardware is different than an IR for Software in a very important way:
 while each function in a software program usually compiles into one blob of
 binary code no matter how many times it is called, each instance in a hardware
-design is typically fully instantiated, because different instance turn into
+design is typically fully instantiated, because different instances turn into
 different gates.  The consequence of this is that the instance tree is really a
 compression mechanism that is eventually elaborated away.
 
@@ -317,7 +317,7 @@ be different, because that would cause everything derived from them to be as
 well.
 
 On the other hand, we expect to support a lot of weird expressions over time (at
-least the full complement that Verilog supports) and canonicalize arbitrary
+least the full complement that Verilog supports) and canonicalizing arbitrary
 expressions in a predictable way is untenable.  As such, we support
 canonicalizing a fixed set of expressions predictably: more may be added in
 the future.
@@ -362,13 +362,13 @@ Note that `clog2(0)` is `0`, which follows the Verilog spec.
 
 Parameters are not [SSA values](https://en.wikipedia.org/wiki/Static_single_assignment_form), so they cannot directly be used within the body
 of the module.  Just like you use `hw.constant` to project a constant integer
-value into the SSA domain, you can use the `hw.param.value` to project an
+value into the SSA domain, you can use the `hw.param.value` to project a
 parameter expression, like so:
 
 ```mlir
 hw.module @M1<param1: i1>(%clock : i1, ...) {
   ...
-  %param1 = sv.param.value i1 = #hw.param.decl.ref<"param1">
+  %param1 = hw.param.value i1 = #hw.param.decl.ref<"param1">
   ...
     sv.if %param1 {  // Compile-time conditional on parameter.
       sv.fwrite "Only happens when the parameter is set\n"


### PR DESCRIPTION
In addition to these changes, I noticed that the two pictures in the folded-vs-unfolded-modules table (at the bottom of [this section](https://circt.llvm.org/docs/FIRRTLAnnotations/#targets)) aren't displaying on the website. I'm not completely sure what the right fix is for that. The diagrams can be found here:

https://circt.llvm.org/includes/img/firrtl-folded-module.png
https://circt.llvm.org/includes/img/firrtl-unfolded-module.png

However, the page is trying to find them at these URLs:

https://circt.llvm.org/docs/FIRRTLAnnotations/includes/img/firrtl-folded-module.png
https://circt.llvm.org/docs/FIRRTLAnnotations/includes/img/firrtl-unfolded-module.png

The images are rendered properly when opening the markdown document in GitHub. I'm not totally sure how the website is set up, but if you have a recommendation for the right fix, I'm happy to include it in this PR.

-Tynan