### PR TITLE
[HWMemSimImpl] Merge pipeline regs into single always block

### DIFF
--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -132,26 +132,21 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_2_4_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-LABEL: @FIRRTLMem_1_1_1_16_10_2_4_0_0
 //COM: This produces a lot of output, we check one field's pipeline
 //CHECK:         %Memory = sv.reg  : !hw.inout<uarray<10xi16>>
-//CHECK:         sv.always posedge %ro_clock_0 {
-//CHECK-NEXT:      sv.passign %0, %ro_en_0 : i1
-//CHECK-NEXT:    }
-//CHECK-NEXT:    %1 = sv.read_inout %0 : !hw.inout<i1>
-//CHECK-NEXT:    %2 = sv.reg {{.+}}  : !hw.inout<i1>
+//CHECK-NEXT:    [[EN_0:%.+]] = sv.reg {{.+}} : !hw.inout<i1>
+//CHECK-NEXT:    [[EN_1:%.+]] = sv.reg {{.+}} : !hw.inout<i1>
+//CHECK-NEXT:    [[ADDR_0:%.+]] = sv.reg {{.+}} : !hw.inout<i4>
+//CHECK-NEXT:    [[ADDR_1:%.+]] = sv.reg {{.+}} : !hw.inout<i4>
 //CHECK-NEXT:    sv.always posedge %ro_clock_0 {
-//CHECK-NEXT:      sv.passign %2, %1 : i1
+//CHECK-NEXT:      sv.passign [[EN_0]], %ro_en_0 : i1
+//CHECK-NEXT:      [[EN_0R:%.+]] = sv.read_inout [[EN_0]] : !hw.inout<i1>
+//CHECK-NEXT:      sv.passign [[EN_1]], [[EN_0R]] : i1
+//CHECK-NEXT:      sv.passign [[ADDR_0]], %ro_addr_0 : i4
+//CHECK-NEXT:      [[ADDR_0R:%.+]] = sv.read_inout [[ADDR_0]] : !hw.inout<i4>
+//CHECK-NEXT:      sv.passign [[ADDR_1]], [[ADDR_0R]] : i4
 //CHECK-NEXT:    }
