### PR TITLE
[FIRRTL] AnnotationDetails.h: be consistent, prefer constexpr [NFC]

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -103,9 +103,9 @@ constexpr const char *injectDUTHierarchyAnnoClass =
     "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation";
 
 // MemToRegOfVec Annotations
-static const char *convertMemToRegOfVecAnnoClass =
+constexpr const char *convertMemToRegOfVecAnnoClass =
     "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$";
-static const char *excludeMemToRegAnnoClass =
+constexpr const char *excludeMemToRegAnnoClass =
     "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec";
 
 // Instance Extraction


### PR DESCRIPTION
Also, squelch warnings about these being unused.