### PR TITLE
[FIRRTL] rework innerref verification, starting with HierPathOp.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -64,11 +65,74 @@ struct PortInfo {
 /// Verification hook for verifying module like operations.
 LogicalResult verifyModuleLikeOpInterface(FModuleLike module);
 
-class InnerSymbolTable {
+namespace detail {
+LogicalResult verifyInnerRefs(Operation *op);
+} // namespace detail
 
+/// A table of inner symbols and their resolutions.
+class InnerSymbolTable {
 public:
   /// Return the name of the attribute used for inner symbol names.
   static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
+
+  /// Build an inner symbol table for the given operation.  The operation must
+  /// have the InnerSymbolTable trait.
+  explicit InnerSymbolTable(Operation *op);
+
+  /// Look up a symbol with the specified name, returning null if no such
+  /// name exists. Names never include the @ on them.
+  Operation *lookup(StringRef name) const;
+  template <typename T>
+  T lookup(StringRef name) const {
+    return dyn_cast_or_null<T>(lookup(name));
+  }
+
+  /// Look up a symbol with the specified name, returning null if no such
+  /// name exists. Names never include the @ on them.
+  Operation *lookup(StringAttr name) const;
+  template <typename T>
+  T lookup(StringAttr name) const {
+    return dyn_cast_or_null<T>(lookup(name));
+  }
+
+private:
+  /// This is the operation this table is constructed for, which must have the
+  /// InnerSymbolTable trait.
+  Operation *innerSymTblOp;
+
+  /// This maps names to operations with that inner symbol.
+  DenseMap<StringAttr, Operation *> symbolTable;
+};
+
+/// This class represents a collection of InnerSymbolTable's.
+class InnerSymbolTableCollection {
+public:
+  /// Get or create the InnerSymbolTable for the specified operation.
+  InnerSymbolTable &getInnerSymbolTable(Operation *op);
+
+  /// Populate tables in parallel for all InnerSymbolTable operations in the
+  /// given InnerRefNamespace operation.
+  void populateTables(Operation *innerRefNSOp);
+
+private:
+  /// This maps Operations to their InnnerSymbolTable's.
+  DenseMap<Operation *, std::unique_ptr<InnerSymbolTable>> symbolTables;
+};
+
+/// This class represents the namespace in which InnerRef's can be resolved.
+struct InnerRefNamespace {
+  SymbolTable &symTable;
+  InnerSymbolTableCollection &innerSymTables;
+
+  /// Resolve the InnerRef to its target within this namespace, returning null
+  /// if no such name exists.
+  ///
+  /// Note that some InnerRef's target ports and must be handled separately.
+  Operation *lookup(hw::InnerRefAttr inner);
+  template <typename T>
+  T lookup(hw::InnerRefAttr inner) {
+    return dyn_cast_or_null<T>(lookup(inner));
+  }
 };
 
 } // namespace firrtl
@@ -76,10 +140,51 @@ public:
 
 namespace mlir {
 namespace OpTrait {
+
+/// This trait is for operations that define a scope for resolving InnerRef's,
+/// and provides verification for InnerRef users (via InnerRefUserOpInterface).
+template <typename ConcreteType>
+class InnerRefNamespace : public TraitBase<ConcreteType, InnerRefNamespace> {
+public:
+  static LogicalResult verifyRegionTrait(Operation *op) {
+    static_assert(
+        ConcreteType::template hasTrait<::mlir::OpTrait::SymbolTable>(),
+        "expected operation to be a SymbolTable");
+
+    if (op->getNumRegions() != 1)
+      return op->emitError("expected operation to have a single region");
+    if (!op->getRegion(0).hasOneBlock())
+      return op->emitError("expected operation to have a single block");
+
+    // Verify all InnerRef users.
+    return ::circt::firrtl::detail::verifyInnerRefs(op);
+  }
+};
+
+/// A trait for inner symbol table functionality on an operation.
 template <typename ConcreteType>
 class InnerSymbolTable : public TraitBase<ConcreteType, InnerSymbolTable> {
 public:
-  static LogicalResult verifyRegionTrait(Operation *op) { return success(); }
+  static LogicalResult verifyRegionTrait(Operation *op) {
+    // Insist that ops with InnerSymbolTable's provide a Symbol, this is
+    // essential to how InnerRef's work.
+    static_assert(
+        ConcreteType::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
+        "expected operation to define a Symbol");
+
+    if (op->getNumRegions() != 1)
+      return op->emitError("expected operation to have a single region");
+    if (!op->getRegion(0).hasOneBlock())
+      return op->emitError("expected operation to have a single block");
+
+    // InnerSymbolTable's must be directly nested within an InnerRefNamespace.
+    auto *parent = op->getParentOp();
+    if (!parent || !parent->hasTrait<InnerRefNamespace>())
+      return op->emitError(
+          "InnerSymbolTable must have InnerRefNamespace parent");
+
+    return success();
+  }
 };
 } // namespace OpTrait
 } // namespace mlir

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -277,6 +277,8 @@ def FConnectLike : OpInterface<"FConnectLike"> {
   ];
 }
 
