### PR TITLE
Treat regreset the same in its initial lattice value as reg

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -167,6 +167,19 @@ private:
 };
 } // end anonymous namespace
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const LatticeValue &lattice) {
+  if (lattice.isUnknown()) {
+    return os << "<Unknown>";
+  } else if (lattice.isOverdefined()) {
+    return os << "<Overdefined>";
+  } else if (lattice.isInvalidValue()) {
+    return os << "<Invalid>";
+  } else {
+    return os << "<" << lattice.getConstant() << ">";
+  }
+}
+
 namespace {
 struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   void runOnOperation() override;
@@ -249,8 +262,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
 
   /// Mark the given block as executable.
   void markBlockExecutable(Block *block);
-  void markWireOrUnresetableRegOp(Operation *wireOrReg);
-  void markRegResetOp(RegResetOp regReset);
+  void markWireRegOp(Operation *wireOrReg);
   void markMemOp(MemOp mem);
 
   void markInvalidValueOp(InvalidValueOp invalid);
@@ -260,6 +272,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
 
   void visitConnect(ConnectOp connect);
   void visitStrictConnect(StrictConnectOp connect);
+  void visitRegResetOp(RegResetOp regReset);
   void visitOperation(Operation *op);
 
 private:
@@ -369,8 +382,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
   for (auto &op : *block) {
 
     // Handle each of the special operations in the firrtl dialect.
-    if (isa<WireOp>(op) || isa<RegOp>(op))
-      markWireOrUnresetableRegOp(&op);
+    if (isWireOrReg(&op))
+      markWireRegOp(&op);
     else if (auto constant = dyn_cast<ConstantOp>(op))
       markConstantOp(constant);
     else if (auto specialConstant = dyn_cast<SpecialConstantOp>(op))
@@ -379,14 +392,12 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
       markInvalidValueOp(invalid);
     else if (auto instance = dyn_cast<InstanceOp>(op))
       markInstanceOp(instance);
-    else if (auto regReset = dyn_cast<RegResetOp>(op))
-      markRegResetOp(regReset);
     else if (auto mem = dyn_cast<MemOp>(op))
       markMemOp(mem);
   }
 }
 
