### PR TITLE
[FIRRTL] Replace SymbolNameAttr with a new InnerSymAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -110,7 +110,7 @@ def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName, FNamableOp]> {
     write latency of 1 and a read latency of 0.
   }];
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
-                       AnnotationArrayAttr:$annotations, OptionalAttr<SymbolNameAttr>:$inner_sym);
+                       AnnotationArrayAttr:$annotations, OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind)
                          custom<CombMemOp>(attr-dict) `:` qualified(type($result))}];
@@ -129,7 +129,7 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, FNamableOp]> {
   }];
   let arguments = (ins RUWAttr:$ruw, StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
-                       OptionalAttr<SymbolNameAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind) $ruw
                          custom<SeqMemOp>(attr-dict) `:` qualified(type($result))}];

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -222,4 +222,22 @@ def NameKindEnumImpl: I32EnumAttr<"NameKindEnum", "name kind",
 
 def NameKindAttr: EnumAttr<FIRRTLDialect, NameKindEnumImpl, "name_kind">;
 
+def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
+  let summary = "Defines the properties of an inner_sym attribute.";
+  let description = [{
+    Defines the properties of an inner_sym attribute. Currently this only has
+    the symbol name. But the plan is to extend it to include perField symbols
+    and visibility.
+  }];
+  let mnemonic = "innerSym";
+  let parameters = (ins "::mlir::StringAttr":$symName);
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
+      return get(sym.getContext(), sym);
+    }]>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -38,7 +38,7 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
                        BoolAttr:$lowerToBind,
-                       OptionalAttr<SymbolNameAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
 
   let results = (outs Variadic<FIRRTLType>:$results);
 
@@ -55,6 +55,16 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"bool","false">:$lowerToBind,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+                   "::mlir::StringRef":$moduleName,
+                   "::mlir::StringRef":$name,
+                   "::circt::firrtl::NameKindEnum":$nameKind,
+                   "::mlir::ArrayRef<Direction>":$portDirections,
+                   "::mlir::ArrayRef<Attribute>":$portNames,
+                   "ArrayRef<Attribute>":$annotations,
+                   "ArrayRef<Attribute>":$portAnnotations,
+                   "bool":$lowerToBind,
+                   "InnerSymAttr":$inner_sym)>,
 
     /// Constructor when you have the target module in hand.
     OpBuilder<(ins "FModuleLike":$module,
@@ -110,7 +120,7 @@ def MemOp : ReferableDeclOp<"mem"> {
          StrArrayAttr:$portNames, StrAttr:$name, NameKindAttr:$nameKind,
          AnnotationArrayAttr:$annotations,
          PortAnnotationsAttr:$portAnnotations,
-         OptionalAttr<SymbolNameAttr>:$inner_sym,
+         OptionalAttr<InnerSymAttr>:$inner_sym,
          OptionalAttr<UI32Attr>:$groupID);
   let results = (outs Variadic<FIRRTLType>:$results);
 
@@ -128,7 +138,16 @@ def MemOp : ReferableDeclOp<"mem"> {
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"StringAttr", "StringAttr()">:$inner_sym)>
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym)>,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+                   "uint32_t":$readLatency, "uint32_t":$writeLatency,
+                   "uint64_t":$depth, "RUWAttr":$ruw,
+                   "ArrayRef<Attribute>":$portNames,
+                   "StringRef":$name,
+                   "NameKindEnum":$nameKind,
+                   "ArrayRef<Attribute>":$annotations,
+                   "ArrayRef<Attribute>":$portAnnotations,
+                   "InnerSymAttr":$inner_sym)>
   ];
 
   let hasVerifier = 1;
