### PR TITLE
[FIRRTL][MemToRegOfVec] avoid unnecessary copies, use const ref. NFC.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -138,8 +138,9 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     return builder.create<SubfieldOp>(bundle, "wdata");
   }
 
-  void generateRead(FirMemory firMem, Value clock, Value addr, Value enable,
-                    Value data, Value regOfVec, ImplicitLocOpBuilder &builder) {
+  void generateRead(const FirMemory &firMem, Value clock, Value addr,
+                    Value enable, Value data, Value regOfVec,
+                    ImplicitLocOpBuilder &builder) {
     if (ignoreReadEnable) {
       // If read enable is ignored, then guard the address update with read
       // enable.
@@ -174,9 +175,9 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     }
   }
 
-  void generateWrite(FirMemory firMem, Value clock, Value addr, Value enable,
-                     Value maskBits, Value wdataIn, Value regOfVec,
-                     ImplicitLocOpBuilder &builder) {
+  void generateWrite(const FirMemory &firMem, Value clock, Value addr,
+                     Value enable, Value maskBits, Value wdataIn,
+                     Value regOfVec, ImplicitLocOpBuilder &builder) {
 
     auto numStages = firMem.writeLatency - 1;
     // Add pipeline stages to respect the write latency. Intermediate registers
@@ -229,7 +230,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     });
   }
 
-  void generateReadWrite(FirMemory firMem, Value clock, Value addr,
+  void generateReadWrite(const FirMemory &firMem, Value clock, Value addr,
                          Value enable, Value maskBits, Value wdataIn,
                          Value rdataOut, Value wmode, Value regOfVec,
                          ImplicitLocOpBuilder &builder) {


### PR DESCRIPTION
These objects aren't trivial, for example contain SmallVector.
On my machine, sizeof(FirMemory) = 184.