### PR TITLE
[FIRRTL][Dedup] Pre-calculate the post-order of modules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1185,11 +1185,13 @@ class DedupPass : public DedupBase<DedupPass> {
     DenseMap<Attribute, StringAttr> dedupMap;
 
     // We must iterate the modules from the bottom up so that we can properly
-    // deduplicate the modules. We use early increment so we can safely delete
-    // nodes from the instance graph as we iterate through it.
-    for (auto *node :
-         llvm::make_early_inc_range(llvm::post_order(&instanceGraph))) {
-      auto module = cast<FModuleLike>(*node->getModule());
+    // deduplicate the modules. We copy the list of modules into a vector first
+    // to avoid iterator invalidation while we mutate the instance graph.
+    std::vector<FModuleLike> modules;
+    for (auto *node : llvm::post_order(&instanceGraph))
+      modules.push_back(cast<FModuleLike>(*node->getModule()));
+
+    for (auto module : modules) {
       auto moduleName = module.moduleNameAttr();
       // If the module is marked with NoDedup, just skip it.
       if (AnnotationSet(module).hasAnnotation(noDedupClass)) {

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1187,9 +1187,10 @@ class DedupPass : public DedupBase<DedupPass> {
     // We must iterate the modules from the bottom up so that we can properly
     // deduplicate the modules. We copy the list of modules into a vector first
     // to avoid iterator invalidation while we mutate the instance graph.
-    std::vector<FModuleLike> modules;
-    for (auto *node : llvm::post_order(&instanceGraph))
-      modules.push_back(cast<FModuleLike>(*node->getModule()));
+    SmallVector<FModuleLike, 0> modules(
+        llvm::map_range(llvm::post_order(&instanceGraph), [](auto *node) {
+          return cast<FModuleLike>(*node->getModule());
+        }));
 
     for (auto module : modules) {
       auto moduleName = module.moduleNameAttr();


### PR DESCRIPTION
We modify the instance graph as dedup runs and have had some issues with
iterator invalidation. This change copies the module list into a
separate array so we don't have to worry about instance graph updates.

This is not the most efficient solution and in the future we should find
something better.  See https://github.com/llvm/circt/issues/3387 for
more information.