### PR TITLE
[MSFT] AppID attribute

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -60,6 +60,13 @@ intptr_t circtMSFTLocationVectorAttrGetNumElements(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute
 circtMSFTLocationVectorAttrGetElement(MlirAttribute attr, intptr_t pos);
 
+MLIR_CAPI_EXPORTED bool circtMSFTAttributeIsAnAppIDAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED
+MlirAttribute circtMSFTAppIDAttrGet(MlirContext, MlirStringRef name,
+                                    uint64_t idx);
+MLIR_CAPI_EXPORTED MlirStringRef circtMSFTAppIDAttrGetName(MlirAttribute attr);
+MLIR_CAPI_EXPORTED uint64_t circtMSFTAppIDAttrGetIdx(MlirAttribute attr);
+
 //===----------------------------------------------------------------------===//
 // PrimitiveDB.
 //===----------------------------------------------------------------------===//

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -63,9 +63,9 @@ circtMSFTLocationVectorAttrGetElement(MlirAttribute attr, intptr_t pos);
 MLIR_CAPI_EXPORTED bool circtMSFTAttributeIsAnAppIDAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED
 MlirAttribute circtMSFTAppIDAttrGet(MlirContext, MlirStringRef name,
-                                    uint64_t idx);
+                                    uint64_t index);
 MLIR_CAPI_EXPORTED MlirStringRef circtMSFTAppIDAttrGetName(MlirAttribute attr);
-MLIR_CAPI_EXPORTED uint64_t circtMSFTAppIDAttrGetIdx(MlirAttribute attr);
+MLIR_CAPI_EXPORTED uint64_t circtMSFTAppIDAttrGetIndex(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // PrimitiveDB.

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -73,3 +73,17 @@ def LocationVector : MSFT_Attr<"LocationVector"> {
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }
+
+def AppIDAttr : MSFT_Attr<"AppID"> {
+  let summary = "An application relevant instance identifier";
+  let description = [{
+    Identifies an instance which is visible through multiple hierarchy levels.
+    Indended to make locating an instance easier in the instance hierarchy.
+  }];
+
+  let parameters = (ins "StringAttr":$name, "uint64_t":$index);
+  let mnemonic = "appid";
+  let assemblyFormat = [{
+    `<` $name `[` $index `]` `>`
+  }];
+}

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -259,3 +259,7 @@ with ir.Context() as ctx, ir.Location.unknown():
       "msft-lower-instances,lower-msft-to-hw,msft-export-tcl{tops=top}")
   pm.run(mod)
   circt.export_verilog(mod, sys.stdout)
+
+  appid1 = msft.AppIDAttr.get("foo", 4)
+  # CHECK: appid1: #msft.appid<"foo"[4]>
+  print(f"appid1: {appid1}")

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -261,5 +261,5 @@ with ir.Context() as ctx, ir.Location.unknown():
   circt.export_verilog(mod, sys.stdout)
 
   appid1 = msft.AppIDAttr.get("foo", 4)
-  # CHECK: appid1: #msft.appid<"foo"[4]>
-  print(f"appid1: {appid1}")
+  # CHECK: appid1: #msft.appid<"foo"[4]>, foo, 4
+  print(f"appid1: {appid1}, {appid1.name}, {appid1.index}")

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -276,4 +276,22 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .def(py::init<CirctMSFTDirection, CirctMSFTDirection>(),
            py::arg("columns") = CirctMSFTDirection::NONE,
            py::arg("rows") = CirctMSFTDirection::NONE);
