### PR TITLE
[FIRRTL] Add InnerSymAttr verifier

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -238,7 +238,12 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
     }]>
   ];
   let extraClassDeclaration = [{
+    /// Get the inner sym name for fieldID=0, if it exists.
     StringAttr getSymName();
+    /// Check if all the elements of props satisfy the predicate lambda.
+    bool all_of_props(std::function<bool (InnerSymPropertiesAttr)>) ;
+    /// Get the number of inner symbols defined.
+    size_t numSymbols() ;
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -238,6 +238,8 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
     }]>
   ];
   let extraClassDeclaration = [{
+    /// Get the inner sym name for fieldID, if it exists.
+    StringAttr getSymIfExists(unsigned fieldID);
     /// Get the inner sym name for fieldID=0, if it exists.
     StringAttr getSymName();
     /// Check if all the elements of props satisfy the predicate lambda.

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -66,8 +66,9 @@ struct PortInfo {
 /// Verification hook for verifying module like operations.
 LogicalResult verifyModuleLikeOpInterface(FModuleLike module);
 
+class InnerSymbolOpInterface;
 /// Verification hook for verifying InnerSym Attribute.
-LogicalResult verifyInnerSymAttr(Operation *op);
+LogicalResult verifyInnerSymAttr(InnerSymbolOpInterface op);
 
 namespace detail {
 LogicalResult verifyInnerRefs(Operation *op);

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -66,6 +66,9 @@ struct PortInfo {
 /// Verification hook for verifying module like operations.
 LogicalResult verifyModuleLikeOpInterface(FModuleLike module);
 
+/// Verification hook for verifying InnerSym Attribute.
+LogicalResult verifyInnerSymAttr(Operation *op);
+
 namespace detail {
 LogicalResult verifyInnerRefs(Operation *op);
 } // namespace detail

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -346,9 +346,18 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             InnerSymbolTable::getInnerSymbol(op));
       }]
     >,
-
+    InterfaceMethod<"Returns the InnerSymAttr.",
+      "InnerSymAttr", "getInnerSymAttr", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return this->getOperation()->template getAttrOfType<InnerSymAttr>(
+              circt::firrtl::InnerSymbolTable::getInnerSymbolAttrName());
+      }]
+    >,
   ];
 
+  let verify = [{
+    return verifyInnerSymAttr(op);
+  }];
 }
 
 def InnerSymbolTable : NativeOpTrait<"InnerSymbolTable">;

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -121,6 +121,13 @@ StringAttr InnerSymAttr::getSymName() {
   return {};
 }
 
