### PR TITLE
[FIRRTL] Disable bypass canonicalizations when name preservation

### DIFF
--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2366,9 +2366,20 @@ firrtl.module @Foo3319(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.and %c0_ui1, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %n = firrtl.node  %0  : !firrtl.uint<1>
+  // CHECK: %n = firrtl.node interesting_name %c0_ui1
+  %n = firrtl.node interesting_name %0  : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %o, %n
   firrtl.strictconnect %o, %n : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %o, %c0_ui1
+}
+
+// CHECK-LABEL: @WireByPass
+firrtl.module @WireByPass(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %n = firrtl.wire interesting_name : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %n, %c0_ui1
+  firrtl.strictconnect %n, %c0_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %o, %n
+  firrtl.strictconnect %o, %n : !firrtl.uint<1>
 }
 
 // Check that canonicalizeSingleSetConnect doesn't remove a wire with an


### PR DESCRIPTION
This commit disables bypass canonicalizations of wire op and node op if name preservation
is enabled. In the name preservation mode, users want to preserve def-uses so the bypass canonicalization 
is problematic in terms of debuggability. 
  
Note that this PR will reopen the issue https://github.com/llvm/circt/issues/3319 but it will be fixed by folders in https://github.com/llvm/circt/pull/3535. 

Close https://github.com/llvm/circt/issues/3148