### PR TITLE
[FIRRTL] Fix double spaces after NameKind printer, NFC

### DIFF
--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -104,7 +104,7 @@ static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
   if (attr.getValue() != NameKindEnum::DroppableName)
-    p << stringifyNameKindEnum(attr.getValue()) << ' ';
+    p << stringifyNameKindEnum(attr.getValue());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3328,7 +3328,7 @@ static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
   if (attr.getValue() != NameKindEnum::DroppableName)
-    p << stringifyNameKindEnum(attr.getValue()) << ' ';
+    p << stringifyNameKindEnum(attr.getValue());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This fixes double-space emission after namekind.
```
circuit top:
  module top:
    input in: UInt<1>
    node a = in
```
```mlir
firrtl.module @top(in %in: !firrtl.uint<1>) {
  %a = firrtl.node interesting_name %in  : !firrtl.uint<1>
}
```

There are still double-space after `%in` but this is different issue. 