### PR TITLE
[FIRRTL] Emit binds alongside the modules and interfaces they bind in

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2130,11 +2130,7 @@ void GrandCentralPass::runOnOperation() {
         instance->getParentOfType<CircuitOp>().getBody());
     auto bind = builder.create<sv::BindInterfaceOp>(getOperation().getLoc(),
                                                     instanceSymbol);
-    bind->setAttr("output_file",
-                  hw::OutputFileAttr::getFromFilename(
-                      &getContext(),
-                      maybeExtractInfo.getValue().bindFilename.getValue(),
-                      /*excludeFromFileList=*/true));
+    bind->setAttr("output_file", iface.getValue()->getAttr("output_file"));
   }
 
   // If a `GrandCentralHierarchyFileAnnotation` was passed in, generate a YAML

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1883,20 +1883,18 @@ void GrandCentralPass::runOnOperation() {
                              op, cast<hw::HWModuleLike>(*dut)))
                 return true;
 
+              // Lower this instance to a bind later.
               instance.getValue()->setAttr("lowerToBind", trueAttr);
-              instance.getValue()->setAttr(
-                  "output_file",
-                  hw::OutputFileAttr::getFromFilename(
-                      &getContext(),
-                      maybeExtractInfo.getValue().bindFilename.getValue(),
-                      /*excludeFromFileList=*/true));
-              op->setAttr("output_file",
-                          hw::OutputFileAttr::getFromDirectoryAndFilename(
-                              &getContext(),
-                              maybeExtractInfo.getValue().directory.getValue(),
-                              op.getName() + ".sv",
-                              /*excludeFromFileList=*/true,
-                              /*includeReplicatedOps=*/true));
+
+              // Put the instance/bind and module in the same file.
+              auto outputFile = hw::OutputFileAttr::getFromDirectoryAndFilename(
+                  &getContext(),
+                  maybeExtractInfo.getValue().directory.getValue(),
+                  op.getName() + ".sv",
+                  /*excludeFromFileList=*/true,
+                  /*includeReplicatedOps=*/true);
+              instance.getValue()->setAttr("output_file", outputFile);
+              op->setAttr("output_file", outputFile);
 
               // Look for any blackboxes instantiated by the companion and mark
               // them for inclusion in the Grand Central extraction directory.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -169,7 +169,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   hw::OutputFileAttr fileName;
   if (path) {
     assert(path.isDirectory() && "output file directory must be specified");
-    auto fileName = hw::OutputFileAttr::getFromDirectoryAndFilename(
+    fileName = hw::OutputFileAttr::getFromDirectoryAndFilename(
         path.getContext(), path.getFilename().getValue(),
         newMod.getName() + ".sv", path.getExcludeFromFilelist().getValue(),
         path.getIncludeReplicatedOps().getValue());


### PR DESCRIPTION
Emitting all of the binds into monolithic *.bindings.sv files makes it
impossible for tools to work with a subset of the design. If they are
only interested in a specific unit, and that unit involves bind
statements, including the monolithic *.bindings.sv files may include
other bind statements to units that do not exist in the portion of the
design under test.

This breaks that up by emitting the bind statements alongside the
generated module or interface that is being bound in.

This is an early work in progress, but I think it is achieving the
goal stated above. In a test, neither Grand Central nor
SVExtractTestCode generated the *.bindings.sv files, and binds were
emitted alongside the generated modules and instances.

If this is the right direction, I can go ahead and finish this up by
removing the remaining traces of the global *.bindings.sv files and
updating the tests to match the new behavior.