### PR TITLE
[FIRRTL] InnerSymbolTable: move to own header, add helpers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/InnerSymbolTable.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "mlir/IR/Attributes.h"
@@ -68,72 +69,6 @@ LogicalResult verifyModuleLikeOpInterface(FModuleLike module);
 namespace detail {
 LogicalResult verifyInnerRefs(Operation *op);
 } // namespace detail
-
-/// A table of inner symbols and their resolutions.
-class InnerSymbolTable {
-public:
-  /// Return the name of the attribute used for inner symbol names.
-  static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
-
-  /// Build an inner symbol table for the given operation.  The operation must
-  /// have the InnerSymbolTable trait.
-  explicit InnerSymbolTable(Operation *op);
-
-  /// Look up a symbol with the specified name, returning null if no such
-  /// name exists. Names never include the @ on them.
-  Operation *lookup(StringRef name) const;
-  template <typename T>
-  T lookup(StringRef name) const {
-    return dyn_cast_or_null<T>(lookup(name));
-  }
-
-  /// Look up a symbol with the specified name, returning null if no such
-  /// name exists. Names never include the @ on them.
-  Operation *lookup(StringAttr name) const;
-  template <typename T>
-  T lookup(StringAttr name) const {
-    return dyn_cast_or_null<T>(lookup(name));
-  }
-
-private:
-  /// This is the operation this table is constructed for, which must have the
-  /// InnerSymbolTable trait.
-  Operation *innerSymTblOp;
-
-  /// This maps names to operations with that inner symbol.
-  DenseMap<StringAttr, Operation *> symbolTable;
-};
-
-/// This class represents a collection of InnerSymbolTable's.
-class InnerSymbolTableCollection {
-public:
-  /// Get or create the InnerSymbolTable for the specified operation.
-  InnerSymbolTable &getInnerSymbolTable(Operation *op);
-
-  /// Populate tables in parallel for all InnerSymbolTable operations in the
-  /// given InnerRefNamespace operation.
-  void populateTables(Operation *innerRefNSOp);
-
-private:
-  /// This maps Operations to their InnnerSymbolTable's.
-  DenseMap<Operation *, std::unique_ptr<InnerSymbolTable>> symbolTables;
-};
-
-/// This class represents the namespace in which InnerRef's can be resolved.
-struct InnerRefNamespace {
-  SymbolTable &symTable;
-  InnerSymbolTableCollection &innerSymTables;
-
-  /// Resolve the InnerRef to its target within this namespace, returning null
-  /// if no such name exists.
-  ///
-  /// Note that some InnerRef's target ports and must be handled separately.
-  Operation *lookup(hw::InnerRefAttr inner);
-  template <typename T>
-  T lookup(hw::InnerRefAttr inner) {
-    return dyn_cast_or_null<T>(lookup(inner));
-  }
-};
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -315,7 +315,8 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
     InterfaceMethod<"Returns the name of this inner symbol.",
       "StringAttr", "getInnerNameAttr", (ins), [{}],
       /*defaultImplementation=*/[{
-        return InnerSymbolTable::getInnerSymbol(this->getOperation());
+        return this->getOperation()->template getAttrOfType<StringAttr>(
+            circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName());
       }]
     >,
     InterfaceMethod<"Returns the name of this inner symbol.",

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -334,6 +334,12 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName(), name);
       }]
     >,
+    InterfaceMethod<"Returns an InnerRef to this operation.  Walks to find parent.",
+      "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return InnerSymbolTable::getInnerRefFor(this->getOperation());
+      }]
+    >,
 
   ];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -335,7 +335,11 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
     InterfaceMethod<"Returns an InnerRef to this operation.  Walks to find parent.",
       "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
       /*defaultImplementation=*/[{
-        return InnerSymbolTable::getInnerRefFor(this->getOperation());
+        auto *op = this->getOperation();
+        return hw::InnerRefAttr::get(
+            SymbolTable::getSymbolName(
+                op->template getParentWithTrait<OpTrait::InnerSymbolTable>()),
+            InnerSymbolTable::getInnerSymbol(op));
       }]
     >,
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -333,7 +333,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             InnerSymbolTable::getInnerSymbolAttrName(), name);
       }]
     >,
