### PR TITLE
[SV] Implement support for the System Verily Streaming operator

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -209,3 +209,41 @@ def SampledOp : SVOp<"system.sampled", [SameOperandsAndResultType]> {
   let results = (outs AnyType:$sampledValue);
   let assemblyFormat = "$expression attr-dict `:` qualified(type($expression))";
 }
+
+def ReorderOp: SVOp<"reorder", [InferTypeOpInterface, NoSideEffect]> {
+  let summary = "Reverse the order of bits";
+  let description = [{
+    The reorder operation is equivalent to a Verilog stream operation
+    when the results of that stream are immediately concatenated.
+
+    This method is used to reverse the order of bits
+
+    Example:
+    ````
+    %3 = sv.reorder %0, %1, %2 : i2, i1, i5
+    ````
+  }];
+
+  let assemblyFormat = "$inputs attr-dict `:` qualified(type($inputs))";
+
+  let arguments = (ins Variadic<HWIntegerType>:$inputs);
+  let results = (outs HWIntegerType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
+      return build($_builder, $_state, ValueRange{lhs, rhs});
+    }]>,
+    OpBuilder<(ins "Value":$hd, "ValueRange":$tl)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+
+}

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -51,6 +51,8 @@ def PrettifyVerilog : Pass<"prettify-verilog", "hw::HWModuleOp"> {
   }];
 
   let constructor = "circt::sv::createPrettifyVerilogPass()";
+
+  let dependentDialects = ["circt::sv::SVDialect"];
 }
 
 def HWStubExternalModules : Pass<"hw-stub-external-modules",

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -30,7 +30,7 @@ public:
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
-            ConstantXOp, ConstantZOp, MacroRefExprOp,
+            ConstantXOp, ConstantZOp, MacroRefExprOp, ReorderOp,
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
@@ -95,6 +95,7 @@ public:
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
   HANDLE(MacroRefExprOp, Unhandled);
