### PR TITLE
[Calyx] Add calyx primitive operation using hw.module.extern

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -36,6 +36,8 @@ def CalyxDialect : Dialect {
     /// Register all Calyx attributes.
     void registerAttributes();
   }];
+  // Depends on the HWDialect to support external primitives using hw.module.extern
+  let dependentDialects = ["circt::hw::HWDialect"];
   let cppNamespace = "::circt::calyx";
 }
 

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_CALYX_OPS_H
 
 #include "circt/Dialect/Calyx/CalyxDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/IR/OpImplementation.h"

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -10,6 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/EnumAttr.td"
+
+// "Forward-declare" these HW attributes rather than including or duplicating
+// them here. This lets us to refer to them in ODS, but delegates to HW in C++.
+// These are used to represent parameters for the PrimitiveOp.
+def ParamDeclAttr : Attr<CPred<"$_self.isa<hw::ParamDeclAttr>()">>;
+def ParamDeclArrayAttr : TypedArrayAttrBase<ParamDeclAttr, "parameter array">;
+
 def UndefinedOp : CalyxOp<"undef", [
     NoSideEffect
   ]> {
@@ -201,6 +209,37 @@ def InstanceOp : CalyxCell<"instance", [
     $sym_name `of` $componentName attr-dict (`:` qualified(type($results))^)?
   }];
 }