+bool InnerSymAttr::all_of_props(
+    std::function<bool(InnerSymPropertiesAttr)> func) {
+  return llvm::all_of(getImpl()->props, func);
+}
+
+size_t InnerSymAttr::numSymbols() { return getImpl()->props.size(); }
+
 Attribute InnerSymAttr::parse(AsmParser &parser, Type type) {
   StringAttr sym;
   NamedAttrList dummyList;

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -112,14 +112,17 @@ void InnerSymPropertiesAttr::print(AsmPrinter &p) const {
     << getSymVisibility().getValue() << ">";
 }
 
-StringAttr InnerSymAttr::getSymName() {
-  auto it = llvm::find_if(getProps(), [&](InnerSymPropertiesAttr p) {
-    return (p.getFieldID() == 0);
-  });
+StringAttr InnerSymAttr::getSymIfExists(unsigned fieldId) {
+  auto it =
+      llvm::find_if(getImpl()->props, [&](const InnerSymPropertiesAttr &p) {
+        return p.getFieldID() == fieldId;
+      });
   if (it != getProps().end())
     return it->getName();
   return {};
 }
+
+StringAttr InnerSymAttr::getSymName() { return getSymIfExists(0); }
 
 bool InnerSymAttr::all_of_props(
     std::function<bool(InnerSymPropertiesAttr)> func) {

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -112,12 +112,8 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   return success();
 }
 
-LogicalResult circt::firrtl::verifyInnerSymAttr(Operation *op) {
-  auto innerSymOp = dyn_cast<InnerSymbolOpInterface>(op);
-  // If not an InnerSymbolOpInterface then ignore.
-  if (!innerSymOp)
-    return success();
-  auto isa = innerSymOp.getInnerSymAttr();
+LogicalResult circt::firrtl::verifyInnerSymAttr(InnerSymbolOpInterface op) {
+  auto isa = op.getInnerSymAttr();
   // If does not have any inner sym then ignore.
   if (!isa)
     return success();

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
 
 using namespace mlir;
@@ -108,6 +109,55 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
           "block argument types should match signature types");
   }
 
+  return success();
+}
+
+LogicalResult circt::firrtl::verifyInnerSymAttr(Operation *op) {
+  auto innerSymOp = dyn_cast<InnerSymbolOpInterface>(op);
+  // If not an InnerSymbolOpInterface then ignore.
+  if (!innerSymOp)
+    return success();
+  auto isa = innerSymOp.getInnerSymAttr();
+  // If does not have any inner sym then ignore.
+  if (!isa)
+    return success();
+  if (op->getNumResults() != 1) {
+    // If more than one results, then the inner sym can only be specified on
+    // fieldID=0.
+    if (isa.numSymbols() > 1 || !isa.getSymName()) {
+      op->emitOpError("cannot assign symbols to non-zero field id, for ops "
+                      "with multiple results");
+      return failure();
+    }
+    return success();
+  }
+  auto maxFields = op->getResultTypes()[0].cast<FIRRTLType>().getMaxFieldID();
+  SmallBitVector indices(maxFields + 1);
+  SmallPtrSet<Attribute, 8> symNames;
+  // Ensure fieldID and symbol names are unique.
+  auto uniqSyms = [&](InnerSymPropertiesAttr p) {
+    if (maxFields < p.getFieldID()) {
+      op->emitOpError("field id:'" + Twine(p.getFieldID()) +
+                      "' is greater than the maximum field id:'" +
+                      Twine(maxFields) + "'");
+      return false;
+    }
+    if (indices.test(p.getFieldID())) {
+      op->emitOpError("cannot assign multiple symbol names to the field id:'" +
+                      Twine(p.getFieldID()) + "'");
+      return false;
+    }
+    indices.set(p.getFieldID());
+    auto it = symNames.insert(p.getName());
+    if (!it.second) {
+      op->emitOpError("cannot reuse symbol name:'" + p.getName().getValue() +
+                      "'");
+      return false;
+    }
+    return true;
+  };
+  if (!isa.all_of_props(uniqSyms))
+    return failure();
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -126,7 +126,7 @@ LogicalResult circt::firrtl::verifyInnerSymAttr(Operation *op) {
     // fieldID=0.
     if (isa.numSymbols() > 1 || !isa.getSymName()) {
       op->emitOpError("cannot assign symbols to non-zero field id, for ops "
-                      "with multiple results");
+                      "with zero or multiple results");
       return failure();
     }
     return success();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -847,17 +847,27 @@ firrtl.circuit "Parent" {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
   }
   firrtl.module @Parent() {
-    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with multiple results}}
+    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with zero or multiple results}}
     firrtl.instance child sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Child()
   }
 }
 
 // -----
 
-
 firrtl.circuit "Foo" {
   firrtl.module @Foo() {
   // expected-error @+1 {{field id:'1' is greater than the maximum field id:'0'}}
     %m = firrtl.mem sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] Undefined {depth = 32 : i64, name = "m", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo"   {
+  firrtl.module @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>, out %c: !firrtl.uint<1>) {
+  }
+  firrtl.module @Foo() {
+    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with zero or multiple results}}
+    %bar_a, %bar_b, %bar_c = firrtl.instance bar sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [{circt.fieldID = 1 : i32, two}], out c: !firrtl.uint<1> [{four}])
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -822,3 +822,42 @@ firrtl.circuit "MismatchedRegister" {
 firrtl.circuit "private_main" {
   firrtl.module private @private_main() {}
 }
+
+// -----
+
+firrtl.circuit "InnerSymAttr" {
+  firrtl.module @InnerSymAttr() {
+    // expected-error @+1 {{cannot assign multiple symbol names to the field id:'2'}}
+    %w3 = firrtl.wire sym [<@w3,2,public>,<@x2,2,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  }
+}
+
+// -----
+
+firrtl.circuit "InnerSymAttr2" {
+  firrtl.module @InnerSymAttr2() {
+    // expected-error @+1 {{cannot reuse symbol name:'w3'}}
+    %w4 = firrtl.wire sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
+  }
+}
+
+// -----
+firrtl.circuit "Parent" {
+  firrtl.module @Child() {
+    %w = firrtl.wire sym @w : !firrtl.uint<1>
+  }
+  firrtl.module @Parent() {
+    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with multiple results}}
+    firrtl.instance child sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Child()
+  }
+}
+
+// -----
+
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+  // expected-error @+1 {{field id:'1' is greater than the maximum field id:'0'}}
+    %m = firrtl.mem sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] Undefined {depth = 32 : i64, name = "m", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<>
+  }
+}


### PR DESCRIPTION
Add the verifier for InnerSymAttr.
The verifier checks that, 
1. All the `fieldID`s specified are unique.
2. All the inner sym names are unique.
3. The `fieldID` is valid.
4. For ops with zero or multiple results, only the `fieldID=0` can have an inner sym.
