### PR TITLE
[HWMemSimImpl] Add support for two flavors of read latencies

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -26,7 +26,8 @@ std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass>
 createHWMemSimImplPass(bool replSeqMem = false,
-                       bool ignoreReadEnableMem = false);
+                       bool ignoreReadEnableMem = false,
+                       bool readLatencyIsPropagationDelay = false);
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -94,11 +94,13 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 
   let options = [
-    Option<"replSeqMem", "repl-seq-mem", "bool",
-                "false", "Prepare seq mems for macro replacement">,
-    Option<"ignoreReadEnableMem", "ignore-read-enable-mem", "bool",
-                "false",
-    "ignore the read enable signal, instead of assigning X on read disable">
+    Option<"replSeqMem", "repl-seq-mem", "bool", "false",
+      "Prepare seq mems for macro replacement">,
+    Option<"ignoreReadEnableMem", "ignore-read-enable-mem", "bool", "false",
+      "Ignore the read enable signal, instead of assigning X on read disable">,
+    Option<"readLatencyIsPropagationDelay", "read-latency-is-propagation-delay",
+      "bool", "false", "Treat read latency as a propagation delay instead of "
+      "an address decoding delay">
    ];
 }
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -160,6 +160,12 @@ static cl::opt<bool>
                                  "assigning X on read disable"),
                         cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool> memoryReadLatencyIsPropagationDelay(
+    "mem-read-latency-is-propagation-delay",
+    cl::desc("Treat memory read latency as a propagation delay instead of an "
+             "address decoding delay"),
+    cl::init(false), cl::cat(mainCategory));
+
 static cl::opt<bool> imconstprop(
     "imconstprop",
     cl::desc(
@@ -606,7 +612,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createSimpleCanonicalizerPass());
       }
     } else {
-      pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem));
+      pm.addPass(
+          sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem,
+                                     memoryReadLatencyIsPropagationDelay));
 
       if (extractTestCode)
         pm.addPass(sv::createSVExtractTestCodePass());


### PR DESCRIPTION
The current version of `HWMemSimImpl` implements read latency by inserting pipeline registers into the address and enable lines, which delays the time until the underlying data array is probed for a value. I think we have inherited this behaviour from SFC.

In real-world SRAMs there is a second component to the read latency: the time it takes for the value sampled in the data array to propagate to the output ports. The choices for this pre- and post-array latency has subtle implications on the read-under-write behaviour of the memory, mainly concerning the order of writes that a given read sees. From experience I would argue that most SRAMs have a post-array latency, and very little pre-array latency.

This commit splits the `readLatency` into two components: a pre- and post-latency. By default, the pass continues to treat the read latency annotated on FIR memories as a pure pre-array latency, and keeps the post-array latency at zero. However, it also introduces the `read-latency-is-propagation-delay` option which switches this behaviour into modeling that read latency entirely with a post-array delay.

The intent here is to have a non-functional change, but with an opt-in switch such that we can start testing the alternate (and in my opinion correct behaviour) on real-world designs. I suspect that none of SiFive's designs relies on this behaviour to ensure portability between different technology nodes, and we can just switch to this new behaviour for completeness' sake.

Also adds a off-by-default `mem-read-latency-is-propagation-delay` option to firtool.

### Todo
- [x] Land #3537 