### PR TITLE
[FIRRTL] Use relative XMRs in GCT Data/Mem Taps

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -81,4 +81,4 @@ circuit TestHarness : %[[
 
 ; CHECK:     module DataTap
 ; CHECK-NOT: endmodule
-; CHECK:       assign _0 = TestHarness.system.test.signal;
+; CHECK:       assign _0 = Top.test.signal;

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -529,12 +529,12 @@ firrtl.circuit "Top" {
   }
 
   // CHECK-LABEL: firrtl.module @MemTap_1_impl_0
-  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}"
-  // CHECK-SAME: symbols = [@Top, #hw.innerNameRef<@Top::@dut>, #hw.innerNameRef<@DUT::@submodule_1>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
+  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}"
+  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@submodule_1>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
   firrtl.extmodule @MemTap_1(out mem_0: !firrtl.uint<1> [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.port", id = 0 : i64, portID = 0 : i64}]) attributes {defname = "MemTap"}
   // CHECK-LABEL: firrtl.module @MemTap_2_impl_0
-  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}"
-  // CHECK-SAME: symbols = [@Top, #hw.innerNameRef<@Top::@dut>, #hw.innerNameRef<@DUT::@submodule_2>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
+  // CHECK-NEXT{LITERAL}: firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}"
+  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@submodule_2>, #hw.innerNameRef<@Submodule::@[[bar_0]]>]
   firrtl.extmodule @MemTap_2(out mem_0: !firrtl.uint<1> [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.port", id = 1 : i64, portID = 0 : i64}]) attributes {defname = "MemTap"}
 }
 


### PR DESCRIPTION
Change the Grand Central (GCT) Data/Mem Taps pass to use relative XMRs
for taps that involve non-local annotations (NLAs).  Previously, NLA
paths were used as-is and did not factor into existing XMR minimization
code.  Change this by adding NLA path information to the existing
InstanceOp array used by minimization code.

This is done to fix issues where a user creates a Data/Mem Tap at a
specific point in the hierarchy and they wind up with an XMR that goes
_above_ this point in the design.  This creates problems for designs
that expect the XMR to be compartmentalized, but where the Chisel API
produces NLA paths that are absolute.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>