### PR TITLE
[HW] Adopt prefixed accessors

### DIFF
--- a/include/circt/Dialect/HW/HWDialect.td
+++ b/include/circt/Dialect/HW/HWDialect.td
@@ -25,6 +25,7 @@ def HWDialect : Dialect {
 
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
+  int emitAccessorPrefix = kEmitAccessorPrefix_Both;
 
   let extraClassDeclaration = [{
     /// Register all HW types.

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -40,11 +40,6 @@ def ConstantOp
     /// Build a ConstantOp from a prebuilt attribute.
     OpBuilder<(ins "IntegerAttr":$value)>
   ];
-  let extraClassDeclaration = [{
-    APInt getValue() {
-      return (*this)->getAttrOfType<IntegerAttr>("value").getValue();
-    }
-  }];
   let hasFolder = true;
   let hasVerifier = 1;
 }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -115,7 +115,7 @@ def HWModuleOp : HWModuleOpBase<"module",
 
     // TODO(mlir): FunctionLike shouldn't produce a getBody() helper, it is
     // squatting on the name.
-    Block *getBodyBlock() { return &body().front(); }
+    Block *getBodyBlock() { return &getBody().front(); }
 
     // Get the module's symbolic name as StringAttr.
     StringAttr getNameAttr() {
@@ -430,12 +430,12 @@ def InstanceOp : HWOp<"instance", [
 
     /// Change the names of all the input ports.
     void setArgumentNames(ArrayAttr names) {
-      argNamesAttr(names);
+      setArgNamesAttr(names);
     }
 
     /// Change the names of all the result ports.
     void setResultNames(ArrayAttr names) {
-      resultNamesAttr(names);
+      setResultNamesAttr(names);
     }
 
     /// Lookup the module or extmodule for the symbol.  This returns null on
@@ -444,12 +444,12 @@ def InstanceOp : HWOp<"instance", [
 
     /// Get the instances's name.
     StringAttr getName() {
-      return instanceNameAttr();
+      return getInstanceNameAttr();
     }
 
     /// Set the instance's name.
     void setName(StringAttr name) {
-      instanceNameAttr(name);
+      setInstanceNameAttr(name);
     }
 
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWTypeDecls.td
+++ b/include/circt/Dialect/HW/HWTypeDecls.td
@@ -30,7 +30,7 @@ def TypeScopeOp : HWOp<"type_scope",
   let assemblyFormat = "$sym_name $body attr-dict";
 
   let extraClassDeclaration = [{
-    Block *getBodyBlock() { return &body().front(); }
+    Block *getBodyBlock() { return &getBody().front(); }
   }];
 }
 

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -62,10 +62,10 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
           $_op->emitOpError("could not find hw.globalRef ") << refSym;
           return nullptr;
         }
-        if (ref.namepath().empty())
+        if (ref.getNamepath().empty())
           return nullptr;
         auto modSym = FlatSymbolRefAttr::get(
-            ref.namepath()[0].cast<hw::InnerRefAttr>().getModule());
+            ref.getNamepath()[0].cast<hw::InnerRefAttr>().getModule());
         return symCache.getDefinition(modSym);
       }]
     >

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -179,7 +179,7 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
   }
 
   // Legalize the parameter names.
