### PR TITLE
Bump LLVM to cb69ba4faaf1de207b363b5198d33e29d0375e5d.

### DIFF
--- a/include/circt/Conversion/SCFToCalyx.h
+++ b/include/circt/Conversion/SCFToCalyx.h
@@ -15,7 +15,7 @@
 #define CIRCT_CONVERSION_SCFTOCALYX_SCFTOCALYX_H
 
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include <memory>
 
 namespace circt {

--- a/include/circt/Conversion/StaticLogicToCalyx.h
+++ b/include/circt/Conversion/StaticLogicToCalyx.h
@@ -15,7 +15,7 @@
 #define CIRCT_CONVERSION_STATICLOGICTOCALYX_H
 
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include <memory>
 
 namespace circt {

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -23,7 +23,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -17,7 +17,7 @@ add_circt_library(CIRCTSchedulingAnalysis
   SchedulingAnalysis.cpp
 
   LINK_LIBS PUBLIC
-  MLIRAffine
+  MLIRAffineDialect
   MLIRIR
   CIRCTDependenceAnalysis
   CIRCTScheduling

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/AnalysisManager.h"
 #include <limits>

--- a/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
+++ b/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
@@ -24,7 +24,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/Dominance.h"

--- a/lib/Conversion/CalyxToHW/CMakeLists.txt
+++ b/lib/Conversion/CalyxToHW/CMakeLists.txt
@@ -17,7 +17,7 @@ add_circt_library(CIRCTCalyxToHW
   CIRCTHW
   MLIRIR
   MLIRPass
-  MLIRFunc
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   )

--- a/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
@@ -10,9 +10,9 @@ add_circt_library(CIRCTHandshakeToFIRRTL
   CIRCTHandshakeTransforms
   MLIRIR
   MLIRPass
-  MLIRArithmetic
-  MLIRControlFlow
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   )

--- a/lib/Conversion/HandshakeToHW/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToHW/CMakeLists.txt
@@ -11,9 +11,9 @@ add_circt_library(CIRCTHandshakeToHW
   CIRCTHandshakeTransforms
   MLIRIR
   MLIRPass
-  MLIRArithmetic
-  MLIRControlFlow
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   )

--- a/lib/Conversion/LLHDToLLVM/CMakeLists.txt
+++ b/lib/Conversion/LLHDToLLVM/CMakeLists.txt
@@ -14,7 +14,7 @@ add_circt_conversion_library(CIRCTLLHDToLLVM
   MLIRControlFlowToLLVM
   MLIRFuncToLLVM
   MLIRLLVMCommonConversion
-  MLIRVector
+  MLIRVectorDialect
   MLIRTransforms
   MLIRReconcileUnrealizedCasts
 )

--- a/lib/Conversion/SCFToCalyx/CMakeLists.txt
+++ b/lib/Conversion/SCFToCalyx/CMakeLists.txt
@@ -13,10 +13,10 @@ add_circt_conversion_library(CIRCTSCFToCalyx
   CIRCTStaticLogicOps
   MLIRIR
   MLIRPass
-  MLIRArithmetic
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   MLIRAffineToStandard
-  MLIRSCF
+  MLIRSCFDialect
 )

--- a/lib/Conversion/StandardToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StandardToHandshake/CMakeLists.txt
@@ -10,9 +10,9 @@ add_circt_library(CIRCTStandardToHandshake
   CIRCTSupport
   MLIRIR
   MLIRPass
-  MLIRArithmetic
-  MLIRControlFlow
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   MLIRAffineToStandard

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -24,7 +24,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"

--- a/lib/Conversion/StandardToStaticLogic/CMakeLists.txt
+++ b/lib/Conversion/StandardToStaticLogic/CMakeLists.txt
@@ -6,7 +6,7 @@ add_circt_library(CIRCTStandardToStaticLogic
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRFunc
+  MLIRFuncDialect
   MLIRPass
   MLIRSupport
   MLIRTransforms

--- a/lib/Conversion/StaticLogicToCalyx/CMakeLists.txt
+++ b/lib/Conversion/StaticLogicToCalyx/CMakeLists.txt
@@ -13,8 +13,8 @@ add_circt_conversion_library(CIRCTStaticLogicToCalyx
   CIRCTStaticLogicOps
   MLIRIR
   MLIRPass
-  MLIRArithmetic
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
   MLIRAffineToStandard

--- a/lib/Dialect/Calyx/CMakeLists.txt
+++ b/lib/Dialect/Calyx/CMakeLists.txt
@@ -14,9 +14,9 @@ set(Calyx_LinkLibs
   CIRCTComb
   CIRCTSV
   CIRCTHW
-  MLIRArithmetic
+  MLIRArithmeticDialect
   MLIRIR
-  MLIRMemRef
+  MLIRMemRefDialect
   MLIRTransforms
   )
 

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -16,10 +16,10 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   CIRCTHW
   CIRCTStaticLogicOps
   CIRCTSupport
-  MLIRArithmetic
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRFuncDialect
   MLIRIR
   MLIRPass
-  MLIRSCF
+  MLIRSCFDialect
   MLIRTransformUtils
   )

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -16,7 +16,7 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Matchers.h"
 
 #include <variant>

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -21,9 +21,9 @@ set(ESI_LinkLibs
   CIRCTHW
   MLIRIR
   MLIRTransforms
-  MLIRControlFlow
-  MLIRFunc
-  MLIRArithmetic
+  MLIRControlFlowDialect
+  MLIRFuncDialect
+  MLIRArithmeticDialect
   MLIRTranslateLib
 )
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -435,7 +435,7 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
   SmallVector<ModuleMappingResult> results;
   results.resize(modules.size());
 
-  mlir::parallelForEachN(
+  mlir::parallelFor(
       circuit.getContext(), 0, modules.size(),
       [&modules, &results](size_t index) {
         ModuleSignalMappings mapper(modules[index]);

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -396,7 +396,7 @@ static void mapResultsToWires(BlockAndValueMapping &mapper,
 
 /// Wrapper for llvm::parallelTransformReduce that performs the transform_reduce
 /// serially when MLIR multi-threading is disabled.
-/// Does not add a ParallelDiagnosticHandler like mlir::parallelForEachN.
+/// Does not add a ParallelDiagnosticHandler like mlir::parallelFor.
 template <class IterTy, class ResultTy, class ReduceFuncTy,
           class TransformFuncTy>
 static ResultTy transformReduce(MLIRContext *context, IterTy Begin, IterTy End,

--- a/lib/Dialect/FSM/CMakeLists.txt
+++ b/lib/Dialect/FSM/CMakeLists.txt
@@ -9,8 +9,8 @@ add_circt_dialect_library(CIRCTFSM
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRFunc
-  MLIRArithmetic
+  MLIRFuncDialect
+  MLIRArithmeticDialect
   )
 
 add_subdirectory(Transforms)

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -12,7 +12,7 @@ add_circt_dialect_library(CIRCTHandshake
   ${PROJECT_BINARY_DIR}/include
 
   LINK_LIBS PUBLIC
-  MLIRFunc
+  MLIRFuncDialect
   MLIRIR
 
   DEPENDS

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -12,6 +12,6 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   MLIRIR
   MLIRPass
   MLIRTransformUtils
-  MLIRMemRef
-  MLIRAffine
+  MLIRMemRefDialect
+  MLIRAffineDialect
   )

--- a/lib/Dialect/LLHD/IR/CMakeLists.txt
+++ b/lib/Dialect/LLHD/IR/CMakeLists.txt
@@ -18,5 +18,5 @@ add_circt_dialect_library(CIRCTLLHD
   MLIRControlFlowInterfaces
   MLIRInferTypeOpInterface
   MLIRCallInterfaces
-  MLIRFunc
+  MLIRFuncDialect
 )

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -12,6 +12,6 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   LINK_LIBS PUBLIC
   CIRCTLLHD
   MLIRIR
-  MLIRFunc
+  MLIRFuncDialect
   MLIRTransformUtils
 )

--- a/lib/Dialect/StaticLogic/CMakeLists.txt
+++ b/lib/Dialect/StaticLogic/CMakeLists.txt
@@ -12,8 +12,8 @@ add_circt_dialect_library(CIRCTStaticLogicOps
   ${PROJECT_BINARY_DIR}/include
 
   LINK_LIBS PUBLIC
-  MLIRArithmetic
-  MLIRFunc
+  MLIRArithmeticDialect
+  MLIRFuncDialect
   MLIRIR
 
   DEPENDS

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SCHEDULING_SOURCES
 
 set(SCHEDULING_LIBS
   MLIRIR
-  MLIRFunc
+  MLIRFuncDialect
   MLIRSupport
   )
 

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -6,8 +6,8 @@ add_circt_library(CIRCTTransforms
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRMemRef
-  MLIRFunc
+  MLIRMemRefDialect
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransformUtils
 

--- a/test/Dialect/ESI/CMakeLists.txt
+++ b/test/Dialect/ESI/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(esi-tester
   MLIRSupport
   MLIRIR
   MLIROptLib
-  MLIRFunc
+  MLIRFuncDialect
   MLIRTransforms
-  MLIRLLVMIR
+  MLIRLLVMDialect
   )

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -48,12 +48,12 @@ target_link_libraries(circt-opt
 
   
   MLIRIR
-  MLIRLLVMIR
-  MLIRMemRef
+  MLIRLLVMDialect
+  MLIRMemRefDialect
   MLIROptLib
   MLIRParser
-  MLIRFunc
+  MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
-  MLIRSCF
+  MLIRSCFDialect
   )

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -20,7 +20,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -18,6 +18,6 @@ target_link_libraries(firtool PRIVATE
   MLIRSupport
   MLIRIR
   MLIROptLib
-  MLIRFunc
+  MLIRFuncDialect
   MLIRTransforms
   )


### PR DESCRIPTION
This bumps the LLVM submodule to the tip of the upstream tree. It was a mostly a straightforward bump, with three non-functional changes required:

- Most of the MLIR dialect CMake targets were slightly renamed to add "Dialect" as a suffix in https://github.com/llvm/llvm-project/commit/e16d13322b2617843511aebb29a502166824b07a
- Some of the include paths for SCF had to be updated due to https://github.com/llvm/llvm-project/commit/8b68da2c7d97ef0e2dde4d9eb867020bde2f5fe2
- `parallelForEachN` was renamed to `parallelFor` in https://github.com/llvm/llvm-project/commit/7effcbda49ba32991b8955821b8fdbd4f8f303e2, with no change in behavior

I can keep this branch updated daily until I merge this in the latter half of this week, but if someone needs a newer LLVM sooner, there's no harm in merging this sooner.