### PR TITLE
[FIRRTL] Add AndOp/OrOp commutative folders

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -492,6 +492,17 @@ OpFoldResult AndPrimOp::fold(ArrayRef<Attribute> operands) {
       return lhs();
   }
 
+  if (auto lhsCst = getConstant(operands[0])) {
+    /// and(0, x) -> 0
+    if (lhsCst->isZero() && lhs().getType() == getType())
+      return getIntZerosAttr(getType());
+
+    /// and(-1, x) -> x
+    if (lhsCst->isAllOnes() && lhs().getType() == getType() &&
+        rhs().getType() == getType())
+      return rhs();
+  }
+
   /// and(x, x) -> x
   if (lhs() == rhs() && rhs().getType() == getType())
     return rhs();
@@ -511,6 +522,17 @@ OpFoldResult OrPrimOp::fold(ArrayRef<Attribute> operands) {
     if (rhsCst.getValue().isAllOnes() && rhs().getType() == getType() &&
         lhs().getType() == getType())
       return rhs();
+  }
+
+  if (auto lhsCst = getConstant(operands[0])) {
+    /// or(0, x) -> x
+    if (lhsCst.getValue().isZero() && rhs().getType() == getType())
+      return rhs();
+
+    /// or(-1, x) -> -1
+    if (lhsCst.getValue().isAllOnes() && lhs().getType() == getType() &&
+        rhs().getType() == getType())
+      return lhs();
   }
 
   /// or(x, x) -> x

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -144,6 +144,10 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   %2 = firrtl.and %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  %inv_2 = firrtl.and %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
+
   // CHECK: firrtl.strictconnect %out, %in
   %3 = firrtl.and %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -198,6 +202,10 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.or %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.strictconnect %out, %in
+  %inv_2 = firrtl.or %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.strictconnect %out, %in
   %3 = firrtl.or %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>


### PR DESCRIPTION
This PR adds folders for AndOp and OrOp to handle the cases when lhs is constant.
IMCP uses folders but it is not guranteed that rhs is always constant, hence
it is necessary to add commutative folders.

This fixes https://github.com/llvm/circt/issues/3319 on top of https://github.com/llvm/circt/pull/3534