### PR TITLE
[FIRRTL][ModuleInliner] Check if nla in current path before renaming.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -373,8 +373,7 @@ public:
 
   void setInnerSym(Attribute module, StringAttr innerSym) {
     assert(symIdx.count(module) && "Mutable NLA did not contain symbol");
-    // The innerRef can be renamed multiple times, so this entry can be
-    // over-written.
+    assert(!renames.count(module) && "Module already renamed");
     renames.insert({module, innerSym});
   }
 };
@@ -460,9 +459,13 @@ private:
   /// referring to some other path.
   bool doesNLAMatchCurrentPath(HierPathOp nla);
 
-  /// Rename an operation and unique any symbols it has.
-  void rename(StringRef prefix, Operation *op,
-              ModuleNamespace &moduleNamespace);
+  /// Rename an operation and unique any symbols it has. If the op is an
+  /// InstanceOp, then `validHierPaths` is the set of HierPaths that the
+  /// InstanceOp participates in. `validHierPaths` is required, since the
+  /// InstanceOp no  longer contains the BreadCrumbs which indicated the
+  /// `HierPathOps` that it participates in.
+  void rename(StringRef prefix, Operation *op, ModuleNamespace &moduleNamespace,
+              SmallVector<StringAttr> &validHierPaths);
 
   /// Clone and rename an operation.
   void cloneAndRename(StringRef prefix, OpBuilder &b,
@@ -568,7 +571,8 @@ bool Inliner::doesNLAMatchCurrentPath(HierPathOp nla) {
 /// these are unique in the namespace.
 // NOLINTNEXTLINE(misc-no-recursion)
 void Inliner::rename(StringRef prefix, Operation *op,
-                     ModuleNamespace &moduleNamespace) {
+                     ModuleNamespace &moduleNamespace,
+                     SmallVector<StringAttr> &validHierPaths) {
   // Add a prefix to things that has a "name" attribute.  We don't prefix
   // memories since it will affect the name of the generated module.
   // TODO: We should find a way to prefix the instance of a memory module.
@@ -611,8 +615,7 @@ void Inliner::rename(StringRef prefix, Operation *op,
         // The InstanceOp is renamed, so move the HierPathOps to the new
         // InnerRefAttr.
         auto newInnerRef = InnerRefAttr::get(instanceParent, newSymAttr);
-        auto oldInnerRef = InnerRefAttr::get(instanceParent, oldInstSym);
-        instOpHierPaths[newInnerRef] = std::move(instOpHierPaths[oldInnerRef]);
+        instOpHierPaths[newInnerRef] = validHierPaths;
         // Update the innerSym for all the affected HierPathOps.
         for (auto nla : instOpHierPaths[newInnerRef]) {
           if (!nlaMap.count(nla))
@@ -620,6 +623,7 @@ void Inliner::rename(StringRef prefix, Operation *op,
           auto &mnla = nlaMap[nla];
           mnla.setInnerSym(moduleNamespace.module.moduleNameAttr(), newSymAttr);
         }
+        auto oldInnerRef = InnerRefAttr::get(instanceParent, oldInstSym);
         instOpHierPaths.erase(oldInnerRef);
       }
     }
@@ -629,7 +633,7 @@ void Inliner::rename(StringRef prefix, Operation *op,
   for (auto &region : op->getRegions())
     for (auto &block : region)
       for (auto &op : block)
-        rename(prefix, &op, moduleNamespace);
+        rename(prefix, &op, moduleNamespace, validHierPaths);
 }
 
 /// This function is used before inlining a module, to handle the conversion
@@ -712,16 +716,40 @@ void Inliner::cloneAndRename(
 
   // Clone and rename.
   auto *newOp = b.clone(op, mapper);
+  // List of HierPathOps that are valid based on the InstanceOp being inlined
+  // and the InstanceOp which is being replaced after inlining. That is the set
+  // of HierPathOps that is common between these two.
+  SmallVector<StringAttr> validHierPaths;
   if (auto instance = dyn_cast<InstanceOp>(&op))
     if (auto instSym = instance.inner_symAttr()) {
+      // Get the innerRef to the original InstanceOp that is being inlined here.
       auto oldInnerRef = InnerRefAttr::get(
           instance->getParentOfType<FModuleOp>().getNameAttr(), instSym);
-      auto newInnerRef =
-          InnerRefAttr::get(newOp->getParentOfType<FModuleOp>().getNameAttr(),
-                            cast<InstanceOp>(newOp).inner_symAttr());
-      instOpHierPaths[newInnerRef] = instOpHierPaths[oldInnerRef];
+      // Now get the currentPath, where this InstanceOp is being inlined.
+      auto &[inlineMod, inlineInst] = currentPath.back();
+      // Only the HierPathOps that participate at both the
+      // InstanceOp(`instance`) being inlined and at the place being
+      // inlined(inlineMod, inlineInst) must be valid after inlining.
+      if (inlineMod && inlineInst)
+        for (auto nlaAtInlineLoc : instOpHierPaths[InnerRefAttr::get(
+                 inlineMod.cast<StringAttr>(),
+                 inlineInst.cast<StringAttr>())]) {
+          // For all the HierPathOps that participate at the current path,
+          // inlining location.
+          for (auto old : instOpHierPaths[oldInnerRef])
+            // For all the HierPathOps that the instance being inlined
+            // participates in.
+            if (old == nlaAtInlineLoc)
+              validHierPaths.push_back(old);
+            else
+              // The HierPathOp name might not match, if it is duplicated after
+              // being retopped. Get all the retopped HierPathOp names.
+              for (auto renamedTops : nlaMap[old].getAdditionalSymbols())
+                if (old == renamedTops.getName())
+                  validHierPaths.push_back(old);
+        }
     }
-  rename(prefix, newOp, moduleNamespace);
+  rename(prefix, newOp, moduleNamespace, validHierPaths);
   if (isa<InstanceOp>(&op)) {
     auto innerRef =
         InnerRefAttr::get(newOp->getParentOfType<FModuleOp>().getNameAttr(),
@@ -893,6 +921,33 @@ void Inliner::inlineInto(StringRef prefix, OpBuilder &b,
       }
     }
 
+    // The InstanceOp `instance` might not have a symbol, if it does not
+    // participate in any HierPathOp. But the reTop might add a symbol to it, if
+    // a HierPathOp is is added to this Op. If we're about to inline a module
+    // that contains a non-local annotation that starts at that module, then we
+    // need to both update the mutable NLA to indicate that this has a new top
+    // and add an annotation on the instance saying that this now participates
+    // in this new NLA.
+    DenseMap<Attribute, Attribute> symbolRenames;
+    if (!rootMap[target.getNameAttr()].empty()) {
+      for (auto sym : rootMap[target.getNameAttr()]) {
+        auto &mnla = nlaMap[sym];
+        sym = mnla.reTop(parent);
+        StringAttr instSym = instance.inner_symAttr();
+        if (!instSym) {
+          instSym = StringAttr::get(context,
+                                    moduleNamespace.newName(instance.name()));
+          instance.inner_symAttr(instSym);
+        }
+        instOpHierPaths[InnerRefAttr::get(moduleName, instSym)].push_back(
+            sym.cast<StringAttr>());
+        // TODO: Update any symbol renames which need to be used by the next
+        // call of inlineInto.  This will then check each instance and rename
+        // any symbols appropriately for that instance.
+        symbolRenames.insert({mnla.getNLA().getNameAttr(), sym});
+      }
+    }
+    // This must be done after the reTop, since it might introduce an innerSym.
     currentPath.emplace_back(moduleName, instance.inner_symAttr());
 
     // Create the wire mapping for results + ports.
@@ -900,22 +955,6 @@ void Inliner::inlineInto(StringRef prefix, OpBuilder &b,
     auto wires =
         mapPortsToWires(nestedPrefix, b, mapper, target, {}, moduleNamespace);
     mapResultsToWires(mapper, wires, instance);
-
-    // If we're about to inline a module that contains a non-local annotation
-    // that starts at that module, then we need to both update the mutable NLA
-    // to indicate that this has a new top and add an annotation on the instance
-    // saying that this now participates in this new NLA.
-    DenseMap<Attribute, Attribute> symbolRenames;
-    if (!rootMap[target.getNameAttr()].empty()) {
-      for (auto sym : rootMap[target.getNameAttr()]) {
-        auto &mnla = nlaMap[sym];
-        sym = mnla.reTop(parent);
-        // TODO: Update any symbol renames which need to be used by the next
-        // call of inlineInto.  This will then check each instance and rename
-        // any symbols appropriately for that instance.
-        symbolRenames.insert({mnla.getNLA().getNameAttr(), sym});
-      }
-    }
 
     // Inline the module, it can be marked as flatten and inline.
     if (toBeFlattened) {
@@ -969,8 +1008,30 @@ void Inliner::inlineInstances(FModuleOp parent) {
       }
     }
 
+    // The InstanceOp `instance` might not have a symbol, if it does not
+    // participate in any HierPathOp. But the reTop might add a symbol to it, if
+    // a HierPathOp is is added to this Op.
+    DenseMap<Attribute, Attribute> symbolRenames;
+    if (!rootMap[target.getNameAttr()].empty()) {
+      for (auto sym : rootMap[target.getNameAttr()]) {
+        auto &mnla = nlaMap[sym];
+        sym = mnla.reTop(parent);
+        StringAttr instSym = instance.inner_symAttr();
+        if (!instSym) {
+          instSym = StringAttr::get(context,
+                                    moduleNamespace.newName(instance.name()));
+          instance.inner_symAttr(instSym);
+        }
+        instOpHierPaths[InnerRefAttr::get(moduleName, instSym)].push_back(
+            sym.cast<StringAttr>());
+        // TODO: Update any symbol renames which need to be used by the next
+        // call of inlineInto.  This will then check each instance and rename
+        // any symbols appropriately for that instance.
+        symbolRenames.insert({mnla.getNLA().getNameAttr(), sym});
+      }
+    }
+    // This must be done after the reTop, since it might introduce an innerSym.
     currentPath.emplace_back(moduleName, instance.inner_symAttr());
-
     // Create the wire mapping for results + ports. We RAUW the results instead
     // of mapping them.
     BlockAndValueMapping mapper;
@@ -980,18 +1041,6 @@ void Inliner::inlineInstances(FModuleOp parent) {
         mapPortsToWires(nestedPrefix, b, mapper, target, {}, moduleNamespace);
     for (unsigned i = 0, e = instance.getNumResults(); i < e; ++i)
       instance.getResult(i).replaceAllUsesWith(wires[i]);
-
-    DenseMap<Attribute, Attribute> symbolRenames;
-    if (!rootMap[target.getNameAttr()].empty()) {
-      for (auto sym : rootMap[target.getNameAttr()]) {
-        auto &mnla = nlaMap[sym];
-        sym = mnla.reTop(parent);
-        // TODO: Update any symbol renames which need to be used by the next
-        // call of inlineInto.  This will then check each instance and rename
-        // any symbols appropriately for that instance.
-        symbolRenames.insert({mnla.getNLA().getNameAttr(), sym});
-      }
-    }
 
     // Inline the module, it can be marked as flatten and inline.
     if (toBeFlattened) {

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -745,7 +745,7 @@ void Inliner::cloneAndRename(
               // The HierPathOp name might not match, if it is duplicated after
               // being retopped. Get all the retopped HierPathOp names.
               for (auto renamedTops : nlaMap[old].getAdditionalSymbols())
-                if (old == renamedTops.getName())
+                if (renamedTops.getName() == nlaAtInlineLoc)
                   validHierPaths.push_back(old);
         }
     }

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -373,7 +373,8 @@ public:
 
   void setInnerSym(Attribute module, StringAttr innerSym) {
     assert(symIdx.count(module) && "Mutable NLA did not contain symbol");
-    assert(!renames.count(module) && "Module already renamed");
+    // The innerRef can be renamed multiple times, so this entry can be
+    // over-written.
     renames.insert({module, innerSym});
   }
 };

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -462,7 +462,7 @@ private:
   /// Rename an operation and unique any symbols it has. If the op is an
   /// InstanceOp, then `validHierPaths` is the set of HierPaths that the
   /// InstanceOp participates in. `validHierPaths` is required, since the
-  /// InstanceOp no  longer contains the BreadCrumbs which indicated the
+  /// InstanceOp no longer contains the BreadCrumbs which indicated the
   /// `HierPathOps` that it participates in.
   void rename(StringRef prefix, Operation *op, ModuleNamespace &moduleNamespace,
               SmallVector<StringAttr> &validHierPaths);

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -373,8 +373,7 @@ public:
 
   void setInnerSym(Attribute module, StringAttr innerSym) {
     assert(symIdx.count(module) && "Mutable NLA did not contain symbol");
-    // The innerRef can be renamed multiple times, so this entry can be
-    // over-written.
+    assert(!renames.count(module) && "Module already renamed");
     renames.insert({module, innerSym});
   }
 };

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -751,12 +751,14 @@ firrtl.circuit "Issue3334_flatten" {
   }
   firrtl.module @Issue3334_flatten() {
     firrtl.instance foo sym @foo @Foo()
+  }
+}
 
 firrtl.circuit "instNameRename"  {
   firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@w_1, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1::@a]
   firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@w_2, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1::@a]
 
   firrtl.module @Leaf() {
     %w = firrtl.wire   : !firrtl.uint<8>
@@ -776,6 +778,8 @@ firrtl.circuit "instNameRename"  {
     firrtl.instance no sym @no @Bar0()
     firrtl.instance bar0 sym @bar0  @Bar0()
     firrtl.instance bar1 sym @bar1  @Bar0()
+    // CHECK:  firrtl.instance bar0_leaf sym @[[w_1]]  @Bar2()
+    // CHECK:  firrtl.instance bar1_leaf sym @[[w_2]]  @Bar2()
 
     %w = firrtl.wire sym @w   : !firrtl.uint<8>
     %inv = firrtl.invalidvalue : !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -751,5 +751,23 @@ firrtl.circuit "Issue3334_flatten" {
   }
   firrtl.module @Issue3334_flatten() {
     firrtl.instance foo sym @foo @Foo()
+
+firrtl.circuit "instNameRename"  {
+  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar1::@a]
+  // CHECK: firrtl.hierpath @nla_5560 [@instNameRename::@[[w_0:.+]], @Bar1::@a]
+  firrtl.module @Leaf() {
+    %w = firrtl.wire   : !firrtl.uint<8>
+  }
+  firrtl.module @Bar1() {
+    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} @Leaf()
+  }
+  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance leaf sym @w  @Bar1()
+  }
+  firrtl.module @instNameRename() {
+    firrtl.instance bar0 sym @bar0  @Bar0()
+    // CHECK: firrtl.instance bar0_leaf sym @[[w_0]]  @Bar1()
+    firrtl.instance bar1 sym @bar1  @Bar0()
+    %w = firrtl.wire sym @w   : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -755,18 +755,12 @@ firrtl.circuit "Issue3334_flatten" {
 }
 
 firrtl.circuit "instNameRename"  {
-  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1::@a]
-  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1::@a]
-
-  firrtl.module @Leaf() {
-    %w = firrtl.wire   : !firrtl.uint<8>
-    %inv = firrtl.invalidvalue : !firrtl.uint<8>
-    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
-  }
+  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1]
+  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1]
+  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1]
+  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1]
   firrtl.module @Bar1() {
-    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"},{circt.nonlocal = @nla_5560_1, class = "test1"}]} @Leaf()
+    %w = firrtl.wire   {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}, {circt.nonlocal = @nla_5560_1, class = "test1"}]} : !firrtl.uint<8>
   }
   firrtl.module @Bar2() {
     firrtl.instance leaf sym @w  @Bar1()
@@ -775,47 +769,11 @@ firrtl.circuit "instNameRename"  {
     firrtl.instance leaf sym @w  @Bar2()
   }
   firrtl.module @instNameRename() {
-    firrtl.instance no sym @no @Bar0()
+    firrtl.instance no sym @no  @Bar0()
     firrtl.instance bar0 sym @bar0  @Bar0()
     firrtl.instance bar1 sym @bar1  @Bar0()
     // CHECK:  firrtl.instance bar0_leaf sym @[[w_1]]  @Bar2()
     // CHECK:  firrtl.instance bar1_leaf sym @[[w_2]]  @Bar2()
-
     %w = firrtl.wire sym @w   : !firrtl.uint<8>
-    %inv = firrtl.invalidvalue : !firrtl.uint<8>
-    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
-  }
-}
-
-firrtl.circuit "instNameRename"  {
-  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1::@a]
-  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1::@a]
-  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1::@a]
-
-  firrtl.module @Leaf() {
-    %w = firrtl.wire   : !firrtl.uint<8>
-    %inv = firrtl.invalidvalue : !firrtl.uint<8>
-    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
-  }
-  firrtl.module @Bar1() {
-    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"},{circt.nonlocal = @nla_5560_1, class = "test1"}]} @Leaf()
-  }
-  firrtl.module @Bar2() {
-    firrtl.instance leaf sym @w  @Bar1()
-  }
-  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-    firrtl.instance leaf sym @w  @Bar2()
-  }
-  firrtl.module @instNameRename() {
-    firrtl.instance no sym @no @Bar0()
-    firrtl.instance bar0 sym @bar0  @Bar0()
-    firrtl.instance bar1 sym @bar1  @Bar0()
-    // CHECK:  firrtl.instance bar0_leaf sym @[[w_1]]  @Bar2()
-    // CHECK:  firrtl.instance bar1_leaf sym @[[w_2]]  @Bar2()
-
-    %w = firrtl.wire sym @w   : !firrtl.uint<8>
-    %inv = firrtl.invalidvalue : !firrtl.uint<8>
-    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -751,6 +751,24 @@ firrtl.circuit "Issue3334_flatten" {
   }
   firrtl.module @Issue3334_flatten() {
     firrtl.instance foo sym @foo @Foo()
+
+firrtl.circuit "instNameRename"  {
+  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar1::@a]
+  // CHECK: firrtl.hierpath @nla_5560 [@instNameRename::@[[w_0:.+]], @Bar1::@a]
+  firrtl.module @Leaf() {
+    %w = firrtl.wire   : !firrtl.uint<8>
+  }
+  firrtl.module @Bar1() {
+    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} @Leaf()
+  }
+  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance leaf sym @w  @Bar1()
+  }
+  firrtl.module @instNameRename() {
+    firrtl.instance bar0 sym @bar0  @Bar0()
+    // CHECK: firrtl.instance bar0_leaf sym @[[w_0]]  @Bar1()
+    firrtl.instance bar1 sym @bar1  @Bar0()
+    %w = firrtl.wire sym @w   : !firrtl.uint<8>
   }
 }
 

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -753,21 +753,32 @@ firrtl.circuit "Issue3334_flatten" {
     firrtl.instance foo sym @foo @Foo()
 
 firrtl.circuit "instNameRename"  {
-  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar1::@a]
-  // CHECK: firrtl.hierpath @nla_5560 [@instNameRename::@[[w_0:.+]], @Bar1::@a]
+  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@w_1, @Bar2::@w, @Bar1::@a]
+  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@w_2, @Bar2::@w, @Bar1::@a]
+
   firrtl.module @Leaf() {
     %w = firrtl.wire   : !firrtl.uint<8>
+    %inv = firrtl.invalidvalue : !firrtl.uint<8>
+    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
   }
   firrtl.module @Bar1() {
-    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} @Leaf()
+    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"},{circt.nonlocal = @nla_5560_1, class = "test1"}]} @Leaf()
   }
