### PR TITLE
[FIRRTL] Switch to exclusive generation of circt.fieldID

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -450,6 +450,8 @@ void Annotation::setDict(DictionaryAttr dict) {
 unsigned Annotation::getFieldID() const {
   if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
     return subAnno.getFieldID();
+  if (auto fieldID = getMember<IntegerAttr>("circt.fieldID"))
+    return fieldID.getInt();
   return 0;
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1017,12 +1017,13 @@ ArrayAttr FIRParser::convertSubAnnotations(ArrayRef<Attribute> annotations,
       modAttr.push_back(attr);
     }
 
-    // Construct the SubAnnotationAttr for the annotation.
-    auto subAnnotation =
-        SubAnnotationAttr::get(constants.context, fieldID.getValue(),
-                               DictionaryAttr::get(constants.context, modAttr));
+    // Add a "circt.fieldID" field with the fieldID.
+    modAttr.append("circt.fieldID",
+                   IntegerAttr::get(IntegerType::get(constants.context, 64,
+                                                     IntegerType::Signless),
+                                    fieldID.getValue()));
 
-    annotationVec.push_back(subAnnotation);
+    annotationVec.push_back(DictionaryAttr::get(constants.context, modAttr));
   }
 
   return ArrayAttr::get(constants.context, annotationVec);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -228,15 +228,17 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
     auto oldPortType = op.getResult(portIdx).getType().cast<BundleType>();
     SmallVector<Attribute> portAnno;
     for (auto attr : newMem.getPortAnnotation(portIdx)) {
-      if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>()) {
-        auto targetIndex = oldPortType.getIndexForFieldID(subAnno.getFieldID());
+      Annotation anno(attr);
+      if (auto annoFieldID = anno.getFieldID()) {
+        auto targetIndex = oldPortType.getIndexForFieldID(annoFieldID);
 
         // Apply annotations to all elements if the target is the whole
         // sub-field.
-        if (subAnno.getFieldID() == oldPortType.getFieldID(targetIndex)) {
-          portAnno.push_back(SubAnnotationAttr::get(
-              b->getContext(), portType.getFieldID(targetIndex),
-              subAnno.getAnnotations()));
+        if (annoFieldID == oldPortType.getFieldID(targetIndex)) {
+          anno.setMember(
+              "circt.fieldID",
+              b->getI32IntegerAttr(portType.getFieldID(targetIndex)));
+          portAnno.push_back(anno.getDict());
           continue;
         }
 
@@ -247,15 +249,15 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
           // sub-field of the memory port, thus we need to add the fieldID of
           // `data` or `mask` sub-field to get the "real" fieldID.
           auto fieldID = field.fieldID + oldPortType.getFieldID(targetIndex);
-          if (subAnno.getFieldID() >= fieldID &&
-              subAnno.getFieldID() <= fieldID + field.type.getMaxFieldID()) {
+          if (annoFieldID >= fieldID &&
+              annoFieldID <= fieldID + field.type.getMaxFieldID()) {
             // Create a new sub-annotation with a new field ID. Similarly, we
             // need to add the fieldID of `data` or `mask` sub-field in the new
             // memory port type here.
-            auto newFieldID = subAnno.getFieldID() - fieldID +
-                              portType.getFieldID(targetIndex);
-            portAnno.push_back(SubAnnotationAttr::get(
-                b->getContext(), newFieldID, subAnno.getAnnotations()));
+            auto newFieldID =
+                annoFieldID - fieldID + portType.getFieldID(targetIndex);
+            anno.setMember("circt.fieldID", b->getI32IntegerAttr(newFieldID));
+            portAnno.push_back(anno.getDict());
           }
         }
       } else
@@ -532,7 +534,10 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(
     if (auto newFieldID = fieldID - field.fieldID) {
       // If the target is a subfield/subindex of the current field, create a
       // new sub-annotation with a new field ID.
-      retval.push_back(SubAnnotationAttr::get(ctxt, newFieldID, annotation));
+      Annotation newAnno(annotation);
+      newAnno.setMember("circt.fieldID",
+                        builder->getI32IntegerAttr(newFieldID));
+      retval.push_back(newAnno.getDict());
       continue;
     }
     if (Annotation(opAttr).getClass() ==

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -251,9 +251,7 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
           auto fieldID = field.fieldID + oldPortType.getFieldID(targetIndex);
           if (annoFieldID >= fieldID &&
               annoFieldID <= fieldID + field.type.getMaxFieldID()) {
-            // Create a new sub-annotation with a new field ID. Similarly, we
-            // need to add the fieldID of `data` or `mask` sub-field in the new
-            // memory port type here.
+            // Set the field ID of the new annotation.
             auto newFieldID =
                 annoFieldID - fieldID + portType.getFieldID(targetIndex);
             anno.setMember("circt.fieldID", b->getI32IntegerAttr(newFieldID));
@@ -533,7 +531,7 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(
 
     if (auto newFieldID = fieldID - field.fieldID) {
       // If the target is a subfield/subindex of the current field, create a
-      // new sub-annotation with a new field ID.
+      // new annotation with the correct circt.fieldID.
       Annotation newAnno(annotation);
       newAnno.setMember("circt.fieldID",
                         builder->getI32IntegerAttr(newFieldID));

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -354,6 +354,8 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
              i != e; ++i) {
           NamedAttrList newAnno;
           newAnno.append("class", anno.getMember("class"));
+          newAnno.append("circt.fieldID",
+                         builder.getI64IntegerAttr(vecType.getFieldID(i)));
           newAnno.append("id", anno.getMember("id"));
           if (auto nla = anno.getMember("circt.nonlocal"))
             newAnno.append("circt.nonlocal", nla);
@@ -361,9 +363,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
               "portID",
               IntegerAttr::get(IntegerType::get(builder.getContext(), 64), i));
 
-          regAnnotations.push_back(SubAnnotationAttr::get(
-              builder.getContext(), vecType.getFieldID(i),
-              builder.getDictionaryAttr(newAnno)));
+          regAnnotations.push_back(builder.getDictionaryAttr(newAnno));
         }
       } else
         regAnnotations.push_back(anno.getAttr());

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -777,8 +777,8 @@ circuit top : %[[
   ; CHECK:      firrtl.module private @a(
   ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
-  ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
-  ; CHECK-SAME:      #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @[[nla_1]], class = "nla1"}>]
+  ; CHECK-SAME:     [{circt.fieldID = 1 : i64, circt.nonlocal = @[[nla_2]], class = "nla2"},
+  ; CHECK-SAME:      {circt.fieldID = 4 : i64, circt.nonlocal = @[[nla_1]], class = "nla1"}]
   module a:
     input i: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     output o: {z: {y: {x: UInt<1>}}, a: UInt<1>}

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -111,14 +111,14 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     ; CHECK: firrtl.module private @Bar
     ; CHECK:      out %b
     ; CHECK-NOT:  sym
-    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
+    ; CHECK-SAME: [{circt.fieldID = 2 : i64, circt.nonlocal = @nla_1, three}]
     ; CHECK-NEXT: %d = firrtl.wire
     ; CHECK-NOT:  sym
-    ; CHECK-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, five}>]}
+    ; CHECK-SAME: {annotations = [{circt.fieldID = 2 : i64, circt.nonlocal = @nla_2, five}]}
     ; CHECK-SAME: : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
     ; CHECK-SAME: [{one}],
-    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 1, {two}>],
+    ; CHECK-SAME: [{circt.fieldID = 1 : i64, two}],
     ; CHECK-SAME: [{four}]
 
 ; // -----
@@ -170,8 +170,8 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>bar.r"},
     ; CHECK-LABEL: module {
     ; CHECK: firrtl.mem
     ; CHECK-SAME: portAnnotations = [
-    ; CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 5, {b}>],
-    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>]
+    ; CHECK-SAME: [{a}, {b, circt.fieldID = 5 : i64}],
+    ; CHECK-SAME: [{c, circt.fieldID = 2 : i64}, {circt.fieldID = 6 : i64, d}]
 
 ; // -----
 
@@ -302,8 +302,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar = firrtl.wire interesting_name {annotations =
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
+    ; CHECK-SAME: {circt.fieldID = 1 : i64, one}
+    ; CHECK-SAME: {circt.fieldID = 5 : i64, two}
 
 
 ; // -----
@@ -316,8 +316,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar = firrtl.reg interesting_name %clock {annotations =
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
+    ; CHECK-SAME: {circt.fieldID = 1 : i64, one}
+    ; CHECK-SAME: {circt.fieldID = 5 : i64, two}
 
 ; // -----
 
@@ -335,7 +335,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>w[9]"}]]
 
     ; CHECK-LABEL: module {
     ; CHECK: %w = firrtl.wire interesting_name {annotations =
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = 10, {a}
+    ; CHECK-SAME: {a, circt.fieldID = 10 : i64}
 
 ; // -----
 

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -966,15 +966,15 @@ firrtl.circuit "TopLevel" {
   firrtl.module private @Foo4() {
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>]
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = 4, {e}>, #firrtl.subAnno<fieldID = 7, {f}>]
+    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i32}],
+    // CHECK-SAME: [{c, circt.fieldID = 2 : i32}]
+    // CHECK-SAME: [{circt.fieldID = 4 : i32, e}, {circt.fieldID = 7 : i32, f}]
 
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 4, {d}>]
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = 4, {e}>]
+    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i32}],
+    // CHECK-SAME: [{c, circt.fieldID = 2 : i32}, {circt.fieldID = 4 : i32, d}]
+    // CHECK-SAME: [{circt.fieldID = 4 : i32, e}]
 
     %bar_r, %bar_w, %bar_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
         portAnnotations = [

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -219,10 +219,10 @@ firrtl.circuit "MemTap" attributes {annotations = [
         !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<32>>
     // CHECK-LABEL: firrtl.module public @MemTap()
     // CHECK:         %rf = firrtl.reg sym @rf %2
-    // CHECK-SAME:      [#firrtl.subAnno<fieldID = 1, {class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 0 : i64}>,
-    // CHECK-SAME:       #firrtl.subAnno<fieldID = 2, {class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 1 : i64}>,
-    // CHECK-SAME:       #firrtl.subAnno<fieldID = 3, {class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 2 : i64}>,
-    // CHECK-SAME:       #firrtl.subAnno<fieldID = 4, {class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 3 : i64}>]}
+    // CHECK-SAME:      [{circt.fieldID = 1 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 0 : i64}
+    // CHECK-SAME:       {circt.fieldID = 2 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 1 : i64},
+    // CHECK-SAME:       {circt.fieldID = 3 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 2 : i64},
+    // CHECK-SAME:       {circt.fieldID = 4 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 3 : i64}]}
     // CHECK-SAME:      : !firrtl.vector<uint<32>, 4>
 	}
 


### PR DESCRIPTION
Modify existing places in the codebase that create `SubAnnotationAttr` to instead add a `circt.fieldID` member to annotations.  This is done as prerequisite work for removing `SubAnnotationAttr`.  This is viewed as being too heavy handed of a solution in favor of the simpler approach of just adding a field to existing annotations.

This requires and is rebased on top of #3427.