### PR TITLE
[FIRRTL] Fix GCT Views for Zero-width

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3602,6 +3602,8 @@ LogicalResult StmtEmitter::visitSV(InterfaceOp op) {
 
 LogicalResult StmtEmitter::visitSV(InterfaceSignalOp op) {
   indent();
+  if (isZeroBitType(op.type()))
+    os << "// ";
   emitter.printPackedType(stripUnpackedTypes(op.type()), os, op->getLoc(),
                           false);
   os << ' ' << getSymOpName(op);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1168,6 +1168,12 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         auto builder =
             OpBuilder::atBlockEnd(companionIDMap.lookup(id).mapping.getBody());
 
+        FIRRTLType tpe = leafValue.getType().cast<FIRRTLType>();
+
+        // If the type is zero-width then do not emit an XMR.
+        if (!tpe.getBitWidthOrSentinel())
+          return true;
+
         // Populate a hierarchical path to the leaf.  For an NLA this is just
         // the namepath of the associated hierarchical path.  For a local
         // annotation, this is computed from the instance path.
@@ -1219,7 +1225,6 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
           path += getInnerRefTo(leafValue.getDefiningOp());
         }
 
-        FIRRTLType tpe = leafValue.getType().cast<FIRRTLType>();
         if (fieldID > tpe.getMaxFieldID()) {
           leafValue.getDefiningOp()->emitError()
               << "subannotation with fieldID=" << fieldID

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -10,6 +10,9 @@ module {
   // CHECK:         modport data_in(input data, input valid, output ready);
   // CHECK:         modport data_out(output data, output valid, input ready);
   // CHECK:         MACRO(data, valid, ready -- data_in)
+  // CHECK:         // logic /*Zero Width*/ zeroGround;
+  // CHECK:         // logic [3:0]/*Zero Width*/ zeroArray;
+  // CHECK:         // logic /*Zero Width*/ zeroUArray[0:3];
   // CHECK:       endinterface
   // CHECK-EMPTY:
   sv.interface @data_vr {
@@ -22,6 +25,9 @@ module {
     sv.interface.modport @data_out (output @data, output @valid, input @ready)
     sv.verbatim  "//MACRO({{0}}, {{1}}, {{2}} -- {{3}})"
                     {symbols = [@data, @valid, @ready, @data_in]}
+    sv.interface.signal @zeroGround : i0
+    sv.interface.signal @zeroArray : !hw.array<4xi0>
+    sv.interface.signal @zeroUArray : !hw.uarray<4xi0>
   }
 
   // CHECK-LABEL: interface struct_vr;

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1170,6 +1170,63 @@ firrtl.circuit "InterfaceInTestHarness" attributes {
 
 // -----
 
+firrtl.circuit "ZeroWidth" attributes {annotations = [
+  {
+    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    defName = "MyInterface",
+    elements = [
+      {
+        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        description = "a zero-width port",
+        id = 1 : i64,
+        name = "ground"
+      }
+    ],
+    id = 0 : i64,
+    name = "MyView"
+  }
+]} {
+  firrtl.module private @MyView_companion() attributes {annotations = [
+    {
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+      id = 0 : i64,
+      name = "MyView",
+      type = "companion"
+    }
+  ]} {}
+  firrtl.module @ZeroWidth() attributes {annotations = [
+    {
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+      id = 0 : i64,
+      name = "MyView",
+      type = "parent"
+    }
+  ]} {
+    %w = firrtl.wire {annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        id = 1 : i64
+      }
+    ]} : !firrtl.uint<0>
+    %invalid_ui0 = firrtl.invalidvalue : !firrtl.uint<0>
+    firrtl.strictconnect %w, %invalid_ui0 : !firrtl.uint<0>
+    firrtl.instance MyView_companion @MyView_companion()
+  }
+}
+
+// Check that a view of a zero-width thing produces a comment in the output and
+// not XMR.
+//
+// CHECK-LABEL: firrtl.module @MyView_mapping() {
+// CHECK-NOT:     sv.verbatim
+// CHECK-NEXT:  }
+//
+// CHECK-LABEL: sv.interface @MyInterface
+// CHECK-NEXT:    sv.verbatim "// a zero-width port"
+// CHECK-NEXT:    sv.interface.signal @ground : i0
+
+// -----
+
 firrtl.circuit "YAMLOutputEmptyInterface" attributes {
   annotations = [
     {class = "sifive.enterprise.grandcentral.AugmentedBundleType",


### PR DESCRIPTION
Fix a bug in the Grand Central (GCT) Views pass where a view of a
zero-width component would create an XMR.  Change the GCT View pass to
not create the XMR. Change ExportVerilog to emit a comment.

Fixes #3460.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>