### PR TITLE
[Analysis][StandardToHandshake] Introduce a loop analysis for the CF dialect

### DIFF
--- a/include/circt/Analysis/ControlFlowLoopAnalysis.h
+++ b/include/circt/Analysis/ControlFlowLoopAnalysis.h
@@ -1,0 +1,57 @@
+//===- ControlFlowLoopAnalysis.h - CF Loop Analysis -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for methods that perform loop analysis on
+// structures expressed as a CFG
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_ANALYSIS_CONTROL_FLOW_LOOP_ANALYSIS_H
+#define CIRCT_ANALYSIS_CONTROL_FLOW_LOOP_ANALYSIS_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Dominance.h"
+#include "llvm/ADT/SmallSet.h"
+
+/// TODO can we reuse parts of Polygeist's implementation?
+namespace circt {
+namespace analysis {
+
+/// Container that holds information about a cfg loop.
+struct LoopInfo {
+  SmallPtrSet<Block *, 2> loopLatches;
+  SmallPtrSet<Block *, 4> inLoop;
+  SmallPtrSet<Block *, 2> exitBlocks;
+  Block *loopHeader;
+};
+
+struct ControlFlowLoopAnalysis {
+  // Construct the analysis from a FuncOp.
+  ControlFlowLoopAnalysis(Region &region);
+  LogicalResult analyzeRegion();
+
+  bool isLoopHeader(Block *b);
+  bool isLoopElement(Block *b);
+  LoopInfo *getLoopInfoForHeader(Block *b);
+  LoopInfo *getLoopInfo(Block *b);
+
+  SmallVector<LoopInfo> topLevelLoops;
+
+private:
+  bool hasBackedge(Block *);
+  LogicalResult collectLoopInfo(Block *entry, LoopInfo &loopInfo);
+
+private:
+  Region &region;
+  mlir::DominanceInfo domInfo;
+};
+
+} // namespace analysis
+} // namespace circt
+
+#endif // CIRCT_ANALYSIS_CONTROL_FLOW_LOOP_ANALYSIS_H

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,7 +1,15 @@
 set(LLVM_OPTIONAL_SOURCES
+  ControlFlowLoopAnalysis.cpp
   DependenceAnalysis.cpp
   SchedulingAnalysis.cpp
   TestPasses.cpp
+  )
+
+add_circt_library(CIRCTControlFlowLoopAnalysis
+  ControlFlowLoopAnalysis.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
   )
 
 add_circt_library(CIRCTDependenceAnalysis
@@ -19,6 +27,7 @@ add_circt_library(CIRCTSchedulingAnalysis
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRIR
+  CIRCTControlFlowLoopAnalysis
   CIRCTDependenceAnalysis
   CIRCTScheduling
   )
@@ -27,6 +36,7 @@ add_circt_library(CIRCTAnalysisTestPasses
   TestPasses.cpp
 
   LINK_LIBS PUBLIC
+  CIRCTControlFlowLoopAnalysis
   CIRCTDependenceAnalysis
   CIRCTSchedulingAnalysis
   MLIRPass

--- a/lib/Analysis/ControlFlowLoopAnalysis.cpp
+++ b/lib/Analysis/ControlFlowLoopAnalysis.cpp
@@ -1,0 +1,181 @@
+//===- ControlFlowLoopAnalysis.cpp - CF Loop Analysis ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements functions that perform loop analysis on structures
+// expressed as a CFG.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/ControlFlowLoopAnalysis.h"
+#include "mlir/IR/BuiltinOps.h"
+
+using namespace mlir;
+using namespace circt::analysis;
+
+namespace {
+// The BFS callback provides the current block as an argument and returns
+// whether search should halt.
+enum class BFSNextState { Halt, SkipSuccessors, Continue, Custom };
+using BFSCallbackExtended = llvm::function_ref<BFSNextState(
+    Block *, DenseSet<Block *> &, SmallVector<Block *> &)>;
+
+void blockBFS(Block *start, BFSCallbackExtended callback) {
+  DenseSet<Block *> visited;
+  SmallVector<Block *> queue = {start};
+  while (!queue.empty()) {
+    Block *currBlock = queue.front();
+    queue.erase(queue.begin());
+    if (visited.contains(currBlock))
+      continue;
+    visited.insert(currBlock);
+
+    switch (callback(currBlock, visited, queue)) {
+    case BFSNextState::Halt:
+      return;
+    case BFSNextState::Continue: {
+      llvm::copy(currBlock->getSuccessors(), std::back_inserter(queue));
+      break;
+    }
+    case BFSNextState::SkipSuccessors:
+      for (auto *succ : currBlock->getSuccessors())
+        visited.insert(succ);
+      break;
+    case BFSNextState::Custom:
+      break;
+    }
+  }
+}
+
+using BFSCallback = llvm::function_ref<BFSNextState(Block *)>;
+void blockBFS(Block *start, BFSCallback callback) {
+  blockBFS(start, [&](Block *block, DenseSet<Block *> &,
+                      SmallVector<Block *> &) { return callback(block); });
+}
+
+/// Performs a BFS to determine whether there exists a path between 'from' and
+/// 'to'.
+static bool isReachable(Block *from, Block *to) {
+  bool isReachable = false;
+  blockBFS(from, [&](Block *currBlock) {
+    if (currBlock == to) {
+      isReachable = true;
+      return BFSNextState::Halt;
+    }
+    return BFSNextState::Continue;
+  });
+  return isReachable;
+}
+
+} // namespace
+
+/// Helper that checks if entry is a loop header. If it is, it collects
+/// additional information about the loop for further processing.
+LogicalResult ControlFlowLoopAnalysis::collectLoopInfo(Block *entry,
+                                                       LoopInfo &loopInfo) {
+  loopInfo.loopHeader = entry;
+
+  for (auto *backedge : entry->getPredecessors()) {
+    bool dominates = domInfo.dominates(entry, backedge);
+    bool formsLoop = isReachable(entry, backedge);
+    if (formsLoop) {
+      if (dominates)
+        loopInfo.loopLatches.insert(backedge);
+      else
+        return entry->getParentOp()->emitError()
+               << "Non-canonical loop structures detected; a potential "
+                  "loop header has backedges not dominated by the loop "
+                  "header. This indicates that the loop has multiple entry "
+                  "points.";
+    }
+  }
+
+  // Exit blocks are the blocks that control is transfered to after exiting
+  // the loop. This is essentially determining the strongly connected
+  // components with the loop header. We perform a BFS from the loop header,
+  // and if the loop header is reachable from the block, it is within the
+  // loop.
+  blockBFS(entry, [&](Block *currBlock) {
+    if (isReachable(currBlock, entry)) {
+      loopInfo.inLoop.insert(currBlock);
+      return BFSNextState::Continue;
+    }
+    loopInfo.exitBlocks.insert(currBlock);
+    return BFSNextState::SkipSuccessors;
+  });
+
+  assert(loopInfo.inLoop.size() >= 2 && "A loop must have at least 2 blocks");
+  assert(loopInfo.exitBlocks.size() != 0 &&
+         "A loop must have an exit block...?");
+
+  return success();
+}
+
+ControlFlowLoopAnalysis::ControlFlowLoopAnalysis(Region &region)
+    : region(region), domInfo(region.getParentOp()) {}
+
+bool ControlFlowLoopAnalysis::hasBackedge(Block *block) {
+  return llvm::any_of(block->getPredecessors(),
+                      [&](Block *pred) { return isReachable(block, pred); });
+}
+
+LogicalResult ControlFlowLoopAnalysis::analyzeRegion() {
+  Block *entry = &region.front();
+  LogicalResult result = success();
+  blockBFS(entry, [&](Block *currBlock, DenseSet<Block *> &visited,
+                      SmallVector<Block *> &queue) {
+    if (!hasBackedge(currBlock))
+      return BFSNextState::Continue;
+
+    LoopInfo newInfo;
+    if (failed(collectLoopInfo(currBlock, newInfo))) {
+      result = failure();
+      return BFSNextState::Halt;
+    }
+
+    // Adjusting the BFS state to jump over the loop.
+    for (Block *loopBlock : newInfo.inLoop)
+      visited.insert(loopBlock);
+    llvm::copy(newInfo.exitBlocks, std::back_inserter(queue));
+
+    topLevelLoops.emplace_back(std::move(newInfo));
+
+    return BFSNextState::Custom;
+  });
+
+  return result;
+}
+
+bool ControlFlowLoopAnalysis::isLoopHeader(Block *b) {
+  for (auto &info : topLevelLoops)
+    if (info.loopHeader == b)
+      return true;
+  return false;
+}
+
+bool ControlFlowLoopAnalysis::isLoopElement(Block *b) {
+  for (auto &info : topLevelLoops)
+    if (info.inLoop.contains(b))
+      return true;
+  return false;
+}
+
+LoopInfo *ControlFlowLoopAnalysis::getLoopInfoForHeader(Block *b) {
+  for (auto &info : topLevelLoops)
+    if (info.loopHeader == b)
+      return &info;
+
+  return nullptr;
+}
+
+LoopInfo *ControlFlowLoopAnalysis::getLoopInfo(Block *b) {
+  for (auto &info : topLevelLoops)
+    if (info.inLoop.contains(b))
+      return &info;
+
+  return nullptr;
+}

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Analysis/ControlFlowLoopAnalysis.h"
 #include "circt/Analysis/DependenceAnalysis.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
 #include "circt/Scheduling/Problems.h"
@@ -111,6 +112,64 @@ void TestSchedulingAnalysisPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// ControlFlowLoopAnalysis passes.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestControlFlowLoopAnalysisPass
+    : public PassWrapper<TestControlFlowLoopAnalysisPass,
+                         OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestControlFlowLoopAnalysisPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-cf-loop-analysis"; }
+  StringRef getDescription() const override {
+    return "Perform cf loop analysis and emit results as attributes";
+  }
+};
+} // namespace
+
+static SmallVector<Attribute> &
+lookupOrInsert(DenseMap<Block *, SmallVector<Attribute>> &map, Block *key) {
+  if (map.count(key) == 0) {
+    map.try_emplace(key, SmallVector<Attribute>());
+  }
+  return map.find(key)->getSecond();
+}
+
+void TestControlFlowLoopAnalysisPass::runOnOperation() {
+  Region &r = getOperation().getRegion();
+  ControlFlowLoopAnalysis analysis(r);
+  if (failed(analysis.analyzeRegion())) {
+    signalPassFailure();
+    return;
+  }
+  OpBuilder builder(r);
+  DenseMap<Block *, SmallVector<Attribute>> blockMap;
+  for (const LoopInfo &info : analysis.topLevelLoops) {
+    Block *header = info.loopHeader;
+    lookupOrInsert(blockMap, header).push_back(builder.getStringAttr("header"));
+
+    for (auto *latch : info.loopLatches)
+      lookupOrInsert(blockMap, latch).push_back(builder.getStringAttr("latch"));
+
+    for (auto *inLoop : info.inLoop)
+      lookupOrInsert(blockMap, inLoop)
+          .push_back(builder.getStringAttr("inLoop"));
+
+    for (auto *exit : info.exitBlocks)
+      lookupOrInsert(blockMap, exit).push_back(builder.getStringAttr("exit"));
+  }
+
+  for (auto it : blockMap) {
+    OperationState opState(builder.getUnknownLoc(), "block.info");
+    opState.addAttribute("loopInfo", builder.getArrayAttr(it.getSecond()));
+    builder.setInsertionPointToStart(it.getFirst());
+    builder.create(opState);
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Pass registration
 //===----------------------------------------------------------------------===//
 
@@ -122,6 +181,9 @@ void registerAnalysisTestPasses() {
   });
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestSchedulingAnalysisPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestControlFlowLoopAnalysisPass>();
   });
 }
 } // namespace test

