### PR TITLE
[MSFT] Implement `HWMutableModuleLike` in `msft.module`

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -72,7 +72,8 @@ def MSFTModuleOp : MSFTOp<"module",
        HasParent<"mlir::ModuleOp">,
        SingleBlockImplicitTerminator<"OutputOp">,
        OpAsmOpInterface,
-       DeclareOpInterfaceMethods<HWModuleLike>]>{
+       DeclareOpInterfaceMethods<HWModuleLike>,
+       DeclareOpInterfaceMethods<HWMutableModuleLike>]>{
   let summary = "MSFT HW Module";
   let description = [{
     A lot like `hw.module`, but with a few differences:
@@ -105,6 +106,12 @@ def MSFTModuleOp : MSFTOp<"module",
 
     // Decode information about the input and output ports on this module.
     ::circt::hw::ModulePortInfo getPorts();
+
+    // Insert and remove ports.
+    void modifyPorts(
+      ArrayRef<std::pair<unsigned, circt::hw::PortInfo>> insertInputs,
+      ArrayRef<std::pair<unsigned, circt::hw::PortInfo>> insertOutputs,
+      ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs);
 
     // Adds input and output ports. Returns a list of new block arguments for
     // the new inputs.

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -316,6 +316,15 @@ SmallVector<unsigned> MSFTModuleOp::removePorts(llvm::BitVector inputs,
   return newToOldResultMap;
 }
 
+void MSFTModuleOp::modifyPorts(
+    llvm::ArrayRef<std::pair<unsigned int, circt::hw::PortInfo>> insertInputs,
+    llvm::ArrayRef<std::pair<unsigned int, circt::hw::PortInfo>> insertOutputs,
+    llvm::ArrayRef<unsigned int> eraseInputs,
+    llvm::ArrayRef<unsigned int> eraseOutputs) {
+  hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
+                        eraseOutputs);
+}
+
 // Copied nearly exactly from hwops.cpp.
 // TODO: Unify code once a `ModuleLike` op interface exists.
 static void buildModule(OpBuilder &builder, OperationState &result,


### PR DESCRIPTION
Allows ESI connect services pass to execute on msft modules.