### PR TITLE
Allow arbitrary order of idempotent or operations 

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -790,7 +790,7 @@ LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
 
   // and(..., x, ..., x) -> and(..., x, ...) -- idempotent
   // Trivial and(x), and(x, x) cases are handled by [AndOp::fold] above.
-  if (canonicalizeIdempotentInputs(op, rewriter).succeeded())
+  if (size > 2 && canonicalizeIdempotentInputs(op, rewriter).succeeded())
     return success();
 
   // Patterns for and with a constant on RHS.
@@ -1049,7 +1049,8 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
   assert(size > 1 && "expected 2 or more operands");
 
   // or(..., x, ..., x, ...) -> or(..., x) -- idempotent
-  if (canonicalizeIdempotentInputs(op, rewriter).succeeded())
+  // Trivial or(x), or(x, x) cases are handled by [OrOp::fold].
+  if (size > 2 && canonicalizeIdempotentInputs(op, rewriter).succeeded())
     return success();
 
   // Patterns for and with a constant on RHS.

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -771,9 +771,8 @@ static LogicalResult canonicalizeIdempotentInputs(Op op,
 
   for (const auto input : inputs) {
     auto insertionResult = dedupedArguments.insert(input);
-    if (insertionResult.second) {
+    if (insertionResult.second)
       uniqueInputs.push_back(input);
-    }
   }
 
   if (uniqueInputs.size() < inputs.size()) {

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -138,30 +138,38 @@ hw.module @andCancel(%a: i4, %b : i4) -> (o1: i4, o2: i4) {
 }
 
 
-// CHECK-LABEL: hw.module @andDedup1(%arg0: i7, %arg1: i7)
-hw.module @andDedup1(%arg0: i7, %arg1: i7) -> (result: i7) {
+// CHECK-LABEL: hw.module @idempotentDeduped1(%arg0: i7, %arg1: i7)
+hw.module @idempotentDeduped1(%arg0: i7, %arg1: i7) -> (resAnd: i7, resOr: i7) {
 // CHECK-NEXT:    %0 = comb.and %arg0, %arg1 : i7
-// CHECK-NEXT:    hw.output %0 : i7
+// CHECK-NEXT:    %1 = comb.or %arg0, %arg1 : i7
+// CHECK-NEXT:    hw.output %0, %1 : i7, i7
   %0 = comb.and %arg0    : i7
   %1 = comb.and %0, %arg1: i7
-  hw.output %1 : i7
+  %2 = comb.or %arg0    : i7
+  %3 = comb.or %0, %arg1: i7
+  hw.output %1, %3 : i7, i7
 }
 
-// CHECK-LABEL: hw.module @andDedup2(%arg0: i7, %arg1: i7)
-hw.module @andDedup2(%arg0: i7, %arg1: i7) -> (result: i7) {
+// CHECK-LABEL: hw.module @idempotentDeduped2(%arg0: i7, %arg1: i7)
+hw.module @idempotentDeduped2(%arg0: i7, %arg1: i7) -> (resAnd: i7, resOr: i7) {
 // CHECK-NEXT:    %0 = comb.and %arg0, %arg1 : i7
-// CHECK-NEXT:    hw.output %0 : i7
+// CHECK-NEXT:    %1 = comb.or %arg0, %arg1 : i7
+// CHECK-NEXT:    hw.output %0, %1 : i7, i7
   %0 = comb.and %arg0, %arg0: i7
   %1 = comb.and %0, %arg1: i7
-  hw.output %1 : i7
+  %2 = comb.or %arg0, %arg0: i7
+  %3 = comb.or %0, %arg1: i7
+  hw.output %1, %3 : i7, i7
 }
 
-// CHECK-LABEL: hw.module @andDedupLong(%arg0: i7, %arg1: i7, %arg2: i7)
-hw.module @andDedupLong(%arg0: i7, %arg1: i7, %arg2: i7) -> (result: i7) {
+// CHECK-LABEL: hw.module @dedupLong(%arg0: i7, %arg1: i7, %arg2: i7)
+hw.module @dedupLong(%arg0: i7, %arg1: i7, %arg2: i7) -> (resAnd: i7, resOr: i7) {
 // CHECK-NEXT:    %0 = comb.and %arg0, %arg1, %arg2 : i7
-// CHECK-NEXT:    hw.output %0 : i7
+// CHECK-NEXT:    %1 = comb.or %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    hw.output %0, %1 : i7, i7
   %0 = comb.and %arg0, %arg1, %arg2, %arg0: i7
-  hw.output %0 : i7
+  %1 = comb.or %arg0, %arg1, %arg2, %arg0: i7
+  hw.output %0, %1 : i7, i7
 }
 
 // CHECK-LABEL: hw.module @orExclusiveConcats


### PR DESCRIPTION
Enables the `or` operator to simplify expressions with duplicate arguments. Currently, this is only possible if the duplicates are at the end, i.e. `or(x, y, a, a)` becomes `or(x, y, a)` but `or(x, y, y, a)` does not become `or(x, y, a)`