@@ -204,7 +223,7 @@ def NodeOp : ReferableDeclOp<"node",
   let arguments = (ins PassiveType:$input, StrAttr:$name,
                        NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
-                       OptionalAttr<SymbolNameAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs FIRRTLType:$result);
 
   let builders = [
@@ -214,7 +233,17 @@ def NodeOp : ReferableDeclOp<"node",
                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, input, name, nameKind,
-                   $_builder.getArrayAttr(annotations), inner_sym);
+                   $_builder.getArrayAttr(annotations),
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
+                  "StringRef":$name,
+                  "NameKindEnum":$nameKind,
+                  "::mlir::ArrayAttr":$annotations,
+                  CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
+      return build($_builder, $_state, elementType, input, name, nameKind,
+                   annotations,
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>
   ];
 
@@ -239,7 +268,7 @@ def RegOp : ReferableDeclOp<"reg"> {
   let arguments = (
     ins ClockType:$clockVal, StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
-        OptionalAttr<SymbolNameAttr>:$inner_sym);
+        OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs AnyRegisterType:$result);
 
   let builders = [
@@ -249,7 +278,17 @@ def RegOp : ReferableDeclOp<"reg"> {
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, name,
-                   nameKind, $_builder.getArrayAttr(annotations), inner_sym);
+                   nameKind, $_builder.getArrayAttr(annotations),
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
+                   "StringRef":$name,
+                   "NameKindEnum":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "StringAttr":$inner_sym), [{
+      return build($_builder, $_state, elementType, clockVal, name,
+                   nameKind, annotations,
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>
   ];
 
@@ -274,7 +313,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
         AnyRegisterType:$resetValue,
         StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
-        OptionalAttr<SymbolNameAttr>:$inner_sym);
+        OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs AnyRegisterType:$result);
 
   let builders = [
@@ -285,7 +324,20 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, name, nameKind, $_builder.getArrayAttr(annotations), inner_sym);
+                   resetValue, name, nameKind,
+                   $_builder.getArrayAttr(annotations),
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
+                   "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
+                   "StringRef":$name,
+                   "NameKindEnum":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "StringAttr":$inner_sym), [{
+      return build($_builder, $_state, elementType, clockVal, resetSignal,
+                   resetValue, name, nameKind,
+                   annotations,
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>
   ];
 
@@ -310,7 +362,7 @@ def WireOp : ReferableDeclOp<"wire"> {
 
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
-                       OptionalAttr<SymbolNameAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs FIRRTLType:$result);
 
   let builders = [
@@ -320,7 +372,25 @@ def WireOp : ReferableDeclOp<"wire"> {
                       CArg<"ArrayRef<Attribute>","{}">:$annotations,
                       CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, name, nameKind,
-                   $_builder.getArrayAttr(annotations), inner_sym);
+                   $_builder.getArrayAttr(annotations),
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                      "StringRef":$name,
+                      "NameKindEnum":$nameKind,
+                      "::mlir::ArrayAttr":$annotations), [{
+      return build($_builder, $_state, elementType, name, nameKind,
+                   annotations,
+                   InnerSymAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                      "StringRef":$name,
+                      "NameKindEnum":$nameKind,
+                      "::mlir::ArrayAttr":$annotations, 
+                      "StringAttr":$inner_sym), [{
+      return build($_builder, $_state, elementType, name, nameKind,
+                   annotations,
+                   inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>,
   ];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -139,13 +139,10 @@ def MemOp : ReferableDeclOp<"mem"> {
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>,
-    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
-                   "uint32_t":$readLatency, "uint32_t":$writeLatency,
-                   "uint64_t":$depth, "RUWAttr":$ruw,
-                   "ArrayRef<Attribute>":$portNames,
-                   "StringRef":$name,
-                   "NameKindEnum":$nameKind,
-                   "ArrayRef<Attribute>":$annotations,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "uint32_t":$readLatency,
+                   "uint32_t":$writeLatency, "uint64_t":$depth, "RUWAttr":$ruw,
+                   "ArrayRef<Attribute>":$portNames, "StringRef":$name,
+                   "NameKindEnum":$nameKind, "ArrayRef<Attribute>":$annotations,
                    "ArrayRef<Attribute>":$portAnnotations,
                    "InnerSymAttr":$inner_sym)>
   ];
@@ -237,8 +234,7 @@ def NodeOp : ReferableDeclOp<"node",
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
-                  "StringRef":$name,
-                  "NameKindEnum":$nameKind,
+                  "StringRef":$name, "NameKindEnum":$nameKind,
                   "::mlir::ArrayAttr":$annotations,
                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, input, name, nameKind,
@@ -282,12 +278,10 @@ def RegOp : ReferableDeclOp<"reg"> {
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
-                   "StringRef":$name,
-                   "NameKindEnum":$nameKind,
-                   "::mlir::ArrayAttr":$annotations,
-                   "StringAttr":$inner_sym), [{
+                   "StringRef":$name, "NameKindEnum":$nameKind,
+                   "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, name,
-                   nameKind, annotations,
+                   nameKind, annotation,
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>
   ];
@@ -330,13 +324,10 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
-                   "StringRef":$name,
-                   "NameKindEnum":$nameKind,
-                   "::mlir::ArrayAttr":$annotations,
-                   "StringAttr":$inner_sym), [{
+                   "StringRef":$name, "NameKindEnum":$nameKind,
+                    "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, name, nameKind,
-                   annotations,
+                   resetValue, name, nameKind, annotation,
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>
   ];
@@ -375,23 +366,12 @@ def WireOp : ReferableDeclOp<"wire"> {
                    $_builder.getArrayAttr(annotations),
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType,
-                      "StringRef":$name,
-                      "NameKindEnum":$nameKind,
-                      "::mlir::ArrayAttr":$annotations), [{
-      return build($_builder, $_state, elementType, name, nameKind,
-                   annotations,
-                   InnerSymAttr());
-    }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType,
-                      "StringRef":$name,
-                      "NameKindEnum":$nameKind,
-                      "::mlir::ArrayAttr":$annotations, 
-                      "StringAttr":$inner_sym), [{
-      return build($_builder, $_state, elementType, name, nameKind,
-                   annotations,
+    OpBuilder<(ins "::mlir::Type":$elementType, "StringRef":$name,
+                   "NameKindEnum":$nameKind, "::mlir::ArrayAttr":$annotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
+      return build($_builder, $_state, elementType, name, nameKind, annotations,
                    inner_sym ? InnerSymAttr::get(inner_sym): InnerSymAttr());
-    }]>,
+    }]>
   ];
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -315,8 +315,12 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
     InterfaceMethod<"Returns the name of this inner symbol.",
       "StringAttr", "getInnerNameAttr", (ins), [{}],
       /*defaultImplementation=*/[{
-        return this->getOperation()->template getAttrOfType<StringAttr>(
+        StringAttr symName;
+        auto attr = this->getOperation()->template getAttrOfType<InnerSymAttr>(
             circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName());
+        if (attr)
+          symName = attr.getSymName();
+        return symName;
       }]
     >,
     InterfaceMethod<"Returns the name of this inner symbol.",
@@ -330,7 +334,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
       "void", "setInnerSymbol", (ins "StringAttr":$name), [{}],
       /*defaultImplementation=*/[{
         this->getOperation()->setAttr(
-            InnerSymbolTable::getInnerSymbolAttrName(), name);
+            InnerSymbolTable::getInnerSymbolAttrName(), InnerSymAttr::get(name));
       }]
     >,
     InterfaceMethod<"Returns an InnerRef to this operation.  Must have inner symbol.",

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -97,7 +97,11 @@ inline MemDirAttr &operator|=(MemDirAttr &lhs, MemDirAttr rhs) {
 
 /// Return the StringAttr for the inner_sym name, if it exists.
 inline StringAttr getInnerSymName(Operation *op) {
-  return op->getAttrOfType<StringAttr>("inner_sym");
+  InnerSymAttr s = op->getAttrOfType<InnerSymAttr>(
+      InnerSymbolTable::getInnerSymbolAttrName());
+  if (s)
+    return s.getSymName();
+  return StringAttr();
 }
 
 /// Check whether a block argument ("port") or the operation defining a value

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2959,7 +2959,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       operands, builder.getArrayAttr(argNames),
       builder.getArrayAttr(resultNames),
       /*parameters=*/builder.getArrayAttr({}),
-      /*sym_name=*/op.inner_symAttr());
+      /*sym_name=*/getInnerSymName(op));
   // Update all users of the result of read ports
   for (auto &ret : returnHolder)
     (void)setLowering(ret.first->getResult(0), inst.getResult(ret.second));

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -201,7 +201,8 @@ void CombMemOp::build(OpBuilder &builder, OperationState &result,
                       ArrayAttr annotations, StringAttr innerSym) {
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), name,
-        nameKind, annotations, innerSym);
+        nameKind, annotations,
+        innerSym ? InnerSymAttr::get(innerSym) : InnerSymAttr());
 }
 
 void CombMemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
@@ -228,7 +229,8 @@ void SeqMemOp::build(OpBuilder &builder, OperationState &result,
                      ArrayAttr annotations, StringAttr innerSym) {
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), ruw,
-        name, nameKind, annotations, innerSym);
+        name, nameKind, annotations,
+        innerSym ? InnerSymAttr::get(innerSym) : InnerSymAttr());
 }
 
 void SeqMemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -11,6 +11,7 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include <iterator>
 
