### PR TITLE
[FIRRTL] Add a new FIRRTL XMR Op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -329,3 +329,20 @@ def WireOp : ReferableDeclOp<"wire"> {
     custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
 }
+
+def XMROp : FIRRTLOp<"xmr", [
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    HasParent<"firrtl::FModuleOp">]> {
+  let summary = "Encode a reference to a non-local net.";
+  let description = [{
+    This represents a non-local hierarchical name to a net, sometimes called a
+    cross-module reference. The hierarchical path is specified by a reference
+    to the symbol defined by a `HierPathOp`. Only downward reference is
+    allowed, hence the HierPathOp must be rooted at the module in which it is
+    used. The op verifier doesn't check if the result type of the XMROp matches
+    with the type of the remote net, but it is assumed that they match.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$hierPathSym);
+  let results = (outs FIRRTLType:$result);
+  let assemblyFormat = "$hierPathSym attr-dict `:` qualified(type($result))";
+}

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -213,15 +213,3 @@ def ProbeOp : FIRRTLOp<"probe"> {
 
   let assemblyFormat = "$inner_sym attr-dict ( `,` $operands^  `:` qualified(type($operands)))?";
 }
-
-def XMROp : FIRRTLOp<"xmr", []> {
-  let summary = "Encode a reference to a non-local net.";
-  let description = [{
-    This represents a non-local hierarchical name to a net, sometimes called a
-    cross-module reference. The hierarchical path is specified by a reference
-    to the symbol defined by a `HierPathOp`.
-  }];
-  let arguments = (ins FlatSymbolRefAttr:$hierPathSym);
-  let results = (outs FIRRTLType:$result);
-  let assemblyFormat = "$hierPathSym attr-dict `:` qualified(type($result))";
-}

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -213,3 +213,4 @@ def ProbeOp : FIRRTLOp<"probe"> {
 
   let assemblyFormat = "$inner_sym attr-dict ( `,` $operands^  `:` qualified(type($operands)))?";
 }
+

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -214,3 +214,14 @@ def ProbeOp : FIRRTLOp<"probe"> {
   let assemblyFormat = "$inner_sym attr-dict ( `,` $operands^  `:` qualified(type($operands)))?";
 }
 
+def XMROp : FIRRTLOp<"xmr", []> {
+  let summary = "Encode a reference to a non-local net.";
+  let description = [{
+    This represents a non-local hierarchical name to a net, sometimes called a
+    cross-module reference. The hierarchical path is specified by a reference
+    to the symbol defined by a `HierPathOp`.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$hierPathSym);
+  let results = (outs FIRRTLType:$result);
+  let assemblyFormat = "$hierPathSym attr-dict `:` qualified(type($result))";
+}

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -155,7 +155,7 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, StrictConnectOp, ForceOp, PrintFOp,
                        SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
-                       ProbeOp>([&](auto opNode) -> ResultType {
+                       ProbeOp, XMROp>([&](auto opNode) -> ResultType {
           return thisCast->visitStmt(opNode, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -192,6 +192,7 @@ public:
   HANDLE(AssumeOp);
   HANDLE(CoverOp);
   HANDLE(ProbeOp);
+  HANDLE(XMROp);
 
 #undef HANDLE
 };

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1580,11 +1580,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @ForceNameSubmodule
   firrtl.hierpath @nla_1 [@ForceNameTop::@sym_foo, @ForceNameSubmodule]
   firrtl.hierpath @nla_2 [@ForceNameTop::@sym_bar, @ForceNameSubmodule]
+  firrtl.hierpath @nla_3 [@ForceNameTop::@sym_bar, @ForceNameSubmodule::@dummy1]
   firrtl.module private @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},
     {circt.nonlocal = @nla_1,
-     class = "chisel3.util.experimental.ForceNameAnnotation", name = "Foo"}]} {}
+     class = "chisel3.util.experimental.ForceNameAnnotation", name = "Foo"}]} {
+        %dummy1 = firrtl.wire sym @dummy1 : !firrtl.uint<4>
+     }
   // CHECK: hw.module private @ForceNameTop
   firrtl.module private @ForceNameTop() {
     firrtl.instance foo sym @sym_foo
@@ -1595,6 +1598,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
       @ForceNameSubmodule()
     // CHECK:      hw.instance "foo" sym @sym_foo {{.+}} {hw.verilogName = "Foo"}
     // CHECK-NEXT: hw.instance "bar" sym @sym_bar {{.+}} {hw.verilogName = "Bar"}
+    %1 = firrtl.wire : !firrtl.uint<4>
+    %2 = firrtl.xmr @nla_3 : !firrtl.uint<4>
+    firrtl.connect %1, %2 : !firrtl.uint<4>, !firrtl.uint<4>
+    // CHECK: %0 = sv.wire  : !hw.inout<i4>
+    // CHECK: %1 = sv.xmr "ForceNameTop", "sym_bar", "dummy1" : !hw.inout<i4>
+    // CHECK: %2 = sv.read_inout %1 : !hw.inout<i4>
+    // CHECK: sv.assign %0, %2 : i4
   }
 
   // CHECK-LABEL: hw.module private @PreserveName

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -822,3 +822,27 @@ firrtl.circuit "MismatchedRegister" {
 firrtl.circuit "private_main" {
   firrtl.module private @private_main() {}
 }
+
+// -----
+
+firrtl.circuit "XMRTop" {
+
+  firrtl.hierpath @nla_1 [@XMRTop::@test,@Aardvark::@test_1, @Zebra::@w]
+  firrtl.module @XMRTop() {
+    firrtl.instance test  sym @test @Aardvark()
+    firrtl.instance test2 @Zebra()
+    %1 = firrtl.xmr @nla_1 : !firrtl.uint<3>
+  }
+
+  firrtl.module @Aardvark() {
+    firrtl.instance test sym @test @Zebra()
+    firrtl.instance test1 sym @test_1 @Zebra()
+    
+    // expected-error @+1 {{must be rooted at the current module 'Aardvark' but HierPathOp rooted at `XMRTop'. Only downward reference is supported.}}
+    %1 = firrtl.xmr @nla_1 : !firrtl.uint<3>
+  }
+
+  firrtl.module @Zebra() {
+    %w = firrtl.wire sym @w : !firrtl.uint<3>
+  }
+}


### PR DESCRIPTION
This PR adds a new `FIRRTL` op for specifying a cross module reference, also known as an XMR.
The XMR represents a non-local hierarchical name to a net. 
The hierarchical path is specified by a reference to the symbol defined by a `HierPathOp`.
Only downward reference is allowed, hence the `HierPathOp` must be rooted at the module in which it is used. 
The verifier will fail, if the `HierPathOp` is not rooted at the current module.
It is assumed that the result type of the `XMROp` matches with the result type of the remote net, but the op verifier doesn't check this property now.
This will be lowered to the `sv::XMROp`.  The use of this op was demonstrated in https://github.com/llvm/circt/pull/3290.
This `XMROp` is intended to replace the GrandCentral generated XMR as `VerbatimOp`.

```mlir
firrtl.hierpath @nla_1 [@XMRTop::@test,@Aardvark::@test_1, @Zebra::@w]
  firrtl.module @XMRTop() {
    firrtl.instance test  sym @test @Aardvark()
    %1 = firrtl.xmr @nla_1 : !firrtl.uint<3>
  }

  firrtl.module @Aardvark() {
    firrtl.instance test sym @test @Zebra()
    firrtl.instance test1 sym @test_1 @Zebra()
  }

  firrtl.module @Zebra() {
    %w = firrtl.wire sym @w : !firrtl.uint<3>
  }
}
```