### PR TITLE
[FIRRTL] EmitOMIR: Drop temporary HierPath's that may be invalid

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -417,6 +417,10 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
       addToPath((*it)->getInstance(), ref.getName());
     }
   }
+
+  // TODO: Don't create NLA if namepath is empty
+  // (care needed to ensure this will be handled correctly elsewhere)
+
   // Add the op itself.
   namepath.push_back(hw::InnerRefAttr::getFromOperation(
       tracker.op, opName,

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -126,7 +126,8 @@ private:
   /// collected.
   SmallVector<Attribute> symbols;
   SmallDenseMap<Attribute, unsigned> symbolIndices;
-  /// Temporary `firrtl.nla` operations to be deleted at the end of the pass.
+  /// Temporary `firrtl.hierpath` operations to be deleted at the end of the
+  /// pass. Vector elements are unique.
   SmallVector<HierPathOp> removeTempNLAs;
   DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
   /// Lookup table of instances by name and parent module.
@@ -293,7 +294,6 @@ void EmitOMIRPass::runOnOperation() {
           return true;
         }
         tracker.nla = cast<HierPathOp>(tmp);
-        removeTempNLAs.push_back(tracker.nla);
       }
       if (sramIDs.erase(tracker.id))
         makeTrackerAbsolute(tracker);
@@ -327,7 +327,14 @@ void EmitOMIRPass::runOnOperation() {
   if (anyFailures)
     return signalPassFailure();
 
+  // Drop temporary (and sometimes invalid) NLA's created during the pass:
+  for (auto nla : removeTempNLAs) {
+    LLVM_DEBUG(llvm::dbgs() << "Removing '" << nla << "'\n");
+    nlaTable->erase(nla);
+    nla.erase();
+  }
   removeTempNLAs.clear();
+
   // Remove the temp symbol from instances.
   for (auto *op : tempSymInstances)
     cast<InstanceOp>(op)->removeAttr("inner_sym");

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -472,6 +472,41 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
 // CHECK-SAME: ]
 
 //===----------------------------------------------------------------------===//
+// Make SRAM Paths Absolute when SRAM is top-level (invalid for NLA)
+//===----------------------------------------------------------------------===//
+
+firrtl.circuit "SRAMPathsTopLevel" attributes {annotations = [{
+  class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+  nodes = [
+    {
+      info = #loc,
+      id = "OMID:0",
+      fields = {
+        omType = {info = #loc, index = 0, value = ["OMString:OMLazyModule", "OMString:OMSRAM"]},
+        finalPath = {info = #loc, index = 1, value = {omir.tracker, id = 0, type = "OMMemberReferenceTarget"}}
+      }
+    }
+  ]
+}]} {
+  firrtl.extmodule @MySRAM()
+  firrtl.module @SRAMPathsTopLevel() {
+    firrtl.instance mem1 {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} @MySRAM()
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "SRAMPathsTopLevel"
+// CHECK:       firrtl.instance mem1 sym [[SYMMEM1:@[a-zA-Z0-9_]+]]
+
+// CHECK:       sv.verbatim
+// CHECK-SAME{LITERAL}:    \22value\22: \22OMMemberInstanceTarget:~SRAMPathsTopLevel|{{0}}/{{1}}:{{2}}\22
+
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @SRAMPathsTopLevel,
+// CHECK-SAME:    #hw.innerNameRef<@SRAMPathsTopLevel::[[SYMMEM1:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @MySRAM
+// CHECK-SAME:  ]
+
+//===----------------------------------------------------------------------===//
 // Add module port information to the OMIR (`SetOMIRPorts`)
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Restore behavior for deleting the HierPath's added in this pass.

They're known to be dead and sometimes are invalid, causing
breakage during circuit verification.

While we cannot delete incoming HierPath's attached to operations in
input IR without a more careful analysis of all possible users, any NLA
explicitly created in this pass can be reasoned about and removed at the
end for cleaner (and valid) IR.

Fixes assertion failure on a real design.

The invalid NLA encountered is when the target is in the root module,
and so we end up making a one-element (InnerRef) NLA.