### PR TITLE
[PyCDE] Make module creation, generation generic

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -288,20 +288,17 @@ def module(func_or_class):
   parameterized module."""
   if inspect.isclass(func_or_class):
     # If it's just a module class, we should wrap it immediately
-    mod = _module_base(func_or_class,
-                       None,
-                       generator_cb=generate_msft_module_op,
-                       create_cb=create_msft_module_op)
+    return _module_base(func_or_class,
+                        None,
+                        generator_cb=generate_msft_module_op,
+                        create_cb=create_msft_module_op)
   elif inspect.isfunction(func_or_class):
-    mod = _parameterized_module(func_or_class,
-                                None,
-                                generator_cb=generate_msft_module_op,
-                                create_cb=create_msft_module_op)
-  else:
-    raise TypeError(
-        "@module decorator must be on class or parameterization function")
-
-  return mod
+    return _parameterized_module(func_or_class,
+                                 None,
+                                 generator_cb=generate_msft_module_op,
+                                 create_cb=create_msft_module_op)
+  raise TypeError(
+      "@module decorator must be on class or parameterization function")
 
 
 def _get_module_cache_key(func,

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -91,6 +91,62 @@ def _create_module_name(name: str, params: mlir.ir.DictAttr):
   return ret.strip("_")
 
 
+def create_msft_module_op(sys, mod: _SpecializedModule, symbol):
+  """Creation callback for creating a MSFTModuleOp."""
+  return msft.MSFTModuleOp(symbol,
+                           mod.input_ports,
+                           mod.output_ports,
+                           mod.parameters,
+                           loc=mod.loc,
+                           ip=sys._get_ip())
+
+
+def generate_msft_module_op(generator: Generator, spec_mod: _SpecializedModule):
+
+  def create_output_op(args: _GeneratorPortAccess):
+    """Create the hw.OutputOp from module I/O ports in 'args'."""
+    output_ports = spec_mod.output_ports
+    outputs: list[Value] = list()
+
+    unconnected_ports = []
+    for (name, _) in output_ports:
+      if name not in args._output_values:
+        unconnected_ports.append(name)
+        outputs.append(None)
+      else:
+        outputs.append(args._output_values[name])
+    if len(unconnected_ports) > 0:
+      raise support.UnconnectedSignalError(unconnected_ports)
+
+    msft.OutputOp([o.value for o in outputs])
+
+  bc = _BlockContext()
+  entry_block = spec_mod.circt_mod.add_entry_block()
+  with mlir.ir.InsertionPoint(
+      entry_block), generator.loc, BackedgeBuilder(), bc:
+    args = _GeneratorPortAccess(spec_mod)
+    outputs = generator.gen_func(args)
+    if outputs is not None:
+      raise ValueError("Generators must not return a value")
+    create_output_op(args)
+
+
+def create_msft_module_extern_op(sys, mod: _SpecializedModule, symbol):
+  """Creation callback for creating a MSFTModuleExternOp."""
+  paramdecl_list = [
+      hw.ParamDeclAttr.get_nodefault(i.name, mlir.ir.TypeAttr.get(i.attr.type))
+      for i in mod.parameters
+  ]
+  return msft.MSFTModuleExternOp(
+      symbol,
+      mod.input_ports,
+      mod.output_ports,
+      parameters=paramdecl_list,
+      attributes={"verilogName": mlir.ir.StringAttr.get(mod.extern_name)},
+      loc=mod.loc,
+      ip=sys._get_ip())
+
+
 class _SpecializedModule:
   """SpecializedModule serves two purposes:
 
@@ -104,14 +160,24 @@ class _SpecializedModule:
 
   __slots__ = [
       "name", "generators", "modcls", "loc", "input_ports", "input_port_lookup",
-      "output_ports", "output_port_lookup", "parameters", "extern_name"
+      "output_ports", "output_port_lookup", "parameters", "extern_name",
+      "create_cb", "generator_cb"
   ]
 
-  def __init__(self, cls: type, parameters: Union[dict, mlir.ir.DictAttr],
-               extern_name: str):
+  def __init__(self,
+               cls: type,
+               parameters: Union[dict, mlir.ir.DictAttr],
+               extern_name: str,
+               create_cb: builtins.function,
+               generator_cb: builtins.function = None):
     self.modcls = cls
     self.extern_name = extern_name
     self.loc = get_user_loc()
+    self.create_cb = create_cb
+    if not self.create_cb:
+      raise NotImplementedError(
+          "Creation callback function must be set for module")
+    self.generator_cb = generator_cb
 
     # Make sure 'parameters' is a DictAttr rather than a python value.
     self.parameters = _obj_to_attribute(parameters)
@@ -147,7 +213,7 @@ class _SpecializedModule:
         attr.name = attr_name
         self.output_ports.append((attr.name, attr.type))
         self.output_port_lookup[attr_name] = len(self.output_ports) - 1
