### PR TITLE
[PyCDE,CAPI] Add support for the FSM dialect

### DIFF
--- a/frontends/PyCDE/src/CMakeLists.txt
+++ b/frontends/PyCDE/src/CMakeLists.txt
@@ -9,27 +9,29 @@
 declare_mlir_python_sources(PyCDESources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
   SOURCES
-    pycde/__init__.py
-    pycde/pycde_types.py
-    pycde/dialects/__init__.py
-    pycde/dialects/msft.py
-    pycde/dialects/seq.py
-    pycde/dialects/hw.py
-    pycde/dialects/comb.py
-    pycde/dialects/sv.py
-    pycde/support.py
-    pycde/module.py
-    pycde/constructs.py
-    pycde/system.py
-    pycde/devicedb.py
-    pycde/instance.py
-    pycde/value.py
-    pycde/ndarray.py
+  pycde/__init__.py
+  pycde/pycde_types.py
+  pycde/dialects/__init__.py
+  pycde/dialects/msft.py
+  pycde/dialects/seq.py
+  pycde/dialects/hw.py
+  pycde/dialects/comb.py
+  pycde/dialects/sv.py
+  pycde/dialects/fsm.py
+  pycde/support.py
+  pycde/module.py
+  pycde/constructs.py
+  pycde/system.py
+  pycde/devicedb.py
+  pycde/instance.py
+  pycde/value.py
+  pycde/ndarray.py
+  pycde/fsm.py
 )
 
 add_mlir_python_modules(PyCDE
   ROOT_PREFIX "${CIRCT_PYTHON_PACKAGES_DIR}/pycde"
   INSTALL_PREFIX "python_packages/pycde"
   DECLARED_SOURCES
-    PyCDESources
+  PyCDESources
 )

--- a/frontends/PyCDE/src/pycde/dialects/fsm.py
+++ b/frontends/PyCDE/src/pycde/dialects/fsm.py
@@ -1,0 +1,9 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ..value import wrap_opviews_with_values
+from circt.dialects import fsm
+
+wrap_opviews_with_values(fsm, __name__,
+                         ["MachineOp", "StateOp", "TransitionOp"])

