### PR TITLE
[FIRRTL] Remove SubAnnotationAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -19,30 +19,8 @@ include "mlir/IR/EnumAttr.td"
 // FIRRTL Annotations Definition
 //===----------------------------------------------------------------------===//
 
-def AnnotationArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are DictionaryAttr or SubAnnotationAttr
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::DictionaryAttr,"
-            "::circt::firrtl::SubAnnotationAttr>();})">]>,
-    "Annotation array attribute"> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
-def SubAnnotationAttr : AttrDef<FIRRTLDialect, "SubAnnotation"> {
-  let summary = "An Annotation that targets part of what it's attached to";
-  let description = [{
-    An Annotation that is only applicable to part of what it is attached to.
-    This uses a field ID to indicate to which field it is applicable.
-  }];
-  let mnemonic = "subAnno";
-  let parameters = (ins "int64_t":$fieldID, "DictionaryAttr":$annotations);
-
-  let assemblyFormat = "`<` `fieldID` `=` $fieldID `,` $annotations `>`";
-}
+def AnnotationArrayAttr
+  : TypedArrayAttrBase<DictionaryAttr, "Annotation array attribute">;
 
 def PortAnnotationsAttr : ArrayAttrBase<
     And<[

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -437,9 +437,7 @@ DictionaryAttr Annotation::getDict() const {
   return attr.cast<DictionaryAttr>();
 }
 
-void Annotation::setDict(DictionaryAttr dict) {
-  attr = dict;
-}
+void Annotation::setDict(DictionaryAttr dict) { attr = dict; }
 
 unsigned Annotation::getFieldID() const {
   if (auto fieldID = getMember<IntegerAttr>("circt.fieldID"))

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -434,22 +434,14 @@ bool AnnotationSet::removePortAnnotations(
 //===----------------------------------------------------------------------===//
 
 DictionaryAttr Annotation::getDict() const {
-  if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
-    return subAnno.getAnnotations();
   return attr.cast<DictionaryAttr>();
 }
 
 void Annotation::setDict(DictionaryAttr dict) {
-  if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
-    attr = SubAnnotationAttr::get(subAnno.getContext(), subAnno.getFieldID(),
-                                  dict);
-  else
-    attr = dict;
+  attr = dict;
 }
 
 unsigned Annotation::getFieldID() const {
-  if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
-    return subAnno.getFieldID();
   if (auto fieldID = getMember<IntegerAttr>("circt.fieldID"))
     return fieldID.getInt();
   return 0;

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -68,7 +68,7 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
       return module.emitOpError(
           "requires port annotations be array attributes");
     if (llvm::any_of(arrayAttr.getValue(), [](Attribute attr) {
-          return !attr.isa<DictionaryAttr, SubAnnotationAttr>();
+          return !attr.isa<DictionaryAttr>();
         }))
       return module.emitOpError(
           "annotations must be dictionaries or subannotations");

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -376,8 +376,8 @@ struct FIRParser {
   /// aggregate type, "{foo: UInt<1>, bar: UInt<1>}[2]", tokens "[0].foo" will
   /// be converted to a field ID range of [2, 2]; tokens "[1]" will be converted
   /// to [4, 6]. The generated field ID range will then be attached to the
-  /// firrtl::subAnnotationAttr in order to indicate the applicable fields of an
-  /// annotation.
+  /// annotation in a "circt.fieldID" field in order to indicate the applicable
+  /// fields of an annotation.
   Optional<unsigned> getFieldIDFromTokens(ArrayAttr tokens, SMLoc loc,
                                           Type type);
 
@@ -903,8 +903,8 @@ ParseResult FIRParser::parseOptionalRUW(RUWAttr &result) {
 /// Convert the input "tokens" to a range of field IDs. Considering a FIRRTL
 /// aggregate type, "{foo: UInt<1>, bar: UInt<1>}[2]", tokens "[0].foo" will be
 /// converted to a field ID range of [2, 2]; tokens "[1]" will be converted to
-/// [4, 6]. The generated field ID range will then be attached to the
-/// firrtl::subAnnotationAttr in order to indicate the applicable fields of an
+/// [4, 6]. The generated field ID range will then be attached to the annotation
+/// in a "circt.fieldID" field to indicate the applicable fields of an
 /// annotation.
 Optional<unsigned> FIRParser::getFieldIDFromTokens(ArrayAttr tokens, SMLoc loc,
                                                    Type type) {
@@ -1511,7 +1511,7 @@ static bool needsSymbol(ArrayAttr &annotations) {
   // Subfield annotations.
   for (Attribute attr : annotations) {
     // Ensure it is a valid annotation.
-    if (!attr.isa<SubAnnotationAttr, DictionaryAttr>())
+    if (!attr.isa<DictionaryAttr>())
       continue;
     Annotation anno(attr);
     // Check if it is a DontTouch annotation that applies to all subfields in

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -38,8 +38,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
     auto hasSubAnno = [&](MemOp op) -> bool {
       for (size_t portIdx = 0, e = op.getNumResults(); portIdx < e; ++portIdx)
         for (auto attr : op.getPortAnnotation(portIdx))
-          if (attr.isa<SubAnnotationAttr>() ||
-              attr.cast<DictionaryAttr>().get("circt.fieldID"))
+          if (attr.cast<DictionaryAttr>().get("circt.fieldID"))
             return true;
 
       return false;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -489,34 +489,21 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(
   for (auto opAttr : annotations) {
     Optional<int64_t> maybeFieldID = None;
     DictionaryAttr annotation;
-    if (auto subAnno = opAttr.dyn_cast<SubAnnotationAttr>()) {
-      maybeFieldID = subAnno.getFieldID();
-      annotation = subAnno.getAnnotations();
-    } else {
-      annotation = opAttr.dyn_cast<DictionaryAttr>();
-      if (annotations)
-        // If this is an annotation targeting a field that uses a
-        // "circt.fieldID" as opposed to being encoded as a SubAnnotationAttr,
-        // then erase the "circt.fieldID" field.  All later logic (in this pass)
-        // assumes that SubAnnotationAttr is the single way of targeting a
-        // fieldID.
-        //
-        // TODO: Fully switch everything over to use "circt.fieldID" instead of
-        // SubAnnotationAttr.
-        if (auto id = annotation.getAs<IntegerAttr>("circt.fieldID")) {
-          maybeFieldID = id.getInt();
-          Annotation anno(annotation);
-          anno.removeMember("circt.fieldID");
-          annotation = anno.getDict();
-        }
-    }
+    annotation = opAttr.dyn_cast<DictionaryAttr>();
+    if (annotations)
+      // Erase the circt.fieldID.  If this is needed later, it will be re-added.
+      if (auto id = annotation.getAs<IntegerAttr>("circt.fieldID")) {
+        maybeFieldID = id.getInt();
+        Annotation anno(annotation);
+        anno.removeMember("circt.fieldID");
+        annotation = anno.getDict();
+      }
     if (!maybeFieldID) {
       retval.push_back(
           updateAnnotationFieldID(ctxt, opAttr, field.fieldID, cache.i64ty));
       continue;
     }
     auto fieldID = maybeFieldID.getValue();
-    /* subAnno handling... */
     // Check whether the annotation falls into the range of the current field.
     if (fieldID != 0 &&
         !(fieldID >= field.fieldID &&
@@ -858,8 +845,8 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
     oldPorts.push_back(wire);
     result.replaceAllUsesWith(wire.getResult());
   }
-  // If subannotations present on aggregate fields, we cannot flatten the
-  // memory. It must be split into one memory per aggregate field.
+  // If annotations targeting fields of an aggregate are present, we cannot
+  // flatten the memory. It must be split into one memory per aggregate field.
   // Do not overwrite the pass flag!
 
   // Memory for each field

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -126,8 +126,6 @@ struct NLARemover {
     } else if (auto array = anno.dyn_cast<ArrayAttr>()) {
       for (auto attr : array)
         markNLAsInAnnotation(attr);
-    } else if (auto subAnno = anno.dyn_cast<firrtl::SubAnnotationAttr>()) {
-      markNLAsInAnnotation(subAnno.getAnnotations());
     }
   }
 


### PR DESCRIPTION
This is the final piece of the puzzle to removing `SubAnnotationAttr`. This does two things:

1. All logic that uses `SubAnnotationAttr` is modified to remove it. (Human-in-the-loop constant folding...)
2. `SubAnnotationAttr` is removed.
3. `AnnotationArrayAttr` is redefined in terms of a `TypeArrayAttr<DictionaryAttr>`.