### PR TITLE
firtool: register passes to fix use of `--mlir-print-ir-{before,after}` options

### DIFF
--- a/test/firtool/print-before.fir
+++ b/test/firtool/print-before.fir
@@ -1,0 +1,14 @@
+; Ensure firtool can dump MLIR from various points of the pipeline.
+; Check passes from different components and registration categories.
+; RUN: firtool %s -mlir-print-ir-before=cse |& FileCheck %s -Dpass=CSE
+; RUN: firtool %s -mlir-print-ir-before=strip-debuginfo -strip-debug-info |& FileCheck %s -Dpass=StripDebugInfo
+; RUN: firtool %s -mlir-print-ir-before=firrtl-inliner -inline |& FileCheck %s -Dpass=Inliner
+; RUN: firtool %s -mlir-print-ir-before=firrtl-lower-annotations |& FileCheck %s -Dpass=LowerFIRRTLAnnotations
+; RUN: firtool %s -mlir-print-ir-before=firrtl-grand-central -firrtl-grand-central |& FileCheck %s -Dpass=GrandCentral
+; RUN: firtool %s -mlir-print-ir-before=export-verilog |& FileCheck %s -Dpass=ExportVerilog
+; RUN: firtool %s -mlir-print-ir-before=export-split-verilog -split-verilog -o %t |& FileCheck %s -Dpass=ExportSplitVerilog
+; RUN: firtool %s -mlir-print-ir-before=hw-cleanup |& FileCheck %s -Dpass=HWCleanup
+; CHECK: IR Dump Before [[pass]]
+circuit Empty:
+  module Empty:
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -842,6 +842,21 @@ int main(int argc, char **argv) {
   // MLIR options are added below.
   cl::HideUnrelatedOptions(mainCategory);
 
+  // Register passes before parsing command-line options, so that they are
+  // available for use with options like `--mlir-print-ir-before`.
+  {
+    // MLIR transforms
+    registerTransformsPasses();
+
+    // Dialect passes
+    firrtl::registerPasses();
+    sv::registerPasses();
+
+    // Export passes
+    registerExportSplitVerilogPass();
+    registerExportVerilogPass();
+  }
+
   // Register any pass manager command line options.
   registerMLIRContextCLOptions();
   registerPassManagerCLOptions();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -845,14 +845,17 @@ int main(int argc, char **argv) {
   // Register passes before parsing command-line options, so that they are
   // available for use with options like `--mlir-print-ir-before`.
   {
-    // MLIR transforms
-    registerTransformsPasses();
+    // MLIR transforms:
+    // Don't use registerTransformsPasses, pulls in too much.
+    registerCSEPass();
+    registerCanonicalizerPass();
+    registerStripDebugInfoPass();
 
-    // Dialect passes
+    // Dialect passes:
     firrtl::registerPasses();
     sv::registerPasses();
 
-    // Export passes
+    // Export passes:
     registerExportSplitVerilogPass();
     registerExportVerilogPass();
   }


### PR DESCRIPTION
From commit message:

----

Ensure the passes we use are registered before parsing the command line
options, so that options such as `--mlir-print-ir-before=` work.

Add test.

It would be better if we didn't have to worry about this,
("did we remember to register all the passes" / early loading)
but in the meantime these options are very helpful for debugging
large designs.

This may pull in more than strictly needed,
Debug binary went 135M -> 140M after this change.

----

I've been sitting on this for a bit, because this might be a pain to maintain (and loses some niceness re:lazy loading?), and either wanted a clean way to ensure that doesn't happen or to add our own variants that don't require this (although printing error message at command-line parse time requires some knowledge of what passes are available).  However this might still be useful regardless, what do folks think?