--- a/frontends/PyCDE/src/pycde/fsm.py
+++ b/frontends/PyCDE/src/pycde/fsm.py
@@ -1,0 +1,253 @@
+from pycde import System, Input, Output, module, generator
+from pycde.module import _SpecializedModule, Generator, _GeneratorPortAccess
+from pycde.dialects import fsm
+from pycde.pycde_types import types
+from typing import Callable
+
+from mlir.ir import InsertionPoint
+from collections import defaultdict
+from functools import lru_cache
+
+from pycde.support import _obj_to_attribute
+from circt.support import connect
+
+
+class _Transition:
+
+  __slots__ = ['from_state', 'to_state', 'condition']
+
+  def __init__(self,
+               from_state: str,
+               to_state: str,
+               condition: Callable = None):
+    if from_state is None or to_state is None:
+      raise ValueError("State and next state must be specified")
+
+    self.from_state = from_state
+    self.to_state = to_state
+    self.condition = condition
+
+  def emit(self, state_op, ports):
+    with InsertionPoint(state_op.transitions):
+      op = fsm.TransitionOp(self.to_state)
+
+      # If a condition function was specified, execute it on the ports and
+      # assign the result as the guard of this transition.
+      if self.condition:
+        op.set_guard(lambda: self.condition(ports))
+
+
+def create_fsm_machine_op(sys, mod: _SpecializedModule, symbol):
+  """Creation callback for creating a FSM MachineOp."""
+
+  # Add attributes for in- and output names.
+  attributes = {}
+  attributes["in_names"] = _obj_to_attribute(
+      [port_name for port_name, _ in mod.input_ports])
+  attributes["out_names"] = _obj_to_attribute(
+      [port_name for port_name, _ in mod.output_ports])
+
+  # Add attributes for clock and reset names.
+  attributes["clock_name"] = _obj_to_attribute(mod.modcls.clock_name)
+  if mod.modcls.reset_name:
+    attributes["reset_name"] = _obj_to_attribute(mod.modcls.reset_name)
+
+  return fsm.MachineOp(symbol,
+                       mod.modcls.fsm_initial_state,
+                       mod.input_ports,
+                       mod.output_ports,
+                       attributes=attributes,
+                       loc=mod.loc,
+                       ip=sys._get_ip())
+
+
+def generate_fsm_machine_op(generate_obj: Generator,
+                            spec_mod: _SpecializedModule):
+  """ Generator callback for generating an FSM op. """
+  entry_block = spec_mod.circt_mod.body.blocks[0]
+  ports = _GeneratorPortAccess(spec_mod)
+
+  # Cache true/false values in machine scope to avoid IR spam.
+  @lru_cache
+  def get_cached_bool(v):
+    with InsertionPoint(entry_block):
+      return types.i1(v)
+
+  # Prime the cache. This is a super minor nit, but being explicit about the
+  # ordering here ensures that %0 = False and %1 = True in the IR as well as
+  # constants being emitted before the FSM ops.
+  get_cached_bool(False)
+  get_cached_bool(True)
+
+  with InsertionPoint(entry_block), generate_obj.loc:
+    for state, state_transitions in spec_mod.modcls.transitions.items():
+      # Create state op and assert the current state in its output vector.
+      state_op = fsm.StateOp(state)
+      with InsertionPoint(state_op.output):
+        outputs = []
+        for state_it in spec_mod.modcls.states:
+          outputs.append(get_cached_bool(state_it == state))
+        fsm.OutputOp(*outputs)
+
+      # Emit outgoing transitions from this state.
+      for transition in state_transitions:
+        transition.emit(state_op, ports)
+
+
+def machine(clock: str = 'clk', reset: str = None):
+  """
+  Top-level FSM decorator which gives the user the option specify port
+  names for the clock and (optional) reset signal.
+  These port names will be used in the FSM HW module wrapper, as well as
+  carried through as attributes on the fsm.machine operation to inform
+  FSM HW lowering about desired port names.
+  """
+
+  def machine_clocked(to_be_wrapped):
+    """
+    Wrap a class as an FSM machine.
+
+    An FSM PyCDE module is expected to implement:
+
+    - A set of input ports:
+        These can be of any type, and are used to drive the FSM.
+    - An `fsm_initial_state` variable:
+        A string denoting the name of the initial state of the FSM.
+    - An `fsm_transitions` variable:
+        A dictionary containing states and state transitions.
+        The dictionary is keyed by state names, and the values are lists of
+        transitions.
+
+        Transitions can be specified either as a tuple of (next_state, condition)
+        or as a single `next_state` string (unconditionally taken).
+        a `condition` function is a function which takes a single input representing
+        the `ports` of a component, similar to the `@generator` decorator used
+        elsewhere in PyCDE.
+    """
+    states = None
+    transition_dict = None
+
+    attr_dict = dir(to_be_wrapped)
+
+    if 'fsm_initial_state' not in attr_dict:
+      raise ValueError("fsm_initial_state must be defined")
+
+    if 'fsm_transitions' not in attr_dict:
+      raise ValueError("fsm_transitions must be defined")
+    transition_dict = to_be_wrapped.fsm_transitions
+
+    # Ensure state uniqueness.
+    states = list(transition_dict.keys())
+    if len(set(states)) != len(states):
+      raise ValueError("fsm_states must be unique.")
+
+    if len(states) == 0:
+      raise ValueError("fsm_states must be non-empty.")
+
+    # Add an output port for each state.
+    for state in states:
+      setattr(to_be_wrapped, 'is_' + state, Output(types.i1))
+
+    # Store requested clock and reset names.
+    to_be_wrapped.clock_name = clock
+    to_be_wrapped.reset_name = reset
+
+    # Create Transition objects.
+    transitions = defaultdict(lambda: [])
+    for from_state, transitionargs in transition_dict.items():
+      if isinstance(transitionargs, list):
+        for transition in transitionargs:
+          transitions[from_state].append(_Transition(from_state, *transition))
+      else:
+        transitions[from_state].append(_Transition(from_state, *transitionargs))
+
+    for _, to_states in transitions.items():
+      for transition in to_states:
+        if transition.from_state not in states:
+          raise ValueError("Invalid transition from state {}".format(
+              transition.from_state))
+        if transition.to_state not in states:
+          raise ValueError("Invalid transition to state {}".format(
+              transition.to_state))
+
+    to_be_wrapped.transitions = transitions
+    to_be_wrapped.states = states
+
+    # Set module creation and generation callbacks.
+    setattr(to_be_wrapped, 'create_cb', create_fsm_machine_op)
+    setattr(to_be_wrapped, 'generator_cb', generate_fsm_machine_op)
+
+    # Create a dummy Generator function to trigger module generation.
+    # This function doesn't do anything, since all generation logic is embedded
+    # within generate_fsm_machine_op. In the future, we may allow an actual
+    # @generator function specified by the user if they want to do something
+    # specific.
+    setattr(to_be_wrapped, 'dummy_generator_f', generator(lambda x: None))
+
+    # Treat the remainder of the class as a module.
+    # Rename the fsm_mod before creating the module to ensure that the wrapped
+    # module will be named as the user specified (that of fsm_mod), and the
+    # FSM itself will have a suffixed name.
+    fsm_name = to_be_wrapped.__name__
+    to_be_wrapped.__name__ = to_be_wrapped.__name__ + '_impl'
+    to_be_wrapped.__qualname__ = to_be_wrapped.__qualname__ + '_impl'
+    fsm_mod = module(to_be_wrapped)
+
+    # Next we build the outer wrapper class that contains clock and reset ports.
+    fsm_hw_mod = fsm_wrapper_class(fsm_mod=fsm_mod,
+                                   fsm_name=fsm_name,
+                                   clock=clock,
+                                   reset=reset)
+
+    return module(fsm_hw_mod)
+
+  return machine_clocked
+
+
+def fsm_wrapper_class(fsm_mod, fsm_name, clock, reset=None):
+  """
+  Generate a wrapper class for the FSM class which contains the clock and reset
+  signals, as well as a `fsm.hw_instance` instaitiation of the FSM.
+  """
+
+  class fsm_hw_mod:
+
+    @generator
+    def construct(ports):
+      in_ports = {
+          port_name: getattr(ports, port_name)
+          for (port_name, _) in fsm_mod._pycde_mod.input_ports
+      }
+      fsm_instance = fsm_mod(**in_ports)
+      # Attach clock and optional reset on the backedges created during
+      # the MachineOp:instatiate call.
+      clock_be = getattr(fsm_instance._instantiation, '_clock_backedge')
+      connect(clock_be, getattr(ports, clock))
+      if hasattr(fsm_instance._instantiation, '_reset_backedge'):
+        reset_be = getattr(fsm_instance._instantiation, '_reset_backedge')
+        connect(reset_be, getattr(ports, reset))
+
+      # Connect outputs
+      for (port_name, _) in fsm_mod._pycde_mod.output_ports:
+        setattr(ports, port_name, getattr(fsm_instance, port_name))
+
+  # Inherit in and output ports. We do this outside of the wrapped class
+  # since we cannot do setattr inside the class scope (def-use).
+  for (name, type) in fsm_mod._pycde_mod.input_ports:
+    setattr(fsm_hw_mod, name, Input(type))
+  for (name, type) in fsm_mod._pycde_mod.output_ports:
+    setattr(fsm_hw_mod, name, Output(type))
+
+  # Add clock and additional reset port.
+  setattr(fsm_hw_mod, clock, Input(types.i1))
+
+  if reset is not None:
+    setattr(fsm_hw_mod, reset, Input(types.i1))
+
+  # The wrapper class now overloads the name of the user-defined FSM.
+  # From this point on, instantiating the user FSM class will actually
+  # instantiate the wrapper HW module class.
+  fsm_hw_mod.__qualname__ = fsm_name
+  fsm_hw_mod.__name__ = fsm_name
+  fsm_hw_mod.__module__ = fsm_name
+  return fsm_hw_mod

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -255,12 +255,12 @@ class _SpecializedModule:
   def instantiate(self, instance_name: str, inputs: dict, loc):
     """Create a instance op."""
     if self.extern_name is None:
