### PR TITLE
[FIRRTL] Add bit-index support (subword assignment)

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -180,6 +180,38 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
   let hasVerifier = 1;
 }
 
+class BitIndexConstraint<string value, string resultValue>
+  : TypesMatchWith<"type should be element of vector type",
+                   value, resultValue,
+                   "firrtl::getSubindexElementType($_self)">;
+
+def BitindexOp : FIRRTLExprOp<"bitindex", [
+    BitIndexConstraint<"input", "result">
+  ]> {
+  let summary = "Extract a bit from a UInt or SInt";
+  let description = [{
+    The bitindex expression statically refers, by index, to a bit
+    of an expression with an integer type. The index must be a non-negative
+    integer and cannot be equal to or exceed the length of the vector it
+    indexes.
+    ```
+      %result = firrtl.bitindex %input[index] : t1
+    ```
+    }];
+
+  let arguments = (ins FIRRTLType:$input, I32Attr:$index);
+  let results = (outs FIRRTLType:$result);
+
+  let assemblyFormat =
+     "$input `[` $index `]` attr-dict `:` qualified(type($input))";
+
+  let firrtlExtraClassDeclaration = [{
+    static bool isBitIndex(ValueRange operands,
+                              ArrayRef<NamedAttribute> attrs,
+                              Optional<Location> loc);
+  }];
+}
+
 class IndexConstraint<string value, string resultValue>
   : TypesMatchWith<"type should be element of vector type",
                    value, resultValue,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -181,9 +181,9 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
 }
 
 class BitIndexConstraint<string value, string resultValue>
-  : TypesMatchWith<"type should be element of vector type",
+  : TypesMatchWith<"type should be UInt or SInt",
                    value, resultValue,
