### PR TITLE
[MSFT] Add default value to __INST_HIER parameter

### DIFF
--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -310,7 +310,8 @@ ModuleOpLowering::matchAndRewrite(MSFTModuleOp mod, OpAdaptor adaptor,
   }
 
   ArrayAttr params = rewriter.getArrayAttr({hw::ParamDeclAttr::get(
-      rewriter.getStringAttr("__INST_HIER"), rewriter.getStringAttr(""))});
+      rewriter.getStringAttr("__INST_HIER"),
+      rewriter.getStringAttr("INSTANTIATE_WITH_INSTANCE_PATH"))});
   auto hwmod = rewriter.replaceOpWithNewOp<hw::HWModuleOp>(
       mod, mod.getNameAttr(), mod.getPorts(), params);
   rewriter.eraseBlock(hwmod.getBodyBlock());

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -310,7 +310,7 @@ ModuleOpLowering::matchAndRewrite(MSFTModuleOp mod, OpAdaptor adaptor,
   }
 
   ArrayAttr params = rewriter.getArrayAttr({hw::ParamDeclAttr::get(
-      rewriter.getStringAttr("__INST_HIER"), rewriter.getNoneType())});
+      rewriter.getStringAttr("__INST_HIER"), rewriter.getStringAttr(""))});
   auto hwmod = rewriter.replaceOpWithNewOp<hw::HWModuleOp>(
       mod, mod.getNameAttr(), mod.getPorts(), params);
   rewriter.eraseBlock(hwmod.getBodyBlock());

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -18,7 +18,7 @@ msft.module @top {} () {
 }
 
 // CHECK-LABEL: msft.module @B {WIDTH = 1 : i64} (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
-// HWLOW-LABEL: hw.module @B<__INST_HIER: none = "">(%a: i4) -> (nameOfPortInSV: i4) attributes {output_file = #hw.output_file<"b.sv", includeReplicatedOps>} {
+// HWLOW-LABEL: hw.module @B<__INST_HIER: none = "INSTANTIATE_WITH_INSTANCE_PATH">(%a: i4) -> (nameOfPortInSV: i4) attributes {output_file = #hw.output_file<"b.sv", includeReplicatedOps>} {
 msft.module @B { "WIDTH" = 1 } (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
   %0 = comb.add %a, %a : i4
   // CHECK: comb.add %a, %a : i4

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -18,7 +18,7 @@ msft.module @top {} () {
 }
 
 // CHECK-LABEL: msft.module @B {WIDTH = 1 : i64} (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
-// HWLOW-LABEL: hw.module @B<__INST_HIER: none>(%a: i4) -> (nameOfPortInSV: i4) attributes {output_file = #hw.output_file<"b.sv", includeReplicatedOps>} {
+// HWLOW-LABEL: hw.module @B<__INST_HIER: none = "">(%a: i4) -> (nameOfPortInSV: i4) attributes {output_file = #hw.output_file<"b.sv", includeReplicatedOps>} {
 msft.module @B { "WIDTH" = 1 } (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
   %0 = comb.add %a, %a : i4
   // CHECK: comb.add %a, %a : i4


### PR DESCRIPTION
Makes some parsers happier (like `iverilog`).