-      return self.circt_mod.create(instance_name, **inputs, loc=loc)
+      return self.circt_mod.instantiate(instance_name, **inputs, loc=loc)
     else:
-      return self.circt_mod.create(instance_name,
-                                   **inputs,
-                                   parameters=self.parameters,
-                                   loc=loc)
+      return self.circt_mod.instantiate(instance_name,
+                                        **inputs,
+                                        parameters=self.parameters,
+                                        loc=loc)
 
   def generate(self):
     """Fill in (generate) this module. Only supports a single generator
@@ -286,17 +286,21 @@ def module(func_or_class):
   function should be treated as a module parameterization function. In the
   latter case, the function must return a python class to be treated as the
   parameterized module."""
+  generate_cb = func_or_class.generator_cb if hasattr(
+      func_or_class, "generator_cb") else generate_msft_module_op
+  create_cb = func_or_class.create_cb if hasattr(
+      func_or_class, "create_cb") else create_msft_module_op
   if inspect.isclass(func_or_class):
     # If it's just a module class, we should wrap it immediately
     return _module_base(func_or_class,
                         None,
-                        generator_cb=generate_msft_module_op,
-                        create_cb=create_msft_module_op)
+                        generator_cb=generate_cb,
+                        create_cb=create_cb)
   elif inspect.isfunction(func_or_class):
     return _parameterized_module(func_or_class,
                                  None,
-                                 generator_cb=generate_msft_module_op,
-                                 create_cb=create_msft_module_op)
+                                 generator_cb=generate_cb,
+                                 create_cb=create_cb)
   raise TypeError(
       "@module decorator must be on class or parameterization function")
 

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -334,7 +334,7 @@ class ChannelValue(Value):
     return Value(unwrap_op.rawOutput), Value(unwrap_op.valid)
 
 