+def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;
+
 def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   let description = [{
     This interface describes an operation that may define an
@@ -338,6 +340,23 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
 }
 
 def InnerSymbolTable : NativeOpTrait<"InnerSymbolTable">;
+
+def InnerRefUserOpInterface : OpInterface<"InnerRefUserOpInterface"> {
+  let description = [{
+    This interface describes an operation that may use a `InnerRef`. This
+    interface allows for users of inner symbols to hook into verification and
+    other inner symbol related utilities that are either costly or otherwise
+    disallowed within a traditional operation.
+  }];
+  let cppNamespace = "::circt::firrtl";
+
+  let methods = [
+    InterfaceMethod<"Verify the inner ref uses held by this operation.",
+      "::mlir::LogicalResult", "verifyInnerRefs",
+      (ins "::circt::firrtl::InnerRefNamespace&":$ns)
+    >,
+  ];
+}
 
 def FNamableOp : OpInterface<"FNamableOp"> {
   let cppNamespace = "circt::firrtl";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -15,7 +15,7 @@ include "circt/Types.td"
 
 def CircuitOp : FIRRTLOp<"circuit",
       [IsolatedFromAbove, SymbolTable, SingleBlock, NoTerminator,
-       NoRegionArguments]> {
+       NoRegionArguments, InnerRefNamespace]> {
   let summary = "FIRRTL Circuit";
   let description = [{
     The "firrtl.circuit" operation represents an overall Verilog circuit,
@@ -191,7 +191,7 @@ def FMemModuleOp : FIRRTLOp<"memmodule",
 
 def HierPathOp : FIRRTLOp<"hierpath",
       [IsolatedFromAbove, Symbol,
-       DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+       DeclareOpInterfaceMethods<InnerRefUserOpInterface>,
        HasParent<"CircuitOp">]> {
   let summary = "Hierarchical path specification";
   let description = [{

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   FIRRTLOps.cpp
   FIRRTLTypes.cpp
   FIRRTLUtils.cpp
+  InnerSymbolTable.cpp
   NLATable.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -1,0 +1,129 @@
+//===- InnerSymbolTable.cpp - InnerSymbolTable and InnerRef verification --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements InnerSymbolTable and verification for InnerRef's.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
+#include "mlir/IR/Threading.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace circt {
+namespace firrtl {
+
+//===----------------------------------------------------------------------===//
+// InnerSymbolTable
+//===----------------------------------------------------------------------===//
+
+InnerSymbolTable::InnerSymbolTable(Operation *op) {
+  assert(op->hasTrait<OpTrait::InnerSymbolTable>() &&
+         "expected operation to have InnerSymbolTable trait");
+  // Save the operation this table is for.
+  this->innerSymTblOp = op;
+
+  // Walk the operation and add InnerSymbol's to the table.
+  StringAttr innerSymId = StringAttr::get(
+      op->getContext(), InnerSymbolTable::getInnerSymbolAttrName());
+  op->walk([&](Operation *symOp) {
+    auto attr = symOp->getAttrOfType<StringAttr>(innerSymId);
+    if (!attr)
+      return;
+    auto it = symbolTable.insert({attr, symOp});
+    (void)it;
+    assert(it.second && "repeated symbol found");
+  });
+}
+
+/// Look up a symbol with the specified name, returning null if no such name
+/// exists. Names never include the @ on them.
+Operation *InnerSymbolTable::lookup(StringRef name) const {
+  return lookup(StringAttr::get(innerSymTblOp->getContext(), name));
+}
+Operation *InnerSymbolTable::lookup(StringAttr name) const {
+  return symbolTable.lookup(name);
+}
+
+//===----------------------------------------------------------------------===//
+// InnerSymbolTableCollection
+//===----------------------------------------------------------------------===//
+
+InnerSymbolTable &
+InnerSymbolTableCollection::getInnerSymbolTable(Operation *op) {
+  auto it = symbolTables.try_emplace(op, nullptr);
+  if (it.second)
+    it.first->second = ::std::make_unique<InnerSymbolTable>(op);
+  return *it.first->second;
+}
+
+void InnerSymbolTableCollection::populateTables(Operation *innerRefNSOp) {
+  // Gather top-level operations.
+  SmallVector<Operation *> childOps(
+      llvm::make_pointer_range(innerRefNSOp->getRegion(0).front()));
+
+  // Filter these to those that have the InnerSymbolTable trait.
+  SmallVector<Operation *> innerSymTableOps(
+      llvm::make_filter_range(childOps, [&](Operation *op) {
+        return op->hasTrait<OpTrait::InnerSymbolTable>();
+      }));
+
+  // Ensure entries exist for each operation.
+  llvm::for_each(innerSymTableOps,
+                 [&](auto *op) { symbolTables.try_emplace(op, nullptr); });
+
+  // Construct the tables in parallel (if context allows it).
+  mlir::parallelForEach(
+      innerRefNSOp->getContext(), innerSymTableOps, [&](auto *op) {
+        auto it = symbolTables.find(op);
+        assert(it != symbolTables.end());
+        if (!it->second)
+          it->second = ::std::make_unique<InnerSymbolTable>(op);
+      });
+}
+
+//===----------------------------------------------------------------------===//
+// InnerRefNamespace
+//===----------------------------------------------------------------------===//
+
+Operation *InnerRefNamespace::lookup(hw::InnerRefAttr inner) {
+  auto *mod = symTable.lookup(inner.getModule());
+  assert(mod->hasTrait<mlir::OpTrait::InnerSymbolTable>());
+  return innerSymTables.getInnerSymbolTable(mod).lookup(inner.getName());
+}
+
+//===----------------------------------------------------------------------===//
+// InnerRef verification
+//===----------------------------------------------------------------------===//
+
+namespace detail {
+
+LogicalResult verifyInnerRefs(Operation *op) {
+  // Construct the symbol tables.
+  InnerSymbolTableCollection innerSymTables;
+  SymbolTable symbolTable(op);
+  InnerRefNamespace ns{symbolTable, innerSymTables};
+  innerSymTables.populateTables(op);
+
+  // Conduct parallel walks of the top-level children of this
+  // InnerRefNamespace, verifying all InnerRefUserOp's discovered within.
+  auto verifySymbolUserFn = [&](Operation *op) -> WalkResult {
+    if (auto user = dyn_cast<InnerRefUserOpInterface>(op))
+      return WalkResult(user.verifyInnerRefs(ns));
+    return WalkResult::advance();
+  };
+  return mlir::failableParallelForEach(
+      op->getContext(), op->getRegion(0).front(), [&](auto &op) {
+        return success(!op.walk(verifySymbolUserFn).wasInterrupted());
+      });
+}
+
+} // namespace detail
+} // namespace firrtl
+} // namespace circt


### PR DESCRIPTION
## Introduction

InnerRef's are expensive to verify presently, as the InnerSymbol
portion requires walking the target operation (FModuleLike).

HierPathOps are chains of these, and so were especially
problematic in this regard.

This is a similar problem to verifying Symbol (SymbolTable) users,
and is solved in a similar way.

## Overview

The primary components of the new approach:

**1. Drive verification from the top of InnerRef resolution scope**

Only walk the relevant IR once, parallelizing where makes sense.

**2. Introduce an interface for verifying InnerRef's**

Operations using InnerRef's can implement the interface
to opt-in to this new verification.

## Details

For (1), a new trait "InnerRefNamespace" is added to mark Operations
in which InnerRef's are resolved.  For now this is only added to CircuitOp.

For (2), introduce "InnerRefUserOpInterface" with a "verifyInnerRefs"
method, similar to SymbolOpUserInterface and verifySymbolUses.
Operations using InnerRef's should prefer this interface, at least for
purposes of verification: since `verifyInnerRefs` also provides the operation
with a SymbolTable, all the same verification done in `verifySymbolUses` can be
done together with verification involving resolving the InnerSymbol's.
(There's no need for a SymbolTableCollection within an InnerRefNamespace,
as there's only one SymbolTable, at the top level.)

In addition, InnerSymbolTable is fleshed out a bit so that it can be
used for basic lookups of InnerSymbols, and "InnerSymbolTableCollection"
is added that serves a similar purpose as SymbolTableCollection.
InnerRefNamespace is also a class (as well as the trait) that combines a
SymbolTable and the InnerSymbolTableCollection, for convenient access to both
in "verifyInnerRefs".

Some structural requirements are now explicitly checked.