### PR TITLE
[PyCDE] Expose AppIDs: add them via Value, shortcuts for regs/instances, accessors in `Instance`s

### DIFF
--- a/frontends/PyCDE/src/pycde/__init__.py
+++ b/frontends/PyCDE/src/pycde/__init__.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .module import (externmodule, generator, module, no_connect)
-from .module import (Clock, Input, InputChannel, Output, OutputChannel)
+from .module import (AppID, Clock, Input, InputChannel, Output, OutputChannel)
 from .system import (System)
 from .pycde_types import (dim, types)
 from .value import (Value)

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -20,6 +20,7 @@ import mlir.ir
 
 import builtins
 from contextvars import ContextVar
+from functools import singledispatchmethod
 import inspect
 import sys
 
@@ -70,6 +71,29 @@ class InputChannel(Input):
   def __init__(self, type: mlir.ir.Type, name: str = None):
     esi_type = esi.ChannelType.get(type)
     super().__init__(esi_type, name)
+
+
+class AppID:
+  AttributeName = "msft.appid"
+
+  @singledispatchmethod
+  def __init__(self, name: str, idx: int):
+    self._appid = msft.AppIDAttr.get(name, idx)
+
+  @__init__.register(mlir.ir.Attribute)
+  def __init__mlir_attr(self, attr: mlir.ir.Attribute):
+    self._appid = msft.AppIDAttr(attr)
+
+  @property
+  def name(self) -> str:
+    return self._appid.name
+
+  @property
+  def index(self) -> int:
+    return self._appid.index
+
+  def __str__(self) -> str:
+    return f"{self.name}[{self.index}]"
 
 
 def _create_module_name(name: str, params: mlir.ir.DictAttr):
@@ -276,15 +300,18 @@ class _SpecializedModule:
     sys = System.current()
     return sys._op_cache.get_circt_mod(self)
 
-  def instantiate(self, instance_name: str, inputs: dict, loc):
+  def instantiate(self, instance_name: str, inputs: dict, appid: AppID, loc):
     """Create a instance op."""
     if self.extern_name is None:
-      return self.circt_mod.instantiate(instance_name, **inputs, loc=loc)
+      ret = self.circt_mod.instantiate(instance_name, **inputs, loc=loc)
     else:
-      return self.circt_mod.instantiate(instance_name,
-                                        **inputs,
-                                        parameters=self.parameters,
-                                        loc=loc)
+      ret = self.circt_mod.instantiate(instance_name,
+                                       **inputs,
+                                       parameters=self.parameters,
+                                       loc=loc)
+    if appid is not None:
+      ret.operation.attributes[AppID.AttributeName] = appid._appid
+    return ret
 
   def generate(self):
     """Fill in (generate) this module. Only supports a single generator
@@ -429,7 +456,11 @@ def _module_base(cls,
 
   class mod(cls):
 
-    def __init__(self, *args, partition: DesignPartition = None, **kwargs):
+    def __init__(self,
+                 *args,
+                 appid: AppID = None,
+                 partition: DesignPartition = None,
+                 **kwargs):
       """Scan the class and eventually instance for Input/Output members and
       treat the inputs as operands and outputs as results."""
       # Ensure the module has been created.
@@ -482,6 +513,7 @@ def _module_base(cls,
       # TODO: This is a held Operation*. Add a level of indirection.
       self._instantiation = mod._pycde_mod.instantiate(instance_name,
                                                        inputs,
+                                                       appid=appid,
                                                        loc=loc)
 
       op = self._instantiation.operation

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -168,11 +168,19 @@ class System:
         m = self._generate_queue.pop()
         m.generate()
         i += 1
-    return len(self._generate_queue)
+
+    # Run passes which must get run between generation and instance hierarch
+    # browsing.
+    gen_left = len(self._generate_queue)
+    if gen_left == 0:
+      pm = mlir.passmanager.PassManager.parse("msft-discover-appids")
+      pm.run(self.mod)
+    return
 
   def get_instance(self,
                    mod_cls: object,
                    instance_name: str = None) -> InstanceHierarchyRoot:
+    assert len(self._generate_queue) == 0, "Ungenerated modules left"
     mod = mod_cls._pycde_mod
     key = (mod, instance_name)
     if key not in self._instance_roots:

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -134,6 +134,8 @@ class Value:
 
   @appid.setter
   def appid(self, appid) -> None:
+    if "sym_name" not in self.value.owner.attributes:
+      raise ValueError("AppIDs can only be attached to ops with symbols")
     from .module import AppID
     self.value.owner.attributes[AppID.AttributeName] = appid._appid
 

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -13,7 +13,7 @@ import mlir.ir as ir
 
 from contextvars import ContextVar
 from functools import singledispatchmethod
-from typing import Union
+from typing import Optional, Union
 import re
 import numpy as np
 
@@ -44,7 +44,13 @@ class Value:
 
   _reg_name = re.compile(r"^(.*)__reg(\d+)$")
 
-  def reg(self, clk=None, rst=None, name=None, cycles=1, sv_attributes=None):
+  def reg(self,
+          clk=None,
+          rst=None,
+          name=None,
+          cycles=1,
+          sv_attributes=None,
+          appid=None):
     """Register this value, returning the delayed value.
     `clk`, `rst`: the clock and reset signals.
     `name`: name this register explicitly.
@@ -85,6 +91,8 @@ class Value:
                             name=give_name,
                             sym_name=give_name,
                             sv_attributes=sv_attributes)
+      if appid is not None:
+        reg.appid = appid
       return reg
 
   @property