-      elif isinstance(attr, _Generate):
+      elif isinstance(attr, Generator):
         self.generators[attr_name] = attr
     self.add_accessors()
 
@@ -172,35 +238,9 @@ class _SpecializedModule:
     """Create the module op. Should not be called outside of a 'System'
     context. Returns the symbol of the module op."""
 
-    # Callback from System.
-    def _create(symbol):
-      if self.extern_name is None:
-        return msft.MSFTModuleOp(symbol,
-                                 self.input_ports,
-                                 self.output_ports,
-                                 self.parameters,
-                                 loc=self.loc,
-                                 ip=sys._get_ip())
-      else:
-        paramdecl_list = [
-            hw.ParamDeclAttr.get_nodefault(i.name,
-                                           mlir.ir.TypeAttr.get(i.attr.type))
-            for i in self.parameters
-        ]
-        return msft.MSFTModuleExternOp(
-            symbol,
-            self.input_ports,
-            self.output_ports,
-            parameters=paramdecl_list,
-            attributes={
-                "verilogName": mlir.ir.StringAttr.get(self.extern_name)
-            },
-            loc=self.loc,
-            ip=sys._get_ip())
-
     from .system import System
     sys = System.current()
-    sys._create_circt_mod(self, _create)
+    sys._create_circt_mod(self, self.create_cb)
 
   @property
   def is_created(self):
@@ -227,7 +267,7 @@ class _SpecializedModule:
     currently."""
     assert len(self.generators) == 1
     for g in self.generators.values():
-      g.generate(self)
+      self.generator_cb(g, self)
       return
 
   def print(self, out):
@@ -248,11 +288,20 @@ def module(func_or_class):
   parameterized module."""
   if inspect.isclass(func_or_class):
     # If it's just a module class, we should wrap it immediately
-    return _module_base(func_or_class, None)
+    mod = _module_base(func_or_class,
+                       None,
+                       generator_cb=generate_msft_module_op,
+                       create_cb=create_msft_module_op)
   elif inspect.isfunction(func_or_class):
