### PR TITLE
[HWMemSimImpl] Remove "mem" from "ignore-read-enable-mem" flag

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -26,7 +26,7 @@ std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createSVTraceIVerilogPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass(
-    bool replSeqMem = false, bool ignoreReadEnableMem = false,
+    bool replSeqMem = false, bool ignoreReadEnable = false,
     bool addMuxPragmas = false, bool disableMemRandomization = false,
     bool disableRegRandomization = false,
     bool addVivadoRAMAddressConflictSynthesisBugWorkaround = false);

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -100,7 +100,7 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
             "Disable emission of register randomization code">,
     Option<"replSeqMem", "repl-seq-mem", "bool",
                 "false", "Prepare seq mems for macro replacement">,
-    Option<"ignoreReadEnableMem", "ignore-read-enable-mem", "bool",
+    Option<"ignoreReadEnable", "ignore-read-enable", "bool",
                 "false",
     "ignore the read enable signal, instead of assigning X on read disable">,
     Option<"addMuxPragmas", "add-mux-pragmas", "bool", "false",

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -52,7 +52,7 @@ struct FirMemory {
 namespace {
 
 class HWMemSimImpl {
-  bool ignoreReadEnableMem;
+  bool ignoreReadEnable;
   bool addMuxPragmas;
   bool disableMemRandomization;
   bool disableRegRandomization;
@@ -68,11 +68,11 @@ class HWMemSimImpl {
 public:
   Namespace &mlirModuleNamespace;
 
-  HWMemSimImpl(bool ignoreReadEnableMem, bool addMuxPragmas,
+  HWMemSimImpl(bool ignoreReadEnable, bool addMuxPragmas,
                bool disableMemRandomization, bool disableRegRandomization,
                bool addVivadoRAMAddressConflictSynthesisBugWorkaround,
                Namespace &mlirModuleNamespace)
-      : ignoreReadEnableMem(ignoreReadEnableMem), addMuxPragmas(addMuxPragmas),
+      : ignoreReadEnable(ignoreReadEnable), addMuxPragmas(addMuxPragmas),
         disableMemRandomization(disableMemRandomization),
         disableRegRandomization(disableRegRandomization),
         addVivadoRAMAddressConflictSynthesisBugWorkaround(
@@ -85,7 +85,7 @@ public:
 struct HWMemSimImplPass : public sv::HWMemSimImplBase<HWMemSimImplPass> {
   void runOnOperation() override;
 
-  using sv::HWMemSimImplBase<HWMemSimImplPass>::ignoreReadEnableMem;
+  using sv::HWMemSimImplBase<HWMemSimImplPass>::ignoreReadEnable;
   using sv::HWMemSimImplBase<HWMemSimImplPass>::replSeqMem;
   using sv::HWMemSimImplBase<HWMemSimImplPass>::addMuxPragmas;
   using sv::HWMemSimImplBase<HWMemSimImplPass>::disableMemRandomization;
@@ -272,7 +272,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
     Value en = op.getBody().getArgument(inArg++);
     Value clock = op.getBody().getArgument(inArg++);
     // Add pipeline stages
-    if (ignoreReadEnableMem) {
+    if (ignoreReadEnable) {
       for (size_t j = 0, e = mem.readLatency; j != e; ++j) {
         auto enLast = en;
         if (j < e - 1)
@@ -287,7 +287,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
 
     // Read Logic
     Value rdata = getMemoryRead(b, reg, addr, addMuxPragmas);
-    if (!ignoreReadEnableMem) {
+    if (!ignoreReadEnable) {
       Value x = b.create<sv::ConstantXOp>(rdata.getType());
       rdata = b.create<comb::MuxOp>(en, rdata, x, false);
     }
@@ -727,8 +727,8 @@ void HWMemSimImplPass::runOnOperation() {
         newModule.setCommentAttr(
             builder.getStringAttr("VCS coverage exclude_file"));
 
-        HWMemSimImpl(ignoreReadEnableMem, addMuxPragmas,
-                     disableMemRandomization, disableRegRandomization,
+        HWMemSimImpl(ignoreReadEnable, addMuxPragmas, disableMemRandomization,
+                     disableRegRandomization,
                      addVivadoRAMAddressConflictSynthesisBugWorkaround,
                      mlirModuleNamespace)
             .generateMemory(newModule, mem);
@@ -744,12 +744,12 @@ void HWMemSimImplPass::runOnOperation() {
 }
 
 std::unique_ptr<Pass> circt::sv::createHWMemSimImplPass(
-    bool replSeqMem, bool ignoreReadEnableMem, bool addMuxPragmas,
+    bool replSeqMem, bool ignoreReadEnable, bool addMuxPragmas,
     bool disableMemRandomization, bool disableRegRandomization,
     bool addVivadoRAMAddressConflictSynthesisBugWorkaround) {
   auto pass = std::make_unique<HWMemSimImplPass>();
   pass->replSeqMem = replSeqMem;
-  pass->ignoreReadEnableMem = ignoreReadEnableMem;
+  pass->ignoreReadEnable = ignoreReadEnable;
   pass->addMuxPragmas = addMuxPragmas;
   pass->disableMemRandomization = disableMemRandomization;
   pass->disableRegRandomization = disableRegRandomization;


### PR DESCRIPTION
Remove the `-mem` suffix in the `ignore-read-enable-mem` option of the `HWMemSimImpl` pass. "Read enable" should be unambiguous already. Note that this does not change the corresponding firtool flag, so no breaking change of CLI flags happens here (except for direct circt-opt invocations).