### PR TITLE
[FIRRTL] Move all name preservation logic into the drop names pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -35,7 +35,6 @@ def EmptyAttrDict : Constraint<CPred<"$0.empty()">>;
 def GetDroppableNameAttr : NativeCodeCall<
   "NameKindEnumAttr::get($_builder.getContext(), NameKindEnum::DroppableName) ">;
 def NonEmptyAttr : Constraint<CPred<"!$0.getValue().empty()">>;
-def uselessNameAttr : Constraint<CPred<"isUselessName($0.getValue())">>;
 def NullAttr : Constraint<CPred<"!$0">>;
 
 // Constraint that enforces equal types

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -96,7 +96,23 @@ createMergeConnectionsPass(bool enableAggressiveMerging = false);
 
 std::unique_ptr<mlir::Pass> createInjectDUTHierarchyPass();
 
-std::unique_ptr<mlir::Pass> createDropNamesPass();
+/// Configure which values will be explicitly preserved by the DropNames pass.
+namespace PreserveValues {
+enum PreserveMode {
+  /// Don't explicitly preserve any named values. Every named operation could
+  /// be optimized away by the compiler.
+  None,
+  // Explicitly preserved values with meaningful names.  If a name begins with
+  // an "_" it is not considered meaningful.
+  Named,
+  // Explicitly preserve all values.  No named operation should be optimized
+  // away by the compiler.
+  All,
+};
+}
+
+std::unique_ptr<mlir::Pass>
+createDropNamesPass(PreserveValues::PreserveMode mode = PreserveValues::None);
 
 std::unique_ptr<mlir::Pass> createExtractInstancesPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -507,8 +507,8 @@ def MemToRegOfVec : Pass<"firrtl-mem-to-reg-of-vec", "firrtl::CircuitOp"> {
 def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
   let summary = "Drop interesting names";
   let description = [{
-    This pass changes names of namable ops to droppable so that
-    we can disable full name preservation. For example,
+    This pass changes names of namable ops to droppable so that we can disable
+    full name preservation. For example,
     before:
     ```mlir
     %a = firrtl.node interesting_name %input
@@ -519,6 +519,19 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
     ```
   }];
   let constructor = "circt::firrtl::createDropNamesPass()";
+  let options = [
+    Option<"preserveMode", "preserve-values", "PreserveValues::PreserveMode", 
+           "PreserveValues::None", 
+           "specify the values which can be optimized away", [{
+            ::llvm::cl::values(
+              clEnumValN(PreserveValues::None, "none",
+                "Preserve no values"),
+              clEnumValN(PreserveValues::Named, "named",
+                "Preserve values with meaningful names"),
+              clEnumValN(PreserveValues::All, "all",
+                "Preserve all values"))
+           }]>
+  ];
   let statistics = [
     Statistic<"numNamesConverted", "num-names-converted",
       "Number of interesting names made droppable">,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -172,11 +172,6 @@ std::pair<bool, Optional<LocationAttr>> circt::firrtl::maybeStringToLocation(
   return {true, result};
 }
 
-static firrtl::NameKindEnum inferNameKind(StringRef name) {
-  return circt::firrtl::isUselessName(name) ? NameKindEnum::DroppableName
-                                            : NameKindEnum::InterestingName;
-}
-
 //===----------------------------------------------------------------------===//
 // SharedParserConstants
 //===----------------------------------------------------------------------===//
@@ -2833,8 +2828,8 @@ ParseResult FIRStmtParser::parseInstance() {
     }
 
   result = builder.create<InstanceOp>(
-      referencedModule, id, inferNameKind(id), annotations.first.getValue(),
-      annotations.second.getValue(), false, sym);
+      referencedModule, id, NameKindEnum::InterestingName,
+      annotations.first.getValue(), annotations.second.getValue(), false, sym);
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues
@@ -2880,9 +2875,9 @@ ParseResult FIRStmtParser::parseCombMem() {
                                moduleContext.targetsInModule, type);
 
   auto sym = getSymbolIfRequired(annotations, id);
-  auto result = builder.create<CombMemOp>(vectorType.getElementType(),
-                                          vectorType.getNumElements(), id,
-                                          inferNameKind(id), annotations, sym);
+  auto result = builder.create<CombMemOp>(
+      vectorType.getElementType(), vectorType.getNumElements(), id,
+      NameKindEnum::InterestingName, annotations, sym);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -2918,9 +2913,9 @@ ParseResult FIRStmtParser::parseSeqMem() {
                                moduleContext.targetsInModule, type);
   auto sym = getSymbolIfRequired(annotations, id);
 
-  auto result = builder.create<SeqMemOp>(vectorType.getElementType(),
-                                         vectorType.getNumElements(), ruw, id,
-                                         inferNameKind(id), annotations, sym);
+  auto result = builder.create<SeqMemOp>(
+      vectorType.getElementType(), vectorType.getNumElements(), ruw, id,
+      NameKindEnum::InterestingName, annotations, sym);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -3059,7 +3054,7 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     }
   result = builder.create<MemOp>(
       resultTypes, readLatency, writeLatency, depth, ruw,
-      builder.getArrayAttr(resultNames), id, inferNameKind(id),
+      builder.getArrayAttr(resultNames), id, NameKindEnum::InterestingName,
       annotations.first, annotations.second,
       sym ? InnerSymAttr::get(sym) : InnerSymAttr(), IntegerAttr());
 
