### PR TITLE
[PrepareForEmission] Add a pass to run only PrepareForEmission

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -18,6 +18,8 @@
 
 namespace circt {
 
+std::unique_ptr<mlir::Pass> createPrepareForEmissionPass();
+
 std::unique_ptr<mlir::Pass> createExportVerilogPass(llvm::raw_ostream &os);
 std::unique_ptr<mlir::Pass> createExportVerilogPass();
 

--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -18,7 +18,7 @@
 
 namespace circt {
 
-std::unique_ptr<mlir::Pass> createPrepareForEmissionPass();
+std::unique_ptr<mlir::Pass> createTestPrepareForEmissionPass();
 
 std::unique_ptr<mlir::Pass> createExportVerilogPass(llvm::raw_ostream &os);
 std::unique_ptr<mlir::Pass> createExportVerilogPass();

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -41,6 +41,20 @@ def AffineToStaticLogic : Pass<"convert-affine-to-staticlogic", "mlir::func::Fun
 // ExportVerilog and ExportSplitVerilog
 //===----------------------------------------------------------------------===//
 
+def PrepareForEmission : Pass<"prepare-for-emission", "mlir::ModuleOp"> {
+  let summary = "Prepare IR for ExportVerilog";
+  let description = [{
+    This pass runs only PrepareForEmission logic for testing purpose.
+    It is not necessary for users to run this pass explicitly since
+    ExportVerilog internally runs PrepareForEmission.
+  }];
+
+  let constructor = "createPrepareForEmissionPass()";
+  let dependentDialects = [
+    "circt::sv::SVDialect", "circt::comb::CombDialect", "circt::hw::HWDialect"
+  ];
+}
+
 def ExportVerilog : Pass<"export-verilog", "mlir::ModuleOp"> {
   let summary = "Emit the IR to a (System)Verilog file";
   let description = [{

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -41,7 +41,7 @@ def AffineToStaticLogic : Pass<"convert-affine-to-staticlogic", "mlir::func::Fun
 // ExportVerilog and ExportSplitVerilog
 //===----------------------------------------------------------------------===//
 
-def PrepareForEmission : Pass<"prepare-for-emission", "mlir::ModuleOp"> {
+def PrepareForEmission : Pass<"prepare-for-emission", "hw::HWModuleOp"> {
   let summary = "Prepare IR for ExportVerilog";
   let description = [{
     This pass runs only PrepareForEmission logic for testing purpose.

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -41,7 +41,7 @@ def AffineToStaticLogic : Pass<"convert-affine-to-staticlogic", "mlir::func::Fun
 // ExportVerilog and ExportSplitVerilog
 //===----------------------------------------------------------------------===//
 
-def PrepareForEmission : Pass<"prepare-for-emission", "hw::HWModuleOp"> {
+def PrepareForEmission : Pass<"test-prepare-for-emission", "hw::HWModuleOp"> {
   let summary = "Prepare IR for ExportVerilog";
   let description = [{
     This pass runs only PrepareForEmission logic for testing purpose.
@@ -49,7 +49,7 @@ def PrepareForEmission : Pass<"prepare-for-emission", "hw::HWModuleOp"> {
     ExportVerilog internally runs PrepareForEmission.
   }];
 
-  let constructor = "createPrepareForEmissionPass()";
+  let constructor = "createTestPrepareForEmissionPass()";
   let dependentDialects = [
     "circt::sv::SVDialect", "circt::comb::CombDialect", "circt::hw::HWDialect"
   ];

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -41,7 +41,8 @@ def AffineToStaticLogic : Pass<"convert-affine-to-staticlogic", "mlir::func::Fun
 // ExportVerilog and ExportSplitVerilog
 //===----------------------------------------------------------------------===//
 
-def PrepareForEmission : Pass<"test-prepare-for-emission", "hw::HWModuleOp"> {
+def TestPrepareForEmission : Pass<"test-prepare-for-emission",
+                                  "hw::HWModuleOp"> {
   let summary = "Prepare IR for ExportVerilog";
   let description = [{
     This pass runs only PrepareForEmission logic for testing purpose.

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -123,6 +123,12 @@ void registerLoweringCLOptions();
 /// Apply any command line specified style options to the mlir module.
 void applyLoweringCLOptions(ModuleOp module);
 
+/// Get a lowering option from CLI option or module op. This function first
+/// tries constructing a lowering option from cli, and if it failed, lowering
+/// option associated with `module` is used. This function doesn't change an
+/// attribute of `module` op so that it can be used by
+LoweringOptions getLoweringCLIOption(ModuleOp module,
+                                     LoweringOptions::ErrorHandlerT);
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_LOWERINGOPTIONS_H

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -126,7 +126,8 @@ void applyLoweringCLOptions(ModuleOp module);
 /// Get a lowering option from CLI option or module op. This function first
 /// tries constructing a lowering option from cli, and if it failed, lowering
 /// option associated with `module` is used. This function doesn't change an
-/// attribute of `module` op so that it can be used by
+/// attribute of `module` so that it can be used by child operations of
+/// mlir::ModuleOp in multi-threading environment.
 LoweringOptions getLoweringCLIOption(ModuleOp module,
                                      LoweringOptions::ErrorHandlerT);
 } // namespace circt

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -676,9 +676,9 @@ void ExportVerilog::prepareHWModule(Block &block,
 
 namespace {
 
-struct PrepareForEmissionPass
-    : public PrepareForEmissionBase<PrepareForEmissionPass> {
-  PrepareForEmissionPass() {}
+struct TestPrepareForEmissionPass
+    : public PrepareForEmissionBase<TestPrepareForEmissionPass> {
+  TestPrepareForEmissionPass() {}
   void runOnOperation() override {
     HWModuleOp module = getOperation();
     LoweringOptions options = getLoweringCLIOption(
@@ -689,6 +689,6 @@ struct PrepareForEmissionPass
 };
 } // end anonymous namespace
 
-std::unique_ptr<mlir::Pass> circt::createPrepareForEmissionPass() {
-  return std::make_unique<PrepareForEmissionPass>();
+std::unique_ptr<mlir::Pass> circt::createTestPrepareForEmissionPass() {
+  return std::make_unique<TestPrepareForEmissionPass>();
 }

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -677,7 +677,7 @@ void ExportVerilog::prepareHWModule(Block &block,
 namespace {
 
 struct TestPrepareForEmissionPass
-    : public PrepareForEmissionBase<TestPrepareForEmissionPass> {
+    : public TestPrepareForEmissionBase<TestPrepareForEmissionPass> {
   TestPrepareForEmissionPass() {}
   void runOnOperation() override {
     HWModuleOp module = getOperation();

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -23,7 +23,6 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
-#include "mlir/IR/Threading.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -678,7 +678,8 @@ namespace {
 
 struct PrepareForEmissionPass
     : public PrepareForEmissionBase<PrepareForEmissionPass> {
-  PrepareForEmissionPass() {} void runOnOperation() override {
+  PrepareForEmissionPass() {}
+  void runOnOperation() override {
     HWModuleOp module = getOperation();
     LoweringOptions options = getLoweringCLIOption(
         cast<mlir::ModuleOp>(module->getParentOp()),

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -678,19 +678,12 @@ namespace {
 
 struct PrepareForEmissionPass
     : public PrepareForEmissionBase<PrepareForEmissionPass> {
-  PrepareForEmissionPass() {}
-  void runOnOperation() override {
-    auto module = getOperation();
-    // Make sure LoweringOptions are applied to the module if it was overridden
-    // on the command line.
-    // TODO: This should be moved up to circt-opt and circt-translate.
-    applyLoweringCLOptions(module);
-    LoweringOptions options(module);
-
-    parallelForEach(module->getContext(), module.getOps<HWModuleOp>(),
-                    [&](HWModuleOp hwmodule) {
-                      prepareHWModule(*hwmodule.getBodyBlock(), options);
-                    });
+  PrepareForEmissionPass() {} void runOnOperation() override {
+    HWModuleOp module = getOperation();
+    LoweringOptions options = getLoweringCLIOption(
+        cast<mlir::ModuleOp>(module->getParentOp()),
+        [&](llvm::Twine twine) { module.emitError(twine); });
+    prepareHWModule(*module.getBodyBlock(), options);
   }
 };
 } // end anonymous namespace

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -204,3 +204,19 @@ void circt::applyLoweringCLOptions(ModuleOp module) {
     clOptions->loweringOptions.setAsAttribute(module);
   }
 }
+
+LoweringOptions
+circt::getLoweringCLIOption(mlir::ModuleOp module,
+                            LoweringOptions::ErrorHandlerT errorHandler) {
+  // If the command line options were not registered in the first place, use the
+  // lowering option associated with module op.
+  if (!clOptions.isConstructed() ||
+      !clOptions->loweringOptions.getNumOccurrences()) {
+    if (auto styleAttr = LoweringOptions::getAttributeFrom(module))
+      return LoweringOptions(styleAttr, errorHandler);
+    // If the module doesn't have a lowering option, then use the default value.
+    return LoweringOptions();
+  }
+
+  return clOptions->loweringOptions.getValue();
+}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1,5 +1,4 @@
 // RUN: circt-opt %s -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s --strict-whitespace
-// RUN: circt-opt %s -export-verilog -o %t.mlir && cat %t.mlir | FileCheck %s --check-prefix=IR
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)
@@ -704,15 +703,6 @@ hw.module @instance_result_reuse_wires() -> (b: i3) {
   sv.assign %some_wire, %out1 : i3
 
   hw.output %read : i3
-}
-
-// IR: @namehint_variadic
-hw.module @namehint_variadic(%a: i3) -> (b: i3) {
-  // IR-NEXT: %0 = comb.add %a, %a : i3
-  // IR-NEXT: %1 = comb.add %a, %0 {sv.namehint = "bar"} : i3
-  // IR-NEXT: hw.output %1
-  %0 = comb.add %a, %a, %a { sv.namehint = "bar" } : i3
-  hw.output %0 : i3
 }
 
 hw.module.extern @ExternDestMod(%a: i1, %b: i2) -> (c: i3, d: i4)

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -prepare-for-emission | FileCheck %s
+// RUN: circt-opt %s -prepare-for-emission --split-input-file | FileCheck %s
 
 // CHECK: @namehint_variadic
 hw.module @namehint_variadic(%a: i3) -> (b: i3) {
@@ -7,4 +7,20 @@ hw.module @namehint_variadic(%a: i3) -> (b: i3) {
   // CHECK-NEXT: hw.output %1
   %0 = comb.add %a, %a, %a { sv.namehint = "bar" } : i3
   hw.output %0 : i3
+}
+
+// -----
+
+module attributes {circt.loweringOptions = "disallowLocalVariables"} {
+  // CHECK: @test_hoist
+  hw.module @test_hoist(%a: i3) -> () {
+    // CHECK-NEXT: %reg = sv.reg
+    %reg = sv.reg : !hw.inout<i3>
+    // CHECK-NEXT: %0 = comb.add
+    // CHECK-NEXT: sv.initial
+    sv.initial {
+      %0 = comb.add %a, %a : i3
+      sv.passign %reg, %0 : i3
+    }
+  }
 }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt %s -prepare-for-emission | FileCheck %s
+
+// CHECK: @namehint_variadic
+hw.module @namehint_variadic(%a: i3) -> (b: i3) {
+  // CHECK-NEXT: %0 = comb.add %a, %a : i3
+  // CHECK-NEXT: %1 = comb.add %a, %0 {sv.namehint = "bar"} : i3
+  // CHECK-NEXT: hw.output %1
+  %0 = comb.add %a, %a, %a { sv.namehint = "bar" } : i3
+  hw.output %0 : i3
+}

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -prepare-for-emission --split-input-file | FileCheck %s
+// RUN: circt-opt %s -test-prepare-for-emission --split-input-file | FileCheck %s
 
 // CHECK: @namehint_variadic
 hw.module @namehint_variadic(%a: i3) -> (b: i3) {


### PR DESCRIPTION
This PR adds a pass to run only PrepareForEmission for testing purpose. Currently prepare is tested as integration tests with 
ExportVerilog. However, considering that PrepareForEmission performs a lot of IR mutations to legalize IRs, it would be more comfortable to test IR mutations to make ExportVerilog less monolithic. 