### PR TITLE
[FIRRTL][LowerTypes] avoid non-trivial copies, use const ref; touchup isa check

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -159,7 +159,7 @@ static bool isNotSubAccess(Operation *op) {
 static SmallVector<Operation *> getSAWritePath(Operation *op) {
   SmallVector<Operation *> retval;
   auto defOp = op->getOperand(0).getDefiningOp();
-  while (defOp && isa<SubfieldOp, SubindexOp, SubaccessOp>(defOp)) {
+  while (isa_and_nonnull<SubfieldOp, SubindexOp, SubaccessOp>(defOp)) {
     retval.push_back(defOp);
     defOp = defOp->getOperand(0).getDefiningOp();
   }


### PR DESCRIPTION
Avoid many copies of field objects as they're not tiny (contain a SmallString, for example).  While visiting, touchup an isa check to use `isa_and_nonnull`.

From commit:

These contain SmallVector's, don't copy them around unnecessarily.

On my machine, sizeof(FlatBundleFieldEntry) = 72.

Also avoid copy when iterating through renames.