@@ -83,4 +84,25 @@ void ParamDeclAttr::print(AsmPrinter &p) const {
   if (getValue())
     p << " = " << getValue();
   p << ">";
+}
+
+//===----------------------------------------------------------------------===//
+// InnerSymAttr
+//===----------------------------------------------------------------------===//
+
+Attribute InnerSymAttr::parse(AsmParser &p, Type type) {
+  //  A sample IR, parse begins after `sym`.
+  //  %wire = firrtl.wire sym @wireSym<fieldID=1><sym_visibility="private"> :
+  StringAttr sym;
+  NamedAttrList dummyList;
+  if (p.parseSymbolName(sym, "dummy", dummyList))
+    return Attribute();
+  return InnerSymAttr::get(p.getContext(), sym);
+}
+
+void InnerSymAttr::print(AsmPrinter &p) const {
+  //  A sample IR, print begins after `sym`.
+  //  %wire = firrtl.wire sym @wireSym<fieldID=1><sym_visibility="private"> :
+
+  p << "@" << getSymName().getValue();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1178,6 +1178,19 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
                        ArrayRef<Attribute> annotations,
                        ArrayRef<Attribute> portAnnotations, bool lowerToBind,
                        StringAttr innerSym) {
+  build(builder, result, resultTypes, moduleName, name, nameKind,
+        portDirections, portNames, annotations, portAnnotations, lowerToBind,
+        innerSym ? InnerSymAttr::get(innerSym) : InnerSymAttr());
+}
+
+void InstanceOp::build(OpBuilder &builder, OperationState &result,
+                       TypeRange resultTypes, StringRef moduleName,
+                       StringRef name, NameKindEnum nameKind,
+                       ArrayRef<Direction> portDirections,
+                       ArrayRef<Attribute> portNames,
+                       ArrayRef<Attribute> annotations,
+                       ArrayRef<Attribute> portAnnotations, bool lowerToBind,
+                       InnerSymAttr innerSym) {
   result.addTypes(resultTypes);
   result.addAttribute("moduleName",
                       SymbolRefAttr::get(builder.getContext(), moduleName));
@@ -1189,7 +1202,7 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   result.addAttribute("annotations", builder.getArrayAttr(annotations));
   result.addAttribute("lowerToBind", builder.getBoolAttr(lowerToBind));
   if (innerSym)
-    result.addAttribute("inner_sym", innerSym);
+    result.addAttribute("inner_sym", (innerSym));
   result.addAttribute("nameKind",
                       NameKindEnumAttr::get(builder.getContext(), nameKind));
 
@@ -1234,7 +1247,8 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
       NameKindEnumAttr::get(builder.getContext(), nameKind),
       module.getPortDirectionsAttr(), module.getPortNamesAttr(),
       builder.getArrayAttr(annotations), portAnnotationsAttr,
-      builder.getBoolAttr(lowerToBind), innerSym);
+      builder.getBoolAttr(lowerToBind),
+      innerSym ? InnerSymAttr::get(innerSym) : InnerSymAttr());
 }
 
 /// Builds a new `InstanceOp` with the ports listed in `portIndices` erased, and
