### PR TITLE
[FIRRTL] Sink Constants into GCT Views XMRs

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1181,7 +1181,6 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         //   1. This is a constant that will be synced into the mappings file.
         //   2. This is something else and we need an XMR.
         // Handle case (1) here and exit.  Handle case (2) following.
-        auto uloc = builder.getUnknownLoc();
         auto driver = getDriverFromConnect(leafValue);
         if (driver) {
           if (auto constant =
@@ -1192,7 +1191,7 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
             constant.value().toStringUnsigned(valueStr, 16);
             path.append(valueStr);
             builder.create<sv::VerbatimOp>(
-                uloc,
+                constant.getLoc(),
                 StringAttr::get(&getContext(),
                                 "assign " + path.getString() + ";"),
                 ValueRange{}, ArrayAttr::get(&getContext(), path.getSymbols()));
@@ -1240,6 +1239,7 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         }
 
         // Add the leaf value to the path.
+        auto uloc = builder.getUnknownLoc();
         path += '.';
         if (auto blockArg = leafValue.dyn_cast<BlockArgument>()) {
           auto module = cast<FModuleOp>(blockArg.getOwner()->getParentOp());

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1227,6 +1227,60 @@ firrtl.circuit "ZeroWidth" attributes {annotations = [
 
 // -----
 
+firrtl.circuit "ZeroWidth" attributes {annotations = [
+  {
+    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    defName = "MyInterface",
+    elements = [
+      {
+        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        id = 1 : i64,
+        name = "ground"
+      }
+    ],
+    id = 0 : i64,
+    name = "MyView"
+  }
+]} {
+  firrtl.module private @MyView_companion() attributes {annotations = [
+    {
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+      id = 0 : i64,
+      name = "MyView",
+      type = "companion"
+    }
+  ]} {}
+  firrtl.module @ZeroWidth() attributes {annotations = [
+    {
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+      id = 0 : i64,
+      name = "MyView",
+      type = "parent"
+    }
+  ]} {
+    %w = firrtl.wire {annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        id = 1 : i64
+      }
+    ]} : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.strictconnect %w, %c1_ui1 : !firrtl.uint<1>
+    firrtl.instance MyView_companion @MyView_companion()
+  }
+}
+
+// Check that a constant is sunk into the interface mapping module and that no
+// symbol is created on the viewed component.
+//
+// CHECK-LABEL:         firrtl.circuit "ZeroWidth"
+// CHECK:                 firrtl.module @ZeroWidth()
+// CHECK-NEXT:            %w = firrtl.wire : !firrtl.uint<1>
+// CHECK:                 firrtl.module @MyView_mapping()
+// CHECK-NEXT{LITERAL}:     sv.verbatim "assign {{0}}.ground = 1'h1;
+
+// -----
+
 firrtl.circuit "YAMLOutputEmptyInterface" attributes {
   annotations = [
     {class = "sifive.enterprise.grandcentral.AugmentedBundleType",


### PR DESCRIPTION
Change Grand Central (GCT) Views pass to sink trivial constants into
sv::VerbatimOp XMRs inside the mappings module.  This has the benefit of
not needing to add a symbol to the viewed component if it is a constant
which enables this to be deleted and avoids lint warnings related to
unused wires/registers.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is reviving logic that used to exist in https://github.com/llvm/circt/pull/3154.