### PR TITLE
[MSFT] Pass to discover AppIDs

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -21,6 +21,11 @@ def InstanceOp : MSFTOp<"instance", [
                        OptionalAttr<SymbolRefAttr>:$targetDesignPartition);
   let results = (outs Variadic<AnyType>);
 
+  let builders = [
+    OpBuilder<(ins "ArrayRef<Type>":$resultTypes, "StringAttr":$sym_name,
+                   "FlatSymbolRefAttr":$moduleName, "ArrayRef<Value>":$inputs)>
+  ];
+
   let extraClassDeclaration = [{
     // Return the name of the specified result or empty string if it cannot be
     // determined.
@@ -48,14 +53,16 @@ def InstanceOp : MSFTOp<"instance", [
 
   /// sym keyword for optional symbol simplifies parsing
   let assemblyFormat = [{
-    $sym_name $moduleName `(` $inputs `)` custom<ParameterList>($parameters) attr-dict
-      `:` functional-type($inputs, results)
+    $sym_name $moduleName `(` $inputs `)` custom<ParameterList>($parameters)
+      attr-dict `:` functional-type($inputs, results)
   }];
 }
 
 def OneOrNoBlocksRegion : Region<
   CPred<"::llvm::hasNItemsOrLess($_self, 1)">,
   "region with at most 1 block">;
+
+def AppIDArrayAttr : TypedArrayAttrBase<AppIDAttr, "Array of AppIDs">;
 
 def MSFTModuleOp : MSFTOp<"module",
       [IsolatedFromAbove, FunctionOpInterface, Symbol, RegionKindInterface,
@@ -72,7 +79,8 @@ def MSFTModuleOp : MSFTOp<"module",
   let arguments = (ins
       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
       DictionaryAttr:$parameters,
-      OptionalAttr<StrAttr>:$fileName);
+      OptionalAttr<StrAttr>:$fileName,
+      OptionalAttr<StrArrayAttr>:$childAppIDBases);
   let results = (outs);
   let regions = (region OneOrNoBlocksRegion:$body);
 

--- a/include/circt/Dialect/MSFT/MSFTPasses.td
+++ b/include/circt/Dialect/MSFT/MSFTPasses.td
@@ -52,3 +52,8 @@ def LowerConstructs: Pass<"msft-lower-constructs", "mlir::ModuleOp"> {
   let constructor = "circt::msft::createLowerConstructsPass()";
   let dependentDialects = ["circt::hw::HWDialect"];
 }
+
+def DiscoverAppIDs: Pass<"msft-discover-appids", "mlir::ModuleOp"> {
+  let summary = "Discover the appids in a module hierarchy";
+  let constructor = "circt::msft::createDiscoverAppIDsPass()";
+}

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -176,6 +176,13 @@ InstanceOp::verifySignatureMatch(const hw::ModulePortInfo &ports) {
   return success();
 }
 
+void InstanceOp::build(OpBuilder &builder, OperationState &state,
+                       ArrayRef<Type> resultTypes, StringAttr sym_name,
+                       FlatSymbolRefAttr moduleName, ArrayRef<Value> inputs) {
+  build(builder, state, resultTypes, sym_name, moduleName, inputs, ArrayAttr(),
+        SymbolRefAttr());
+}
+
 /// Return an encapsulated set of information about input and output ports of
 /// the specified module or instance.  The input ports always come before the
 /// output ports in the list.

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1889,6 +1889,8 @@ void DiscoverAppIDsPass::processMod(MSFTModuleOp mod) {
                 .attachNote(localAppIDs[appid]->getLoc())
             << "first AppID located here";
         signalPassFailure();
+      } else {
+        localAppIDs[appid] = op;
       }
       localAppIDBases.insert(appid.getName());
     }
@@ -1907,13 +1909,14 @@ void DiscoverAppIDsPass::processMod(MSFTModuleOp mod) {
 
   // Collect the list of AppID base names with which to annotate 'mod'.
   SmallVector<Attribute, 32> finalModBases;
-  for (auto baseCount : appBaseCounts)
+  for (auto baseCount : appBaseCounts) {
     // If multiple instances expose the same base name, don't expose them
     // through this module. If any of the instances expose basenames which are
     // exposed locally, also don't expose them up.
     if (baseCount.getSecond() == 1 &&
         !localAppIDBases.contains(baseCount.getFirst()))
       finalModBases.push_back(baseCount.getFirst());
+  }
 
   // Add all of the local base names.
   for (StringAttr lclBase : localAppIDBases)

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1393,9 +1393,8 @@ MSFTModuleOp PartitionPass::partition(DesignPartitionOp partOp,
   SmallVector<Type> instRetTypes(
       llvm::map_range(newOutputs, [](Value v) { return v.getType(); }));
   auto partInst = OpBuilder(partOp).create<InstanceOp>(
-      loc, instRetTypes, partOp.getNameAttr(),
-      SymbolTable::getSymbolName(partMod), instInputs, ArrayAttr(),
-      SymbolRefAttr());
+      loc, instRetTypes, partOp.getNameAttr(), FlatSymbolRefAttr::get(partMod),
+      instInputs);
   moduleInstantiations[partMod].push_back(partInst);
 
   // And set the outputs properly.
@@ -1847,6 +1846,81 @@ std::unique_ptr<Pass> createLowerConstructsPass() {
 } // namespace msft
 } // namespace circt
 
+//===----------------------------------------------------------------------===//
+// Discover AppIDs pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct DiscoverAppIDsPass : public DiscoverAppIDsBase<DiscoverAppIDsPass>,
+                            PassCommon {
+  void runOnOperation() override;
+  void processMod(MSFTModuleOp);
+};
+} // anonymous namespace
+
+void DiscoverAppIDsPass::runOnOperation() {
+  ModuleOp topMod = getOperation();
+  topLevelSyms.addDefinitions(topMod);
+  if (failed(verifyInstances(topMod))) {
+    signalPassFailure();
+    return;
+  }
+
+  SmallVector<MSFTModuleOp> sortedMods;
+  getAndSortModules(topMod, sortedMods);
+
+  for (MSFTModuleOp mod : sortedMods)
+    processMod(mod);
+}
+
+void DiscoverAppIDsPass::processMod(MSFTModuleOp mod) {
+  SmallDenseMap<StringAttr, uint64_t> appBaseCounts;
+  SmallPtrSet<StringAttr, 32> localAppIDBases;
+  SmallDenseMap<AppIDAttr, Operation *> localAppIDs;
+
+  mod.walk([&](Operation *op) {
+    if (auto appid = op->getAttrOfType<AppIDAttr>("appid")) {
+      if (localAppIDs.find(appid) != localAppIDs.end()) {
+        op->emitOpError("Found multiple identical AppIDs in same module")
+                .attachNote(localAppIDs[appid]->getLoc())
+            << "first AppID located here";
+        signalPassFailure();
+      }
+      localAppIDBases.insert(appid.getName());
+    }
+
+    if (auto inst = dyn_cast<InstanceOp>(op)) {
+      auto targetMod = dyn_cast<MSFTModuleOp>(
+          topLevelSyms.getDefinition(inst.moduleNameAttr()));
+      if (targetMod && targetMod.childAppIDBases())
+        for (auto base :
+             targetMod.childAppIDBasesAttr().getAsRange<StringAttr>())
+          appBaseCounts[base] += 1;
+    }
+  });
+
+  SmallVector<Attribute, 32> finalModBases;
+  for (auto baseCount : appBaseCounts)
+    if (baseCount.getSecond() == 1 &&
+        !localAppIDBases.contains(baseCount.getFirst()))
+      finalModBases.push_back(baseCount.getFirst());
+
+  for (StringAttr lclBase : localAppIDBases)
+    finalModBases.push_back(lclBase);
+
+  if (finalModBases.empty())
+    return;
+  ArrayAttr childrenBases = ArrayAttr::get(mod.getContext(), finalModBases);
+  mod.childAppIDBasesAttr(childrenBases);
+}
+
+namespace circt {
+namespace msft {
+std::unique_ptr<Pass> createDiscoverAppIDsPass() {
+  return std::make_unique<DiscoverAppIDsPass>();
+}
+} // namespace msft
+} // namespace circt
 namespace {
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/MSFT/MSFTPasses.h.inc"

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -1,11 +1,13 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --msft-discover-appids -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s --check-prefix=APPID
 // RUN: circt-opt %s --lower-msft-to-hw -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s --check-prefix=HWLOW
 
 // CHECK-LABEL: msft.module @top
+// APPID-LABEL: msft.module @top {} () attributes {childAppIDBases = ["extern", "foo"]}
 // HWLOW-LABEL: hw.module @top
 msft.module @top {} () {
-  msft.instance @foo @Foo() : () -> (i32)
-  // CHECK: %foo.x = msft.instance @foo @Foo() : () -> i32
+  msft.instance @foo @Foo() {appid = #msft.appid<"foo"[0]>} : () -> (i32)
+  // CHECK: %foo.x = msft.instance @foo @Foo() {appid = #msft.appid<"foo"[0]>} : () -> i32
   // HWLOW: %foo.x = hw.instance "foo" sym @foo @Foo<__INST_HIER: none = #hw.param.expr.str.concat<#hw.param.decl.ref<"__INST_HIER">, ".foo">>() -> (x: i32)
 
   %true = hw.constant true
@@ -28,7 +30,12 @@ msft.module @B { "WIDTH" = 1 } (%a: i4) -> (nameOfPortInSV: i4) attributes {file
 // HWLOW-LABEL: Module not generated: \22UnGenerated\22 params {DEPTH = 3 : i64}
 msft.module @UnGenerated { DEPTH = 3 } (%a: i1) -> (nameOfPortInSV: i1)
 
+// APPID-LABEL: msft.module @Foo {WIDTH = 1 : i64} () -> (x: i32) attributes {childAppIDBases = ["extern", "foo"]}
 msft.module @Foo { "WIDTH" = 1 } () -> (x: i32) {
+  %true = hw.constant true
+  msft.instance @extern @Extern(%true)<param: i1 = false> {appid=#msft.appid<"extern"[0]>} : (i1) -> i1
+  %c1_4 = hw.constant 1 : i4
+  msft.instance @b @B(%c1_4) {appid=#msft.appid<"foo"[0]>} : (i4) -> i4
   %c0 = hw.constant 0 : i32
   msft.output %c0 : i32
 }

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -6,8 +6,8 @@
 // APPID-LABEL: msft.module @top {} () attributes {childAppIDBases = ["extern", "foo"]}
 // HWLOW-LABEL: hw.module @top
 msft.module @top {} () {
-  msft.instance @foo @Foo() {appid = #msft.appid<"foo"[0]>} : () -> (i32)
-  // CHECK: %foo.x = msft.instance @foo @Foo() {appid = #msft.appid<"foo"[0]>} : () -> i32
+  msft.instance @foo @Foo() {msft.appid = #msft.appid<"foo"[0]>} : () -> (i32)
+  // CHECK: %foo.x = msft.instance @foo @Foo() {msft.appid = #msft.appid<"foo"[0]>} : () -> i32
   // HWLOW: %foo.x = hw.instance "foo" sym @foo @Foo<__INST_HIER: none = #hw.param.expr.str.concat<#hw.param.decl.ref<"__INST_HIER">, ".foo">>() -> (x: i32)
 
   %true = hw.constant true
@@ -33,9 +33,9 @@ msft.module @UnGenerated { DEPTH = 3 } (%a: i1) -> (nameOfPortInSV: i1)
 // APPID-LABEL: msft.module @Foo {WIDTH = 1 : i64} () -> (x: i32) attributes {childAppIDBases = ["extern", "foo"]}
 msft.module @Foo { "WIDTH" = 1 } () -> (x: i32) {
   %true = hw.constant true
-  msft.instance @extern @Extern(%true)<param: i1 = false> {appid=#msft.appid<"extern"[0]>} : (i1) -> i1
+  msft.instance @extern @Extern(%true)<param: i1 = false> {msft.appid=#msft.appid<"extern"[0]>} : (i1) -> i1
   %c1_4 = hw.constant 1 : i4
-  msft.instance @b @B(%c1_4) {appid=#msft.appid<"foo"[0]>} : (i4) -> i4
+  msft.instance @b @B(%c1_4) {msft.appid=#msft.appid<"foo"[0]>} : (i4) -> i4
   %c0 = hw.constant 0 : i32
   msft.output %c0 : i32
 }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -verify-diagnostics -split-input-file
+// RUN: circt-opt %s --msft-discover-appids -verify-diagnostics -split-input-file
 
 hw.module.extern @Foo()
 
@@ -35,3 +35,13 @@ msft.instance.hierarchy @reg {
 
 // expected-error @+1 {{'msft.pd.location' op must have either a global ref symbol of belong to a dynamic instance op}}
 msft.pd.location FF x: 0 y: 0 n: 0
+
+// -----
+
+msft.module @M {} (%x : i32) {
+  // expected-note @+1 {{first AppID located here}}
+  comb.add %x, %x {msft.appid=#msft.appid<"add"[0]>} : i32
+  // expected-error @+1 {{'comb.add' op Found multiple identical AppIDs in same module}}
+  comb.add %x, %x {msft.appid=#msft.appid<"add"[0]>} : i32
+  msft.output
+}


### PR DESCRIPTION
Introduces a pass to discover AppIDs and annotate modules with the AppID
base names for all of the AppIDs they recursively contain. Will be used
to efficiently implement instance hierarchy browsing be AppID.