### PR TITLE
ExtractInstances: fix memory safety issue re:DenseMap

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -634,8 +634,10 @@ void ExtractInstancesPass::extractInstances() {
       }
 
       // Inherit the old instance's extraction path.
+      extractionPaths.try_emplace(newInst); // (create entry first)
       auto &extractionPath = (extractionPaths[newInst] = extractionPaths[inst]);
       extractionPath.push_back(getInnerRefTo(newParentInst));
+      originalInstanceParents.try_emplace(newInst); // (create entry first)
       originalInstanceParents[newInst] = originalInstanceParents[inst];
       // Record the Nonlocal annotations that need to be applied to the new
       // Inst.


### PR DESCRIPTION
Don't create entries while reading from the map (`map[key2] = map[key1]`),
as sometimes this requires the map to grow which invalidates pointers to entries.

Workaround by ensuring (possibly new) entries exist before copying the vectors over.

Found with help of Address Sanitizer.

