### PR TITLE
Require iverilog version >=11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,19 @@ if (IVERILOG_DISABLE)
 else()
   find_program(IVERILOG_PATH "iverilog")
   if(EXISTS ${IVERILOG_PATH})
+    # Find iverilog version.
+    execute_process(COMMAND ${IVERILOG_PATH} -V
+      OUTPUT_VARIABLE IVERILOG_VERSION)
+
+    string(REGEX MATCH "Icarus Verilog version (([0-9]+)\.([0-9]+)) \.*"
+      MATCH ${IVERILOG_VERSION})
+    
+    if (${CMAKE_MATCH_1} LESS 11.0)
+      message(FATAL_ERROR "CIRCT only supports Icarus Verilog version 11.0 and up. \
+                           Found version: ${CMAKE_MATCH_1}. You can disable \
+                           the Icarus Verilog tests with '-DIVERILOG_DISABLE=ON'.")
+      set(IVERILOG_PATH "")
+    endif()
     message(STATUS "Found iverilog at ${IVERILOG_PATH}.")
   else()
     set(IVERILOG_PATH "")


### PR DESCRIPTION
Icarus verilog v11, released in 2020, adds support for important constructs such as `always_ff, always_comb` in SV. Since virtually all non-trivial circuits will leverage these constructs during SV emission, it seems sensible to require an `iverilog` version that is actually able to simulate the circuits we generate.