### PR TITLE
[FIRRTL] Extend InnerSymbolTable for ports, per-field syms on operations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -111,11 +111,6 @@ public:
         ConcreteType::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
         "expected operation to define a Symbol");
 
-    if (op->getNumRegions() != 1)
-      return op->emitError("expected operation to have a single region");
-    if (!op->getRegion(0).hasOneBlock())
-      return op->emitError("expected operation to have a single block");
-
     // InnerSymbolTable's must be directly nested within an InnerRefNamespace.
     auto *parent = op->getParentOp();
     if (!parent || !parent->hasTrait<InnerRefNamespace>())

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -261,6 +261,9 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     static_assert(
         ConcreteOp::template hasTrait<::circt::hw::HWModuleLike::Trait>(),
         "expected operation to be also be a hardware module");
+    static_assert(
+        ConcreteOp::template hasTrait<OpTrait::InnerSymbolTable>(),
+        "expected operation to be an inner symbol table");
     return verifyModuleLikeOpInterface(op);
   }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -110,7 +110,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
 
 def FExtModuleOp : FIRRTLOp<"extmodule",
       [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, OpAsmOpInterface,
-       DeclareOpInterfaceMethods<FModuleLike>,
+       DeclareOpInterfaceMethods<FModuleLike>, InnerSymbolTable,
        DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "FIRRTL extmodule";
   let description = [{
@@ -145,7 +145,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
 
 def FMemModuleOp : FIRRTLOp<"memmodule",
       [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, OpAsmOpInterface,
-       DeclareOpInterfaceMethods<FModuleLike>,
+       DeclareOpInterfaceMethods<FModuleLike>, InnerSymbolTable,
        DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "FIRRTL Generated Module";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -104,30 +104,6 @@ public:
     return dyn_cast_or_null<T>(lookupOp(name));
   }
 
-  /// Return an InnerRef to the given operation, or null attribute if the
-  /// operation does not have an inner symbol already.
-  hw::InnerRefAttr getInnerRef(Operation *op);
-
-  /// Return an InnerRef to the given target, or null attribute if the
-  /// target does not have an inner symbol already.
-  hw::InnerRefAttr getInnerRef(InnerSymTarget target);
-
-  /// Return an InnerRef for the given inner symbol, or null attribute
-  /// if the name is not a valid inner symbol in this table.
-  hw::InnerRefAttr getInnerRef(StringRef name) {
-    if (auto target = lookup(name))
-      return getInnerRef(target);
-    return hw::InnerRefAttr();
-  }
-
-  /// Return an InnerRef for the given inner symbol, or null attribute
-  /// if the name is not a valid inner symbol in this table.
-  hw::InnerRefAttr getInnerRef(StringAttr name) {
-    if (auto target = lookup(name))
-      return getInnerRef(target);
-    return hw::InnerRefAttr();
-  }
-
   /// Get InnerSymbol for an operation.
   static StringAttr getInnerSymbol(Operation *op);
 

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -37,10 +37,13 @@ public:
   explicit InnerSymTarget(size_t portIdx, Operation *op, size_t fieldID = 0)
       : op(op), portIdx(portIdx), fieldID(fieldID) {}
 
-  /// Create a target for a field, given a target to a base.
-  explicit InnerSymTarget(const InnerSymTarget &base, size_t fieldID)
-      : op(base.op), portIdx(base.portIdx), fieldID(fieldID) {
-    assert(base.fieldID == 0);
+  /// Return a target to the specified field within the given base.
+  /// FieldID is relative to the specified base target.
+  static InnerSymTarget getTargetForSubfield(const InnerSymTarget &base,
+                                             size_t fieldID) {
+    if (base.isPort())
+      return InnerSymTarget(base.portIdx, base.op, base.fieldID + fieldID);
+    return InnerSymTarget(base.op, base.fieldID + fieldID);
   }
 
   InnerSymTarget(const InnerSymTarget &) = default;

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace circt {
@@ -173,6 +174,24 @@ struct InnerRefNamespace {
     return dyn_cast_or_null<T>(lookupOp(inner));
   }
 };
+
+/// Printing InnerSymTarget's.
+template <typename OS>
+OS &operator<<(OS &os, const InnerSymTarget &target) {
+  if (!target)
+    return os << "<invalid target>";
+
+  if (target.isField())
+    os << "field " << target.getField() << " of ";
+
+  if (target.isPort())
+    os << "<port " << target.getPort() << " on @"
+       << SymbolTable::getSymbolName(target.getOp()) << ">";
+  else
+    os << "<op " << *target.getOp() << ">";
+
+  return os;
+}
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -47,17 +47,17 @@ public:
   InnerSymTarget(InnerSymTarget &&) = default;
 
   // Accessors
-  auto getField() { return fieldID; }
-  Operation *getOp() { return op; }
-  auto getPort() {
+  auto getField() const { return fieldID; }
+  Operation *getOp() const { return op; }
+  auto getPort() const {
     assert(isPort());
     return portIdx;
   }
 
   // Classification
-  bool isField() { return fieldID != 0; }
-  bool isPort() { return portIdx != invalidPort; }
-  bool isOpOnly() { return !isPort() && !isField(); }
+  bool isField() const { return fieldID != 0; }
+  bool isPort() const { return portIdx != invalidPort; }
+  bool isOpOnly() const { return !isPort() && !isField(); }
 
 private:
   auto asTuple() const { return std::tie(op, portIdx, fieldID); }

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -46,12 +46,6 @@ public:
   InnerSymTarget(const InnerSymTarget &) = default;
   InnerSymTarget(InnerSymTarget &&) = default;
 
-  InnerSymTarget &operator=(InnerSymTarget &&) = default;
-  InnerSymTarget &operator=(const InnerSymTarget &) = default;
-
-  // All targets must involve a valid op.
-  operator bool() const { return op; }
-
   // Accessors
   auto getField() { return fieldID; }
   Operation *getOp() { return op; }
@@ -66,10 +60,27 @@ public:
   bool isOpOnly() { return !isPort() && !isField(); }
 
 private:
+  auto asTuple() const { return std::tie(op, portIdx, fieldID); }
   Operation *op = nullptr;
   size_t portIdx = 0;
   size_t fieldID = 0;
   static constexpr size_t invalidPort = ~size_t{0};
+
+public:
+  // Comparison operators
+  bool operator<(const InnerSymTarget &rhs) const {
+    return asTuple() < rhs.asTuple();
+  }
+  bool operator==(const InnerSymTarget &rhs) const {
+    return asTuple() == rhs.asTuple();
+  }
+
+  // Assignment
+  InnerSymTarget &operator=(InnerSymTarget &&) = default;
+  InnerSymTarget &operator=(const InnerSymTarget &) = default;
+
+  // All targets must involve a valid op.
+  operator bool() const { return op; }
 };
 
 /// A table of inner symbols and their resolutions.

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -104,20 +104,28 @@ public:
     return dyn_cast_or_null<T>(lookupOp(name));
   }
 
-  /// Return an InnerRef to the given operation which must be within this table.
+  /// Return an InnerRef to the given operation, or null attribute if the
+  /// operation does not have an inner symbol already.
   hw::InnerRefAttr getInnerRef(Operation *op);
 
-  /// Return an InnerRef to the given target which must be within this table.
+  /// Return an InnerRef to the given target, or null attribute if the
+  /// target does not have an inner symbol already.
   hw::InnerRefAttr getInnerRef(InnerSymTarget target);
 
-  /// Return an InnerRef for the given inner symbol, which must be valid.
+  /// Return an InnerRef for the given inner symbol, or null attribute
+  /// if the name is not a valid inner symbol in this table.
   hw::InnerRefAttr getInnerRef(StringRef name) {
-    return getInnerRef(lookup(name));
+    if (auto target = lookup(name))
+      return getInnerRef(target);
+    return hw::InnerRefAttr();
   }
 
-  /// Return an InnerRef for the given inner symbol, which must be valid.
+  /// Return an InnerRef for the given inner symbol, or null attribute
+  /// if the name is not a valid inner symbol in this table.
   hw::InnerRefAttr getInnerRef(StringAttr name) {
-    return getInnerRef(lookup(name));
+    if (auto target = lookup(name))
+      return getInnerRef(target);
+    return hw::InnerRefAttr();
   }
 
   /// Get InnerSymbol for an operation.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -205,12 +205,6 @@ void getAsmBlockArgumentNamesImpl(Operation *op, mlir::Region &region,
   }
 }
 
-static bool hasPortNamed(FModuleLike op, StringAttr name) {
-  return llvm::any_of(op.getPortSymbols(), [name](Attribute pname) {
-    return pname.cast<StringAttr>() == name;
-  });
-}
-
 /// A forward declaration for `NameKind` attribute parser.
 static ParseResult parseNameKind(OpAsmParser &parser,
                                  firrtl::NameKindEnumAttr &result);
@@ -3679,7 +3673,7 @@ LogicalResult HierPathOp::verifyInnerRefs(InnerRefNamespace &ns) {
       return emitOpError() << "instance path is incorrect. Expected module: "
                            << expectedModuleName
                            << " instead found: " << innerRef.getModule();
-    InstanceOp instOp = ns.lookup<InstanceOp>(innerRef);
+    InstanceOp instOp = ns.lookupOp<InstanceOp>(innerRef);
     if (!instOp)
       return emitOpError() << " module: " << innerRef.getModule()
                            << " does not contain any instance with symbol: "
@@ -3689,9 +3683,8 @@ LogicalResult HierPathOp::verifyInnerRefs(InnerRefNamespace &ns) {
   // The instance path has been verified. Now verify the last element.
   auto leafRef = getNamepath()[getNamepath().size() - 1];
   if (auto innerRef = leafRef.dyn_cast<hw::InnerRefAttr>()) {
-    auto *fmod = ns.symTable.lookup(innerRef.getModule());
-    auto mod = cast<FModuleLike>(fmod);
-    if (!hasPortNamed(mod, innerRef.getName()) && !ns.lookup(innerRef)) {
+    auto target = ns.lookup(innerRef);
+    if (!target) {
       return emitOpError() << " operation with symbol: " << innerRef
                            << " was not found ";
     }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3683,8 +3683,7 @@ LogicalResult HierPathOp::verifyInnerRefs(InnerRefNamespace &ns) {
   // The instance path has been verified. Now verify the last element.
   auto leafRef = getNamepath()[getNamepath().size() - 1];
   if (auto innerRef = leafRef.dyn_cast<hw::InnerRefAttr>()) {
-    auto target = ns.lookup(innerRef);
-    if (!target) {
+    if (!ns.lookup(innerRef)) {
       return emitOpError() << " operation with symbol: " << innerRef
                            << " was not found ";
     }

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -13,6 +13,9 @@
 #include "circt/Dialect/FIRRTL/InnerSymbolTable.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "mlir/IR/Threading.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "ist"
 
 using namespace circt;
 using namespace firrtl;
@@ -25,12 +28,17 @@ namespace firrtl {
 //===----------------------------------------------------------------------===//
 
 InnerSymbolTable::InnerSymbolTable(Operation *op) {
+  using llvm::dbgs;
+  LLVM_DEBUG(dbgs() << "===----- InnerSymbolTable -----===\n";
+             dbgs() << "Constructing table for @"
+                    << SymbolTable::getSymbolName(op) << "\n");
   assert(op->hasTrait<OpTrait::InnerSymbolTable>() &&
          "expected operation to have InnerSymbolTable trait");
   // Save the operation this table is for.
   this->innerSymTblOp = op;
 
   auto addSym = [&](StringAttr name, InnerSymTarget target) {
+    LLVM_DEBUG(dbgs() << " - @" << name << " -> " << target << "\n");
     assert(name && !name.getValue().empty());
     auto it = symbolTable.insert({name, target});
     if (!it.second) {

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -47,8 +47,8 @@ InnerSymbolTable::InnerSymbolTable(Operation *op) {
       return;
     assert(baseTarget.getField() == 0);
     for (const auto &symProp : symAttr.getProps()) {
-      addSym(symProp.getName(),
-             InnerSymTarget(baseTarget, symProp.getFieldID()));
+      addSym(symProp.getName(), InnerSymTarget::getTargetForSubfield(
+                                    baseTarget, symProp.getFieldID()));
     }
   };
 

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -126,26 +126,6 @@ StringAttr InnerSymbolTable::getInnerSymbol(InnerSymTarget target) {
   return base.getSymIfExists(target.getField());
 }
 
-/// Return an InnerRef to the given operation.
-hw::InnerRefAttr InnerSymbolTable::getInnerRef(Operation *op) {
-  assert(op->getParentWithTrait<OpTrait::InnerSymbolTable>() == innerSymTblOp);
-  if (auto sym = getInnerSymbol(op))
-    return hw::InnerRefAttr::get(SymbolTable::getSymbolName(innerSymTblOp),
-                                 sym);
-  return hw::InnerRefAttr();
-}
-
-hw::InnerRefAttr InnerSymbolTable::getInnerRef(InnerSymTarget target) {
-  assert(target.isPort() && target.getOp() == innerSymTblOp ||
-         !target.isPort() &&
-             target.getOp()->getParentWithTrait<OpTrait::InnerSymbolTable>() ==
-                 innerSymTblOp);
-  if (auto sym = getInnerSymbol(target))
-    return hw::InnerRefAttr::get(SymbolTable::getSymbolName(innerSymTblOp),
-                                 sym);
-  return hw::InnerRefAttr();
-}
-
 //===----------------------------------------------------------------------===//
 // InnerSymbolTableCollection
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -102,27 +102,25 @@ StringAttr InnerSymbolTable::getInnerSymbol(InnerSymTarget target) {
   // Assert on misuse, but try to handle queries otherwise.
   assert(target);
 
-  InnerSymAttr base;
   if (target.isPort()) {
     auto mod = dyn_cast<FModuleLike>(target.getOp());
     if (!mod)
       return {};
     assert(target.getPort() < mod.getNumPorts());
     // TODO: update this when ports support per-field symbols
-    // base = mod.getPortSymbolAttr(target.getPort());
     auto sym = mod.getPortSymbolAttr(target.getPort());
     // Workaround quirk with empty string for no symbol on ports.
     if (sym && sym.getValue().empty())
       return {};
     return sym;
-  } else {
-    // InnerSymbols only supported if op implements the interface.
-    auto symOp = dyn_cast<InnerSymbolOpInterface>(target.getOp());
-    if (!symOp)
-      return {};
-    base = symOp.getInnerSymAttr();
   }
 
+  // InnerSymbols only supported if op implements the interface.
+  auto symOp = dyn_cast<InnerSymbolOpInterface>(target.getOp());
+  if (!symOp)
+    return {};
+
+  auto base = symOp.getInnerSymAttr();
   return base.getSymIfExists(target.getField());
 }
 

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -130,9 +130,10 @@ hw::InnerRefAttr InnerSymbolTable::getInnerRef(Operation *op) {
 }
 
 hw::InnerRefAttr InnerSymbolTable::getInnerRef(InnerSymTarget target) {
-  assert(target.getOp() == innerSymTblOp ||
-         target.getOp()->getParentWithTrait<OpTrait::InnerSymbolTable>() ==
-             innerSymTblOp);
+  assert(target.isPort() && target.getOp() == innerSymTblOp ||
+         !target.isPort() &&
+             target.getOp()->getParentWithTrait<OpTrait::InnerSymbolTable>() ==
+                 innerSymTblOp);
   return hw::InnerRefAttr::get(SymbolTable::getSymbolName(innerSymTblOp),
                                getInnerSymbol(target));
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -25,10 +25,10 @@ firrtl.circuit "top" {
   // symbol so check  that `%source` is preserved too.
   // CHECK-LABEL: firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>) {
   firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>, in %dead: !firrtl.uint<1>) {
-    // CHECK-NEXT: %sym_wire = firrtl.wire sym @sym   : !firrtl.uint<1>
+    // CHECK-NEXT: %sym_wire = firrtl.wire sym @sym2   : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
     // CHECK-NEXT: }
-    %sym_wire = firrtl.wire sym @sym : !firrtl.uint<1>
+    %sym_wire = firrtl.wire sym @sym2 : !firrtl.uint<1>
     firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
 
   }

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -48,9 +48,9 @@ firrtl.circuit "Top"   {
   }
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
-  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym2)
   firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
+    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym2"]}
   {
     // CHECK: firrtl.connect %c, %{{invalid_ui1.*}}
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
@@ -119,9 +119,9 @@ firrtl.circuit "Top"   {
   }
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
-  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym2)
   firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
+    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym2"]}
   {
     // CHECK: firrtl.strictconnect %c, %{{invalid_ui1.*}}
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>


### PR DESCRIPTION
Primarily: Flesh out IST to understand all the places that have inner symbols.

This is done by adding a new "InnerSymTarget" class that represents entities that inner symbols may name (can also be used for query), and updating IST and friends to use this.

FWIW, representation of per-field symbols on ports is accommodated but will need some small changes when that happens.

Since they contain entities with inner symbols that are expected to be resolved, now require all FModuleLike constructs to have the IST trait (and add a static_assert to ensure this isn't missed in the future).

Update existing users to the changed IST interface.

Finally, fixup some tests that newly fail now that symbols on ports are considered in InnerSymbolTable construction as well.