-def wrap_opviews_with_values(dialect, module_name):
+def wrap_opviews_with_values(dialect, module_name, excluded=[]):
   """Wraps all of a dialect's OpView classes to have their create method return
      a PyCDE Value instead of an OpView. The wrapped classes are inserted into
      the provided module."""
@@ -344,7 +344,8 @@ def wrap_opviews_with_values(dialect, module_name):
   for attr in dir(dialect):
     cls = getattr(dialect, attr)
 
-    if isinstance(cls, type) and issubclass(cls, ir.OpView):
+    if attr not in excluded and isinstance(cls, type) and issubclass(
+        cls, ir.OpView):
 
       def specialize_create(cls):
 

--- a/frontends/PyCDE/test/test_fsm.py
+++ b/frontends/PyCDE/test/test_fsm.py
@@ -1,0 +1,148 @@
+# RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
+
+from re import A
+from pycde import System, Input, Output, module, generator, externmodule
+
+from pycde.dialects import comb
+from pycde import fsm
+from pycde.pycde_types import types, dim
+
+from circt.support import connect
+
+# FSM instantiation example
+
+# CHECK-LABEL: msft.module @FSMUser {} (%a: i1, %b: i1, %clk: i1) -> (is_a: i1, is_b: i1) attributes {fileName = "FSMUser.sv"} {
+# CHECK:         %FSM.is_A, %FSM.is_B = msft.instance @FSM @FSM(%a, %b, %clk)  : (i1, i1, i1) -> (i1, i1)
+# CHECK:         msft.output %FSM.is_A, %FSM.is_B : i1, i1
+# CHECK:       }
+# CHECK-LABEL: msft.module @FSM {} (%a: i1, %b: i1, %clock: i1) -> (is_A: i1, is_B: i1) attributes {fileName = "FSM.sv"} {
+# CHECK:         %0:2 = "fsm.hw_instance"(%a, %b, %clock) {machine = "FSM_impl", operand_segment_sizes = dense<[2, 1, 0]> : vector<3xi32>, sym_name = "FSM"} : (i1, i1, i1) -> (i1, i1)
+# CHECK:         msft.output %0#0, %0#1 : i1, i1
+# CHECK:       }
+
+
+@fsm.machine(clock="clock")
+class FSM:
+  a = Input(types.i1)
+  b = Input(types.i1)
+
+  fsm_initial_state = 'A'
+  fsm_transitions = {
+      'A': ('B', lambda ports: ports.a),
+      'B': ('A', lambda ports: ports.b),
+  }
+
+
+@module
+class FSMUser:
+  a = Input(types.i1)
+  b = Input(types.i1)
+  clk = Input(types.i1)
+  is_a = Output(types.i1)
+  is_b = Output(types.i1)
+
+  @generator
+  def construct(ports):
+    fsm = FSM(a=ports.a, b=ports.b, clock=ports.clk)
+    ports.is_a = fsm.is_A
+    ports.is_b = fsm.is_B
+
+
+system = System([FSMUser])
+system.generate()
+system.print()
+
+# -----
+
+# FSM state transitions example
+
+# CHECK: "fsm.machine"() ({
+# CHECK:   ^bb0(%arg0: i1, %arg1: i1, %arg2: i1):
+# CHECK:     %false = hw.constant false
+# CHECK:     %true = hw.constant true
+# CHECK:     "fsm.state"() ({
+# CHECK:       "fsm.output"(%true, %false, %false, %false) : (i1, i1, i1, i1) -> ()
+# CHECK:     }, {
+# CHECK:       "fsm.transition"() ({
+# CHECK:         "fsm.return"(%arg0) : (i1) -> ()
+# CHECK:       }, {
+# CHECK:       }) {nextState = @a} : () -> ()
+# CHECK:     }) {sym_name = "idle"} : () -> ()
+# CHECK:     "fsm.state"() ({
+# CHECK:       "fsm.output"(%false, %true, %false, %false) : (i1, i1, i1, i1) -> ()
+# CHECK:     }, {
+# CHECK:       "fsm.transition"() ({
+# CHECK:       }, {
+# CHECK:       }) {nextState = @b} : () -> ()
+# CHECK:     }) {sym_name = "a"} : () -> ()
+# CHECK:     "fsm.state"() ({
+# CHECK:       "fsm.output"(%false, %false, %true, %false) : (i1, i1, i1, i1) -> ()
+# CHECK:     }, {
+# CHECK:       "fsm.transition"() ({
+# CHECK:         %0 = comb.and %arg0, %arg1 : i1
+# CHECK:         %true_0 = hw.constant true
+# CHECK:         %1 = comb.xor %0, %true_0 : i1
+# CHECK:         %2 = comb.and %arg1, %arg2 : i1
+# CHECK:         %true_1 = hw.constant true
+# CHECK:         %3 = comb.xor %2, %true_1 : i1
+# CHECK:         %4 = comb.and %arg0, %arg2 : i1
+# CHECK:         %true_2 = hw.constant true
+# CHECK:         %5 = comb.xor %4, %true_2 : i1
+# CHECK:         %6 = comb.and %1, %3, %5 : i1
+# CHECK:         %true_3 = hw.constant true
+# CHECK:         %7 = comb.xor %6, %true_3 : i1
+# CHECK:         "fsm.return"(%7) : (i1) -> ()
+# CHECK:       }, {
+# CHECK:       }) {nextState = @c} : () -> ()
+# CHECK:     }) {sym_name = "b"} : () -> ()
+# CHECK:     "fsm.state"() ({
+# CHECK:       "fsm.output"(%false, %false, %false, %true) : (i1, i1, i1, i1) -> ()
+# CHECK:     }, {
+# CHECK:       "fsm.transition"() ({
+# CHECK:         "fsm.return"(%arg2) : (i1) -> ()
+# CHECK:       }, {
+# CHECK:       }) {nextState = @idle} : () -> ()
+# CHECK:       "fsm.transition"() ({
+# CHECK:         %true_0 = hw.constant true
+# CHECK:         %0 = comb.xor %arg1, %true_0 : i1
+# CHECK:         "fsm.return"(%0) : (i1) -> ()
+# CHECK:       }, {
+# CHECK:       }) {nextState = @a} : () -> ()
+# CHECK:     }) {sym_name = "c"} : () -> ()
+# CHECK:   }) {clock_name = "clock", function_type = (i1, i1, i1) -> (i1, i1, i1, i1), in_names = ["a", "b", "c"], initialState = "idle", out_names = ["is_a", "is_b", "is_c", "is_idle"], sym_name = "F0_impl"} : () -> ()
+
+
+@fsm.machine(clock="clock")
+class F0:
+  a = Input(types.i1)
+  b = Input(types.i1)
+  c = Input(types.i1)
+
+  def maj3(ports):
+
+    def nand(*args):
+      return comb.XorOp(comb.AndOp(*args), types.i1(1))
+
+    c1 = nand(ports.a, ports.b)
+    c2 = nand(ports.b, ports.c)
+    c3 = nand(ports.a, ports.c)
+    return nand(c1, c2, c3)
+
+  fsm_initial_state = 'idle'
+  fsm_transitions = {
+      # Always taken transition
+      'idle':
+          'a',
+      # Transition using inline function
+      'a': ('b', lambda ports: ports.a),
+      # Transition using outlined function
+      'b': ('c', maj3),
+      # Multiple transitions
+      'c': [('idle', lambda ports: ports.c),
+            ('a', lambda ports: comb.XorOp(ports.b, types.i1(1)))],
+  }
+
+
+system = System([F0])
+system.generate()
+system.print()

