### PR TITLE
[SV] Create SVAttributesAttr and `emitAsComments` flag

### DIFF
--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -37,7 +37,7 @@ MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGet(MlirContext cCtxt,
                                                        bool emitAsComments);
 MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGetAttributes(MlirAttribute);
 MLIR_CAPI_EXPORTED
-bool svSVAttributeAttrGetEmitAsComments(MlirAttribute);
+bool svSVAttributesAttrGetEmitAsComments(MlirAttribute);
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -31,6 +31,14 @@ MLIR_CAPI_EXPORTED MlirAttribute svSVAttributeAttrGet(MlirContext cCtxt,
 MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetName(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute);
 
+MLIR_CAPI_EXPORTED bool svAttrIsASVAttributesAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGet(MlirContext cCtxt,
+                                                       MlirAttribute attributes,
+                                                       bool emitAsComments);
+MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGetAttributes(MlirAttribute);
+MLIR_CAPI_EXPORTED
+bool svSVAttributeAttrGetEmitAsComments(MlirAttribute);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/circt/Dialect/SV/SVAttributes.h
+++ b/include/circt/Dialect/SV/SVAttributes.h
@@ -16,10 +16,11 @@
 
 namespace circt {
 namespace sv {
+class SVAttributesAttr;
 
 /// Helper functions to handle SV attributes.
 bool hasSVAttributes(mlir::Operation *op);
-mlir::ArrayAttr getSVAttributes(mlir::Operation *op);
+SVAttributesAttr getSVAttributes(mlir::Operation *op);
 void setSVAttributes(mlir::Operation *op, mlir::Attribute);
 
 } // namespace sv

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -64,9 +64,15 @@ def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
 }
 
 def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
-  let summary = "a Verilog Attribute";
+  let summary = "a container of system verilog attributes";
   let mnemonic = "attributes";
   let description = [{
+    This attribute is used to store SV attributes. The `attributes` field
+    represents SV attributes we want to annotate. The `emitAsComments` field
+    controls its emission style: SV spec defines the syntax of SV attributes as
+    `(* identifier (= identifer)? *)`. However, unfortunately many vendor-specific
+    pragmas violate the syntax and they are intended to be attached as comments.
+    Hence we emit given attributes as comments if `emitAsComments` field is true.
   }];
   let parameters = (ins "mlir::ArrayAttr":$attributes,
                       DefaultValuedParameter<"mlir::BoolAttr",

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -71,7 +71,5 @@ def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
   let parameters = (ins "mlir::ArrayAttr":$attributes,
                       DefaultValuedParameter<"mlir::BoolAttr",
                       "mlir::BoolAttr::get($_ctxt, false)">:$emitAsComments);
-  // TODO: <$attributes, emitAsComments> would be nicer syntax.
-  let assemblyFormat = [{ `<` $attributes
-                          (`,` `comments` `=` $emitAsComments^)?  `>` }];
+  let hasCustomAssemblyFormat = true;
 }

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -64,7 +64,7 @@ def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
 }
 
 def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
-  let summary = "a container of system verilog attributes";
+  let summary = "A container of system verilog attributes";
   let mnemonic = "attributes";
   let description = [{
     This attribute is used to store SV attributes. The `attributes` field

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -62,3 +62,16 @@ def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
         getSVAttributesAttrName() { return "sv.attributes"; }
   }];
 }
+
+def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
+  let summary = "a Verilog Attribute";
+  let mnemonic = "attributes";
+  let description = [{
+  }];
+  let parameters = (ins "mlir::ArrayAttr":$attributes,
+                      DefaultValuedParameter<"mlir::BoolAttr",
+                      "mlir::BoolAttr::get($_ctxt, false)">:$emitAsComments);
+  // TODO: <$attributes, emitAsComments> would be nicer syntax.
+  let assemblyFormat = [{ `<` $attributes
+                          (`,` `comments` `=` $emitAsComments^)?  `>` }];
+}

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -47,11 +47,12 @@ with Context() as ctx, Location.unknown():
       # CHECK: %FuBar = seq.compreg {{.+}}
       seq.reg(reg_input, module.clk, name="FuBar")
 
-      # CHECK: %reg1 = seq.compreg %[[INPUT_VAL]], %clk {sv.attributes = [#sv.attribute<"no_merge">]} : i32
+      # CHECK: %reg1 = seq.compreg %[[INPUT_VAL]], %clk {sv.attributes = #sv.attributes<[#sv.attribute<"no_merge">]>} : i32
       sv_attr = sv.SVAttributeAttr.get("no_merge")
       reg1 = seq.CompRegOp.create(i32, clk=module.clk, name="reg1")
 
-      reg1.attributes["sv.attributes"] = ArrayAttr.get([sv_attr])
+      reg1.attributes["sv.attributes"] = sv.SVAttributesAttr.get(
+          ArrayAttr.get([sv_attr]))
       connect(reg1.input, reg_input)
 
       # CHECK: %reg2 = seq.compreg %[[INPUT_VAL]], %clk

