### PR TITLE
[FIRRTL] InnerSymAttr: Add per field inner symbol

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -200,20 +200,45 @@ def NameKindEnumImpl: I32EnumAttr<"NameKindEnum", "name kind",
 
 def NameKindAttr: EnumAttr<FIRRTLDialect, NameKindEnumImpl, "name_kind">;
 
+def InnerSymProperties : AttrDef<FIRRTLDialect, "InnerSymProperties"> {
+  let mnemonic = "innerSymProps";
+  let parameters = (ins
+         "StringAttr":$name,
+         DefaultValuedParameter<"int64_t", "0">:$fieldID,
+         DefaultValuedParameter<"::mlir::StringAttr", "public">:$sym_visibility
+                     );
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
+      return get(sym.getContext(), sym, 0,
+                        StringAttr::get(sym.getContext(), "public") );
+    }]>
+  ];
+  let hasCustomAssemblyFormat = 1;
+  //let assemblyFormat = "`<` `@` $name `,` $fieldID `,` $sym_visibility `>`";
+}
+
 def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
   let summary = "Inner symbol definition";
   let description = [{
-    Defines the properties of an inner_sym attribute. Currently this only has
-    the symbol name. But the plan is to extend it to include per field symbols
-    and visibility.
+    Defines the properties of an inner_sym attribute. It specifies the symbol
+    name, and symbol visibility for each field ID. For any ground types,
+    there are no subfields and the field ID is 0. For aggregate types, a
+    unique field ID is assigned to each field by visiting them in a 
+    depth-first pre-order. The custom assembly format ensures that for ground
+    types, only `@<sym_name>` is printed.
   }];
   let mnemonic = "innerSym";
-  let parameters = (ins "::mlir::StringAttr":$symName);
+  let parameters = (ins ArrayRefParameter<"InnerSymPropertiesAttr">:$props);
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
-      return get(sym.getContext(), sym);
+      return get(sym.getContext(), 
+      {InnerSymPropertiesAttr::get(sym.getContext(), sym, 0,
+                        StringAttr::get(sym.getContext(), "public"))});
     }]>
   ];
+  let extraClassDeclaration = [{
+    StringAttr getSymName();
+  }];
 
   let hasCustomAssemblyFormat = 1;
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -214,7 +214,8 @@ def InnerSymProperties : AttrDef<FIRRTLDialect, "InnerSymProperties"> {
     }]>
   ];
   let hasCustomAssemblyFormat = 1;
-  //let assemblyFormat = "`<` `@` $name `,` $fieldID `,` $sym_visibility `>`";
+  // The assembly format is as follows:
+  // "`<` `@` $name `,` $fieldID `,` $sym_visibility `>`";
 }
 
 def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
@@ -241,6 +242,8 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
   }];
 
   let hasCustomAssemblyFormat = 1;