--- a/include/circt-c/Dialect/FSM.h
+++ b/include/circt-c/Dialect/FSM.h
@@ -1,0 +1,27 @@
+//===-- circt-c/FSMDialect.h - C API for FSM dialect --------------*- C -*-===//
+//
+// This header declares the C interface for registering and accessing the
+// FSM dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_FSM_H
+#define CIRCT_C_DIALECT_FSM_H
+
+#include "mlir-c/Registration.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FSM, fsm);
+MLIR_CAPI_EXPORTED void registerFSMPasses();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_FSM_H

--- a/include/circt/Dialect/FSM/FSM.td
+++ b/include/circt/Dialect/FSM/FSM.td
@@ -33,7 +33,7 @@ class FSMType<string name> : TypeDef<FSMDialect, name> {}
 class FSMOp<string mnemonic, list<Trait> traits = []> :
     Op<FSMDialect, mnemonic, traits>;
 
-include "FSMTypes.td"
-include "FSMOps.td"
+include "circt/Dialect/FSM/FSMTypes.td"
+include "circt/Dialect/FSM/FSMOps.td"
 
 #endif // CIRCT_DIALECT_FSM_TD

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -10,6 +10,7 @@
 
 #include "circt-c/Dialect/Comb.h"
 #include "circt-c/Dialect/ESI.h"
