### PR TITLE
[FSM] Make state names SymbolNameAttrs

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -149,7 +149,7 @@ def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol, NoTerminator]> {
     contains all the transitions of this state.
   }];
 
-  let arguments = (ins StrAttr:$sym_name);
+  let arguments = (ins SymbolNameAttr:$sym_name);
   let regions = (region SizedRegion<1>:$output, SizedRegion<1>:$transitions);
 
   let hasCanonicalizeMethod = true;

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -2,7 +2,7 @@
 
 // CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
 // CHECK:   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
-// CHECK:   fsm.state "IDLE" output  {
+// CHECK:   fsm.state @IDLE output  {
 // CHECK:     %true = arith.constant true
 // CHECK:     fsm.output %true : i1
 // CHECK:   } transitions  {
@@ -13,7 +13,7 @@
 // CHECK:       fsm.update %cnt, %c256_i16 : i16
 // CHECK:     }
 // CHECK:   }
-// CHECK:   fsm.state "BUSY" output  {
+// CHECK:   fsm.state @BUSY output  {
 // CHECK:     %false = arith.constant false
 // CHECK:     fsm.output %false : i1
 // CHECK:   } transitions  {
@@ -50,7 +50,7 @@
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
-  fsm.state "IDLE" output  {
+  fsm.state @IDLE output  {
     %true = arith.constant true
     fsm.output %true : i1
   } transitions  {
@@ -63,7 +63,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
     }
   }
 
-  fsm.state "BUSY" output  {
+  fsm.state @BUSY output  {
     %false = arith.constant false
     fsm.output %false : i1
   } transitions  {
@@ -110,17 +110,17 @@ func.func @qux() {
 
 // CHECK:   fsm.machine @foo(%[[VAL_0:.*]]: i1) -> i1 attributes {initialState = "A"} {
 // CHECK:           %[[VAL_1:.*]] = fsm.variable "cnt" {initValue = 0 : i16} : i16
-// CHECK:           fsm.state "A" output {
+// CHECK:           fsm.state @A output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
 // CHECK:           } transitions {
 // CHECK:             fsm.transition @A
 // CHECK:           }
-// CHECK:           fsm.state "B" output {
+// CHECK:           fsm.state @B output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
 // CHECK:           } transitions {
 // CHECK:             fsm.transition @B
 // CHECK:           }
-// CHECK:           fsm.state "C" output {
+// CHECK:           fsm.state @C output {
 // CHECK:             fsm.output %[[VAL_0]] : i1
 // CHECK:           } transitions {
 // CHECK:             fsm.transition @C
@@ -129,20 +129,20 @@ func.func @qux() {
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "A"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
-  fsm.state "A" output  {
+  fsm.state @A output  {
     fsm.output %arg0 : i1
   } transitions {
     fsm.transition @A action  {
     }
   }
 
-  fsm.state "B" output  {
+  fsm.state @B output  {
     fsm.output %arg0 : i1
   } transitions {
     fsm.transition @B guard {}
   }
 
-  fsm.state "C" output  {
+  fsm.state @C output  {
     fsm.output %arg0 : i1
   } transitions {
     fsm.transition @C

--- a/test/Dialect/FSM/errors.mlir
+++ b/test/Dialect/FSM/errors.mlir
@@ -10,7 +10,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {}
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
-  fsm.state "IDLE" output  {
+  fsm.state @IDLE output  {
     %true = arith.constant true
 // expected-error @+1 {{'fsm.output' op operand types must match the machine output types}}
     fsm.output %true, %true : i1, i1
@@ -25,7 +25,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
   // expected-error @+1 {{'fsm.state' op output block must have a single OutputOp terminator}}
-  fsm.state "IDLE" output  {
+  fsm.state @IDLE output  {
     %true = arith.constant true
   } transitions {
     fsm.transition @IDLE
@@ -38,7 +38,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
-  fsm.state "IDLE" output  {
+  fsm.state @IDLE output  {
     %true = arith.constant true
     fsm.output %true : i1
   } transitions {
@@ -54,7 +54,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
 fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
-  fsm.state "IDLE" output  {
+  fsm.state @IDLE output  {
     %true = arith.constant true
     fsm.output %true : i1
   } transitions {

--- a/test/Dialect/FSM/print-graph.mlir
+++ b/test/Dialect/FSM/print-graph.mlir
@@ -15,7 +15,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
   %c256_i16 = arith.constant 256 : i16
   %true = arith.constant true
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
-  fsm.state "IDLE" output {
+  fsm.state @IDLE output {
     fsm.output %true : i1
   } transitions {
     fsm.transition @BUSY guard {
@@ -24,7 +24,7 @@ fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE"} {
       fsm.update %cnt, %c256_i16 : i16
     }
   }
-  fsm.state "BUSY" output {
+  fsm.state @BUSY output {
     fsm.output %false : i1
   } transitions {
     fsm.transition @BUSY guard {


### PR DESCRIPTION
States are now described as a symbol (using @) instead of the previously used string notation.