### PR TITLE
[FIRRTL] Stop Adding DontTouch to GCT Views/Taps

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -957,7 +957,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
     // non-local and local targets are totally equivalent.
     auto target = maybeTarget.getValue();
 
-    NamedAttrList elementIface, elementScattered, dontTouch;
+    NamedAttrList elementIface, elementScattered;
 
     // Populate the annotation for the interface element.
     elementIface.append("class", classAttr);
@@ -972,12 +972,8 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
     auto targetAttr = StringAttr::get(context, target);
     elementScattered.append("target", targetAttr);
 
-    dontTouch.append("class", StringAttr::get(context, dontTouchAnnoClass));
-    dontTouch.append("target", targetAttr);
-
     state.addToWorklistFn(
         DictionaryAttr::getWithSorted(context, elementScattered));
-    state.addToWorklistFn(DictionaryAttr::getWithSorted(context, dontTouch));
 
     return DictionaryAttr::getWithSorted(context, elementIface);
   }

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -297,13 +297,6 @@ LogicalResult circt::firrtl::applyGCTDataTaps(AnnoPathValue target,
   auto *context = state.circuit.getContext();
   auto loc = state.circuit.getLoc();
 
-  auto dontTouch = [&](StringRef targetStr) {
-    NamedAttrList anno;
-    anno.append("class", StringAttr::get(context, dontTouchAnnoClass));
-    anno.append("target", StringAttr::get(context, targetStr));
-    state.addToWorklistFn(DictionaryAttr::get(context, anno));
-  };
-
   auto id = state.newID();
   NamedAttrList attrs;
   attrs.append("class", StringAttr::get(context, dataTapsBlackboxClass));
@@ -357,7 +350,6 @@ LogicalResult circt::firrtl::applyGCTDataTaps(AnnoPathValue target,
       source.append("target", StringAttr::get(context, sourceTarget));
 
       state.addToWorklistFn(DictionaryAttr::get(context, source));
-      dontTouch(sourceTarget);
 
       // Annotate the data tap module port.
       port.append("class", StringAttr::get(context, referenceKeyPortClass));

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/PortDelete.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/PortDelete.fir
@@ -1,0 +1,69 @@
+; RUN: firtool -firrtl-grand-central %s | FileCheck %s
+
+circuit PortDelete : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
+    "name": "MyView",
+    "companion": "~PortDelete|MyView_companion",
+    "parent": "~PortDelete|DUT",
+    "view": {
+      "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+      "defName": "MyInterface",
+      "elements": [
+        {
+          "name": "ground",
+          "description": "a ground type port",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "PortDelete",
+              "module": "PortDelete",
+              "path": [
+                {
+                  "_1": {
+                    "class": "firrtl.annotations.TargetToken$Instance",
+                    "value": "dut"
+                  },
+                  "_2": {
+                    "class": "firrtl.annotations.TargetToken$OfModule",
+                    "value": "DUT"
+                  }
+                }
+              ],
+              "ref": "w",
+              "component": []
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
+        }
+      ]
+    }
+  }
+]]
+  module MyView_companion :
+
+    wire _WIRE : UInt<1>
+    _WIRE <= UInt<1>("h0")
+
+  module DUT :
+    output out : UInt<1>
+
+    wire w : UInt<1>
+    w <= UInt<1>("h1")
+    out <= w
+    inst MyView_companion of MyView_companion
+
+  module PortDelete :
+    output out : UInt<1>
+
+    inst dut of DUT
+    out <= dut.out
+
+; Assert that the DUT has no ports in Verilog.  This ensures that even though
+; wire "w" is part of a Grand Central View, it does not block optimizations.
+; The constant one is allowed to flow through w and out of the design which
+; makes the output port "out" on the DUT capable of being deleted.
+;
+; CHECK-LABEL: module DUT();

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -236,7 +236,7 @@ firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}]
 // members of the interface inside the parent.  Both port "a" and register
 // "r" should be annotated.
 // CHECK: firrtl.module @GCTInterface
-// CHECK-SAME: %a: !firrtl.uint<1> sym @a [
+// CHECK-SAME: %a: !firrtl.uint<1> [
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
 // CHECK-SAME:    d = [[ID_port]] : i64}
 // CHECK-SAME: annotations = [
@@ -245,6 +245,7 @@ firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}]
 // CHECK-SAME:    name = "view",
 // CHECK-SAME:    type = "parent"}]
 // CHECK: firrtl.reg
+// CHECK-NOT:  sym
 // CHECK-SAME: annotations
 // CHECK-SAME:   {circt.fieldID = 2 : i32,
 // CHECK-SAME:    class = "sifive.enterprise.grandcentral.AugmentedGroundType",
@@ -453,7 +454,8 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME: ]
 
 // CHECK-LABEL: firrtl.module private @InnerMod
-// CHECK-NEXT: %w = firrtl.wire sym @w
+// CHECK-NEXT: %w = firrtl.wire
+// CHECK-NOT:  sym
 // CHECK-SAME: annotations = [
 // CHECK-SAME:   {
 // CHECK-SAME:     circt.nonlocal = [[NLA]]
@@ -464,7 +466,8 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME: ]
 
 // CHECK: firrtl.module @GCTDataTap
-// CHECK-LABEL: firrtl.reg sym @r
+// CHECK-LABEL: firrtl.reg
+// CHECK-NOT:  sym
 // CHECk-SAME: annotations = [
 // CHECK-SAME:   {
 // CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source"
@@ -474,11 +477,8 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME: ]
 
 // CHECK-LABEL: firrtl.wire
+// CHECK-NOT:  sym
 // CHECK-SAME: annotations = [
-// CHECK-SAME:   {
-// CHECK-SAME:     circt.fieldID = 1
-// CHECK-SAME:     class = "firrtl.transforms.DontTouchAnnotation"
-// CHECK-SAME:   }
 // CHECK-SAME:   {
 // CHECK-SAME:     circt.fieldID = 1
 // CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source"


### PR DESCRIPTION
Modify both Grand Central (GCT) Views and Taps annotation lowering to
not add DontTouchAnnotations (inner symbols) to anything that is tapped.
This enables anything that is viewed/tapped to no longer block
optimizations, e.g., constant folding.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Note: I believe this is entirely safe to merge on its own as https://github.com/llvm/circt/commit/d7366a63c30cc436536198b2ac874bbc1e50d4eb makes it so that anything with an Annotation will not get deleted. I.e., adding the `DontTouchAnnotation` here is completely unnecessary.