@@ -1448,7 +1462,7 @@ void InstanceOp::print(OpAsmPrinter &p) {
   p.printKeywordOrString(name());
   if (auto attr = inner_symAttr()) {
     p << " sym ";
-    p.printSymbolName(attr.getValue());
+    p.printSymbolName(attr.getSymName());
   }
   if (nameKindAttr().getValue() != NameKindEnum::DroppableName)
     p << ' ' << stringifyNameKindEnum(nameKindAttr().getValue());
@@ -1484,7 +1498,7 @@ ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
   auto &resultAttrs = result.attributes;
 
   std::string name;
-  StringAttr innerSymAttr;
+  InnerSymAttr innerSymAttr;
   FlatSymbolRefAttr moduleName;
   SmallVector<OpAsmParser::Argument> entryArgs;
   SmallVector<Direction, 4> portDirections;
@@ -1497,10 +1511,15 @@ ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseKeywordOrString(&name))
     return failure();
   if (succeeded(parser.parseOptionalKeyword("sym"))) {
+    if (parser.parseCustomAttributeWithFallback(
+            innerSymAttr, ::mlir::Type{}, "inner_sym", result.attributes)) {
+      return ::mlir::failure();
+    }
     // Parsing an optional symbol name doesn't fail, so no need to check the
     // result.
-    (void)parser.parseOptionalSymbolName(
-        innerSymAttr, hw::InnerName::getInnerNameAttrName(), result.attributes);
+    //  (void)parser.parseOptionalSymbolName(
+    //      innerSymAttr, hw::InnerName::getInnerNameAttrName(),
+    //      result.attributes);
   }
   if (parseNameKind(parser, nameKind) ||
       parser.parseOptionalAttrDict(result.attributes) ||
@@ -1557,7 +1576,7 @@ void MemOp::build(OpBuilder &builder, OperationState &result,
                   uint32_t writeLatency, uint64_t depth, RUWAttr ruw,
                   ArrayRef<Attribute> portNames, StringRef name,
                   NameKindEnum nameKind, ArrayRef<Attribute> annotations,
-                  ArrayRef<Attribute> portAnnotations, StringAttr innerSym) {
+                  ArrayRef<Attribute> portAnnotations, InnerSymAttr innerSym) {
   result.addAttribute(
       "readLatency",
       builder.getIntegerAttr(builder.getIntegerType(32), readLatency));
@@ -1586,6 +1605,17 @@ void MemOp::build(OpBuilder &builder, OperationState &result,
     result.addAttribute("portAnnotations",
                         builder.getArrayAttr(portAnnotations));
   }
+}
+
+void MemOp::build(OpBuilder &builder, OperationState &result,
+                  TypeRange resultTypes, uint32_t readLatency,
+                  uint32_t writeLatency, uint64_t depth, RUWAttr ruw,
+                  ArrayRef<Attribute> portNames, StringRef name,
+                  NameKindEnum nameKind, ArrayRef<Attribute> annotations,
+                  ArrayRef<Attribute> portAnnotations, StringAttr innerSym) {
+  build(builder, result, resultTypes, readLatency, writeLatency, depth, ruw,
+        portNames, name, nameKind, annotations, portAnnotations,
+        innerSym ? InnerSymAttr::get(innerSym) : InnerSymAttr());
 }
 
 ArrayAttr MemOp::getPortAnnotation(unsigned portIdx) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1202,7 +1202,7 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   result.addAttribute("annotations", builder.getArrayAttr(annotations));
   result.addAttribute("lowerToBind", builder.getBoolAttr(lowerToBind));
   if (innerSym)
-    result.addAttribute("inner_sym", (innerSym));
+    result.addAttribute("inner_sym", innerSym);
   result.addAttribute("nameKind",
                       NameKindEnumAttr::get(builder.getContext(), nameKind));
 
@@ -1515,11 +1515,6 @@ ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
             innerSymAttr, ::mlir::Type{}, "inner_sym", result.attributes)) {
       return ::mlir::failure();
     }