-  for (auto param : module.parameters()) {
+  for (auto param : module.getParameters()) {
     auto paramAttr = param.cast<ParamDeclAttr>();
     auto newName = nameResolver.getLegalName(paramAttr.getName());
     if (newName != paramAttr.getName().getValue())

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1023,7 +1023,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   if (auto outputFile = oldModule->getAttr("output_file"))
     newModule->setAttr("output_file", outputFile);
   if (auto comment = oldModule->getAttrOfType<StringAttr>("comment"))
-    newModule.commentAttr(comment);
+    newModule.setCommentAttr(comment);
 
   // If the circuit has an entry point, set all other modules private.
   // Otherwise, mark all modules as public.
@@ -1042,7 +1042,8 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
       newModule->setAttr("output_file", testBenchDir);
       newModule->setAttr("firrtl.extract.do_not_extract",
                          builder.getUnitAttr());
-      newModule.commentAttr(builder.getStringAttr("VCS coverage exclude_file"));
+      newModule.setCommentAttr(
+          builder.getStringAttr("VCS coverage exclude_file"));
     }
 
   bool failed = false;
@@ -1251,7 +1252,7 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
   if (!newModule)
     return success();
 
-  ImplicitLocOpBuilder bodyBuilder(oldModule.getLoc(), newModule.body());
+  ImplicitLocOpBuilder bodyBuilder(oldModule.getLoc(), newModule.getBody());
 
   // Use a placeholder instruction be a cursor that indicates where we want to
   // move the new function body to.  This is important because we insert some
@@ -1283,7 +1284,7 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
     if (!port.isOutput() && !isZeroWidth) {
       // Inputs and InOuts are modeled as arguments in the result, so we can
       // just map them over.  We model zero bit outputs as inouts.
-      Value newArg = newModule.body().getArgument(nextNewArg++);
+      Value newArg = newModule.getBody().getArgument(nextNewArg++);
 
       // Cast the argument to the old type, reintroducing sign information in
       // the hw.module body.
@@ -2048,7 +2049,7 @@ LogicalResult FIRRTLLowering::setPossiblyFoldedLowering(Value orig,
   // If this is a constant, check to see if we have it in our unique mapping:
   // it could have come from folding an operation.
   if (auto cst = dyn_cast_or_null<hw::ConstantOp>(result.getDefiningOp())) {
-    auto &entry = hwConstantMap[cst.valueAttr()];
+    auto &entry = hwConstantMap[cst.getValueAttr()];
     if (entry == cst) {
       // We're already using an entry in the constant map, nothing to do.
     } else if (entry) {
@@ -3036,10 +3037,10 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   if (oldInstance.lowerToBind())
     newInstance->setAttr("doNotPrint", builder.getBoolAttr(true));
 
-  if (newInstance.inner_symAttr())
+  if (newInstance.getInnerSymAttr())
     if (auto forceName = circuitState.instanceForceNames.lookup(
             {cast<hw::HWModuleOp>(newInstance->getParentOp()).getNameAttr(),
-             newInstance.inner_symAttr()}))
+             newInstance.getInnerSymAttr()}))
       newInstance->setAttr("hw.verilogName", forceName);
 
   // Now that we have the new hw.instance, we need to remap all of the users

--- a/lib/Conversion/HWToLLHD/HWToLLHD.cpp
+++ b/lib/Conversion/HWToLLHD/HWToLLHD.cpp
@@ -255,7 +255,7 @@ struct ConvertInstance : public OpConversionPattern<InstanceOp> {
     // original instance for replacement with the new values probed from the
     // signals attached to the LLHD instance.
     rewriter.create<InstOp>(instance.getLoc(), instance.instanceName(),
-                            instance.moduleName(), arguments, resultSigs);
+                            instance.getModuleName(), arguments, resultSigs);
     rewriter.replaceOp(instance, resultValues);
 
     return success();

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -392,7 +392,7 @@ private:
         .Case<hw::ConstantOp>([&](auto op) {
           // A constant is defined as <bit-width>'<base><value>, where the base
           // is `b` (binary), `o` (octal), `h` hexadecimal, or `d` (decimal).
-          APInt value = op.value();
+          APInt value = op.getValue();
 
           (isIndented ? indent() : os)
               << std::to_string(value.getBitWidth()) << apostrophe() << "d";

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -88,7 +88,7 @@ struct ConstantIntMatcher {
   ConstantIntMatcher(APInt &value) : value(value) {}
   bool match(Operation *op) {
     if (auto cst = dyn_cast<hw::ConstantOp>(op)) {
-      value = cst.value();
+      value = cst.getValue();
       return true;
     }
     return false;

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -183,7 +183,7 @@ StringAttr hw::getResultSym(Operation *op, unsigned i) {
 
 void ConstantOp::print(OpAsmPrinter &p) {
   p << " ";
-  p.printAttribute(valueAttr());
+  p.printAttribute(getValueAttr());
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"value"});
 }
 
@@ -200,7 +200,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 
 LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  if (value().getBitWidth() != getType().getWidth())
+  if (getValue().getBitWidth() != getType().getWidth())
     return emitError(
         "hw.constant attribute bitwidth doesn't match return type");
 
@@ -252,7 +252,7 @@ void ConstantOp::getAsmResultNames(
 
 OpFoldResult ConstantOp::fold(ArrayRef<Attribute> constants) {
   assert(constants.empty() && "constant has no operands");
-  return valueAttr();
+  return getValueAttr();
 }
 
 //===----------------------------------------------------------------------===//
@@ -276,12 +276,12 @@ static void printParamValue(OpAsmPrinter &p, Operation *, Attribute value,
 LogicalResult ParamValueOp::verify() {
   // Check that the attribute expression is valid in this module.
   return checkParameterInContext(
-      value(), (*this)->getParentOfType<hw::HWModuleOp>(), *this);
+      getValue(), (*this)->getParentOfType<hw::HWModuleOp>(), *this);
 }
 
 OpFoldResult ParamValueOp::fold(ArrayRef<Attribute> constants) {
   assert(constants.empty() && "hw.param.value has no operands");
-  return valueAttr();
+  return getValueAttr();
 }
 
 //===----------------------------------------------------------------------===//
@@ -587,14 +587,14 @@ void HWModuleOp::modifyPorts(
 /// here.  This is typically the symbol, but can be overridden with the
 /// verilogName attribute.
 StringAttr HWModuleExternOp::getVerilogModuleNameAttr() {
-  if (auto vName = verilogNameAttr())
+  if (auto vName = getVerilogNameAttr())
     return vName;
 
   return (*this)->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
 }
 
 StringAttr HWModuleGeneratedOp::getVerilogModuleNameAttr() {
-  if (auto vName = verilogNameAttr()) {
+  if (auto vName = getVerilogNameAttr()) {
     return vName;
   }
   return (*this)->getAttrOfType<StringAttr>(
@@ -938,7 +938,7 @@ static void printModuleOp(OpAsmPrinter &p, Operation *op,
   p.printSymbolName(SymbolTable::getSymbolName(op).getValue());
   if (modKind == GenMod) {
     p << ", ";
-    p.printSymbolName(cast<HWModuleGeneratedOp>(op).generatorKind());
+    p.printSymbolName(cast<HWModuleGeneratedOp>(op).getGeneratorKind());
   }
 
   // Print the parameter list if present.
@@ -1071,17 +1071,17 @@ void HWModuleExternOp::getAsmBlockArgumentNames(
 /// invalid IR.
 Operation *HWModuleGeneratedOp::getGeneratorKindOp() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  return topLevelModuleOp.lookupSymbol(generatorKind());
+  return topLevelModuleOp.lookupSymbol(getGeneratorKind());
 }
 
 LogicalResult
 HWModuleGeneratedOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto *referencedKind =
-      symbolTable.lookupNearestSymbolFrom(*this, generatorKindAttr());
+      symbolTable.lookupNearestSymbolFrom(*this, getGeneratorKindAttr());
 
   if (referencedKind == nullptr)
     return emitError("Cannot find generator definition '")
-           << generatorKind() << "'";
+           << getGeneratorKind() << "'";
 
   if (!isa<HWGeneratorSchemaOp>(referencedKind))
     return emitError("Symbol resolved to '")
@@ -1089,7 +1089,7 @@ HWModuleGeneratedOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
            << "' which is not a HWGeneratorSchemaOp";
 
   auto referencedKindOp = dyn_cast<HWGeneratorSchemaOp>(referencedKind);
-  auto paramRef = referencedKindOp.requiredAttrs();
+  auto paramRef = referencedKindOp.getRequiredAttrs();
   auto dict = (*this)->getAttrDictionary();
   for (auto str : paramRef) {
     auto strAttr = str.dyn_cast<StringAttr>();
@@ -1138,22 +1138,24 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule(const HWSymbolCache *cache) {
   if (cache)
-    if (auto *result = cache->getDefinition(moduleNameAttr()))
+    if (auto *result = cache->getDefinition(getModuleNameAttr()))
       return result;
 
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  return topLevelModuleOp.lookupSymbol(moduleName());
+  return topLevelModuleOp.lookupSymbol(getModuleName());
 }
 
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  auto *module = symbolTable.lookupNearestSymbolFrom(*this, moduleNameAttr());
+  auto *module =
+      symbolTable.lookupNearestSymbolFrom(*this, getModuleNameAttr());
   if (module == nullptr)
-    return emitError("Cannot find module definition '") << moduleName() << "'";
+    return emitError("Cannot find module definition '")
+           << getModuleName() << "'";
 
   // It must be some sort of module.
   if (!isAnyModule(module))
     return emitError("symbol reference '")
-           << moduleName() << "' isn't a module";
+           << getModuleName() << "' isn't a module";
 
   // Check that input and result types are consistent with the referenced
   // module.
@@ -1168,7 +1170,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   };
 
   // Make sure our port and result names match.
-  ArrayAttr argNames = argNamesAttr();
+  ArrayAttr argNames = getArgNamesAttr();
   ArrayAttr modArgNames = module->getAttrOfType<ArrayAttr>("argNames");
 
   // Check operand types first.
@@ -1188,8 +1190,8 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     });
 
   for (size_t i = 0; i != numOperands; ++i) {
-    auto expectedType =
-        evaluateParametricType(getLoc(), parameters(), expectedOperandTypes[i]);
+    auto expectedType = evaluateParametricType(getLoc(), getParameters(),
+                                               expectedOperandTypes[i]);
     if (failed(expectedType))
       return emitError([&](auto &diag) {
         diag << "failed to resolve parametric input of instantiated module";
@@ -1212,7 +1214,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check result types and labels.
   auto numResults = getOperation()->getNumResults();
   auto expectedResultTypes = getModuleType(module).getResults();
-  ArrayAttr resultNames = resultNamesAttr();
+  ArrayAttr resultNames = getResultNamesAttr();
   ArrayAttr modResultNames = module->getAttrOfType<ArrayAttr>("resultNames");
 
   if (expectedResultTypes.size() != numResults)
@@ -1227,8 +1229,8 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     });
 
   for (size_t i = 0; i != numResults; ++i) {
-    auto expectedType =
-        evaluateParametricType(getLoc(), parameters(), expectedResultTypes[i]);
+    auto expectedType = evaluateParametricType(getLoc(), getParameters(),
+                                               expectedResultTypes[i]);
     if (failed(expectedType))
       return emitError([&](auto &diag) {
         diag << "failed to resolve parametric input of instantiated module";
@@ -1248,7 +1250,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   }
 
   // Check parameters match up.
-  ArrayAttr parameters = this->parameters();
+  ArrayAttr parameters = this->getParameters();
   ArrayAttr modParameters = module->getAttrOfType<ArrayAttr>("parameters");
   auto numParameters = parameters.size();
   if (numParameters != modParameters.size())
@@ -1286,7 +1288,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 LogicalResult InstanceOp::verify() {
   // Check that all the parameter values specified to the instance are
   // structurally valid.
-  for (auto param : parameters()) {
+  for (auto param : getParameters()) {
     auto paramAttr = param.cast<ParamDeclAttr>();
     auto value = paramAttr.getValue();
     // The SymbolUses verifier which checks that this exists may not have been
@@ -1309,7 +1311,7 @@ LogicalResult InstanceOp::verify() {
 ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
   auto *context = result.getContext();
   StringAttr instanceNameAttr;
-  StringAttr sym_nameAttr;
+  StringAttr symNameAttr;
   FlatSymbolRefAttr moduleNameAttr;
   SmallVector<OpAsmParser::UnresolvedOperand, 4> inputsOperands;
   SmallVector<Type> inputsTypes;
@@ -1325,7 +1327,7 @@ ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
     // Parsing an optional symbol name doesn't fail, so no need to check the
     // result.
     (void)parser.parseOptionalSymbolName(
-        sym_nameAttr, InnerName::getInnerNameAttrName(), result.attributes);
+        symNameAttr, InnerName::getInnerNameAttrName(), result.attributes);
   }
 
   auto parseInputPort = [&]() -> ParseResult {
@@ -1391,16 +1393,16 @@ void InstanceOp::print(OpAsmPrinter &p) {
   };
 
   p << ' ';
-  p.printAttributeWithoutType(instanceNameAttr());
-  if (auto attr = inner_symAttr()) {
+  p.printAttributeWithoutType(getInstanceNameAttr());
+  if (auto attr = getInnerSymAttr()) {
     p << " sym ";
     p.printSymbolName(attr.getValue());
   }
   p << ' ';
-  p.printAttributeWithoutType(moduleNameAttr());
-  printParameterList(parameters(), p);
+  p.printAttributeWithoutType(getModuleNameAttr());
+  printParameterList(getParameters(), p);
   p << '(';
-  llvm::interleaveComma(inputs(), p, [&](Value op) {
+  llvm::interleaveComma(getInputs(), p, [&](Value op) {
     printPortName(nextInputPort, portInfo.inputs);
     p << op << ": " << op.getType();
   });
@@ -1419,7 +1421,7 @@ void InstanceOp::print(OpAsmPrinter &p) {
 /// Return the name of the specified input port or null if it cannot be
 /// determined.
 StringAttr InstanceOp::getArgumentName(size_t idx) {
-  auto names = argNames();
+  auto names = getArgNames();
   // Tolerate malformed IR here to enable debug printing etc.
   if (names && idx < names.size())
     return names[idx].cast<StringAttr>();
@@ -1429,7 +1431,7 @@ StringAttr InstanceOp::getArgumentName(size_t idx) {
 /// Return the name of the specified result or null if it cannot be
 /// determined.
 StringAttr InstanceOp::getResultName(size_t idx) {
-  auto names = resultNames();
+  auto names = getResultNames();
   // Tolerate malformed IR here to enable debug printing etc.
   if (names && idx < names.size())
     return names[idx].cast<StringAttr>();
@@ -1438,7 +1440,7 @@ StringAttr InstanceOp::getResultName(size_t idx) {
 
 /// Change the name of the specified input port.
 void InstanceOp::setArgumentName(size_t i, StringAttr name) {
-  auto names = argNames();
+  auto names = getArgNames();
   SmallVector<Attribute> newNames(names.begin(), names.end());
   if (newNames[i] == name)
     return;
@@ -1448,7 +1450,7 @@ void InstanceOp::setArgumentName(size_t i, StringAttr name) {
 
 /// Change the name of the specified output port.
 void InstanceOp::setResultName(size_t i, StringAttr name) {
-  auto names = resultNames();
+  auto names = getResultNames();
   SmallVector<Attribute> newNames(names.begin(), names.end());
   if (newNames[i] == name)
     return;
@@ -1513,7 +1515,7 @@ LogicalResult
 GlobalRefOp::verifySymbolUses(mlir::SymbolTableCollection &symTables) {
   Operation *parent = (*this)->getParentOp();
   SymbolTable &symTable = symTables.getSymbolTable(parent);
-  StringAttr symNameAttr = (*this).sym_nameAttr();
+  StringAttr symNameAttr = (*this).getSymNameAttr();
   auto hasGlobalRef = [&](Attribute attr) -> bool {
     if (!attr)
       return false;
@@ -1524,7 +1526,7 @@ GlobalRefOp::verifySymbolUses(mlir::SymbolTableCollection &symTables) {
   };
   // For all inner refs in the namepath, ensure they have a corresponding
   // GlobalRefAttr to this GlobalRefOp.
-  for (auto innerRef : namepath().getAsRange<hw::InnerRefAttr>()) {
+  for (auto innerRef : getNamepath().getAsRange<hw::InnerRefAttr>()) {
     StringAttr modName = innerRef.getModule();
     StringAttr innerSym = innerRef.getName();
     Operation *mod = symTable.lookup(modName);
@@ -1627,9 +1629,9 @@ ParseResult ArrayCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void ArrayCreateOp::print(OpAsmPrinter &p) {
   p << " ";
-  p.printOperands(inputs());
+  p.printOperands(getInputs());
   p.printOptionalAttrDict((*this)->getAttrs());
-  p << " : " << inputs()[0].getType();
+  p << " : " << getInputs()[0].getType();
 }
 
 void ArrayCreateOp::build(OpBuilder &b, OperationState &state,
@@ -1645,15 +1647,15 @@ void ArrayCreateOp::build(OpBuilder &b, OperationState &state,
 
 LogicalResult ArrayCreateOp::verify() {
   unsigned returnSize = getType().cast<ArrayType>().getSize();
-  if (inputs().size() != returnSize)
+  if (getInputs().size() != returnSize)
     return failure();
   return success();
 }
 
 LogicalResult ArraySliceOp::verify() {
-  unsigned inputSize = type_cast<ArrayType>(input().getType()).getSize();
+  unsigned inputSize = type_cast<ArrayType>(getInput().getType()).getSize();
   if (llvm::Log2_64_Ceil(inputSize) !=
-      lowIndex().getType().getIntOrFloatBitWidth())
+      getLowIndex().getType().getIntOrFloatBitWidth())
     return emitOpError(
         "ArraySlice: index width must match clog2 of array size");
   return success();
@@ -1741,18 +1743,18 @@ ParseResult EnumConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void EnumConstantOp::print(OpAsmPrinter &p) {
-  p << " " << field().getField().getValue() << " : "
-    << field().getType().getValue();
+  p << " " << getField().getField().getValue() << " : "
+    << getField().getType().getValue();
 }
 
 void EnumConstantOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(getResult(), field().getField().str());
+  setNameFn(getResult(), getField().getField().str());
 }
 
 OpFoldResult EnumConstantOp::fold(ArrayRef<Attribute> constants) {
   assert(constants.empty() && "constant has no operands");
-  return fieldAttr();
+  return getFieldAttr();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1786,7 +1788,7 @@ ParseResult StructCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void StructCreateOp::print(OpAsmPrinter &printer) {
   printer << " (";
-  printer.printOperands(input());
+  printer.printOperands(getInput());
   printer << ")";
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getType();
@@ -1821,9 +1823,9 @@ ParseResult StructExplodeOp::parse(OpAsmParser &parser,
 
 void StructExplodeOp::print(OpAsmPrinter &printer) {
   printer << " ";
-  printer.printOperand(input());
+  printer.printOperand(getInput());
   printer.printOptionalAttrDict((*this)->getAttrs());
-  printer << " : " << input().getType();
+  printer << " : " << getInput().getType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1866,10 +1868,10 @@ static ParseResult parseExtractOp(OpAsmParser &parser, OperationState &result) {
 template <typename AggType>
 static void printExtractOp(OpAsmPrinter &printer, AggType op) {
   printer << " ";
-  printer.printOperand(op.input());
-  printer << "[\"" << op.field() << "\"]";
+  printer.printOperand(op.getInput());
+  printer << "[\"" << op.getField() << "\"]";
   printer.printOptionalAttrDict(op->getAttrs(), {"field"});
-  printer << " : " << op.input().getType();
+  printer << " : " << op.getInput().getType();
 }
 
 ParseResult StructExtractOp::parse(OpAsmParser &parser,
@@ -1895,13 +1897,14 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
 
 // A struct extract of a struct create -> corresponding struct create operand.
 OpFoldResult StructExtractOp::fold(ArrayRef<Attribute> operands) {
-  auto structCreate = dyn_cast_or_null<StructCreateOp>(input().getDefiningOp());
+  auto structCreate =
+      dyn_cast_or_null<StructCreateOp>(getInput().getDefiningOp());
   if (!structCreate)
     return {};
-  auto ty = type_cast<StructType>(input().getType());
+  auto ty = type_cast<StructType>(getInput().getType());
   if (!ty)
     return {};
-  if (auto idx = ty.getFieldIndex(field()))
+  if (auto idx = ty.getFieldIndex(getField()))
     return structCreate.getOperand(*idx);
   return {};
 }
@@ -1942,11 +1945,11 @@ ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void StructInjectOp::print(OpAsmPrinter &printer) {
   printer << " ";
-  printer.printOperand(input());
-  printer << "[\"" << field() << "\"], ";
-  printer.printOperand(newValue());
+  printer.printOperand(getInput());
+  printer << "[\"" << getField() << "\"], ";
+  printer.printOperand(getNewValue());
   printer.printOptionalAttrDict((*this)->getAttrs(), {"field"});
-  printer << " : " << input().getType();
+  printer << " : " << getInput().getType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1984,8 +1987,8 @@ ParseResult UnionCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void UnionCreateOp::print(OpAsmPrinter &printer) {
-  printer << " \"" << field() << "\", ";
-  printer.printOperand(input());
+  printer << " \"" << getField() << "\", ";
+  printer.printOperand(getInput());
   printer.printOptionalAttrDict((*this)->getAttrs(), {"field"});
   printer << " : " << getType();
 }
@@ -2015,7 +2018,8 @@ void ArrayGetOp::build(OpBuilder &builder, OperationState &result, Value input,
 // An array_get of an array_create with a constant index can just be the
 // array_create operand at the constant index.
 OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
-  auto inputCreate = dyn_cast_or_null<ArrayCreateOp>(input().getDefiningOp());
+  auto inputCreate =
+      dyn_cast_or_null<ArrayCreateOp>(getInput().getDefiningOp());
   if (!inputCreate)
     return {};
 
@@ -2024,7 +2028,7 @@ OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
     return {};
 
   uint64_t idx = constIdx.getValue().getLimitedValue();
-  auto createInputs = inputCreate.inputs();
+  auto createInputs = inputCreate.getInputs();
   if (idx >= createInputs.size())
     return {};
   return createInputs[createInputs.size() - idx - 1];
@@ -2035,7 +2039,7 @@ OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 StringRef TypedeclOp::getPreferredName() {
-  return verilogName().getValueOr(getName());
+  return getVerilogName().getValueOr(getName());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2056,17 +2060,18 @@ LogicalResult BitcastOp::canonicalize(BitcastOp op, PatternRewriter &rewriter) {
   // %b = bitcast(%a) : A -> B
   //      bitcast(%b) : B -> C
   // ===> bitcast(%a) : A -> C
-  auto inputBitcast = dyn_cast_or_null<BitcastOp>(op.input().getDefiningOp());
+  auto inputBitcast =
+      dyn_cast_or_null<BitcastOp>(op.getInput().getDefiningOp());
   if (!inputBitcast)
     return failure();
   auto bitcast = rewriter.createOrFold<BitcastOp>(op.getLoc(), op.getType(),
-                                                  inputBitcast.input());
+                                                  inputBitcast.getInput());
   rewriter.replaceOp(op, bitcast);
   return success();
 }
 
 LogicalResult BitcastOp::verify() {
-  if (getBitWidth(input().getType()) != getBitWidth(result().getType()))
+  if (getBitWidth(getInput().getType()) != getBitWidth(getResult().getType()))
     return this->emitOpError("Bitwidth of input must match result");
   return success();
 }

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -133,7 +133,7 @@ void TclOutputState::emitInnerRefPart(hw::InnerRefAttr innerRef) {
 void TclOutputState::emitPath(hw::GlobalRefOp ref,
                               Optional<StringRef> subpath) {
   // Traverse each part of the path.
-  auto parts = ref.namepathAttr().getAsRange<hw::InnerRefAttr>();
+  auto parts = ref.getNamepathAttr().getAsRange<hw::InnerRefAttr>();
   auto lastPart = std::prev(parts.end());
   for (auto part : parts) {
     emitInnerRefPart(part);

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -921,7 +921,7 @@ static StringRef getValueName(Value v, const SymbolCache &syms,
   }
   if (auto constOp = dyn_cast<hw::ConstantOp>(defOp)) {
     buff.clear();
-    llvm::raw_string_ostream(buff) << "c" << constOp.value();
+    llvm::raw_string_ostream(buff) << "c" << constOp.getValue();
     return buff;
   }
 
@@ -995,7 +995,7 @@ void PartitionPass::bubbleUpGlobalRefs(
     auto globalRefOp = dyn_cast_or_null<hw::GlobalRefOp>(
         topLevelSyms.getDefinition(refSymbol));
     assert(globalRefOp && "symbol must reference a GlobalRefOp");
-    auto oldPath = globalRefOp.namepath().getValue();
+    auto oldPath = globalRefOp.getNamepath().getValue();
     assert(!oldPath.empty());
 
     // If the path already points to the target design partition, we are done.
@@ -1041,7 +1041,7 @@ void PartitionPass::bubbleUpGlobalRefs(
 
     // Update the path on the GlobalRefOp.
     auto newPathAttr = ArrayAttr::get(op->getContext(), newPath);
-    globalRefOp.namepathAttr(newPathAttr);
+    globalRefOp.setNamepathAttr(newPathAttr);
 
     refsMoved.insert(globalRef);
   }
@@ -1061,7 +1061,7 @@ void PartitionPass::pushDownGlobalRefs(
     auto globalRefOp = dyn_cast_or_null<hw::GlobalRefOp>(
         topLevelSyms.getDefinition(refSymbol));
     assert(globalRefOp && "symbol must reference a GlobalRefOp");
-    auto oldPath = globalRefOp.namepath().getValue();
+    auto oldPath = globalRefOp.getNamepath().getValue();
     assert(!oldPath.empty());
 
     // Get the module containing the partition and the partition's name.
@@ -1110,7 +1110,7 @@ void PartitionPass::pushDownGlobalRefs(
 
     // Update the path on the GlobalRefOp.
     auto newPathAttr = ArrayAttr::get(op->getContext(), newPath);
-    globalRefOp.namepathAttr(newPathAttr);
+    globalRefOp.setNamepathAttr(newPathAttr);
 
     // Ensure the part instance will have this GlobalRefAttr.
     // global refs if not.

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -75,7 +75,7 @@ void HWGeneratorCalloutPass::processGenerator(
 
   // Ignore the generator op if the schema does not match the user specified
   // schema name from command line "-schema-name"
-  if (genSchema.descriptor().str() != schemaName)
+  if (genSchema.getDescriptor().str() != schemaName)
     return;
 
   SmallVector<std::string> generatorArgs;
@@ -93,7 +93,7 @@ void HWGeneratorCalloutPass::processGenerator(
   // Iterate over all the attributes in the schema.
   // Assumption: All the options required by the generator program must be
   // present in the schema.
-  for (auto attr : genSchema.requiredAttrs()) {
+  for (auto attr : genSchema.getRequiredAttrs()) {
     auto sAttr = attr.cast<StringAttr>();
     // Get the port name from schema.
     StringRef portName = sAttr.getValue();

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -42,7 +42,7 @@ struct HWExportModuleHierarchyPass
 /// Recursively print the module hierarchy as serialized as JSON.
 static void printHierarchy(hw::InstanceOp &inst, SymbolTable &symbolTable,
                            llvm::json::OStream &j) {
-  auto moduleOp = symbolTable.lookup(inst.moduleNameAttr().getValue());
+  auto moduleOp = symbolTable.lookup(inst.getModuleNameAttr().getValue());
 
   j.object([&] {
     j.attribute("instance_name", inst.instanceName());

--- a/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
@@ -57,12 +57,12 @@ private:
 /// otherwise.
 Operation *HWLegalizeModulesPass::tryLoweringArrayGet(hw::ArrayGetOp getOp) {
   // If the operand is an array_create, then we can lower this into a casez.
-  auto createOp = getOp.input().getDefiningOp<hw::ArrayCreateOp>();
+  auto createOp = getOp.getInput().getDefiningOp<hw::ArrayCreateOp>();
   if (!createOp)
     return nullptr;
 
   // array_get(idx, array_create(a,b,c,d)) ==> casez(idx).
-  Value index = getOp.index();
+  Value index = getOp.getIndex();
 
   // Create the wire for the result of the casez in the hw.module.
   OpBuilder builder(&thisHWModule.getBodyBlock()->front());

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -146,9 +146,9 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
 
   size_t inArg = 0;
   for (size_t i = 0; i < mem.numReadPorts; ++i) {
-    Value addr = op.body().getArgument(inArg++);
-    Value en = op.body().getArgument(inArg++);
-    Value clock = op.body().getArgument(inArg++);
+    Value addr = op.getBody().getArgument(inArg++);
+    Value en = op.getBody().getArgument(inArg++);
+    Value clock = op.getBody().getArgument(inArg++);
     // Add pipeline stages
     if (ignoreReadEnableMem) {
       for (size_t j = 0, e = mem.readLatency; j != e; ++j) {
@@ -177,16 +177,16 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
     auto numReadStages = mem.readLatency;
     auto numWriteStages = mem.writeLatency - 1;
     auto numCommonStages = std::min(numReadStages, numWriteStages);
-    Value addr = op.body().getArgument(inArg++);
-    Value en = op.body().getArgument(inArg++);
-    Value clock = op.body().getArgument(inArg++);
-    Value wmode = op.body().getArgument(inArg++);
-    Value wdataIn = op.body().getArgument(inArg++);
+    Value addr = op.getBody().getArgument(inArg++);
+    Value en = op.getBody().getArgument(inArg++);
+    Value clock = op.getBody().getArgument(inArg++);
+    Value wmode = op.getBody().getArgument(inArg++);
+    Value wdataIn = op.getBody().getArgument(inArg++);
     Value wmaskBits;
     // There are no input mask ports, if maskBits =1. Create a dummy true value
     // for mask.
     if (isMasked)
-      wmaskBits = op.body().getArgument(inArg++);
+      wmaskBits = op.getBody().getArgument(inArg++);
     else
       wmaskBits = b.create<ConstantOp>(b.getIntegerAttr(en.getType(), 1));
 
@@ -265,15 +265,15 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
   DenseMap<unsigned, Operation *> writeProcesses;
   for (size_t i = 0; i < mem.numWritePorts; ++i) {
     auto numStages = mem.writeLatency - 1;
-    Value addr = op.body().getArgument(inArg++);
-    Value en = op.body().getArgument(inArg++);
-    Value clock = op.body().getArgument(inArg++);
-    Value wdataIn = op.body().getArgument(inArg++);
+    Value addr = op.getBody().getArgument(inArg++);
+    Value en = op.getBody().getArgument(inArg++);
+    Value clock = op.getBody().getArgument(inArg++);
+    Value wdataIn = op.getBody().getArgument(inArg++);
     Value wmaskBits;
     // There are no input mask ports, if maskBits =1. Create a dummy true value
     // for mask.
     if (isMasked)
-      wmaskBits = op.body().getArgument(inArg++);
+      wmaskBits = op.getBody().getArgument(inArg++);
     else
       wmaskBits = b.create<ConstantOp>(b.getIntegerAttr(en.getType(), 1));
     // Add pipeline stages
@@ -486,11 +486,11 @@ void HWMemSimImplPass::runOnOperation() {
   for (auto op :
        llvm::make_early_inc_range(topModule->getOps<HWModuleGeneratedOp>())) {
     auto oldModule = cast<HWModuleGeneratedOp>(op);
-    auto gen = oldModule.generatorKind();
+    auto gen = oldModule.getGeneratorKind();
     auto genOp = cast<HWGeneratorSchemaOp>(
         SymbolTable::lookupSymbolIn(getOperation(), gen));
 
-    if (genOp.descriptor() == "FIRRTL_Memory") {
+    if (genOp.getDescriptor() == "FIRRTL_Memory") {
       auto mem = analyzeMemOp(oldModule);
 
       OpBuilder builder(oldModule);
@@ -511,7 +511,7 @@ void HWMemSimImplPass::runOnOperation() {
             oldModule.getLoc(), nameAttr, oldModule.getPorts());
         if (auto outdir = oldModule->getAttr("output_file"))
           newModule->setAttr("output_file", outdir);
-        newModule.commentAttr(
+        newModule.setCommentAttr(
             builder.getStringAttr("VCS coverage exclude_file"));
 
         HWMemSimImpl(getContext(), replSeqMem, ignoreReadEnableMem)

--- a/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
@@ -38,7 +38,7 @@ void HWStubExternalModulesPass::runOnOperation() {
       hw::ModulePortInfo ports = module.getPorts();
       auto nameAttr = module.getNameAttr();
       auto newModule = builder.create<hw::HWModuleOp>(
-          module.getLoc(), nameAttr, ports, module.parameters());
+          module.getLoc(), nameAttr, ports, module.getParameters());
       auto outputOp = newModule.getBodyBlock()->getTerminator();
       OpBuilder innerBuilder(outputOp);
       SmallVector<Value, 8> outputs;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -152,7 +152,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   // Construct the ports, this is just the input Values
   SmallVector<hw::PortInfo> ports;
   {
-    auto srcPorts = op.argNames();
+    auto srcPorts = op.getArgNames();
     for (auto port : llvm::enumerate(inputs)) {
       auto name = getNameForPort(port.value(), srcPorts);
       ports.push_back({b.getStringAttr(name), hw::PortDirection::INPUT,
@@ -166,11 +166,11 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
       b.getStringAttr(getVerilogModuleNameAttr(op).getValue() + suffix), ports);
   if (path)
     newMod->setAttr("output_file", path);
-  newMod.commentAttr(b.getStringAttr("VCS coverage exclude_file"));
+  newMod.setCommentAttr(b.getStringAttr("VCS coverage exclude_file"));
 
   // Update the mapping from old values to cloned values
   for (auto port : llvm::enumerate(inputs))
-    cutMap.map(port.value(), newMod.body().getArgument(port.index()));
+    cutMap.map(port.value(), newMod.getBody().getArgument(port.index()));
   cutMap.map(op.getBodyBlock(), newMod.getBodyBlock());
 
   // Add an instance in the old module for the extracted module
@@ -183,8 +183,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   b = OpBuilder::atBlockEnd(
       &op->getParentOfType<mlir::ModuleOp>()->getRegion(0).front());
 
-  auto bindOp =
-      b.create<sv::BindOp>(op.getLoc(), op.getNameAttr(), inst.inner_symAttr());
+  auto bindOp = b.create<sv::BindOp>(op.getLoc(), op.getNameAttr(),
+                                     inst.getInnerSymAttr());
   if (fileName)
     bindOp->setAttr("output_file", fileName);
   return newMod;
@@ -330,7 +330,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
   // phase and are not instances that could possibly have extract flags on them.
   auto isAssert = [&symCache](Operation *op) -> bool {
     if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
+      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
         if (mod->getAttr("firrtl.extract.assert.extra"))
           return true;
 
@@ -351,14 +351,14 @@ void SVExtractTestCodeImplPass::runOnOperation() {
   };
   auto isAssume = [&symCache](Operation *op) -> bool {
     if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
+      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
         if (mod->getAttr("firrtl.extract.assume.extra"))
           return true;
     return isa<AssumeOp>(op) || isa<AssumeConcurrentOp>(op);
   };
   auto isCover = [&symCache](Operation *op) -> bool {
     if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
+      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
         if (mod->getAttr("firrtl.extract.cover.extra"))
           return true;
     return isa<CoverOp>(op) || isa<CoverConcurrentOp>(op);

--- a/unittests/Dialect/HW/HWModuleTest.cpp
+++ b/unittests/Dialect/HW/HWModuleTest.cpp
@@ -69,10 +69,10 @@ TEST(HWModuleOpTest, AddOutputs) {
   auto output = cast<OutputOp>(top.getBodyBlock()->getTerminator());
   ASSERT_EQ(output->getNumOperands(), 4);
 
-  EXPECT_EQ(output->getOperand(0), wireA.result());
-  EXPECT_EQ(output->getOperand(1), wireB.result());
-  EXPECT_EQ(output->getOperand(2), wireC.result());
-  EXPECT_EQ(output->getOperand(3), wireD.result());
+  EXPECT_EQ(output->getOperand(0), wireA.getResult());
+  EXPECT_EQ(output->getOperand(1), wireB.getResult());
+  EXPECT_EQ(output->getOperand(2), wireC.getResult());
+  EXPECT_EQ(output->getOperand(3), wireD.getResult());
 }
 
 } // namespace


### PR DESCRIPTION
We cannot directly switch to prefixed only because of the use of duck-typing in `HWOpInterfaces.td` and `SVOps.cpp`. This means we need to generate both the prefixed and non-prefixed accessors until all dialects that make use of HWInstanceLike have switched. This includes HW, SV, FIRRTL, MSFT.