### PR TITLE
[PyCDE] Add shorthand FSM builder function

### DIFF
--- a/frontends/PyCDE/src/pycde/fsm.py
+++ b/frontends/PyCDE/src/pycde/fsm.py
@@ -251,7 +251,7 @@ def fsm_wrapper_class(fsm_mod, fsm_name, clock, reset=None):
   return fsm_hw_mod
 
 
-def gen_fsm(transitions, name="MyFSM"):
+def gen_fsm(transitions: dict, name: str = "MyFSM"):
   """
   Generate a FSM from a dictionary of states and their transitions.
 
@@ -296,17 +296,15 @@ def gen_fsm(transitions, name="MyFSM"):
   for (state, state_transitions) in transitions.items():
     currentStateAttr = ensure_state(state, initial)
     if not type(state_transitions) is list:
-      raise Exception(f"Transitions for state '{state}' must be a list")
+      raise TypeError(f"Transitions for state '{state}' must be a list")
 
     for transition in state_transitions:
       guard_port = None
-      try:
-        # Guarded transition
+      if isinstance(transition, tuple):
         (nextState, guard_port) = transition
-      except:
-        # Unguarded transition
+      else:
         if not type(transition) is str:
-          raise Exception(
+          raise TypeError(
               f"Transition for state '{state}' must be of the form 'nextstate' or ('nextstate', 'guard')"
           )
         nextState = transition

--- a/frontends/PyCDE/src/pycde/fsm.py
+++ b/frontends/PyCDE/src/pycde/fsm.py
@@ -27,13 +27,12 @@ class State:
       self.condition = condition
 
     def _emit(self, state_op, ports):
-      with InsertionPoint(state_op.transitions):
-        op = fsm.TransitionOp(self.to_state.name)
+      op = fsm.TransitionOp(self.to_state.name)
 
-        # If a condition function was specified, execute it on the ports and
-        # assign the result as the guard of this transition.
-        if self.condition:
-          op.set_guard(lambda: self.condition(ports))
+      # If a condition function was specified, execute it on the ports and
+      # assign the result as the guard of this transition.
+      if self.condition:
+        op.set_guard(lambda: self.condition(ports))
 
   def __init__(self, initial=False):
     self.initial = initial
@@ -45,6 +44,9 @@ class State:
 
   def set_transitions(self, *transitions):
     self.transitions = [State.Transition(*t) for t in transitions]
+
+  def add_transitions(self, *transitions):
+    self.transitions.extend([State.Transition(*t) for t in transitions])
 
   def _emit(self, spec_mod, ports):
     # Create state op
@@ -59,8 +61,9 @@ class State:
       fsm.OutputOp(*outputs)
 
     # Emit outgoing transitions from this state.
-    for transition in self.transitions:
-      transition._emit(state_op, ports)
+    with InsertionPoint(state_op.transitions):
+      for transition in self.transitions:
+        transition._emit(state_op, ports)
 
 
 def States(n):
@@ -246,3 +249,76 @@ def fsm_wrapper_class(fsm_mod, fsm_name, clock, reset=None):
   fsm_hw_mod.__name__ = fsm_name
   fsm_hw_mod.__module__ = fsm_name
   return fsm_hw_mod
+
+
+def gen_fsm(transitions, name="MyFSM"):
+  """
+  Generate a FSM from a dictionary of states and their transitions.
+
+  E.g.:
+  {
+    "a": [
+      ("c", "go"),
+      "b",
+    ],
+    "b": [],
+    "c": []
+  }
+
+  creates an FSM with 3 states (a, b, c). 'b' and 'c' have no outgoing transitions,
+  and 'a' has two outgoing transitions. The first transition ("c", "go") transitions
+  to 'c' whenever an input port 'go' is asserted. The second transition is a default
+  transition to 'b'.
+
+  Any state and guard referenced within the dictionary will automatically be created
+  as a state operation and top-level input, respectively.
+  """
+
+  class FSM:
+    pass
+
+  # Gather states and input variables
+  states = set()
+  inputs = set()
+  initial = True
+
+  def ensure_state(state, initial=False):
+    if state not in states:
+      setattr(FSM, state, State(initial=initial))
+      states.add(state)
+    return getattr(FSM, state)
+
+  def ensure_input(input):
+    if input not in inputs:
+      setattr(FSM, input, Input(types.i1))
+      inputs.add(input)
+
+  for (state, state_transitions) in transitions.items():
+    currentStateAttr = ensure_state(state, initial)
+    if not type(state_transitions) is list:
+      raise Exception(f"Transitions for state '{state}' must be a list")
+
+    for transition in state_transitions:
+      guard_port = None
+      try:
+        # Guarded transition
+        (nextState, guard_port) = transition
+      except:
+        # Unguarded transition
+        if not type(transition) is str:
+          raise Exception(
+              f"Transition for state '{state}' must be of the form 'nextstate' or ('nextstate', 'guard')"
+          )
+        nextState = transition
+
+      nextStateAttr = ensure_state(nextState)
+      if guard_port:
+        ensure_input(guard_port)
+        currentStateAttr.add_transitions(
+            (nextStateAttr, lambda ports: getattr(ports, guard_port)))
+      else:
+        currentStateAttr.add_transitions((nextStateAttr,))
+
+  setattr(FSM, "__name__", name)
+  setattr(FSM, "__qualname__", name)
+  return machine()(FSM)

--- a/frontends/PyCDE/test/test_fsm.py
+++ b/frontends/PyCDE/test/test_fsm.py
@@ -149,3 +149,61 @@ class F0:
 system = System([F0])
 system.generate()
 system.print()
+
+# -----
+
+# Shorthand FSM generator.
+
+# CHECK:      fsm.machine @Generated_FSM_impl(%arg0: i1) -> (i1, i1, i1) attributes {clock_name = "clk", in_names = ["go"], initialState = "a", out_names = ["is_a", "is_b", "is_c"], reset_name = "rst"} {
+# CHECK-NEXT:    fsm.state @a output {
+# CHECK-NEXT:      %true = hw.constant true
+# CHECK-NEXT:      %false = hw.constant false
+# CHECK-NEXT:      %false_0 = hw.constant false
+# CHECK-NEXT:      fsm.output %true, %false, %false_0 : i1, i1, i1
+# CHECK-NEXT:    } transitions {
+# CHECK-NEXT:      fsm.transition @b
+# CHECK-NEXT:      fsm.transition @c guard {
+# CHECK-NEXT:        fsm.return %arg0
+# CHECK-NEXT:      }
+# CHECK-NEXT:    }
+# CHECK-NEXT:    fsm.state @b output {
+# CHECK-NEXT:      %false = hw.constant false
+# CHECK-NEXT:      %true = hw.constant true
+# CHECK-NEXT:      %false_0 = hw.constant false
+# CHECK-NEXT:      fsm.output %false, %true, %false_0 : i1, i1, i1
+# CHECK-NEXT:    } transitions {
+# CHECK-NEXT:    }
+# CHECK-NEXT:    fsm.state @c output {
+# CHECK-NEXT:      %false = hw.constant false
+# CHECK-NEXT:      %false_0 = hw.constant false
+# CHECK-NEXT:      %true = hw.constant true
+# CHECK-NEXT:      fsm.output %false, %false_0, %true : i1, i1, i1
+# CHECK-NEXT:    } transitions {
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+
+
+@unittestmodule()
+class FSMUser:
+  go = Input(types.i1)
+  clk = Input(types.i1)
+  rst = Input(types.i1)
+  is_a = Output(types.i1)
+  is_b = Output(types.i1)
+  is_c = Output(types.i1)
+
+  @generator
+  def construct(ports):
+    MyFSM = fsm.gen_fsm({
+        "a": [
+            "b",
+            ("c", "go"),
+        ],
+        "b": [],
+        "c": []
+    }, "Generated_FSM")
+
+    inst = MyFSM(go=ports.go, clk=ports.clk, rst=ports.rst)
+    ports.is_a = inst.is_a
+    ports.is_b = inst.is_b
+    ports.is_c = inst.is_c


### PR DESCRIPTION
Generate a FSM from a dictionary of states and their transitions.

E.g.:
```
{
    "a": [
        ("c", "go"),
        "b",
    ],
    "b": [],
    "c": []
}
```

creates an FSM with 3 states (a, b, c). 'b' and 'c' have no outgoing transitions, and 'a' has two outgoing transitions (priority encoded). The first transition ("c", "go") transitions to 'c' whenever an input port 'go' is asserted. The second transition is a default transition to 'b'.

Any state and guard referenced within the dictionary will automatically be created as a state operation and top-level input, respectively.