### PR TITLE
Update LLVM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = llvm
 	url = https://github.com/llvm/llvm-project.git
 	shallow = true
+	branch = main

--- a/include/circt-c/Dialect/Comb.h
+++ b/include/circt-c/Dialect/Comb.h
@@ -11,7 +11,7 @@
 #ifndef CIRCT_C_DIALECT_COMB_H
 #define CIRCT_C_DIALECT_COMB_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -11,7 +11,7 @@
 #ifndef CIRCT_C_DIALECT_ESI_H
 #define CIRCT_C_DIALECT_ESI_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/FSM.h
+++ b/include/circt-c/Dialect/FSM.h
@@ -11,7 +11,7 @@
 #ifndef CIRCT_C_DIALECT_FSM_H
 #define CIRCT_C_DIALECT_FSM_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -18,7 +18,6 @@
 #define CIRCT_C_DIALECT_HW_H
 
 #include "mlir-c/IR.h"
-#include "mlir-c/Registration.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/LLHD.h
+++ b/include/circt-c/Dialect/LLHD.h
@@ -9,7 +9,7 @@
 #ifndef CIRCT_C_DIALECT_LLHD_H
 #define CIRCT_C_DIALECT_LLHD_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -14,7 +14,6 @@
 #include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/Pass.h"
-#include "mlir-c/Registration.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -9,7 +9,7 @@
 #ifndef CIRCT_C_DIALECT_MOORE_H
 #define CIRCT_C_DIALECT_MOORE_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -11,7 +11,7 @@
 #ifndef CIRCT_C_DIALECT_SV_H
 #define CIRCT_C_DIALECT_SV_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt-c/Dialect/Seq.h
+++ b/include/circt-c/Dialect/Seq.h
@@ -11,7 +11,7 @@
 #ifndef CIRCT_C_DIALECT_SEQ_H
 #define CIRCT_C_DIALECT_SEQ_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -130,7 +130,7 @@ class SV_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>
 
 def ModportStruct : SV_Attr<"ModportStruct", "mod_port"> {
 	let parameters = (ins
-                    ModportDirectionAttr:$direction,
+                    "::circt::sv::ModportDirectionAttr":$direction,
                     "mlir::FlatSymbolRefAttr":$signal);
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -17,7 +17,7 @@
 #include "circt-c/Dialect/Seq.h"
 #include "circt-c/ExportVerilog.h"
 #include "mlir-c/Bindings/Python/Interop.h"
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
 #include "llvm-c/ErrorHandling.h"

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -43,9 +43,7 @@ void HWDialect::registerAttributes() {
 Attribute HWDialect::parseAttribute(DialectAsmParser &p, Type type) const {
   StringRef attrName;
   Attribute attr;
-  if (p.parseKeyword(&attrName))
-    return Attribute();
-  auto parseResult = generatedAttributeParser(p, attrName, type, attr);
+  auto parseResult = generatedAttributeParser(p, &attrName, type, attr);
   if (parseResult.hasValue())
     return attr;
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -171,9 +171,7 @@ static ParseResult parseHWElementType(Type &result, AsmParser &p) {
       typeString.startswith("uarray<") || typeString.startswith("struct<") ||
       typeString.startswith("typealias<") || typeString.startswith("int<")) {
     llvm::StringRef mnemonic;
-    if (p.parseKeyword(&mnemonic))
-      llvm_unreachable("should have an array or inout keyword here");
-    auto parseResult = generatedTypeParser(p, mnemonic, result);
+    auto parseResult = generatedTypeParser(p, &mnemonic, result);
     return parseResult.hasValue() ? success() : failure();
   }
 

--- a/lib/Dialect/Moore/MooreTypes.cpp
+++ b/lib/Dialect/Moore/MooreTypes.cpp
@@ -1549,10 +1549,7 @@ static ParseResult parseMooreType(DialectAsmParser &parser, Subset subset,
                                   Type &type) {
   llvm::SMLoc loc = parser.getCurrentLocation();
   StringRef mnemonic;
-  if (parser.parseKeyword(&mnemonic))
-    return failure();
-
-  OptionalParseResult result = generatedTypeParser(parser, mnemonic, type);
+  OptionalParseResult result = generatedTypeParser(parser, &mnemonic, type);
   if (result.hasValue())
     return result.getValue();
 

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(circt-capi-ir-test
   PRIVATE
   ${dialect_libs}
 
-  MLIRCAPIRegistration
   CIRCTCAPIComb
   CIRCTCAPIHW
   CIRCTCAPISeq

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -17,7 +17,7 @@
 #include "mlir-c/AffineMap.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/Diagnostics.h"
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #include <assert.h>
 #include <math.h>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -133,7 +133,7 @@ circuit invalid_bits :
   module invalid_bits:
      input a: UInt<8>
      output b: UInt<4>
-     ; expected-error@+1 {{high must be equal or greater than low, but got high = 4, low = 7}};
+     ; expected-error @+1 {{high must be equal or greater than low, but got high = 4, low = 7}}
      b <= bits(a, 4, 7)
 
 ;// -----


### PR DESCRIPTION
Specified branch we follow for easier updating (`git submodule update --remote --merge`).

* [generated{Attr,Type}Parser now parse mnemonic as well](https://github.com/llvm/llvm-project/commit/fe4f512be7a57ea7bbaa36b5261c2fa00e306cf9), part of series of code completion changes/features (completion of attributes/types?!).
* [Python changes](https://discourse.llvm.org/t/psa-mlir-c-python-api-registration-overhaul/63873) -- rework dialect registration/loading, maybe also trims down our build deps?

Also, this update also brings:
* Code-completion (last week as well) support in the MLIR language server (which we use in the CIRCT language server):
  * [Dialect, operation, SSA value, block names](https://github.com/llvm/llvm-project/commit/ed2fb1736ac1515838d136b57e5ad9a5c805001b)
  * [Keyword](https://github.com/llvm/llvm-project/commit/2e41ea32472a2342f2563f57e2957a149bad5f3f)
  * [Attributes and Types](https://github.com/llvm/llvm-project/commit/fe4f512be7a57ea7bbaa36b5261c2fa00e306cf9)
 * Upstream is migrating `llvm::Optional` users to method names that match `std::optional`.  We have time to update our codebase, but probably should be tackled soon.
 
 Integration tests: https://github.com/llvm/circt/actions/runs/2690778515 .