### PR TITLE
[ExportVerilog] Add an option to legalize IR at PrepareForEmission

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -122,7 +122,7 @@ struct LoweringOptions {
   /// explicitly spilled to wire ops instead of implicilty being spilled at
   /// emission. Once ExportVerilog simplification is completed, this feature
   /// shoiuld be enabled by default.
-  bool legalizeExpressionsAtPrepare = false;
+  bool spillWiresAtPrepare = false;
 };
 
 /// Register commandline options for the verilog emitter.

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -116,6 +116,13 @@ struct LoweringOptions {
 
   /// Print debug info.
   bool printDebugInfo = false;
+
+  /// If true, verilog expression legalization is performed at
+  /// PrepareForEmission via IR mutation. This means temporary wires are
+  /// explicitly spilled to wire ops instead of implicilty being spilled at
+  /// emission. Once ExportVerilog simplification is completed, this feature
+  /// shoiuld be enabled by default.
+  bool legalizeExpressionsAtPrepare = false;
 };
 
 /// Register commandline options for the verilog emitter.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -550,7 +550,7 @@ static bool isOkToBitSelectFrom(Value v) {
 /// happens because not all Verilog expressions are composable, notably you
 /// can only use bit selects like x[4:6] on simple expressions, you cannot use
 /// expressions in the sensitivity list of always blocks, etc.
