### PR TITLE
[FIRRTL] GrandCentralTaps: Fix use-after-free

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -629,6 +629,7 @@ void GrandCentralTapsPass::runOnOperation() {
       for (auto *use : instancePaths.instanceGraph[extModule]->uses())
         use->getInstance().erase();
       extModule.erase();
+      continue;
     }
 
     // Go through the module ports and collect the annotated ones.


### PR DESCRIPTION
After erasing the operation, be sure to skip to next iteration.

Otherwise, the code below will try to use the free'd value.
(e.g., L636's invocation of getNumPorts)

Caught by sanitizer.