### PR TITLE
[SV] Add support for `sv.case` with `hw.enum`

### DIFF
--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -33,7 +33,9 @@ public:
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
                        // Cast operation
-                       BitcastOp, ParamValueOp>([&](auto expr) -> ResultType {
+                       BitcastOp, ParamValueOp,
+                       // Enum operations
+                       EnumConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitTypeOp(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -69,6 +71,7 @@ public:
   HANDLE(ArrayGetOp, Unhandled);
   HANDLE(ArrayCreateOp, Unhandled);
   HANDLE(ArrayConcatOp, Unhandled);
+  HANDLE(EnumConstantOp, Unhandled);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -53,6 +53,12 @@ public:
   virtual ~CasePattern() {}
   CasePatternKind getKind() const { return kind; }
 
+  /// Return true if this pattern has an X.
+  virtual bool hasX() const { return false; }
+
+  /// Return true if this pattern has an Z.
+  virtual bool hasZ() const { return false; }
+
   virtual Attribute attr() const = 0;
 
 private:
@@ -88,11 +94,8 @@ public:
   /// Return the specified bit, bit 0 is the least significant bit.
   CasePatternBit getBit(size_t bitNumber) const;
 
-  /// Return true if this pattern has an X.
-  bool hasX() const;
-
-  /// Return true if this pattern has an Z.
-  bool hasZ() const;
+  bool hasX() const override;
+  bool hasZ() const override;
 
   Attribute attr() const override { return intAttr; }
 

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_SV_OPS_H
 #define CIRCT_DIALECT_SV_OPS_H
 
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVTypes.h"
@@ -44,19 +45,48 @@ enum class CasePatternBit { Zero = 0, One = 1, AnyX = 2, AnyZ = 3 };
 char getLetter(CasePatternBit bit);
 
 // This is provides convenient access to encode and decode a pattern.
-struct CasePattern {
-  IntegerAttr attr;
+class CasePattern {
 
-  struct DefaultPatternTag {};
+public:
+  enum CasePatternKind { CPK_bit, CPK_enum, CPK_default };
+  CasePattern(CasePatternKind kind) : kind(kind) {}
+  virtual ~CasePattern() {}
+  CasePatternKind getKind() const { return kind; }
 
+  virtual Attribute attr() const = 0;
+
+private:
+  const CasePatternKind kind;
+};
+
+class CaseDefaultPattern : public CasePattern {
+public:
+  using AttrType = mlir::UnitAttr;
+  CaseDefaultPattern(MLIRContext *ctx)
+      : CasePattern(CasePatternKind::CPK_default) {
+    unitAttr = AttrType::get(ctx);
+  }
+
+  Attribute attr() const override { return unitAttr; }
+
+  static bool classof(const CasePattern *S) {
+    return S->getKind() == CPK_default;
+  }
+
+private:
+  // The default pattern is recognized by a UnitAttr. This is needed since we
+  // need to be able to determine the pattern type of a case based on an
+  // attribute attached to the sv.case op.
+  UnitAttr unitAttr;
+};
+
+class CaseBitPattern : public CasePattern {
+public:
   // Return the number of bits in the pattern.
-  size_t getWidth() const { return attr.getValue().getBitWidth() / 2; }
+  size_t getWidth() const { return intAttr.getValue().getBitWidth() / 2; }
 
   /// Return the specified bit, bit 0 is the least significant bit.
   CasePatternBit getBit(size_t bitNumber) const;
-
-  /// Return true if this pattern always matches.
-  bool isDefault() const;
 
   /// Return true if this pattern has an X.
   bool hasX() const;
@@ -64,24 +94,45 @@ struct CasePattern {
   /// Return true if this pattern has an Z.
   bool hasZ() const;
 
+  Attribute attr() const override { return intAttr; }
+
   /// Get a CasePattern from a specified list of CasePatternBit.  Bits are
   /// specified in most least significant order - element zero is the least
   /// significant bit.
-  CasePattern(ArrayRef<CasePatternBit> bits, MLIRContext *context);
+  CaseBitPattern(ArrayRef<CasePatternBit> bits, MLIRContext *context);
 
   /// Get a CasePattern for the specified constant value.
-  CasePattern(const APInt &value, MLIRContext *context);
+  CaseBitPattern(const APInt &value, MLIRContext *context);
 
   /// Get a CasePattern with a correctly encoded attribute.
-  CasePattern(IntegerAttr attr) : attr(attr) {}
+  CaseBitPattern(IntegerAttr attr) : CasePattern(CPK_bit), intAttr(attr) {}
 
-  /// Get a CasePattern of a default for the specified width.
-  CasePattern(size_t width, DefaultPatternTag, MLIRContext *context);
+  static bool classof(const CasePattern *S) { return S->getKind() == CPK_bit; }
+
+private:
+  IntegerAttr intAttr;
+};
+
+class CaseEnumPattern : public CasePattern {
+public:
+  // Get a CasePattern for the specified enum value attribute.
+  CaseEnumPattern(hw::EnumFieldAttr attr)
+      : CasePattern(CPK_enum), enumAttr(attr) {}
+
+  // Return the named value of this enumeration.
+  StringRef getFieldValue() const;
+
+  Attribute attr() const override { return enumAttr; }
+
+  static bool classof(const CasePattern *S) { return S->getKind() == CPK_enum; }
+
+private:
+  hw::EnumFieldAttr enumAttr;
 };
 
 // This provides information about one case.
 struct CaseInfo {
-  CasePattern pattern;
+  std::unique_ptr<CasePattern> pattern;
   Block *block;
 };
 

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -352,10 +352,10 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let regions = (region VariadicRegion<SizedRegion<1>>:$caseRegions);
   let arguments = (ins DefaultValuedAttr<CaseStmtTypeAttr,
                                          "CaseStmtType::CaseStmt">:$caseStyle,
-                       HWIntegerType:$cond, ArrayAttr:$casePatterns,
+                       AnyType:$cond, ArrayAttr:$casePatterns,
                        DefaultValuedAttr<ValidationQualifierTypeAttr,
                        "ValidationQualifierTypeEnum::ValidationQualifierPlain">:
-                       $validationQualifier);
+                      $validationQualifier);
   let results = (outs);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
@@ -367,9 +367,9 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
     OpBuilder<(ins "CaseStmtType":$caseStyle,
                    "ValidationQualifierTypeEnum":$validationQualifier,
                    "Value":$cond, "size_t":$numCases,
-                   "std::function<CasePattern(size_t)>":$caseCtor)>,
+                   "std::function<std::unique_ptr<CasePattern>(size_t)>":$caseCtor)>,
     OpBuilder<(ins "CaseStmtType":$caseStyle, "Value":$cond, "size_t":$numCases,
-               "std::function<CasePattern(size_t)>":$caseCtor), [{
+               "std::function<std::unique_ptr<CasePattern>(size_t)>":$caseCtor), [{
       build($_builder, $_state, caseStyle,
             ValidationQualifierTypeEnum::ValidationQualifierPlain, cond,  numCases,
             caseCtor);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -233,7 +233,7 @@ bool ExportVerilog::isVerilogExpression(Operation *op) {
   // These are SV dialect expressions.
   if (isa<ReadInOutOp, ArrayIndexInOutOp, IndexedPartSelectInOutOp,
           StructFieldInOutOp, IndexedPartSelectOp, ParamValueOp, XMROp,
-          SampledOp>(op))
+          SampledOp, EnumConstantOp>(op))
     return true;
 
   // All HW combinational logic ops and SV expression ops are Verilog
@@ -282,7 +282,7 @@ static void getTypeDims(SmallVectorImpl<Attribute> &dims, Type type,
     return getTypeDims(dims, inout.getElementType(), loc);
   if (auto uarray = hw::type_dyn_cast<hw::UnpackedArrayType>(type))
     return getTypeDims(dims, uarray.getElementType(), loc);
-  if (hw::type_isa<InterfaceType, StructType>(type))
+  if (hw::type_isa<InterfaceType, StructType, EnumType>(type))
     return;
 
   mlir::emitError(loc, "value has an unsupported verilog type ") << type;
@@ -352,6 +352,8 @@ static StringRef getVerilogDeclWord(Operation *op,
     auto elementType =
         op->getResult(0).getType().cast<InOutType>().getElementType();
     if (elementType.isa<StructType>())
+      return "";
+    if (elementType.isa<EnumType>())
       return "";
     if (auto innerType = elementType.dyn_cast<ArrayType>()) {
       while (innerType.getElementType().isa<ArrayType>())
@@ -1251,6 +1253,15 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
                                    implicitIntType, singleBitDefaultType,
                                    emitter);
       })
+      .Case<EnumType>([&](EnumType enumType) {
+        os << "enum {";
+        llvm::interleaveComma(enumType.getFields(), os,
+                              [&](Attribute enumerator) {
+                                os << enumerator.cast<StringAttr>().getValue();
+                              });
+        os << "}";
+        return true;
+      })
       .Case<StructType>([&](StructType structType) {
         if (structType.getElements().empty()) {
           if (!implicitIntType)
@@ -1669,6 +1680,7 @@ private:
   SubExprInfo visitTypeOp(StructCreateOp op);
   SubExprInfo visitTypeOp(StructExtractOp op);
   SubExprInfo visitTypeOp(StructInjectOp op);
+  SubExprInfo visitTypeOp(EnumConstantOp op);
 
   // Comb Dialect Operations
   using CombinationalVisitor::visitComb;
@@ -2282,6 +2294,11 @@ SubExprInfo ExprEmitter::visitTypeOp(StructInjectOp op) {
         }
       });
   os << '}';
+  return {Selection, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitTypeOp(EnumConstantOp op) {
+  os << op.field().getField().getValue();
   return {Selection, IsUnsigned};
 }
 
@@ -3412,18 +3429,22 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
   emitLocationInfoAndNewLine(ops);
 
   addIndent();
-  for (auto caseInfo : op.getCases()) {
-    auto pattern = caseInfo.pattern;
+  for (auto &caseInfo : op.getCases()) {
+    auto &pattern = caseInfo.pattern;
 
-    if (pattern.isDefault())
-      indent() << "default";
-    else {
-      // TODO: We could emit in hex if/when the size is a multiple of 4 and
-      // there are no x's crossing nibble boundaries.
-      indent() << pattern.getWidth() << "'b";
-      for (size_t bit = 0, e = pattern.getWidth(); bit != e; ++bit)
-        os << getLetter(pattern.getBit(e - bit - 1));
-    }
+    llvm::TypeSwitch<CasePattern *>(pattern.get())
+        .Case<CaseBitPattern>([&](auto bitPattern) {
+          // TODO: We could emit in hex if/when the size is a multiple of 4 and
+          // there are no x's crossing nibble boundaries.
+          indent() << bitPattern->getWidth() << "'b";
+          for (size_t bit = 0, e = bitPattern->getWidth(); bit != e; ++bit)
+            os << getLetter(bitPattern->getBit(e - bit - 1));
+        })
+        .Case<CaseEnumPattern>(
+            [&](auto enumPattern) { indent() << enumPattern->getFieldValue(); })
+        .Case<CaseDefaultPattern>([&](auto) { indent() << "default"; })
+        .Default([&](auto) { llvm_unreachable("unhandled case pattern"); });
+
     os << ":";
     emitBlockAsStatement(caseInfo.block, emptyOps);
   }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3443,7 +3443,7 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
         .Case<CaseEnumPattern>(
             [&](auto enumPattern) { indent() << enumPattern->getFieldValue(); })
         .Case<CaseDefaultPattern>([&](auto) { indent() << "default"; })
-        .Default([&](auto) { llvm_unreachable("unhandled case pattern"); });
+        .Default([&](auto) { assert(false && "unhandled case pattern"); });
 
     os << ":";
     emitBlockAsStatement(caseInfo.block, emptyOps);

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1718,7 +1718,7 @@ void ArrayConcatOp::build(OpBuilder &b, OperationState &state,
 //===----------------------------------------------------------------------===//
 
 ParseResult EnumConstantOp::parse(OpAsmParser &parser, OperationState &result) {
-  hw::EnumType type;
+  Type type;
   StringRef field;
 
   auto loc = parser.getEncodedSourceLoc(parser.getCurrentLocation());

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1718,6 +1718,9 @@ void ArrayConcatOp::build(OpBuilder &b, OperationState &state,
 //===----------------------------------------------------------------------===//
 
 ParseResult EnumConstantOp::parse(OpAsmParser &parser, OperationState &result) {
+  // Parse a Type instead of an EnumType since the type might be a type alias.
+  // The validity of the canonical type is checked during construction of the
+  // EnumFieldAttr.
   Type type;
   StringRef field;
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -982,17 +982,17 @@ void OrderedOutputOp::build(OpBuilder &builder, OperationState &result,
 
 LogicalResult BPAssignOp::verify() {
   if (isa<sv::WireOp>(dest().getDefiningOp()))
-    return emitOpError("Verilog disallows procedural assignment to a net "
-                       "type (did you intend "
-                       "to use a variable type, e.g., sv.reg?)");
+    return emitOpError(
+        "Verilog disallows procedural assignment to a net type (did you intend "
+        "to use a variable type, e.g., sv.reg?)");
   return success();
 }
 
 LogicalResult PAssignOp::verify() {
   if (isa<sv::WireOp>(dest().getDefiningOp()))
-    return emitOpError("Verilog disallows procedural assignment to a net "
-                       "type (did you intend "
-                       "to use a variable type, e.g., sv.reg?)");
+    return emitOpError(
+        "Verilog disallows procedural assignment to a net type (did you intend "
+        "to use a variable type, e.g., sv.reg?)");
   return success();
 }
 
@@ -1264,8 +1264,8 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 
     // Otherwise must be an assign, and we must not have seen a write yet.
     auto assign = dyn_cast<sv::AssignOp>(user);
-    // Either the wire has more than one write or another kind of Op (other
-    // than AssignOp and ReadInOutOp), then can't optimize.
+    // Either the wire has more than one write or another kind of Op (other than
+    // AssignOp and ReadInOutOp), then can't optimize.
     if (!assign || write)
       return failure();
 
@@ -1455,8 +1455,8 @@ LogicalResult AliasOp::verify() {
 //===----------------------------------------------------------------------===//
 
 // reg s <= cond ? val : s simplification.
-// Don't assign a register's value to itself, conditionally assign the new
-// value instead.
+// Don't assign a register's value to itself, conditionally assign the new value
+// instead.
 LogicalResult PAssignOp::canonicalize(PAssignOp op, PatternRewriter &rewriter) {
   auto mux = op.src().getDefiningOp<comb::MuxOp>();
   if (!mux)
@@ -1714,8 +1714,8 @@ void AssumeConcurrentOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 void CoverConcurrentOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                     MLIRContext *context) {
-  results.add(canonicalizeConcurrentVerifOp<CoverConcurrentOp,
-                                            /* EraseIfZero */ true>);
+  results.add(
+      canonicalizeConcurrentVerifOp<CoverConcurrentOp, /* EraseIfZero */ true>);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
@@ -90,21 +90,21 @@ Operation *HWLegalizeModulesPass::tryLoweringArrayGet(hw::ArrayGetOp getOp) {
   APInt caseValue(index.getType().getIntOrFloatBitWidth(), 0);
   auto *context = builder.getContext();
 
-  using sv::CasePattern;
-
   // Create the casez itself.
   builder.create<sv::CaseOp>(
       createOp.getLoc(), CaseStmtType::CaseZStmt, index, caseValues.size(),
-      [&](size_t caseIdx) -> CasePattern {
+      [&](size_t caseIdx) -> std::unique_ptr<sv::CasePattern> {
         // Use a default pattern for the last value, even if we are complete.
         // This avoids tools thinking they need to insert a latch due to
         // potentially incomplete case coverage.
         bool isDefault = caseIdx == caseValues.size() - 1;
         Value theValue = caseValues[caseIdx];
-        sv::CasePattern thePattern =
-            isDefault ? CasePattern(caseValue.getBitWidth(),
-                                    CasePattern::DefaultPatternTag(), context)
-                      : CasePattern(caseValue, context);
+        std::unique_ptr<sv::CasePattern> thePattern;
+
+        if (isDefault)
+          thePattern = std::make_unique<sv::CaseDefaultPattern>(context);
+        else
+          thePattern = std::make_unique<sv::CaseBitPattern>(caseValue, context);
         ++caseValue;
         builder.create<sv::BPAssignOp>(createOp.getLoc(), theWire, theValue);
         return thePattern;

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -17,6 +17,8 @@ hw.type_scope @__hw_typedecls {
   hw.typedecl @qux, "customName" : i32
   // CHECK: typedef struct packed {foo a; _other_scope_foo b; } nestedRef;
   hw.typedecl @nestedRef : !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo,i1>, b: !hw.typealias<@_other_scope::@foo,i2>>
+  // CHECK: typedef enum {A, B, C} myEnum;
+  hw.typedecl @myEnum : !hw.enum<A, B, C>
 }
 
 hw.type_scope @_other_scope {
@@ -45,7 +47,9 @@ hw.module @testTypeAlias(
   // CHECK: input  arr      arrArg,
   %arrArg: !hw.typealias<@__hw_typedecls::@arr,!hw.array<16xi8>>,
   // CHECK: input  bar      structArg,
-  %structArg: !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>) ->
+  %structArg: !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>,
+  // CHECK: input  myEnum   enumArg,
+  %enumArg: !hw.typealias<@__hw_typedecls::@myEnum,!hw.enum<A, B, C>>) ->
   // CHECK: output foo      out
   (out: !hw.typealias<@__hw_typedecls::@foo, i1>) {
   // CHECK: out = arg0 + arg1
@@ -87,4 +91,11 @@ hw.module @testAggregateInout(%i: i1) -> (out1: i8, out2: i1) {
   %2 = sv.read_inout %0 : !hw.inout<i8>
   %3 = sv.read_inout %1 : !hw.inout<i1>
   hw.output %2, %3 : i8, i1
+}
+
+// CHECK-LABEL: module testEnumOps
+hw.module @testEnumOps() -> (out1: !hw.typealias<@__hw_typedecls::@myEnum,!hw.enum<A, B, C>>) {
+  // CHECK: assign out1 = A;
+  %0 = hw.enum.constant A : !hw.typealias<@__hw_typedecls::@myEnum,!hw.enum<A, B, C>>
+  hw.output %0 : !hw.typealias<@__hw_typedecls::@myEnum,!hw.enum<A, B, C>>
 }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1001,7 +1001,7 @@ hw.module @AnFSM(%clock : i1) {
   sv.always posedge %clock {
     sv.case case %reg_read : !hw.enum<A, B, C>
       case A : { sv.passign %reg, %B : !hw.enum<A, B, C> }
-      case B : { sv.passign %reg, %C : !hw.enum<A, B, C> }
+       case B : { sv.passign %reg, %C : !hw.enum<A, B, C> }
       default : { sv.passign %reg, %A : !hw.enum<A, B, C> }
   }
 }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -976,6 +976,36 @@ hw.module @ConstantDefBeforeUse() {
   }
 }
 
+
+// CHECK-LABEL: module AnFSM
+// CHECK:   enum {A, B, C} reg_0;
+// CHECK:   always @(posedge clock) begin
+// CHECK:     case (reg_0)
+// CHECK:       A:
+// CHECK:         reg_0 <= B;
+// CHECK:       B:
+// CHECK:         reg_0 <= C;
+// CHECK:       default:
+// CHECK:         reg_0 <= A;
+// CHECK:     endcase
+// CHECK:   end
+
+hw.module @AnFSM(%clock : i1) {
+  %reg = sv.reg : !hw.inout<!hw.enum<A, B, C>>
+  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B, C>>
+  
+  %A = hw.enum.constant A : !hw.enum<A, B, C>
+  %B = hw.enum.constant B : !hw.enum<A, B, C>
+  %C = hw.enum.constant C : !hw.enum<A, B, C>
+
+  sv.always posedge %clock {
+    sv.case case %reg_read : !hw.enum<A, B, C>
+      case A : { sv.passign %reg, %B : !hw.enum<A, B, C> }
+      case B : { sv.passign %reg, %C : !hw.enum<A, B, C> }
+      default : { sv.passign %reg, %A : !hw.enum<A, B, C> }
+  }
+}
+
 // Constants defined after use in non-procedural regions should be moved to the
 // top of the block.
 // CHECK-LABEL: module ConstantDefAfterUse

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -218,3 +218,14 @@ hw.module @ZeroWidthConstantZ() {
   // expected-error @+1 {{unsupported type}}
   %0 = sv.constantZ : !hw.struct<>
 }
+
+// -----
+
+hw.module @CaseEnum() {
+  %0 = hw.enum.constant A : !hw.enum<A, B, C>
+  // expected-error @+1 {{custom op 'sv.case' case value 'D' is not a member of enum type '!hw.enum<A, B, C>'}}
+  sv.case %0 : !hw.enum<A, B, C>
+    case D: {
+      sv.fwrite %fd, "x"
+    }
+}


### PR DESCRIPTION
This commit adds support in `sv.case` for switching on enum values. In doing so, a fair bit of refactoring is done to `CasePattern`s to more cleanly handle the different cases of bit, enum, and default patterns.

Since `hw.enum` doesn't yet include any notion of value encoding, the `sv.case` operation exclusively works on either an enum or bit pattern.
Furthermore, only a single case value can be compared in a case statement (as opposed to `case A, B : ...`). I think this is a good starting point - if support is needed in the future, it will not be complicated to add.

```mlir
hw.module @AnFSM(%clock : i1) {
  %reg = sv.reg : !hw.inout<!hw.enum<A, B, C>>
  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B, C>>

  %A = hw.enum.constant A : !hw.enum<A, B, C>
  %B = hw.enum.constant B : !hw.enum<A, B, C>
  %C = hw.enum.constant C : !hw.enum<A, B, C>

  sv.always posedge %clock {
    sv.case case %reg_read : !hw.enum<A, B, C>
      case A : { sv.passign %reg, %B : !hw.enum<A, B, C> }
      case B : { sv.passign %reg, %C : !hw.enum<A, B, C> }
      default : { sv.passign %reg, %A : !hw.enum<A, B, C> }
  }
}
```

emits
```systemverilog
module AnFSM
    enum {A, B, C} reg_0;
    always @(posedge clock) begin
    case (reg_0)
        A:
        reg_0 <= B;
        B:
        reg_0 <= C;
        default:
        reg_0 <= A;
    endcase
```