--- a/lib/Bindings/Python/SVModule.cpp
+++ b/lib/Bindings/Python/SVModule.cpp
@@ -63,13 +63,14 @@ void circt::python::populateDialectSVSubmodule(py::module &m) {
              MlirContext ctxt) {
             return cls(svSVAttributesAttrGet(ctxt, attributes, emitAsComments));
           },
-          "Create SV attributes", py::arg(), py::arg("attributes"),
+          "Create SV attributes attr", py::arg(), py::arg("attributes"),
           py::arg("emit_as_comments") = py::none(),
           py::arg("ctxt") = py::none())
       .def_property_readonly("attributes",
                              [](MlirAttribute self) {
                                return svSVAttributesAttrGetAttributes(self);
                              })
-      .def_property_readonly("emit_as_comments",
-                             [](MlirAttribute self) { return false; });
+      .def_property_readonly("emit_as_comments", [](MlirAttribute self) {
+        return svSVAttributesAttrGetEmitAsComments(self);
+      });
 }

--- a/lib/Bindings/Python/SVModule.cpp
+++ b/lib/Bindings/Python/SVModule.cpp
@@ -55,4 +55,21 @@ void circt::python::populateDialectSVSubmodule(py::module &m) {
               return py::none();
             return py::str(std::string(name.data, name.length));
           });
+
+  mlir_attribute_subclass(m, "SVAttributesAttr", svAttrIsASVAttributesAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirAttribute attributes, bool emitAsComments,
+             MlirContext ctxt) {
+            return cls(svSVAttributesAttrGet(ctxt, attributes, emitAsComments));
+          },
+          "Create SV attributes", py::arg(), py::arg("attributes"),
+          py::arg("emit_as_comments") = py::none(),
+          py::arg("ctxt") = py::none())
+      .def_property_readonly("attributes",
+                             [](MlirAttribute self) {
+                               return svSVAttributesAttrGetAttributes(self);
+                             })
+      .def_property_readonly("emit_as_comments",
+                             [](MlirAttribute self) { return false; });
 }

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -41,3 +41,26 @@ MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute cAttr) {
     return wrap(expr.getValue());
   return {nullptr, 0};
 }