@@ -3115,8 +3110,9 @@ ParseResult FIRStmtParser::parseNode() {
                                moduleContext.targetsInModule, initializerType);
 
   auto sym = getSymbolIfRequired(annotations, id);
-  auto result = builder.create<NodeOp>(initializer.getType(), initializer, id,
-                                       inferNameKind(id), annotations, sym);
+  auto result =
+      builder.create<NodeOp>(initializer.getType(), initializer, id,
+                             NameKindEnum::InterestingName, annotations, sym);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -3143,9 +3139,9 @@ ParseResult FIRStmtParser::parseWire() {
                                moduleContext.targetsInModule, type);
 
   auto sym = getSymbolIfRequired(annotations, id);
-  auto result =
-      builder.create<WireOp>(type, id, inferNameKind(id), annotations,
-                             sym ? InnerSymAttr::get(sym) : InnerSymAttr());
+  auto result = builder.create<WireOp>(
+      type, id, NameKindEnum::InterestingName, annotations,
+      sym ? InnerSymAttr::get(sym) : InnerSymAttr());
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -3238,12 +3234,12 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   Value result;
   auto sym = getSymbolIfRequired(annotations, id);
   if (resetSignal)
-    result =
-        builder.create<RegResetOp>(type, clock, resetSignal, resetValue, id,
-                                   inferNameKind(id), annotations, sym);
+    result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
+                                        id, NameKindEnum::InterestingName,
+                                        annotations, sym);
   else
-    result = builder.create<RegOp>(type, clock, id, inferNameKind(id),
-                                   annotations, sym);
+    result = builder.create<RegOp>(
+        type, clock, id, NameKindEnum::InterestingName, annotations, sym);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -12,6 +12,7 @@
 
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 
 using namespace circt;
