### PR TITLE
[PyCDE] Add `@testmodule` to reduce test boilerplate

### DIFF
--- a/frontends/PyCDE/src/CMakeLists.txt
+++ b/frontends/PyCDE/src/CMakeLists.txt
@@ -25,6 +25,7 @@ declare_mlir_python_sources(PyCDESources
     pycde/instance.py
     pycde/value.py
     pycde/ndarray.py
+    pycde/testing.py
 )
 
 add_mlir_python_modules(PyCDE

--- a/frontends/PyCDE/src/pycde/testing.py
+++ b/frontends/PyCDE/src/pycde/testing.py
@@ -1,0 +1,43 @@
+from pycde import System, module
+
+import builtins
+import inspect
+
+
+def testmodule(generate=True,
+               print=True,
+               run_passes=False,
+               emit_outputs=False,
+               **kwargs):
+  """
+  Like @module, but additionally performs system instantiation, generation,
+  and printing to reduce boilerplate in tests.
+  In case of wrapping a function, @testmodule accepts kwargs which are passed
+  to the function as arguments.
+  """
+
+  def testmodule_inner(func_or_class):
+    mod = module(func_or_class)
+
+    # Apply any provided kwargs if this was a function.
+    if inspect.isfunction(func_or_class):
+      mod = mod(**kwargs)
+
+    # Add the module to global scope in case it's referenced within the
+    # module generator functions
+    #globals()[mod.__name__] = mod
+    setattr(builtins, mod.__name__, mod)
+
+    sys = System([mod])
+    if generate:
+      sys.generate()
+      if print:
+        sys.print()
+      if run_passes:
+        sys.run_passes()
+      if emit_outputs:
+        sys.emit_outputs()
+
+    return mod
+
+  return testmodule_inner

--- a/frontends/PyCDE/src/pycde/testing.py
+++ b/frontends/PyCDE/src/pycde/testing.py
@@ -4,11 +4,11 @@ import builtins
 import inspect
 
 
-def testmodule(generate=True,
-               print=True,
-               run_passes=False,
-               emit_outputs=False,
-               **kwargs):
+def unittestmodule(generate=True,
+                   print=True,
+                   run_passes=False,
+                   emit_outputs=False,
+                   **kwargs):
   """
   Like @module, but additionally performs system instantiation, generation,
   and printing to reduce boilerplate in tests.
@@ -25,7 +25,6 @@ def testmodule(generate=True,
 
     # Add the module to global scope in case it's referenced within the
     # module generator functions
-    #globals()[mod.__name__] = mod
     setattr(builtins, mod.__name__, mod)
 
     sys = System([mod])

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,34 +1,12 @@
-# RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
+# RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
-from pycde import module, System, generator, dim, Input, Output, Value, types
+from pycde import System, generator, dim, Input, Output, Value, types
+from pycde.testing import testmodule
 import sys
 
 
 def array_from_tuple(*input):
   return Value(input)
-
-
-@module
-class ComplexMux:
-
-  Clk = Input(dim(1))
-  In = Input(dim(3, 4, 5))
-  Sel = Input(dim(1))
-  Out = Output(dim(3, 4))
-  OutArr = Output(dim(3, 4, 2))
-  OutSlice = Output(dim(3, 4, 3))
-  OutInt = Output(types.i1)
-
-  @generator
-  def create(ports):
-    clk = ports.Clk
-    select_from = Value([ports.In[3].reg(clk).reg(clk, cycles=2), ports.In[1]])
-    ports.Out = select_from[ports.Sel]
-
-    ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
-    ports.OutSlice = ports.In[0:3]
-
-    ports.OutInt = ports.In[0][0][ports.Sel]
 
 
 # CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>, OutInt: i1, OutSlice: !hw.array<3xarray<4xi3>>)
@@ -55,7 +33,45 @@ class ComplexMux:
 # CHECK:         msft.output [[R3]], [[R6]], [[R12]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, i1, !hw.array<3xarray<4xi3>>
 
 
-@module
+@testmodule()
+class ComplexMux:
+
+  Clk = Input(dim(1))
+  In = Input(dim(3, 4, 5))
+  Sel = Input(dim(1))
+  Out = Output(dim(3, 4))
+  OutArr = Output(dim(3, 4, 2))
+  OutSlice = Output(dim(3, 4, 3))
+  OutInt = Output(types.i1)
+
+  @generator
+  def create(ports):
+    clk = ports.Clk
+    select_from = Value([ports.In[3].reg(clk).reg(clk, cycles=2), ports.In[1]])
+    ports.Out = select_from[ports.Sel]
+
+    ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
+    ports.OutSlice = ports.In[0:3]
+
+    ports.OutInt = ports.In[0][0][ports.Sel]
+
+
+# -----
+
+# CHECK-LABEL:  msft.module @Slicing {} (%In: !hw.array<5xarray<4xi8>>, %Sel2: i2, %Sel8: i8) -> (OutArrSlice2: !hw.array<2xarray<4xi8>>, OutArrSlice8: !hw.array<2xarray<4xi8>>, OutIntSlice: i2)
+# CHECK:          [[R0:%.+]] = hw.array_get %In[%c0_i3] {sv.namehint = "In__0"} : !hw.array<5xarray<4xi8>>
+# CHECK:          [[R1:%.+]] = hw.array_get %0[%c0_i2] {sv.namehint = "In__0__0"} : !hw.array<4xi8>
+# CHECK:          [[R2:%.+]] = comb.concat %c0_i6, %Sel2 : i6, i2
+# CHECK:          [[R3:%.+]] = comb.shru [[R1]], [[R2]] : i8
+# CHECK:          [[R4:%.+]] = comb.extract [[R3]] from 0 : (i8) -> i2
+# CHECK:          [[R5:%.+]] = comb.concat %false, %Sel2 : i1, i2
+# CHECK:          [[R6:%.+]] = hw.array_slice %In[[[R5]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
+# CHECK:          [[R7:%.+]] = comb.extract %Sel8 from 0 : (i8) -> i3
+# CHECK:          [[R8:%.+]] = hw.array_slice %In[[[R7]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
+# CHECK:          msft.output [[R6]], [[R8]], [[R4]] : !hw.array<2xarray<4xi8>>, !hw.array<2xarray<4xi8>>, i2
+
+
+@testmodule()
 class Slicing:
   In = Input(dim(8, 4, 5))
   Sel8 = Input(types.i8)
@@ -71,22 +87,3 @@ class Slicing:
     ports.OutIntSlice = i.slice(ports.Sel2, 2)
     ports.OutArrSlice2 = ports.In.slice(ports.Sel2, 2)
     ports.OutArrSlice8 = ports.In.slice(ports.Sel8, 2)
-
-
-# CHECK-LABEL:  msft.module @Slicing {} (%In: !hw.array<5xarray<4xi8>>, %Sel2: i2, %Sel8: i8) -> (OutArrSlice2: !hw.array<2xarray<4xi8>>, OutArrSlice8: !hw.array<2xarray<4xi8>>, OutIntSlice: i2)
-# CHECK:          [[R0:%.+]] = hw.array_get %In[%c0_i3] {sv.namehint = "In__0"} : !hw.array<5xarray<4xi8>>
-# CHECK:          [[R1:%.+]] = hw.array_get %0[%c0_i2] {sv.namehint = "In__0__0"} : !hw.array<4xi8>
-# CHECK:          [[R2:%.+]] = comb.concat %c0_i6, %Sel2 : i6, i2
-# CHECK:          [[R3:%.+]] = comb.shru [[R1]], [[R2]] : i8
-# CHECK:          [[R4:%.+]] = comb.extract [[R3]] from 0 : (i8) -> i2
-# CHECK:          [[R5:%.+]] = comb.concat %false, %Sel2 : i1, i2
-# CHECK:          [[R6:%.+]] = hw.array_slice %In[[[R5]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
-# CHECK:          [[R7:%.+]] = comb.extract %Sel8 from 0 : (i8) -> i3
-# CHECK:          [[R8:%.+]] = hw.array_slice %In[[[R7]]] : (!hw.array<5xarray<4xi8>>) -> !hw.array<2xarray<4xi8>>
-# CHECK:          msft.output [[R6]], [[R8]], [[R4]] : !hw.array<2xarray<4xi8>>, !hw.array<2xarray<4xi8>>, i2
-
-s = System([ComplexMux, Slicing], name="Muxing", output_directory=sys.argv[1])
-s.generate()
-s.print()
-
-s.emit_outputs()

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,7 +1,7 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
 from pycde import System, generator, dim, Input, Output, Value, types
-from pycde.testing import testmodule
+from pycde.testing import unittestmodule
 import sys
 
 
@@ -33,7 +33,7 @@ def array_from_tuple(*input):
 # CHECK:         msft.output [[R3]], [[R6]], [[R12]], [[R7]] : !hw.array<4xi3>, !hw.array<2xarray<4xi3>>, i1, !hw.array<3xarray<4xi3>>
 
 
-@testmodule()
+@unittestmodule()
 class ComplexMux:
 
   Clk = Input(dim(1))
@@ -71,7 +71,7 @@ class ComplexMux:
 # CHECK:          msft.output [[R6]], [[R8]], [[R4]] : !hw.array<2xarray<4xi8>>, !hw.array<2xarray<4xi8>>, i2
 
 
-@testmodule()
+@unittestmodule()
 class Slicing:
   In = Input(dim(8, 4, 5))
   Sel8 = Input(types.i8)

--- a/frontends/PyCDE/test/pycde_values.py
+++ b/frontends/PyCDE/test/pycde_values.py
@@ -2,10 +2,10 @@
 
 from pycde.dialects import comb, hw
 from pycde import dim, generator, Input, Output
-from pycde.testing import testmodule
+from pycde.testing import unittestmodule
 
 
-@testmodule(SIZE=4)
+@unittestmodule(SIZE=4)
 def MyModule(SIZE: int):
 
   class Mod:

--- a/frontends/PyCDE/test/pycde_values.py
+++ b/frontends/PyCDE/test/pycde_values.py
@@ -1,11 +1,11 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
-import pycde
 from pycde.dialects import comb, hw
-from pycde import dim, module, generator, Input, Output
+from pycde import dim, generator, Input, Output
+from pycde.testing import testmodule
 
 
-@module
+@testmodule(SIZE=4)
 def MyModule(SIZE: int):
 
   class Mod:
@@ -26,9 +26,3 @@ def MyModule(SIZE: int):
       mod.out = hw.BitcastOp(dim(SIZE), combined)
 
   return Mod
-
-
-mymod = MyModule(4)
-module = pycde.System([mymod], name="mymod")
-module.generate()
-module.print()

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -3,7 +3,7 @@
 from pycde import (Output, Input, module, generator, types, dim, System,
                    no_connect)
 from pycde.module import externmodule
-from pycde.testing import testmodule
+from pycde.testing import unittestmodule
 
 # CHECK-LABEL:  msft.module @Top {} () attributes {fileName = "Top.sv"} {
 # CHECK:    %c7_i12 = hw.constant 7 : i12
@@ -45,7 +45,7 @@ class StupidLegacy:
 BarType = types.struct({"foo": types.i12}, "bar")
 
 
-@testmodule()
+@unittestmodule()
 class Top:
 
   @generator
@@ -73,7 +73,7 @@ class Top:
 # CHECK:    msft.output [[REGR2]], [[REG1]], [[REG3]] : i32, i32, i32
 
 
-@testmodule()
+@unittestmodule()
 class ComplexPorts:
   clk = Input(types.i1)
   sel = Input(types.i2)

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -3,64 +3,7 @@
 from pycde import (Output, Input, module, generator, types, dim, System,
                    no_connect)
 from pycde.module import externmodule
-
-
-@module
-class Taps:
-  taps = Output(dim(8, 3))
-
-  @generator
-  def build(ports):
-    ports.taps = [203, 100, 23]
-
-
-@externmodule
-class StupidLegacy:
-  ignore = Input(dim(1, 4))
-
-
-BarType = types.struct({"foo": types.i12}, "bar")
-
-
-@module
-class Top:
-
-  @generator
-  def build(_):
-    types.struct({"foo": types.i12})({"foo": 7})
-    dim(types.i8, 2)([42, 45])
-    types.i8(5)
-
-    BarType({"foo": 7})
-
-    Taps()
-    StupidLegacy(ignore=no_connect)
-
-
-@module
-class ComplexPorts:
-  clk = Input(types.i1)
-  sel = Input(types.i2)
-  data_in = Input(dim(32, 3))
-  struct_data_in = Input(types.struct({"foo": types.i36}))
-
-  a = Output(types.i32)
-  b = Output(types.i32)
-  c = Output(types.i32)
-
-  @generator
-  def build(ports):
-    assert len(ports.data_in) == 3
-    ports.set_all_ports({
-        'a': ports.data_in[0].reg(ports.clk).reg(ports.clk),
-        'b': ports.data_in[ports.sel],
-        'c': ports.struct_data_in.foo[:-4]
-    })
-
-
-top = System([Top])
-top.generate()
-top.print()
+from pycde.testing import testmodule
 
 # CHECK-LABEL:  msft.module @Top {} () attributes {fileName = "Top.sv"} {
 # CHECK:    %c7_i12 = hw.constant 7 : i12
@@ -84,9 +27,41 @@ top.print()
 # CHECK:    msft.output [[R0]] : !hw.array<3xi8>
 # CHECK:  msft.module.extern @StupidLegacy(%ignore: !hw.array<4xi1>) attributes {verilogName = "StupidLegacy"}
 
-sys = System([ComplexPorts])
-sys.generate()
-sys.print()
+
+@module
+class Taps:
+  taps = Output(dim(8, 3))
+
+  @generator
+  def build(ports):
+    ports.taps = [203, 100, 23]
+
+
+@externmodule
+class StupidLegacy:
+  ignore = Input(dim(1, 4))
+
+
+BarType = types.struct({"foo": types.i12}, "bar")
+
+
+@testmodule()
+class Top:
+
+  @generator
+  def build(_):
+    types.struct({"foo": types.i12})({"foo": 7})
+    dim(types.i8, 2)([42, 45])
+    types.i8(5)
+
+    BarType({"foo": 7})
+
+    Taps()
+    StupidLegacy(ignore=no_connect)
+
+
+# -----
+
 # CHECK:  msft.module @ComplexPorts {} (%clk: i1, %data_in: !hw.array<3xi32>, %sel: i2, %struct_data_in: !hw.struct<foo: i36>) -> (a: i32, b: i32, c: i32)
 # CHECK:    %c0_i2 = hw.constant 0 : i2
 # CHECK:    [[REG0:%.+]] = hw.array_get %data_in[%c0_i2] {sv.namehint = "data_in__0"} : !hw.array<3xi32>
@@ -96,3 +71,24 @@ sys.print()
 # CHECK:    [[REG2:%.+]] = hw.struct_extract %struct_data_in["foo"] {sv.namehint = "struct_data_in__foo"} : !hw.struct<foo: i36>
 # CHECK:    [[REG3:%.+]] = comb.extract [[REG2]] from 0 {sv.namehint = "struct_data_in__foo_0upto32"} : (i36) -> i32
 # CHECK:    msft.output [[REGR2]], [[REG1]], [[REG3]] : i32, i32, i32
+
+
+@testmodule()
+class ComplexPorts:
+  clk = Input(types.i1)
+  sel = Input(types.i2)
+  data_in = Input(dim(32, 3))
+  struct_data_in = Input(types.struct({"foo": types.i36}))
+
+  a = Output(types.i32)
+  b = Output(types.i32)
+  c = Output(types.i32)
+
+  @generator
+  def build(ports):
+    assert len(ports.data_in) == 3
+    ports.set_all_ports({
+        'a': ports.data_in[0].reg(ports.clk).reg(ports.clk),
+        'b': ports.data_in[ports.sel],
+        'c': ports.struct_data_in.foo[:-4]
+    })

--- a/frontends/PyCDE/test/test_ndarray.py
+++ b/frontends/PyCDE/test/test_ndarray.py
@@ -1,6 +1,7 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
-from pycde import System, Input, Output, module, generator
+from pycde import Input, Output, generator
+from pycde.testing import testmodule
 
 from pycde.ndarray import NDArray
 from pycde.dialects import hw
@@ -13,7 +14,7 @@ from pycde.value import ListValue
 # will probably want to use the Numpy features directly on the ListValue.
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 4, 8))
   out = Output(dim(types.i32, 8, 4))
@@ -23,16 +24,12 @@ class M1:
     ports.out = ports.in1.transpose((1, 0))
 
 
-m1 = System([M1])
-m1.generate()
-m1.print()
-
 # -----
 
 # Composing multiple ndarray transformations
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 4, 8))
   out = Output(dim(types.i32, 2, 16))
@@ -42,14 +39,10 @@ class M1:
     ports.out = ports.in1.transpose((1, 0)).reshape((16, 2))
 
 
-m1 = System([M1])
-m1.generate()
-m1.print()
-
 # -----
 
 
-@module
+@testmodule()
 class M2:
   in0 = Input(dim(types.i32, 16))
   in1 = Input(types.i32)
@@ -67,14 +60,9 @@ class M2:
     ports.c = m.to_circt()
 
 
-m2 = System([M2])
-m2.generate()
-m2.print()
-
-
 # -----
-@module
-class M1:
+@testmodule()
+class M5:
   in0 = Input(dim(types.i32, 16))
   in1 = Input(types.i32)
   t_c = dim(types.i32, 16)
@@ -103,19 +91,15 @@ class M1:
     # that is: 32x32xi1 => 32xi32
     # This has massive overhead in the generated IR, and can be easily
     # achieved by a bitcast.
-    ports.c = hw.BitcastOp(M1.t_c, m.to_circt())
+    ports.c = hw.BitcastOp(M5.t_c, m.to_circt())
 
-
-m1 = System([M1])
-m1.generate()
-m1.print()
 
 # -----
 
 # ndarray from value
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 10, 10))
   out = Output(dim(types.i32, 10, 10))
@@ -126,16 +110,12 @@ class M1:
     ports.out = m.to_circt()
 
 
-m1 = System([M1])
-m1.generate()
-m1.print()
-
 # -----
 
 # No barrier wire
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   out = Output(dim(types.i32, 10))
@@ -146,16 +126,12 @@ class M1:
     ports.out = m.to_circt(create_wire=False)
 
 
-m1 = System([M1])
-m1.generate()
-m1.print()
-
 # -----
 
 # Concatenation using both explicit NDArrays as well as ListValues.
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   in2 = Input(dim(types.i32, 10))
@@ -171,16 +147,12 @@ class M1:
     ports.out = ports.in2.concatenate((m, ports.in3))
 
 
-m1 = System([M1])
-m1.generate()
-m1.print()
-
 # -----
 
 # Rolling
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   out = Output(dim(types.i32, 10))
@@ -189,10 +161,6 @@ class M1:
   def build(ports):
     ports.out = ports.in1.roll(3)
 
-
-m1 = System([M1])
-m1.generate()
-m1.print()
 
 # -----
 
@@ -217,7 +185,7 @@ m1.print()
 # CHECK:         }
 
 
-@module
+@testmodule()
 class M1:
   out = Output(dim(types.i32, 3, 3))
 
@@ -228,8 +196,3 @@ class M1:
       for j in range(3):
         m[i][j] = types.i32(i * 3 + j)
     ports.out = m.to_circt()
-
-
-m1 = System([M1])
-m1.generate()
-m1.print()

--- a/frontends/PyCDE/test/test_ndarray.py
+++ b/frontends/PyCDE/test/test_ndarray.py
@@ -1,7 +1,7 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
 from pycde import Input, Output, generator
-from pycde.testing import testmodule
+from pycde.testing import unittestmodule
 
 from pycde.ndarray import NDArray
 from pycde.dialects import hw
@@ -14,7 +14,7 @@ from pycde.value import ListValue
 # will probably want to use the Numpy features directly on the ListValue.
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 4, 8))
   out = Output(dim(types.i32, 8, 4))
@@ -29,7 +29,7 @@ class M1:
 # Composing multiple ndarray transformations
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 4, 8))
   out = Output(dim(types.i32, 2, 16))
@@ -42,7 +42,7 @@ class M1:
 # -----
 
 
-@testmodule()
+@unittestmodule()
 class M2:
   in0 = Input(dim(types.i32, 16))
   in1 = Input(types.i32)
@@ -61,7 +61,7 @@ class M2:
 
 
 # -----
-@testmodule()
+@unittestmodule()
 class M5:
   in0 = Input(dim(types.i32, 16))
   in1 = Input(types.i32)
@@ -99,7 +99,7 @@ class M5:
 # ndarray from value
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 10, 10))
   out = Output(dim(types.i32, 10, 10))
@@ -115,7 +115,7 @@ class M1:
 # No barrier wire
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   out = Output(dim(types.i32, 10))
@@ -131,7 +131,7 @@ class M1:
 # Concatenation using both explicit NDArrays as well as ListValues.
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   in2 = Input(dim(types.i32, 10))
@@ -152,7 +152,7 @@ class M1:
 # Rolling
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
   out = Output(dim(types.i32, 10))
@@ -185,7 +185,7 @@ class M1:
 # CHECK:         }
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   out = Output(dim(types.i32, 3, 3))
 

--- a/frontends/PyCDE/test/test_ndarray_errors.py
+++ b/frontends/PyCDE/test/test_ndarray_errors.py
@@ -1,14 +1,14 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
 from pycde import System, Input, generator
-from pycde.testing import testmodule
+from pycde.testing import unittestmodule
 from pycde.pycde_types import types, dim
 from pycde.ndarray import NDArray
 
 # Missing assignment
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(types.i32)
 
@@ -27,7 +27,7 @@ class M1:
 # dtype mismatch
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(types.i33)
 
@@ -43,7 +43,7 @@ class M1:
 # Invalid constructor
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
 
@@ -58,7 +58,7 @@ class M1:
 # Cast mismatch
 
 
-@testmodule()
+@unittestmodule()
 class M1:
   in1 = Input(types.i31)
 

--- a/frontends/PyCDE/test/test_ndarray_errors.py
+++ b/frontends/PyCDE/test/test_ndarray_errors.py
@@ -1,13 +1,14 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
-from pycde import System, Input, module, generator
+from pycde import System, Input, generator
+from pycde.testing import testmodule
 from pycde.pycde_types import types, dim
 from pycde.ndarray import NDArray
 
 # Missing assignment
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(types.i32)
 
@@ -21,14 +22,12 @@ class M1:
     m.to_circt()
 
 
-System([M1]).generate()
-
 # -----
 
 # dtype mismatch
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(types.i33)
 
@@ -39,14 +38,12 @@ class M1:
     m[0] = ports.in1
 
 
-System([M1]).generate()
-
 # -----
 
 # Invalid constructor
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(dim(types.i32, 10))
 
@@ -56,14 +53,12 @@ class M1:
     NDArray((10, 32), from_value=ports.in1, dtype=types.i1, name='m1')
 
 
-System([M1]).generate()
-
 # -----
 
 # Cast mismatch
 
 
-@module
+@testmodule()
 class M1:
   in1 = Input(types.i31)
 
@@ -72,6 +67,3 @@ class M1:
     m = NDArray((32, 32), dtype=types.i1, name='m1')
     # CHECK: ValueError: Width mismatch between provided BitVectorValue (i31) and target shape ([32]i1).
     m[0] = ports.in1
-
-
-System([M1]).generate()


### PR DESCRIPTION
Tests can now use the `@testmodule` to reduce boilerplate such as system instantiation, generation, and printing.

In case of wrapping a function, `@testmodule` accepts kwargs which are passed to the function as arguments.
Also reorders some checks to come before the code-under-test, as opposed to after, in an attempt to align test case style with the remainder of CIRCT.