-//CHECK-NEXT:    %3 = sv.read_inout %2 : !hw.inout<i1>
-//CHECK-NEXT:    %4 = sv.reg {{.+}}  : !hw.inout<i4>
-//CHECK-NEXT:    sv.always posedge %ro_clock_0 {
-//CHECK-NEXT:      sv.passign %4, %ro_addr_0 : i4
-//CHECK-NEXT:    }
-//CHECK-NEXT:    %5 = sv.read_inout %4 : !hw.inout<i4>
-//CHECK-NEXT:    %6 = sv.reg {{.+}} : !hw.inout<i4>
-//CHECK-NEXT:    sv.always posedge %ro_clock_0 {
-//CHECK-NEXT:      sv.passign %6, %5 : i4
-//CHECK-NEXT:    }
-//CHECK-NEXT:    %7 = sv.read_inout %6 : !hw.inout<i4>
-//CHECK-NEXT:    %8 = sv.array_index_inout %Memory[%7] : !hw.inout<uarray<10xi16>>, i4
+//CHECK-NEXT:    [[EN_1R:%.+]] = sv.read_inout [[EN_1]] : !hw.inout<i1>
+//CHECK-NEXT:    [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]] : !hw.inout<i4>
+//CHECK-NEXT:    {{%.+}} = sv.array_index_inout %Memory[[[ADDR_1R]]] : !hw.inout<uarray<10xi16>>, i4
 
 hw.module.generated @FIRRTLMemOneAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1,%wo_data_0: i8, %wo_addr_1: i4,  %wo_en_1: i1, %wo_clock_1: i1, %wo_data_1: i8) attributes {depth = 16 : i64, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
@@ -207,21 +202,15 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i
   // CHECK:  %[[v9:.+]] = sv.read_inout
   // CHECK:  %[[x_i32:.+]] = sv.constantX : i32
   // CHECK:  %[[v13:.+]] = comb.mux
-  // CHECK:  sv.always posedge %W0_clk {
-  // CHECK:    sv.passign %[[v22:.+]], %W0_data : i32
-  // CHECK:  }
-  // CHECK:  %[[v23:.+]] = sv.read_inout %[[v22]] : !hw.inout<i32>
   // CHECK:  %[[v24:.+]] = sv.reg {{.+}} : !hw.inout<i32>
   // CHECK:  sv.always posedge %W0_clk {
-  // CHECK:    sv.passign %[[v24:.+]], %[[v23:.+]] : i32
-  // CHECK:  }
-  // CHECK:  %[[v25:.+]] = sv.read_inout %[[v24]] : !hw.inout<i32>
-  // CHECK:  sv.always posedge %W0_clk {
+  // CHECK:    sv.passign %[[v22:.+]], %W0_data : i32
+  // CHECK:    %[[v23:.+]] = sv.read_inout %[[v22]] : !hw.inout<i32>
+  // CHECK:    sv.passign %[[v24:.+]], %[[v23]] : i32
   // CHECK:    sv.passign %[[v26:.+]], %W0_mask : i2
-  // CHECK:  }
-  // CHECK:  sv.always posedge %W0_clk {
   // CHECK:    sv.passign %[[v28:.+]], %[[v27:.+]] : i2
   // CHECK:  }
+  // CHECK:  %[[v25:.+]] = sv.read_inout %[[v24]] : !hw.inout<i32>
   // CHECK:  %[[v29:.+]] = sv.read_inout %[[v28]] : !hw.inout<i2>
   // CHECK:  %[[v30:.+]] = comb.extract %[[v29]] from 0 : (i2) -> i1
   // CHECK:  %[[v31:.+]] = comb.extract %[[v25]] from 0 : (i32) -> i16
@@ -232,8 +221,8 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i
   // CHECK:    sv.if %[[v34]]  {
   // CHECK:      %[[v36:.+]] = sv.array_index_inout %[[Memory0]][%[[v117:.+]]] :
   // CHECK:      %c0_i32 = hw.constant 0 : i32
-  // CHECK:      %[[v36:.+]] = sv.indexed_part_select_inout %33[%c0_i32 : 16] : !hw.inout<i32>, i32
-  // CHECK:      sv.passign %[[v36]], %[[v31]] : i16
+  // CHECK:      %[[v37:.+]] = sv.indexed_part_select_inout %[[v36]][%c0_i32 : 16] : !hw.inout<i32>, i32
+  // CHECK:      sv.passign %[[v37]], %[[v31]] : i16
   // CHECK:    }
   // CHECK:  hw.output %[[v13]] : i32
   // CHECK:}
@@ -261,8 +250,6 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 // CHECK:    %[[v56:.+]] = sv.read_inout %[[v52]] :
 // CHECK:    sv.always posedge %wo_clock_0 {
 // CHECK:      sv.passign %[[v70:.+]], %wo_data_0 : i16
-// CHECK:    }
-// CHECK:    sv.always posedge %wo_clock_0 {
 // CHECK:      sv.passign %[[v76:.+]], %wo_mask_0 : i2
 // CHECK:    }
 // CHECK:    %[[v82:.+]] = comb.extract %[[v81:.+]] from 0 : (i2) -> i1
@@ -304,32 +291,34 @@ hw.module.generated @ReadWriteWithHighReadLatency, @FIRRTLMem(%rw_addr: i4, %rw_
 // CHECK: sv.passign [[ADDR_0:%.+]], %rw_addr
 // CHECK: [[ADDR_0R:%.+]] = sv.read_inout [[ADDR_0]]
 // CHECK: sv.passign [[ADDR_1:%.+]], [[ADDR_0R]]
-// CHECK: [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]]
 
 // CHECK: sv.passign [[EN_0:%.+]], %rw_en
 // CHECK: [[EN_0R:%.+]] = sv.read_inout [[EN_0]]
 // CHECK: sv.passign [[EN_1:%.+]], [[EN_0R]]
-// CHECK: [[EN_1R:%.+]] = sv.read_inout [[EN_1]]
 
 // CHECK: sv.passign [[WMODE_0:%.+]], %rw_wmode
 // CHECK: [[WMODE_0R:%.+]] = sv.read_inout [[WMODE_0]]
 // CHECK: sv.passign [[WMODE_1:%.+]], [[WMODE_0R]]
+
+// CHECK: [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]]
+// CHECK: [[EN_1R:%.+]] = sv.read_inout [[EN_1]]
 // CHECK: [[WMODE_1R:%.+]] = sv.read_inout [[WMODE_1]]
 
 // Additional read pipeline stages (2x)
 // CHECK: sv.passign [[READ_ADDR_2:%.+]], [[ADDR_1R]]
 // CHECK: [[READ_ADDR_2R:%.+]] = sv.read_inout [[READ_ADDR_2]]
 // CHECK: sv.passign [[READ_ADDR_3:%.+]], [[READ_ADDR_2R]]
-// CHECK: [[READ_ADDR_3R:%.+]] = sv.read_inout [[READ_ADDR_3]]
 
 // CHECK: sv.passign [[READ_EN_2:%.+]], [[EN_1R]]
 // CHECK: [[READ_EN_2R:%.+]] = sv.read_inout [[READ_EN_2]]
 // CHECK: sv.passign [[READ_EN_3:%.+]], [[READ_EN_2R]]
-// CHECK: [[READ_EN_3R:%.+]] = sv.read_inout [[READ_EN_3]]
 
 // CHECK: sv.passign [[READ_WMODE_2:%.+]], [[WMODE_1R]]
 // CHECK: [[READ_WMODE_2R:%.+]] = sv.read_inout [[READ_WMODE_2]]
 // CHECK: sv.passign [[READ_WMODE_3:%.+]], [[READ_WMODE_2R]]
+
+// CHECK: [[READ_ADDR_3R:%.+]] = sv.read_inout [[READ_ADDR_3]]
+// CHECK: [[READ_EN_3R:%.+]] = sv.read_inout [[READ_EN_3]]
 // CHECK: [[READ_WMODE_3R:%.+]] = sv.read_inout [[READ_WMODE_3]]
 
 // Read port
@@ -351,32 +340,34 @@ hw.module.generated @ReadWriteWithHighWriteLatency, @FIRRTLMem(%rw_addr: i4, %rw
 // CHECK: sv.passign [[ADDR_0:%.+]], %rw_addr
 // CHECK: [[ADDR_0R:%.+]] = sv.read_inout [[ADDR_0]]
 // CHECK: sv.passign [[ADDR_1:%.+]], [[ADDR_0R]]
-// CHECK: [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]]
 
 // CHECK: sv.passign [[EN_0:%.+]], %rw_en
 // CHECK: [[EN_0R:%.+]] = sv.read_inout [[EN_0]]
 // CHECK: sv.passign [[EN_1:%.+]], [[EN_0R]]
-// CHECK: [[EN_1R:%.+]] = sv.read_inout [[EN_1]]
 
 // CHECK: sv.passign [[WMODE_0:%.+]], %rw_wmode
 // CHECK: [[WMODE_0R:%.+]] = sv.read_inout [[WMODE_0]]
 // CHECK: sv.passign [[WMODE_1:%.+]], [[WMODE_0R]]
+
+// CHECK: [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]]
+// CHECK: [[EN_1R:%.+]] = sv.read_inout [[EN_1]]
 // CHECK: [[WMODE_1R:%.+]] = sv.read_inout [[WMODE_1]]
 
 // Additional write pipeline stages (2x)
 // CHECK: sv.passign [[WRITE_ADDR_2:%.+]], [[ADDR_1R]]
 // CHECK: [[WRITE_ADDR_2R:%.+]] = sv.read_inout [[WRITE_ADDR_2]]
 // CHECK: sv.passign [[WRITE_ADDR_3:%.+]], [[WRITE_ADDR_2R]]
-// CHECK: [[WRITE_ADDR_3R:%.+]] = sv.read_inout [[WRITE_ADDR_3]]
 
 // CHECK: sv.passign [[WRITE_EN_2:%.+]], [[EN_1R]]
 // CHECK: [[WRITE_EN_2R:%.+]] = sv.read_inout [[WRITE_EN_2]]
 // CHECK: sv.passign [[WRITE_EN_3:%.+]], [[WRITE_EN_2R]]
-// CHECK: [[WRITE_EN_3R:%.+]] = sv.read_inout [[WRITE_EN_3]]
 
 // CHECK: sv.passign [[WRITE_WMODE_2:%.+]], [[WMODE_1R]]
 // CHECK: [[WRITE_WMODE_2R:%.+]] = sv.read_inout [[WRITE_WMODE_2]]
 // CHECK: sv.passign [[WRITE_WMODE_3:%.+]], [[WRITE_WMODE_2R]]
+
+// CHECK: [[WRITE_ADDR_3R:%.+]] = sv.read_inout [[WRITE_ADDR_3]]
+// CHECK: [[WRITE_EN_3R:%.+]] = sv.read_inout [[WRITE_EN_3]]
 // CHECK: [[WRITE_WMODE_3R:%.+]] = sv.read_inout [[WRITE_WMODE_3]]
 
 // Read port


### PR DESCRIPTION
Make `addPipelineStages` try to reuse the always block of the previous pipeline. This requires checking if the clocks match, and that all the values that we'd stick into this block are accessible at the block location.

Does not change functionality, just produces slightly shorter IR.