@@ -19,21 +20,37 @@ using namespace firrtl;
 
 namespace {
 struct DropNamesPass : public DropNameBase<DropNamesPass> {
+  DropNamesPass(PreserveValues::PreserveMode preserveMode) {
+    this->preserveMode = preserveMode;
+  }
+
   void runOnOperation() override {
+    if (preserveMode == PreserveValues::None) {
+      // Drop all names.
+      numNamesConverted += dropNamesIf([](FNamableOp) { return true; });
+    } else if (preserveMode == PreserveValues::Named) {
+      // Drop the name if it isn't considered meaningful.
+      numNamesConverted += dropNamesIf(
+          [](FNamableOp op) { return isUselessName(op.getName()); });
+    }
+  }
+
+private:
+  size_t dropNamesIf(llvm::function_ref<bool(FNamableOp)> pred) {
     size_t changedNames = 0;
-    getOperation()->walk([&changedNames](FNamableOp op) {
-      if (!op.hasDroppableName()) {
+    getOperation()->walk([&](FNamableOp op) {
+      if (pred(op)) {
         ++changedNames;
         op.dropName();
       }
     });
-
-    numNamesConverted += changedNames;
+    return changedNames;
   }
 };
 
 } // end anonymous namespace
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createDropNamesPass() {
-  return std::make_unique<DropNamesPass>();
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createDropNamesPass(PreserveValues::PreserveMode mode) {
+  return std::make_unique<DropNamesPass>(mode);
 }

--- a/lib/Dialect/FIRRTL/Transforms/PassDetails.h
+++ b/lib/Dialect/FIRRTL/Transforms/PassDetails.h
@@ -17,6 +17,7 @@
 #define DIALECT_FIRRTL_TRANSFORMS_PASSDETAILS_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,5 +1,5 @@
 ; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
+; RUN: firtool --firrtl-grand-central --preserve-values=named --verilog --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
 ; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
 ; RUN: firtool --firrtl-grand-central --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
 
@@ -221,7 +221,7 @@ circuit Top :
     ; EXTRACT:        module MyView_companion();
     ; EXTRACT:          Tap tap (
     ; EXTRACT-NEXT:       .b     (r),
-    ; EXTRACT-NEXT:       .clock (clock),
+    ; EXTRACT-NEXT:       .clock (_tap_clock),
     ; EXTRACT-NEXT:       .a     (_tap_a)
     ; EXTRACT-NEXT:     );
     ; EXTRACT-NEXT:     MyView_mapping MyView_mapping{{ *}}();

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -14,10 +14,10 @@ circuit Foo:
     literal[1] <= UInt<1>("h00")
     literal[2] <= UInt<1>("h00")
     literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
-    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
-    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, literal))
     r <= x
     z <= r
@@ -40,10 +40,10 @@ circuit Foo:
     complex_literal[1] <= literal[1]
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -65,10 +65,10 @@ circuit Foo:
     complex_literal[1] <= bundle.b
     complex_literal[2] <= UInt<1>("h00")
     complex_literal[3] <= UInt<1>("h00")
-    ; CHECK: %r_0 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
-    ; CHECK: %r_1 = firrtl.regreset {{.+}} %clock, %reset, %c1_ui1
-    ; CHECK: %r_2 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
-    ; CHECK: %r_3 = firrtl.regreset {{.+}} %clock, %reset, %c0_ui1
+    ; CHECK: %r_0 = firrtl.regreset %clock, %reset, %c1_ui1
+    ; CHECK: %r_1 = firrtl.regreset %clock, %reset, %c1_ui1
+    ; CHECK: %r_2 = firrtl.regreset %clock, %reset, %c0_ui1
+    ; CHECK: %r_3 = firrtl.regreset %clock, %reset, %c0_ui1
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     r <= x
     z <= r
@@ -83,11 +83,11 @@ circuit Foo:
     input x : SInt<4>
     output y : SInt<4>
     output z : SInt<4>
-    ; CHECK: %r = firrtl.regreset {{.+}} %clock, %reset, %c0_si1
+    ; CHECK: %r = firrtl.regreset %clock, %reset, %c0_si1
     reg r : SInt<4>, clock with : (reset => (reset, asSInt(UInt(0))))
     r <= x
     wire w : SInt<4>
-    ; CHECK: %r2 = firrtl.regreset {{.+}} %clock, %reset, %c-1_si4
+    ; CHECK: %r2 = firrtl.regreset %clock, %reset, %c-1_si4
     reg r2 : SInt<4>, clock with : (reset => (reset, w))
     r2 <= x
     node n = UInt("hf")

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -18,7 +18,7 @@
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -37,13 +37,13 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
   ; CHECK: firrtl.module private @A
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.instance b {{.+}} @B(
+    ; CHECK: firrtl.instance b @B(
     inst b of B
     x <= b.x
   module A_ :
@@ -67,8 +67,8 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK: firrtl.instance a1 {{.+}} @A(
-    ; CHECK: firrtl.instance a2 {{.+}} @A(
+    ; CHECK: firrtl.instance a1 @A(
+    ; CHECK: firrtl.instance a2 @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -96,7 +96,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
   module A : @[yy 2:2]
@@ -116,14 +116,14 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
   ; CHECK: firrtl.module private @A
   module A : @[yy 2:2]
     output x: UInt<1> @[yy 2:2]
-    ; CHECK-NEXT: firrtl.instance b {{.+}} @B(
+    ; CHECK-NEXT: firrtl.instance b @B(
     inst b of B
     x <= b.u
   module A_ : @[xx 1:1]
@@ -150,8 +150,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 {{.+}} @A(
-    ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A_(
+    ; CHECK-NEXT: firrtl.instance a1 @A(
+    ; CHECK-NEXT: firrtl.instance a2 @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -183,8 +183,8 @@ circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
     output out: UInt<1>
-    ; CHECK-NEXT: firrtl.instance a1 {{.+}} @A(
-    ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A_(
+    ; CHECK-NEXT: firrtl.instance a1 @A(
+    ; CHECK-NEXT: firrtl.instance a2 @A_(
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
@@ -228,8 +228,8 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip bar : UInt<1>, buzz : UInt<1>}}
-    ; CHECK: firrtl.instance foo {{.+}} @FooModule
-    ; CHECK: firrtl.instance bar {{.+}} @FooModule
+    ; CHECK: firrtl.instance foo @FooModule
+    ; CHECK: firrtl.instance bar @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <- foo.io
@@ -252,7 +252,7 @@ circuit FooAndBarModule :
   ; CHECK: firrtl.module @FooAndBarModule
   module FooAndBarModule :
     output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip foo : UInt<1>, fuzz : UInt<1>}}
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} {{.+}} @FooModule
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{(foo|bar)}} @FooModule
     inst foo of FooModule
     inst bar of BarModule
     io.foo <= foo.io
@@ -265,7 +265,7 @@ circuit FooAndBarModule :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -293,7 +293,7 @@ circuit Top :
 circuit Top :
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} {{.+}} @A(
+    ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
   module A :
@@ -321,8 +321,8 @@ circuit Top : %[[
 ]]
   ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
-  ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
+  ; CHECK-NEXT: firrtl.instance a2 @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -357,8 +357,8 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
-  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {{.+}} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
+  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
   module Top :
     inst a1 of A
     inst a2 of A_
@@ -456,9 +456,9 @@ circuit Top : %[[
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] {{.+}} @A()
+    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
     inst a of A
-    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] {{.+}} @A()
+    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] @A()
     inst a_ of A_
   ; CHECK: firrtl.module private @A
   module A :

--- a/test/Dialect/FIRRTL/SFCTests/invalid-reg-pass.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-reg-pass.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -split-input-file -drop-names -verilog %s | FileCheck %s
+; RUN: firtool -split-input-file -verilog %s | FileCheck %s
 
 ; This test checks register removal behavior for situations where the register
 ; is invalidated _through a primitive operation_.  This is intended to tease out

--- a/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/remove-reset.fir
@@ -13,8 +13,8 @@ circuit Example :
     output out : UInt<1>[2]
     wire bar : UInt<1>
     bar is invalid
-    ; CHECK: %foo0 = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo1 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo0 = firrtl.reg %clock :
+    ; CHECK: %foo1 = firrtl.reg %clock :
     reg foo0 : UInt<1>, clock with : (reset => (arst, bar))
     reg foo1 : UInt<1>, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -40,12 +40,12 @@ circuit Example :
     bar is invalid
     bar.a[1] <= UInt<1>(0)
 
-    ; CHECK: %foo0_a_0 = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo0_a_1 = firrtl.regreset {{.+}} %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo1_a_0 = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo1_a_1 = firrtl.regreset {{.+}} %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo0_a_0 = firrtl.reg %clock :
+    ; CHECK: %foo0_a_1 = firrtl.regreset %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg %clock :
+    ; CHECK: %foo1_a_0 = firrtl.reg %clock :
+    ; CHECK: %foo1_a_1 = firrtl.regreset %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg %clock :
     reg foo0 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (arst, bar))
     reg foo1 : {a : UInt<1>[2], b : UInt<1>}, clock with : (reset => (srst, bar))
     foo0 <= in
@@ -75,10 +75,10 @@ circuit Example :
     baz is invalid
     baz <= bar
 
-    ; CHECK: %foo0_a = firrtl.regreset {{.+}} %clock, %arst,
-    ; CHECK: %foo0_b = firrtl.reg {{.+}} %clock
-    ; CHECK: %foo1_a = firrtl.regreset {{.+}} %clock, %srst,
-    ; CHECK: %foo1_b = firrtl.reg {{.+}} %clock
+    ; CHECK: %foo0_a = firrtl.regreset %clock, %arst,
+    ; CHECK: %foo0_b = firrtl.reg %clock
+    ; CHECK: %foo1_a = firrtl.regreset %clock, %srst,
+    ; CHECK: %foo1_b = firrtl.reg %clock
     reg foo0 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (arst, baz))
     reg foo1 : { a : UInt<1>, b : UInt<1> }, clock with : (reset => (srst, baz))
     foo0 <= in
@@ -104,9 +104,9 @@ circuit Example :
     arst <= asAsyncReset(UInt<1>(0))
     srst <= UInt<1>(0)
 
-    ; CHECK: %foo0 = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo1 = firrtl.reg {{.+}} %clock :
-    ; CHECK: %foo2 = firrtl.reg {{.+}} %clock :
+    ; CHECK: %foo0 = firrtl.reg %clock :
+    ; CHECK: %foo1 = firrtl.reg %clock :
+    ; CHECK: %foo2 = firrtl.reg %clock :
     reg foo0 : UInt<2>, clock with : (reset => (rst, UInt(3)))
     reg foo1 : UInt<2>, clock with : (reset => (arst, UInt(3)))
     reg foo2 : UInt<2>, clock with : (reset => (srst, UInt(3)))

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -339,50 +339,6 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>w[9]"}]]
 
 ; // -----
 
-; Annotations should apply even when the target's name is dropped.
-circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "a": "a"},
-                {"target": "~Foo|Foo>_T_1", "a": "a"},
-                {"target": "~Foo|Foo>_T_2", "a": "a"},
-                {"target": "~Foo|Foo>_T_3", "a": "a"},
-                {"target": "~Foo|Foo>_T_4", "a": "a"},
-                {"target": "~Foo|Foo>_T_5", "a": "a"},
-                {"target": "~Foo|Foo>_T_6", "a": "a"},
-                {"target": "~Foo|Foo>_T_7", "a": "a"},
-                {"target": "~Foo|Foo>_T_8", "a": "a"}]]
-  module Bar:
-    skip
-  module Foo:
-    input reset : UInt<1>
-    input clock : Clock
-
-    ; CHECK: %_T_0 = firrtl.wire  {annotations = [{a = "a"}]}
-    wire _T_0 : UInt<1>
-    ; CHECK: %_T_1 = firrtl.node
-    node _T_1 = _T_0
-    ; CHECK: %_T_2 = firrtl.reg %clock  {annotations = [{a = "a"}]}
-    reg _T_2 : UInt<1>, clock
-    ; CHECK: %_T_3 = firrtl.regreset {{.+}}  {annotations = [{a = "a"}]}
-    reg _T_3 : UInt<4>, clock with :
-      reset => (reset, UInt<4>("h0"))
-    ; CHECK: %_T_4 = chirrtl.seqmem Undefined {annotations = [{a = "a"}]}
-    smem _T_4 : UInt<1>[9] [256]
-    ; CHECK: %_T_5 = chirrtl.combmem {annotations = [{a = "a"}]}
-    cmem _T_5 : UInt<1>[9] [256]
-    ; CHECK: chirrtl.memoryport {{.+}} {annotations = [{a = "a"}]
-    infer mport _T_6 = _T_5[reset], clock
-    ; CHECK: firrtl.instance _T_7 {annotations = [{a = "a"}]}
-    inst _T_7 of Bar
-    ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}]
-    mem _T_8 :
-        data-type => UInt<4>
-        depth => 8
-        writer => w
-        read-latency => 0
-        write-latency => 1
-        read-under-write => undefined
-
-; // -----
-
 ; Test that an annotated, anonymous node is preserved if annotated.  Normally,
 ; the FIRRTL parser will aggressively eliminate these.
 circuit AnnotationsBlockNodePruning: %[[

--- a/test/Dialect/FIRRTL/drop-name.mlir
+++ b/test/Dialect/FIRRTL/drop-name.mlir
@@ -1,9 +1,17 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names))' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=all}))' %s   | FileCheck %s --check-prefix=ALL
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=named}))' %s | FileCheck %s --check-prefix=NAMED
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=none}))' %s  | FileCheck %s --check-prefix=NONE
 
 firrtl.circuit "Foo" {
-  // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
-    // CHECK-NEXT:  %a = firrtl.wire  : !firrtl.uint<1>
+    // ALL:   %a = firrtl.wire  interesting_name : !firrtl.uint<1>
+    // NAMED: %a = firrtl.wire  interesting_name : !firrtl.uint<1>
+    // NONE:  %a = firrtl.wire  : !firrtl.uint<1>
     %a = firrtl.wire interesting_name : !firrtl.uint<1>
+
+    // ALL:   %_a = firrtl.wire  interesting_name : !firrtl.uint<1>
+    // NAMED: %_a = firrtl.wire  : !firrtl.uint<1>
+    // NONE:  %_a = firrtl.wire  : !firrtl.uint<1>
+    %_a = firrtl.wire interesting_name : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -87,10 +87,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input a8 : Analog<8>          ; CHECK: in %a8: !firrtl.analog<8>,
     input ab : {x : Analog<1>}    ; CHECK: in %ab: !firrtl.bundle<x: analog<1>>)
 
