### PR TITLE
[HW] Memory Lowering: Use Generated Op and Schema to lower FMemModuleOp

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3923,7 +3923,7 @@ void ModuleEmitter::emitHWExternModule(HWModuleExternOp module) {
 
 void ModuleEmitter::emitHWGeneratedModule(HWModuleGeneratedOp module) {
   auto verilogName = module.getVerilogModuleNameAttr();
-  os << "// external generated module " << verilogName.getValue() << "\n\n";
+  os << "// external module " << verilogName.getValue() << "\n\n";
 }
 
 // This may be called in the top-level, not just in an hw.module.  Thus we can't
@@ -4420,7 +4420,7 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
           else
             rootFile.ops.push_back(info);
         })
-        .Case<HWModuleExternOp>([&](HWModuleExternOp op) {
+        .Case<HWModuleExternOp, HWModuleGeneratedOp>([&](auto op) {
           // Build the IR cache.
           symbolCache.addDefinition(op.getNameAttr(), op);
           collectPorts(op);

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -479,12 +479,9 @@ void HWMemSimImplPass::runOnOperation() {
       // 2. only one readwrite port or write port.
       // 3. zero or one read port.
       // 4. undefined read-under-write behavior.
-      if (replSeqMem && ((mem.readLatency == 1 && mem.writeLatency == 1) &&
-                         (mem.numWritePorts + mem.numReadWritePorts == 1) &&
-                         (mem.numReadPorts <= 1) && mem.dataWidth > 0)) {
-        builder.create<HWModuleExternOp>(oldModule.getLoc(), nameAttr,
-                                         oldModule.getPorts());
-      } else {
+      if (!(replSeqMem && ((mem.readLatency == 1 && mem.writeLatency == 1) &&
+                           (mem.numWritePorts + mem.numReadWritePorts == 1) &&
+                           (mem.numReadPorts <= 1) && mem.dataWidth > 0))) {
         auto newModule = builder.create<HWModuleOp>(
             oldModule.getLoc(), nameAttr, oldModule.getPorts());
         if (auto outdir = oldModule->getAttr("output_file"))

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -256,7 +256,9 @@ firrtl.circuit "Simple" {
   }
   
   // Memory modules are lowered to plain external modules.
-  // CHECK: hw.module.extern @MRead_ext(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {verilogName = "MRead_ext"}
+  // CHECK: hw.module.generated @MRead_ext, @FIRRTLSeqMemSchema(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42)
+  // CHECK-SAME: attributes {depth = 12 : ui64, extraPorts = [], maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32,
+  // CHECK-SAME: numWritePorts = 0 : ui32, readLatency = 0 : ui32, verilogName = "MRead_ext", width = 42 : ui32, writeLatency = 1 : ui32}
   firrtl.memmodule @MRead_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.uint<1>, out R0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 0 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, writeLatency = 1 : ui32}
   
   // The following operations should be passed through without an error.

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -118,5 +118,5 @@ circuit Foo : %[[
 ; CHECK:        firrtl.memmodule @prefix1_mem
 ; CHECK:        firrtl.memmodule @prefix2_mem
 
-; HW-LABEL: hw.module.extern @prefix1_mem
-; HW-LABEL: hw.module.extern @prefix2_mem
+; HW-LABEL: hw.module.generated @prefix1_mem
+; HW-LABEL: hw.module.generated @prefix2_mem


### PR DESCRIPTION
This PR lowers the `FMemModuleOp` to `HWModuleGeneratedOp` and `HWGeneratorSchemaOp` instead of `HWModuleExternOp`. Also ensure the `HWModuleGeneratedOp` is lowered exactly as `HWModuleExternOp` in `ExportVerilog`.

This PR is an attempt to preserve the metadata required for memory macro replacement from the FIRRTL dialect, after `LowerToHW`. This should replace the requirement for embedding the memory metadata into verbatim Ops for json export.

All the attributes that are being embedded into the `VerbatimOp` in the `CreateSifiveMetadata` will be stored with the `hw.generator.schema` op, and the `hw.module.generated` stores the values for the corresponding attributes.

An example:
```
hw.generator.schema @FIRRTLSeqMemSchema, "FIRRTL_Seq_Memory", 
  ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency",
   "width", "maskGran", "extraPorts"]
hw.module.generated @SiFive_CCache_cc_dir_ext, @FIRRTLSeqMemSchema(%RW0_addr: i8, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i216, %RW0_wmask: i8, %user_inputs: i8)
  ->  (RW0_rdata: i216) attributes 
    {depth = 256 : ui64, extraPorts = [{direction = "input", name = "user_inputs", width = 8 : ui32}],
     maskGran = 27 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32,
     readLatency = 1 : ui32, verilogName = "SiFive_CCache_cc_dir_ext", width = 216 : ui32, writeLatency = 1 : ui32}
```

The `mlir` can now be queried by other tools like python, to get the required metadata instead of parsing the json.