-    // Parsing an optional symbol name doesn't fail, so no need to check the
-    // result.
-    //  (void)parser.parseOptionalSymbolName(
-    //      innerSymAttr, hw::InnerName::getInnerNameAttrName(),
-    //      result.attributes);
   }
   if (parseNameKind(parser, nameKind) ||
       parser.parseOptionalAttrDict(result.attributes) ||

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -367,7 +367,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
   }
   auto name = getNamespace(mod).newName(nameHint);
   attr = StringAttr::get(op->getContext(), name);
-  op->setAttr("inner_sym", attr);
+  op->setAttr("inner_sym", InnerSymAttr::get(attr));
   return attr;
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3056,10 +3056,11 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
       if (sym)
         break;
     }
-  result = builder.create<MemOp>(resultTypes, readLatency, writeLatency, depth,
-                                 ruw, builder.getArrayAttr(resultNames), id,
-                                 inferNameKind(id), annotations.first,
-                                 annotations.second, sym, IntegerAttr());
+  result = builder.create<MemOp>(
+      resultTypes, readLatency, writeLatency, depth, ruw,
+      builder.getArrayAttr(resultNames), id, inferNameKind(id),
+      annotations.first, annotations.second,
+      sym ? InnerSymAttr::get(sym) : InnerSymAttr(), IntegerAttr());
 
   UnbundledValueEntry unbundledValueEntry;
   unbundledValueEntry.reserve(result.getNumResults());