-                   "firrtl::getSubindexElementType($_self)">;
+                   "firrtl::getBitindexElementType($_self)">;
 
 def BitindexOp : FIRRTLExprOp<"bitindex", [
     BitIndexConstraint<"input", "result">

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -204,12 +204,6 @@ def BitindexOp : FIRRTLExprOp<"bitindex", [
 
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` qualified(type($input))";
-
-  let firrtlExtraClassDeclaration = [{
-    static bool isBitIndex(ValueRange operands,
-                           ArrayRef<NamedAttribute> attrs,
-                           Optional<Location> loc);
-  }];
 }
 
 class IndexConstraint<string value, string resultValue>

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -207,8 +207,8 @@ def BitindexOp : FIRRTLExprOp<"bitindex", [
 
   let firrtlExtraClassDeclaration = [{
     static bool isBitIndex(ValueRange operands,
-                              ArrayRef<NamedAttribute> attrs,
-                              Optional<Location> loc);
+                           ArrayRef<NamedAttribute> attrs,
+                           Optional<Location> loc);
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -152,6 +152,7 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
 bool isTypeLarger(FIRRTLType dstType, FIRRTLType srcType);
 
 mlir::Type getVectorElementType(mlir::Type array);
+mlir::Type getSubindexElementType(mlir::Type array);
 mlir::Type getPassiveType(mlir::Type anyFIRRTLType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -152,7 +152,7 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
 bool isTypeLarger(FIRRTLType dstType, FIRRTLType srcType);
 
 mlir::Type getVectorElementType(mlir::Type array);
-mlir::Type getSubindexElementType(mlir::Type array);
+mlir::Type getBitindexElementType(mlir::Type array);
 mlir::Type getPassiveType(mlir::Type anyFIRRTLType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -32,6 +32,8 @@ std::unique_ptr<mlir::Pass>
 createLowerFIRRTLTypesPass(bool preserveAggregate = false,
                            bool preservePublicTypes = true);
 
+std::unique_ptr<mlir::Pass> createLowerBitindexPass();
+
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 
 std::unique_ptr<mlir::Pass> createLowerCHIRRTLPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -42,6 +42,19 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
   ];
 }
 
+def LowerBitindex : Pass<"firrtl-lower-bitindex", "firrtl::CircuitOp"> {
+  let summary = "Lower bitindex operations to subindex operations";
+  let description = [{
+    Lower bitindex operations to subindex operations. Int types that are
+    accessed via a bitindex are wrapped with vec types with subindex
+    operations.
+  }];
+  let constructor = "circt::firrtl::createLowerBitindexPass()";
+  let options = [
+  ];
+  let dependentDialects = ["hw::HWDialect"];
+}
+
 def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL types to ground types";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -42,19 +42,6 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
   ];
 }
 
-def LowerBitindex : Pass<"firrtl-lower-bitindex", "firrtl::CircuitOp"> {
-  let summary = "Lower bitindex operations to subindex operations";
-  let description = [{
-    Lower bitindex operations to subindex operations. Int types that are
-    accessed via a bitindex are wrapped with vec types with subindex
-    operations.
-  }];
-  let constructor = "circt::firrtl::createLowerBitindexPass()";
-  let options = [
-  ];
-  let dependentDialects = ["hw::HWDialect"];
-}
-
 def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL types to ground types";
   let description = [{
@@ -459,6 +446,11 @@ def CheckCombCycles : Pass<"firrtl-check-comb-cycles", "firrtl::CircuitOp"> {
 def SFCCompat : Pass<"firrtl-sfc-compat", "firrtl::FModuleOp"> {
   let summary = "Perform SFC Compatibility fixes";
   let constructor = "circt::firrtl::createSFCCompatPass()";
+}
+
+def LowerBitindex : Pass<"firrtl-lower-bitindex", "firrtl::FModuleOp"> {
+  let summary = "Lower bitindex operations to subindex operations";
+  let constructor = "circt::firrtl::createLowerBitindexPass()";
 }
 
 def MergeConnections : Pass<"merge-connections", "firrtl::FModuleOp"> {

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -88,6 +88,7 @@ struct Emitter {
   void emitExpression(SubfieldOp op);
   void emitExpression(SubindexOp op);
   void emitExpression(SubaccessOp op);
+  void emitExpression(BitindexOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
                     ArrayRef<uint32_t> attrs = {});
@@ -625,6 +626,7 @@ void Emitter::emitExpression(Value value) {
       .Case<
           // Basic expressions
           ConstantOp, SpecialConstantOp, SubfieldOp, SubindexOp, SubaccessOp,
+          BitindexOp,
           // Binary
           AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
           OrPrimOp, XorPrimOp, LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp,
@@ -679,6 +681,11 @@ void Emitter::emitExpression(SubaccessOp op) {
   os << "[";
   emitExpression(op.index());
   os << "]";
+}
+
+void Emitter::emitExpression(BitindexOp op) {
+  emitExpression(op.input());
+  os << "[" << op.index() << "]";
 }
 
 void Emitter::emitPrimExpr(StringRef mnemonic, Operation *op,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -128,7 +128,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return foldFlow(op.input(),
                         op.isFieldFlipped() ? swap() : accumulatedFlow);
       })
-      .Case<SubindexOp, SubaccessOp>(
+      .Case<SubindexOp, SubaccessOp, BitindexOp>(
           [&](auto op) { return foldFlow(op.input(), accumulatedFlow); })
       // Registers, Wires, and behavioral memory ports are always Duplex.
       .Case<RegOp, RegResetOp, WireOp, MemoryPortOp>(
@@ -2504,6 +2504,7 @@ FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
 
   if (auto intType = inType.dyn_cast<IntType>()) {
+    // TODO: fix warning about signedness
     if (fieldIdx < intType.getWidthOrSentinel())
       return UIntType::get(inType.getContext(), 1);
     if (loc)

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -128,10 +128,12 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return foldFlow(op.input(),
                         op.isFieldFlipped() ? swap() : accumulatedFlow);
       })
+      .Case<BitindexOp>(
+          [](auto) { return Flow::Sink; })
       .Case<SubindexOp, SubaccessOp>(
           [&](auto op) { return foldFlow(op.input(), accumulatedFlow); })
       // Registers, Wires, and behavioral memory ports are always Duplex.
-      .Case<RegOp, RegResetOp, WireOp, MemoryPortOp, BitindexOp>(
+      .Case<RegOp, RegResetOp, WireOp, MemoryPortOp>(
           [](auto) { return Flow::Duplex; })
       .Case<InstanceOp>([&](auto inst) {
         auto resultNo = val.cast<OpResult>().getResultNumber();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2490,12 +2490,6 @@ FIRRTLType SubindexOp::inferReturnType(ValueRange operands,
   return {};
 }
 
-bool BitindexOp::isBitIndex(ValueRange operands, ArrayRef<NamedAttribute> attrs,
-                            Optional<Location> loc) {
-  auto inType = operands[0].getType();
-  return inType.isa<IntType>();
-}
-
 FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        Optional<Location> loc) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -89,7 +89,7 @@ bool firrtl::isDuplexValue(Value val) {
   if (!op)
     return false;
   return TypeSwitch<Operation *, bool>(op)
-      .Case<SubfieldOp, SubindexOp, SubaccessOp, BitindexOp>(
+      .Case<SubfieldOp, SubindexOp, SubaccessOp>(
           [](auto op) { return isDuplexValue(op.input()); })
       .Case<RegOp, RegResetOp, WireOp>([](auto) { return true; })
       .Default([](auto) { return false; });
@@ -155,7 +155,7 @@ DeclKind firrtl::getDeclarationKind(Value val) {
 
   return TypeSwitch<Operation *, DeclKind>(op)
       .Case<InstanceOp>([](auto) { return DeclKind::Instance; })
-      .Case<SubfieldOp, SubindexOp, SubaccessOp, BitindexOp>(
+      .Case<SubfieldOp, SubindexOp, SubaccessOp>(
           [](auto op) { return getDeclarationKind(op.input()); })
       .Default([](auto) { return DeclKind::Other; });
 }
@@ -2507,7 +2507,7 @@ FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
 
   if (auto intType = inType.dyn_cast<IntType>()) {
     // TODO: fix warning about signedness
-    if (fieldIdx < intType.getWidthOrSentinel())
+    if ((int) fieldIdx < intType.getWidthOrSentinel())
       return UIntType::get(inType.getContext(), 1);
     if (loc)
       mlir::emitError(*loc, "out of range index '")

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2506,9 +2506,9 @@ FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
 
   if (auto intType = inType.dyn_cast<IntType>()) {
-    // TODO: fix warning about signedness
-    if ((int) fieldIdx < intType.getWidthOrSentinel())
-      return UIntType::get(inType.getContext(), 1);
+    if ((int) fieldIdx < intType.getWidthOrSentinel()) {
+        return UIntType::get(inType.getContext(), 1);
+    }
     if (loc)
       mlir::emitError(*loc, "out of range index '")
           << fieldIdx << "' in int type " << inType;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -128,8 +128,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return foldFlow(op.input(),
                         op.isFieldFlipped() ? swap() : accumulatedFlow);
       })
-      .Case<BitindexOp>(
-          [](auto) { return Flow::Sink; })
+      .Case<BitindexOp>([](auto) { return Flow::Sink; })
       .Case<SubindexOp, SubaccessOp>(
           [&](auto op) { return foldFlow(op.input(), accumulatedFlow); })
       // Registers, Wires, and behavioral memory ports are always Duplex.
@@ -2491,8 +2490,7 @@ FIRRTLType SubindexOp::inferReturnType(ValueRange operands,
   return {};
 }
 
-bool BitindexOp::isBitIndex(ValueRange operands,
-                            ArrayRef<NamedAttribute> attrs,
+bool BitindexOp::isBitIndex(ValueRange operands, ArrayRef<NamedAttribute> attrs,
                             Optional<Location> loc) {
   auto inType = operands[0].getType();
   return inType.isa<IntType>();
@@ -2506,8 +2504,8 @@ FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
 
   if (auto intType = inType.dyn_cast<IntType>()) {
-    if ((int) fieldIdx < intType.getWidthOrSentinel()) {
-        return UIntType::get(inType.getContext(), 1);
+    if ((int)fieldIdx < intType.getWidthOrSentinel()) {
+      return UIntType::get(inType.getContext(), 1);
     }
     if (loc)
       mlir::emitError(*loc, "out of range index '")
@@ -2518,7 +2516,7 @@ FIRRTLType BitindexOp::inferReturnType(ValueRange operands,
   if (loc)
     mlir::emitError(*loc, "bitindex requires UInt or SInt");
 
-  return{};
+  return {};
 }
 
 FIRRTLType SubaccessOp::inferReturnType(ValueRange operands,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -89,7 +89,7 @@ bool firrtl::isDuplexValue(Value val) {
   if (!op)
     return false;
   return TypeSwitch<Operation *, bool>(op)
-      .Case<SubfieldOp, SubindexOp, SubaccessOp>(
+      .Case<SubfieldOp, SubindexOp, SubaccessOp, BitindexOp>(
           [](auto op) { return isDuplexValue(op.input()); })
       .Case<RegOp, RegResetOp, WireOp>([](auto) { return true; })
       .Default([](auto) { return false; });
@@ -128,10 +128,10 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return foldFlow(op.input(),
                         op.isFieldFlipped() ? swap() : accumulatedFlow);
       })
-      .Case<SubindexOp, SubaccessOp, BitindexOp>(
+      .Case<SubindexOp, SubaccessOp>(
           [&](auto op) { return foldFlow(op.input(), accumulatedFlow); })
       // Registers, Wires, and behavioral memory ports are always Duplex.
-      .Case<RegOp, RegResetOp, WireOp, MemoryPortOp>(
+      .Case<RegOp, RegResetOp, WireOp, MemoryPortOp, BitindexOp>(
           [](auto) { return Flow::Duplex; })
       .Case<InstanceOp>([&](auto inst) {
         auto resultNo = val.cast<OpResult>().getResultNumber();
@@ -153,7 +153,7 @@ DeclKind firrtl::getDeclarationKind(Value val) {
 
   return TypeSwitch<Operation *, DeclKind>(op)
       .Case<InstanceOp>([](auto) { return DeclKind::Instance; })
-      .Case<SubfieldOp, SubindexOp, SubaccessOp>(
+      .Case<SubfieldOp, SubindexOp, SubaccessOp, BitindexOp>(
           [](auto op) { return getDeclarationKind(op.input()); })
       .Default([](auto) { return DeclKind::Other; });
 }

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -626,7 +626,7 @@ Type firrtl::getVectorElementType(Type array) {
 }
 
 Type firrtl::getBitindexElementType(Type array) {
-  if (array.isa<UIntType>() || array.isa<SIntType>()) {
+  if (array.isa<IntType>()) {
     return UIntType::get(array.getContext(), 1);
   }
   return Type();

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -625,6 +625,13 @@ Type firrtl::getVectorElementType(Type array) {
   return vectorType.getElementType();
 }
 
+Type firrtl::getSubindexElementType(Type array) {
+  if (array.isa<UIntType>() || array.isa<SIntType>()) {
+    return UIntType::get(array.getContext(), 1);
+  }
+  return firrtl::getVectorElementType(array);
+}
+
 /// Return the passiver version of a firrtl type
 /// top level for ODS constraint usage
 Type firrtl::getPassiveType(Type anyFIRRTLType) {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -625,11 +625,11 @@ Type firrtl::getVectorElementType(Type array) {
   return vectorType.getElementType();
 }
 
-Type firrtl::getSubindexElementType(Type array) {
+Type firrtl::getBitindexElementType(Type array) {
   if (array.isa<UIntType>() || array.isa<SIntType>()) {
     return UIntType::get(array.getContext(), 1);
   }
-  return firrtl::getVectorElementType(array);
+  return Type();
 }
 
 /// Return the passiver version of a firrtl type

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1824,7 +1824,7 @@ ParseResult FIRStmtParser::parsePostFixIntSubscript(Value &result) {
   // builder (https://llvm.discourse.group/t/3504).
   NamedAttribute attrs = {getConstants().indexIdentifier,
                           builder.getI32IntegerAttr(indexNo)};
-  bool bitindex = BitindexOp::isBitIndex({result}, attrs, {});
+  bool bitindex = result.getType().isa<IntType>();
   FIRRTLType resultType;
   if (bitindex) {
     resultType = BitindexOp::inferReturnType({result}, attrs, {});

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1834,9 +1834,11 @@ ParseResult FIRStmtParser::parsePostFixIntSubscript(Value &result) {
   if (!resultType) {
     // Emit the error at the right location.  translateLocation is expensive.
     if (bitindex) {
-      (void)BitindexOp::inferReturnType({result}, attrs, translateLocation(loc));
+      (void)BitindexOp::inferReturnType({result}, attrs,
+                                        translateLocation(loc));
     } else {
-      (void)SubindexOp::inferReturnType({result}, attrs, translateLocation(loc));
+      (void)SubindexOp::inferReturnType({result}, attrs,
+                                        translateLocation(loc));
     }
     return failure();
   }

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   InferWidths.cpp
   InjectDUTHierarchy.cpp
   LowerAnnotations.cpp
+  LowerBitindex.cpp
   LowerCHIRRTL.cpp
   LowerMemory.cpp
   LowerTypes.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -126,6 +126,15 @@ void LowerBitIndexPass::runOnOperation() {
           bits.erase();
         }
       }
+      if (isa_and_nonnull<RegOp>(defn)) {
+        ImplicitLocOpBuilder builder(defn->getLoc(), defn);
+        builder.setInsertionPointAfter(wire);
+        for (int i = 0; i < w; i++) {
+          Value bitsOp = builder.create<BitsPrimOp>(var, i, i);
+          Value subidxOp = builder.create<SubindexOp>(wire, i);
+          builder.create<StrictConnectOp>(subidxOp, bitsOp);
+        }
+      }
     }
   }
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -49,7 +49,8 @@ void LowerBitIndexPass::runOnOperation() {
     auto *defn = var.getDefiningOp();
     llvm::StringRef name;
     ImplicitLocOpBuilder builder(var.getLoc(), var.getContext());
-    if (auto mod = dyn_cast<FModuleOp>(defn)) {
+    if (!defn) {
+        auto mod = getOperation();
         name = "port.bitindex.wrapper";
         builder.setInsertionPointToStart(mod.getBody());
     } else {

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -1,0 +1,48 @@
+//===- LowerBitindex.cpp - Lower Bitindex  -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the LowerBitindex pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Parallel.h"
+
+#define DEBUG_TYPE "firrtl-lower-bitindex"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct LowerBitindex : public LowerBitindexBase<LowerBitindex> {
+  LowerBitindex() {
+  }
+
+  void runOnOperation() override {
+    LLVM_DEBUG(
+        llvm::dbgs() << "===- Running LowerBitindex Pass "
+                        "------------------------------------------------===\n");
+    std::vector<FModuleLike> ops;
+
+    llvm::for_each(getOperation().getBody()->getOperations(), [&](Operation &op) {
+      if (auto module = dyn_cast<FModuleLike>(op))
+        ops.push_back(module);
+    });
+  }
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createLowerBitindexPass() {
+  return std::make_unique<LowerBitindex>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -48,7 +48,7 @@ void LowerBitIndexPass::runOnOperation() {
   for (auto var : variables) {
     auto *defn = var.getDefiningOp();
     llvm::StringRef name;
-    ImplicitLocOpBuilder builder(var.getLoc(), var);
+    ImplicitLocOpBuilder builder(var.getLoc(), var.getContext());
     if (auto mod = dyn_cast<FModuleOp>(defn)) {
         name = "port.bitindex.wrapper";
         builder.setInsertionPointToStart(mod.getBody());

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -99,6 +99,9 @@ void LowerBitIndexPass::runOnOperation() {
         Value cat = builder.create<CatPrimOp>(subidx, prev);
         prev = cat;
       }
+      if (i.isa<SIntType>()) {
+        prev = builder.create<AsSIntPrimOp>(prev);
+      }
       // connect here after replacing all other connects
       builder.create<StrictConnectOp>(var, prev);
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBitindex.cpp
@@ -9,6 +9,22 @@
 //
 // This file defines the LowerBitindex pass.
 //
+// The lowering algorithm looks for all values that are bit-indexed. For each
+// such value `val`, it creates a new wire `v_wire` that is a vector
+// `UInt<1>[val.width]`.
+// Then it makes the following transformations:
+//
+// * `val <= e` becomes `v_wire[i] <= bits(e, i, i)` for all `i` up to `val.width`
+// * `val[n] <= e` becomes `v_wire[n] <= e`.
+// * `bits(val, hi, lo)` becomes `cat(v_wire[hi], v_wire[hi-1], ..., v_wire[lo])`.
+//
+// Then it connects the concatenation of the vector v_wire to the variable (`val <=
+// cat(v_wire[n], v_wire[n-1], ..., v_wire[0])` where `n` is `val.width-1`).
+//
+// If the bit-indexed value is a register, the pass additionally creates
+// state-preserving connections `v_wire[i] <= bits(val, i, i)` just after the
+// definition of `v_wire`.
+//
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"

--- a/test/Dialect/FIRRTL/lower-bitindex.mlir
+++ b/test/Dialect/FIRRTL/lower-bitindex.mlir
@@ -5,7 +5,7 @@ firrtl.circuit "Test"  {
 // CHECK-LABEL: firrtl.module @Test1
 firrtl.module @Test1(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
 
-  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire{{.*}}   : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
   // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
   // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -26,7 +26,7 @@ firrtl.module @Test1(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !fi
 firrtl.module @Test2(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
 
   // CHECK: %r = firrtl.reg interesting_name %clock  : !firrtl.uint<4>
-  // CHECK: %r_0 = firrtl.wire   {name = "r"} : !firrtl.vector<uint<1>, 4>
+  // CHECK: %r_0 = firrtl.wire{{.*}}   {name = "r"} : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.bits %r 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   // CHECK: %1 = firrtl.subindex %r_0[0] : !firrtl.vector<uint<1>, 4>
   // CHECK: firrtl.strictconnect %1, %0 : !firrtl.uint<1>
@@ -68,7 +68,7 @@ firrtl.module @Test2(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>, in %y: !f
 
 // CHECK-LABEL: firrtl.module @Test
 firrtl.module @Test(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
-  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire{{.*}}   : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
   // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
   // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -102,7 +102,7 @@ firrtl.module @Test(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !fir
 // CHECK-LABEL: firrtl.module @Test4
 firrtl.module @Test4(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
 
-  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire{{.*}}   : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
   // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
   // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -137,7 +137,7 @@ firrtl.module @Test4(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !fi
 // CHECK-LABEL: firrtl.module @Test5
 firrtl.module @Test5(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, in %en_2: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
 
-  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire{{.*}}   : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
   // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
   // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -193,7 +193,7 @@ firrtl.module @Test5(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !fi
 // CHECK-LABEL: firrtl.module @Test6
 firrtl.module @Test6(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<4>, out %out: !firrtl.uint<4>) {
 
-  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire{{.*}}   : !firrtl.vector<uint<1>, 4>
   // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
   // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
   // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/lower-bitindex.mlir
+++ b/test/Dialect/FIRRTL/lower-bitindex.mlir
@@ -1,0 +1,235 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-bitindex))'  %s | FileCheck %s
+
+firrtl.circuit "Test"  {
+
+// CHECK-LABEL: firrtl.module @Test1
+firrtl.module @Test1(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
+
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %3 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %4 = firrtl.cat %3, %2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %5 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %6 = firrtl.cat %5, %4 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %out, %6 : !firrtl.uint<4>
+  // CHECK: %7 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %7, %y : !firrtl.uint<1>
+
+
+  %0 = firrtl.bitindex %out[0] : !firrtl.uint<4>
+  firrtl.strictconnect %0, %y : !firrtl.uint<1>
+}
+
+// CHECK-LABEL: firrtl.module @Test2
+firrtl.module @Test2(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
+
+  // CHECK: %r = firrtl.reg interesting_name %clock  : !firrtl.uint<4>
+  // CHECK: %r_0 = firrtl.wire   {name = "r"} : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.bits %r 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %1 = firrtl.subindex %r_0[0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  // CHECK: %2 = firrtl.bits %r 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %3 = firrtl.subindex %r_0[1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+  // CHECK: %4 = firrtl.bits %r 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %5 = firrtl.subindex %r_0[2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+  // CHECK: %6 = firrtl.bits %r 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %7 = firrtl.subindex %r_0[3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %7, %6 : !firrtl.uint<1>
+  // CHECK: %8 = firrtl.subindex %r_0[0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %9 = firrtl.subindex %r_0[1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %10 = firrtl.cat %9, %8 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %11 = firrtl.subindex %r_0[2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %12 = firrtl.cat %11, %10 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %13 = firrtl.subindex %r_0[3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %14 = firrtl.cat %13, %12 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %r, %14 : !firrtl.uint<4>
+  // CHECK: %15 = firrtl.subindex %r_0[0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.when %en {
+  // CHECK:   firrtl.strictconnect %15, %y : !firrtl.uint<1>
+  // CHECK: }
+  // CHECK: firrtl.strictconnect %out, %r : !firrtl.uint<4>
+
+
+  %r = firrtl.reg interesting_name %clock  : !firrtl.uint<4>
+  %0 = firrtl.bitindex %r[0] : !firrtl.uint<4>
+  firrtl.when %en {
+    firrtl.strictconnect %0, %y : !firrtl.uint<1>
+  }
+  firrtl.strictconnect %out, %r : !firrtl.uint<4>
+}
+
+
+
+
+
+// CHECK-LABEL: firrtl.module @Test
+firrtl.module @Test(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %3 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %4 = firrtl.cat %3, %2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %5 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %6 = firrtl.cat %5, %4 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %out, %6 : !firrtl.uint<4>
+  // CHECK: %7 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %8 = firrtl.bits %x 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %9 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+  // CHECK: %10 = firrtl.bits %x 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %11 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %11, %10 : !firrtl.uint<1>
+  // CHECK: %12 = firrtl.bits %x 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %13 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %13, %12 : !firrtl.uint<1>
+  // CHECK: %14 = firrtl.bits %x 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %15 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %15, %14 : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %7, %y : !firrtl.uint<1>
+
+
+  %0 = firrtl.bitindex %out[2] : !firrtl.uint<4>
+  firrtl.strictconnect %out, %x : !firrtl.uint<4>
+  firrtl.strictconnect %0, %y : !firrtl.uint<1>
+}
+
+
+// CHECK-LABEL: firrtl.module @Test4
+firrtl.module @Test4(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
+
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %3 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %4 = firrtl.cat %3, %2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %5 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %6 = firrtl.cat %5, %4 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %out, %6 : !firrtl.uint<4>
+  // CHECK: %7 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %8 = firrtl.bits %x 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %9 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+  // CHECK: %10 = firrtl.bits %x 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %11 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %11, %10 : !firrtl.uint<1>
+  // CHECK: %12 = firrtl.bits %x 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %13 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %13, %12 : !firrtl.uint<1>
+  // CHECK: %14 = firrtl.bits %x 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %15 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %15, %14 : !firrtl.uint<1>
+  // CHECK: %16 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %7, %16 : !firrtl.uint<1>
+
+
+  %0 = firrtl.bitindex %out[0] : !firrtl.uint<4>
+  firrtl.strictconnect %out, %x : !firrtl.uint<4>
+  %1 = firrtl.bits %out 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+}
+
+// CHECK-LABEL: firrtl.module @Test5
+firrtl.module @Test5(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<1>, in %en: !firrtl.uint<1>, in %en_2: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
+
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %3 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %4 = firrtl.cat %3, %2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %5 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %6 = firrtl.cat %5, %4 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %out, %6 : !firrtl.uint<4>
+  // CHECK: %7 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %8 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %9 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %10 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %11 = firrtl.bits %x 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %12 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %12, %11 : !firrtl.uint<1>
+  // CHECK: %13 = firrtl.bits %x 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %14 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %14, %13 : !firrtl.uint<1>
+  // CHECK: %15 = firrtl.bits %x 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %16 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %16, %15 : !firrtl.uint<1>
+  // CHECK: %17 = firrtl.bits %x 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %18 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %18, %17 : !firrtl.uint<1>
+  // CHECK: firrtl.when %en {
+  // CHECK:   firrtl.strictconnect %10, %y : !firrtl.uint<1>
+  // CHECK:   firrtl.when %en_2 {
+  // CHECK:     firrtl.strictconnect %9, %y : !firrtl.uint<1>
+  // CHECK:     firrtl.strictconnect %8, %y : !firrtl.uint<1>
+  // CHECK:   }
+  // CHECK: } else {
+  // CHECK:   firrtl.strictconnect %9, %y : !firrtl.uint<1>
+  // CHECK: }
+  // CHECK: firrtl.strictconnect %7, %y : !firrtl.uint<1>
+
+  %0 = firrtl.bitindex %out[3] : !firrtl.uint<4>
+  %1 = firrtl.bitindex %out[2] : !firrtl.uint<4>
+  %2 = firrtl.bitindex %out[1] : !firrtl.uint<4>
+  %3 = firrtl.bitindex %out[0] : !firrtl.uint<4>
+  firrtl.strictconnect %out, %x : !firrtl.uint<4>
+  firrtl.when %en {
+    firrtl.strictconnect %3, %y : !firrtl.uint<1>
+    firrtl.when %en_2 {
+      firrtl.strictconnect %2, %y : !firrtl.uint<1>
+      firrtl.strictconnect %1, %y : !firrtl.uint<1>
+    }
+  } else {
+    firrtl.strictconnect %2, %y : !firrtl.uint<1>
+  }
+  firrtl.strictconnect %0, %y : !firrtl.uint<1>
+}
+
+// CHECK-LABEL: firrtl.module @Test6
+firrtl.module @Test6(in %x: !firrtl.uint<4>, in %y: !firrtl.uint<4>, out %out: !firrtl.uint<4>) {
+
+  // CHECK: [[WRAPPER:%.+]] = firrtl.wire   : !firrtl.vector<uint<1>, 4>
+  // CHECK: %0 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %1 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %2 = firrtl.cat %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK: %3 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %4 = firrtl.cat %3, %2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  // CHECK: %5 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %6 = firrtl.cat %5, %4 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %out, %6 : !firrtl.uint<4>
+  // CHECK: %7 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %8 = firrtl.bits %x 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %9 = firrtl.subindex [[WRAPPER]][0] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+  // CHECK: %10 = firrtl.bits %x 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %11 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %11, %10 : !firrtl.uint<1>
+  // CHECK: %12 = firrtl.bits %x 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %13 = firrtl.subindex [[WRAPPER]][2] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %13, %12 : !firrtl.uint<1>
+  // CHECK: %14 = firrtl.bits %x 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %15 = firrtl.subindex [[WRAPPER]][3] : !firrtl.vector<uint<1>, 4>
+  // CHECK: firrtl.strictconnect %15, %14 : !firrtl.uint<1>
+  // CHECK: %16 = firrtl.subindex [[WRAPPER]][1] : !firrtl.vector<uint<1>, 4>
+  // CHECK: %17 = firrtl.bits %y 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: %18 = firrtl.or %16, %17 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %7, %18 : !firrtl.uint<1>
+
+
+  %0 = firrtl.bitindex %out[0] : !firrtl.uint<4>
+  firrtl.strictconnect %out, %x : !firrtl.uint<4>
+  %1 = firrtl.bits %out 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %2 = firrtl.bits %y 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %3 = firrtl.or %1, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.strictconnect %0, %3 : !firrtl.uint<1>
+}
+
+
+
+}
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -463,6 +463,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.addInstrumentation(std::make_unique<FirtoolPassInstrumentation>());
   applyPassManagerCLOptions(pm);
 
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerBitindexPass());
+
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
       disableAnnotationsUnknown, disableAnnotationsClassless));
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -463,7 +463,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.addInstrumentation(std::make_unique<FirtoolPassInstrumentation>());
   applyPassManagerCLOptions(pm);
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerBitindexPass());
+  auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
+  modulePM.addPass(firrtl::createLowerBitindexPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
       disableAnnotationsUnknown, disableAnnotationsClassless));


### PR DESCRIPTION
This PR adds support for the bit-index operator in FIRRTL. See https://github.com/chipsalliance/firrtl-spec/pull/26 for the proposal and a description of the lowering algorithm. This PR adds support via a lowering pass in the FIRRTL dialect called `LowerBitindex`. This is my first time using/contributing to this codebase so there are probably many things in my code that could be done better. Please let me know what to change. Thanks!