### PR TITLE
[FIRParser] Handle annotations on instance ports properly.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2825,6 +2825,14 @@ ParseResult FIRStmtParser::parseInstance() {
       startTok.getLoc(), resultNamesAndTypes, moduleContext.targetsInModule);
 
   auto sym = getSymbolIfRequired(annotations.first, id);
+  // Also check for port annotations that may require adding a symbol
+  if (!sym)
+    for (auto portAnno : annotations.second.getAsRange<ArrayAttr>()) {
+      sym = getSymbolIfRequired(portAnno, id);
+      if (sym)
+        break;
+    }
+
   result = builder.create<InstanceOp>(
       referencedModule, id, inferNameKind(id), annotations.first.getValue(),
       annotations.second.getValue(), false, sym);

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -609,3 +609,25 @@ circuit RawAnnotations: %[[
     ; CHECK-SAME:      "circt.test"
     ; Check-SAME:      "circt.testNT"
     ; Check-SAME:      "circt.missing"
+
+
+; // -----
+
+; Test annotation targeting an instance port
+; https://github.com/llvm/circt/issues/3340
+circuit instportAnno: %[[
+  {"class":"hello","target":"~instportAnno|instportAnno/bar:Bar>baz.a"}
+]]
+  module Baz:
+    output a: UInt<1>
+    a is invalid
+
+  module Bar:
+    inst baz of Baz
+
+  module instportAnno:
+    inst bar of Bar
+
+; CHECK-LABEL: firrtl.circuit "instportAnno"
+; CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz]
+; CHECK:        %baz_a = firrtl.instance baz sym @baz interesting_name @Baz(out a: !firrtl.uint<1> [{circt.nonlocal = @[[HIER]], class = "hello"}])


### PR DESCRIPTION
These require adding a symbol to the instance,
if one isn't otherwise already warranted.

Fixes #3340.

This was addressed for memory ports in #2792.