+#include "circt-c/Dialect/FSM.h"
 #include "circt-c/Dialect/HW.h"
 #include "circt-c/Dialect/MSFT.h"
 #include "circt-c/Dialect/SV.h"
@@ -68,6 +69,10 @@ PYBIND11_MODULE(_circt, m) {
         MlirDialectHandle sv = mlirGetDialectHandle__sv__();
         mlirDialectHandleRegisterDialect(sv, context);
         mlirDialectHandleLoadDialect(sv, context);
+
+        MlirDialectHandle fsm = mlirGetDialectHandle__fsm__();
+        mlirDialectHandleRegisterDialect(fsm, context);
+        mlirDialectHandleLoadDialect(fsm, context);
       },
       "Register CIRCT dialects on a PyMlirContext.");
 

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -35,6 +35,7 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension.Core
     CIRCTCAPISeq
     CIRCTCAPISV
     CIRCTCAPIExportVerilog
+    CIRCTCAPIFSM
   PRIVATE_LINK_LIBS
     ${_depends}
 )
@@ -113,6 +114,15 @@ declare_mlir_dialect_python_bindings(
     circt/dialects/sv.py
     circt/dialects/_sv_ops_ext.py
   DIALECT_NAME sv)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  TD_FILE circt/dialects/FSMOps.td
+  SOURCES
+    circt/dialects/fsm.py
+    circt/dialects/_fsm_ops_ext.py
+  DIALECT_NAME fsm)
 
 ################################################################################
 # Build composite binaries

--- a/lib/Bindings/Python/circt/dialects/FSMOps.td
+++ b/lib/Bindings/Python/circt/dialects/FSMOps.td
@@ -1,0 +1,15 @@
+//===-- FSMOps.td - Entry point for FSMOps bindings --------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BINDINGS_PYTHON_FSM_OPS
+#define BINDINGS_PYTHON_FSM_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "circt/Dialect/FSM/FSM.td"
+
+#endif