+  HANDLE(ReorderOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1632,6 +1632,7 @@ private:
   SubExprInfo visitSV(MacroRefExprOp op);
   SubExprInfo visitSV(ConstantXOp op);
   SubExprInfo visitSV(ConstantZOp op);
+  SubExprInfo visitSV(ReorderOp op);
 
   // Noop cast operators.
   SubExprInfo visitSV(ReadInOutOp op) {
@@ -2097,6 +2098,14 @@ SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {
   os << op.getWidth() << "'bz";
+  return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(ReorderOp op) {
+  os << "{<<{";
+  llvm::interleaveComma(op.inputs(), os,
+                        [&](Value v) { emitSubExpr(v, LowestPrecedence); });
+  os << "}}";
   return {Unary, IsUnsigned};
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -29,7 +29,7 @@ using namespace sv;
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
   return isa<VerbatimExprOp, VerbatimExprSEOp, GetModportOp,
-             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp>(
+             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp, ReorderOp>(
       op);
 }
 
@@ -1654,6 +1654,20 @@ void CoverConcurrentOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                     MLIRContext *context) {
   results.add(
       canonicalizeConcurrentVerifOp<CoverConcurrentOp, /* EraseIfZero */ true>);
+}
+
+LogicalResult ReorderOp::inferReturnTypes(MLIRContext *context,
+                                         Optional<Location> loc,
+                                         ValueRange operands,
+                                         DictionaryAttr attrs,
+                                         mlir::RegionRange regions,
+                                         SmallVectorImpl<Type> &results) {
+  unsigned resultWidth = 0;
+  for (auto input : operands) {
+    resultWidth += input.getType().cast<IntegerType>().getWidth();
+  }
+  results.push_back(IntegerType::get(context, resultWidth));
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -22,8 +22,11 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 using namespace circt;
 
@@ -36,15 +39,69 @@ struct PrettifyVerilogPass
     : public sv::PrettifyVerilogBase<PrettifyVerilogPass> {
   void runOnOperation() override;
 
+  void markChanges() { anythingChanged = true; }
+
 private:
   void processPostOrder(Block &block);
   bool prettifyUnaryOperator(Operation *op);
   void sinkOrCloneOpToUses(Operation *op);
   void sinkExpression(Operation *op);
   void useNamedOperands(Operation *op, DenseMap<Value, Operation *> &pipeMap);
+  void replaceConcatWithStream(Operation *op);
 
   bool anythingChanged;
 };
+
+struct ReplaceConcatWithStreamPattern: public OpRewritePattern<comb::ConcatOp> {
+  ReplaceConcatWithStreamPattern(MLIRContext *context, PrettifyVerilogPass *pass): OpRewritePattern(context), pass(pass) {};
+
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(comb::ConcatOp op,
+                                PatternRewriter &rewriter) const override {
+    auto inputs = op.inputs();
+    auto size = inputs.size();
+    // Do not change anything that has less than 3 inputs since it confuses
+    // more than it helps
+    if (inputs.size() < 3) {
+      return failure();
+    }
+
+    auto sourceOp = inputs[0].getDefiningOp<comb::ExtractOp>();
+    if (!sourceOp)
+      return failure();
+    
+    Value source = sourceOp.getOperand();
+
+    // Fast path: the input size is not equal to the width of the source.
+    if (size != source.getType().getIntOrFloatBitWidth())
+      return failure();
+
+    // Tracks the order of the bits that were extracted
+    SmallVector<size_t> insertionOrder(size);
+    insertionOrder[0] = sourceOp.lowBit();
+
+    for (size_t i = 1; i != size; ++i) {
+      auto extractOp = inputs[i].getDefiningOp<comb::ExtractOp>();
+      if (!extractOp || extractOp.getOperand() != source)
+        return failure();
+      insertionOrder[i] = extractOp.lowBit();
+    }
+
+    // Check if the insertion is reversed, return if it isn't
+    for (size_t i = 0; i < size; ++i) {
+      if (insertionOrder[i] != i)
+        return failure();
+    }
+    rewriter.replaceOpWithNewOp<sv::ReorderOp>(op, source.getType(), llvm::makeArrayRef(source));
+    pass->markChanges();
+    return success();
+  }
+
+private:
+  PrettifyVerilogPass *pass;
+};
+
 } // end anonymous namespace
 
 /// Return true if this is something that will get printed as a unary operator
@@ -302,6 +359,16 @@ void PrettifyVerilogPass::runOnOperation() {
   // Keeps track if anything changed during this pass, used to determine if
   // the analyses were preserved.
   anythingChanged = false;
+
+  ConversionTarget target(getContext());
+  target.addLegalOp<sv::ReorderOp>();
+
+  RewritePatternSet patterns(&getContext());
+
+  patterns.insert<ReplaceConcatWithStreamPattern>(&getContext(), this);
+
+  if (failed(applyPartialConversion(thisModule, target, std::move(patterns))))
+    signalPassFailure();
 
   // Walk the operations in post-order, transforming any that are interesting.
   processPostOrder(*thisModule.getBodyBlock());

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -240,3 +240,14 @@ hw.module @unary_sink_no_duplicate(%arg0: i4) -> (result: i4) {
   %r = comb.concat %a, %b, %c : i1, i1, i2
   hw.output %r : i4
 }
+
+// CHECK-LABEL: exportStream
+hw.module @exportStream(%arg: i4) -> (o: i4) {
+  %0 = comb.extract %arg from 0 : (i4) -> i1
+  %1 = comb.extract %arg from 1 : (i4) -> i1
+  %2 = comb.extract %arg from 2 : (i4) -> i1
+  %3 = comb.extract %arg from 3 : (i4) -> i1
+  %4 = comb.concat %0, %1, %2, %3 : i1, i1, i1, i1
+  // CHECK: %4 = sv.reorder %arg : i4
+  hw.output %4 : i4
+}


### PR DESCRIPTION
This PR implements initial support for the left streaming operator `{<<{...}}` to simplify bit-swap expressions. The scope of this PR is very limited and only aims at supporting a very basic subset of what the operator can do. The following is implemented

- A new SV op: `sv.reorder args... : returnType`
- A beautification in the `PrettifyVerilog` pass to transform expressions of the type `{a[0], a[1], a[2], ..., a[n-1]}` to the expression `{<<{a}}`

More complex transformations can be added in the future. I have created this PR with the following two in mind:

- Enable slices for the reorder-operation so that common operations like byte-swap, nibble-swaps and swaps of arbitrary block sizes are possible
- Enable multiple arguments, i.e. `{<<{a, b}}` should be infered from `{b[0], b[1], ..., b[n-1], a[0], a[1], ..., a[m-1]}`

I'm not quite sure about the naming of the Operation. I think it describes fairly well what it does but it doesn't have an immediate SV representation. I also thought about simply using `sv.stream` but that might give a wrong impression since the streaming operator is technically only the `<<` operator. I am happy to discuss any other names.