### PR TITLE
[FIRRTL][LowerAnnotations] avoid non-trivial copies, use const ref. NFC.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -166,17 +166,17 @@ private:
   unsigned annotationID = 0;
 };
 
-LogicalResult applyGCTView(AnnoPathValue target, DictionaryAttr anno,
+LogicalResult applyGCTView(const AnnoPathValue &target, DictionaryAttr anno,
                            ApplyState &state);
 
-LogicalResult applyGCTDataTaps(AnnoPathValue target, DictionaryAttr anno,
+LogicalResult applyGCTDataTaps(const AnnoPathValue &target, DictionaryAttr anno,
                                ApplyState &state);
 
-LogicalResult applyGCTMemTaps(AnnoPathValue target, DictionaryAttr anno,
+LogicalResult applyGCTMemTaps(const AnnoPathValue &target, DictionaryAttr anno,
                               ApplyState &state);
 
-LogicalResult applyGCTSignalMappings(AnnoPathValue target, DictionaryAttr anno,
-                                     ApplyState &state);
+LogicalResult applyGCTSignalMappings(const AnnoPathValue &target,
+                                     DictionaryAttr anno, ApplyState &state);
 
 /// Implements the same behavior as DictionaryAttr::getAs<A> to return the
 /// value of a specific type associated with a key in a dictionary. However,

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1026,7 +1026,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
   return None;
 }
 
-LogicalResult circt::firrtl::applyGCTView(AnnoPathValue target,
+LogicalResult circt::firrtl::applyGCTView(const AnnoPathValue &target,
                                           DictionaryAttr anno,
                                           ApplyState &state) {
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -121,7 +121,7 @@ static T &operator<<(T &os, const SignalMapping &mapping) {
 // Code related to annotation handling
 //===----------------------------------------------------------------------===//
 
-LogicalResult circt::firrtl::applyGCTSignalMappings(AnnoPathValue target,
+LogicalResult circt::firrtl::applyGCTSignalMappings(const AnnoPathValue &target,
                                                     DictionaryAttr anno,
                                                     ApplyState &state) {
   auto id = state.newID();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -291,7 +291,7 @@ static FailureOr<Literal> parseIntegerLiteral(MLIRContext *context,
 // A Literal is a FIRRTL IR literal serialized to a string.  For now, just
 // store the string.
 // TODO: Parse the literal string into a UInt or SInt literal.
-LogicalResult circt::firrtl::applyGCTDataTaps(AnnoPathValue target,
+LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
                                               DictionaryAttr anno,
                                               ApplyState &state) {
 
@@ -427,7 +427,7 @@ LogicalResult circt::firrtl::applyGCTDataTaps(AnnoPathValue target,
   return success();
 }
 
-LogicalResult circt::firrtl::applyGCTMemTaps(AnnoPathValue target,
+LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
                                              DictionaryAttr anno,
                                              ApplyState &state) {
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -100,7 +100,8 @@ static void addAnnotation(AnnoTarget ref, unsigned fieldIdx,
 
 /// Make an anchor for a non-local annotation.  Use the expanded path to build
 /// the module and name list in the anchor.
-static FlatSymbolRefAttr buildNLA(AnnoPathValue target, ApplyState &state) {
+static FlatSymbolRefAttr buildNLA(const AnnoPathValue &target,
+                                  ApplyState &state) {
   OpBuilder b(state.circuit.getBodyRegion());
   SmallVector<Attribute> insts;
   for (auto inst : target.instances) {
@@ -120,7 +121,7 @@ static FlatSymbolRefAttr buildNLA(AnnoPathValue target, ApplyState &state) {
 /// along the instance path.  Returns symbol name used to anchor annotations to
 /// path.
 // FIXME: uniq annotation chain links
-static FlatSymbolRefAttr scatterNonLocalPath(AnnoPathValue target,
+static FlatSymbolRefAttr scatterNonLocalPath(const AnnoPathValue &target,
                                              ApplyState &state) {
 
   FlatSymbolRefAttr sym = buildNLA(target, state);
@@ -191,7 +192,7 @@ static Optional<AnnoPathValue> tryResolve(DictionaryAttr anno,
 
 /// An applier which puts the annotation on the target and drops the 'target'
 /// field from the annotaiton.  Optionally handles non-local annotations.
-static LogicalResult applyWithoutTargetImpl(AnnoPathValue target,
+static LogicalResult applyWithoutTargetImpl(const AnnoPathValue &target,
                                             DictionaryAttr anno,
                                             ApplyState &state,
                                             bool allowNonLocal) {
@@ -223,7 +224,7 @@ static LogicalResult applyWithoutTargetImpl(AnnoPathValue target,
 /// field from the annotaiton.  Optionally handles non-local annotations.
 /// Ensures the target resolves to an expected type of operation.
 template <bool allowNonLocal, typename T, typename... Tr>
-static LogicalResult applyWithoutTarget(AnnoPathValue target,
+static LogicalResult applyWithoutTarget(const AnnoPathValue &target,
                                         DictionaryAttr anno,
                                         ApplyState &state) {
   if (!target.isOpOfType<T, Tr...>())
@@ -234,7 +235,7 @@ static LogicalResult applyWithoutTarget(AnnoPathValue target,
 /// An applier which puts the annotation on the target and drops the 'target'
 /// field from the annotaiton.  Optionally handles non-local annotations.
 template <bool allowNonLocal = false>
-static LogicalResult applyWithoutTarget(AnnoPathValue target,
+static LogicalResult applyWithoutTarget(const AnnoPathValue &target,
                                         DictionaryAttr anno,
                                         ApplyState &state) {
   return applyWithoutTargetImpl(target, anno, state, allowNonLocal);
@@ -243,8 +244,8 @@ static LogicalResult applyWithoutTarget(AnnoPathValue target,
 /// Apply a DontTouchAnnotation to the circuit.  For almost all operations, this
 /// just adds a symbol.  For CHIRRTL memory ports, this preserves the
 /// annotation.
-static LogicalResult applyDontTouch(AnnoPathValue target, DictionaryAttr anno,
-                                    ApplyState &state) {
+static LogicalResult applyDontTouch(const AnnoPathValue &target,
+                                    DictionaryAttr anno, ApplyState &state) {
 
   // A DontTouchAnnotation is only allowed to be placed on a ReferenceTarget.
   // If this winds up on a module. then it indicates that the original
@@ -274,7 +275,8 @@ namespace {
 struct AnnoRecord {
   llvm::function_ref<Optional<AnnoPathValue>(DictionaryAttr, ApplyState &)>
       resolver;
-  llvm::function_ref<LogicalResult(AnnoPathValue, DictionaryAttr, ApplyState &)>
+  llvm::function_ref<LogicalResult(const AnnoPathValue &, DictionaryAttr,
+                                   ApplyState &)>
       applier;
 };
 } // end anonymous namespace


### PR DESCRIPTION
No need to copy these, and let's not since they include a SmallVector.
On my machine, sizeof(AnnoPathValue) = 88.