-    InterfaceMethod<"Returns an InnerRef to this operation.  Walks to find parent.",
+    InterfaceMethod<"Returns an InnerRef to this operation.  Must have inner symbol.",
       "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
       /*defaultImplementation=*/[{
         auto *op = this->getOperation();

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -315,15 +315,13 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
     InterfaceMethod<"Returns the name of this inner symbol.",
       "StringAttr", "getInnerNameAttr", (ins), [{}],
       /*defaultImplementation=*/[{
-        return this->getOperation()->template getAttrOfType<StringAttr>(
-            circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName());
+        return InnerSymbolTable::getInnerSymbol(this->getOperation());
       }]
     >,
     InterfaceMethod<"Returns the name of this inner symbol.",
       "Optional<StringRef>", "getInnerName", (ins), [{}],
       /*defaultImplementation=*/[{
-        auto attr = this->getOperation()->template getAttrOfType<StringAttr>(
-            circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName());
+        auto attr = this->getInnerNameAttr();
         return attr ? Optional<StringRef>(attr.getValue()) : None;
       }]
     >,
@@ -331,7 +329,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
       "void", "setInnerSymbol", (ins "StringAttr":$name), [{}],
       /*defaultImplementation=*/[{
         this->getOperation()->setAttr(
-            circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName(), name);
+            InnerSymbolTable::getInnerSymbolAttrName(), name);
       }]
     >,
     InterfaceMethod<"Returns an InnerRef to this operation.  Walks to find parent.",

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -55,6 +55,22 @@ public:
   /// Get InnerSymbol for an operation.
   static StringAttr getInnerSymbol(Operation *op);
 
+  /// Return an InnerRef to the given operation which must be within this table.
+  hw::InnerRefAttr getInnerRef(Operation *op);
+
+  /// Return an InnerRef to the given operation.
+  static hw::InnerRefAttr getInnerRefFor(Operation *op);
+
+  /// Return an InnerRef for the given inner symbol, which must be valid.
+  hw::InnerRefAttr getInnerRef(StringRef name) {
+    return getInnerRef(lookup(name));
+  }
+
+  /// Return an InnerRef for the given inner symbol, which must be valid.
+  hw::InnerRefAttr getInnerRef(StringAttr name) {
+    return getInnerRef(lookup(name));
+  }
+
 private:
   /// This is the operation this table is constructed for, which must have the
   /// InnerSymbolTable trait.

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -1,0 +1,94 @@
+//===- InnerSymbolTable.h - Inner Symbol Table -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the InnerSymbolTable and related classes, used for
+// managing and tracking "inner symbols".
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_INNERSYMBOLTABLE_H
+#define CIRCT_DIALECT_FIRRTL_INNERSYMBOLTABLE_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace circt {
+namespace firrtl {
+
+/// A table of inner symbols and their resolutions.
+class InnerSymbolTable {
+public:
+  /// Return the name of the attribute used for inner symbol names.
+  static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
+
+  /// Build an inner symbol table for the given operation.  The operation must
+  /// have the InnerSymbolTable trait.
+  explicit InnerSymbolTable(Operation *op);
+
+  /// Look up a symbol with the specified name, returning null if no such
+  /// name exists. Names never include the @ on them.
+  Operation *lookup(StringRef name) const;
+  template <typename T>
+  T lookup(StringRef name) const {
+    return dyn_cast_or_null<T>(lookup(name));
+  }
+
+  /// Look up a symbol with the specified name, returning null if no such
+  /// name exists. Names never include the @ on them.
+  Operation *lookup(StringAttr name) const;
+  template <typename T>
+  T lookup(StringAttr name) const {
+    return dyn_cast_or_null<T>(lookup(name));
+  }
+
+private:
+  /// This is the operation this table is constructed for, which must have the
+  /// InnerSymbolTable trait.
+  Operation *innerSymTblOp;
+
+  /// This maps names to operations with that inner symbol.
+  DenseMap<StringAttr, Operation *> symbolTable;
+};
+
+/// This class represents a collection of InnerSymbolTable's.
+class InnerSymbolTableCollection {
+public:
+  /// Get or create the InnerSymbolTable for the specified operation.
+  InnerSymbolTable &getInnerSymbolTable(Operation *op);
+
+  /// Populate tables in parallel for all InnerSymbolTable operations in the
+  /// given InnerRefNamespace operation.
+  void populateTables(Operation *innerRefNSOp);
+
+private:
+  /// This maps Operations to their InnnerSymbolTable's.
+  DenseMap<Operation *, std::unique_ptr<InnerSymbolTable>> symbolTables;
+};
+
+/// This class represents the namespace in which InnerRef's can be resolved.
+struct InnerRefNamespace {
+  SymbolTable &symTable;
+  InnerSymbolTableCollection &innerSymTables;
+
+  /// Resolve the InnerRef to its target within this namespace, returning null
+  /// if no such name exists.
+  ///
+  /// Note that some InnerRef's target ports and must be handled separately.
+  Operation *lookup(hw::InnerRefAttr inner);
+  template <typename T>
+  T lookup(hw::InnerRefAttr inner) {
+    return dyn_cast_or_null<T>(lookup(inner));
+  }
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_INNERSYMBOLTABLE_H

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -62,9 +62,6 @@ public:
     return getInnerRef(lookup(name));
   }
 
-  /// Return an InnerRef to the given operation.
-  static hw::InnerRefAttr getInnerRefFor(Operation *op);
-
   /// Get InnerSymbol for an operation.
   static StringAttr getInnerSymbol(Operation *op);
 

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -25,9 +25,6 @@ namespace firrtl {
 /// A table of inner symbols and their resolutions.
 class InnerSymbolTable {
 public:
-  /// Return the name of the attribute used for inner symbol names.
-  static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
-
   /// Build an inner symbol table for the given operation.  The operation must
   /// have the InnerSymbolTable trait.
   explicit InnerSymbolTable(Operation *op);
@@ -52,14 +49,8 @@ public:
     return dyn_cast_or_null<T>(lookup(name));
   }
 
-  /// Get InnerSymbol for an operation.
-  static StringAttr getInnerSymbol(Operation *op);
-
   /// Return an InnerRef to the given operation which must be within this table.
   hw::InnerRefAttr getInnerRef(Operation *op);
-
-  /// Return an InnerRef to the given operation.
-  static hw::InnerRefAttr getInnerRefFor(Operation *op);
 
   /// Return an InnerRef for the given inner symbol, which must be valid.
   hw::InnerRefAttr getInnerRef(StringRef name) {
@@ -70,6 +61,15 @@ public:
   hw::InnerRefAttr getInnerRef(StringAttr name) {
     return getInnerRef(lookup(name));
   }
+
+  /// Return an InnerRef to the given operation.
+  static hw::InnerRefAttr getInnerRefFor(Operation *op);
+
+  /// Get InnerSymbol for an operation.
+  static StringAttr getInnerSymbol(Operation *op);
+
+  /// Return the name of the attribute used for inner symbol names.
+  static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
 
 private:
   /// This is the operation this table is constructed for, which must have the

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -52,6 +52,9 @@ public:
     return dyn_cast_or_null<T>(lookup(name));
   }
 
+  /// Get InnerSymbol for an operation.
+  static StringAttr getInnerSymbol(Operation *op);
+
 private:
   /// This is the operation this table is constructed for, which must have the
   /// InnerSymbolTable trait.

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -32,6 +32,10 @@ public:
   /// have the InnerSymbolTable trait.
   explicit InnerSymbolTable(Operation *op);
 
+  /// Non-copyable
+  InnerSymbolTable(const InnerSymbolTable &) = delete;
+  InnerSymbolTable &operator=(InnerSymbolTable &) = delete;
+
   /// Look up a symbol with the specified name, returning null if no such
   /// name exists. Names never include the @ on them.
   Operation *lookup(StringRef name) const;
@@ -66,6 +70,10 @@ public:
   /// Populate tables in parallel for all InnerSymbolTable operations in the
   /// given InnerRefNamespace operation.
   void populateTables(Operation *innerRefNSOp);
+
+  explicit InnerSymbolTableCollection() = default;
+  InnerSymbolTableCollection(const InnerSymbolTableCollection &) = delete;
+  InnerSymbolTableCollection &operator=(InnerSymbolTableCollection &) = delete;
 
 private:
   /// This maps Operations to their InnnerSymbolTable's.

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -58,6 +58,19 @@ StringAttr InnerSymbolTable::getInnerSymbol(Operation *op) {
       InnerSymbolTable::getInnerSymbolAttrName());
 }
 
+/// Return an InnerRef to the given operation.
+hw::InnerRefAttr InnerSymbolTable::getInnerRef(Operation *op) {
+  assert(op->getParentWithTrait<OpTrait::InnerSymbolTable>() == innerSymTblOp);
+  return hw::InnerRefAttr::get(SymbolTable::getSymbolName(innerSymTblOp),
+                               getInnerSymbol(op));
+}
+hw::InnerRefAttr InnerSymbolTable::getInnerRefFor(Operation *op) {
+  return hw::InnerRefAttr::get(
+      SymbolTable::getSymbolName(
+          op->getParentWithTrait<OpTrait::InnerSymbolTable>()),
+      getInnerSymbol(op));
+}
+
 //===----------------------------------------------------------------------===//
 // InnerSymbolTableCollection
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -52,6 +52,12 @@ Operation *InnerSymbolTable::lookup(StringAttr name) const {
   return symbolTable.lookup(name);
 }
 
+/// Get InnerSymbol for an operation.
+StringAttr InnerSymbolTable::getInnerSymbol(Operation *op) {
+  return op->getAttrOfType<StringAttr>(
+      InnerSymbolTable::getInnerSymbolAttrName());
+}
+
 //===----------------------------------------------------------------------===//
 // InnerSymbolTableCollection
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -64,12 +64,6 @@ hw::InnerRefAttr InnerSymbolTable::getInnerRef(Operation *op) {
   return hw::InnerRefAttr::get(SymbolTable::getSymbolName(innerSymTblOp),
                                getInnerSymbol(op));
 }
-hw::InnerRefAttr InnerSymbolTable::getInnerRefFor(Operation *op) {
-  return hw::InnerRefAttr::get(
-      SymbolTable::getSymbolName(
-          op->getParentWithTrait<OpTrait::InnerSymbolTable>()),
-      getInnerSymbol(op));
-}
 
 //===----------------------------------------------------------------------===//
 // InnerSymbolTableCollection

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/FIRRTL/InnerSymbolTable.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "mlir/IR/Threading.h"
 

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -31,10 +31,8 @@ InnerSymbolTable::InnerSymbolTable(Operation *op) {
   this->innerSymTblOp = op;
 
   // Walk the operation and add InnerSymbol's to the table.
-  StringAttr innerSymId = StringAttr::get(
-      op->getContext(), InnerSymbolTable::getInnerSymbolAttrName());
-  op->walk([&](Operation *symOp) {
-    auto attr = symOp->getAttrOfType<StringAttr>(innerSymId);
+  op->walk([&](InnerSymbolOpInterface symOp) {
+    auto attr = symOp.getInnerNameAttr();
     if (!attr)
       return;
     auto it = symbolTable.insert({attr, symOp});
@@ -54,8 +52,9 @@ Operation *InnerSymbolTable::lookup(StringAttr name) const {
 
 /// Get InnerSymbol for an operation.
 StringAttr InnerSymbolTable::getInnerSymbol(Operation *op) {
-  return op->getAttrOfType<StringAttr>(
-      InnerSymbolTable::getInnerSymbolAttrName());
+  if (auto innerSymOp = dyn_cast<InnerSymbolOpInterface>(op))
+    return innerSymOp.getInnerNameAttr();
+  return {};
 }
 
 /// Return an InnerRef to the given operation.

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -810,7 +810,7 @@ void GrandCentralTapsPass::runOnOperation() {
               auto refPart = getRefPart(segment);
               if (!refPart)
                 continue;
-              auto innerSymTbl = innerSymTblCol.getInnerSymbolTable(
+              auto &innerSymTbl = innerSymTblCol.getInnerSymbolTable(
                   symtbl.lookup(getModPart(segment)));
               prefixWithNLA.push_back(
                   cast<InstanceOp>(innerSymTbl.lookup(refPart)));


### PR DESCRIPTION
Improvements to InnerSymbolTable.

* Move it and related classes out of Op Interfaces and to a dedicated header
* Provide method for obtaining inner symbol for an operation, nowhere outside these classes should muck with grabbing that attribute manually (if possible).
* Make classes non-copyable, fix copy
* Add helpers for creating InnerRef's to operations with inner symbols.

InnerRef helpers are not quite what we really need to simplify our passes, yet--  often passes want something like `getInnerRefAndInnerSymAsNeeded(Operation *op)` which usually leverages `ModuleNamespace`(s), and the sort of names assigned when not already present varies across passes (but may not be critical).
Finding a better way to unify these things, cleanly would be good.