### PR TITLE
[ESI] [Capnp] Compile library with exceptions

### DIFF
--- a/include/circt/Dialect/ESI/cosim/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/cosim/CMakeLists.txt
@@ -12,6 +12,12 @@ if(CapnProto_FOUND)
   set(COSIM_SCHEMA_HDR ${CIRCT_BINARY_DIR}/include/circt/Dialect/ESI/CosimSchema.h)
   configure_file(CosimSchema.h.in ${COSIM_SCHEMA_HDR})
 
+  if (MSVC)
+    string(REPLACE "/EHs-c-" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  else ()
+    string(REPLACE "-fno-exceptions" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  endif ()
+
   add_definitions(${CAPNP_DEFINITIONS})
   capnp_generate_cpp(COSIM_CAPNP_SRCS COSIM_CANPN_HDRS CosimDpi.capnp)
   add_library(EsiCosimCapnp

--- a/lib/Dialect/ESI/cosim/cosim_dpi_server/CMakeLists.txt
+++ b/lib/Dialect/ESI/cosim/cosim_dpi_server/CMakeLists.txt
@@ -10,6 +10,12 @@ if(ESI_COSIM)
     Server.cpp
     Endpoint.cpp)
 
+  if (MSVC)
+    string(REPLACE "/EHs-c-" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  else ()
+    string(REPLACE "-fno-exceptions" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  endif ()
+
   set_target_properties(EsiCosimDpiServer
       PROPERTIES
           LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib


### PR DESCRIPTION
The EsiCosimCapnp library never gets linked into any MLIR code. It is
used exclusively to build the DPI shared library. As such, it can get
compiled with exceptions.

Should fix #3474 .