+  // Example format:
+  // firrtl.wire sym [<@x,1,private>, <@w,2,public>, <@syh,4,public>]
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -221,7 +221,7 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
   let summary = "Inner symbol definition";
   let description = [{
     Defines the properties of an inner_sym attribute. It specifies the symbol
-    name, and symbol visibility for each field ID. For any ground types,
+    name and symbol visibility for each field ID. For any ground types,
     there are no subfields and the field ID is 0. For aggregate types, a
     unique field ID is assigned to each field by visiting them in a 
     depth-first pre-order. The custom assembly format ensures that for ground

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -150,12 +150,14 @@ Attribute InnerSymAttr::parse(AsmParser &parser, Type type) {
 
 void InnerSymAttr::print(AsmPrinter &p) const {
 
-  if (auto sym = const_cast<InnerSymAttr *>(this)->getSymName()) {
-    p << "@" << sym.getValue();
-    if (getProps().size() == 1)
-      return;
+  auto props = getProps();
+  if (props.size() == 1 &&
+      props[0].getSymVisibility().getValue().equals("public") &&
+      props[0].getFieldID() == 0) {
+    p << "@" << props[0].getName().getValue();
+    return;
   }
-  auto names = getProps().vec();
+  auto names = props.vec();
 
   std::sort(names.begin(), names.end(),
             [&](InnerSymPropertiesAttr a, InnerSymPropertiesAttr b) {

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -89,19 +89,84 @@ void ParamDeclAttr::print(AsmPrinter &p) const {
 // InnerSymAttr
 //===----------------------------------------------------------------------===//
 
-Attribute InnerSymAttr::parse(AsmParser &p, Type type) {
-  //  A sample IR, parse begins after `sym`.
-  //  %wire = firrtl.wire sym @wireSym<fieldID=1><sym_visibility="private"> :
+Attribute InnerSymPropertiesAttr::parse(AsmParser &parser, Type type) {
+  StringAttr name;
+  NamedAttrList dummyList;
+  int64_t fieldId = 0;
+  StringRef visibility;
+  if (parser.parseLess() || parser.parseSymbolName(name, "name", dummyList) ||
+      parser.parseComma() || parser.parseInteger(fieldId) ||
+      parser.parseComma() ||
+      parser.parseOptionalKeyword(&visibility,
+                                  {"public", "private", "nested"}) ||
+      parser.parseGreater())
+    return Attribute();
+  StringAttr visibilityAttr = parser.getBuilder().getStringAttr(visibility);
+
+  return InnerSymPropertiesAttr::get(parser.getContext(), name, fieldId,
+                                     visibilityAttr);
+}
+
+void InnerSymPropertiesAttr::print(AsmPrinter &p) const {
+  p << "<@" << getName().getValue() << "," << getFieldID() << ","
+    << getSymVisibility().getValue() << ">";
+}
+
+StringAttr InnerSymAttr::getSymName() {
+  auto it  =
+      llvm::find_if(getProps(), [&](InnerSymPropertiesAttr p) {
+        return (p.getFieldID() == 0);
+      });
+  if (it != getProps().end())
+    return it->getName();
+  return {};
+}
+
+Attribute InnerSymAttr::parse(AsmParser &parser, Type type) {
   StringAttr sym;
   NamedAttrList dummyList;
-  if (p.parseSymbolName(sym, "dummy", dummyList))
+  SmallVector<InnerSymPropertiesAttr, 4> names;
+  if (!parser.parseOptionalSymbolName(sym, "dummy", dummyList))
+    names.push_back(InnerSymPropertiesAttr::get(sym));
+  else if (parser.parseCommaSeparatedList(
+               OpAsmParser::Delimiter::Square, [&]() -> ParseResult {
+                 InnerSymPropertiesAttr prop;
+                 if (parser.parseCustomAttributeWithFallback(
+                         prop, mlir::Type{}, "dummy", dummyList))
+                   return failure();
+
+                 names.push_back(prop);
+
+                 return success();
+               }))
     return Attribute();
-  return InnerSymAttr::get(p.getContext(), sym);
+
+  std::sort(names.begin(), names.end(),
+            [&](InnerSymPropertiesAttr a, InnerSymPropertiesAttr b) {
+              return a.getFieldID() < b.getFieldID();
+            });
+
+  return InnerSymAttr::get(parser.getContext(), names);
 }
 
 void InnerSymAttr::print(AsmPrinter &p) const {
-  //  A sample IR, print begins after `sym`.
-  //  %wire = firrtl.wire sym @wireSym<fieldID=1><sym_visibility="private"> :
 
-  p << "@" << getSymName().getValue();
+  if (auto sym = const_cast<InnerSymAttr *>(this)->getSymName()) {
+    p << "@" << sym.getValue();
+    if (getProps().size() == 1)
+      return;
+  }
+  auto names = getProps().vec();
+
+  std::sort(names.begin(), names.end(),
+            [&](InnerSymPropertiesAttr a, InnerSymPropertiesAttr b) {
+              return a.getFieldID() < b.getFieldID();
+            });
+  p << "[";
+  llvm::interleaveComma(names, p, [&](InnerSymPropertiesAttr attr) {
+    attr.print(p);
+    // p << "<@" << attr.getName().getValue() << "," << attr.getFieldID() << ","
+    //   << attr.getSymVisibility().getValue() << ">";
+  });
+  p << "]";
 }

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -113,10 +113,9 @@ void InnerSymPropertiesAttr::print(AsmPrinter &p) const {
 }
 
 StringAttr InnerSymAttr::getSymName() {
-  auto it  =
-      llvm::find_if(getProps(), [&](InnerSymPropertiesAttr p) {
-        return (p.getFieldID() == 0);
-      });
+  auto it = llvm::find_if(getProps(), [&](InnerSymPropertiesAttr p) {
+    return (p.getFieldID() == 0);
+  });
   if (it != getProps().end())
     return it->getName();
   return {};

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -196,5 +196,11 @@ firrtl.module @ProbeTest(in %in1 : !firrtl.uint<2>, in %in2 : !firrtl.uint<3>, o
 firrtl.module @InnerSymAttr() {
   %w = firrtl.wire sym [<@w,2,public>,<@x,1,private>,<@syh,4,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
   // CHECK: %w = firrtl.wire sym [<@x,1,private>, <@w,2,public>, <@syh,4,public>]
+  %w1 = firrtl.wire sym [<@w1,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  // CHECK: %w1 = firrtl.wire sym @w1
+  %w2 = firrtl.wire sym [<@w2,0,private>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  // CHECK: %w2 = firrtl.wire sym [<@w2,0,private>]
+  %w3 = firrtl.wire sym [<@w3,2,public>,<@x2,1,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  // CHECK: %w3 = firrtl.wire sym [<@syh2,0,public>, <@x2,1,private>, <@w3,2,public>]
 }
 }

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -192,4 +192,9 @@ firrtl.module @ProbeTest(in %in1 : !firrtl.uint<2>, in %in2 : !firrtl.uint<3>, o
   firrtl.probe @foobar, %in1, %in2, %out3, %w1, %w2, %someNode : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
 }
 
+// CHECK-LABEL: firrtl.module @InnerSymAttr
+firrtl.module @InnerSymAttr() {
+  %w = firrtl.wire sym [<@w,2,public>,<@x,1,private>,<@syh,4,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  // CHECK: %w = firrtl.wire sym [<@x,1,private>, <@w,2,public>, <@syh,4,public>]
+}
 }


### PR DESCRIPTION
This PR updates the `InnerSymAttr` to add per field inner symbols.
 `InnerSymAttr` defines the properties of the `inner_sym` attribute. It specifies the symbol
    name and symbol visibility for each field ID.
 For any ground types, there are no subfields and the field ID is 0. For aggregate types, a
    unique field ID is assigned to each field by visiting them in a depth-first pre-order.
 The custom assembly format ensures that there is no change for the default case.
If a symbol for any field other than `fieldID=0` is specified, then the format is like this:
`%w = firrtl.wire sym [<@w,2,public>,<@x,1,private>,<@syh,4,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>`
This also adds the capability to specify the visibility of each symbol.
Some followup work pending:
1. Implement verifier for the `InnerSymbol` trait.
2. Update the `InnerSymbolTable` to handle per field symbols.
3. Update all renaming logic for different passes to consider the symbols per field.

