### PR TITLE
[FIRRTL] LowerAnnnos: Add a few statistics

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -30,6 +30,16 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
       "Ignore unknown annotations.">
   ];
   let dependentDialects = ["hw::HWDialect"];
+  let statistics = [
+    Statistic<"numRawAnnotations", "num-raw-annos",
+      "Number of raw annotations on circuit">,
+    Statistic<"numAddedAnnos", "num-added-annos",
+       "Number of additional annotations">,
+    Statistic<"numAnnos", "num-annos",
+       "Total number of annotations processed">,
+    Statistic<"numUnhandled", "num-unhandled-annos",
+      "Number of unhandled annotations">,
+  ];
 }
 
 def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -357,10 +357,16 @@ LogicalResult LowerAnnotationsPass::applyAnnotation(DictionaryAttr anno,
     return state.circuit.emitError("Annotation without a class: ") << anno;
 
   // See if we handle the class
-  auto *record = getAnnotationHandler(annoClassVal, ignoreUnhandledAnno);
-  if (!record)
-    return mlir::emitWarning(state.circuit.getLoc())
-           << "Unhandled annotation: " << anno;
+  auto *record = getAnnotationHandler(annoClassVal, false);
+  if (!record) {
+    ++numUnhandled;
+    if (!ignoreUnhandledAnno)
+      return state.circuit->emitWarning("Unhandled annotation: ") << anno;
+
+    // Try again, requesting the fallback handler.
+    record = getAnnotationHandler(annoClassVal, ignoreUnhandledAnno);
+    assert(record);
+  }
 
   // Try to apply the annotation
   auto target = record->resolver(anno, state);
@@ -395,8 +401,11 @@ void LowerAnnotationsPass::runOnOperation() {
   // Grab the annotations.
   for (auto anno : annotations)
     worklistAttrs.push_back(anno.cast<DictionaryAttr>());
+
   size_t numFailures = 0;
+  size_t numAdded = 0;
   auto addToWorklist = [&](DictionaryAttr anno) {
+    ++numAdded;
     worklistAttrs.push_back(anno);
   };
   ApplyState state{circuit, modules, addToWorklist};
@@ -406,6 +415,12 @@ void LowerAnnotationsPass::runOnOperation() {
     if (applyAnnotation(attr, state).failed())
       ++numFailures;
   }
+
+  // Update statistics
+  numRawAnnotations += annotations.size();
+  numAddedAnnos += numAdded;
+  numAnnos += numAdded + annotations.size();
+
   if (numFailures)
     signalPassFailure();
 }


### PR DESCRIPTION
Add statistics for

1. number of raw annotations processed
2. number of additional annotations processed
3. number of unhandled annotations (included in above counts)
4. total number of annotations (=1+2)

Preserve implementation and interface to annotation handling registry.