+
+bool svAttrIsASVAttributesAttr(MlirAttribute cAttr) {
+  return unwrap(cAttr).isa<SVAttributesAttr>();
+}
+
+MlirAttribute svSVAttributesAttrGet(MlirContext cCtxt, MlirAttribute attributes,
+                                    bool emitAsComments) {
+  mlir::MLIRContext *ctxt = unwrap(cCtxt);
+  return wrap(SVAttributesAttr::get(ctxt,
+                                    unwrap(attributes).cast<mlir::ArrayAttr>(),
+                                    mlir::BoolAttr::get(ctxt, emitAsComments)));
+}
+
+MlirAttribute svSVAttributesAttrGetAttributes(MlirAttribute attributes) {
+  return wrap(unwrap(attributes).cast<SVAttributesAttr>().getAttributes());
+}
+
+bool svSVAttributesAttrGetEmitAsComments(MlirAttribute attributes) {
+  return unwrap(attributes)
+      .cast<SVAttributesAttr>()
+      .getEmitAsComments()
+      .getValue();
+}

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -649,15 +649,17 @@ static IfOp findNestedElseIf(Block *elseBlock) {
 
 /// Emit SystemVerilog attributes.
 static void emitSVAttributesImpl(llvm::raw_ostream &os,
-                                 mlir::ArrayAttr svAttrs) {
-  os << "(* ";
-  llvm::interleaveComma(svAttrs, os, [&](Attribute attr) {
+                                 sv::SVAttributesAttr svAttrs) {
+  auto body = svAttrs.getAttributes();
+  auto emitAsComments = svAttrs.getEmitAsComments().getValue();
+  os << (emitAsComments ? "/* " : "(* ");
+  llvm::interleaveComma(body, os, [&](Attribute attr) {
     auto svattr = attr.cast<SVAttributeAttr>();
     os << svattr.getName().getValue();
     if (svattr.getExpression())
       os << " = " << svattr.getExpression().getValue();
   });
-  os << " *)";
+  os << (emitAsComments ? " */" : " *)");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/SVAttributes.cpp
+++ b/lib/Dialect/SV/SVAttributes.cpp
@@ -30,8 +30,8 @@ bool circt::sv::hasSVAttributes(mlir::Operation *op) {
   return op->hasAttr(sv::SVAttributeAttr::getSVAttributesAttrName());
 }
 
-mlir::ArrayAttr circt::sv::getSVAttributes(mlir::Operation *op) {
-  return op->getAttrOfType<mlir::ArrayAttr>(
+sv::SVAttributesAttr circt::sv::getSVAttributes(mlir::Operation *op) {
+  return op->getAttrOfType<sv::SVAttributesAttr>(
       sv::SVAttributeAttr::getSVAttributesAttrName());
 }
 

--- a/lib/Dialect/SV/SVAttributes.cpp
+++ b/lib/Dialect/SV/SVAttributes.cpp
@@ -30,13 +30,38 @@ bool circt::sv::hasSVAttributes(mlir::Operation *op) {
   return op->hasAttr(sv::SVAttributeAttr::getSVAttributesAttrName());
 }
 
-sv::SVAttributesAttr circt::sv::getSVAttributes(mlir::Operation *op) {
-  return op->getAttrOfType<sv::SVAttributesAttr>(
-      sv::SVAttributeAttr::getSVAttributesAttrName());
+SVAttributesAttr circt::sv::getSVAttributes(mlir::Operation *op) {
+  return op->getAttrOfType<SVAttributesAttr>(
+      SVAttributeAttr::getSVAttributesAttrName());
 }
 
 void circt::sv::setSVAttributes(mlir::Operation *op, mlir::Attribute attr) {
-  return op->setAttr(sv::SVAttributeAttr::getSVAttributesAttrName(), attr);
+  return op->setAttr(SVAttributeAttr::getSVAttributesAttrName(), attr);
+}
+
+mlir::Attribute SVAttributesAttr::parse(mlir::AsmParser &p, mlir::Type type) {
+  mlir::ArrayAttr attributes;
+  if (p.parseLess() || p.parseAttribute<ArrayAttr>(attributes))
+    return Attribute();
+  bool emitAsComments = false;
+  if (!p.parseOptionalComma()) {
+    if (p.parseKeyword("emitAsComments"))
+      return Attribute();
+    emitAsComments = true;
+  }
+
+  if (p.parseGreater())
+    return Attribute();
+
+  return SVAttributesAttr::get(p.getContext(), attributes,
+                               BoolAttr::get(p.getContext(), emitAsComments));
+}
+
+void SVAttributesAttr::print(::mlir::AsmPrinter &p) const {
+  p << "<" << getAttributes();
+  if (getEmitAsComments().getValue())
+    p << ", emitAsComments";
+  p << ">";
 }
 
 void SVDialect::registerAttributes() {

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -77,7 +77,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   // make tests brittle. This line breaking does not mean your change is no
   // good! You'll just have to find a new place for `sv.namehint`.
   %elem2d = hw.array_get %array2d[%a] { sv.namehint="array2d_idx_0_name" } : !hw.array<12 x array<10xi4>>
-  %37 = hw.array_get %elem2d[%b] {sv.attributes=[#sv.attribute<"svAttr">]}: !hw.array<10xi4>
+  %37 = hw.array_get %elem2d[%b] {sv.attributes=#sv.attributes<[#sv.attribute<"svAttr">]>}: !hw.array<10xi4>
 
   %36 = comb.replicate %a : (i4) -> i12
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -480,16 +480,16 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-EMPTY:
   // CHECK-NEXT: (* dont_merge *)
   // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i8>
+  %myReg = sv.reg {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">]>} : !hw.inout<i8>
 
   // CHECK-NEXT: (* dont_merge, dont_retime = true *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">]} : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">]>} : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
-  // CHECK-NEXT: (* assign_attr *)
+  // CHECK-NEXT: /* assign_attr */
   // CHECK-NEXT: assign myReg = in8;
-  sv.assign %myReg, %in8 {sv.attributes = [#sv.attribute<"assign_attr">]} : i8
+  sv.assign %myReg, %in8 {sv.attributes = #sv.attributes<[#sv.attribute<"assign_attr">], comments = true>} : i8
 
   %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;
@@ -1113,7 +1113,7 @@ hw.module @verbatim_M1(%clock : i1, %cond : i1, %val : i8) {
   %reg2 = sv.reg sym @verbatim_reg2: !hw.inout<i8>
   // CHECK:      (* dont_merge *)
   // CHECK-NEXT: wire [22:0] wire25
-  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i23>
+  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">]>} : !hw.inout<i23>
   %add = comb.add %val, %c42 : i8
   %c42_2 = hw.constant 42 : i8
   %xor = comb.xor %val, %c42_2 : i8

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -489,7 +489,7 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-EMPTY:
   // CHECK-NEXT: /* assign_attr */
   // CHECK-NEXT: assign myReg = in8;
-  sv.assign %myReg, %in8 {sv.attributes = #sv.attributes<[#sv.attribute<"assign_attr">], comments = true>} : i8
+  sv.assign %myReg, %in8 {sv.attributes = #sv.attributes<[#sv.attribute<"assign_attr">], emitAsComments>} : i8
 
   %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;


### PR DESCRIPTION
This PR proposes `emitAsComments` functionality for SV attributes.
Unfortunately, some of vendor specific pragmas are not strictly valid
SV attributes. For example, `(* cadence map_to_mux *)` is not valid SV
attribute  hence vendor compilers recognize comments as some sort of
attributes. Therefore, this (draft) PR proposes a way to emit SV
attributes as comments.

Example:
```mlir
%0 = sv.wire {sv.attributes = #sv.attributes<[#sv.attribute<"foo bar">], emitAsComments>} : i1
 
==>
/* foo bar */
wire GEN;
```