-    ; CHECK: %_t = firrtl.wire : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
 
-    ; CHECK: %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_2 = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     wire _t_2 : UInt<1>[12]
 
     ; CHECK: firrtl.strictconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
@@ -135,9 +135,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
-    ; CHECK: %_t_3 = firrtl.wire : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_3 = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[A:%.+]] = firrtl.subindex %_t_3[0] : !firrtl.vector<uint<1>, 12>
-    ; CHECK: %_t_4 = firrtl.wire : !firrtl.vector<uint<1>, 12>
+    ; CHECK: %_t_4 = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[B:%.+]] = firrtl.subindex %_t_4[0] : !firrtl.vector<uint<1>, 12>
     ; CHECK: firrtl.strictconnect [[A]], [[B]]
     wire _t_3 : UInt<1>[12] @[Nodes.scala 370:76]
@@ -307,11 +307,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint) -> !firrtl.uint
     node n8 = mux(reset, i8, UInt(4))
 
-    ; CHECK: %_t_2621 = firrtl.regreset %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
     reg _t_2621 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0")) @[Edges.scala 230:27]
 
-    ; CHECK: %_t_1601 = firrtl.regreset %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     reg _t_1601 : UInt<2>, clock with :
       (reset => (reset, UInt<2>("h00"))) @[Edges.scala 230:27]
 
