### PR TITLE
[SV] Add sv.logic op

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -208,3 +208,37 @@ def StructFieldInOutOp : SVOp<"struct_field_inout",
   }];
 
 }
+
+def LogicOp : SVOp<"logic", [DeclareOpInterfaceMethods<OpAsmOpInterface,
+                                                       ["getAsmResultNames"]>]> {
+  let summary = "Define a logic";
+  let description = [{
+    Declare a SystemVerilog Variable Declaration of 'logic' type.
+    See SV Spec 6.8, pp100.
+    }];
+
+  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$inner_sym);
+  let results = (outs InOutType:$result);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                      CArg<"StringAttr", "StringAttr()">:$name,
+                      CArg<"StringAttr", "StringAttr()">:$inner_sym)>,
+    OpBuilder<(ins "::mlir::Type":$elementType, CArg<"StringRef">:$name), [{
+      return build($_builder, $_state, elementType,
+                   $_builder.getStringAttr(name));
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict) `:`
+                                                qualified(type($result))
+  }];
+
+  let extraClassDeclaration = [{
+    Type getElementType() {
+      return result().getType().cast<InOutType>().getElementType();
+    }
+  }];
+}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -32,7 +32,7 @@ public:
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, MacroRefExprOp,
             // Declarations.
-            RegOp, WireOp, LocalParamOp, XMROp,
+            RegOp, WireOp, LogicOp, LocalParamOp, XMROp,
             // Control flow.
             OrderedOutputOp, IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp,
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
@@ -83,6 +83,7 @@ public:
   // Declarations
   HANDLE(RegOp, Unhandled);
   HANDLE(WireOp, Unhandled);
+  HANDLE(LogicOp, Unhandled);
   HANDLE(LocalParamOp, Unhandled);
   HANDLE(XMROp, Unhandled);
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -157,8 +157,8 @@ static bool isDuplicatableExpression(Operation *op) {
 }
 
 /// Return the verilog name of the operations that can define a symbol.
