### PR TITLE
[HW,SV] Initial commit for `hw.enum` + `sv.case` support

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -15,6 +15,7 @@
 namespace circt {
 namespace hw {
 class PEOAttr;
+class EnumType;
 enum class PEO : uint32_t;
 
 // Eventually move this to an op trait

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -264,6 +264,32 @@ def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+// An attribute to indicate an enumeration value.
+def EnumValueAttr : AttrDef<HWDialect, "EnumValue"> {
+  let summary = "Enumeration value attribute";
+  let description = [{
+    This attribute represents a value of an enumeration.
+    
+    Examples:
+    ```mlir
+      #hw.enum.value<A, !hw.enum<A, B, C>>
+    ```
+  }];
+  let mnemonic = "enum.value";
+  let parameters = (ins "::mlir::StringAttr":$value, "::mlir::TypeAttr":$type);
+
+  // Force all clients to go through our custom builder so we can check
+  // whether the requested enum value is part of the provided enum type.
+  let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    /// Builds a new EnumValueAttr of the provided value.
+    /// This will fail if the value is not a member of the provided enum type.
+    static Attribute get(::mlir::Location loc, ::mlir::StringAttr value, circt::hw::EnumType type);
+  }];
+}
+
 
 let cppNamespace = "circt::hw" in {
 def WUW_Undefined : I32EnumAttrCase<"Undefined", 0>;

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -82,3 +82,23 @@ def ParamValueOp : HWOp<"param.value",
   let hasVerifier = 1;
   let hasFolder = true;
 }