@@ -329,7 +329,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; The Scala implementation of FIRRTL prints registers without a reset value
     ; using the register name as the reset.  Make sure we handle this for
     ; compatibility.
-    ; CHECK: %_t_2622 = firrtl.reg %clock : !firrtl.uint<4>
+    ; CHECK: %_t_2622 = firrtl.reg interesting_name %clock : !firrtl.uint<4>
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 
@@ -388,7 +388,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node n13 = not(auto)
 
 
-    ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
+    ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem interesting_name Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
     ; CHECK-SAME: readLatency = 0 : i32, writeLatency = 1 : i32} :
     ; CHECK-SAME: !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>,
     ; CHECK-SAME: !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>,
@@ -581,7 +581,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf(0)
-    ; CHECK: %_T = firrtl.node %0
+    ; CHECK: %_T = firrtl.node interesting_name %0
     node _T = bf.int_1
     ; CHECK: firrtl.when %_T {
     when _T :

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -94,31 +94,31 @@ circuit test_mod : %[[{"a": "a"}]]
 
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>, out %out_implicitTrunc: !firrtl.uint<1>, out %out_prettifyExample: !firrtl.uint<1>, out %out_multibitMux: !firrtl.uint<1>) {
-; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat interesting_name  @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
+; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
 ; MLIR-NEXT:    firrtl.strictconnect %cat_a, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.strictconnect %cat_b, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.strictconnect %cat_c, %b : !firrtl.uint<2>
-; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc interesting_name @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
+; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
 ; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
-; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample interesting_name @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
+; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop interesting_name @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
+; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_clock, %clock : !firrtl.clock
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_a_d, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %c, %flipFlop_a_q : !firrtl.uint<1>
-; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux interesting_name @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
+; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.instance unusedPortsMod interesting_name @UnusedPortsMod()
+; MLIR-NEXT:    firrtl.instance unusedPortsMod @UnusedPortsMod()
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod
 ; ANNOTATIONS-SAME: info = "a ModuleTarget Annotation"

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir  --ir-sv | FileCheck %s
+; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
 
 circuit Qux: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
@@ -61,21 +61,15 @@ circuit Qux: %[[{
 
 
 ;CHECK-LABEL: hw.module @Qux
-;CHECK:    %[[memory_r_data:.+]] = sv.wire sym @__Qux__memory_r_data  : !hw.inout<i8>
-;CHECK:    %[[v0:.+]] = sv.read_inout %[[memory_r_data]]
 ;CHECK:    %[[memory_0:.+]] = sv.reg
 ;CHECK:    %[[memory_1:.+]] = sv.reg
 ;CHECK:    %[[memory_2:.+]] = sv.reg
 ;CHECK:    %[[memory_3:.+]] = sv.reg
 ;CHECK:    %[[addr:.+]] = sv.reg
-;CHECK:    %[[v5:.+]] = sv.read_inout %[[addr]]
-;CHECK:    %[[v6:.+]] = hw.array_create
-;CHECK:    %[[v7:.+]] = hw.array_get %[[v6]][%[[v5]]]
-;CHECK:    sv.assign %[[memory_r_data]], %[[v7]] : i8
-;CHECK:    %[[memory_rw_rdata:.+]] = sv.wire sym @__Qux__memory_rw_rdata  : !hw.inout<i8>
-;CHECK:    %[[v8:.+]] = sv.read_inout %memory_rw_rdata : !hw.inout<i8>
-;CHECK:    %[[v9:.+]] = hw.array_get %[[v6]][%rwAddr] : !hw.array<4xi8>
-;CHECK:    sv.assign %[[memory_rw_rdata]], %[[v9]] : i8
+;CHECK:    %[[v4:.+]] = sv.read_inout %[[addr]]
+;CHECK:    %[[v5:.+]] = hw.array_create
+;CHECK:    %[[v6:.+]] = hw.array_get %[[v5]][%[[v4]]]
+;CHECK:    %[[v7:.+]] = hw.array_get %[[v5]][%rwAddr] : !hw.array<4xi8>
 ;CHECK:    sv.always posedge %clock {
 ;CHECK-NEXT:      sv.passign %[[addr]], %rAddr : i2
 ;CHECK-NEXT:      sv.passign %[[memory_0]]
@@ -83,4 +77,4 @@ circuit Qux: %[[{
 ;CHECK-NEXT:      sv.passign %[[memory_2]]
 ;CHECK-NEXT:      sv.passign %[[memory_3]]
 ;CHECK-NEXT:    }
-;CHECK:    hw.output %[[v0]], %[[v8]]
+;CHECK:    hw.output %[[v6]], %[[v7]]

--- a/test/firtool/name-preservation.fir
+++ b/test/firtool/name-preservation.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | FileCheck %s 
+; RUN: firtool --preserve-values=named %s | FileCheck %s 
 
 circuit Foo:
   ; CHECK-LABEL: module Foo

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -112,9 +112,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:          firrtl.instance mem interesting_name @prefix1_mem
+; CHECK:          firrtl.instance mem @prefix1_mem
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:          firrtl.instance mem interesting_name @prefix2_mem
+; CHECK:          firrtl.instance mem @prefix2_mem
 ; CHECK:        firrtl.memmodule @prefix1_mem
 ; CHECK:        firrtl.memmodule @prefix2_mem
 


### PR DESCRIPTION
This change moves more logic related to name preservation into the
DropNames pass.  The parser no longer determines if names should be
droppable at parse time, it always creates wires and registers with
`interesting_name`s.

The drop names pass used to unconditionally mark all operation as
"droppable_name"s when run.  The `DropNames` pass now takes a parameter
if it should preserve everything, nothing, or only things with meaningful
names.

I think that there is a problem with our current naming of "name
preservation": it is not about whether the "name" is preserved or
dropped, it describes whether a wire or register should be preserved or
dropped.  For this reason I think it makes more sense to refer to it as
"value preservation". As the first step toward moving the focus , I
changed the command line option of `firtool` from `-drop-names` to
`--preserve-values=[none | named | all]`.  Alternatives suggestions
welcome!

In the future, I think it would make sense to change the enum attributes
`interesting_name` to `preserved` and `droppable_name` to `droppable`.

This also changes firtool to mark all values droppable by default.