-/// Except for <WireOp, RegOp, LocalParamOp, InstanceOp>, check global state
-/// `getDeclarationVerilogName` for them.
+/// Except for <WireOp, RegOp, LogicOp, LocalParamOp, InstanceOp>, check global
+/// state `getDeclarationVerilogName` for them.
 static StringRef getSymOpName(Operation *symOp) {
   // Typeswitch of operation types which can define a symbol.
   // If legalizeNames has renamed it, then the attribute must be set.
@@ -367,6 +367,8 @@ static StringRef getVerilogDeclWord(Operation *op,
   }
   if (isa<WireOp>(op))
     return "wire";
+  if (isa<LogicOp>(op))
+    return "logic";
   if (isa<ConstantOp, LocalParamOp, ParamValueOp>(op))
     return "localparam";
 
@@ -530,7 +532,8 @@ static bool isOkToBitSelectFrom(Value v) {
   // Uses of a wire or register can be done inline.
   if (auto read = v.getDefiningOp<ReadInOutOp>()) {
     if (read.input().getDefiningOp<WireOp>() ||
-        read.input().getDefiningOp<RegOp>())
+        read.input().getDefiningOp<RegOp>() ||
+        read.input().getDefiningOp<LogicOp>())
       return true;
   }
 
@@ -656,7 +659,7 @@ struct ModuleNameManager {
   StringRef getName(Value value) { return getName(ValueOrOp(value)); }
   StringRef getName(Operation *op) {
     // If RegOp or WireOp, then result has the name.
-    if (isa<sv::WireOp, sv::RegOp>(op))
+    if (isa<sv::WireOp, sv::RegOp, sv::LogicOp>(op))
       return getName(op->getResult(0));
     return getName(ValueOrOp(op));
   }
@@ -665,7 +668,7 @@ struct ModuleNameManager {
 
   bool hasName(Operation *op) {
     // If RegOp or WireOp, then result has the name.
-    if (isa<sv::WireOp, sv::RegOp>(op))
+    if (isa<sv::WireOp, sv::RegOp, sv::LogicOp>(op))
       return nameTable.count(op->getResult(0));
     return nameTable.count(ValueOrOp(op));
   }
@@ -1012,8 +1015,8 @@ StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
     result = StringAttr::get(expr.getContext(), name);
 
   } else if (auto *op = expr.getDefiningOp()) {
-    // Uses of a wire or register can be done inline.
-    if (isa<WireOp, RegOp>(op)) {
+    // Uses of a wire, register or logic can be done inline.
+    if (isa<WireOp, RegOp, LogicOp>(op)) {
       StringRef name = getSymOpName(op);
       result = StringAttr::get(expr.getContext(), name);
 
@@ -2353,7 +2356,7 @@ void NameCollector::collectNames(Block &block) {
       continue;
     }
 
-    if (isa<WireOp, RegOp, LocalParamOp>(op)) {
+    if (isa<WireOp, RegOp, LogicOp, LocalParamOp>(op)) {
       names.addName(op.getResult(0), getSymOpName(&op));
       continue;
     }
@@ -2494,6 +2497,7 @@ private:
 
   LogicalResult visitSV(WireOp op) { return emitNoop(); }
   LogicalResult visitSV(RegOp op) { return emitNoop(); }
+  LogicalResult visitSV(LogicOp op) { return emitNoop(); }
   LogicalResult visitSV(LocalParamOp op) { return emitNoop(); }
   LogicalResult visitSV(AssignOp op);
   LogicalResult visitSV(BPAssignOp op);
@@ -3994,7 +3998,7 @@ StringRef ModuleEmitter::getNameRemotely(Value value,
     auto *wireInput = readinout.input().getDefiningOp();
     if (!wireInput)
       return {};
-    if (isa<WireOp, RegOp>(wireInput))
+    if (isa<WireOp, RegOp, LogicOp>(wireInput))
       return getSymOpName(wireInput);
   }
 
@@ -4006,7 +4010,7 @@ StringRef ModuleEmitter::getNameRemotely(Value value,
         continue;
       Value drivenOnto = user->getOperand(0);
       Operation *drivenOntoOp = drivenOnto.getDefiningOp();
-      if (isa<WireOp, RegOp>(drivenOntoOp))
+      if (isa<WireOp, RegOp, LogicOp>(drivenOntoOp))
         return getSymOpName(drivenOntoOp);
     }
   }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -270,6 +270,29 @@ LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// LogicOp
+//===----------------------------------------------------------------------===//
+
+void LogicOp::build(OpBuilder &builder, OperationState &odsState,
+                    Type elementType, StringAttr name, StringAttr sym_name) {
+  if (!name)
+    name = builder.getStringAttr("");
+  odsState.addAttribute("name", name);
+  if (sym_name)
+    odsState.addAttribute(hw::InnerName::getInnerNameAttrName(), sym_name);
+  odsState.addTypes(hw::InOutType::get(elementType));
+}
+
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void LogicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // If the logic has an optional 'name' attribute, use it.
+  auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
+  if (!nameAttr.getValue().empty())
+    setNameFn(getResult(), nameAttr.getValue());
+}
+
+//===----------------------------------------------------------------------===//
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -16,10 +16,20 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK: localparam [41:0] param_y = param1;
   %param_y = sv.localparam : i42 { value = #hw.param.decl.ref<"param1">: i42 }
 
+  // CHECK: logic {{.*}} [7:0]  logic_op;
+  // CHECK: assign logic_op = val;
+  %logic_op = sv.logic : !hw.inout<i8>
+  sv.assign %logic_op, %val: i8
+
   // CHECK:      always @(posedge clock) begin
   sv.always posedge %clock {
+    // CHECK-NEXT: logic [7:0] logic_op_procedural;
+    // CHECK-EMPTY:
     // CHECK-NEXT: force forceWire = cond;
     sv.force %forceWire, %cond : i1
+    %logic_op_procedural = sv.logic : !hw.inout<i8>
+    // CHECK-NEXT: logic_op_procedural <= val;
+    sv.passign %logic_op_procedural, %val: i8
   // CHECK-NEXT:   `ifndef SYNTHESIS
     sv.ifdef.procedural "SYNTHESIS" {
     } else {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -10,26 +10,31 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   %fd = hw.constant 0x80000002 : i32
 
   %c11_i42 = hw.constant 11: i42
-  // CHECK: localparam [41:0] param_x = 42'd11;
+  // CHECK: localparam [41:0] {{.*}} param_x = 42'd11;
   %param_x = sv.localparam : i42 { value = 11: i42 }
 
-  // CHECK: localparam [41:0] param_y = param1;
+  // CHECK: localparam [41:0] {{.*}} param_y = param1;
   %param_y = sv.localparam : i42 { value = #hw.param.decl.ref<"param1">: i42 }
 
-  // CHECK: logic {{.*}} [7:0]  logic_op;
+  // CHECK:       logic {{.*}} [7:0] {{.*}} logic_op;
+  // CHECK-NEXT:  struct packed {logic b; } logic_op_struct;
   // CHECK: assign logic_op = val;
   %logic_op = sv.logic : !hw.inout<i8>
+  %logic_op_struct = sv.logic : !hw.inout<struct<b: i1>>
   sv.assign %logic_op, %val: i8
 
   // CHECK:      always @(posedge clock) begin
   sv.always posedge %clock {
-    // CHECK-NEXT: logic [7:0] logic_op_procedural;
+    // CHECK-NEXT: automatic logic [7:0]                     logic_op_procedural;
+    // CHECK-NEXT: automatic       struct packed {logic b; } logic_op_struct_procedural
     // CHECK-EMPTY:
     // CHECK-NEXT: force forceWire = cond;
     sv.force %forceWire, %cond : i1
     %logic_op_procedural = sv.logic : !hw.inout<i8>
-    // CHECK-NEXT: logic_op_procedural <= val;
-    sv.passign %logic_op_procedural, %val: i8
+    %logic_op_struct_procedural = sv.logic : !hw.inout<struct<b: i1>>
+
+    // CHECK-NEXT: logic_op_procedural = val;
+    sv.bpassign %logic_op_procedural, %val: i8
   // CHECK-NEXT:   `ifndef SYNTHESIS
     sv.ifdef.procedural "SYNTHESIS" {
     } else {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -10,13 +10,13 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   %fd = hw.constant 0x80000002 : i32
 
   %c11_i42 = hw.constant 11: i42
-  // CHECK: localparam [41:0] {{.*}} param_x = 42'd11;
+  // CHECK: localparam [41:0]{{ *}} param_x = 42'd11;
   %param_x = sv.localparam : i42 { value = 11: i42 }
 
-  // CHECK: localparam [41:0] {{.*}} param_y = param1;
+  // CHECK: localparam [41:0]{{ *}} param_y = param1;
   %param_y = sv.localparam : i42 { value = #hw.param.decl.ref<"param1">: i42 }
 
-  // CHECK:       logic {{.*}} [7:0] {{.*}} logic_op;
+  // CHECK:       logic{{ *}} [7:0]{{ *}} logic_op;
   // CHECK-NEXT:  struct packed {logic b; } logic_op_struct;
   // CHECK: assign logic_op = val;
   %logic_op = sv.logic : !hw.inout<i8>


### PR DESCRIPTION
As we talked in the last ODM, we need an operation `sv.logic` 
to represent a temporary in a procedural region. 
This implements sv.logic op which represent "logic" variable in SV spec.
Implementation is almost identical to sv.wire and sv.reg except that 
sv.logic is allowed to be defined in procedural and non-procedural
region. If sv.logic is defined in a procedural region, "automatic" keyword is
added to its declaration in emission.