### PR TITLE
[FIRRTL] Fix mutate-while-iterate bug in Dedup

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1167,9 +1167,10 @@ class DedupPass : public DedupBase<DedupPass> {
     DenseMap<Attribute, StringAttr> dedupMap;
 
     // We must iterate the modules from the bottom up so that we can properly
-    // deduplicate the modules. We have to store the visit order first so that
-    // we can safely delete nodes as we go from the instance graph.
-    for (auto *node : llvm::post_order(&instanceGraph)) {
+    // deduplicate the modules. We use early increment so we can safely delete
+    // nodes from the instance graph as we iterate through it.
+    for (auto *node :
+         llvm::make_early_inc_range(llvm::post_order(&instanceGraph))) {
       auto module = cast<FModuleLike>(*node->getModule());
       auto moduleName = module.moduleNameAttr();
       // If the module is marked with NoDedup, just skip it.

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -496,3 +496,15 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
     firrtl.instance simple1 @Simple1()
   }
 }
+
+// Check that the following doesn't crash.
+// https://github.com/llvm/circt/issues/3360
+firrtl.circuit "Foo"  {
+  firrtl.module private @X() { }
+  firrtl.module private @Y() { }
+  firrtl.module @Foo() {
+    firrtl.instance x0 @X()
+    firrtl.instance y0 @Y()
+    firrtl.instance y1 @Y()
+  }
+}


### PR DESCRIPTION
For some designs, the DedupPass would cause a segmentation fault, since
it removes elements from the `instanceGraph` while iterating over it.
Using `make_early_inc_range` makes this mutate-while-iterate operation
safe.

Fixes #3360.