@@ -3142,7 +3143,8 @@ ParseResult FIRStmtParser::parseWire() {
 
   auto sym = getSymbolIfRequired(annotations, id);
   auto result =
-      builder.create<WireOp>(type, id, inferNameKind(id), annotations, sym);
+      builder.create<WireOp>(type, id, inferNameKind(id), annotations,
+                             sym ? InnerSymAttr::get(sym) : InnerSymAttr());
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -261,7 +261,7 @@ void EmitOMIRPass::runOnOperation() {
     if (auto instOp = dyn_cast<InstanceOp>(op)) {
       // This instance does not have a symbol, but we are adding one. Remove it
       // after the pass.
-      if (!op->getAttrOfType<StringAttr>("inner_sym"))
+      if (!op->getAttr("inner_sym"))
         tempSymInstances.insert(instOp);
 
       instancesByName.insert({getInnerRefTo(op), instOp});

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -593,7 +593,8 @@ void ExtractInstancesPass::extractInstances() {
         auto newName =
             getModuleNamespace(newParent).newName(instSym.getValue());
         if (newName != instSym.getValue())
-          newInst.inner_symAttr(StringAttr::get(&getContext(), newName));
+          newInst.inner_symAttr(
+              InnerSymAttr::get(StringAttr::get(&getContext(), newName)));
       }
 
       // Add the moved instance and hook it up to the added ports.

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -338,7 +338,7 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name,
       cmem->getAttrOfType<firrtl::NameKindEnumAttr>("nameKind").getValue(),
-      annotations, memBuilder.getArrayAttr(portAnnotations), StringAttr{},
+      annotations, memBuilder.getArrayAttr(portAnnotations), InnerSymAttr(),
       IntegerAttr());
   if (auto innerSym = cmem->getAttr("inner_sym"))
     memory->setAttr("inner_sym", innerSym);

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -292,7 +292,7 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
     return true;
   });
   if (nlaUpdated) {
-    memInst.inner_symAttr(leafSym);
+    memInst.inner_symAttr(InnerSymAttr::get(leafSym));
     AnnotationSet newAnnos(memInst);
     newAnnos.addAnnotations(newMemModAnnos);
     newAnnos.applyToOperation(memInst);

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -596,7 +596,7 @@ void Inliner::rename(StringRef prefix, Operation *op,
     auto newSym = moduleNamespace.newName(sym.getValue());
     if (newSym != sym.getValue()) {
       auto newSymAttr = StringAttr::get(op->getContext(), newSym);
-      op->setAttr("inner_sym", newSymAttr);
+      op->setAttr("inner_sym", InnerSymAttr::get(newSymAttr));
       for (Annotation anno : AnnotationSet(op)) {
         auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
         if (!sym)
@@ -937,7 +937,7 @@ void Inliner::inlineInto(StringRef prefix, OpBuilder &b,
         if (!instSym) {
           instSym = StringAttr::get(context,
                                     moduleNamespace.newName(instance.name()));
-          instance.inner_symAttr(instSym);
+          instance.inner_symAttr(InnerSymAttr::get(instSym));
         }
         instOpHierPaths[InnerRefAttr::get(moduleName, instSym)].push_back(
             sym.cast<StringAttr>());
@@ -1020,7 +1020,7 @@ void Inliner::inlineInstances(FModuleOp parent) {
         if (!instSym) {
           instSym = StringAttr::get(context,
                                     moduleNamespace.newName(instance.name()));
-          instance.inner_symAttr(instSym);
+          instance.inner_symAttr(InnerSymAttr::get(instSym));
         }
         instOpHierPaths[InnerRefAttr::get(moduleName, instSym)].push_back(
             sym.cast<StringAttr>());

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -190,20 +190,6 @@ void InnerRefAttr::print(AsmPrinter &p) const {
   p << ">";
 }
 
-/// Get an InnerRefAttr, and add the sym to the op if not already
-/// there. Also reponsibility of client to ensure the symName is unique.
-InnerRefAttr InnerRefAttr::getFromOperation(mlir::Operation *op,
-                                            mlir::StringAttr symName,
-                                            mlir::StringAttr moduleName) {
-  char attrName[] = "inner_sym";
-  auto attr = op->getAttrOfType<StringAttr>(attrName);
-  if (!attr) {
-    attr = symName;
-    op->setAttr(attrName, attr);
-  }
-  return InnerRefAttr::get(moduleName, attr);
-}
-
 //===----------------------------------------------------------------------===//
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -354,7 +354,7 @@ firrtl.circuit "NLAGarbageCollection" {
     %bar_out_MPORT_clk = firrtl.wire  : !firrtl.clock
     %bar_0 = firrtl.reg sym @bar_0 %bar_out_MPORT_clk  {annotations = [{circt.nonlocal = @nla_3, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 0 : i64, portID = 0 : i64}]} : !firrtl.uint<1>
     // CHECK:  %bar_0 = firrtl.reg sym @[[bar_0:.+]] %bar_out_MPORT_clk  : !firrtl.uint<1>
-    %bar_out_MPORT = firrtl.mem sym Undefined {
+    %bar_out_MPORT = firrtl.mem Undefined {
       depth = 1 : i64,
       name = "bar",
       portNames = ["out_MPORT"],

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -794,7 +794,8 @@ struct NodeSymbolRemover : public Reduction {
 
   bool match(Operation *op) override {
     if (auto nodeOp = dyn_cast<firrtl::NodeOp>(op))
-      return nodeOp.inner_sym() && !nodeOp.inner_sym().getValue().empty();
+      return nodeOp.inner_sym() &&
+             !nodeOp.inner_sym()->getSymName().getValue().empty();
     return false;
   }
 


### PR DESCRIPTION
This PR creates a new `Attribute` for `inner_sym`, and replaces the `SymbolNameAttr` with `InnerSymAttr`.
The `InnerSymAttr` contains a single field `StringAttr` for the `inner_sym` name. 
The plan is to extend the `InnerSymAttr` to specify symbols per field of an aggregate type, and also specify `public`/`private` visibility for each symbol.
Most of the changes in this PR is to just move the `StringAttr` `inner_sym` to the new `InnerSymAttr`.