-bool ExportVerilog::isExpressionUnableToInline(Operation *op) {
+static bool isExpressionUnableToInline(Operation *op) {
   if (auto cast = dyn_cast<BitcastOp>(op))
     if (!haveMatchingDims(cast.input().getType(), cast.result().getType(),
                           op->getLoc()))
@@ -597,7 +597,7 @@ bool ExportVerilog::isExpressionUnableToInline(Operation *op) {
 
 /// Return true if this expression should be emitted inline into any statement
 /// that uses it.
-static bool isExpressionEmittedInline(Operation *op) {
+bool ExportVerilog::isExpressionEmittedInline(Operation *op) {
   // Never create a temporary which is only going to be assigned to an output
   // port.
   if (op->hasOneUse() && isa<hw::OutputOp>(*op->getUsers().begin()))

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -550,7 +550,7 @@ static bool isOkToBitSelectFrom(Value v) {
 /// happens because not all Verilog expressions are composable, notably you
 /// can only use bit selects like x[4:6] on simple expressions, you cannot use
 /// expressions in the sensitivity list of always blocks, etc.
-static bool isExpressionUnableToInline(Operation *op) {
+bool ExportVerilog::isExpressionUnableToInline(Operation *op) {
   if (auto cast = dyn_cast<BitcastOp>(op))
     if (!haveMatchingDims(cast.input().getType(), cast.result().getType(),
                           op->getLoc()))

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -288,11 +288,9 @@ static inline bool isConstantExpression(Operation *op) {
 /// MemoryEffects should be checked if a client cares.
 bool isVerilogExpression(Operation *op);
 
-/// Return true if we are unable to ever inline the specified operation.  This
-/// happens because not all Verilog expressions are composable, notably you
-/// can only use bit selects like x[4:6] on simple expressions, you cannot use
-/// expressions in the sensitivity list of always blocks, etc.
-bool isExpressionUnableToInline(Operation *op);
+/// Return true if this expression should be emitted inline into any statement
+/// that uses it.
+bool isExpressionEmittedInline(Operation *op);
 
 /// For each module we emit, do a prepass over the structure, pre-lowering and
 /// otherwise rewriting operations we don't want to emit.

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -288,6 +288,12 @@ static inline bool isConstantExpression(Operation *op) {
 /// MemoryEffects should be checked if a client cares.
 bool isVerilogExpression(Operation *op);
 
+/// Return true if we are unable to ever inline the specified operation.  This
+/// happens because not all Verilog expressions are composable, notably you
+/// can only use bit selects like x[4:6] on simple expressions, you cannot use
+/// expressions in the sensitivity list of always blocks, etc.
+bool isExpressionUnableToInline(Operation *op);
+
 /// For each module we emit, do a prepass over the structure, pre-lowering and
 /// otherwise rewriting operations we don't want to emit.
 void prepareHWModule(Block &block, const LoweringOptions &options);

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -76,6 +76,12 @@ static bool shouldSpillWire(Operation &op, const LoweringOptions &options) {
       llvm::any_of(op.getResult(0).getUsers(), isConcat))
     return true;
 
+  // When `legalizeExpressionsAtPrepare` is true, legalize expressions that
+  // require temporary wires.
+  if (options.legalizeExpressionsAtPrepare &&
+      ExportVerilog::isExpressionUnableToInline(&op))
+    return true;
+
   return false;
 }
 

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -76,10 +76,9 @@ static bool shouldSpillWire(Operation &op, const LoweringOptions &options) {
       llvm::any_of(op.getResult(0).getUsers(), isConcat))
     return true;
 
-  // When `legalizeExpressionsAtPrepare` is true, legalize expressions that
-  // require temporary wires.
-  if (options.legalizeExpressionsAtPrepare &&
-      ExportVerilog::isExpressionUnableToInline(&op))
+  // When `spillWiresAtPrepare` is true, spill temporary wires if necessary.
+  if (options.spillWiresAtPrepare &&
+      !ExportVerilog::isExpressionEmittedInline(&op))
     return true;
 
   return false;

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -88,12 +88,20 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       disallowPortDeclSharing = true;
     } else if (option == "printDebugInfo") {
       printDebugInfo = true;
-    } else if (option == "legalizeExpressionsAtPrepare") {
-      legalizeExpressionsAtPrepare = true;
+    } else if (option == "spillWiresAtPrepare") {
+      spillWiresAtPrepare = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
     }
+  }
+
+  if (spillWiresAtPrepare && !disallowLocalVariables) {
+    // FIXME: Currently we cannot spill temporaries in procedural regions. Hence
+    // `spillWiresAtPrepare` must be used together with
+    // `disallowLocalVariables`.
+    errorHandler(llvm::Twine(
+        "`spillWiresAtPrepare` must be used with `disallowLocalVariables`"));
   }
 }
 
@@ -122,8 +130,8 @@ std::string LoweringOptions::toString() const {
     options += "disallowPortDeclSharing,";
   if (printDebugInfo)
     options += "printDebugInfo,";
-  if (legalizeExpressionsAtPrepare)
-    options += "legalizeExpressionsAtPrepare,";
+  if (spillWiresAtPrepare)
+    options += "spillWiresAtPrepare,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -88,6 +88,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       disallowPortDeclSharing = true;
     } else if (option == "printDebugInfo") {
       printDebugInfo = true;
+    } else if (option == "legalizeExpressionsAtPrepare") {
+      legalizeExpressionsAtPrepare = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -120,6 +122,8 @@ std::string LoweringOptions::toString() const {
     options += "disallowPortDeclSharing,";
   if (printDebugInfo)
     options += "printDebugInfo,";
+  if (legalizeExpressionsAtPrepare)
+    options += "legalizeExpressionsAtPrepare,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -test-prepare-for-emission --split-input-file | FileCheck %s
+// RUN: circt-opt %s -test-prepare-for-emission --split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK: @namehint_variadic
 hw.module @namehint_variadic(%a: i3) -> (b: i3) {
@@ -11,7 +11,7 @@ hw.module @namehint_variadic(%a: i3) -> (b: i3) {
 
 // -----
 
-module attributes {circt.loweringOptions = "disallowLocalVariables,legalizeExpressionsAtPrepare"} {
+module attributes {circt.loweringOptions = "disallowLocalVariables,spillWiresAtPrepare"} {
   // CHECK: @test_hoist
   hw.module @test_hoist(%a: i3) -> () {
     // CHECK-NEXT: %reg = sv.reg
@@ -24,7 +24,7 @@ module attributes {circt.loweringOptions = "disallowLocalVariables,legalizeExpre
     }
   }
 
-  // CHECK:  hw.module @SpillTemporary
+  // CHECK-LABEL:  hw.module @SpillTemporary
   hw.module @SpillTemporary(%a: i4, %b: i4) -> (c: i1) {
     // CHECK-NEXT:  %0 = sv.wire
     // CHECK-NEXT:  %1 = comb.add %a, %b
@@ -37,9 +37,9 @@ module attributes {circt.loweringOptions = "disallowLocalVariables,legalizeExpre
     hw.output %1 : i1
   }
 
-  // CHECK:  hw.module @SpillTemporaryInProceduralRegion
+  // CHECK-LABEL:  hw.module @SpillTemporaryInProceduralRegion
   hw.module @SpillTemporaryInProceduralRegion(%a: i4, %b: i4, %fd: i32) -> () {
-    // CHECK:      %0 = sv.wire
+    // CHECK-NEXT: %0 = sv.wire
     // CHECK-NEXT: %r = sv.reg
     // CHECK-NEXT: %1 = comb.add %a, %b
     // CHECK-NEXT: sv.assign %0, %1
@@ -56,4 +56,23 @@ module attributes {circt.loweringOptions = "disallowLocalVariables,legalizeExpre
       sv.passign %r, %1: i1
     }
   }
+
+  // CHECK-LABEL: @SpillTemporaryWireForMultipleUseExpression
+  hw.module @SpillTemporaryWireForMultipleUseExpression(%a: i4, %b: i4) -> (c: i4, d: i4) {
+    // CHECK-NEXT: %0 = sv.wire
+    // CHECK-NEXT: %1 = comb.add %a, %b
+    // CHECK-NEXT: sv.assign %0, %1
+    // CHECK-NEXT: %2 = sv.read_inout %0
+    // CHECK-NEXT: %3 = sv.read_inout %0
+    // CHECK-NEXT: hw.output %3, %2
+    %0 = comb.add %a, %b : i4
+    hw.output %0, %0 : i4, i4
+  }
+}
+
+// -----
+
+module attributes {circt.loweringOptions = "spillWiresAtPrepare"} {
+  // expected-error @+1 {{`spillWiresAtPrepare` must be used with `disallowLocalVariables`}}
+  hw.module @Foo() -> () {}
 }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -11,7 +11,7 @@ hw.module @namehint_variadic(%a: i3) -> (b: i3) {
 
 // -----
 
-module attributes {circt.loweringOptions = "disallowLocalVariables"} {
+module attributes {circt.loweringOptions = "disallowLocalVariables,legalizeExpressionsAtPrepare"} {
   // CHECK: @test_hoist
   hw.module @test_hoist(%a: i3) -> () {
     // CHECK-NEXT: %reg = sv.reg
@@ -21,6 +21,39 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     sv.initial {
       %0 = comb.add %a, %a : i3
       sv.passign %reg, %0 : i3
+    }
+  }
+
+  // CHECK:  hw.module @SpillTemporary
+  hw.module @SpillTemporary(%a: i4, %b: i4) -> (c: i1) {
+    // CHECK-NEXT:  %0 = sv.wire
+    // CHECK-NEXT:  %1 = comb.add %a, %b
+    // CHECK-NEXT:  sv.assign %0, %1
+    // CHECK-NEXT:  %2 = sv.read_inout %0
+    // CHECK-NEXT:  %3 = comb.extract %2 from 3
+    // CHECK-NEXT:  hw.output %3
+    %0 = comb.add %a, %b : i4
+    %1 = comb.extract %0 from 3 : (i4) -> i1
+    hw.output %1 : i1
+  }
+
+  // CHECK:  hw.module @SpillTemporaryInProceduralRegion
+  hw.module @SpillTemporaryInProceduralRegion(%a: i4, %b: i4, %fd: i32) -> () {
+    // CHECK:      %0 = sv.wire
+    // CHECK-NEXT: %r = sv.reg
+    // CHECK-NEXT: %1 = comb.add %a, %b
+    // CHECK-NEXT: sv.assign %0, %1
+    // CHECK-NEXT: %2 = sv.read_inout %0
+    // CHECK-NEXT: %3 = comb.extract %2 from 3
+    // CHECK-NEXT: sv.initial {
+    // CHECK-NEXT:   sv.passign %r, %3
+    // CHECK-NEXT: }
+    // CHECK-NEXT: hw.output
+    %r = sv.reg : !hw.inout<i1>
+    sv.initial {
+      %0 = comb.add %a, %b : i4
+      %1 = comb.extract %0 from 3 : (i4) -> i1
+      sv.passign %r, %1: i1
     }
   }
 }


### PR DESCRIPTION
This PR adds an option to perform verilog expression legalization at
PrepareForEmission via IR mutation. This means temporary wires are
explicitly spilled to wire ops instead of implicilty being spilled at
emission. Once ExportVerilog simplification is completed, this feature
shoiuld be enabled by default.

This is the first and second part of https://discourse.llvm.org/t/exportverilog-simplification-for-pretty-printing-output-verilog/63363#plan-3.