### PR TITLE
[CMake] Reduce number of deps

### DIFF
--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -3,10 +3,8 @@ add_llvm_executable(circt-capi-ir-test
 )
 llvm_update_compile_flags(circt-capi-ir-test)
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 target_link_libraries(circt-capi-ir-test
   PRIVATE
-  ${dialect_libs}
 
   CIRCTCAPIComb
   CIRCTCAPIHW

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,8 +25,6 @@ set(CIRCT_TEST_DEPENDS
   esi-tester
   handshake-runner
   firtool
-  mlir-opt
-  mlir-cpu-runner
   )
 
 if (CIRCT_GTEST_AVAILABLE)

--- a/test/handshake-runner/simple_loop.mlir
+++ b/test/handshake-runner/simple_loop.mlir
@@ -1,4 +1,3 @@
-// RUN: mlir-opt --convert-func-to-llvm %s | mlir-cpu-runner --entry-point-result=i64 | FileCheck %s
 // RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
 // RUN: handshake-runner %s | FileCheck %s
 // CHECK: 42

--- a/tools/handshake-runner/CMakeLists.txt
+++ b/tools/handshake-runner/CMakeLists.txt
@@ -1,12 +1,11 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-
 add_llvm_executable(handshake-runner handshake-runner.cpp Simulation.cpp)
 
 llvm_update_compile_flags(handshake-runner)
 target_link_libraries(handshake-runner PRIVATE
-  ${dialect_libs}
-  ${conversion_libs}
+  MLIRIR
+  MLIRParser
+  MLIRSupport
+
   CIRCTHandshake
   CIRCTStandardToHandshake
   )

--- a/tools/llhd-sim/CMakeLists.txt
+++ b/tools/llhd-sim/CMakeLists.txt
@@ -1,9 +1,4 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-
 set(LIBS
-        ${dialect_libs}
-        ${conversion_libs}
         CIRCTLLHD
         CIRCTComb
         CIRCTHW


### PR DESCRIPTION
Cull unnecessary dependences. Reduces the number of files which need to
be compiled for check-circt by ~20%. Compiles and links fine on my machine,
but we've had linking issues in the past, so this may be bumpy.