### PR TITLE
[FSM] Remove SingleBlockImplicitTerminator from StateOp, TransitionOp

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -140,8 +140,7 @@ def HWInstanceOp : FSMOp<"hw_instance", [Symbol, AttrSizedOperandSegments]> {
   let hasVerifier = 1;
 }
 
-def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
-       SingleBlockImplicitTerminator<"OutputOp">]> {
+def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol, NoTerminator]> {
   let summary = "Define a state of a machine";
   let description = [{
     `fsm.state` represents a state of a state machine. This op includes an
@@ -169,6 +168,7 @@ def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
   ];
 
   let skipDefaultBuilders = 1;
+  let hasVerifier = 1;
 }
 
 def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
@@ -188,8 +188,7 @@ def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
   let hasVerifier = 1;
 }
 
-def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
-      SingleBlockImplicitTerminator<"ReturnOp">]> {
+def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">, NoTerminator]> {
   let summary = "Define a transition of a state";
   let description = [{
     `fsm.transition` represents a transition of a state with a symbol reference

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -211,11 +211,10 @@ LogicalResult HWInstanceOp::verify() { return verifyCallerTypes(*this); }
 void StateOp::build(OpBuilder &builder, OperationState &state,
                     StringRef stateName) {
   Region *output = state.addRegion();
+  output->push_back(new Block());
   Region *transitions = state.addRegion();
+  transitions->push_back(new Block());
   state.addAttribute("sym_name", builder.getStringAttr(stateName));
-
-  ensureTerminator(*output, builder, state.location);
-  ensureTerminator(*transitions, builder, state.location);
 }
 
 SetVector<StateOp> StateOp::getNextStates() {
@@ -242,6 +241,15 @@ LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
     rewriter.eraseOp(transition);
 
   return failure(transitionsToErase.empty());
+}
+
+LogicalResult StateOp::verify() {
+  // Ensure that the output block has a single OutputOp terminator.
+  Block *outputBlock = &output().front();
+  if (outputBlock->empty() || !isa<fsm::OutputOp>(outputBlock->back()))
+    return emitOpError("output block must have a single OutputOp terminator");
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -272,12 +280,11 @@ LogicalResult OutputOp::verify() {
 void TransitionOp::build(OpBuilder &builder, OperationState &state,
                          StringRef nextState) {
   Region *guard = state.addRegion();
+  guard->push_back(new Block());
   Region *action = state.addRegion();
+  action->push_back(new Block());
   state.addAttribute("nextState",
                      FlatSymbolRefAttr::get(builder.getStringAttr(nextState)));
-
-  ensureTerminator(*guard, builder, state.location);
-  ensureTerminator(*action, builder, state.location);
 }
 
 void TransitionOp::build(OpBuilder &builder, OperationState &state,
@@ -340,9 +347,12 @@ LogicalResult TransitionOp::verify() {
     return emitOpError("cannot find the definition of the next state `")
            << nextState() << "`";
 
-  // Verify the action region.
-  if (hasAction() && action().front().getTerminator()->getNumOperands() != 0)
-    return emitOpError("action region must not return any value");
+  // Verify the action region, if present.
+  if (hasGuard()) {
+    if (guard().front().empty() ||
+        !isa_and_nonnull<fsm::ReturnOp>(&guard().front().back()))
+      return emitOpError("guard region must terminate with a ReturnOp");
+  }
 
   // Verify the transition is located in the correct region.
   if ((*this)->getParentRegion() != &getCurrentState().transitions())

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -8,7 +8,7 @@
 // CHECK:   } transitions  {
 // CHECK:     fsm.transition @BUSY guard  {
 // CHECK:       fsm.return %arg0
-// CHECK:     } action  {
+// CHECK:     } action {
 // CHECK:       %c256_i16 = arith.constant 256 : i16
 // CHECK:       fsm.update %cnt, %c256_i16 : i16
 // CHECK:     }
@@ -21,7 +21,7 @@
 // CHECK:       %c0_i16 = arith.constant 0 : i16
 // CHECK:       %0 = arith.cmpi ne, %cnt, %c0_i16 : i16
 // CHECK:       fsm.return %0
-// CHECK:     } action  {
+// CHECK:     } action {
 // CHECK:       %c1_i16 = arith.constant 1 : i16
 // CHECK:       %0 = arith.subi %cnt, %c1_i16 : i16
 // CHECK:       fsm.update %cnt, %0 : i16
@@ -30,7 +30,6 @@
 // CHECK:       %c0_i16 = arith.constant 0 : i16
 // CHECK:       %0 = arith.cmpi eq, %cnt, %c0_i16 : i16
 // CHECK:       fsm.return %0
-// CHECK:     } action  {
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
@@ -114,14 +113,12 @@ func.func @qux() {
 // CHECK:           fsm.state "A" output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
 // CHECK:           } transitions {
-// CHECK:             fsm.transition @A action {
-// CHECK:             }
+// CHECK:             fsm.transition @A
 // CHECK:           }
 // CHECK:           fsm.state "B" output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
 // CHECK:           } transitions {
-// CHECK:             fsm.transition @B guard {
-// CHECK:             }
+// CHECK:             fsm.transition @B
 // CHECK:           }
 // CHECK:           fsm.state "C" output {
 // CHECK:             fsm.output %[[VAL_0]] : i1

--- a/test/Dialect/FSM/errors.mlir
+++ b/test/Dialect/FSM/errors.mlir
@@ -4,3 +4,65 @@
 
 // expected-error @+1 {{'fsm.machine' op initial state 'IDLE' was not defined in the machine}}
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {}
+
+// -----
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "IDLE" output  {
+    %true = arith.constant true
+// expected-error @+1 {{'fsm.output' op operand types must match the machine output types}}
+    fsm.output %true, %true : i1, i1
+  } transitions {
+    fsm.transition @IDLE
+  }
+}
+
+// -----
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  // expected-error @+1 {{'fsm.state' op output block must have a single OutputOp terminator}}
+  fsm.state "IDLE" output  {
+    %true = arith.constant true
+  } transitions {
+    fsm.transition @IDLE
+  }
+}
+
+
+// -----
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "IDLE" output  {
+    %true = arith.constant true
+    fsm.output %true : i1
+  } transitions {
+    // expected-error @+1 {{'fsm.transition' op guard region must terminate with a ReturnOp}}
+    fsm.transition @IDLE guard {
+      %true = arith.constant true
+    }
+  }
+}
+
+// -----
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "IDLE" output  {
+    %true = arith.constant true
+    fsm.output %true : i1
+  } transitions {
+    fsm.transition @IDLE guard {
+      // expected-note @+1 {{prior use here}}
+      %c2 = arith.constant 2 : i2
+      // expected-error @+1 {{use of value '%c2' expects different type than prior uses: 'i1' vs 'i2'}}
+      fsm.return %c2
+    }
+  }
+}


### PR DESCRIPTION
This was enforcing unintended ops which shows up when generating FSM IR from a frontend. Previously, `SingleBlockImplicitTerminator<"OutputOp">` required an OutputOp to be in both the output and transition regions, where it really only made sense for the output region.

It's a similar story for the TransitionOp and `SingleBlockImplicitTerminator<"ReturnOp">`.

This, and other small fixes, have been moved to FSMOps.cpp