### PR TITLE
[FIRRTL][GCSM] Use buffer wires for forced output ports

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -579,10 +579,10 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
     // port with a wire that's connected to a wire that is connected to the
     // port. This is done to cause an 'assign' to be created, disconnecting
     // the forced input port's net from its uses.
-    auto breakNet = [&](OpBuilder &builder, Value port,
+    auto breakNet = [modName = mod.moduleName()](OpBuilder &builder, Value port,
                         ModuleNamespace &moduleNamespace, StringRef portName) {
       auto replacementWireName = builder.getStringAttr(
-          moduleNamespace.newName(mod.moduleName() + "_" + portName));
+          moduleNamespace.newName(modName + "_" + portName));
       auto bufferWireName = builder.getStringAttr(
           moduleNamespace.newName(replacementWireName.getValue() + "_buffer"));
       auto bufferWire =

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -579,7 +579,8 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
     // Replace uses of each driven port with a wire that's connected to a wire
     // that is connected to the port. This is done to cause an 'assign' to be
     // created, disconnecting the forced port's net from its uses.
-    auto breakNet = [modName = mod.moduleName()](OpBuilder &builder, Value port,
+    auto breakNet = [modName = mod.moduleName()](
+                        OpBuilder &builder, Value port,
                         ModuleNamespace &moduleNamespace, StringRef portName) {
       // Create chain like:
       // port_result <= foo_dataIn_x_buffer

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -49,7 +49,7 @@ using namespace firrtl;
 // Signal driver annotations are needed when processing both circuits:
 //
 // First the original annotations are used with the main circuit, in order to
-// emit extra wires around forced inputs and to emit updated annotations
+// emit extra wires around forced ports and to emit updated annotations
 // pointing to the values across naming or hierarchy changes performed.
 //
 // Second these updated annotations are used when processing the subcircuit
@@ -123,7 +123,7 @@ static T &operator<<(T &os, const SignalMapping &mapping) {
 /// dictated by the presence of `SignalDriverAnnotation` on the module and
 /// individual operations inside it.
 /// If the module is the "remote" (main) circuit, gather those mappings
-/// for use handling forced input ports and creating updated mappings.
+/// for use handling forced ports and creating updated mappings.
 void ModuleSignalMappings::run() {
   // Check whether this module has any `SignalDriverAnnotation`s. These indicate
   // whether the module contains any operations with such annotations and
@@ -348,8 +348,8 @@ struct ExtModules {
   SmallVector<FExtModuleOp> json;
 };
 
-/// Information gathered about mappings, used for identifying forced input ports
-/// and generating updated mappings for the remote side (main circuit).
+/// Information gathered about mappings, used for identifying forced ports and
+/// generating updated mappings for the remote side (main circuit).
 struct ModuleMappingResult {
   /// Were changes made that invalidate analyses?
   bool allAnalysesPreserved;
@@ -368,7 +368,7 @@ class GrandCentralSignalMappingsPass
                           StringRef outputFilename,
                           const ExtModules &extmodules);
 
-  /// Fixup forced input ports and emit updated mappings
+  /// Fixup forced ports and emit updated mappings.
   /// Used when processing the main (remote) circuit.
   FailureOr<bool>
   emitUpdatedMappings(CircuitOp circuit, StringAttr circuitPackage,
@@ -451,7 +451,7 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
 
   // If this is a subcircuit, then emit JSON information necessary to drive
   // SiFive tools.
-  // Otherwise handle any forced input ports and emit updated mappings.
+  // Otherwise handle any forced ports and emit updated mappings.
   if (isSubCircuit) {
     emitSubCircuitJSON(circuit, circuitPackage, outputFilename, extmodules);
   } else {
@@ -544,7 +544,8 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
     }
   }
 
-  // (2) Find input ports that are sinks, insert wires at instantiation points
+  // (2) Find ports that are sinks, insert buffer wires to break the net.
+  // Input ports are buffered at instantiation points, outputs in the module.
   auto *instanceGraph = &getAnalysis<InstanceGraph>();
   llvm::SmallVector<unsigned, 32> forcedInputPorts;
   llvm::SmallVector<unsigned, 32> forcedOutputPorts;
@@ -575,12 +576,14 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
         std::unique(forcedOutputPorts.begin(), forcedOutputPorts.end()),
         forcedOutputPorts.end());
 
-    // Find all instantiations of this module, and replace uses of each driven
-    // port with a wire that's connected to a wire that is connected to the
-    // port. This is done to cause an 'assign' to be created, disconnecting
-    // the forced input port's net from its uses.
+    // Replace uses of each driven port with a wire that's connected to a wire
+    // that is connected to the port. This is done to cause an 'assign' to be
+    // created, disconnecting the forced port's net from its uses.
     auto breakNet = [modName = mod.moduleName()](OpBuilder &builder, Value port,
                         ModuleNamespace &moduleNamespace, StringRef portName) {
+      // Create chain like:
+      // port_result <= foo_dataIn_x_buffer
+      // foo_dataIn_x_buffer <= foo_dataIn_x
       auto replacementWireName = builder.getStringAttr(
           moduleNamespace.newName(modName + "_" + portName));
       auto bufferWireName = builder.getStringAttr(
@@ -623,9 +626,6 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
 
       for (auto portIdx : forcedInputPorts) {
         auto port = inst->getResult(portIdx);
-        // Create chain like:
-        // port_result <= foo_dataIn_x_buffer
-        // foo_dataIn_x_buffer <= foo_dataIn_x
         breakNet(builder, port, moduleNamespace, mod.getPortName(portIdx));
       }
     }


### PR DESCRIPTION
We use buffer wires to break the verilog net when using force
statements.  So far we have only seen a need to do this for input ports,
but the same situation can happen with output ports.  When we are
forcing the value of an output port, we need to insert a wire inside the
module between it and submodule ports, so that the submodule's output
port is not also forced.