### PR TITLE
[PrepareForEmission] Don't spill wires in procedural regions

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -566,7 +566,9 @@ void ExportVerilog::prepareHWModule(Block &block,
       // it, we are good to generate a wire.
       if (!isProceduralRegion ||
           (isProceduralRegion && hoistNonSideEffectExpr(&op))) {
-        lowerUsersToTemporaryWire(op);
+        // If op is moved to a non-procedural region, create a temporary wire.
+        if (!op.getParentOp()->hasTrait<ProceduralRegion>())
+          lowerUsersToTemporaryWire(op);
 
         // If we're in a procedural region, we move on to the next op in the
         // block. The expression splitting and canonicalization below will


### PR DESCRIPTION
This fixes a bug that sv.wire is created in a procedural region when `hoistNonSideEffectExpr` returns true but hoists the op one level up. Fixes https://github.com/llvm/circt/issues/3547. 