### PR TITLE
[FIRRTL] [IMCP] Preserve named registers and add another regreset prop

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -31,9 +31,8 @@ static bool isAggregate(Operation *op) {
 
 /// Return true if this is a wire or register we're allowed to delete.
 static bool isDeletableWireOrReg(Operation *op) {
-  if (auto wire = dyn_cast<WireOp>(op))
-    if (!wire.hasDroppableName())
-      return false;
+  if (!hasDroppableName(op))
+    return false;
   return isWireOrReg(op) && AnnotationSet(op).empty() && !hasDontTouch(op);
 }
 
@@ -417,6 +416,9 @@ void IMConstPropPass::markRegResetOp(RegResetOp regReset) {
   if (enable.isOverdefined() ||
       (enable.isConstant() && !enable.getConstant().getValue().isZero()))
     mergeLatticeValue(regReset, srcValue);
+
+  if (enable.isConstant() && enable.getConstant().getValue().isZero())
+    mergeLatticeValue(regReset, InvalidValueAttr::get(regReset.getType()));
 }
 
 void IMConstPropPass::markMemOp(MemOp mem) {

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -410,14 +410,17 @@ void IMConstPropPass::markRegResetOp(RegResetOp regReset) {
   auto srcValue = getExtendedLatticeValue(regReset.resetValue(),
                                           regReset.getType().cast<FIRRTLType>(),
                                           /*allowTruncation=*/true);
-  auto enable = getExtendedLatticeValue(regReset.resetSignal(),
-                                        regReset.getType().cast<FIRRTLType>(),
-                                        /*allowTruncation=*/true);
-  if (enable.isOverdefined() ||
-      (enable.isConstant() && !enable.getConstant().getValue().isZero()))
+  auto resetValue = getExtendedLatticeValue(
+      regReset.resetSignal(), regReset.getType().cast<FIRRTLType>(),
+      /*allowTruncation=*/true);
+  if (resetValue.isOverdefined() ||
+      (resetValue.isConstant() &&
+       !resetValue.getConstant().getValue().isZero()))
     mergeLatticeValue(regReset, srcValue);
 
-  if (enable.isConstant() && enable.getConstant().getValue().isZero())
+  // If the reset is a constant zero, the register is never initialized so merge
+  // invalid value.
+  if (resetValue.isConstant() && resetValue.getConstant().getValue().isZero())
     mergeLatticeValue(regReset, InvalidValueAttr::get(regReset.getType()));
 }
 

--- a/test/Dialect/FIRRTL/SFCTests/invalid-reg-pass.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-reg-pass.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -split-input-file -verilog %s | FileCheck %s
+; RUN: firtool -split-input-file -drop-names -verilog %s | FileCheck %s
 
 ; This test checks register removal behavior for situations where the register
 ; is invalidated _through a primitive operation_.  This is intended to tease out

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -590,3 +590,28 @@ firrtl.circuit "AnnotationsBlockRemoval"  {
     firrtl.strictconnect %b, %w : !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "Issue3372"  {
+  firrtl.module @Issue3372(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %value: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %other_zero = firrtl.instance other interesting_name  @Other(out zero: !firrtl.uint<1>)
+    %shared = firrtl.regreset interesting_name %clock, %c0_ui1, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.strictconnect %shared, %shared : !firrtl.uint<1>
+    %test = firrtl.wire interesting_name  : !firrtl.uint<1>
+    firrtl.strictconnect %test, %shared : !firrtl.uint<1>
+    firrtl.strictconnect %value, %invalid_ui1 : !firrtl.uint<1>
+    // CHECK:      %shared = firrtl.regreset interesting_name %clock, %c0_ui1, %c1_ui1
+    // CHECK-NEXT: firrtl.strictconnect %shared, %invalid_ui1
+    // CHECK-NEXT: %test = firrtl.wire interesting_name  : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %test, %invalid_ui1
+    // CHECK-NEXT: firrtl.strictconnect %value, %invalid_ui1
+  }
+  firrtl.module private @Other(out %zero: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
This commit fixes a weird bug in name preservation mode.
Sometimes named registers are never written but they are preserved
because of name preservation. This commit fixes the bug by preserving
connections of named registers and adding another lattice transition for
regreset op. This fixes https://github.com/llvm/circt/issues/3372. 
For the example in #3372, 

Before:
```verilog
 reg  shared;
 wire test;
 ...
 assign test = shared;
 Other other ();
 assign value = 1'h0;
```
After:
```verilog
 reg  shared;	// foo.mlir:7:15
 wire test = 1'h0;	// foo.mlir:9:13
 ...
 always @(posedge clock)	// foo.mlir:8:5
   shared <= 1'h0;	// foo.mlir:8:5, :9:13
 Other other ();	// foo.mlir:6:19
 assign value = 1'h0;	// foo.mlir:2:3, :9:13
```