### PR TITLE
[PyCDE] Clock inputs and clocking blocks

### DIFF
--- a/frontends/PyCDE/src/pycde/__init__.py
+++ b/frontends/PyCDE/src/pycde/__init__.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .module import (externmodule, generator, module, no_connect)
-from .module import (Input, InputChannel, Output, OutputChannel)
+from .module import (Clock, Input, InputChannel, Output, OutputChannel)
 from .system import (System)
 from .pycde_types import (dim, types)
 from .value import (Value)

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -4,8 +4,8 @@
 
 from collections import OrderedDict
 
-from .value import (BitVectorValue, ChannelValue, ListValue, StructValue,
-                    RegularValue, InOutValue, Value)
+from .value import (BitVectorValue, ChannelValue, ClockValue, ListValue,
+                    StructValue, RegularValue, InOutValue, Value)
 
 import mlir.ir
 from circt.dialects import esi, hw, sv
@@ -265,12 +265,23 @@ class BitVectorType(PyCDEType):
     return BitVectorValue
 
 
+class ClockType(PyCDEType):
+  """A special single bit to represent a clock. Can't do any special operations
+  on it, except enter it as a implicit clock block."""
+
+  def __init__(self):
+    super().__init__(mlir.ir.IntegerType.get_signless(1))
+
+  def _get_value_class(self):
+    return ClockValue
+
+
 class ChannelType(PyCDEType):
   """An ESI channel type."""
 
   @property
   def inner_type(self):
-    return PyCDEType(self._type.inner)
+    return Type(self._type.inner)
 
   def _get_value_class(self):
     return ChannelValue

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -125,6 +125,8 @@ _current_clock_context = ContextVar("current_clock_context")
 
 
 class ClockValue(Value):
+  """A clock signal."""
+
   __slots__ = ["_old_token"]
 
   def __enter__(self):

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -11,6 +11,7 @@ import circt.support as support
 
 import mlir.ir as ir
 
+from contextvars import ContextVar
 from functools import singledispatchmethod
 from typing import Union
 import re
@@ -43,13 +44,19 @@ class Value:
 
   _reg_name = re.compile(r"^(.*)__reg(\d+)$")
 
-  def reg(self, clk, rst=None, name=None, cycles=1, sv_attributes=None):
+  def reg(self, clk=None, rst=None, name=None, cycles=1, sv_attributes=None):
     """Register this value, returning the delayed value.
     `clk`, `rst`: the clock and reset signals.
     `name`: name this register explicitly.
     `cycles`: number of registers to add."""
+
+    if clk is None:
+      clk = ClockValue._get_current_clock_block()
+      if clk is None:
+        raise ValueError("If 'clk' not specified, must be in clock block")
     if sv_attributes is not None:
       sv_attributes = [sv.SVAttributeAttr.get(attr) for attr in sv_attributes]
+
     from .dialects import seq
     if name is None:
       basename = None
@@ -112,6 +119,25 @@ class Value:
 
 class RegularValue(Value):
   pass
+
+
+_current_clock_context = ContextVar("current_clock_context")
+
+
+class ClockValue(Value):
+  __slots__ = ["_old_token"]
+
+  def __enter__(self):
+    self._old_token = _current_clock_context.set(self)
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    if exc_value is not None:
+      return
+    _current_clock_context.reset(self._old_token)
+
+  @staticmethod
+  def _get_current_clock_block():
+    return _current_clock_context.get(None)
 
 
 class InOutValue(Value):

--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -4,10 +4,9 @@
 # RUN: FileCheck %s --input-file %t/CompReg.tcl --check-prefix TCL
 
 import pycde
-from pycde import types, module, Input, Output
+from pycde import types, module, Clock, Input, Output
 from pycde.devicedb import LocationVector
 
-from pycde.dialects import seq
 from pycde.module import generator
 
 import sys
@@ -15,16 +14,15 @@ import sys
 
 @module
 class CompReg:
-  clk = Input(types.i1)
+  clk = Clock()
   input = Input(types.i8)
   output = Output(types.i8)
 
   @generator
   def build(ports):
-    compreg = ports.input.reg(clk=ports.clk,
-                              name="reg",
-                              sv_attributes=["dont_merge"])
-    ports.output = compreg
+    with ports.clk:
+      compreg = ports.input.reg(name="reg", sv_attributes=["dont_merge"])
+      ports.output = compreg
 
 
 mod = pycde.System([CompReg], name="CompReg", output_directory=sys.argv[1])

--- a/frontends/PyCDE/test/good_example.py
+++ b/frontends/PyCDE/test/good_example.py
@@ -4,7 +4,7 @@
 # This is intended to be a simple 'tutorial' example.  Run it as a test to
 # ensure that we keep it up to date (ensure it doesn't crash).
 
-from pycde import dim, module, generator, types, Input, Output
+from pycde import dim, module, generator, types, Clock, Input, Output
 import pycde
 
 import sys
@@ -12,7 +12,7 @@ import sys
 
 @module
 class Mux:
-  clk = Input(types.i1)
+  clk = Clock()
   data = Input(dim(8, 14))
   sel = Input(types.i4)
 
@@ -20,8 +20,8 @@ class Mux:
 
   @generator
   def build(ports):
-    sel_reg = ports.sel.reg(ports.clk)
-    ports.out = ports.data.reg(ports.clk)[sel_reg].reg(ports.clk)
+    sel_reg = ports.sel.reg()
+    ports.out = ports.data.reg()[sel_reg].reg()
 
 
 t = pycde.System([Mux], name="MuxDemo", output_directory=sys.argv[1])


### PR DESCRIPTION
Add a `Clock` input port type. Allow a `with` on that port to enter a 'clocking block', which the `Value.reg` function recognizes and uses as the `clk` input. Implicitly enter a clocking block when a module has exactly one `Clock` port.

Whether or not this should be considered syntactic sugar (and implemented in Python as this PR does) or should be represented in the IR is debatable. For now, this is easier but we may consider an IR representation later on.