-  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  firrtl.module @Bar2() {
     firrtl.instance leaf sym @w  @Bar1()
   }
+  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance leaf sym @w  @Bar2()
+  }
   firrtl.module @instNameRename() {
+    firrtl.instance no sym @no @Bar0()
     firrtl.instance bar0 sym @bar0  @Bar0()
-    // CHECK: firrtl.instance bar0_leaf sym @[[w_0]]  @Bar1()
     firrtl.instance bar1 sym @bar1  @Bar0()
+
     %w = firrtl.wire sym @w   : !firrtl.uint<8>
+    %inv = firrtl.invalidvalue : !firrtl.uint<8>
+    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -753,22 +753,33 @@ firrtl.circuit "Issue3334_flatten" {
     firrtl.instance foo sym @foo @Foo()
 
 firrtl.circuit "instNameRename"  {
-  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar1::@a]
-  // CHECK: firrtl.hierpath @nla_5560 [@instNameRename::@[[w_0:.+]], @Bar1::@a]
+  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@w_1, @Bar2::@w, @Bar1::@a]
+  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1::@a]
+  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@w_2, @Bar2::@w, @Bar1::@a]
+
   firrtl.module @Leaf() {
     %w = firrtl.wire   : !firrtl.uint<8>
+    %inv = firrtl.invalidvalue : !firrtl.uint<8>
+    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
   }
   firrtl.module @Bar1() {
-    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} @Leaf()
+    firrtl.instance leaf sym @a  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"},{circt.nonlocal = @nla_5560_1, class = "test1"}]} @Leaf()
   }
