### PR TITLE
[FIRRTL] Fix GCT Taps for Zero-width

### DIFF
--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -563,3 +563,49 @@ firrtl.circuit "Top" {
 //  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo]
 //  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule]
 //  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule]
+
+// -----
+
+// Check that zero-width data taps are no-ops.  These should generate no XMRs.
+//
+firrtl.circuit "Top"  {
+  firrtl.extmodule private @DataTap(
+    out _0: !firrtl.uint<0> [
+      {
+        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.port",
+        id = 0 : i64,
+        portID = 1 : i64
+      }
+    ],
+    out _1: !firrtl.uint<0> [
+      {
+        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.port",
+        id = 0 : i64,
+        portID = 2 : i64
+      }
+    ]) attributes {annotations = [
+      {class = "sifive.enterprise.grandcentral.DataTapsAnnotation.blackbox"}
+    ]}
+  firrtl.module @Top(
+    out %p: !firrtl.uint<0> [
+      {
+        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source",
+        id = 0 : i64,
+        portID = 2 : i64
+      }
+    ]) {
+    %w = firrtl.wire {annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source",
+        id = 0 : i64,
+        portID = 1 : i64
+      }
+    ]} : !firrtl.uint<0>
+    %tap_0, %tap_1 = firrtl.instance tap @DataTap(
+      out _0: !firrtl.uint<0>,
+      out _1: !firrtl.uint<0>
+    )
+  }
+}
+
+// CHECK-NOT: firrtl.verbatim.expr


### PR DESCRIPTION
Fix a bug in the Grand Central (GCT) Taps pass where XMRs would be
generated for zero-width data taps.  This then avoids a crash in
LowerToHW where the zero-width, tapped components could _not_ be removed
as they were the targets of XMRs and preventing full lowering of the
FIRRTL IR.  This commit changes the pass to generate no XMRs and this
then enables LowerToHW to correctly remove the zero-width ports on the
data tap module.

Fixes #3458.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>