### PR TITLE
[Calyx] Fix stack-use-after-scope (pointer to freed stack)

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -510,7 +510,7 @@ public:
 
   /// Returns the component operation associated with the currently executing
   /// partial lowering.
-  calyx::ComponentOp *getComponent() const;
+  calyx::ComponentOp getComponent() const;
 
   // Returns the component state associated with the currently executing
   // partial lowering.
@@ -537,7 +537,7 @@ protected:
   DenseMap<mlir::func::FuncOp, calyx::ComponentOp> &functionMapping;
 
 private:
-  mutable ComponentOp *componentOp = nullptr;
+  mutable ComponentOp componentOp;
   mutable ComponentLoweringStateInterface *componentLoweringState = nullptr;
   ProgramLoweringState &programLoweringState;
 };

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -400,17 +400,16 @@ FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp funcOp,
   // Initialize the component op references if a calyx::ComponentOp has been
   // created for the matched funcOp.
   if (auto it = functionMapping.find(funcOp); it != functionMapping.end()) {
-    calyx::ComponentOp op = it->second;
-    componentOp = &op;
+    componentOp = it->second;
     componentLoweringState =
-        programLoweringState.getState<ComponentLoweringStateInterface>(op);
+        programLoweringState.getState<ComponentLoweringStateInterface>(componentOp);
   }
 
   return partiallyLowerFuncToComp(funcOp, rewriter);
 }
 
-calyx::ComponentOp *FuncOpPartialLoweringPattern::getComponent() const {
-  assert(componentOp != nullptr &&
+calyx::ComponentOp FuncOpPartialLoweringPattern::getComponent() const {
+  assert(componentOp &&
          "Component operation should be set during pattern construction");
   return componentOp;
 }
@@ -651,7 +650,7 @@ BuildBasicBlockRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
       unsigned width = argType.getIntOrFloatBitWidth();
       std::string index = std::to_string(arg.index());
       std::string name = programState().blockName(block) + "_arg" + index;
-      auto reg = createRegister(arg.value().getLoc(), rewriter, *getComponent(),
+      auto reg = createRegister(arg.value().getLoc(), rewriter, getComponent(),
                                 width, name);
       getState().addBlockArgReg(block, reg, arg.index());
       arg.value().replaceAllUsesWith(reg.out());
@@ -674,14 +673,14 @@ BuildReturnRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
     unsigned width = convArgType.getIntOrFloatBitWidth();
     std::string name = "ret_arg" + std::to_string(argType.index());
     auto reg =
-        createRegister(funcOp.getLoc(), rewriter, *getComponent(), width, name);
+        createRegister(funcOp.getLoc(), rewriter, getComponent(), width, name);
     getState().addReturnReg(reg, argType.index());
 
-    rewriter.setInsertionPointToStart(getComponent()->getWiresOp().getBody());
+    rewriter.setInsertionPointToStart(getComponent().getWiresOp().getBody());
     rewriter.create<calyx::AssignOp>(
         funcOp->getLoc(),
         calyx::getComponentOutput(
-            *getComponent(),
+            getComponent(),
             getState().getFuncOpResultMapping(argType.index())),
         reg.out());
   }

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -402,7 +402,8 @@ FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp funcOp,
   if (auto it = functionMapping.find(funcOp); it != functionMapping.end()) {
     componentOp = it->second;
     componentLoweringState =
-        programLoweringState.getState<ComponentLoweringStateInterface>(componentOp);
+        programLoweringState.getState<ComponentLoweringStateInterface>(
+            componentOp);
   }
 
   return partiallyLowerFuncToComp(funcOp, rewriter);
@@ -680,8 +681,7 @@ BuildReturnRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
     rewriter.create<calyx::AssignOp>(
         funcOp->getLoc(),
         calyx::getComponentOutput(
-            getComponent(),
-            getState().getFuncOpResultMapping(argType.index())),
+            getComponent(), getState().getFuncOpResultMapping(argType.index())),
         reg.out());
   }
   return success();


### PR DESCRIPTION
Encountered crashes running various Calyx tests, this fixes the problem.

cc #3235 .

Sanitizers helped track down the cause.