### PR TITLE
[FIRRTL] Sink Constants in GCT Taps

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -1042,6 +1042,15 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
         wiring.prefices =
             instancePaths.getAbsolutePaths(op->getParentOfType<FModuleOp>());
       wiring.target = PortWiring::Target(op);
+
+      // If the tapped operation is trivially driven by a constant, set
+      // information about the literal so that this can later be used instead of
+      // an XMR.
+      if (auto driver = getDriverFromConnect(op->getResult(0)))
+        if (auto constant =
+                dyn_cast_or_null<ConstantOp>(driver.getDefiningOp()))
+          wiring.literal = {constant.valueAttr(), constant.getType()};
+
       portWiring.push_back(std::move(wiring));
       return;
     }

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -437,3 +437,25 @@ circuit Top : %[[
     ; CHECK:      assign _3 = Top.dut.submodule.port_Submodule
     ; CHECK-NEXT: assign _4 = Top.dut.port_DUT
     ; CHECK-NEXT: assign _5 = Top.port_Top
+
+; // -----
+
+circuit ConstantSinking : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox": "~ConstantSinking|DataTap",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~ConstantSinking|ConstantSinking>w",
+        "portName": "~ConstantSinking|DataTap>a"
+      }
+    ]
+  }
+]]
+  extmodule DataTap :
+    output a : UInt<1>
+
+  module ConstantSinking:
+    inst dataTap of DataTap
+    node w = UInt<1>(1)


### PR DESCRIPTION
Change Grand Central (GCT) Data/Mem Taps pass to use constants for data
taps when trivially obvious.  This has the result of _not_ emitting an
XMR when a wire is trivially driven by a constant.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>