### PR TITLE
Implement left-streaming pack operator

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -209,3 +209,44 @@ def SampledOp : SVOp<"system.sampled", [SameOperandsAndResultType]> {
   let results = (outs AnyType:$sampledValue);
   let assemblyFormat = "$expression attr-dict `:` qualified(type($expression))";
 }
+
+// The operators LStreamUnpackOp, RStreamPackOp, RStreamUnpackOp could also be added
+// when the demand arises
+def LStreamPackOp: SVOp<"lstream_pack", [InferTypeOpInterface, NoSideEffect]> {
+  let summary = "The System Verilog stream expression using the left-stream operator";
+  let description = [{
+    The Left-Streaming Pack Operator corrstponds to the `{<<[n]{...}}` System Verilog
+    operator (See section 11.4.14 of the Verilog 2017 Standard for more).
+
+    This operator takes a variadic amount of inputs, streams them in chunks of size
+    `slice`, re-orders that stream going from right-to-left.
+
+    It is legal for the result width not to be an integer multiple of the size of the slice.
+    In that case, the last block has fewer bits than the slice.
+  }];
+
+  // This operation also accepts other 'streamable' types, i.e. structs, queues, 
+  // dynamically sized arrays, e.t.c. For now, only accept a subset of types
+  // where this operation is actually used for.
+  let arguments = (ins Variadic<HWIntegerType>:$inputs, I32Attr:$slice);
+  let results = (outs HWIntegerType:$result);
+
+  let assemblyFormat = "$inputs `slice` $slice attr-dict `:` qualified(type($inputs))";
+
+  let builders = [
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
+      return build($_builder, $_state, ValueRange{lhs, rhs});
+    }]>,
+    OpBuilder<(ins "Value":$hd, "ValueRange":$tl)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -30,7 +30,7 @@ public:
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
-            ConstantXOp, ConstantZOp, MacroRefExprOp,
+            ConstantXOp, ConstantZOp, MacroRefExprOp, LStreamPackOp,
             // Declarations.
             RegOp, WireOp, LogicOp, LocalParamOp, XMROp,
             // Control flow.
@@ -98,6 +98,7 @@ public:
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
   HANDLE(MacroRefExprOp, Unhandled);
+  HANDLE(LStreamPackOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1644,6 +1644,7 @@ private:
   SubExprInfo visitSV(MacroRefExprOp op);
   SubExprInfo visitSV(ConstantXOp op);
   SubExprInfo visitSV(ConstantZOp op);
+  SubExprInfo visitSV(LStreamPackOp op);
 
   // Noop cast operators.
   SubExprInfo visitSV(ReadInOutOp op) {
@@ -2109,6 +2110,17 @@ SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {
   os << op.getWidth() << "'bz";
+  return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(LStreamPackOp op) {
+  os << "{<<";
+  if (op.slice() != 1)
+    os << op.slice();
+  os << "{";
+  llvm::interleaveComma(op.inputs(), os,
+                         [&](Value v) { emitSubExpr(v, LowestPrecedence); });
+  os << "}}";
   return {Unary, IsUnsigned};
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -29,8 +29,8 @@ using namespace sv;
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
   return isa<VerbatimExprOp, VerbatimExprSEOp, GetModportOp,
-             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp>(
-      op);
+             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp, 
+             LStreamPackOp>(op);
 }
 
 LogicalResult sv::verifyInProceduralRegion(Operation *op) {
@@ -1741,6 +1741,20 @@ LogicalResult GenerateCaseOp::verify() {
 
   // mlir::FailureOr<Type> condType = evaluateParametricType();
 
+  return success();
+}
+
+LogicalResult LStreamPackOp::inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results) {
+  unsigned resultWidth = 0;
+  for (auto input : operands) {
+    resultWidth += input.getType().cast<IntegerType>().getWidth();
+  }
+  results.push_back(IntegerType::get(context, resultWidth));
   return success();
 }
 

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -23,11 +23,13 @@ hw.module @no_ports() {
 // CHECK-NEXT:    output [15:0] out16,
 // CHECK-NEXT:                  out16s,
 // CHECK-NEXT:    output [16:0] sext17,
-// CHECK-NEXT:    output [1:0]  orvout);
+// CHECK-NEXT:    output [1:0]  orvout,
+// CHECK-NEXT:    output [7:0]  streamout_1,
+// CHECK-NEXT:                  streamout_2);
 
 hw.module @Expressions(%in4: i4, %clock: i1) ->
   (out1a: i1, out1b: i1, out1c: i1,
-   out4: i4, out4s: i4, out16: i16, out16s: i16, sext17: i17, orvout: i2) {
+   out4: i4, out4s: i4, out16: i16, out16s: i16, sext17: i17, orvout: i2, streamout_1: i8, streamout_2: i8) {
   %c1_i4 = hw.constant 1 : i4
   %c2_i4 = hw.constant 2 : i4
   %c3_i4 = hw.constant 3 : i4
@@ -129,7 +131,13 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   %orpre2 = comb.extract %in4 from 2 : (i4) -> i2
   %orpre3 = comb.extract %in4 from 1 : (i4) -> i2
   %orv = comb.or %orpre1, %orpre2, %orpre3 {sv.namehint = "hintyhint"}: i2
-  hw.output %0, %1, %2, %w1_use, %11, %w2_use, %w3_use, %35, %orv : i1, i1, i1, i4, i4, i16, i16, i17, i2
+
+  // CHECK: assign streamout_1 = {<<{4'h1, in4}};
+  // CHECK: assign streamout_2 = {<<4{4'h1, in4}};
+  %stream0 = sv.lstream_pack %c1_i4, %in4 slice 1 : i4, i4
+  %stream1 = sv.lstream_pack %c1_i4, %in4 slice 4 : i4, i4
+
+  hw.output %0, %1, %2, %w1_use, %11, %w2_use, %w3_use, %35, %orv, %stream0, %stream1 : i1, i1, i1, i4, i4, i16, i16, i17, i2, i8, i8
 }
 
 // CHECK-LABEL: module Precedence(


### PR DESCRIPTION
This PR is related to #3441. I want to discuss a potential implementation of a System Verilog Streaming operation.

Rationale
====

The SV streaming operator comes in two different flavors:
- The right-streaming operator `>>`
- The left-streaming operator `<<`

These streaming operators are exclusively used to form a Streaming Concatenation that has the following syntax (SV 2017 sec. 11.4.14):
```
streaming_concatenation ::= `{` stream_operator [ slice_size ] stream_concatenation `}`
``` 

When there are only non-dynamic elements within the `stream_concatenation`, the `stream_concatenation` is a simple list of expressions surrounded by curly braces. Therefore, I have chosen to implement an `sv.lstream` operator that expands to the following SV syntax
```
sv.lstream(slice_size, args...) -> {<<[slice_size]{ [args] }}
```

According to the specification, a streaming concatenation can be used as the right-hand side of an expression (called 'pack') or the left-hand side of an expression (called 'unpack'). Since at the moment only the pack operator is relevant, I have opted to implement only this and called the whole thing `sv.lstream_pack`. Future implementations could implement the operators `sv.rstream_pack`, `sv.lstream_unpack` and `sv.rstream_unpack` to enable the various use-cases of the streaming operators
