### PR TITLE
[PrettifyVerilog] Fix double free

### DIFF
--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -307,7 +307,7 @@ void PrettifyVerilogPass::sinkOrCloneOpToUses(Operation *op) {
   }
   // If this op is no longer used, drop it.
   if (op->use_empty()) {
-    op->erase();
+    toDelete.insert(op);
     anythingChanged = true;
   }
 }


### PR DESCRIPTION
This fixes a bug in https://github.com/llvm/circt/commit/61fb54e41bf23c6fbd787decc53e5705b0f691bf. 
PrettifyVerilog frees same operations twice when operations are
stored to `toDelete` and erased by `sinkOrCloneOpToUses`. This fixes
the issue by storing operations into `toDelete` within sinkOrCloneOpToUses
as well.