--- a/lib/Bindings/Python/circt/dialects/_fsm_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_fsm_ops_ext.py
@@ -1,0 +1,172 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from http.client import REQUEST_URI_TOO_LONG
+from circt.dialects import hw, fsm as fsm
+import circt.dialects._hw_ops_ext as _hw_ext
+import circt.support as support
+
+from mlir.ir import *
+
+
+def _get_or_add_single_block(region, args=[]):
+  if len(region.blocks) == 0:
+    region.blocks.append(*args)
+  return region.blocks[0]
+
+
+class MachineOp:
+
+  def __init__(self,
+               name,
+               initial_state,
+               input_ports,
+               output_ports,
+               *,
+               attributes={},
+               loc=None,
+               ip=None):
+    attributes["sym_name"] = StringAttr.get(name)
+    attributes["initialState"] = StringAttr.get(initial_state)
+
+    input_types = []
+    output_types = []
+    for (i, (_, port_type)) in enumerate(input_ports):
+      input_types.append(port_type)
+
+    for (i, (_, port_type)) in enumerate(output_ports):
+      output_types.append(port_type)
+
+    attributes["function_type"] = TypeAttr.get(
+        FunctionType.get(inputs=input_types, results=output_types))
+
+    OpView.__init__(
+        self,
+        self.build_generic(attributes=attributes,
+                           results=[],
+                           operands=[],
+                           successors=None,
+                           regions=1,
+                           loc=loc,
+                           ip=ip))
+
+    _get_or_add_single_block(self.body, self.type.inputs)
+
+  @property
+  def type(self):
+    return FunctionType(TypeAttr(self.attributes["function_type"]).value)
+
+  def instantiate(self, name: str, loc=None, ip=None, **kwargs):
+    """ FSM Instantiation function"""
+    in_names = support.attribute_to_var(self.attributes['in_names'])
+    inputs = [kwargs[port].value for port in in_names]
+
+    # Clock and resets are not part of the input ports of the FSM, but
+    # it is at the point of `fsm.hw_instance` instantiation that they
+    # must be connected.
+    # Attach backedges to these, and associate these backedges to the operation.
+    # They can then be accessed at the point of instantiation and assigned.
+    clock = support.BackedgeBuilder().create(
+        IntegerType.get_signed(1),
+        StringAttr(self.attributes['clock_name']).value, self)
+    reset = None
+    if 'reset_name' in self.attributes:
+      reset = support.BackedgeBuilder().create(
+          IntegerType.get_signed(1),
+          StringAttr(self.attributes['reset_name']).value, self)
+
+    op = fsm.HWInstanceOp(outputs=self.type.results,
+                          inputs=inputs,
+                          sym_name=StringAttr.get(name),
+                          machine=self.sym_name,
+                          clock=clock.result,
+                          reset=reset.result if reset else None,
+                          loc=loc,
+                          ip=ip)
+    op.backedges = {}
+
+    def set_OpOperand(name, backedge):
+      index = None
+      for i, operand in enumerate(op.operands):
+        if operand == backedge.result:
+          index = i
+          break
+      assert index is not None
+      op_operand = support.OpOperand(op, index, op.operands[index], op)
+      setattr(op, f'_{name}_backedge', op_operand)
+      op.backedges[i] = backedge
+
+    set_OpOperand('clock', clock)
+    if reset:
+      set_OpOperand('reset', reset)
+
+    return op
+
+
+class TransitionOp:
+
+  def __init__(self, next_state, *, loc=None, ip=None):
+    attributes = {
+        "nextState": FlatSymbolRefAttr.get(next_state),
+    }
+    super().__init__(
+        self.build_generic(attributes=attributes,
+                           results=[],
+                           operands=[],
+                           successors=None,
+                           regions=2,
+                           loc=loc,
+                           ip=ip))
+
+  @staticmethod
+  def create(to_state):
+    op = fsm.TransitionOp(to_state)
+    return op
+
+  def set_guard(self, guard_fn):
+    """Executes a function to generate a guard for the transition.
+    The function is executed within the guard region of this operation."""
+    guard_block = _get_or_add_single_block(self.guard)
+    with InsertionPoint(guard_block):
+      guard = guard_fn()
+      guard_type = support.type_to_pytype(guard.type)
+      if guard_type.width != 1:
+        raise ValueError('The guard must be a single bit')
+      fsm.ReturnOp(operand=guard.value)
+
+
+class StateOp:
+
+  def __init__(self, name, *, loc=None, ip=None):
+    attributes = {}
+    attributes["sym_name"] = StringAttr.get(name)
+
+    OpView.__init__(
+        self,
+        self.build_generic(attributes=attributes,
+                           results=[],
+                           operands=[],
+                           successors=None,
+                           regions=2,
+                           loc=loc,
+                           ip=ip))
+
+  @staticmethod
+  def create(name):
+    return fsm.StateOp(name)
+
+  @property
+  def output(self):
+    return _get_or_add_single_block(super().output)
+
+  @property
+  def transitions(self):
+    return _get_or_add_single_block(super().transitions)
+
+
+class OutputOp:
+
+  @staticmethod
+  def create(*operands):
+    return fsm.OutputOp(operands)

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -91,7 +91,7 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
                      loc=loc,
                      ip=ip)
 
-  def create(self, name: str, loc=None, ip=None, **kwargs):
+  def instantiate(self, name: str, loc=None, ip=None, **kwargs):
     return InstanceBuilder(self, name, kwargs, loc=loc, ip=ip)
 
   def add_entry_block(self):
@@ -116,13 +116,13 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
 
 class MSFTModuleExternOp(_hw_ext.ModuleLike):
 
