### PR TITLE
[FIRRTL] Use Minimal XMRs in GCT Views

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1146,10 +1146,16 @@ Optional<Attribute> GrandCentralPass::fromAttr(Attribute attr) {
   return None;
 }
 
+static StringAttr getModPart(Attribute pathSegment) {
+  return TypeSwitch<Attribute, StringAttr>(pathSegment)
+      .Case<FlatSymbolRefAttr>([](auto a) { return a.getAttr(); })
+      .Case<hw::InnerRefAttr>([](auto a) { return a.getModule(); });
+}
+
 bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
                                      VerbatimBuilder &path) {
   return TypeSwitch<Attribute, bool>(field)
-      .Case<AugmentedGroundTypeAttr>([&](auto ground) {
+      .Case<AugmentedGroundTypeAttr>([&](AugmentedGroundTypeAttr ground) {
         auto [fieldRef, sym] = leafMap.lookup(ground.getID());
         HierPathOp nla;
         if (sym)
@@ -1161,39 +1167,46 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         auto builder =
             OpBuilder::atBlockEnd(companionIDMap.lookup(id).mapping.getBody());
 
-        // The enclosing module is either the module where the leaf lives or its
-        // the root of the NLA.  After computing this, the enclosing module
-        // should be singly-instantiated.
-        FModuleLike enclosing;
-        if (!nla)
-          enclosing = getEnclosingModule(leafValue, sym);
-        else
-          enclosing = getSymbolTable().lookup<FModuleOp>(nla.root());
-
-        auto srcPaths = instancePaths->getAbsolutePaths(enclosing);
-        assert(srcPaths.size() == 1 &&
-               "Unable to handle multiply instantiated companions");
-
-        // Add the root module.
-        path += " = ";
-        path += FlatSymbolRefAttr::get(SymbolTable::getSymbolName(
-            srcPaths[0].empty()
-                ? enclosing
-                : srcPaths[0][0]->getParentOfType<FModuleLike>()));
-
-        // Add the source path from the enclosing module to the root.
-        for (auto inst : srcPaths[0]) {
-          path += '.';
-          path += getInnerRefTo(inst);
+        // Populate a hierarchical path to the leaf.  For an NLA this is just
+        // the namepath of the associated hierarchical path.  For a local
+        // annotation, this is computed from the instance path.
+        SmallVector<Attribute> fullLeafPath;
+        if (nla) {
+          fullLeafPath.append(nla.namepath().begin(), nla.namepath().end());
+        } else {
+          FModuleLike enclosing = getEnclosingModule(leafValue, sym);
+          auto enclosingPaths = instancePaths->getAbsolutePaths(enclosing);
+          assert(enclosingPaths.size() == 1 &&
+                 "Unable to handle multiply instantiated companions");
+          if (enclosingPaths.size() != 1)
+            return false;
+          StringAttr root =
+              instancePaths->instanceGraph.getTopLevelModule().moduleNameAttr();
+          for (auto segment : enclosingPaths[0]) {
+            fullLeafPath.push_back(getInnerRefTo(segment));
+            root = segment.moduleNameAttr().getAttr();
+          }
+          fullLeafPath.push_back(FlatSymbolRefAttr::get(root));
         }
 
-        // If this is an NLA, append the path from the enclosing module down to
-        // the module that contains the NLA.
-        if (nla)
-          for (size_t i = 0, e = nla.namepath().size() - 1; i != e; ++i) {
-            path += '.';
-            path += nla.namepath()[i];
+        // Compute the lowest common ancestor (LCA) of the leaf path and the
+        // parent module.  This enables the generated XMR to be as short as
+        // possible while not losing specificity.
+        ArrayRef<Attribute> minimalLeafPath(fullLeafPath);
+        StringAttr parentNameAttr =
+            parentIDMap.lookup(id).second.moduleNameAttr();
+        minimalLeafPath = minimalLeafPath.drop_until(
+            [&](Attribute attr) { return getModPart(attr) == parentNameAttr; });
+
+        // Generate the path from the LCA to the module that contains the leaf.
+        path += " = ";
+        path += FlatSymbolRefAttr::get(getModPart(minimalLeafPath.front()));
+        if (minimalLeafPath.size() > 0) {
+          for (auto segment : minimalLeafPath.drop_back()) {
+            path += ".";
+            path += segment;
           }
+        }
 
         // Add the leaf value to the path.
         auto uloc = builder.getUnknownLoc();

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -35,7 +35,7 @@ circuit Top:
     ; CHECK:      endmodule
 
     ; CHECK:      module MyView_mapping();
-    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = Top.[[dutName]].[[wireName]]
+    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = DUT.[[wireName]]
     ; CHECK-NEXT: endmodule
 
     ; CHECK: interface MyInterface

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -230,28 +230,28 @@ circuit Top :
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyView_mapping.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/MyView_mapping.sv
     ; CHECK:          module MyView_mapping();
-    ; CHECK-NEXT:       assign MyView.uint = Top.dut.w_uint;
-    ; CHECK-NEXT:       assign MyView.vec[0] = Top.dut.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.vec[1] = Top.dut.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][0] = Top.dut.w_multivec_0_0;
-    ; CHECK-NEXT:       assign MyView.multivec[0][1] = Top.dut.w_multivec_0_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][2] = Top.dut.w_multivec_0_2;
-    ; CHECK-NEXT:       assign MyView.multivec[1][0] = Top.dut.w_multivec_1_0;
-    ; CHECK-NEXT:       assign MyView.multivec[1][1] = Top.dut.w_multivec_1_1;
-    ; CHECK-NEXT:       assign MyView.multivec[1][2] = Top.dut.w_multivec_1_2;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = Top.dut.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = Top.dut.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = Top.dut.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = Top.dut.w_vecOfBundle_1_uint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = Top.dut.w_otherOther_other_sint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = Top.dut.w_otherOther_other_uint;
-    ; CHECK-NEXT:       assign MyView.sub_uint = Top.dut.submodule.w_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vec[0] = Top.dut.submodule.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.sub_vec[1] = Top.dut.submodule.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = Top.dut.submodule.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = Top.dut.submodule.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = Top.dut.submodule.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = Top.dut.submodule.w_vecOfBundle_1_uint;
+    ; CHECK-NEXT:       assign MyView.uint = DUT.w_uint;
+    ; CHECK-NEXT:       assign MyView.vec[0] = DUT.w_vec_0;
+    ; CHECK-NEXT:       assign MyView.vec[1] = DUT.w_vec_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][0] = DUT.w_multivec_0_0;
+    ; CHECK-NEXT:       assign MyView.multivec[0][1] = DUT.w_multivec_0_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][2] = DUT.w_multivec_0_2;
+    ; CHECK-NEXT:       assign MyView.multivec[1][0] = DUT.w_multivec_1_0;
+    ; CHECK-NEXT:       assign MyView.multivec[1][1] = DUT.w_multivec_1_1;
+    ; CHECK-NEXT:       assign MyView.multivec[1][2] = DUT.w_multivec_1_2;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = DUT.w_vecOfBundle_0_sint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = DUT.w_vecOfBundle_0_uint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = DUT.w_vecOfBundle_1_sint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = DUT.w_vecOfBundle_1_uint;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = DUT.w_otherOther_other_sint;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = DUT.w_otherOther_other_uint;
+    ; CHECK-NEXT:       assign MyView.sub_uint = DUT.submodule.w_uint;
+    ; CHECK-NEXT:       assign MyView.sub_vec[0] = DUT.submodule.w_vec_0;
+    ; CHECK-NEXT:       assign MyView.sub_vec[1] = DUT.submodule.w_vec_1;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = DUT.submodule.w_vecOfBundle_0_sint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = DUT.submodule.w_vecOfBundle_0_uint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = DUT.submodule.w_vecOfBundle_1_sint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = DUT.submodule.w_vecOfBundle_1_uint;
     ; CHECK:          endmodule
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyInterface.sv"

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -75,20 +75,17 @@ firrtl.circuit "InterfaceGroundType" attributes {
 
 // CHECK: firrtl.module @View_mapping
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/View_mapping.sv"
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:   @InterfaceGroundType
-// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   @DUT
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@a>
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.bar = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.bar = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:   @InterfaceGroundType
-// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   @DUT
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@b>
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.baz = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}[1].d;"
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.baz = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}[1].d;"
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:   @InterfaceGroundType
-// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   @DUT
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@c>]
 
 // CHECK: sv.interface {
@@ -798,35 +795,29 @@ firrtl.circuit "NestedInterfaceVectorTypes" attributes {annotations = [
 
 // CHECK-LABEL: firrtl.circuit "NestedInterfaceVectorTypes"
 // CHECK:         firrtl.module @View_mapping
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@a0>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@a1>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@a2>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@b0>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@b1>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
-// CHECK-SAME:        @NestedInterfaceVectorTypes
-// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        @DUT
 // CHECK-SAME:        #hw.innerNameRef<@DUT::@b2>
 // CHECK:         sv.interface {
 // CHECK-SAME:      @Foo
@@ -1027,30 +1018,27 @@ firrtl.circuit "DedupedPath" attributes {
 // CHECK:                  firrtl.module @DUT()
 // CHECK-NOT:                circt.nonlocal
 // CHECK:                  firrtl.module @DedupedPath
-// CHECK-NEXT:               firrtl.instance dut sym @[[dutSym:[a-zA-Z0-9]+]]
+// CHECK-NEXT:               firrtl.instance dut
+// CHECK-NOT:                  sym
 // CHECK:                  firrtl.module @MyView_mapping()
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.foo = {{1}}.{{2}}.{{3}}.{{4}};"
+// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.foo = {{1}}.{{2}}.{{3}};"
 // CHECK-SAME:                 symbols = [#hw.innerNameRef<@DUT::@__MyView_Foo__>,
-// CHECK-SAME:                   @DedupedPath,
-// CHECK-SAME:                   #hw.innerNameRef<@DedupedPath::@[[dutSym]]>,
+// CHECK-SAME:                   @DUT,
 // CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile1>,
 // CHECK-SAME:                   #hw.innerNameRef<@Tile::@w>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.bar = {{1}}.{{2}}.{{3}}.{{4}};"
+// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.bar = {{1}}.{{2}}.{{3}};"
 // CHECK-SAME:                 symbols = [#hw.innerNameRef<@DUT::@__MyView_Foo__>,
-// CHECK-SAME:                   @DedupedPath,
-// CHECK-SAME:                   #hw.innerNameRef<@DedupedPath::@[[dutSym]]>,
+// CHECK-SAME:                   @DUT,
 // CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile2>,
 // CHECK-SAME:                   #hw.innerNameRef<@Tile::@w>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.baz = {{1}}.{{2}}.{{3}}.{{4}};"
+// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.baz = {{1}}.{{2}}.{{3}};"
 // CHECK-SAME:                 symbols = [#hw.innerNameRef<@DUT::@__MyView_Foo__>,
-// CHECK-SAME:                   @DedupedPath,
-// CHECK-SAME:                   #hw.innerNameRef<@DedupedPath::@[[dutSym]]>,
+// CHECK-SAME:                   @DUT,
 // CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile1>,
 // CHECK-SAME:                   #hw.innerNameRef<@Tile::@x>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.qux = {{1}}.{{2}}.{{3}}.{{4}};"
+// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.qux = {{1}}.{{2}}.{{3}};"
 // CHECK-SAME:                 symbols = [#hw.innerNameRef<@DUT::@__MyView_Foo__>,
-// CHECK-SAME:                   @DedupedPath,
-// CHECK-SAME:                   #hw.innerNameRef<@DedupedPath::@[[dutSym]]>,
+// CHECK-SAME:                   @DUT,
 // CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile2>,
 // CHECK-SAME:                   #hw.innerNameRef<@Tile::@x>]
 


### PR DESCRIPTION
Modify the Grand Central (GCT) Views pass to generate SV
Verbatim-encoded XMRs that are as short as possible.  Do this with a
naive lowest-common ancestor (LCA) computation the prunes the XMR path
to start at the GCT View parent module (the module where the mapping
module containing the XMRs is instantiated).

Previously, the full non-local annotation (NLA) hierarchical path would
be blindly used under the assumption that this path was what the user
wanted.  This was problematic as the Chisel API will always generate an
absolute path starting from the FIRRTL circuit's main module instead of
a path starting from where the GCT API is used.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>