### PR TITLE
[SystemC] Add ExportSystemC skeleton

### DIFF
--- a/include/circt/Conversion/ExportSystemC.h
+++ b/include/circt/Conversion/ExportSystemC.h
@@ -1,0 +1,28 @@
+//===- ExportSystemC.h - SystemC Exporter -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the interface to the SystemC emitter.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TRANSLATION_EXPORTSYSTEMC_H
+#define CIRCT_TRANSLATION_EXPORTSYSTEMC_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+
+std::unique_ptr<mlir::Pass> createExportSystemCPass(llvm::raw_ostream &os);
+std::unique_ptr<mlir::Pass> createExportSystemCPass();
+
+std::unique_ptr<mlir::Pass>
+createExportSplitSystemCPass(llvm::StringRef directory = "./");
+
+} // namespace circt
+
+#endif // CIRCT_TRANSLATION_EXPORTSYSTEMC_H

--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -15,6 +15,7 @@
 
 #include "circt/Conversion/AffineToStaticLogic.h"
 #include "circt/Conversion/CalyxToHW.h"
+#include "circt/Conversion/ExportSystemC.h"
 #include "circt/Conversion/ExportVerilog.h"
 #include "circt/Conversion/FIRRTLToHW.h"
 #include "circt/Conversion/FSMToSV.h"

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -88,6 +88,43 @@ def ExportSplitVerilog : Pass<"export-split-verilog", "mlir::ModuleOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ExportSystemC and ExportSplitSystemC
+//===----------------------------------------------------------------------===//
+
+def ExportSystemC : Pass<"export-systemc", "mlir::ModuleOp"> {
+  let summary = "Emit the IR to a SystemC C++ file";
+  let description = [{
+    This pass generates SystemC code for the current design. It outputs
+    the entire design to a single output stream.
+  }];
+
+  let constructor = "createExportSystemCPass()";
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect",
+    "circt::systemc::SystemCDialect"
+  ];
+}
+
+def ExportSplitSystemC : Pass<"export-split-systemc", "mlir::ModuleOp"> {
+  let summary = "Emit the IR to a directory of SystemC C++ files";
+  let description = [{
+    This pass generates SystemC code for the current design. It creates a new
+    header file for every module in the design.
+  }];
+
+  let constructor = "createExportSplitSystemCPass()";
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect",
+    "circt::systemc::SystemCDialect"
+  ];
+
+  let options = [
+    Option<"directoryName", "dir-name", "std::string",
+            "", "Directory to emit into">
+   ];
+}
+
+//===----------------------------------------------------------------------===//
 // SCFToCalyx
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(AffineToStaticLogic)
 add_subdirectory(CalyxToHW)
+add_subdirectory(ExportSystemC)
 add_subdirectory(ExportVerilog)
 add_subdirectory(FIRRTLToHW)
 add_subdirectory(HWArithToHW)

--- a/lib/Conversion/ExportSystemC/CMakeLists.txt
+++ b/lib/Conversion/ExportSystemC/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+add_circt_translation_library(CIRCTExportSystemC
+  ExportSystemC.cpp
+
+  ADDITIONAL_HEADER_DIRS
+
+  DEPENDS
+  CIRCTConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  CIRCTComb
+  CIRCTHW
+  CIRCTSystemC
+  CIRCTSupport
+  MLIRPass
+  MLIRSideEffectInterfaces
+  )

--- a/lib/Conversion/ExportSystemC/ExportSystemC.cpp
+++ b/lib/Conversion/ExportSystemC/ExportSystemC.cpp
@@ -1,0 +1,82 @@
+//===- ExportSystemC.cpp - SystemC Emitter --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the main SystemC emitter implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Conversion/ExportSystemC.h"
+#include "../PassDetail.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/SystemC/SystemCDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+
+using namespace circt;
+
+#define DEBUG_TYPE "export-systemc"
+
+static LogicalResult emitModule(ModuleOp module, raw_ostream &os) {
+  os << "Not implemented yet.\n";
+
+  return success();
+}
+
+static LogicalResult emitModule(ModuleOp module, StringRef directory) {
+  return emitModule(module, llvm::outs());
+}
+
+//===----------------------------------------------------------------------===//
+// Unified Emitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct ExportSystemCPass : public ExportSystemCBase<ExportSystemCPass> {
+  ExportSystemCPass(raw_ostream &os) : os(os) {}
+  void runOnOperation() override {
+    if (failed(emitModule(getOperation(), os)))
+      signalPassFailure();
+  }
+
+private:
+  raw_ostream &os;
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass>
+circt::createExportSystemCPass(llvm::raw_ostream &os) {
+  return std::make_unique<ExportSystemCPass>(os);
+}
+
+std::unique_ptr<mlir::Pass> circt::createExportSystemCPass() {
+  return createExportSystemCPass(llvm::outs());
+}
+
+//===----------------------------------------------------------------------===//
+// Split Emitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct ExportSplitSystemCPass
+    : public ExportSplitSystemCBase<ExportSplitSystemCPass> {
+  ExportSplitSystemCPass(StringRef directory) {
+    directoryName = directory.str();
+  }
+  void runOnOperation() override {
+    if (failed(emitModule(getOperation(), directoryName)))
+      signalPassFailure();
+  }
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass>
+circt::createExportSplitSystemCPass(StringRef directory) {
+  return std::make_unique<ExportSplitSystemCPass>(directory);
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(circt-opt
   CIRCTCalyxToHW
   CIRCTCalyxTransforms
   CIRCTESI
+  CIRCTExportSystemC
   CIRCTExportVerilog
   CIRCTFIRRTL
   CIRCTFIRRTLToHW


### PR DESCRIPTION
Depends on #3520

This adds the very basic conversion pass registration code for ExportSystemC to emit SystemC code.