@@ -115,6 +123,19 @@ class Value:
       owner.attributes[self._namehint_attrname] = ir.StringAttr.get(new)
     else:
       self._name = new
+
+  @property
+  def appid(self) -> Optional[object]:  # Optional AppID.
+    from .module import AppID
+    owner = self.value.owner
+    if AppID.AttributeName in owner.attributes:
+      return AppID(owner.attributes[AppID.AttributeName])
+    return None
+
+  @appid.setter
+  def appid(self, appid) -> None:
+    from .module import AppID
+    self.value.owner.attributes[AppID.AttributeName] = appid._appid
 
 
 class RegularValue(Value):

--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -4,7 +4,7 @@
 # RUN: FileCheck %s --input-file %t/CompReg.tcl --check-prefix TCL
 
 import pycde
-from pycde import types, module, Clock, Input, Output
+from pycde import types, module, AppID, Clock, Input, Output
 from pycde.devicedb import LocationVector
 
 from pycde.module import generator
@@ -22,6 +22,7 @@ class CompReg:
   def build(ports):
     with ports.clk:
       compreg = ports.input.reg(name="reg", sv_attributes=["dont_merge"])
+      compreg.appid = AppID("reg", 0)
       ports.output = compreg
 
 

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -36,6 +36,19 @@ class ClkError:
 # -----
 
 
+@unittestmodule()
+class AppIDError:
+
+  @generator
+  def build(ports):
+    c = types.i32(4)
+    # CHECK: ValueError: AppIDs can only be attached to ops with symbols
+    c.appid = AppID("c", 0)
+
+
+# -----
+
+
 @module
 class Test:
   clk = Clock()

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -1,7 +1,7 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
-from pycde import Input, Output, types
-from pycde.module import externmodule, generator
+from pycde import Clock, Input, types, System
+from pycde.module import AppID, externmodule, generator, module
 from pycde.testing import unittestmodule
 
 
@@ -31,3 +31,24 @@ class ClkError:
   def build(ports):
     # CHECK: ValueError: If 'clk' not specified, must be in clock block
     ports.a.reg()
+
+
+# -----
+
+
+@module
+class Test:
+  clk = Clock()
+  x = Input(types.i32)
+
+  @generator
+  def build(ports):
+    ports.x.reg(appid=AppID("reg", 5))
+
+
+t = System([Test], name="Test")
+t.generate()
+
+inst = t.get_instance(Test)
+# CHECK: reg[8] not found
+inst.reg[8]

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -85,9 +85,6 @@ print("=== Hierarchy")
 test_inst = t.get_instance(Test)
 test_inst.walk(lambda inst: print(inst))
 
-for ui in test_inst.unparam:
-  print(f"unparam: {ui}")
-
 reg = test_inst.unparam[0].reg[4]
 print(f"unparam[0].reg[4]: {reg}")
 # CHECK: unparam[0].reg[4]: <instance: [UnParameterized, Delay, x__reg1]>

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import pycde
-from pycde import (Input, Output, module, externmodule, generator, types, dim)
+from pycde import (AppID, Input, Output, module, externmodule, generator, types)
 from pycde.dialects import comb, hw
 from circt.support import connect
 
@@ -92,7 +92,8 @@ class PolynomialSystem:
   def construct(ports):
     i32 = types.i32
     x = hw.ConstantOp(i32, 23)
-    poly = PolynomialCompute(Coefficients([62, 42, 6]))("example")
+    poly = PolynomialCompute(Coefficients([62, 42, 6]))("example",
+                                                        appid=AppID("poly", 0))
     connect(poly.x, x)
     PolynomialCompute(coefficients=Coefficients([62, 42, 6]))("example2",
                                                               x=poly.y)
@@ -118,7 +119,7 @@ poly.generate(iters=1)
 print("Printing...")
 poly.print()
 # CHECK-LABEL: msft.module @PolynomialSystem {} () -> (y: i32) attributes {fileName = "PolynomialSystem.sv"} {
-# CHECK:         %example.y = msft.instance @example @PolyComputeForCoeff_62_42_6(%c23_i32) : (i32) -> i32
+# CHECK:         %example.y = msft.instance @example @PolyComputeForCoeff_62_42_6(%c23_i32) {msft.appid = #msft.appid<"poly"[0]>} : (i32) -> i32
 # CHECK:         %example2.y = msft.instance @example2 @PolyComputeForCoeff_62_42_6(%example.y) : (i32) -> i32
 # CHECK:         %example2_1.y = msft.instance @example2_1 @PolyComputeForCoeff_1_2_3_4_5(%example.y) : (i32) -> i32
 # CHECK:         %CoolPolynomialCompute.y = msft.instance @CoolPolynomialCompute @supercooldevice(%{{.+}}) : (i32) -> i32

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -113,6 +113,15 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
         for p in _ir.DictAttr(self.attributes["parameters"])
     ]
 
+  @property
+  def childAppIDBases(self):
+    if "childAppIDBases" not in self.attributes:
+      return None
+    bases = self.attributes["childAppIDBases"]
+    if bases is None:
+      return None
+    return [_ir.StringAttr(n) for n in _ir.ArrayAttr(bases)]
+
 
 class MSFTModuleExternOp(_hw_ext.ModuleLike):
 


### PR DESCRIPTION
Expose AppIDs through PyCDE and allow them to be added to any Operation with a `sym_name` attribute. Add arguments to set the appid on instances and registers as shortcuts. Adds AppID-based accessors to the `Instance` hierarchy.