+
+def PrimitiveOp : CalyxCell<"primitive", [
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+  ]> {
+  let summary = "Calyx Primitive Instance";
+  let description = [{
+    Represents an instance of a Calyx primitive.
+
+    ```mlir
+      %c.in, %c.out = calyx.primitive @c of @MyExternalPrimitive : i64, i16
+    ```
+  }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the component for the symbol. This returns null on
+    /// invalid IR.
+    hw::HWModuleExternOp getReferencedPrimitive();
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<ParamDeclArrayAttr>:$parameters,
+    FlatSymbolRefAttr:$primitiveName
+  );
+  let results = (outs Variadic<AnyType>:$results);
+
+  let assemblyFormat = [{
+    $sym_name `of` $primitiveName``custom<ParameterList>($parameters) attr-dict (`:` qualified(type($results))^)?
+  }];
+}
+
 
 def GroupOp : CalyxOp<"group", [
     HasParent<"WiresOp">,

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -12,7 +12,9 @@
 
 #include "circt/Dialect/Calyx/CalyxOps.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -1266,6 +1268,220 @@ SmallVector<DictionaryAttr> InstanceOp::portAttributes() {
   for (const PortInfo &port : getReferencedComponent().getPortInfo())
     portAttributes.push_back(port.attributes);
   return portAttributes;
+}
+
+//===----------------------------------------------------------------------===//
+// PrimitiveOp
+//===----------------------------------------------------------------------===//
+
+/// Lookup the component for the symbol. This returns null on
+/// invalid IR.
+hw::HWModuleExternOp PrimitiveOp::getReferencedPrimitive() {
+  auto module = (*this)->getParentOfType<ModuleOp>();
+  if (!module)
+    return nullptr;
+
+  return module.lookupSymbol<hw::HWModuleExternOp>(primitiveName());
+}
+
+/// Verifies the port information in comparison with the referenced component
+/// of an instance. This helper function avoids conducting a lookup for the
+/// referenced component twice.
+static LogicalResult
+verifyPrimitiveOpType(PrimitiveOp instance,
+                      hw::HWModuleExternOp referencedPrimitive) {
+  auto module = instance->getParentOfType<ModuleOp>();
+  StringRef entryPointName =
+      module->getAttrOfType<StringAttr>("calyx.entrypoint");
+  if (instance.primitiveName() == entryPointName)
+    return instance.emitOpError()
+           << "cannot reference the entry-point component: '" << entryPointName
+           << "'.";
+
+  // Verify the instance result ports with those of its referenced component.
+  SmallVector<hw::PortInfo> primitivePorts = referencedPrimitive.getAllPorts();
+  size_t numPorts = primitivePorts.size();
+
+  size_t numResults = instance.getNumResults();
+  if (numResults != numPorts)
+    return instance.emitOpError()
+           << "has a wrong number of results; expected: " << numPorts
+           << " but got " << numResults;
+
+  // Verify parameters match up
+  ArrayAttr modParameters = referencedPrimitive.getParameters();
+  ArrayAttr parameters = instance.parameters().getValueOr(ArrayAttr());
+  size_t numExpected = modParameters.size();
+  size_t numParams = parameters.size();
+  if (numParams != numExpected)
+    return instance.emitOpError()
+           << "has the wrong number of parameters; expected: " << numExpected
+           << " but got " << numParams;
+
+  for (size_t i = 0; i != numExpected; ++i) {
+    auto param = parameters[i].cast<circt::hw::ParamDeclAttr>();
+    auto modParam = modParameters[i].cast<circt::hw::ParamDeclAttr>();
+
+    auto paramName = param.getName();
+    if (paramName != modParam.getName())
+      return instance.emitOpError()
+             << "parameter #" << i << " should have name " << modParam.getName()
+             << " but has name " << paramName;
+
+    if (param.getType() != modParam.getType())
+      return instance.emitOpError()
+             << "parameter " << paramName << " should have type "
+             << modParam.getType() << " but has type " << param.getType();
+
+    // All instance parameters must have a value.  Specify the same value as
+    // a module's default value if you want the default.
+    if (!param.getValue())
+      return instance.emitOpError("parameter ")
+             << paramName << " must have a value";
+  }
+
+  for (size_t i = 0; i != numResults; ++i) {
+    auto resultType = instance.getResult(i).getType();
+    auto expectedType = primitivePorts[i].type;
+    auto replacedType = hw::evaluateParametricType(
+        instance.getLoc(), instance.parametersAttr(), expectedType);
+    if (failed(replacedType))
+      return failure();
+    if (resultType == replacedType)
+      continue;
+    return instance.emitOpError()
+           << "result type for " << primitivePorts[i].name << " must be "
+           << expectedType << ", but got " << resultType;
+  }
+  return success();
+}
+
+LogicalResult
+PrimitiveOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *op = *this;
+  auto module = op->getParentOfType<ModuleOp>();
+  Operation *referencedPrimitive =
+      symbolTable.lookupNearestSymbolFrom(module, primitiveNameAttr());
+  if (referencedPrimitive == nullptr)
+    return emitError() << "referencing primitive: '" << primitiveName()
+                       << "', which does not exist.";
+
+  Operation *shadowedPrimitiveName =
+      symbolTable.lookupNearestSymbolFrom(module, sym_nameAttr());
+  if (shadowedPrimitiveName != nullptr)
+    return emitError() << "instance symbol: '" << instanceName()
+                       << "' is already a symbol for another primitive.";
+
+  // Verify the referenced primitive is not instantiating itself.
+  auto parentPrimitive = op->getParentOfType<hw::HWModuleExternOp>();
+  if (parentPrimitive == referencedPrimitive)
+    return emitError() << "recursive instantiation of its parent primitive: '"
+                       << primitiveName() << "'";
+
+  assert(isa<hw::HWModuleExternOp>(referencedPrimitive) &&
+         "Should be a HardwareModuleExternOp.");
+
+  return verifyPrimitiveOpType(*this,
+                               cast<hw::HWModuleExternOp>(referencedPrimitive));
+}
+
+/// Provide meaningful names to the result values of an PrimitiveOp.
+void PrimitiveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  getCellAsmResultNames(setNameFn, *this, this->portNames());
+}
+
+SmallVector<StringRef> PrimitiveOp::portNames() {
+  SmallVector<StringRef> portNames;
+  for (hw::PortInfo port : getReferencedPrimitive().getAllPorts())
+    portNames.push_back(port.name.getValue());
+
+  return portNames;
+}
+
+Direction convertHWDirectionToCalyx(hw::PortDirection direction) {
+  switch (direction) {
+  case hw::PortDirection::INPUT:
+    return Direction::Input;
+  case hw::PortDirection::OUTPUT:
+    return Direction::Output;
+  case hw::PortDirection::INOUT:
+    llvm_unreachable("InOut ports not supported by Calyx");
+  }
+}
+
+SmallVector<Direction> PrimitiveOp::portDirections() {
+  SmallVector<Direction> portDirections;
+  for (hw::PortInfo port : getReferencedPrimitive().getAllPorts())
+    portDirections.push_back(convertHWDirectionToCalyx(port.direction));
+  return portDirections;
+}
+
+SmallVector<DictionaryAttr> PrimitiveOp::portAttributes() {
+  SmallVector<DictionaryAttr> portAttributes;
+  for (size_t i = 0; i < getReferencedPrimitive().getAllPorts().size(); ++i)
+    portAttributes.push_back(DictionaryAttr());
+  return portAttributes;
+}
+
+/// Parse an parameter list if present. Same format as HW dialect.
+/// module-parameter-list ::= `<` parameter-decl (`,` parameter-decl)* `>`
+/// parameter-decl ::= identifier `:` type
+/// parameter-decl ::= identifier `:` type `=` attribute
+///
+static ParseResult parseParameterList(OpAsmParser &parser,
+                                      SmallVector<Attribute> &parameters) {
+
+  return parser.parseCommaSeparatedList(
+      OpAsmParser::Delimiter::OptionalLessGreater, [&]() {
+        std::string name;
+        Type type;
+        Attribute value;
+
+        if (parser.parseKeywordOrString(&name) || parser.parseColonType(type))
+          return failure();
+
+        // Parse the default value if present.
+        if (succeeded(parser.parseOptionalEqual())) {
+          if (parser.parseAttribute(value, type))
+            return failure();
+        }
+
+        auto &builder = parser.getBuilder();
+        parameters.push_back(hw::ParamDeclAttr::get(
+            builder.getContext(), builder.getStringAttr(name),
+            TypeAttr::get(type), value));
+        return success();
+      });
+}
+
+/// Shim to also use this for the InstanceOp custom parser.
+static ParseResult parseParameterList(OpAsmParser &parser,
+                                      ArrayAttr &parameters) {
+  SmallVector<Attribute> parseParameters;
+  if (failed(parseParameterList(parser, parseParameters)))
+    return failure();
+
+  parameters = ArrayAttr::get(parser.getContext(), parseParameters);
+
+  return success();
+}
+
+/// Print a parameter list for a module or instance. Same format as HW dialect.
+static void printParameterList(OpAsmPrinter &p, Operation *op,
+                               ArrayAttr parameters) {
+  if (parameters.empty())
+    return;
+
+  p << '<';
+  llvm::interleaveComma(parameters, p, [&](Attribute param) {
+    auto paramAttr = param.cast<hw::ParamDeclAttr>();
+    p << paramAttr.getName().getValue() << ": " << paramAttr.getType();
+    if (auto value = paramAttr.getValue()) {
+      p << " = ";
+      p.printAttributeWithoutType(value);
+    }
+  });
+  p << '>';
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -842,7 +842,7 @@ FailureOr<Attribute> hw::evaluateParametricAttr(Location loc,
 
 FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
                                            Type type) {
-  return llvm::TypeSwitch<Type, Type>(type)
+  return llvm::TypeSwitch<Type, FailureOr<Type>>(type)
       .Case<hw::IntType>([&](hw::IntType t) -> FailureOr<Type> {
         auto evaluatedWidth =
             evaluateParametricAttr(loc, parameters, t.getWidth());

--- a/test/Dialect/Calyx/emit-custom-primitives.mlir
+++ b/test/Dialect/Calyx/emit-custom-primitives.mlir
@@ -1,0 +1,60 @@
+// RUN: circt-translate --export-calyx --split-input-file --verify-diagnostics %s | FileCheck %s --strict-whitespace
+
+module attributes {calyx.entrypoint = "A"} {
+  // CHECK-LABEL: extern "test.v" {
+  // CHECK: primitive prim(in: 32) -> (out: 32);
+  // CHECK: }
+  hw.module.extern @prim(%in: i32) -> (out: i32) attributes {filename = "test.v"}
+  // CHECK-LABEL: extern "test.v" {
+  // CHECK: primitive params[WIDTH](in: WIDTH) -> (out: WIDTH);
+  // CHECK: }
+  hw.module.extern @params<WIDTH: i32>(%in: !hw.int<#hw.param.decl.ref<"WIDTH">>) -> (out: !hw.int<#hw.param.decl.ref<"WIDTH">>) attributes {filename = "test.v"}
+
+  // CHECK-LABEL: component A<"static"=1>(in_0: 32, in_1: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out_0: 32, out_1: 32, @done done: 1) {
+  calyx.component @A(%in_0: i32, %in_1: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out_0: i32, %out_1: i32, %done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // CHECK: params_0 = params(32);
+    %params.in, %params.out = calyx.primitive @params_0 of @params<WIDTH: i32 = 32> : i32, i32
+    // CHECK: prim_0 = prim();
+    %prim.in, %prim.out = calyx.primitive @prim_0 of @prim : i32, i32
+
+    calyx.wires {
+      // CHECK: done = 1'd1;
+      calyx.assign %done = %c1_1 : i1
+      // CHECK: params_0.in = in_0;
+      calyx.assign %params.in = %in_0 : i32
+      // CHECK: out_0 = params_0.out;
+      calyx.assign %out_0 = %params.out : i32
+      // CHECK: prim_0.in = in_1;
+      calyx.assign %prim.in = %in_1 : i32
+      // CHECK: out_1 = prim_0.out;
+      calyx.assign %out_1 = %prim.out : i32
+    }
+    calyx.control {}
+  } {static = 1}
+}
+
+// -----
+module attributes {calyx.entrypoint = "A"} {
+  // CHECK-LABEL: extern "test.v" {
+  // CHECK: primitive params[WIDTH](in: WIDTH, @clk clk: 1, @go go: 1) -> (out: WIDTH, @done done: 1);
+  // CHECK: }
+  hw.module.extern @params<WIDTH: i32>(%in: !hw.int<#hw.param.decl.ref<"WIDTH">>, %clk: i1 {calyx.clk}, %go: i1 {calyx.go}) -> (out: !hw.int<#hw.param.decl.ref<"WIDTH">>, done: i1 {calyx.done}) attributes {filename = "test.v"}
+
+  // CHECK-LABEL: component A<"static"=1>(in_0: 32, in_1: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out_0: 32, out_1: 32, @done done: 1) {
+  calyx.component @A(%in_0: i32, %in_1: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out_0: i32, %out_1: i32, %done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // CHECK: params_0 = params(32);
+    %params.in, %params.clk, %params.go, %params.out, %params.done = calyx.primitive @params_0 of @params<WIDTH: i32 = 32> : i32, i1, i1, i32, i1
+
+    calyx.wires {
+      // CHECK: done = 1'd1;
+      calyx.assign %done = %c1_1 : i1
+      // CHECK: params_0.in = in_0;
+      calyx.assign %params.in = %in_0 : i32
+      // CHECK: out_0 = params_0.out;
+      calyx.assign %out_0 = %params.out : i32
+    }
+    calyx.control {}
+  } {static = 1}
+}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -863,3 +863,57 @@ module attributes {calyx.entrypoint = "main"} {
     }
   }
 }
+
+// -----
+module attributes {calyx.entrypoint = "A"} {
+  hw.module.extern @params<WIDTH: i32>(%in: !hw.int<#hw.param.decl.ref<"WIDTH">>, %clk: i1 {calyx.clk}, %go: i1 {calyx.go = 1}) -> (out: !hw.int<#hw.param.decl.ref<"WIDTH">>, done: i1 {calyx.done}) attributes {filename = "test.v"}
+
+  calyx.component @A(%in_0: i32, %in_1: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out_0: i32, %out_1: i32, %done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // expected-error @+1 {{'calyx.primitive' op has the wrong number of parameters; expected: 1 but got 0}}
+    %params.in, %params.clk, %params.go, %params.out, %params.done = calyx.primitive @params_0 of @params : i32, i1, i1, i32, i1
+
+    calyx.wires {
+      calyx.assign %done = %c1_1 : i1
+      calyx.assign %params.in = %in_0 : i32
+      calyx.assign %out_0 = %params.out : i32
+    }
+    calyx.control {}
+  } {static = 1}
+}
+
+// -----
+module attributes {calyx.entrypoint = "A"} {
+  hw.module.extern @params<WIDTH: i32>(%in: !hw.int<#hw.param.decl.ref<"WIDTH">>, %clk: i1 {calyx.clk}, %go: i1 {calyx.go = 1}) -> (out: !hw.int<#hw.param.decl.ref<"WIDTH">>, done: i1 {calyx.done}) attributes {filename = "test.v"}
+
+  calyx.component @A(%in_0: i32, %in_1: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out_0: i32, %out_1: i32, %done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // expected-error @+1 {{'calyx.primitive' op parameter #0 should have name "WIDTH" but has name "TEST"}}
+    %params.in, %params.clk, %params.go, %params.out, %params.done = calyx.primitive @params_0 of @params<TEST: i32 = 1> : i32, i1, i1, i32, i1
+
+    calyx.wires {
+      calyx.assign %done = %c1_1 : i1
+      calyx.assign %params.in = %in_0 : i32
+      calyx.assign %out_0 = %params.out : i32
+    }
+    calyx.control {}
+  } {static = 1}
+}
+
+// -----
+module attributes {calyx.entrypoint = "A"} {
+  hw.module.extern @params<WIDTH: i32>(%in: !hw.int<#hw.param.decl.ref<"TEST">>, %clk: i1 {calyx.clk}, %go: i1 {calyx.go = 1}) -> (out: !hw.int<#hw.param.decl.ref<"WIDTH">>, done: i1 {calyx.done}) attributes {filename = "test.v"}
+
+  calyx.component @A(%in_0: i32, %in_1: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out_0: i32, %out_1: i32, %done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // expected-error @+1 {{Could not find parameter TEST in the provided parameters for the expression!}}
+    %params.in, %params.clk, %params.go, %params.out, %params.done = calyx.primitive @params_0 of @params<WIDTH: i32 = 1> : i32, i1, i1, i32, i1
+
+    calyx.wires {
+      calyx.assign %done = %c1_1 : i1
+      calyx.assign %params.in = %in_0 : i32
+      calyx.assign %out_0 = %params.out : i32
+    }
+    calyx.control {}
+  } {static = 1}
+}


### PR DESCRIPTION
Attempt to solve #2923, using the hw.module.extern operation to represent primitives as suggested. There are two known issues with this implementation currently:

1. Requires a modification to the HWModuleExtern Op to allow it to be used within a Calyx Program Op. Currently this is done by just removing the requirement that HWModuleExtern Ops must have a ModuleOp as a parent. Let me know if there is a better way to handle this issue.
2. HWModuleExtern does not natively support attributes per port in the same way Calyx ComponentOp does. These attributes will be required in the future to fully support external primitives. Please let me know what the correct course of action is here. The two paths I have considered are modifying HWModuleExtern to support these per port attributes or developing some encoding for these per port attributes in the Op attributes.