### PR TITLE
Updating default llvm path in lib/Bindings/Python

### DIFF
--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -62,7 +62,7 @@ class CMakeBuild(build_py):
     cmake_install_dir = os.path.join(cmake_build_dir, "..", "install")
     llvm_dir = os.getenv("CIRCT_LLVM_DIR")
     if not llvm_dir:
-      llvm_dir = os.path.join(circt_dir, "llvm")
+      llvm_dir = os.path.join(circt_dir, "llvm", "llvm")
     cmake_args = [
         "-DCMAKE_BUILD_TYPE=Release",  # not used on MSVC, but no harm
         "-DCMAKE_INSTALL_PREFIX={}".format(os.path.abspath(cmake_install_dir)),


### PR DESCRIPTION
It seems the python setup is trying to locate llvm's root CMakeLists.txt and cannot find it under `circt/llvm/`. (It seems it is under `circt/llvm/llvm`). 