-    return _parameterized_module(func_or_class, None)
-  raise TypeError(
-      "@module decorator must be on class or parameterization function")
+    mod = _parameterized_module(func_or_class,
+                                None,
+                                generator_cb=generate_msft_module_op,
+                                create_cb=create_msft_module_op)
+  else:
+    raise TypeError(
+        "@module decorator must be on class or parameterization function")
+
+  return mod
 
 
 def _get_module_cache_key(func,
@@ -274,7 +323,11 @@ class _parameterized_module:
   extern_mod = None
 
   # When the decorator is attached, this runs.
-  def __init__(self, func: builtins.function, extern_name):
+  def __init__(self,
+               func: builtins.function,
+               extern_name,
+               create_cb: builtins.function,
+               generator_cb: builtins.function = None):
     self.extern_name = extern_name
 
     # If it's a module parameterization function, inspect the arguments to
@@ -286,6 +339,8 @@ class _parameterized_module:
         raise TypeError("Module parameter definitions cannot have **kwargs")
       if param.kind == param.VAR_POSITIONAL:
         raise TypeError("Module parameter definitions cannot have *args")
+    self.create_cb = create_cb
+    self.generator_cb = generator_cb
 
   # This function gets executed in two situations:
   #   - In the case of a module function parameterizer, it is called when the
@@ -313,7 +368,11 @@ class _parameterized_module:
     if cls is None:
       raise ValueError("Parameterization function must return module class")
 
-    mod = _module_base(cls, self.extern_name, params)
+    mod = _module_base(cls,
+                       self.extern_name,
+                       params=params,
+                       create_cb=self.create_cb,
+                       generator_cb=self.generator_cb)
     _MODULE_CACHE[cache_key] = mod
     return mod
 
@@ -321,7 +380,6 @@ class _parameterized_module:
 def externmodule(to_be_wrapped, extern_name=None):
   """Wrap an externally implemented module. If no name given in the decorator
   argument, use the class name."""
-
   if isinstance(to_be_wrapped, str):
     return lambda cls, extern_name=to_be_wrapped: externmodule(cls, extern_name)
 
@@ -329,11 +387,19 @@ def externmodule(to_be_wrapped, extern_name=None):
     extern_name = to_be_wrapped.__name__
   if inspect.isclass(to_be_wrapped):
     # If it's just a module class, we should wrap it immediately
-    return _module_base(to_be_wrapped, extern_name)
-  return _parameterized_module(to_be_wrapped, extern_name)
+    return _module_base(to_be_wrapped,
+                        extern_name,
+                        create_cb=create_msft_module_extern_op)
+  return _parameterized_module(to_be_wrapped,
+                               extern_name,
+                               create_cb=create_msft_module_extern_op)
 
 
-def _module_base(cls, extern_name: str, params={}):
+def _module_base(cls,
+                 extern_name: str,
+                 create_cb: builtins.function,
+                 generator_cb: builtins.function = None,
+                 params={}):
   """Wrap a class, making it a PyCDE module."""
 
   class mod(cls):
@@ -418,7 +484,11 @@ def _module_base(cls, extern_name: str, params={}):
   mod.__qualname__ = cls.__qualname__
   mod.__name__ = cls.__name__
   mod.__module__ = cls.__module__
-  mod._pycde_mod = _SpecializedModule(mod, params, extern_name)
+  mod._pycde_mod = _SpecializedModule(mod,
+                                      params,
+                                      extern_name,
+                                      create_cb=create_cb,
+                                      generator_cb=generator_cb)
   return mod
 
 
@@ -458,9 +528,12 @@ class _BlockContext:
     return ret
 
 
-class _Generate:
-  """Represents a generator. Stores the generate function and wraps it with the
-  necessary logic to build a module."""
+class Generator:
+  """
+  Represents a generator. Stores the generate function and location of
+  the generate call. Generator objects are passed to module-specific generator
+  object handlers.
+  """
 
   def __init__(self, gen_func):
     sig = inspect.signature(gen_func)
@@ -471,39 +544,10 @@ class _Generate:
     self.gen_func = gen_func
     self.loc = get_user_loc()
 
-  def generate(self, specialized_mod: _SpecializedModule):
-    """Build an HWModuleOp and run the generator as the body builder."""
-
-    bc = _BlockContext()
-    entry_block = specialized_mod.circt_mod.add_entry_block()
-    with mlir.ir.InsertionPoint(entry_block), self.loc, BackedgeBuilder(), bc:
-      args = _GeneratorPortAccess(specialized_mod)
-      outputs = self.gen_func(args)
-      if outputs is not None:
-        raise ValueError("Generators must not return a value")
-      self._create_output_op(args, specialized_mod)
-
-  def _create_output_op(self, args: _GeneratorPortAccess, spec_mod):
-    """Create the hw.OutputOp from module I/O ports in 'args'."""
-    output_ports = spec_mod.output_ports
-    outputs: list[Value] = list()
-
-    unconnected_ports = []
-    for (name, _) in output_ports:
-      if name not in args._output_values:
-        unconnected_ports.append(name)
-        outputs.append(None)
-      else:
-        outputs.append(args._output_values[name])
-    if len(unconnected_ports) > 0:
-      raise support.UnconnectedSignalError(unconnected_ports)
-
-    msft.OutputOp([o.value for o in outputs])
-
 
 def generator(func):
   """Decorator for generation functions."""
-  return _Generate(func)
+  return Generator(func)
 
 
 class _GeneratorPortAccess:
@@ -519,7 +563,8 @@ class _GeneratorPortAccess:
   def __getattr__(self, name):
     if name in self._mod.input_port_lookup:
       idx = self._mod.input_port_lookup[name]
-      val = self._mod.circt_mod.entry_block.arguments[idx]
+      entry_block = self._mod.circt_mod.regions[0].blocks[0]
+      val = entry_block.arguments[idx]
       return Value(val)
     if name in self._mod.output_port_lookup:
       if name not in self._output_values:

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -102,11 +102,11 @@ class System:
       return
 
     # Build the correct op.
-    op = create_cb(symbol)
+    op = create_cb(self, spec_mod, symbol)
     # Install the op in the cache.
     install_func(op)
-    # Add to the generation queue, if necessary.
-    if isinstance(op, circt.dialects.msft.MSFTModuleOp):
+    # Add to the generation queue if the module has a generator callback.
+    if hasattr(spec_mod, 'generator_cb') and spec_mod.generator_cb is not None:
       self._generate_queue.append(spec_mod)
       file_name = spec_mod.modcls.__name__ + ".sv"
       self.files.add(os.path.join(self._output_directory, file_name))

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -107,6 +107,7 @@ class System:
     install_func(op)
     # Add to the generation queue if the module has a generator callback.
     if hasattr(spec_mod, 'generator_cb') and spec_mod.generator_cb is not None:
+      assert callable(spec_mod.generator_cb)
       self._generate_queue.append(spec_mod)
       file_name = spec_mod.modcls.__name__ + ".sv"
       self.files.add(os.path.join(self._output_directory, file_name))


### PR DESCRIPTION
This is a step on the way to untangling logic in module.py to be specific to `MSFTModuleOp`.
Classes can now supply callbacks for generation and creation, which allows for creating, generating modules that aren't necessarily  `MSFTModule(Extern)Op`s.

This commit will make a bit more sense through a later PR which adds support for FSM `MachineOp`s. This support is achieved solely through setting the new `create_cb,generator_cb` with no other changes required.