-void IMConstPropPass::markWireOrUnresetableRegOp(Operation *wireOrReg) {
+void IMConstPropPass::markWireRegOp(Operation *wireOrReg) {
   // If the wire/reg has a non-ground type, then it is too complex for us to
   // handle, mark it as overdefined.
   // TODO: Eventually add a field-sensitive model.
@@ -396,26 +407,6 @@ void IMConstPropPass::markWireOrUnresetableRegOp(Operation *wireOrReg) {
 
   // Otherwise, this starts out as InvalidValue and is upgraded by connects.
   mergeLatticeValue(resultValue, InvalidValueAttr::get(resultValue.getType()));
-}
-
-void IMConstPropPass::markRegResetOp(RegResetOp regReset) {
-  // If the reg has a non-ground type, then it is too complex for us to handle,
-  // mark it as overdefined.
-  // TODO: Eventually add a field-sensitive model.
-  if (!regReset.getType().getPassiveType().isGround())
-    return markOverdefined(regReset);
-
-  // The reset value may be known - if so, merge it in if the enable is greater
-  // than invalid.
-  auto srcValue = getExtendedLatticeValue(regReset.resetValue(),
-                                          regReset.getType().cast<FIRRTLType>(),
-                                          /*allowTruncation=*/true);
-  auto enable = getExtendedLatticeValue(regReset.resetSignal(),
-                                        regReset.getType().cast<FIRRTLType>(),
-                                        /*allowTruncation=*/true);
-  if (enable.isOverdefined() ||
-      (enable.isConstant() && !enable.getConstant().getValue().isZero()))
-    mergeLatticeValue(regReset, srcValue);
 }
 
 void IMConstPropPass::markMemOp(MemOp mem) {
@@ -604,6 +595,27 @@ void IMConstPropPass::visitStrictConnect(StrictConnectOp connect) {
       << "strictconnect destination is here";
 }
 
+void IMConstPropPass::visitRegResetOp(RegResetOp regReset) {
+  // If the reg has a non-ground type, then it is too complex for us to handle,
+  // mark it as overdefined.
+  // TODO: Eventually add a field-sensitive model.
+  if (!regReset.getType().getPassiveType().isGround())
+    return markOverdefined(regReset);
+
+  // The reset value may be known - if so, merge it in if the enable is greater
+  // than invalid.
+  auto srcValue = getExtendedLatticeValue(regReset.resetValue(),
+                                          regReset.getType().cast<FIRRTLType>(),
+                                          /*allowTruncation=*/true);
+  auto enable = getExtendedLatticeValue(
+      regReset.resetSignal(),
+      regReset.resetSignal().getType().cast<FIRRTLType>(),
+      /*allowTruncation=*/true);
+  if (enable.isOverdefined() ||
+      (enable.isConstant() && !enable.getConstant().getValue().isZero()))
+    mergeLatticeValue(regReset, srcValue);
+}
+
 /// This method is invoked when an operand of the specified op changes its
 /// lattice value state and when the block containing the operation is first
 /// noticed as being alive.
@@ -617,7 +629,7 @@ void IMConstPropPass::visitOperation(Operation *op) {
   if (auto strictConnectOp = dyn_cast<StrictConnectOp>(op))
     return visitStrictConnect(strictConnectOp);
   if (auto regResetOp = dyn_cast<RegResetOp>(op))
-    return markRegResetOp(regResetOp);
+    return visitRegResetOp(regResetOp);
 
   // The clock operand of regop changing doesn't change its result value.
   if (isa<RegOp>(op))

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -167,8 +167,8 @@ private:
 };
 } // end anonymous namespace
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const LatticeValue &lattice) {
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const LatticeValue &lattice) {
   if (lattice.isUnknown()) {
     return os << "<Unknown>";
   } else if (lattice.isOverdefined()) {

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -495,67 +495,6 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
 
 // -----
 
-firrtl.circuit "constRegReset" {
-// CHECK-LABEL: firrtl.module @constRegReset
-firrtl.module @constRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK:  %[[C13:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C13]]
-  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-}
-}
-
-// -----
-
-firrtl.circuit "constRegReset2" {
-// CHECK-LABEL: firrtl.module @constRegReset2
-firrtl.module @constRegReset2(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK:  %[[C14:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C14]]
-  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-}
-}
-
-// -----
-
-firrtl.circuit "regMuxTree"   {
-  // CHECK-LABEL: firrtl.module @regMuxTree
-  firrtl.module @regMuxTree(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cmd: !firrtl.uint<3>, out %z: !firrtl.uint<8>) {
-    %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
-    %c2_ui8 = firrtl.constant 2 : !firrtl.uint<8>
-    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
-    %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
-    %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c7_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
-    %0 = firrtl.orr %cmd : (!firrtl.uint<3>) -> !firrtl.uint<1>
-    %1 = firrtl.not %0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %3 = firrtl.eq %cmd, %c1_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %4 = firrtl.and %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %5 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %6 = firrtl.and %2, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %7 = firrtl.eq %cmd, %c2_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %8 = firrtl.and %6, %7 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %9 = firrtl.mux(%8, %c7_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    %10 = firrtl.mux(%4, %r, %9) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    %11 = firrtl.mux(%1, %c7_ui8, %10) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    firrtl.connect %r, %11 : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK:  %[[c7_ui8:.+]] = firrtl.constant 7 : !firrtl.uint<8>
-    // CHECK:  firrtl.connect %z, %[[c7_ui8]] : !firrtl.uint<8>, !firrtl.uint<8>
-  }
-}
-
-// -----
-
 // issue 1793
 // Ensure don't touch on output port is seen by instances
 firrtl.circuit "dntOutput" {
@@ -588,5 +527,30 @@ firrtl.circuit "AnnotationsBlockRemoval"  {
     firrtl.strictconnect %w, %c1_ui1 : !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %b, %c1_ui1
     firrtl.strictconnect %b, %w : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: "Issue3372"
+firrtl.circuit "Issue3372"  {
+  firrtl.module @Issue3372(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %value: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %other_zero = firrtl.instance other interesting_name  @Other(out zero: !firrtl.uint<1>)
+    %shared = firrtl.regreset interesting_name %clock, %c0_ui1, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.strictconnect %shared, %shared : !firrtl.uint<1>
+    %test = firrtl.wire interesting_name  : !firrtl.uint<1>
+    firrtl.strictconnect %test, %shared : !firrtl.uint<1>
+    firrtl.strictconnect %value, %invalid_ui1 : !firrtl.uint<1>
+  }
+// CHECK:  firrtl.strictconnect %shared, %invalid_ui1 : !firrtl.uint<1>
+// CHECK:  firrtl.strictconnect %test, %invalid_ui1 : !firrtl.uint<1>
+// CHECK:  firrtl.strictconnect %value, %invalid_ui1_0 : !firrtl.uint<1>
+
+  firrtl.module private @Other(out %zero: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
This breaks two tests, which arguably were wrong before, though might have matched SFC.

This makes all registers and wires start in an invalid state (rather than invalid for reg and wire and unknown for regreset).

This doesn't necessarily make sense, possibly all regs should start unknown and all wires invalid?