### PR TITLE
[SV] Add sv.attributes support to assign op

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -394,9 +394,15 @@ def AssignOp : SVOp<"assign", [InOutTypeConstraint<"src", "dest">,
     A SystemVerilog assignment statement 'x = y;'.
     These occur in module scope.  See SV Spec 10.3.2.
   }];
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins InOutType:$dest, InOutElementType:$src,
+                  OptionalAttr<SVAttributeArrayAttr>:$svAttributes);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
+  let assemblyFormat = [{$dest `,` $src (`svattrs` $svAttributes^)? attr-dict
+                       `:` qualified(type($src))}];
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$dest, "::mlir::Value":$src),
+      "return build($_builder, $_state, dest, src, ArrayAttr());">
+  ];
 }
 
 def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2670,6 +2670,10 @@ LogicalResult StmtEmitter::visitSV(AssignOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 
+  // If we have SV attributes attached to the op, those need to be emitted
+  // first.
+  emitSVAttributes(op.svAttributesAttr(), op);
+
   indent() << "assign ";
   emitExpression(op.dest(), ops);
   os << " = ";

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1206,6 +1206,11 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
     // AssignOp and ReadInOutOp), then can't optimize.
     if (!assign || write)
       return failure();
+
+    // If the assign op has SV attributes, we don't want to delete the assignment.
+    if (assign.svAttributesAttr())
+      return failure();
+
     write = assign;
   }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -472,7 +472,9 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   %myRegArray1 = sv.reg svattrs [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">] : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
-  sv.assign %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;
+  // CHECK-NEXT: (* assign_attr *)
+  // CHECK-NEXT: assign myReg = in8;
+  sv.assign %myReg, %in8 svattrs [#sv.attribute<"assign_attr">] : i8
 
   %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -158,6 +158,15 @@ hw.module @assert_canonicalization(%clock: i1) {
   sv.cover.concurrent posedge %clock, %false
 }
 
+
+// CHECK-LABEL: hw.module @svAttrPreventsCanonicalization(%arg0: i1) {
+hw.module @svAttrPreventsCanonicalization(%arg0: i1) {
+  %0 = sv.wire : !hw.inout<i1>
+  // CHECK:      %0 = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT: sv.assign %0, %arg0 svattrs [#sv.attribute<"attr">] : i1
+  sv.assign %0, %arg0 svattrs [#sv.attribute<"attr">] : i1
+}
+
 // CHECK-LABEL: @case_stmt
 hw.module @case_stmt(%arg: i3) {
   %fd = hw.constant 0x80000002 : i32


### PR DESCRIPTION
Following https://github.com/llvm/circt/commit/761b6107e78f8ef89576754731ff5367a1b9060f, this commit adds sv.attributes support to the assign op.

One nontrivial change I made is that assign with SV attributes prevent canonicalization of wire op that bypasses simple single assignment. 