### PR TITLE
[FIRRTL] Fix bug in GCT Taps XMRs

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -104,6 +104,21 @@ circuit Top : %[[
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
         "portName":"~Top|DataTap_Submodule>_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "portName":"~Top|DataTap_Submodule>_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "portName":"~Top|DataTap_Submodule>_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "portName":"~Top|DataTap_Submodule>_5"
       }
     ]
   },
@@ -125,6 +140,21 @@ circuit Top : %[[
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
         "portName":"~Top|DataTap_DUT>_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "portName":"~Top|DataTap_DUT>_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "portName":"~Top|DataTap_DUT>_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "portName":"~Top|DataTap_DUT>_5"
       }
     ]
   },
@@ -146,6 +176,21 @@ circuit Top : %[[
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
         "portName":"~Top|DataTap_Top>_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "portName":"~Top|DataTap_Top>_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "portName":"~Top|DataTap_Top>_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "portName":"~Top|DataTap_Top>_5"
       }
     ]
   }
@@ -154,18 +199,30 @@ circuit Top : %[[
     output _0 : UInt<1>
     output _1 : UInt<1>
     output _2 : UInt<1>
+    output _3 : UInt<1>
+    output _4 : UInt<1>
+    output _5 : UInt<1>
+
 
   extmodule DataTap_DUT :
     output _0 : UInt<1>
     output _1 : UInt<1>
     output _2 : UInt<1>
+    output _3 : UInt<1>
+    output _4 : UInt<1>
+    output _5 : UInt<1>
 
   extmodule DataTap_Top :
     output _0 : UInt<1>
     output _1 : UInt<1>
     output _2 : UInt<1>
+    output _3 : UInt<1>
+    output _4 : UInt<1>
+    output _5 : UInt<1>
 
   module Submodule :
+    output port_Submodule: UInt<1>
+    port_Submodule is invalid
 
     wire wire_Submodule: UInt<1>
     wire_Submodule is invalid
@@ -173,6 +230,8 @@ circuit Top : %[[
     inst tap of DataTap_Submodule
 
   module DUT :
+    output port_DUT: UInt<1>
+    port_DUT is invalid
 
     wire wire_DUT: UInt<1>
     wire_DUT is invalid
@@ -182,6 +241,8 @@ circuit Top : %[[
     inst tap of DataTap_DUT
 
   module Top :
+    output port_Top : UInt<1>
+    port_Top is invalid
 
     wire wire_Top: UInt<1>
     wire_Top is invalid
@@ -193,13 +254,22 @@ circuit Top : %[[
     ; CHECK:      assign _0 = Submodule.wire_Submodule
     ; CHECK-NEXT: assign _1 = DUT.wire_DUT
     ; CHECK-NEXT: assign _2 = Top.wire_Top
+    ; CHECK:      assign _3 = Submodule.port_Submodule
+    ; CHECK-NEXT: assign _4 = DUT.port_DUT
+    ; CHECK-NEXT: assign _5 = Top.port_Top
 
     ; CHECK: module DataTap_DUT
     ; CHECK:      assign _0 = DUT.submodule.wire_Submodule
     ; CHECK-NEXT: assign _1 = DUT.wire_DUT
     ; CHECK-NEXT: assign _2 = Top.wire_Top
+    ; CHECK:      assign _3 = DUT.submodule.port_Submodule
+    ; CHECK-NEXT: assign _4 = DUT.port_DUT
+    ; CHECK-NEXT: assign _5 = Top.port_Top
 
     ; CHECK: module DataTap_Top
     ; CHECK:      assign _0 = Top.dut.submodule.wire_Submodule
     ; CHECK-NEXT: assign _1 = Top.dut.wire_DUT
     ; CHECK-NEXT: assign _2 = Top.wire_Top
+    ; CHECK:      assign _3 = Top.dut.submodule.port_Submodule
+    ; CHECK-NEXT: assign _4 = Top.dut.port_DUT
+    ; CHECK-NEXT: assign _5 = Top.port_Top

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -82,3 +82,124 @@ circuit TestHarness : %[[
 ; CHECK:     module DataTap
 ; CHECK-NOT: endmodule
 ; CHECK:       assign _0 = Top.test.signal;
+
+; // -----
+
+circuit Top : %[[
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap_Submodule",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "portName":"~Top|DataTap_Submodule>_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "portName":"~Top|DataTap_Submodule>_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "portName":"~Top|DataTap_Submodule>_2"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap_DUT",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "portName":"~Top|DataTap_DUT>_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "portName":"~Top|DataTap_DUT>_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "portName":"~Top|DataTap_DUT>_2"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap_Top",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "portName":"~Top|DataTap_Top>_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "portName":"~Top|DataTap_Top>_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "portName":"~Top|DataTap_Top>_2"
+      }
+    ]
+  }
+]]
+  extmodule DataTap_Submodule :
+    output _0 : UInt<1>
+    output _1 : UInt<1>
+    output _2 : UInt<1>
+
+  extmodule DataTap_DUT :
+    output _0 : UInt<1>
+    output _1 : UInt<1>
+    output _2 : UInt<1>
+
+  extmodule DataTap_Top :
+    output _0 : UInt<1>
+    output _1 : UInt<1>
+    output _2 : UInt<1>
+
+  module Submodule :
+
+    wire wire_Submodule: UInt<1>
+    wire_Submodule is invalid
+
+    inst tap of DataTap_Submodule
+
+  module DUT :
+
+    wire wire_DUT: UInt<1>
+    wire_DUT is invalid
+
+    inst submodule of Submodule
+
+    inst tap of DataTap_DUT
+
+  module Top :
+
+    wire wire_Top: UInt<1>
+    wire_Top is invalid
+
+    inst dut of DUT
+    inst tap of DataTap_Top
+
+    ; CHECK:      module DataTap_Submodule
+    ; CHECK:      assign _0 = Submodule.wire_Submodule
+    ; CHECK-NEXT: assign _1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign _2 = Top.wire_Top
+
+    ; CHECK: module DataTap_DUT
+    ; CHECK:      assign _0 = DUT.submodule.wire_Submodule
+    ; CHECK-NEXT: assign _1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign _2 = Top.wire_Top
+
+    ; CHECK: module DataTap_Top
+    ; CHECK:      assign _0 = Top.dut.submodule.wire_Submodule
+    ; CHECK-NEXT: assign _1 = Top.dut.wire_DUT
+    ; CHECK-NEXT: assign _2 = Top.wire_Top


### PR DESCRIPTION
Fix a bug in Grand Central (GCT) Data/Mem Taps pass where Data Taps
could be produced with invalid XMRs.  An exhaustive test case is added
that checks all permutations of upwards and downwards XMRs including
corner cases where the tap module is a leaf and the root.

Fixes #3414.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>