### PR TITLE
[FIRRTL] Proposal for FIRRTL XMR Representation

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -220,7 +220,7 @@ def NodeOp : ReferableDeclOp<"node",
                        NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLnonRefType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
@@ -353,7 +353,7 @@ def WireOp : ReferableDeclOp<"wire"> {
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLnonRefType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -687,10 +687,10 @@ class RefPortConstraint<string ref>
                 CPred<"($" # ref # ".isa<BlockArgument>()"
                 " || (isa<InstanceOp>($" # ref # ".getDefiningOp())))">>;
 
-def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">,
+def RefResolveOp: FIRRTLOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
                                     RefSingleUserConstraint<"ref">,
                                     RefInstancePortConstraint<"ref">]> {
-  let summary = "FIRRTL XMR Get";
+  let summary = "FIRRTL Resolve a Reference";
   let description = [{
     Resolve a remote reference (XMR) for reading/writing.
     If an XMR is emitted for this reference, it will be at the location
@@ -702,13 +702,13 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">,
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
+def RefSendOp: FIRRTLOp<"ref.send", [RefTypeConstraint<"ref","result">,
                                     RefSingleUserConstraint<"ref">,
                                     RefPortConstraint<"ref">]> {
-  let summary = "FIRRTL XMR Read";
+  let summary = "FIRRTL Send through Reference";
   let description = [{
-    Endpoint of remote reference (XMR), read from
-    the firrtl.xmr.get op.
+    Endpoint of remote reference (XMR), send value through a reference
+    to be read from the firrtl.ref.resolve op.
   }];
   let arguments = (ins RefType:$ref, FIRRTLType:$result);
   let hasVerifier = 1;
@@ -716,14 +716,14 @@ def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
   let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
 }
 
-def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">,
+def RefRecvOp: FIRRTLOp<"ref.recv", [RefTypeConstraint<"ref","result">,
                                     RefSingleUserConstraint<"ref">,
                                     RefPortConstraint<"ref">]> {
-  let summary = "FIRRTL XMR Write";
+  let summary = "FIRRTL Receive from Reference";
   let description = [{
-    Endpoint of remote reference (XMR), written from
-    the firrtl.xmr.get end. This should override any
-    other write to $result.
+    Endpoint of remote reference (XMR), receive value through a reference
+    written from the firrtl.ref.resolve end.
+    This should override any other write to $result.
   }];
   let arguments = (ins FIRRTLType:$result, RefType:$ref);
   let hasVerifier = 1;

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -715,18 +715,3 @@ def RefSendOp: FIRRTLOp<"ref.send", [RefTypeConstraint<"ref","result">,
 
   let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
 }
-
-def RefRecvOp: FIRRTLOp<"ref.recv", [RefTypeConstraint<"ref","result">,
-                                    RefSingleUserConstraint<"ref">,
-                                    RefPortConstraint<"ref">]> {
-  let summary = "FIRRTL Receive from Reference";
-  let description = [{
-    Endpoint of remote reference (XMR), receive value through a reference
-    written from the firrtl.ref.resolve end.
-    This should override any other write to $result.
-  }];
-  let arguments = (ins FIRRTLType:$result, RefType:$ref);
-  let hasVerifier = 1;
-
-  let assemblyFormat = "$result `,` $ref attr-dict `:` qualified(type($ref))";
-}

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -667,9 +667,12 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 // Cross Module Reference (XMR) Operations
 //===----------------------------------------------------------------------===//
 
-def XMRGetOp : FIRRTLOp<"xmr.get", [
-  TypesMatchWith<"result should be reference base type",
-    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+class RefTypeConstraint<string ref, string base>
+  : TypesMatchWith<"reference base type should match",
+                   ref, base,
+                   "$_self.cast<RefType>().getType()">;
+
+def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL XMR Get";
   let description = [{
     Resolve a remote reference (XMR) for reading/writing.
@@ -682,9 +685,7 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def XMRReadOp : FIRRTLOp<"xmr.read", [
-  TypesMatchWith<"result should be reference base type",
-    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL XMR Read";
   let description = [{
     Endpoint of remote reference (XMR), read from
@@ -695,9 +696,7 @@ def XMRReadOp : FIRRTLOp<"xmr.read", [
   let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
 }
 
-def XMRWriteOp : FIRRTLOp<"xmr.write", [
-  TypesMatchWith<"result should be reference base type",
-    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL XMR Write";
   let description = [{
     Endpoint of remote reference (XMR), written from

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -672,7 +672,12 @@ class RefTypeConstraint<string ref, string base>
                    ref, base,
                    "$_self.cast<RefType>().getType()">;
 
-def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">]> {
+class RefSingleUserConstraint<string ref>
+  : PredOpTrait<"reference port operand cannot be reused by any other op",
+                CPred<"$" # ref # ".hasOneUse()">>;
+
+def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">,
+                                    RefSingleUserConstraint<"ref">]> {
   let summary = "FIRRTL XMR Get";
   let description = [{
     Resolve a remote reference (XMR) for reading/writing.
@@ -681,12 +686,12 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">]> {
   }];
   let arguments = (ins RefType:$ref);
   let results = (outs FIRRTLType:$result);
-  let hasVerifier = 1;
 
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">]> {
+def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
+                                    RefSingleUserConstraint<"ref">]> {
   let summary = "FIRRTL XMR Read";
   let description = [{
     Endpoint of remote reference (XMR), read from
@@ -697,7 +702,8 @@ def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">]> {
   let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
 }
 
-def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">]> {
+def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">,
+                                    RefSingleUserConstraint<"ref">]> {
   let summary = "FIRRTL XMR Write";
   let description = [{
     Endpoint of remote reference (XMR), written from

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -662,3 +662,23 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 
   let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";
 }
+
+//===----------------------------------------------------------------------===//
+// XMR
+//===----------------------------------------------------------------------===//
+
+// TODO: Finish me, just enough to poke at RefType
+// TODO: result = ref.getType()
+// InferTypeOpInterface
+def XMRGet : FIRRTLOp<"xmr.get", [
+  TypesMatchWith<"result should be reference base type",
+    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+  let summary = "FIRRTL XMR Get";
+  let description = [{
+    Describe me!
+  }];
+  let arguments = (ins RefType:$ref);
+  let results = (outs FIRRTLType:$result);
+
+  let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
+}

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -677,6 +677,7 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [
   }];
   let arguments = (ins RefType:$ref);
   let results = (outs FIRRTLType:$result);
+  let hasVerifier = 1;
 
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -676,8 +676,20 @@ class RefSingleUserConstraint<string ref>
   : PredOpTrait<"reference port operand cannot be reused by any other op",
                 CPred<"$" # ref # ".hasOneUse()">>;
 
+class RefInstancePortConstraint<string ref>
+  : PredOpTrait<"it cannot have module port as an operand because it implies"
+  " upward reference XMR, which are not supported."
+  " The reference operand must be a port from firrtl.instance",
+                CPred<"!($" # ref # ".isa<BlockArgument>())">>;
+
+class RefPortConstraint<string ref>
+  : PredOpTrait<"reference port operand can only be a module or instance port",
+                CPred<"($" # ref # ".isa<BlockArgument>()"
+                " || (isa<InstanceOp>($" # ref # ".getDefiningOp())))">>;
+
 def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">,
-                                    RefSingleUserConstraint<"ref">]> {
+                                    RefSingleUserConstraint<"ref">,
+                                    RefInstancePortConstraint<"ref">]> {
   let summary = "FIRRTL XMR Get";
   let description = [{
     Resolve a remote reference (XMR) for reading/writing.
@@ -691,7 +703,8 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">,
 }
 
 def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
-                                    RefSingleUserConstraint<"ref">]> {
+                                    RefSingleUserConstraint<"ref">,
+                                    RefPortConstraint<"ref">]> {
   let summary = "FIRRTL XMR Read";
   let description = [{
     Endpoint of remote reference (XMR), read from
@@ -703,7 +716,8 @@ def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
 }
 
 def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">,
-                                    RefSingleUserConstraint<"ref">]> {
+                                    RefSingleUserConstraint<"ref">,
+                                    RefPortConstraint<"ref">]> {
   let summary = "FIRRTL XMR Write";
   let description = [{
     Endpoint of remote reference (XMR), written from

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -676,7 +676,8 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL XMR Get";
   let description = [{
     Resolve a remote reference (XMR) for reading/writing.
-    If an XMR is emitted for this reference, it will be here.
+    If an XMR is emitted for this reference, it will be at the location
+    of this operation.
   }];
   let arguments = (ins RefType:$ref);
   let results = (outs FIRRTLType:$result);

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -670,7 +670,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 // TODO: Finish me, just enough to poke at RefType
 // TODO: result = ref.getType()
 // InferTypeOpInterface
-def XMRGet : FIRRTLOp<"xmr.get", [
+def XMRGetOp : FIRRTLOp<"xmr.get", [
   TypesMatchWith<"result should be reference base type",
     "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
   let summary = "FIRRTL XMR Get";
@@ -684,7 +684,7 @@ def XMRGet : FIRRTLOp<"xmr.get", [
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def XMREnd : FIRRTLOp<"xmr.end", [
+def XMREndOp : FIRRTLOp<"xmr.end", [
   TypesMatchWith<"result should be reference base type",
     "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
   let summary = "FIRRTL XMR End";

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -667,9 +667,6 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 // XMR
 //===----------------------------------------------------------------------===//
 
-// TODO: Finish me, just enough to poke at RefType
-// TODO: result = ref.getType()
-// InferTypeOpInterface
 def XMRGetOp : FIRRTLOp<"xmr.get", [
   TypesMatchWith<"result should be reference base type",
     "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
@@ -684,16 +681,29 @@ def XMRGetOp : FIRRTLOp<"xmr.get", [
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def XMREndOp : FIRRTLOp<"xmr.end", [
+def XMRReadOp : FIRRTLOp<"xmr.read", [
   TypesMatchWith<"result should be reference base type",
     "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
-  let summary = "FIRRTL XMR End";
+  let summary = "FIRRTL XMR Read";
   let description = [{
-    Endpoint of remote reference (XMR), read or written from
-    the firrtl.xmr.get end.
+    Endpoint of remote reference (XMR), read from
+    the firrtl.xmr.get op.
   }];
-  let arguments = (ins RefType:$ref);
-  let results = (outs FIRRTLType:$result);
+  let arguments = (ins RefType:$ref, FIRRTLType:$result);
 
-  let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
+  let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
+}
+
+def XMRWriteOp : FIRRTLOp<"xmr.write", [
+  TypesMatchWith<"result should be reference base type",
+    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+  let summary = "FIRRTL XMR Write";
+  let description = [{
+    Endpoint of remote reference (XMR), written from
+    the firrtl.xmr.get end. This should override any
+    other write to $result.
+  }];
+  let arguments = (ins FIRRTLType:$result, RefType:$ref);
+
+  let assemblyFormat = "$result `,` $ref attr-dict `:` qualified(type($ref))";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -664,7 +664,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 }
 
 //===----------------------------------------------------------------------===//
-// XMR
+// Cross Module Reference (XMR) Operations
 //===----------------------------------------------------------------------===//
 
 def XMRGetOp : FIRRTLOp<"xmr.get", [

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -711,6 +711,7 @@ def XMRReadOp : FIRRTLOp<"xmr.read", [RefTypeConstraint<"ref","result">,
     the firrtl.xmr.get op.
   }];
   let arguments = (ins RefType:$ref, FIRRTLType:$result);
+  let hasVerifier = 1;
 
   let assemblyFormat = "$ref `,` $result attr-dict `:` qualified(type($ref))";
 }
@@ -725,6 +726,7 @@ def XMRWriteOp : FIRRTLOp<"xmr.write", [RefTypeConstraint<"ref","result">,
     other write to $result.
   }];
   let arguments = (ins FIRRTLType:$result, RefType:$ref);
+  let hasVerifier = 1;
 
   let assemblyFormat = "$result `,` $ref attr-dict `:` qualified(type($ref))";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -675,7 +675,22 @@ def XMRGet : FIRRTLOp<"xmr.get", [
     "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
   let summary = "FIRRTL XMR Get";
   let description = [{
-    Describe me!
+    Resolve a remote reference (XMR) for reading/writing.
+    If an XMR is emitted for this reference, it will be here.
+  }];
+  let arguments = (ins RefType:$ref);
+  let results = (outs FIRRTLType:$result);
+
+  let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
+}
+
+def XMREnd : FIRRTLOp<"xmr.end", [
+  TypesMatchWith<"result should be reference base type",
+    "ref", "result", "$_self.cast<RefType>().getType()"> ]> {
+  let summary = "FIRRTL XMR End";
+  let description = [{
+    Endpoint of remote reference (XMR), read or written from
+    the firrtl.xmr.get end.
   }];
   let arguments = (ins RefType:$ref);
   let results = (outs FIRRTLType:$result);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -24,6 +24,7 @@ struct WidthTypeStorage;
 struct BundleTypeStorage;
 struct VectorTypeStorage;
 struct CMemoryTypeStorage;
+struct RefTypeStorage;
 } // namespace detail.
 
 class ClockType;
@@ -34,6 +35,7 @@ class UIntType;
 class AnalogType;
 class BundleType;
 class FVectorType;
+class RefType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -416,6 +418,24 @@ public:
   /// Returns the new id and whether the id is in the given child.
   std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
 };
+
+
+//===----------------------------------------------------------------------===//
+// XMR Ref Type
+//===----------------------------------------------------------------------===//
+
+class RefType : public FIRRTLType::TypeBase<RefType, FIRRTLType, detail::RefTypeStorage> {
+public:
+  using Base::Base;
+  static FIRRTLType get(FIRRTLType type);
+
+  /// Return the underlying type.
+  FIRRTLType getType();
+};
+
+//===----------------------------------------------------------------------===//
+// Type helpers
+//===----------------------------------------------------------------------===//
 
 // Get the bit width for this type, return None  if unknown. Unlike
 // getBitWidthOrSentinel(), this can recursively compute the bitwidth of

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -419,12 +419,12 @@ public:
   std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
 };
 
-
 //===----------------------------------------------------------------------===//
 // XMR Ref Type
 //===----------------------------------------------------------------------===//
 
-class RefType : public FIRRTLType::TypeBase<RefType, FIRRTLType, detail::RefTypeStorage> {
+class RefType
+    : public FIRRTLType::TypeBase<RefType, FIRRTLType, detail::RefTypeStorage> {
 public:
   using Base::Base;
   static FIRRTLType get(FIRRTLType type);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -67,6 +67,9 @@ def PassiveType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
   "a passive type (contain no flips)", "::circt::firrtl::FIRRTLType">;
 
+def RefType : DialectType<FIRRTLDialect, CPred<"$_self.isa<RefType>()">,
+  "reference type", "::circt::firrtl::RefType">;
+
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -86,8 +86,9 @@ def AnyResetType : DialectType<FIRRTLDialect,
 
 def AnyRegisterType : DialectType<FIRRTLDialect,
     CPred<"$_self.isa<FIRRTLType>() && "
-          "$_self.cast<FIRRTLType>().isRegisterType()">,
-    "a passive type that does not contain analog",
+          "$_self.cast<FIRRTLType>().isRegisterType() && "
+          "!$_self.isa<RefType>()">,
+    "a passive type that does not contain analog and is not a ref type",
     "::circt::firrtl::FIRRTLType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
@@ -98,6 +99,10 @@ def OneBitCastableType : AnyTypeOf<
   [OneBitType, AnyResetType, AsyncResetType, ClockType],
   "1-bit uint/sint/analog, reset, asyncreset, or clock",
                                   "::circt::firrtl::FIRRTLType">;
+
+def FIRRTLnonRefType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<FIRRTLType>() && !$_self.isa<RefType>()">,
+  "a base type, it cannot be a Ref Type", "::circt::firrtl::FIRRTLType">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Enum Definitions

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -67,7 +67,8 @@ def PassiveType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
   "a passive type (contain no flips)", "::circt::firrtl::FIRRTLType">;
 
-def RefType : DialectType<FIRRTLDialect, CPred<"$_self.isa<RefType>()">,
+def RefType : DialectType<FIRRTLDialect,
+   CPred<"$_self.isa<RefType>() && $_self.cast<RefType>().getType().isGround()">,
   "reference type", "::circt::firrtl::RefType">;
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -86,6 +86,8 @@ std::unique_ptr<mlir::Pass> createInferResetsPass();
 
 std::unique_ptr<mlir::Pass> createLowerMemoryPass();
 
+std::unique_ptr<mlir::Pass> createLowerXMRPass();
+
 std::unique_ptr<mlir::Pass>
 createMemToRegOfVecPass(bool replSeqMem = false, bool ignoreReadEnable = false);
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -585,4 +585,12 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
   ];
 }
 
+def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
+  let summary = "Lower ref ports to XMR";
+  let description = [{
+    This pass lowers FIRRTL ref ports to verbatim encoded XMRs.
+  }];
+  let constructor = "circt::firrtl::createLowerXMRPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3964,7 +3964,7 @@ LogicalResult RefSendOp::verify() {
 
 LogicalResult RefRecvOp::verify() {
   // Check that the flows make sense.
-  if (failed(checkConnectFlow(*this, /*disallowOutputPortSink=*/ true)))
+  if (failed(checkConnectFlow(*this, /*disallowOutputPortSink=*/true)))
     return failure();
   // The result of the ref recv op (xmr write) cannot be used as the destination
   // of any connect op in the module.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -140,6 +140,9 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return swap();
       })
       .Case<MemOp>([&](auto op) { return swap(); })
+      .Case<XMRGetOp,XMREndOp>([&](auto op) {
+          return foldFlow(op.ref(), accumulatedFlow);
+      })
       // Anything else acts like a universal source.
       .Default([&](auto) { return accumulatedFlow; });
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -140,9 +140,8 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         return swap();
       })
       .Case<MemOp>([&](auto op) { return swap(); })
-      .Case<XMRGetOp,XMREndOp>([&](auto op) {
-          return foldFlow(op.ref(), accumulatedFlow);
-      })
+      .Case<XMRGetOp>(
+          [&](auto op) { return foldFlow(op->getOperand(0), accumulatedFlow); })
       // Anything else acts like a universal source.
       .Default([&](auto) { return accumulatedFlow; });
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3946,8 +3946,9 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
-// TblGen Generated Logic.
+// Cross Module Reference verifiers.
 //===----------------------------------------------------------------------===//
+
 LogicalResult XMRReadOp::verify() {
   // Check that the flows make sense.
   if (failed(checkConnectFlow(*this)))

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3915,6 +3915,20 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
+// XMR Verifiers.
+//===----------------------------------------------------------------------===//
+
+LogicalResult XMRGetOp::verify() {
+  auto refPort = getRef();
+  if (!refPort.hasOneUse()) {
+    emitOpError(
+        "the Ref port operand cannot be reused by any other operations");
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2089,10 +2089,10 @@ static LogicalResult checkConnectFlow(Operation *connect,
 
   // If the connect is for RefType, implement the constraint for downward only
   // references. We cannot connect
-  //  1. an input reference port to the output reference port.
-  //  2. instance reference results to each other.
-  //  This means, the connect can only be used for forwarding RefType module
-  //  ports to Instance ports.
+  //   1. an input reference port to the output reference port.
+  //   2. instance reference results to each other.
+  // This means, the connect can only be used for forwarding RefType module
+  // ports to Instance ports.
   if (dst.getType().isa<RefType>()) {
     if (getDeclarationKind(src) == getDeclarationKind(dst)) {
       auto srcRef = getFieldRefFromValue(src);
@@ -3964,7 +3964,7 @@ LogicalResult RefSendOp::verify() {
 
 LogicalResult RefRecvOp::verify() {
   // Check that the flows make sense.
-  if (failed(checkConnectFlow(*this, true)))
+  if (failed(checkConnectFlow(*this, /*disallowOutputPortSink=*/ true)))
     return failure();
   // The result of the ref recv op (xmr write) cannot be used as the destination
   // of any connect op in the module.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3915,20 +3915,6 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
-// XMR Verifiers.
-//===----------------------------------------------------------------------===//
-
-LogicalResult XMRGetOp::verify() {
-  auto refPort = getRef();
-  if (!refPort.hasOneUse()) {
-    emitOpError(
-        "the Ref port operand cannot be reused by any other operations");
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -350,7 +350,10 @@ RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() {
       .Case<FVectorType>([](FVectorType vectorType) {
         return vectorType.getRecursiveTypeProperties();
       })
-      // TODO: RefType (maybe in above cases)
+      .Case<RefType>([](auto type) {
+        // Forward properties of underlying type.
+        return type.getType().getRecursiveTypeProperties();
+      })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return RecursiveTypeProperties{};

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1033,15 +1033,14 @@ std::pair<size_t, bool> FVectorType::rootChildFieldID(size_t fieldID,
 namespace circt {
 namespace firrtl {
 namespace detail {
-struct RefTypeStorage: mlir::TypeStorage {
+struct RefTypeStorage : mlir::TypeStorage {
   using KeyTy = FIRRTLType;
 
   RefTypeStorage(KeyTy value) : value(value) {}
 
   bool operator==(const KeyTy &key) const { return key == value; }
 
-  static RefTypeStorage *construct(TypeStorageAllocator &allocator,
-                                      KeyTy key) {
+  static RefTypeStorage *construct(TypeStorageAllocator &allocator, KeyTy key) {
     return new (allocator.allocate<RefTypeStorage>()) RefTypeStorage(key);
   }
 
@@ -1056,9 +1055,7 @@ auto RefType::get(FIRRTLType type) -> FIRRTLType {
   return Base::get(type.getContext(), type);
 }
 
-auto RefType::getType() -> FIRRTLType {
-  return getImpl()->value;
-}
+auto RefType::getType() -> FIRRTLType { return getImpl()->value; }
 
 //===----------------------------------------------------------------------===//
 // FIRRTLDialect

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -321,6 +321,7 @@ unsigned RecursiveTypeProperties::toFlags() const {
 
 /// Return true if this is a 'ground' type, aka a non-aggregate type.
 bool FIRRTLType::isGround() {
+  // TODO: RefType
   return TypeSwitch<FIRRTLType, bool>(*this)
       .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
             AnalogType>([](Type) { return true; })
@@ -349,6 +350,7 @@ RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() {
       .Case<FVectorType>([](FVectorType vectorType) {
         return vectorType.getRecursiveTypeProperties();
       })
+      // TODO: RefType (maybe in above cases)
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return RecursiveTypeProperties{};
@@ -1102,6 +1104,7 @@ llvm::Optional<int64_t> firrtl::getBitWidth(FIRRTLType type) {
             return llvm::Optional<int64_t>(None);
         })
         .Case<ClockType, ResetType, AsyncResetType>([](Type) { return 1; })
+        // TODO: RefType
         .Default([&](auto t) { return llvm::Optional<int64_t>(None); });
   };
   return getWidth(type);

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -321,11 +321,11 @@ unsigned RecursiveTypeProperties::toFlags() const {
 
 /// Return true if this is a 'ground' type, aka a non-aggregate type.
 bool FIRRTLType::isGround() {
-  // TODO: RefType
   return TypeSwitch<FIRRTLType, bool>(*this)
       .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
             AnalogType>([](Type) { return true; })
       .Case<BundleType, FVectorType>([](Type) { return false; })
+      .Case<RefType>([](auto type) { return type.getType().isGround(); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return false;

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerCHIRRTL.cpp
   LowerMemory.cpp
   LowerTypes.cpp
+  LowerXMR.cpp
   MergeConnections.cpp
   MemToRegOfVec.cpp
   ModuleInliner.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -1,0 +1,251 @@
+//===- LowerXMR.cpp - FIRRTL Lower to XMR -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements FIRRTL XMR Lowering.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-lower-xmr"
+
+using namespace circt;
+using namespace firrtl;
+using hw::InnerRefAttr;
+
+// The LowerXMRPass, replaces every RefResolveOp with a verbatim expr op,
+// with the corresponding XMR. And also removes every Ref port from the modules
+// and corresponding instances.
+// This is a dataflow analysis over a very constrained RefType.
+// Domain of the dataflow analysis is the set of all RefSendOps
+// (and RefRecvOp). Essentially every RefType value must be mapped to one and
+// only one RefSendOp.
+// The analysis propagates the dataflow from every RefSendOp to the module
+// port it is connected to. And subsequently to the modules that instantiate it
+// through the instance port connections. The RefResolveOp is the final leaf
+// into which the dataflow must flow into.
+//
+// Algorithm:
+// Due to the downward only reference constraint on XMRs, the port order
+//  traversal ensures that the RefSendOp (and RefRecvOp) will be encountered
+// before any RefResolveOp.
+// For every RefSendOp
+//  0. RefSendOp has two ops, the result op and the reference port op.
+//  1. create a new entry into the remoteRefToXMRsymVec.
+//  2. Get the InnerRef to the result of RefSendOp and initialize the
+//     remoteRefToXMRsymVec with it. (This is the remote op that the remote
+//     xmr needs to refer to)
+//  3. Get the module ref port for the RefSendOp and record it in the
+//     refPortToXmrMap. This map tracks the dataflow from the original
+//     RefSendOp to the corresponding ref ports.
+// For every InstanceOp
+//  1. For every RefType port of the InstanceOp, get the remote RefSendOp
+//     that flows into the corresponding port of the Referenced module.
+//     Because of the order of traversal and the constraints on the ref
+//     ports, the Referenced module ref ports must already be resolved.
+// 3. Update the remoteRefToXMRsymVec for the corresponding RefSendOp,
+//    with an InnerRef to this InstanceOp. This denotes that the final
+//    XMR must include this InstanceOp.
+// 2. Forall users of the Instance ref port
+//    1. If it is a connect op, it must be connected to a module ref port.
+//       Record the corresponding remote RefSendOp to the module ref port.
+//       Update the refPortToXmrMap.
+//    2. If this is a RefResolveOp,
+//       Replace the op result with a VerbatimExpr, representing the XMR.
+//       The InnerRef sequence of symbols from remoteRefToXMRsymVec is
+//       used to construct the symbol list for the verbatim.
+//
+class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
+
+  /// This function forwards the dataflow information from the instance port to
+  /// its users.
+  void handleRefPort(Value instanceResult, Operation *remoteOp) {
+    // Given the instance port `instanceResult` and the corresponding remote
+    // RefSendOp `remoteOp` from which the instance port carries the dataflow
+    // from, forward the dataflow infomration into the users of the instance
+    // port. The instance ref port can either be connected to the module ref
+    // port or to a RefResolveOp. Replace the RefResolveOp with the
+    // corresponding verbatim Expr. Forward the data flow information regarding
+    // the remote RefSendOp from the instance op to the module port to which its
+    // connected.
+    for (Operation *user : instanceResult.getUsers()) {
+      if (auto connect = dyn_cast<FConnectLike>(user)) {
+        Value driver;
+        if (connect.getDest() == instanceResult)
+          driver = connect.getSrc();
+        else if (connect.getSrc() == instanceResult)
+          driver = connect.getDest();
+        // Downward reference constraint ensures that it must be a block
+        // argument.
+        auto blockArg = driver.cast<BlockArgument>();
+        // Record the remote op from which the dataflow is established to this
+        // module port.
+        refPortToXmrMap[std::make_pair(
+            instanceResult.getDefiningOp()->getParentOfType<FModuleOp>(),
+            blockArg.getArgNumber())] = remoteOp;
+      } else if (auto getOp = dyn_cast<RefResolveOp>(user)) {
+        // The source of the dataflow for this RefResolveOp is established. So
+        // replace the RefResolveOp with the coresponding VerbatimExpr to
+        // generate the XMR.
+        SmallVector<Attribute> xmrHierPath(
+            remoteRefToXMRsymVec[remoteOp].rbegin(),
+            remoteRefToXMRsymVec[remoteOp].rend());
+        SmallString<128> xmrString;
+        for (unsigned id = 0, e = xmrHierPath.size(); id < e; ++id) {
+          ("{{" + Twine(id) + "}}").toVector(xmrString);
+          if (id < e - 1)
+            xmrString += '.';
+        }
+        ImplicitLocOpBuilder builder(getOp.getLoc(), getOp);
+        auto xmrVerbatim = builder.create<VerbatimExprOp>(
+            getOp.getType().cast<FIRRTLType>(), xmrString, ValueRange{},
+            xmrHierPath);
+        getOp.getResult().replaceAllUsesWith(xmrVerbatim);
+        LLVM_DEBUG(llvm::dbgs() << "\n The get op:" << getOp
+                                << "\n is connected to :" << remoteOp;
+                   for (auto attr
+                        : remoteRefToXMRsymVec[remoteOp]) llvm::dbgs()
+                   << ":" << attr;);
+      } else
+        user->emitError("unhandled user of reference port");
+      // This reference port will be removed, so remove all its users also.
+      opsToRemove.push_back(user);
+    }
+  }
+
+  bool handleRemoteReference(Operation *op, FModuleOp module) {
+    Value xmrPort, xmrResult;
+    if (auto xmrEnd = dyn_cast<RefSendOp>(op)) {
+      xmrPort = xmrEnd.getRef();
+      xmrResult = xmrEnd.getResult();
+    } else // Handle RefRecvOp when its implemented.
+      return false;
+    LLVM_DEBUG(llvm::errs()
+               << "\n xmr get/end drives :"
+               << "\n for xmr get/end op :" << op << "\n xmr port" << xmrPort);
+    // Get a reference to the actual signal to which the XMR will be generated.
+    auto xmrDefOp = getInnerRefTo(xmrResult.getDefiningOp());
+    remoteRefToXMRsymVec[op] = {xmrDefOp};
+
+    // The downward reference constraint ensures that xmrPort must be a
+    // BlockArg.
+    auto blockArg = xmrPort.cast<BlockArgument>();
+    // Record the remote reference op, that this module port refers to.
+    refPortToXmrMap[std::make_pair(module, blockArg.getArgNumber())] = op;
+    opsToRemove.push_back(op);
+    return true;
+  }
+
+  bool handleInstanceOp(Operation *op, FModuleOp module) {
+    auto inst = dyn_cast<InstanceOp>(op);
+    if (!inst)
+      return false;
+    auto refMod = inst.getReferencedModule();
+    for (size_t portNum = 0, e = cast<FModuleLike>(refMod).getNumPorts();
+         portNum < e; ++portNum) {
+      auto instanceResult = inst.getResult(portNum);
+      if (!instanceResult.getType().isa<RefType>())
+        continue;
+      // Reference ports must be removed.
+      refPortsToRemoveMap[inst].push_back(portNum);
+      auto portModPair = std::make_pair(refMod, portNum);
+      // Get the remote RefSendOp, that flows through the module ports.
+      auto iter = refPortToXmrMap.find(portModPair);
+      if (iter == refPortToXmrMap.end()) {
+        inst.emitOpError("Ref port connection cannot be traced back to the "
+                         "remote read/write op");
+        return false;
+      }
+      auto remoteOp = iter->getSecond();
+      // This instance op must participate in the XMR hierarchical path, so
+      // record the innerRef to it.
+      remoteRefToXMRsymVec[remoteOp].push_back(getInnerRefTo(inst));
+      handleRefPort(instanceResult, remoteOp);
+    }
+    return true;
+  }
+
+  void runOnOperation() override {
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    // Get the post order traversal of the modules in the InstanceGraph.
+    SmallVector<FModuleOp, 0> modules(
+        llvm::map_range(llvm::post_order(&instanceGraph), [](auto *node) {
+          return cast<FModuleOp>(*node->getModule());
+        }));
+    // Traverse the modules in post order.
+    for (auto module : modules) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "\n Traversing module:" << module.moduleNameAttr());
+      for (Operation &op :
+           llvm::make_early_inc_range(module.getBodyBlock()->getOperations()))
+        // This only handles the RefSendOp (and RefRecvOp when its implemented)
+        if (handleRemoteReference(&op, module))
+          continue;
+        else if (handleInstanceOp(&op, module))
+          continue;
+
+      for (size_t portNum = 0, e = module.getNumPorts(); portNum < e; ++portNum)
+        if (module.getPortType(portNum).isa<RefType>()) {
+          refPortsToRemoveMap[module].push_back(portNum);
+        }
+    }
+    for (auto op : opsToRemove)
+      op->erase();
+    for (auto iter : refPortsToRemoveMap)
+      if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
+        mod.erasePorts(iter.getSecond());
+      else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
+        ImplicitLocOpBuilder b(inst.getLoc(), inst);
+        inst.erasePorts(b, iter.getSecond());
+        inst.erase();
+      }
+  }
+
+  /// Get the cached namespace for a module.
+  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+    auto it = moduleNamespaces.find(module);
+    if (it != moduleNamespaces.end())
+      return it->second;
+    return moduleNamespaces.insert({module, ModuleNamespace(module)})
+        .first->second;
+  }
+
+  InnerRefAttr getInnerRefTo(Operation *op) {
+    return ::getInnerRefTo(op, "xmr_sym",
+                           [&](FModuleOp mod) -> ModuleNamespace & {
+                             return getModuleNamespace(mod);
+                           });
+  }
+  /// Cached module namespaces.
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+
+  /// Map of a ref port to the RefSend op. Each ref port can be satically
+  /// resolved to a single remote send op, according to the constraints on the
+  /// ref ports. The pair represents the module and the port number.
+  DenseMap<std::pair<Operation *, size_t>, Operation *> refPortToXmrMap;
+  /// Map of the remote RefSend op, to the sequence of the InnerRef symbols that
+  /// represents the Final XMR. Each of the intermediary symbol is an instance
+  /// op, and the final symbol represents the leaf operation corresponding to
+  /// the XMR. The symbol sequence can represent a hierarchical path to the
+  /// operation, for which the XMR needs to be constructed.
+  DenseMap<Operation *, SmallVector<Attribute>> remoteRefToXMRsymVec;
+  SmallVector<Operation *> opsToRemove;
+  // Instance and module ref ports that needs to be removed.
+  DenseMap<Operation *, SmallVector<unsigned>> refPortsToRemoveMap;
+};
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerXMRPass() {
+  return std::make_unique<LowerXMRPass>();
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -914,7 +914,7 @@ firrtl.circuit "Foo" {
     %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    // expected-error @+1 {{the Ref port operand cannot be reused by any other operation}}
+    // expected-error @+1 {{reference port operand cannot be reused by any other op}}
     %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
     firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -903,3 +903,20 @@ firrtl.circuit "DupSymField" {
     %w3 = firrtl.wire sym [<@x,1,public>] : !firrtl.vector<uint<1>,1>
   }
 }
+
+// -----
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Foo(in %fa: !firrtl.ref<uint<1>>) {
+    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
+
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // expected-error @+1 {{the Ref port operand cannot be reused by any other operation}}
+    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+    firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -943,3 +943,37 @@ firrtl.circuit "MyView" {
     firrtl.xmr.read  %ref_in1, %in1 : !firrtl.ref<uint<1>>
   }
 }
+
+// -----
+// Check upward reference XMRs
+
+firrtl.circuit "func2" {
+  firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
+    // expected-error @+1 {{connect has invalid flow for Ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
+    firrtl.strictconnect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Check flow semantics for xmr.write
+
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{source was defined here}}
+  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    // expected-error @+1 {{connect has invalid flow: the source expression "_a" has sink flow, expected source or duplex flow}}
+    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Check flow semantics for xmr.read
+
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{destination was defined here}}
+  firrtl.module @Foo(in  %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    // expected-error @+1 {{connect has invalid flow: the destination expression "_a" has source flow, expected sink or duplex flow}}
+    firrtl.xmr.read %_a, %a : !firrtl.ref<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -906,21 +906,21 @@ firrtl.circuit "DupSymField" {
 
 // -----
 // Check single usage of reference ports
-firrtl.circuit "Foo" {
-  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
-    %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
-  }
-  firrtl.module @Foo(in %fa: !firrtl.ref<uint<1>>) {
-    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
-
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    // expected-error @+1 {{reference port operand cannot be reused by any other op}}
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
-    firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>
-  }
-}
+//firrtl.circuit "Foo" {
+//  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+//    %a = firrtl.wire : !firrtl.uint<1>
+//    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
+//  }
+//  firrtl.module @Foo(in %fa: !firrtl.ref<uint<1>>) {
+//    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
+//
+//    %zero = firrtl.constant 0 : !firrtl.uint<1>
+//    // xpected-error @+1 {{reference port operand cannot be reused by any other op}}
+//    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+//    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+//    firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>
+//  }
+//}
 
 // -----
 // Check upward reference XMRs
@@ -943,16 +943,16 @@ firrtl.circuit "func2" {
 }
 
 // -----
-// Check flow semantics for ref.recv
-
-firrtl.circuit "Foo" {
-  // expected-note @+1 {{source was defined here}}
-  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
-    %a = firrtl.wire : !firrtl.uint<1>
-    // expected-error @+1 {{connect has invalid flow: the source expression "_a" has sink flow, expected source or duplex flow}}
-    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
-  }
-}
+//// Check flow semantics for ref.recv
+//
+//firrtl.circuit "Foo" {
+//  // xpected-note @+1 {{source was defined here}}
+//  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
+//    %a = firrtl.wire : !firrtl.uint<1>
+//    // xpected-error @+1 {{connect has invalid flow: the source expression "_a" has sink flow, expected source or duplex flow}}
+//    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
+//  }
+//}
 
 // -----
 // Check flow semantics for ref.send
@@ -967,18 +967,18 @@ firrtl.circuit "Foo" {
 }
 
 // -----
-// Check flow semantics for ref.recv
-
-firrtl.circuit "Bar" {
-  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
-    %a = firrtl.wire : !firrtl.uint<1>
-    %b = firrtl.wire : !firrtl.uint<1>
-    // expected-error @+1 {{ref recv result "a" cannot be used as the destination of a connect}}
-    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
-    // expected-note @+1 {{the connect was defined here}}
-    firrtl.strictconnect %a, %b : !firrtl.uint<1>
-  }
-}
+// // Check flow semantics for ref.recv
+// 
+// firrtl.circuit "Bar" {
+//   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+//     %a = firrtl.wire : !firrtl.uint<1>
+//     %b = firrtl.wire : !firrtl.uint<1>
+//     // xpected-error @+1 {{ref recv result "a" cannot be used as the destination of a connect}}
+//     firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
+//     // xpected-note @+1 {{the connect was defined here}}
+//     firrtl.strictconnect %a, %b : !firrtl.uint<1>
+//   }
+// }
 
 // -----
 // Reference port cannot be reused

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -909,14 +909,14 @@ firrtl.circuit "DupSymField" {
 firrtl.circuit "Foo" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Foo(in %fa: !firrtl.ref<uint<1>>) {
     %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // expected-error @+1 {{reference port operand cannot be reused by any other op}}
-    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
     firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>
   }
@@ -927,8 +927,8 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "MyView_mapping" {
   firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{'firrtl.xmr.get' op failed to verify that it cannot have module port as an operand because it implies upward reference XMR, which are not supported. The reference operand must be a port from firrtl.instance}}
-    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
+    // expected-error @+1 {{'firrtl.ref.resolve' op failed to verify that it cannot have module port as an operand because it implies upward reference XMR, which are not supported. The reference operand must be a port from firrtl.instance}}
+    %0 = firrtl.ref.resolve %ref_in1 : !firrtl.ref<uint<1>>
   }
 }
 
@@ -940,7 +940,7 @@ firrtl.circuit "MyView" {
     %ref_in1 = firrtl.wire : !firrtl.ref<uint<1>>
     %in1 = firrtl.wire : !firrtl.uint<1>
     // expected-error @+1 {{that reference port operand can only be a module or instance port}}
-    firrtl.xmr.read  %ref_in1, %in1 : !firrtl.ref<uint<1>>
+    firrtl.ref.send  %ref_in1, %in1 : !firrtl.ref<uint<1>>
   }
 }
 
@@ -955,38 +955,38 @@ firrtl.circuit "func2" {
 }
 
 // -----
-// Check flow semantics for xmr.write
+// Check flow semantics for ref.recv
 
 firrtl.circuit "Foo" {
   // expected-note @+1 {{source was defined here}}
   firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     // expected-error @+1 {{connect has invalid flow: the source expression "_a" has sink flow, expected source or duplex flow}}
-    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
   }
 }
 
 // -----
-// Check flow semantics for xmr.read
+// Check flow semantics for ref.send
 
 firrtl.circuit "Foo" {
   // expected-note @+1 {{destination was defined here}}
   firrtl.module @Foo(in  %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     // expected-error @+1 {{connect has invalid flow: the destination expression "_a" has source flow, expected sink or duplex flow}}
-    firrtl.xmr.read %_a, %a : !firrtl.ref<uint<1>>
+    firrtl.ref.send %_a, %a : !firrtl.ref<uint<1>>
   }
 }
 
 // -----
-// Check flow semantics for xmr.write
+// Check flow semantics for ref.recv
 
 firrtl.circuit "Bar" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     %b = firrtl.wire : !firrtl.uint<1>
-    // expected-error @+1 {{xmr write result "a" cannot be used as the destination of a connect}}
-    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    // expected-error @+1 {{ref recv (xmr write) result "a" cannot be used as the destination of a connect}}
+    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
     // expected-note @+1 {{the connect was defined here}}
     firrtl.strictconnect %a, %b : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -977,3 +977,17 @@ firrtl.circuit "Foo" {
     firrtl.xmr.read %_a, %a : !firrtl.ref<uint<1>>
   }
 }
+
+// -----
+// Check flow semantics for xmr.write
+
+firrtl.circuit "Bar" {
+  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.wire : !firrtl.uint<1>
+    // expected-error @+1 {{xmr write result "a" cannot be used as the destination of a connect}}
+    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    // expected-note @+1 {{the connect was defined here}}
+    firrtl.strictconnect %a, %b : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -905,6 +905,7 @@ firrtl.circuit "DupSymField" {
 }
 
 // -----
+// Check single usage of reference ports
 firrtl.circuit "Foo" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
@@ -918,5 +919,27 @@ firrtl.circuit "Foo" {
     %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
     firrtl.strictconnect %fa, %bar_a : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Check upward reference XMRs
+
+firrtl.circuit "MyView_mapping" {
+  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>) {
+    // expected-error @+1 {{'firrtl.xmr.get' op failed to verify that it cannot have module port as an operand because it implies upward reference XMR, which are not supported. The reference operand must be a port from firrtl.instance}}
+    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Incorrect connections
+
+firrtl.circuit "MyView" {
+  firrtl.module @MyView() {
+    %ref_in1 = firrtl.wire : !firrtl.ref<uint<1>>
+    %in1 = firrtl.wire : !firrtl.uint<1>
+    // expected-error @+1 {{that reference port operand can only be a module or instance port}}
+    firrtl.xmr.read  %ref_in1, %in1 : !firrtl.ref<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -1,0 +1,116 @@
+// RUN: circt-opt %s  --firrtl-lower-xmr -split-input-file |  FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "xmr"
+firrtl.circuit "xmr" {
+  firrtl.module private @Test(out %x: !firrtl.ref<uint<2>>) {
+    %w = firrtl.wire : !firrtl.uint<2>
+    firrtl.ref.send %x, %w : !firrtl.ref<uint<2>>
+  }
+  firrtl.module @xmr() {
+    %test_x = firrtl.instance test @Test(out x: !firrtl.ref<uint<2>>)
+    %x = firrtl.ref.resolve %test_x : !firrtl.ref<uint<2>>
+    // This should be lowered to:
+    //  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<2>
+    //  {symbols = [#hw.innerNameRef<@xmr::@xmr_sym>, #hw.innerNameRef<@Test::@xmr_sym>]}
+  }
+  // CHECK:   firrtl.module private @Test() {
+  // CHECK:     %w = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
+  // CHECK:   }
+  // CHECK:   firrtl.module @xmr() {
+  // CHECK:     firrtl.instance test sym @xmr_sym  @Test()
+  // CHECK:     %0 = firrtl.verbatim.expr 
+  // CHECK-SAME: > !firrtl.uint<2> {symbols = [#hw.innerNameRef<@xmr::@xmr_sym>, #hw.innerNameRef<@Test::@xmr_sym>]}
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.circuit "DUT" {
+firrtl.circuit "DUT" {
+  firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
+  // CHECK:  firrtl.module private @Submodule() {
+    %w_data1 = firrtl.wire : !firrtl.uint<1>
+    firrtl.ref.send %ref_out1, %w_data1 : !firrtl.ref<uint<1>>
+    %w_data2 = firrtl.wire : !firrtl.uint<4>
+    firrtl.ref.send %ref_out2, %w_data2 : !firrtl.ref<uint<4>>
+  // CHECK:    %w_data1 = firrtl.wire sym @xmr_sym   : !firrtl.uint<1>
+  // CHECK:    %w_data2 = firrtl.wire sym @xmr_sym_0   : !firrtl.uint<4>
+  }
+  firrtl.module @DUT() {
+    %w = firrtl.wire sym @w : !firrtl.uint<1>
+    %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.ref<uint<1>>, out ref_out2: !firrtl.ref<uint<4>>)
+    %view_in1, %view_in2 = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.uint<1>, in ref_in2: !firrtl.uint<4>)
+
+    %1 = firrtl.ref.resolve %view_out1 : !firrtl.ref<uint<1>>
+    //  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@DUT::@xmr_sym>, #hw.innerNameRef<@Submodule::@xmr_sym>]}
+    %2 = firrtl.ref.resolve %view_out2 : !firrtl.ref<uint<4>>
+    //  %1 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<4> {symbols = [#hw.innerNameRef<@DUT::@xmr_sym>, #hw.innerNameRef<@Submodule::@xmr_sym_0>]}
+    firrtl.strictconnect %view_in1, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %view_in2, %2 : !firrtl.uint<4>
+    // CHECK:  %0 = firrtl.verbatim.expr
+    // CHECK-SAME: !firrtl.uint<1> {symbols = [#hw.innerNameRef<@DUT::@xmr_sym>, #hw.innerNameRef<@Submodule::@xmr_sym>]}
+    // CHECK:  %1 = firrtl.verbatim.expr
+    // CHECK-SAME: !firrtl.uint<4> {symbols = [#hw.innerNameRef<@DUT::@xmr_sym>, #hw.innerNameRef<@Submodule::@xmr_sym_0>]}
+    // CHECK:  firrtl.strictconnect %MyView_companion_ref_in1, %0 : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %MyView_companion_ref_in2, %1 : !firrtl.uint<4>
+  }
+
+  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.uint<1>, in %ref_in2: !firrtl.uint<4>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
+    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
+    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
+  }
+
+  sv.interface @MyInterface {
+    sv.verbatim "// a wire called 'bool'" {symbols = []}
+    sv.interface.signal @bool : i1
+  }
+}
+
+// -----
+
+// "Example 2"
+// CHECK-LABEL: firrtl.circuit "SimpleRead" {
+firrtl.circuit "SimpleRead" {
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+  // CHECK:  firrtl.module @Bar() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
+    // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
+  }
+  firrtl.module @SimpleRead() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @xmr_sym  @Bar()
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    //   %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@SimpleRead::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.verbatim.expr
+    // CHECK-SAME: !firrtl.uint<1> {symbols = [#hw.innerNameRef<@SimpleRead::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>]}
+    // CHECK: firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.circuit "ForwardToInstance" {
+firrtl.circuit "ForwardToInstance" {
+  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @Bar2() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
+    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @ForwardToInstance() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    //  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    // CHECK:  -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -12,7 +12,7 @@
 
 firrtl.circuit "xmr" {
   firrtl.module private @Test(in %x: !firrtl.ref<uint<2>>) {
-    // %e = firrtl.xmr.end %x : !firrtl.ref<uint<2>>;
+    %e = firrtl.xmr.end %x : !firrtl.ref<uint<2>>
   }
   firrtl.module @xmr() {
     %test_x = firrtl.instance test @Test(in x: !firrtl.ref<uint<2>>)

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -3,11 +3,11 @@
 firrtl.circuit "xmr" {
   firrtl.module private @Test(in %x: !firrtl.ref<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
-    firrtl.xmr.write %w, %x : !firrtl.ref<uint<2>>
+    firrtl.ref.recv %w, %x : !firrtl.ref<uint<2>>
   }
   firrtl.module @xmr() {
     %test_x = firrtl.instance test @Test(in x: !firrtl.ref<uint<2>>)
-    %x = firrtl.xmr.get %test_x : !firrtl.ref<uint<2>>
+    %x = firrtl.ref.resolve %test_x : !firrtl.ref<uint<2>>
   }
 }
 
@@ -16,17 +16,17 @@ firrtl.circuit "xmr" {
 firrtl.circuit "DUT" {
   firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
     %w_data1 = firrtl.wire : !firrtl.uint<1>
-    firrtl.xmr.read %ref_out1, %w_data1 : !firrtl.ref<uint<1>>
+    firrtl.ref.send %ref_out1, %w_data1 : !firrtl.ref<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
-    firrtl.xmr.read %ref_out2, %w_data2 : !firrtl.ref<uint<4>>
+    firrtl.ref.send %ref_out2, %w_data2 : !firrtl.ref<uint<4>>
   }
   firrtl.module @DUT() {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
     %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.ref<uint<1>>, out ref_out2: !firrtl.ref<uint<4>>)
     %view_in1, %view_in2 = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.uint<1>, in ref_in2: !firrtl.uint<4>)
 
-    %1 = firrtl.xmr.get %view_out1 : !firrtl.ref<uint<1>>
-    %2 = firrtl.xmr.get %view_out2 : !firrtl.ref<uint<4>>
+    %1 = firrtl.ref.resolve %view_out1 : !firrtl.ref<uint<1>>
+    %2 = firrtl.ref.resolve %view_out2 : !firrtl.ref<uint<4>>
     firrtl.strictconnect %view_in1, %1 : !firrtl.uint<1>
     firrtl.strictconnect %view_in2, %2 : !firrtl.uint<4>
   }
@@ -50,13 +50,13 @@ firrtl.circuit "DUT" {
 firrtl.circuit "SimpleWrite" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @SimpleWrite() {
     %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
   }
 }
@@ -67,12 +67,12 @@ firrtl.circuit "SimpleWrite" {
 firrtl.circuit "SimpleRead" {
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
+    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
   }
   firrtl.module @SimpleRead() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -82,7 +82,7 @@ firrtl.circuit "SimpleRead" {
 firrtl.circuit "UnconnectedRef" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @UnconnectedRef() {
     %bar_a = firrtl.instance bar1 @Bar(in _a: !firrtl.ref<uint<1>>)
@@ -90,7 +90,7 @@ firrtl.circuit "UnconnectedRef" {
     %bar_b = firrtl.instance bar2 @Bar(in _a: !firrtl.ref<uint<1>>)
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
   }
 }
@@ -100,7 +100,7 @@ firrtl.circuit "UnconnectedRef" {
 firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
+    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
@@ -109,7 +109,7 @@ firrtl.circuit "ForwardToInstance" {
   firrtl.module @ForwardToInstance() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -19,3 +19,64 @@ firrtl.circuit "xmr" {
     %x = firrtl.xmr.get %test_x : !firrtl.ref<uint<2>>
   }
 }
+
+// -----
+
+// From design doc
+
+firrtl.circuit "DUT" {
+  firrtl.module @DUT() {
+    %w = firrtl.wire sym @w : !firrtl.uint<1>
+
+    %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
+
+    %view_in_end = firrtl.xmr.end %view_in : !firrtl.ref<uint<1>>
+    // TODO: error: connect has invalid flow: the destination expression has source flow, expected sink or duplex flow
+    // firrtl.strictconnect %view_in_end, %w : !firrtl.uint<1>
+    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
+    // Sink of XMR
+    %view_out_end = firrtl.xmr.end %view_out : !firrtl.ref<uint<1>>
+    sv.interface.signal.assign %iface(@MyInterface::@bool) = %view_out_end : !firrtl.uint<1>
+    // firrtl.strictconnect %view_out_end, %iface : !firrtl.uint<1>>
+  }
+
+  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
+    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
+
+    %view_in, %view_out = firrtl.instance MyView_mapping @MyView_mapping(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %view_in, %ref_in1 : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %ref_out1, %view_out : !firrtl.ref<uint<1>>
+  }
+
+  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
+    %1 = firrtl.xmr.get %ref_out1 : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  }
+  sv.interface @MyInterface {
+    sv.verbatim "// a wire called 'bool'" {symbols = []}
+    sv.interface.signal @bool : i1
+  }
+}
+
+// -----
+
+// "Example 1"
+
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.xmr.end %_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+  firrtl.module @Foo() {
+    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
+
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    // TODO: error: connect has invalid flow: the destination expression has source flow, expected sink or duplex flow
+    // firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -31,8 +31,7 @@ firrtl.circuit "DUT" {
     %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
 
     %view_in_end = firrtl.xmr.end %view_in : !firrtl.ref<uint<1>>
-    // TODO: error: connect has invalid flow: the destination expression has source flow, expected sink or duplex flow
-    // firrtl.strictconnect %view_in_end, %w : !firrtl.uint<1>
+    firrtl.strictconnect %view_in_end, %w : !firrtl.uint<1>
     %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
     // Sink of XMR
     %view_out_end = firrtl.xmr.end %view_out : !firrtl.ref<uint<1>>
@@ -76,7 +75,6 @@ firrtl.circuit "Foo" {
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
-    // TODO: error: connect has invalid flow: the destination expression has source flow, expected sink or duplex flow
-    // firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -78,3 +78,19 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %0, %zero : !firrtl.uint<1>
   }
 }
+
+// -----
+
+// "Example 2"
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Foo() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -1,13 +1,3 @@
-// For now, just checking very basic cases parse properly.
-
-// Lots of checking around RefType likely warranted:
-// * firrtl.ref<uint> -- handling?
-// 
-// Errors:
-// * nested ref
-// * Use anywhere other than handful of approved places
-// * use in an aggregate type (bundle/vector/etc)
-
 // RUN: circt-opt %s -split-input-file
 
 firrtl.circuit "xmr" {
@@ -57,13 +47,12 @@ firrtl.circuit "DUT" {
 // -----
 
 // "Example 1"
-
-firrtl.circuit "Foo" {
+firrtl.circuit "SimpleWrite" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
   }
-  firrtl.module @Foo() {
+  firrtl.module @SimpleWrite() {
     %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
 
     %zero = firrtl.constant 0 : !firrtl.uint<1>
@@ -75,12 +64,12 @@ firrtl.circuit "Foo" {
 // -----
 
 // "Example 2"
-firrtl.circuit "Foo" {
+firrtl.circuit "SimpleRead" {
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
   }
-  firrtl.module @Foo() {
+  firrtl.module @SimpleRead() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
@@ -90,14 +79,12 @@ firrtl.circuit "Foo" {
 
 // -----
 
-// "Example 1"
-
-firrtl.circuit "Foo" {
+firrtl.circuit "UnconnectedRef" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
   }
-  firrtl.module @Foo() {
+  firrtl.module @UnconnectedRef() {
     %bar_a = firrtl.instance bar1 @Bar(in _a: !firrtl.ref<uint<1>>)
     // bar_b is unconnected.
     %bar_b = firrtl.instance bar2 @Bar(in _a: !firrtl.ref<uint<1>>)
@@ -110,8 +97,7 @@ firrtl.circuit "Foo" {
 
 // -----
 
-// "Example 2"
-firrtl.circuit "Foo" {
+firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
@@ -120,7 +106,7 @@ firrtl.circuit "Foo" {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
   }
-  firrtl.module @Foo() {
+  firrtl.module @ForwardToInstance() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -12,7 +12,8 @@
 
 firrtl.circuit "xmr" {
   firrtl.module private @Test(in %x: !firrtl.ref<uint<2>>) {
-    %e = firrtl.xmr.end %x : !firrtl.ref<uint<2>>
+    %w = firrtl.wire : !firrtl.uint<2>
+    firrtl.xmr.write %w, %x : !firrtl.ref<uint<2>>
   }
   firrtl.module @xmr() {
     %test_x = firrtl.instance test @Test(in x: !firrtl.ref<uint<2>>)
@@ -30,12 +31,12 @@ firrtl.circuit "DUT" {
 
     %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
 
-    %view_in_end = firrtl.xmr.end %view_in : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %view_in_end, %w : !firrtl.uint<1>
+    firrtl.xmr.read %view_in, %w : !firrtl.ref<uint<1>>
     %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
-    // Sink of XMR
-    %view_out_end = firrtl.xmr.end %view_out : !firrtl.ref<uint<1>>
-    sv.interface.signal.assign %iface(@MyInterface::@bool) = %view_out_end : !firrtl.uint<1>
+
+    %w2 = firrtl.wire sym @w2 : !firrtl.uint<1>
+    firrtl.xmr.write %w2, %view_out : !firrtl.ref<uint<1>>
+
     // firrtl.strictconnect %view_out_end, %iface : !firrtl.uint<1>>
   }
 
@@ -67,8 +68,7 @@ firrtl.circuit "DUT" {
 firrtl.circuit "Foo" {
   firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.xmr.end %_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Foo() {
     %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -23,41 +23,36 @@ firrtl.circuit "xmr" {
 
 // -----
 
-//firrtl.circuit "DUT" {
-//  firrtl.module @DUT() {
-//    %w = firrtl.wire sym @w : !firrtl.uint<1>
-//
-//    %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
-//
-//    firrtl.xmr.read %view_in, %w : !firrtl.ref<uint<1>>
-//    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
-//
-//    %w2 = firrtl.wire sym @w2 : !firrtl.uint<1>
-//    firrtl.xmr.write %w2, %view_out : !firrtl.ref<uint<1>>
-//
-//    // firrtl.strictconnect %view_out_end, %iface : !firrtl.uint<1>>
-//  }
-//
-//  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
-//    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-//    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
-//    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
-//
-//    %view_in, %view_out = firrtl.instance MyView_mapping @MyView_mapping(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
-//    firrtl.strictconnect %view_in, %ref_in1 : !firrtl.ref<uint<1>>
-//    firrtl.strictconnect %ref_out1, %view_out : !firrtl.ref<uint<1>>
-//  }
-//
-//  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
-//    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
-//    %1 = firrtl.xmr.get %ref_out1 : !firrtl.ref<uint<1>>
-//    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
-//  }
-//  sv.interface @MyInterface {
-//    sv.verbatim "// a wire called 'bool'" {symbols = []}
-//    sv.interface.signal @bool : i1
-//  }
-//}
+firrtl.circuit "DUT" {
+  firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
+    %w_data1 = firrtl.wire : !firrtl.uint<1>
+    firrtl.xmr.read %ref_out1, %w_data1 : !firrtl.ref<uint<1>>
+    %w_data2 = firrtl.wire : !firrtl.uint<4>
+    firrtl.xmr.read %ref_out2, %w_data2 : !firrtl.ref<uint<4>>
+  }
+  firrtl.module @DUT() {
+    %w = firrtl.wire sym @w : !firrtl.uint<1>
+    %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.ref<uint<1>>, out ref_out2: !firrtl.ref<uint<4>>)
+    %view_in1, %view_in2 = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.uint<1>, in ref_in2: !firrtl.uint<4>)
+
+    %1 = firrtl.xmr.get %view_out1 : !firrtl.ref<uint<1>>
+    %2 = firrtl.xmr.get %view_out2 : !firrtl.ref<uint<4>>
+    firrtl.strictconnect %view_in1, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %view_in2, %2 : !firrtl.uint<4>
+  }
+
+  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.uint<1>, in %ref_in2: !firrtl.uint<4>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
+    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
+    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
+  }
+
+  sv.interface @MyInterface {
+    sv.verbatim "// a wire called 'bool'" {symbols = []}
+    sv.interface.signal @bool : i1
+  }
+}
 
 // -----
 
@@ -84,6 +79,46 @@ firrtl.circuit "Foo" {
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Foo() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// "Example 1"
+
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    firrtl.xmr.write %a, %_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Foo() {
+    %bar_a = firrtl.instance bar1 @Bar(in _a: !firrtl.ref<uint<1>>)
+    // bar_b is unconnected.
+    %bar_b = firrtl.instance bar2 @Bar(in _a: !firrtl.ref<uint<1>>)
+
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %0 = firrtl.xmr.get %bar_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// "Example 2"
+firrtl.circuit "Foo" {
+  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.xmr.read %_a, %zero : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Foo() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -23,43 +23,41 @@ firrtl.circuit "xmr" {
 
 // -----
 
-// From design doc
-
-firrtl.circuit "DUT" {
-  firrtl.module @DUT() {
-    %w = firrtl.wire sym @w : !firrtl.uint<1>
-
-    %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
-
-    firrtl.xmr.read %view_in, %w : !firrtl.ref<uint<1>>
-    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
-
-    %w2 = firrtl.wire sym @w2 : !firrtl.uint<1>
-    firrtl.xmr.write %w2, %view_out : !firrtl.ref<uint<1>>
-
-    // firrtl.strictconnect %view_out_end, %iface : !firrtl.uint<1>>
-  }
-
-  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
-    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
-
-    %view_in, %view_out = firrtl.instance MyView_mapping @MyView_mapping(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %view_in, %ref_in1 : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %ref_out1, %view_out : !firrtl.ref<uint<1>>
-  }
-
-  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
-    %1 = firrtl.xmr.get %ref_out1 : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
-  }
-  sv.interface @MyInterface {
-    sv.verbatim "// a wire called 'bool'" {symbols = []}
-    sv.interface.signal @bool : i1
-  }
-}
+//firrtl.circuit "DUT" {
+//  firrtl.module @DUT() {
+//    %w = firrtl.wire sym @w : !firrtl.uint<1>
+//
+//    %view_in, %view_out = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
+//
+//    firrtl.xmr.read %view_in, %w : !firrtl.ref<uint<1>>
+//    %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
+//
+//    %w2 = firrtl.wire sym @w2 : !firrtl.uint<1>
+//    firrtl.xmr.write %w2, %view_out : !firrtl.ref<uint<1>>
+//
+//    // firrtl.strictconnect %view_out_end, %iface : !firrtl.uint<1>>
+//  }
+//
+//  firrtl.module private @MyView_companion (in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
+//    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+//    %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
+//    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
+//
+//    %view_in, %view_out = firrtl.instance MyView_mapping @MyView_mapping(in ref_in1: !firrtl.ref<uint<1>>, out ref_out1: !firrtl.ref<uint<1>>)
+//    firrtl.strictconnect %view_in, %ref_in1 : !firrtl.ref<uint<1>>
+//    firrtl.strictconnect %ref_out1, %view_out : !firrtl.ref<uint<1>>
+//  }
+//
+//  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out1: !firrtl.ref<uint<1>>) {
+//    %0 = firrtl.xmr.get %ref_in1 : !firrtl.ref<uint<1>>
+//    %1 = firrtl.xmr.get %ref_out1 : !firrtl.ref<uint<1>>
+//    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+//  }
+//  sv.interface @MyInterface {
+//    sv.verbatim "// a wire called 'bool'" {symbols = []}
+//    sv.interface.signal @bool : i1
+//  }
+//}
 
 // -----
 

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt %s -split-input-file
 
 firrtl.circuit "xmr" {
-  firrtl.module private @Test(in %x: !firrtl.ref<uint<2>>) {
+  firrtl.module private @Test(out %x: !firrtl.ref<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
-    firrtl.ref.recv %w, %x : !firrtl.ref<uint<2>>
+    firrtl.ref.send %x, %w : !firrtl.ref<uint<2>>
   }
   firrtl.module @xmr() {
-    %test_x = firrtl.instance test @Test(in x: !firrtl.ref<uint<2>>)
+    %test_x = firrtl.instance test @Test(out x: !firrtl.ref<uint<2>>)
     %x = firrtl.ref.resolve %test_x : !firrtl.ref<uint<2>>
   }
 }
@@ -46,20 +46,20 @@ firrtl.circuit "DUT" {
 
 // -----
 
-// "Example 1"
-firrtl.circuit "SimpleWrite" {
-  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
-    %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
-  }
-  firrtl.module @SimpleWrite() {
-    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)
-
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
-  }
-}
+//// "Example 1"
+//firrtl.circuit "SimpleWrite" {
+//  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+//    %zero = firrtl.constant 0 : !firrtl.uint<1>
+//    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
+//  }
+//  firrtl.module @SimpleWrite() {
+//    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+//
+//    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+//    %a = firrtl.wire : !firrtl.uint<1>
+//    firrtl.strictconnect %0, %a    : !firrtl.uint<1>
+//  }
+//}
 
 // -----
 
@@ -79,21 +79,21 @@ firrtl.circuit "SimpleRead" {
 
 // -----
 
-firrtl.circuit "UnconnectedRef" {
-  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
-    %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
-  }
-  firrtl.module @UnconnectedRef() {
-    %bar_a = firrtl.instance bar1 @Bar(in _a: !firrtl.ref<uint<1>>)
-    // bar_b is unconnected.
-    %bar_b = firrtl.instance bar2 @Bar(in _a: !firrtl.ref<uint<1>>)
-
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
-  }
-}
+//firrtl.circuit "UnconnectedRef" {
+//  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
+//    %a = firrtl.wire : !firrtl.uint<1>
+//    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
+//  }
+//  firrtl.module @UnconnectedRef() {
+//    %bar_a = firrtl.instance bar1 @Bar(in _a: !firrtl.ref<uint<1>>)
+//    // bar_b is unconnected.
+//    %bar_b = firrtl.instance bar2 @Bar(in _a: !firrtl.ref<uint<1>>)
+//
+//    %zero = firrtl.constant 0 : !firrtl.uint<1>
+//    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+//    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
+//  }
+//}
 
 // -----
 

--- a/test/Dialect/FIRRTL/xmr.mlir
+++ b/test/Dialect/FIRRTL/xmr.mlir
@@ -1,0 +1,21 @@
+// For now, just checking very basic cases parse properly.
+
+// Lots of checking around RefType likely warranted:
+// * firrtl.ref<uint> -- handling?
+// 
+// Errors:
+// * nested ref
+// * Use anywhere other than handful of approved places
+// * use in an aggregate type (bundle/vector/etc)
+
+// RUN: circt-opt %s -split-input-file
+
+firrtl.circuit "xmr" {
+  firrtl.module private @Test(in %x: !firrtl.ref<uint<2>>) {
+    // %e = firrtl.xmr.end %x : !firrtl.ref<uint<2>>;
+  }
+  firrtl.module @xmr() {
+    %test_x = firrtl.instance test @Test(in x: !firrtl.ref<uint<2>>)
+    %x = firrtl.xmr.get %test_x : !firrtl.ref<uint<2>>
+  }
+}


### PR DESCRIPTION
### This PR implements a Proposal for FIRRTL XMR representation

**Problem**
How to express  XMRs using ports in FIRRTL dialect. The ports can be removed during lowering and replaced with `sv.XMROp`

**Problem with current representation:**
- XMRs are embedded into verbatim ops, which cannot be verified.
- Dataflow is not explicit and a lot of special case handling is required for constant propagation.
- Relies on a lot of annotations, instead of explicitly representing it in the IR.

**Proposal**

1. A Reference Type, `!firrtl.ref<*>`, is a boxed FIRRTL type that denotes a reference to some value that will eventually participate in an XMR.
2. A Reference Port is any port of type `!firrtl.ref<*>`.  A Reference Port behaves just like any other port. It may be connected to or participate in the firrtl.xmr operations defined below.
3. An operation to denote the component referenced by the XMR: `firrtl.ref.send <ref type>, <SSA value>`
    1. This operation captures a read only reference from the SSA value
    2. This is used to specify the signal that the remote XMR refers to.
4. An operation to denote the remote write by the XMR: `firrtl.ref.send <SSA value>, <ref type>`
    1. This operation denotes a remote force write to the SSA value
    2. This should override all other assignments to the SSA value
5. An operation to denote the location of the XMR op: `<SSA value> = firrtl.ref.resolve <ref_port>`
    1. This converts `!firrtl.ref<*>` to a `!firrtl.*`.
    2. This statement will be lowered to an SV XMR

Constraints implemented for the XMR representation
1. Each reference port can only be lowered to a single XMR.
2. Only downward references are allowed
3. If there is a remote XMR write to a signal, then there can be no other local assignments to the wire.

 Example 1
```mlir
firrtl.circuit "Foo" {
  firrtl.module @Bar(in %_a: !firrtl.ref<uint<1>>) {
    %a = firrtl.wire : !firrtl.uint<1>
    firrtl.ref.recv %a, %_a : !firrtl.ref<uint<1>>
  }
  firrtl.module @Foo() {
    %bar_a = firrtl.instance bar @Bar(in _a: !firrtl.ref<uint<1>>)

    %zero = firrtl.constant 0 : !firrtl.uint<1>
    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
    firrtl.strictconnect %0, %zero : !firrtl.uint<1>
  }
}
```

```verilog
module Bar();
  wire a;
endmodule

module Foo();
  Bar bar();

  wire zero = 1'h0;
  force bar.a = zero;
endmodule
```


Example 2
// -----------------------------------------------------------------------------
``` mlir
firrtl.circuit "Foo" {
  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
    %zero = firrtl.constant 0 : !firrtl.uint<1>
    firrtl.ref.send %_a, %zero : !firrtl.ref<uint<1>>
  }
  firrtl.module @Foo() {
    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
    %a = firrtl.wire : !firrtl.uint<1>
    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
  }
}
```
```verilog
module Bar();
  wire zero = 1'h0;
endmodule

module Foo();
  Bar bar();

  wire a;
  assign a = bar.zero;
endmodule
```