### PR TITLE
[FIRRTL][LowerTypes] Fix DontTouch application on ports

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -537,8 +537,8 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(
     }
     // We are keeping the annotation.  If the anotation is non-local and this is
     // a ground type (this won't be further lowered) then generate a symbol.
-    needsSym =
-        isGroundType && annotation.getAs<FlatSymbolRefAttr>("circt.nonlocal");
+    if (isGroundType && annotation.getAs<FlatSymbolRefAttr>("circt.nonlocal"))
+      needsSym = true;
     retval.push_back(annotation);
   }
   return ArrayAttr::get(ctxt, retval);

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1215,3 +1215,16 @@ firrtl.circuit "SymbolCollision" {
     in %b: !firrtl.bundle<foo: uint<1>> [{circt.fieldID = 1 : i32, circt.nonlocal = @bar}]) {
   }
 }
+
+// Check that we don't lose the DontTouchAnnotation when it is not the last
+// annotation in the list of annotations.
+// https://github.com/llvm/circt/issues/3504
+// CHECK-LABEL: firrtl.circuit "DontTouch"
+firrtl.circuit "DontTouch" {
+  // CHECK: in %port_field: !firrtl.uint<1> sym @port_field [{class = "Test"}]
+  firrtl.module @DontTouch (in %port: !firrtl.bundle<field: uint<1>> [
+    {circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"},
+    {circt.fieldID = 1 : i32, class = "Test"}
+  ]) {
+ }
+}


### PR DESCRIPTION
During LowerTypes we take ports of bundle type, with fields annotated
with DontTouch, and exchange the annotation for a symbol on the port.
This was broken when the DontTouch was not the last annotation applied
to the port, as subsequent annotations would overwrite the `needsSym`
local variable.

Fixes #3504