### PR TITLE
[FSM] Remove statetype from MachineOp

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -24,14 +24,13 @@ def MachineOp : FSMOp<"machine", [FunctionOpInterface,
     includes a `$body` region that contains internal variables and states.
   }];
 
-  let arguments = (ins StrAttr:$sym_name, TypeAttr:$stateType,
-                       StrAttr:$initialState,
+  let arguments = (ins StrAttr:$sym_name, StrAttr:$initialState,
                        TypeAttrOf<FunctionType>:$function_type);
   let regions = (region SizedRegion<1>:$body);
 
   let builders = [
     OpBuilder<(ins "StringRef":$name, "StringRef":$initialState,
-      "Type":$stateType, "FunctionType":$function_type,
+      "FunctionType":$function_type,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
       CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)>
   ];

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -23,12 +23,11 @@ using namespace fsm;
 //===----------------------------------------------------------------------===//
 
 void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
-                      StringRef initialStateName, Type stateType,
-                      FunctionType type, ArrayRef<NamedAttribute> attrs,
+                      StringRef initialStateName, FunctionType type,
+                      ArrayRef<NamedAttribute> attrs,
                       ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(mlir::SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
-  state.addAttribute("stateType", TypeAttr::get(stateType));
   state.addAttribute(getTypeAttrName(), TypeAttr::get(type));
   state.addAttribute("initialState",
                      StringAttr::get(state.getContext(), initialStateName));
@@ -109,9 +108,6 @@ LogicalResult MachineOp::verify() {
   // If this function is external there is nothing to do.
   if (isExternal())
     return success();
-
-  if (!stateType().isa<IntegerType>())
-    return emitOpError("state must be integer type");
 
   // Verify that the argument list of the function and the arg list of the entry
   // block line up.  The trait already verified that the number of arguments is

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt --split-input-file %s | FileCheck %s
 
-// CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
+// CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
 // CHECK:   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 // CHECK:   fsm.state "IDLE" output  {
 // CHECK:     %true = arith.constant true
@@ -48,7 +48,7 @@
 // CHECK:   return
 // CHECK: }
 
-fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
   fsm.state "IDLE" output  {
@@ -109,7 +109,7 @@ func.func @qux() {
 
 // Optional guard and action regions
 
-// CHECK:   fsm.machine @foo(%[[VAL_0:.*]]: i1) -> i1 attributes {initialState = "A", stateType = i1} {
+// CHECK:   fsm.machine @foo(%[[VAL_0:.*]]: i1) -> i1 attributes {initialState = "A"} {
 // CHECK:           %[[VAL_1:.*]] = fsm.variable "cnt" {initValue = 0 : i16} : i16
 // CHECK:           fsm.state "A" output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
@@ -129,7 +129,7 @@ func.func @qux() {
 // CHECK:             fsm.transition @C
 // CHECK:           }
 // CHECK:         }
-fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "A", stateType = i1} {
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "A"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
   fsm.state "A" output  {

--- a/test/Dialect/FSM/errors.mlir
+++ b/test/Dialect/FSM/errors.mlir
@@ -3,4 +3,4 @@
 // Test missing initial state.
 
 // expected-error @+1 {{'fsm.machine' op initial state 'IDLE' was not defined in the machine}}
-fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1, initialState = "IDLE"} {}
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {}

--- a/test/Dialect/FSM/print-graph.mlir
+++ b/test/Dialect/FSM/print-graph.mlir
@@ -8,7 +8,7 @@
 // CHECK: [[BUSY]] ->
 // CHECK: variables [shape=record,label="Variables|%c1_i16 = arith.constant 1 : i16\n%c0_i16 = arith.constant 0 : i16\n%false = arith.constant false\n%c256_i16 = arith.constant 256 : i16\n%true = arith.constant true\n%cnt = fsm.variable \"cnt\" \{initValue = 0 : i16\} : i16"]}
 
-fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %c1_i16 = arith.constant 1 : i16
   %c0_i16 = arith.constant 0 : i16
   %false = arith.constant false


### PR DESCRIPTION
There is currently no rationale for explicitly annotating the type that states (a state register) should be inferred as for a machine op. Annotating it upon constructing the machine op is therefore just an extra burden on the front-end, and may also be a premature constraint.

As i see it, default behaviour should just be to infer a state type via. e.g. ceil_log2(# states) when lowering to hardware. If some other behaviour is needed, then this should be lowering specific.