### PR TITLE
[LowerToHW] Generalize handling of non-FIRRTL ops

### DIFF
--- a/test/Conversion/FIRRTLToHW/errors.mlir
+++ b/test/Conversion/FIRRTLToHW/errors.mlir
@@ -15,7 +15,8 @@
 // COM: This is a memory with aggregates which is currently not supported.
 firrtl.circuit "Div" {
   firrtl.module @Div(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
-  // expected-error @+1 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
+    // expected-error @+2 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
+    // expected-error @+1 {{'firrtl.mem' op LowerToHW couldn't handle this operation}}
     %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: bundle<id: uint<4>, other: sint<8>>>, !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>
   }
 }
@@ -34,7 +35,8 @@ firrtl.circuit "Div" {
 // COM: This is an aggregate memory which is not supported.
 firrtl.circuit "MemOne" {
   firrtl.module @MemOne() {
-  // expected-error @+1 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
+    // expected-error @+2 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
+    // expected-error @+1 {{'firrtl.mem' op LowerToHW couldn't handle this operation}}
     %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: bundle<id: uint<4>, other: sint<8>>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1656,7 +1656,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @eliminateSingleOutputConnects(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     firrtl.strictconnect %b, %a : !firrtl.uint<1>
   }
-  
+
   // Check that modules with comments are lowered.
   // CHECK-LABEL: hw.module private @Commented() attributes {
   // CHECK-SAME:      comment = "this module is commented"
@@ -1664,4 +1664,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @Commented() attributes {
       comment = "this module is commented"
   } {}
+
+  // CHECK-LABEL: hw.module @preLoweredOps
+  firrtl.module @preLoweredOps() {
+    // CHECK-NEXT: %0 = builtin.unrealized_conversion_cast to f32
+    // CHECK-NEXT: %1 = arith.addf %0, %0 : f32
+    // CHECK-NEXT: builtin.unrealized_conversion_cast %1 : f32 to index
+    %0 = builtin.unrealized_conversion_cast to f32
+    %1 = arith.addf %0, %0 : f32
+    builtin.unrealized_conversion_cast %1 : f32 to index
+  }
 }


### PR DESCRIPTION
Adjust `FIRRTLLowering::handleUnloweredOp` to apply a consistent lowering to operations from dialects other than FIRRTL. This used to be a very specific snippet of code that allowed `hw.output` and the `unrealized_conversion_cast` inserted after block args to be passed through.

With this change, `handleUnloweredOp` will check if an operation comes from outside of FIRRTL. If it does we replace all operands with a potentially lowered value, and record the results as identity lowerings. As a result, we no longer have to have special treatment of the `unrealized_conversion_cast` inserted after block args.

This is a first step towards foreign type support, and will cause `LowerToHW` to do the right thing for operations from other dialects that are present in the module (operand updating and recording of the op as already lowered).

As an implementation detail, this requires adjusting `getPossiblyInoutLoweredValue` to always consider block args as already lowered, and making `setLowering` accept non-FIRRTL values. The latter still asserts that the lowering is sane in case the pre-lowering value has a FIRRTL type, but it admits non-FIRRTL pre-lowering values and requires them to have a non-null lowering.