-  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  firrtl.module @Bar2() {
     firrtl.instance leaf sym @w  @Bar1()
   }
+  firrtl.module @Bar0() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance leaf sym @w  @Bar2()
+  }
   firrtl.module @instNameRename() {
+    firrtl.instance no sym @no @Bar0()
     firrtl.instance bar0 sym @bar0  @Bar0()
-    // CHECK: firrtl.instance bar0_leaf sym @[[w_0]]  @Bar1()
     firrtl.instance bar1 sym @bar1  @Bar0()
+
     %w = firrtl.wire sym @w   : !firrtl.uint<8>
+    %inv = firrtl.invalidvalue : !firrtl.uint<8>
+    firrtl.strictconnect %w, %inv : !firrtl.uint<8>
   }
 }
 


### PR DESCRIPTION
This commit filters the `HierPathOp`s that participate in an instance based on where it is being inlined at.
If an `InstanceOp`  `@InlinedMod::@inst1` is being inlined to replace InstanceOp `@ParentMod::@inst2`, then only the `HierPathOps` that participate in both `@inst1` and `@inst2` are valid after inlining. 
If a `HierPathOp` begins at `@InlinedMod::@inst1`, then it implicitly participates at all places, where `@InelinedMod` is instantiated.   

This commit fixes a crash with the `ModuleInliner`, whenever an `InnerRef` is renamed without checking if it occurs in the current path. This triggers an assert when the `InnerRef` is renamed twice.