### PR TITLE
[FIRRTL] Add helper utility to get InnerSym name. NFC.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -95,6 +95,7 @@ inline MemDirAttr &operator|=(MemDirAttr &lhs, MemDirAttr rhs) {
   return lhs;
 }
 
+/// Return the StringAttr for the inner_sym name, if it exists.
 inline StringAttr getInnerSymName(Operation *op) {
   return op->getAttrOfType<StringAttr>("inner_sym");
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -95,6 +95,10 @@ inline MemDirAttr &operator|=(MemDirAttr &lhs, MemDirAttr rhs) {
   return lhs;
 }
 
+inline StringAttr getInnerSymName(Operation *op) {
+  return op->getAttrOfType<StringAttr>("inner_sym");
+}
+
 /// Check whether a block argument ("port") or the operation defining a value
 /// has a `DontTouch` annotation, or a symbol that should prevent certain types
 /// of canonicalizations.

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -68,7 +68,7 @@ public:
   /// Get the NLAs that the InstanceOp participates in, insert it to the
   /// DenseSet `nlas`.
   void getInstanceNLAs(InstanceOp inst, DenseSet<HierPathOp> &nlas) {
-    auto instSym = inst.inner_symAttr();
+    auto instSym = getInnerSymName(inst);
     // If there is no inner sym on the InstanceOp, then it does not participate
     // in any NLA.
     if (!instSym)

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -65,7 +65,7 @@ struct ModuleNamespace : public Namespace {
   /// Populate the namespace with the body of a module-like operation.
   void addBody(FModuleLike module) {
     module.walk([&](Operation *op) {
-      auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+      auto attr = getInnerSymName(op);
       if (attr)
         nextIndex.insert({attr.getValue(), 0});
     });

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2441,7 +2441,7 @@ LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
     return setLowering(op, Value());
 
   // Name attr is required on sv.wire but optional on firrtl.wire.
-  auto symName = op.inner_symAttr();
+  StringAttr symName = getInnerSymName(op);
   auto name = op.nameAttr();
   if (AnnotationSet::removeAnnotations(
           op, "firrtl.transforms.DontTouchAnnotation") &&
@@ -2495,7 +2495,7 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   // Node operations are logical noops, but may carry annotations or be
   // referred to through an inner name. If a don't touch is present, ensure
   // that we have a symbol name so we can keep the node as a wire.
-  auto symName = op.inner_symAttr();
+  auto symName = getInnerSymName(op);
   auto name = op.nameAttr();
   if (AnnotationSet::removeAnnotations(
           op, "firrtl.transforms.DontTouchAnnotation") &&
@@ -2732,7 +2732,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
     return setLowering(op, Value());
 
   // Add symbol if DontTouch annotation present.
-  auto symName = op.inner_symAttr();
+  auto symName = getInnerSymName(op);
   if (AnnotationSet::removeAnnotations(
           op, "firrtl.transforms.DontTouchAnnotation") &&
       !symName)
@@ -2762,7 +2762,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   if (!clockVal || !resetSignal || !resetValue)
     return failure();
 
-  auto symName = op.inner_symAttr();
+  auto symName = getInnerSymName(op);
   if (AnnotationSet::removeAnnotations(
           op, "firrtl.transforms.DontTouchAnnotation") &&
       !symName)
@@ -3040,7 +3040,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   // for it and generate a bind op.  Enter the bind into global
   // CircuitLoweringState so that this can be moved outside of module once
   // we're guaranteed to not be a parallel context.
-  StringAttr symbol = oldInstance.inner_symAttr();
+  StringAttr symbol = getInnerSymName(oldInstance);
   if (oldInstance.lowerToBind()) {
     if (!symbol)
       symbol = builder.getStringAttr("__" + oldInstance.name() + "__");

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "mlir/IR/FunctionImplementation.h"
@@ -596,7 +597,7 @@ void OpAnnoTarget::setAnnotations(AnnotationSet annotations) const {
 
 StringAttr OpAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
   auto *context = getOp()->getContext();
-  auto innerSym = getOp()->getAttrOfType<StringAttr>("inner_sym");
+  auto innerSym = getInnerSymName(getOp());
   if (!innerSym) {
     // Try to come up with a reasonable name.
     StringRef name = "inner_sym";

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -922,7 +922,7 @@ private:
                         Operation *from) {
     // If the "from" operation has an inner_sym, we need to make sure the
     // "to" operation also has an `inner_sym` and then record the renaming.
-    if (auto fromSym = from->getAttrOfType<StringAttr>("inner_sym")) {
+    if (auto fromSym = getInnerSymName(from)) {
       auto toSym = OpAnnoTarget(to).getInnerSym(getNamespace(toModule));
       renameMap[fromSym] = toSym;
     }

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -409,7 +409,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
       // Find the instance referenced by the NLA.
       auto *node = instanceGraph->lookup(ref.getModule());
       auto it = llvm::find_if(*node, [&](hw::InstanceRecord *record) {
-        return cast<InstanceOp>(*record->getInstance()).inner_symAttr() ==
+        return getInnerSymName(cast<InstanceOp>(*record->getInstance())) ==
                ref.getName();
       });
       assert(it != node->end() &&
@@ -864,7 +864,7 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
 
 StringAttr EmitOMIRPass::getOrAddInnerSym(Operation *op) {
   tempSymInstances.erase(op);
-  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  auto attr = getInnerSymName(op);
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2196,7 +2196,7 @@ void GrandCentralPass::runOnOperation() {
 }
 
 StringAttr GrandCentralPass::getOrAddInnerSym(Operation *op) {
-  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  auto attr = getInnerSymName(op);
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -621,7 +621,7 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
   SmallVector<Attribute> symbols;
   SmallDenseMap<Attribute, size_t> symMap;
   auto getOrAddInnerSym = [&](Operation *op) -> StringAttr {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    auto attr = getInnerSymName(op);
     if (attr)
       return attr;
     StringRef name = "sym";

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -1169,7 +1169,7 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
 }
 
 StringAttr GrandCentralTapsPass::getOrAddInnerSym(Operation *op) {
-  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  auto attr = getInnerSymName(op);
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -48,8 +48,8 @@ static void addHierarchy(HierPathOp path, FModuleOp dut,
   newNamepath.reserve(namepath.size() + 1);
   while (path.modPart(nlaIdx) != dut.getNameAttr())
     newNamepath.push_back(namepath[nlaIdx++]);
-  newNamepath.push_back(
-      hw::InnerRefAttr::get(dut.moduleNameAttr(), wrapperInst.inner_symAttr()));
+  newNamepath.push_back(hw::InnerRefAttr::get(dut.moduleNameAttr(),
+                                              getInnerSymName(wrapperInst)));
 
   // Add the extra level of hierarchy.
   if (auto dutRef = namepath[nlaIdx].dyn_cast<hw::InnerRefAttr>())

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -92,7 +92,7 @@ struct LowerMemoryPass : public LowerMemoryBase<LowerMemoryPass> {
 
   /// Returns an operation's `inner_sym`, adding one if necessary.
   StringAttr getOrAddInnerSym(Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    auto attr = getInnerSymName(op);
     if (attr)
       return attr;
     auto module = op->getParentOfType<FModuleOp>();


### PR DESCRIPTION
Add a helper utility to get the `inner_sym` attribute from any operation.
This commit removes any direct access to the `inner_sym` attribute, and instead uses a helper utility to get the `inner_sym` name of an operation.
This utility will be required to get the `inner_sym` name, when the `inner_sym` attribute is a complex `Attribute` instead of a  `StringAttr`. This also reduces the number of changes required for a followup `InnerSymAttr` PR. 