-  def create(self,
-             name: str,
-             parameters=None,
-             results=None,
-             loc=None,
-             ip=None,
-             **kwargs):
+  def instantiate(self,
+                  name: str,
+                  parameters=None,
+                  results=None,
+                  loc=None,
+                  ip=None,
+                  **kwargs):
     return InstanceBuilder(self,
                            name,
                            kwargs,

--- a/lib/Bindings/Python/circt/dialects/fsm.py
+++ b/lib/Bindings/Python/circt/dialects/fsm.py
@@ -1,0 +1,5 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._fsm_ops_gen import *

--- a/lib/Bindings/Tcl/CMakeLists.txt
+++ b/lib/Bindings/Tcl/CMakeLists.txt
@@ -1,15 +1,16 @@
 add_library(circt-tcl
   SHARED
-    circt_tcl.cpp
+  circt_tcl.cpp
 )
 target_link_libraries(circt-tcl
   PUBLIC
-    CIRCTCAPIComb
-    CIRCTCAPIESI
-    CIRCTCAPIMSFT
-    CIRCTCAPIHW
-    CIRCTCAPISeq
-    CIRCTCAPISV
+  CIRCTCAPIComb
+  CIRCTCAPIESI
+  CIRCTCAPIMSFT
+  CIRCTCAPIHW
+  CIRCTCAPISeq
+  CIRCTCAPISV
+  CIRCTCAPIFSM
 )
 target_compile_definitions(circt-tcl PUBLIC -DUSE_TCL_STUBS)
 target_link_libraries(circt-tcl PUBLIC ${TCL_STUB_LIBRARY})

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LLVM_OPTIONAL_SOURCES
   Moore.cpp
   Seq.cpp
   SV.cpp
+  FSM.cpp
 )
 
 add_mlir_public_c_api_library(CIRCTCAPIComb
@@ -16,7 +17,7 @@ add_mlir_public_c_api_library(CIRCTCAPIComb
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTComb
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPIESI
   ESI.cpp
@@ -24,7 +25,7 @@ add_mlir_public_c_api_library(CIRCTCAPIESI
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTESI
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPIMSFT
   MSFT.cpp
@@ -36,7 +37,7 @@ add_mlir_public_c_api_library(CIRCTCAPIMSFT
   MLIRCAPIIR
   MLIRTransforms
   CIRCTMSFT
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPIHW
   HW.cpp
@@ -44,7 +45,7 @@ add_mlir_public_c_api_library(CIRCTCAPIHW
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTHW
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPILLHD
   LLHD.cpp
@@ -52,7 +53,7 @@ add_mlir_public_c_api_library(CIRCTCAPILLHD
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTLLHD
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPIMoore
   Moore.cpp
@@ -60,7 +61,7 @@ add_mlir_public_c_api_library(CIRCTCAPIMoore
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTMoore
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPISeq
   Seq.cpp
@@ -69,7 +70,7 @@ add_mlir_public_c_api_library(CIRCTCAPISeq
   MLIRCAPIIR
   CIRCTSeq
   CIRCTSeqTransforms
-  )
+)
 
 add_mlir_public_c_api_library(CIRCTCAPISV
   SV.cpp
@@ -78,4 +79,13 @@ add_mlir_public_c_api_library(CIRCTCAPISV
   MLIRCAPIIR
   CIRCTSV
   CIRCTSVTransforms
-  )
+)
+
+add_mlir_public_c_api_library(CIRCTCAPIFSM
+  FSM.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTFSM
+  CIRCTFSMTransforms
+)

--- a/lib/CAPI/Dialect/FSM.cpp
+++ b/lib/CAPI/Dialect/FSM.cpp
@@ -1,0 +1,17 @@
+//===- FSMDialect.cpp - C Interface for the FSM Dialect -------------------===//
+//
+//  Implements a C Interface for the FSM Dialect
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/FSM.h"
+#include "circt/Dialect/FSM/FSMDialect.h"
+#include "circt/Dialect/FSM/FSMPasses.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+using namespace circt::fsm;
+
+void registerFSMPasses() { registerPasses(); }
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FSM, fsm, FSMDialect)

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_llvm_executable(circt-capi-ir-test
   ir.c
-  )
+)
 llvm_update_compile_flags(circt-capi-ir-test)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
@@ -13,5 +13,6 @@ target_link_libraries(circt-capi-ir-test
   CIRCTCAPIHW
   CIRCTCAPISeq
   CIRCTCAPISV
+  CIRCTCAPIFSM
   CIRCTCAPIExportVerilog
-  )
+)


### PR DESCRIPTION
This is an initial commit for adding a CAPI for FSM as well as PyCDE support for constructing these.

See `test_fsm.py` for usage.

FSMs are constructed in a similar manner to PyCDE modules through a decorator on a class describing the FSM.
The FSM class may contain inputs (no outputs for now) and must provide
- A dictionary containing the states and their transitions
- A default state

State transitions may be either always taken, or taken based on some guard. This guard is defined by a function provided to the transition, which (like `@generator` functions) acts on the ports of the FSM.

The FSM will then be constructed with an output for each state, asserted when that state is active.

One important implementation note is the fact that the `fsm.machine` operation is treated as a PyCDE Module - there was surprisingly little friction slotting it into the current code and everything works as expected wrt. referencing `fsm.machine` in/out arguments through the transition guard functions.
However, modules instantiating the FSM expect a hardware-like interface, this being the ports of the `fsm.machine` operation + clock and reset signals. An `fsm.machine` op does not have these signals at the top level, since these are added during hardware lowering. To me, this is a sensible design choice, seeing that the FSM dialect should be applicable to both software and hardware representations (...eventually).

To get around this, the user will specify the intended name of the `clock` and optional `reset` signal of an FSM. A wrapper module is then created that provides the correct interface to the instantiating module, as well as instantiating the FSM through a `fsm.hw_instance` operation, doing the proper hoop-jumping to attach the clock signal (see `fsm_wrapper_class`).

There's still some work to do on the CIRCT side of the FSM dialect to clean it up a bit + make it a viable target for a front-end, but this commit represents the brunt of work on the PyCDE side.