--- a/lib/Conversion/StandardToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StandardToHandshake/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_library(CIRCTStandardToHandshake
   CIRCTHandshake
   CIRCTHandshakeTransforms
   CIRCTSupport
+  CIRCTControlFlowLoopAnalysis
   MLIRIR
   MLIRPass
   MLIRArithmeticDialect

--- a/test/Analysis/cf-loop-analysis.mlir
+++ b/test/Analysis/cf-loop-analysis.mlir
@@ -1,0 +1,98 @@
+// RUN: circt-opt --test-cf-loop-analysis %s --allow-unregistered-dialect --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @simple_loop
+func.func @simple_loop(%n: i64) {
+  %c0 = arith.constant 1 : i64
+  cf.br ^0(%c0 : i64)
+^0(%i: i64):
+// CHECK: "block.info"() {loopInfo = ["header", "inLoop"]}
+  %cond = arith.cmpi eq, %i, %n : i64
+  cf.cond_br %cond, ^2, ^1
+^1:
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  %c1 = arith.constant 1 : i64
+  %ni = arith.addi %i, %c1 : i64
+  cf.br ^0(%ni: i64)
+^2:
+// CHECK: "block.info"() {loopInfo = ["exit"]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multi_latch
+func.func @multi_latch(%n: i64) {
+  %c0 = arith.constant 1 : i64
+  cf.br ^0(%c0 : i64)
+^0(%i: i64):
+// CHECK: "block.info"() {loopInfo = ["header", "inLoop"]}
+  %cond = arith.cmpi eq, %i, %n : i64
+  cf.cond_br %cond, ^3, ^1
+^1:
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  %c1 = arith.constant 1 : i64
+  %ni = arith.addi %i, %c1 : i64
+  cf.cond_br %cond, ^0(%ni: i64), ^2
+^2:
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  cf.br ^0(%ni: i64)
+^3:
+// CHECK: "block.info"() {loopInfo = ["exit"]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multiple_loops
+func.func @multiple_loops(%n: i64) {
+  %c0 = arith.constant 1 : i64
+  %c1 = arith.constant 1 : i64
+  cf.br ^0(%c0 : i64)
+^0(%i: i64):
+// CHECK: "block.info"() {loopInfo = ["header", "inLoop"]}
+  %cond = arith.cmpi eq, %i, %n : i64
+  cf.cond_br %cond, ^2(%c0: i64), ^1
+^1:
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  %ni = arith.addi %i, %c1 : i64
+  cf.br ^0(%ni: i64)
+^2(%j: i64):
+// CHECK: "block.info"() {loopInfo = ["exit", "header", "inLoop"]}
+  %cond2 = arith.cmpi eq, %j, %n : i64
+  cf.cond_br %cond2, ^end, ^3
+^3:
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  %nj = arith.addi %j, %c1 : i64
+  cf.br ^2(%nj: i64)
+^end:
+// CHECK: "block.info"() {loopInfo = ["exit"]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @nested
+func.func @nested(%n: i64) {
+  %c0 = arith.constant 1 : i64
+  %c1 = arith.constant 1 : i64
+  cf.br ^0(%c0 : i64)
+^0(%i: i64):
+// CHECK: "block.info"() {loopInfo = ["header", "inLoop"]}
+  %cond = arith.cmpi eq, %i, %n : i64
+  cf.cond_br %cond, ^end, ^1
+^1:
+// CHECK: "block.info"() {loopInfo = ["inLoop"]}
+  %ni = arith.addi %i, %c1 : i64
+  cf.br ^2(%ni: i64)
+^2(%j: i64):
+// CHECK: "block.info"() {loopInfo = ["latch", "inLoop"]}
+  %cond2 = arith.cmpi eq, %j, %n : i64
+  cf.cond_br %cond2, ^0(%ni: i64), ^3
+^3:
+// CHECK: "block.info"() {loopInfo = ["inLoop"]}
+  %nj = arith.addi %j, %c1 : i64
+  cf.br ^2(%nj: i64)
+^end:
+// CHECK: "block.info"() {loopInfo = ["exit"]}
+  return
+}

--- a/test/Conversion/StandardToHandshake/errors.mlir
+++ b/test/Conversion/StandardToHandshake/errors.mlir
@@ -22,7 +22,7 @@ func.func @dynsize(%dyn : index) -> i32{
 
 // Test non-canonical loops that have multiple entry points (irreducible cfg).
 
-// expected-error @+1 {{Non-canonical loop structures detected; a potential loop header has backedges not dominated by the loop header. This indicates that the loop has multiple entry points. Handshake lowering does not yet support this form of control flow, exiting.}}
+// expected-error @+1 {{Non-canonical loop structures detected; a potential loop header has backedges not dominated by the loop header. This indicates that the loop has multiple entry points.}}
 func.func @non_canon_loop(%arg0 : memref<100xi32>, %arg1 : i32) -> i32 {
     %c0_i32 = arith.constant 0 : i32
     %c100 = arith.constant 100 : index


### PR DESCRIPTION
This PR factors out the top level loop analysis used in `StandardToHandshake` and adds tests for it. 
It might make sense to keep this as part of the `StandardToHandshake` conversion, but then we have to add another place for test passes. 

Note that Polygeist implements something similar (https://github.com/llvm/Polygeist/blob/main/lib/polygeist/Passes/LoopRestructure.cpp), but it cannot be ported easily due to a ton of issues caused by casts.