+
+def EnumConstantOp : HWOp<"enum.constant", [NoSideEffect, ConstantLike,
+         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Produce a constant enumarion value.";
+  let description = [{
+    The enum.constant operation produces an enumeration value of the specified
+    enum value attribute.
+    ```
+      %0 = hw.enum.constant #hw.enum.value<A, !hw.enum<A, B, C>>
+    ```
+    }];
+
+  let arguments = (ins EnumValueAttr:$enumerator);
+  let results = (outs EnumType:$result);
+  let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    OpBuilder<(ins "hw::EnumValueAttr":$enumerator)>,
+  ];
+}

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -28,6 +28,8 @@
 namespace circt {
 namespace hw {
 
+class EnumValueAttr;
+
 /// A module port direction.
 enum class PortDirection {
   INPUT = 1,

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -63,15 +63,15 @@ int64_t getBitWidth(mlir::Type type);
 /// false on known InOut types, rather than any unknown types.
 bool hasHWInOutType(mlir::Type type);
 
-template <typename BaseTy>
+template <typename... BaseTy>
 bool type_isa(Type type) {
   // First check if the type is the requested type.
-  if (type.isa<BaseTy>())
+  if (type.isa<BaseTy...>())
     return true;
 
   // Then check if it is a type alias wrapping the requested type.
   if (auto alias = type.dyn_cast<TypeAliasType>())
-    return alias.getInnerType().isa<BaseTy>();
+    return alias.getInnerType().isa<BaseTy...>();
 
   return false;
 }

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -54,6 +54,11 @@ def UnionType : DialectType<HWDialect,
     CPred<"::circt::hw::type_isa<circt::hw::UnionType>($_self)">,
           "a UnionType", "::circt::hw::TypeAliasOr<hw::UnionType>">;
 
+// A handle to refer to circt::hw::EnumType in ODS.
+def EnumType : DialectType<HWDialect,
+    CPred<"::circt::hw::type_isa<circt::hw::EnumType>($_self)">,
+          "a EnumType", "::circt::hw::TypeAliasOr<circt::hw::EnumType>">;
+
 //===----------------------------------------------------------------------===//
 // Type Definitions
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -138,6 +138,31 @@ def StructTypeImpl : HWType<"Struct"> {
   }];
 }
 
+// An enum type. Declares the hw::EnumType in C++.
+def EnumTypeImpl : HWType<"Enum"> {
+  let summary = "HW Enum type";
+  let description = [{
+    Represents an enumeration of values. Enums are interpreted as integers with
+    a synthesis-defined encoding.
+    !hw.enum<field1, field2>
+  }];
+  let mnemonic = "enum";
+  let parameters = (
+    ins "mlir::ArrayAttr":$fields
+  );
+
+  let extraClassDeclaration = [{
+    /// Returns true if the requested field is part of this enum
+    bool contains(mlir::StringRef field);
+
+    /// Returns the index of the requested field, or a nullopt if the field is
+    // not part of this enum.
+    llvm::Optional<size_t> indexOf(mlir::StringRef field);
+  }];
+  
+  let hasCustomAssemblyFormat = 1;
+}
+
 // An untagged union. Declares the hw::UnionType in C++.
 def UnionTypeImpl : HWType<"Union"> {
   let summary = "An untagged union of types";

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -33,7 +33,9 @@ public:
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
                        // Cast operation
-                       BitcastOp, ParamValueOp>([&](auto expr) -> ResultType {
+                       BitcastOp, ParamValueOp,
+                       // Enum operations
+                       EnumConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitTypeOp(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -69,6 +71,7 @@ public:
   HANDLE(ArrayGetOp, Unhandled);
   HANDLE(ArrayCreateOp, Unhandled);
   HANDLE(ArrayConcatOp, Unhandled);
+  HANDLE(EnumConstantOp, Unhandled);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -352,10 +352,10 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let regions = (region VariadicRegion<SizedRegion<1>>:$caseRegions);
   let arguments = (ins DefaultValuedAttr<CaseStmtTypeAttr,
                                          "CaseStmtType::CaseStmt">:$caseStyle,
-                       HWIntegerType:$cond, ArrayAttr:$casePatterns,
+                       AnyType:$cond, ArrayAttr:$casePatterns,
                        DefaultValuedAttr<ValidationQualifierTypeAttr,
                        "ValidationQualifierTypeEnum::ValidationQualifierPlain">:
-                       $validationQualifier);
+                      $validationQualifier);
   let results = (outs);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
@@ -367,9 +367,9 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
     OpBuilder<(ins "CaseStmtType":$caseStyle,
                    "ValidationQualifierTypeEnum":$validationQualifier,
                    "Value":$cond, "size_t":$numCases,
-                   "std::function<CasePattern(size_t)>":$caseCtor)>,
+                   "std::function<std::unique_ptr<CasePattern>(size_t)>":$caseCtor)>,
     OpBuilder<(ins "CaseStmtType":$caseStyle, "Value":$cond, "size_t":$numCases,
-               "std::function<CasePattern(size_t)>":$caseCtor), [{
+               "std::function<std::unique_ptr<CasePattern>(size_t)>":$caseCtor), [{
       build($_builder, $_state, caseStyle,
             ValidationQualifierTypeEnum::ValidationQualifierPlain, cond,  numCases,
             caseCtor);

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1714,6 +1714,31 @@ void ArrayConcatOp::build(OpBuilder &b, OperationState &state,
 }
 
 //===----------------------------------------------------------------------===//
+// EnumConstantOp
+//===----------------------------------------------------------------------===//
+
+ParseResult EnumConstantOp::parse(OpAsmParser &parser, OperationState &result) {
+  EnumValueAttr value;
+  if (parser.parseAttribute(value))
+    return failure();
+
+  result.addAttribute("enumerator", value);
+  result.addTypes(value.getType().getValue());
+
+  return success();
+}
+
+void EnumConstantOp::print(OpAsmPrinter &p) {
+  p << " ";
+  p.printAttribute(enumerator());
+}
+
+void EnumConstantOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), enumerator().getValue().str());
+}
+
+//===----------------------------------------------------------------------===//
 // StructCreateOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
@@ -90,21 +90,21 @@ Operation *HWLegalizeModulesPass::tryLoweringArrayGet(hw::ArrayGetOp getOp) {
   APInt caseValue(index.getType().getIntOrFloatBitWidth(), 0);
   auto *context = builder.getContext();
 
-  using sv::CasePattern;
-
   // Create the casez itself.
   builder.create<sv::CaseOp>(
       createOp.getLoc(), CaseStmtType::CaseZStmt, index, caseValues.size(),
-      [&](size_t caseIdx) -> CasePattern {
+      [&](size_t caseIdx) -> std::unique_ptr<sv::CasePattern> {
         // Use a default pattern for the last value, even if we are complete.
         // This avoids tools thinking they need to insert a latch due to
         // potentially incomplete case coverage.
         bool isDefault = caseIdx == caseValues.size() - 1;
         Value theValue = caseValues[caseIdx];
-        sv::CasePattern thePattern =
-            isDefault ? CasePattern(caseValue.getBitWidth(),
-                                    CasePattern::DefaultPatternTag(), context)
-                      : CasePattern(caseValue, context);
+        std::unique_ptr<sv::CasePattern> thePattern;
+
+        if (isDefault)
+          thePattern = std::make_unique<sv::CaseDefaultPattern>();
+        else
+          thePattern = std::make_unique<sv::CaseBitPattern>(caseValue, context);
         ++caseValue;
         builder.create<sv::BPAssignOp>(createOp.getLoc(), theWire, theValue);
         return thePattern;

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -17,6 +17,8 @@ hw.type_scope @__hw_typedecls {
   hw.typedecl @qux, "customName" : i32
   // CHECK: typedef struct packed {foo a; _other_scope_foo b; } nestedRef;
   hw.typedecl @nestedRef : !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo,i1>, b: !hw.typealias<@_other_scope::@foo,i2>>
+  // CHECK: typedef enum {A, B, C} myEnum;
+  hw.typedecl @myEnum : !hw.enum<A, B, C>
 }
 
 hw.type_scope @_other_scope {

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -105,6 +105,8 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   %arr2 = hw.array_create %small1, %small2, %add : i19
   // CHECK-NEXT: = hw.array_concat [[ARR1]], [[ARR2]] : !hw.array<2xi19>, !hw.array<3xi19>
   %bigArray = hw.array_concat %arrCreated, %arr2 : !hw.array<2 x i19>, !hw.array<3 x i19>
+  // CHECK-NEXT: %A = hw.enum.constant #hw.enum.value<A, !hw.enum<A, B, C>>
+  %A_enum = hw.enum.constant #hw.enum.value<A, !hw.enum<A, B, C>>
 
   // CHECK-NEXT:    hw.output [[RES8]] : i50
   hw.output %result : i50

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -329,3 +329,11 @@ module {
 
 // expected-error @+1 {{unsupported dimension kind in hw.array}}
 hw.module @bab<param: i32, N: i32> ( %array2d: !hw.array<i3 x i4>) {}
+
+// -----
+
+hw.module @foo() {
+  // expected-error @+1 {{enum value 'D' is not a member of enum type '!hw.enum<A, B, C>'}}
+  %0 = hw.enum.constant #hw.enum.value<D, !hw.enum<A, B, C>>
+  hw.output
+}

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -218,3 +218,14 @@ hw.module @ZeroWidthConstantZ() {
   // expected-error @+1 {{unsupported type}}
   %0 = sv.constantZ : !hw.struct<>
 }
+
+// -----
+
+hw.module @CaseEnum() {
+  %0 = hw.enum.constant #hw.enum.value<A, !hw.enum<A, B, C>>
+  // expected-error @+1 {{custom op 'sv.case' case value 'D' is not a member of enum type '!hw.enum<A, B, C>'}}
+  sv.case %0 : !hw.enum<A, B, C>
+    case D: {
+      sv.fwrite %fd, "x"
+    }
+}


### PR DESCRIPTION
Taking a stab at https://github.com/llvm/circt/issues/971.
A new type is introduced to the HW dialect, `!hw.enum<...>` which represents an enumeration.

This initial commit leaves all encoding up to the synthesis tool. If needed, the type can in the future be elaborated with optional data type (e.g. `unsigned int` in sv) as well as custom encodings for each enumerated value.

Specific enumeration values are represented by the `#hw.enum.value` attribute. This attribute is also used to create SSA enum values; `%0 = hw.enum_get #hw.enum.value<A, !hw.enum<A, B, C>>` and internally in the `sv.case` operator.

In terms of operation support, this commit modifies `sv.case` to support enumerated case statements.

```mlir
hw.module @AnFSM(%clock : i1) {
  %reg = sv.reg : !hw.inout<!hw.enum<A, B, C>>
  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B, C>>

  %A = hw.enum_get #hw.enum.value<A, !hw.enum<A, B, C>>
  %B = hw.enum_get #hw.enum.value<B, !hw.enum<A, B, C>>
  %C = hw.enum_get #hw.enum.value<C, !hw.enum<A, B, C>>

  sv.always posedge %clock {
    sv.case case %reg_read : !hw.enum<A, B, C>
      case A : { sv.passign %reg, %B : !hw.enum<A, B, C> }
      case B : { sv.passign %reg, %C : !hw.enum<A, B, C> }
      default : { sv.passign %reg, %A : !hw.enum<A, B, C> }
  }
}
```