+
+  mlir_attribute_subclass(m, "AppIDAttr", circtMSFTAttributeIsAnAppIDAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, std::string name, uint64_t idx, MlirContext ctxt) {
+            return cls(circtMSFTAppIDAttrGet(ctxt, wrap(name), idx));
+          },
+          "Create an AppID attribute", py::arg("cls"), py::arg("name"),
+          py::arg("idx"), py::arg("context") = py::none())
+      .def_property_readonly("name",
+                             [](MlirAttribute self) {
+                               StringRef name =
+                                   unwrap(circtMSFTAppIDAttrGetName(self));
+                               return std::string(name.data(), name.size());
+                             })
+      .def_property_readonly("idx", [](MlirAttribute self) {
+        return circtMSFTAppIDAttrGetIdx(self);
+      });
 }

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -280,18 +280,19 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "AppIDAttr", circtMSFTAttributeIsAnAppIDAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, std::string name, uint64_t idx, MlirContext ctxt) {
-            return cls(circtMSFTAppIDAttrGet(ctxt, wrap(name), idx));
+          [](py::object cls, std::string name, uint64_t index,
+             MlirContext ctxt) {
+            return cls(circtMSFTAppIDAttrGet(ctxt, wrap(name), index));
           },
           "Create an AppID attribute", py::arg("cls"), py::arg("name"),
-          py::arg("idx"), py::arg("context") = py::none())
+          py::arg("index"), py::arg("context") = py::none())
       .def_property_readonly("name",
                              [](MlirAttribute self) {
                                StringRef name =
                                    unwrap(circtMSFTAppIDAttrGetName(self));
                                return std::string(name.data(), name.size());
                              })
-      .def_property_readonly("idx", [](MlirAttribute self) {
-        return circtMSFTAppIDAttrGetIdx(self);
+      .def_property_readonly("index", [](MlirAttribute self) {
+        return circtMSFTAppIDAttrGetIndex(self);
       });
 }

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -232,13 +232,13 @@ bool circtMSFTAttributeIsAnAppIDAttr(MlirAttribute attr) {
 }
 
 MlirAttribute circtMSFTAppIDAttrGet(MlirContext ctxt, MlirStringRef name,
-                                    uint64_t idx) {
-  return wrap(AppIDAttr::get(unwrap(ctxt),
-                             StringAttr::get(unwrap(ctxt), unwrap(name)), idx));
+                                    uint64_t index) {
+  return wrap(AppIDAttr::get(
+      unwrap(ctxt), StringAttr::get(unwrap(ctxt), unwrap(name)), index));
 }
 MlirStringRef circtMSFTAppIDAttrGetName(MlirAttribute attr) {
   return wrap(unwrap(attr).cast<AppIDAttr>().getName().getValue());
 }
-uint64_t circtMSFTAppIDAttrGetIdx(MlirAttribute attr) {
+uint64_t circtMSFTAppIDAttrGetIndex(MlirAttribute attr) {
   return unwrap(attr).cast<AppIDAttr>().getIndex();
 }

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -226,3 +226,19 @@ MlirAttribute circtMSFTLocationVectorAttrGetElement(MlirAttribute attr,
                                                     intptr_t pos) {
   return wrap(unwrap(attr).cast<LocationVectorAttr>().getLocs()[pos]);
 }
+
+bool circtMSFTAttributeIsAnAppIDAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<AppIDAttr>();
+}
+
+MlirAttribute circtMSFTAppIDAttrGet(MlirContext ctxt, MlirStringRef name,
+                                    uint64_t idx) {
+  return wrap(AppIDAttr::get(unwrap(ctxt),
+                             StringAttr::get(unwrap(ctxt), unwrap(name)), idx));
+}
+MlirStringRef circtMSFTAppIDAttrGetName(MlirAttribute attr) {
+  return wrap(unwrap(attr).cast<AppIDAttr>().getName().getValue());
+}
+uint64_t circtMSFTAppIDAttrGetIdx(MlirAttribute attr) {
+  return unwrap(attr).cast<AppIDAttr>().getIndex();
+}

--- a/test/Dialect/MSFT/attributes.mlir
+++ b/test/Dialect/MSFT/attributes.mlir
@@ -9,3 +9,6 @@ msft.physical_region @region1, [
 
 // CHECK: #msft.location_vec<i3, [*, <1, 2, 3>, #msft.physloc<DSP, 4, 5, 6>]>
 "dummy.op" () {"vec" = #msft.location_vec<i3, [*, <1, 2, 3>, #msft.physloc<DSP, 4, 5, 6>]>} : () -> ()
+
+// CHECK: #msft.appid<"foo"[4]>
+"dummy.op" () {"appid" = #msft.appid<"foo"[4]> } : () -> ()


### PR DESCRIPTION
An 'AppID' is intended to make browsing the instance hierarchy easier.
Instead of having to reason about instance names, users can specify an
'AppID' consisting of a (name, index) pair and browse the hierarchy that
way. Said browsing also looks through the instance hierarchy (with
several rules about transparency) to mask implementation details at
various levels of the hierarchy.

This commit adds an `AppID` attribute and exposes it through Python.