### PR TITLE
[ESI] Support `none`-typed channels

### DIFF
--- a/include/circt/Dialect/ESI/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/CMakeLists.txt
@@ -6,4 +6,10 @@ mlir_tablegen(ESIPasses.h.inc -gen-pass-decls)
 add_public_tablegen_target(MLIRESITransformsIncGen)
 add_circt_doc(ESI ESIPasses -gen-pass-doc)
 
+set(LLVM_TARGET_DEFINITIONS ESIInterfaces.td)
+mlir_tablegen(ESIInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(ESIInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(MLIRESIInterfacesIncGen)
+add_dependencies(circt-headers MLIRESIInterfacesIncGen)
+
 add_subdirectory(cosim)

--- a/include/circt/Dialect/ESI/ESI.td
+++ b/include/circt/Dialect/ESI/ESI.td
@@ -47,6 +47,7 @@ class ESI_Abstract_Op<string mnemonic, list<Trait> traits = []> :
 class ESI_Physical_Op<string mnemonic, list<Trait> traits = []> :
     ESI_Op<mnemonic, traits>;
 
+include "circt/Dialect/ESI/ESIInterfaces.td"
 include "circt/Dialect/ESI/ESIPorts.td"
 include "circt/Dialect/ESI/ESITypes.td"
 include "circt/Dialect/ESI/ESIOps.td"

--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -18,10 +18,8 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
 
   let methods = [
     InterfaceMethod<
-      [{"Returns any value of this operation that carries data semantics.
-         This value is only used for inspection purposes and may therefore point
-         to either in or outputs of an operation."}],
-      "mlir::Value", "anyChannel"
+      [{"Returns the channel type of this operation."}],
+      "circt::esi::ChannelPort", "channelType"
     >,
     InterfaceMethod<
         "Returns true if this channel carries data.",
@@ -30,7 +28,7 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
         (ins),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{
-          return $_op.anyChannel().getType().template cast<circt::esi::ChannelPort>().hasData();
+          return $_op.channelType().hasData();
         }]>,
     InterfaceMethod<
         [{"Returns the inner type of this channel. This will be the type of the
@@ -43,7 +41,7 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
         /*defaultImplementation=*/[{
           if(!$_op.hasData())
             return mlir::NoneType::get($_op.getContext());
-          return $_op.anyChannel().getType().template cast<circt::esi::ChannelPort>().getInner();
+          return $_op.channelType().getInner();
         }]>
   ];
 }

--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -1,0 +1,49 @@
+//===- ESIInterfaces.td - ESI Interfaces -----------------*- tablegen -*---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the interfaces in the ESI dialect.
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/OpBase.td"
+
+def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
+  let description =
+      [{"An interface for operations which carries channel semantics."}];
+
+  let methods = [
+    InterfaceMethod<
+      [{"Returns any value of this operation that carries data semantics.
+         This value is only used for inspection purposes and may therefore point
+         to either in or outputs of an operation."}],
+      "mlir::Value", "anyChannel"
+    >,
+    InterfaceMethod<
+        "Returns true if this channel carries data.",
+        "bool",
+        "hasData",
+        (ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+          return $_op.anyChannel().getType().template cast<circt::esi::ChannelPort>().hasData();
+        }]>,
+    InterfaceMethod<
+        [{"Returns the inner type of this channel. This will be the type of the
+           data value of the channel, if the channel carries data semantics. Else,
+           return NoneType."}],
+        "mlir::Type",
+        "innerType",
+        (ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+          if(!$_op.hasData())
+            return mlir::NoneType::get($_op.getContext());
+          return $_op.anyChannel().getType().template cast<circt::esi::ChannelPort>().getInner();
+        }]>
+  ];
+}

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -21,6 +21,8 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include "circt/Dialect/ESI/ESIInterfaces.h.inc"
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/ESI/ESI.h.inc"
 

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -130,3 +130,23 @@ def NullSourceOp : ESI_Physical_Op<"null", [NoSideEffect]> {
 
   let assemblyFormat = [{ attr-dict `:` qualified(type($out)) }];
 }
+
+def NoneSourceOp : ESI_Physical_Op<"none", [NoSideEffect]> {
+  let summary = [{"
+    An op which produces a 'none'-typed value, used in conjunction.
+    with data-less channels.
+  "}];
+
+  let arguments = (ins);
+  let results = (outs NoneType:$out);
+
+  let assemblyFormat = [{ attr-dict `:` qualified(type($out)) }];
+
+  let builders = [
+    OpBuilder<(ins), [{
+      $_state.addTypes($_builder.getNoneType());
+    }]>
+  ];
+
+
+}

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-def ChannelBuffer : ESI_Abstract_Op<"buffer", [NoSideEffect]> {
+def ChannelBuffer : ESI_Abstract_Op<"buffer", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "Control options for an ESI channel.";
   let description = [{
     A channel buffer (`buffer`) is essentially a set of options on a channel.
@@ -46,7 +49,10 @@ def ChannelBuffer : ESI_Abstract_Op<"buffer", [NoSideEffect]> {
   let hasCustomAssemblyFormat = 1;
 }
 
-def PipelineStage : ESI_Physical_Op<"stage", [NoSideEffect]> {
+def PipelineStage : ESI_Physical_Op<"stage", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "An elastic buffer stage.";
   let description = [{
     An individual elastic pipeline register. Generally lowered to from a

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -66,14 +66,12 @@ def WrapValidReady : ESI_Op<"wrap.vr", [
     ready signal from the other end of the channel.
   }];
 
-  let arguments = (ins Optional<AnyType>:$rawInput, I1:$valid);
+  let arguments = (ins AnyType:$rawInput, I1:$valid);
   let results = (outs ChannelType:$chanOutput, I1:$ready);
   let hasCustomAssemblyFormat = 1;
   let hasFolder = 1;
 
   let builders = [
-    // If $data == Value(), an !esi.channel<none> is returned. Else,
-    // an !esi.channel<$data.getType()> is returned.
     OpBuilder<(ins "mlir::Value":$data, "mlir::Value":$valid)>
   ];
 }
@@ -90,22 +88,12 @@ def UnwrapValidReady : ESI_Op<"unwrap.vr", [
   }];
 
   let arguments = (ins ChannelType:$chanInput, I1:$ready);
-  let results = (outs Variadic<AnyType>:$rawOutput, I1:$valid);
+  let results = (outs AnyType:$rawOutput, I1:$valid);
   let hasCustomAssemblyFormat = 1;
-  let skipDefaultBuilders = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$inChan, "mlir::Value":$ready)>
   ];
-
-  let extraClassDeclaration = [{
-    /// Returns the raw output of this operation, assuming that the channel
-    /// carries data.
-    mlir::Value getRawOutput() {
-      assert(hasData() && "Operation does not have a data value");
-      return rawOutput().front();
-    }
-  }];
 }
 
 def ModportType:

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -38,6 +38,14 @@ def Channel : ESI_Port<"Channel"> {
   let parameters = (ins "Type":$inner);
 
   let assemblyFormat = "`<` $inner `>`";
+
+  let extraClassDeclaration = [{
+    /// Returns true if this channel carries a data value.
+    bool hasData() {
+      return !getInner().isa<mlir::NoneType>();
+    }
+  }];
+
 }
 
 def ChannelType :
@@ -47,7 +55,10 @@ def ChannelType :
 //=========
 // Operations on ports.
 
-def WrapValidReady : ESI_Op<"wrap.vr", [NoSideEffect]> {
+def WrapValidReady : ESI_Op<"wrap.vr", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "Wrap a value into an ESI port";
   let description = [{
     Wrapping a value into an ESI port type allows modules to send values down
@@ -55,17 +66,22 @@ def WrapValidReady : ESI_Op<"wrap.vr", [NoSideEffect]> {
     ready signal from the other end of the channel.
   }];
 
-  let arguments = (ins AnyType:$rawInput, I1:$valid);
+  let arguments = (ins Optional<AnyType>:$rawInput, I1:$valid);
   let results = (outs ChannelType:$chanOutput, I1:$ready);
   let hasCustomAssemblyFormat = 1;
   let hasFolder = 1;
 
   let builders = [
+    // If $data == Value(), an !esi.channel<none> is returned. Else,
+    // an !esi.channel<$data.getType()> is returned.
     OpBuilder<(ins "mlir::Value":$data, "mlir::Value":$valid)>
   ];
 }
 
-def UnwrapValidReady : ESI_Op<"unwrap.vr", [NoSideEffect]> {
+def UnwrapValidReady : ESI_Op<"unwrap.vr", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "Unwrap a value from an ESI port";
   let description = [{
     Unwrapping a value allows operations on the contained value. Unwrap the
@@ -74,18 +90,31 @@ def UnwrapValidReady : ESI_Op<"unwrap.vr", [NoSideEffect]> {
   }];
 
   let arguments = (ins ChannelType:$chanInput, I1:$ready);
-  let results = (outs AnyType:$rawOutput, I1:$valid);
+  let results = (outs Variadic<AnyType>:$rawOutput, I1:$valid);
   let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$inChan, "mlir::Value":$ready)>
   ];
+
+  let extraClassDeclaration = [{
+    /// Returns the raw output of this operation, assuming that the channel
+    /// carries data.
+    mlir::Value getRawOutput() {
+      assert(hasData() && "Operation does not have a data value");
+      return rawOutput().front();
+    }
+  }];
 }
 
 def ModportType:
   Type<CPred<"$_self.isa<::circt::sv::ModportType>()">, "sv.interface">;
 
-def WrapSVInterface: ESI_Op<"wrap.iface", [NoSideEffect]> {
+def WrapSVInterface: ESI_Op<"wrap.iface", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "Wrap an SV interface into an ESI port";
   let description = [{
     Wrap a SystemVerilog interface into an ESI channel. Interface MUST look
@@ -103,7 +132,9 @@ def WrapSVInterface: ESI_Op<"wrap.iface", [NoSideEffect]> {
   let hasVerifier = 1;
 }
 
-def UnwrapSVInterface : ESI_Op<"unwrap.iface", []> {
+def UnwrapSVInterface : ESI_Op<"unwrap.iface", [
+    DeclareOpInterfaceMethods<ChannelOpInterface>
+  ]> {
   let summary = "Unwrap an SV interface from an ESI port";
   let description = [{
     Unwrap an ESI channel into a SystemVerilog interface containing valid,

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ESI_LinkLibs
 set(ESI_Deps
   ${ESI_LinkLibs}
   MLIRESITransformsIncGen
+  MLIRESIInterfacesIncGen
 )
 
 if(CapnProto_FOUND)

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -278,7 +278,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
     Backedge ready = bb.get(modBuilder.getI1Type());
     backedges.insert(std::make_pair(esiPort->second.ready.argNum, ready));
     auto unwrap = modBuilder.create<UnwrapValidReady>(arg, ready);
-    pearlOperands[esiPort->second.data.argNum] = unwrap.getRawOutput();
+    pearlOperands[esiPort->second.data.argNum] = unwrap.rawOutput();
     pearlOperands[esiPort->second.valid.argNum] = unwrap.valid();
   }
 

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -278,7 +278,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
     Backedge ready = bb.get(modBuilder.getI1Type());
     backedges.insert(std::make_pair(esiPort->second.ready.argNum, ready));
     auto unwrap = modBuilder.create<UnwrapValidReady>(arg, ready);
-    pearlOperands[esiPort->second.data.argNum] = unwrap.rawOutput();
+    pearlOperands[esiPort->second.data.argNum] = unwrap.getRawOutput();
     pearlOperands[esiPort->second.valid.argNum] = unwrap.valid();
   }
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -55,7 +55,9 @@ void ChannelBuffer::print(OpAsmPrinter &p) {
   p << " : " << innerType();
 }
 
-Value ChannelBuffer::anyChannel() { return input(); }
+circt::esi::ChannelPort ChannelBuffer::channelType() {
+  return input().getType().cast<circt::esi::ChannelPort>();
+}
 
 //===----------------------------------------------------------------------===//
 // PipelineStage functions.
@@ -87,7 +89,9 @@ void PipelineStage::print(OpAsmPrinter &p) {
   p << " : " << innerType();
 }
 
-Value PipelineStage::anyChannel() { return input(); }
+circt::esi::ChannelPort PipelineStage::channelType() {
+  return input().getType().cast<circt::esi::ChannelPort>();
+}
 
 //===----------------------------------------------------------------------===//
 // Wrap / unwrap.
@@ -154,7 +158,9 @@ void UnwrapValidReady::print(OpAsmPrinter &p) {
   p << " : " << rawOutput().getType();
 }
 
-Value WrapValidReady::anyChannel() { return chanOutput(); }
+circt::esi::ChannelPort WrapValidReady::channelType() {
+  return chanOutput().getType().cast<circt::esi::ChannelPort>();
+}
 
 void UnwrapValidReady::build(OpBuilder &b, OperationState &state, Value inChan,
                              Value ready) {
@@ -162,7 +168,9 @@ void UnwrapValidReady::build(OpBuilder &b, OperationState &state, Value inChan,
   build(b, state, inChanType.getInner(), b.getI1Type(), inChan, ready);
 }
 
-Value UnwrapValidReady::anyChannel() { return chanInput(); }
+circt::esi::ChannelPort UnwrapValidReady::channelType() {
+  return chanInput().getType().cast<circt::esi::ChannelPort>();
+}
 
 /// If 'iface' looks like an ESI interface, return the inner data type.
 static Type getEsiDataType(circt::sv::InterfaceOp iface) {
@@ -206,7 +214,9 @@ LogicalResult WrapSVInterface::verify() {
   return verifySVInterface(*this, modportType, chanType);
 }
 
-Value WrapSVInterface::anyChannel() { return output(); }
+circt::esi::ChannelPort WrapSVInterface::channelType() {
+  return output().getType().cast<circt::esi::ChannelPort>();
+}
 
 LogicalResult UnwrapSVInterface::verify() {
   auto modportType = interfaceSource().getType().cast<circt::sv::ModportType>();
@@ -214,7 +224,9 @@ LogicalResult UnwrapSVInterface::verify() {
   return verifySVInterface(*this, modportType, chanType);
 }
 
-Value UnwrapSVInterface::anyChannel() { return chanInput(); }
+circt::esi::ChannelPort UnwrapSVInterface::channelType() {
+  return chanInput().getType().cast<circt::esi::ChannelPort>();
+}
 
 /// Get the port declaration op for the specified service decl, port name.
 template <class OpType>

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -54,7 +54,7 @@ public:
 
   ArrayAttr getStageParameterList(Attribute value);
 
-  HWModuleExternOp declareStage(Operation *symTable, Type);
+  HWModuleExternOp declareStage(Operation *symTable, PipelineStage);
   // Will be unused when CAPNP is undefined
   HWModuleExternOp declareCosimEndpoint(Operation *symTable, Type sendType,
                                         Type recvType) LLVM_ATTRIBUTE_UNUSED;
@@ -181,28 +181,37 @@ ArrayAttr ESIHWBuilder::getStageParameterList(Attribute value) {
 /// implementation is double-buffered and fully pipelines the reverse-flow ready
 /// signal.
 HWModuleExternOp ESIHWBuilder::declareStage(Operation *symTable,
-                                            Type dataType) {
-  HWModuleExternOp &stage = declaredStage[dataType];
-  if (stage)
-    return stage;
+                                            PipelineStage stage) {
+  Type dataType = stage.innerType();
+  HWModuleExternOp &stageMod = declaredStage[dataType];
+  if (stageMod)
+    return stageMod;
 
   // Since this module has parameterized widths on the a input and x output,
   // give the extern declation a None type since nothing else makes sense.
   // Will be refining this when we decide how to better handle parameterized
   // types and ops.
-  PortInfo ports[] = {{clk, PortDirection::INPUT, getI1Type(), 0},
-                      {rstn, PortDirection::INPUT, getI1Type(), 1},
-                      {a, PortDirection::INPUT, dataType, 2},
-                      {aValid, PortDirection::INPUT, getI1Type(), 3},
-                      {aReady, PortDirection::OUTPUT, getI1Type(), 0},
-                      {x, PortDirection::OUTPUT, dataType, 1},
-                      {xValid, PortDirection::OUTPUT, getI1Type(), 2},
-                      {xReady, PortDirection::INPUT, getI1Type(), 4}};
+  size_t argn = 0;
+  size_t resn = 0;
+  llvm::SmallVector<PortInfo> ports = {
+      {clk, PortDirection::INPUT, getI1Type(), argn++},
+      {rstn, PortDirection::INPUT, getI1Type(), argn++}};
 
-  stage = create<HWModuleExternOp>(
+  if (stage.hasData())
+    ports.push_back({a, PortDirection::INPUT, dataType, argn++});
+
+  ports.push_back({aValid, PortDirection::INPUT, getI1Type(), argn++});
+  ports.push_back({aReady, PortDirection::OUTPUT, getI1Type(), resn++});
+  if (stage.hasData())
+    ports.push_back({x, PortDirection::OUTPUT, dataType, resn++});
+
+  ports.push_back({xValid, PortDirection::OUTPUT, getI1Type(), resn++});
+  ports.push_back({xReady, PortDirection::INPUT, getI1Type(), argn++});
+
+  stageMod = create<HWModuleExternOp>(
       constructUniqueSymbol(symTable, "ESI_PipelineStage"), ports,
       "ESI_PipelineStage", getStageParameterList({}));
-  return stage;
+  return stageMod;
 }
 
 /// Write an 'ExternModuleOp' to use a hand-coded SystemVerilog module. Said
@@ -257,14 +266,18 @@ InterfaceOp ESIHWBuilder::constructInterface(ChannelPort chan) {
   return create<InterfaceOp>(constructInterfaceName(chan).getValue(), [&]() {
     create<InterfaceSignalOp>(validStr, getI1Type());
     create<InterfaceSignalOp>(readyStr, getI1Type());
-    create<InterfaceSignalOp>(dataStr, chan.getInner());
-    create<InterfaceModportOp>(
-        sinkStr, /*inputs=*/ArrayRef<StringRef>{readyStr},
-        /*outputs=*/ArrayRef<StringRef>{validStr, dataStr});
-    create<InterfaceModportOp>(
-        sourceStr,
-        /*inputs=*/ArrayRef<StringRef>{validStr, dataStr},
-        /*outputs=*/ArrayRef<StringRef>{readyStr});
+    if (chan.hasData())
+      create<InterfaceSignalOp>(dataStr, chan.getInner());
+    llvm::SmallVector<StringRef> validDataStrs;
+    validDataStrs.push_back(validStr);
+    if (chan.hasData())
+      validDataStrs.push_back(dataStr);
+    create<InterfaceModportOp>(sinkStr,
+                               /*inputs=*/ArrayRef<StringRef>{readyStr},
+                               /*outputs=*/validDataStrs);
+    create<InterfaceModportOp>(sourceStr,
+                               /*inputs=*/validDataStrs,
+                               /*outputs=*/ArrayRef<StringRef>{readyStr});
   });
 }
 
@@ -397,6 +410,8 @@ void ESIPortsPass::runOnOperation() {
   });
 
   build = nullptr;
+
+  top.dump();
 }
 
 /// Return a attribute with the specified suffix appended.
@@ -440,31 +455,27 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
       newArgNames.push_back(argNameAttr);
       continue;
     }
-
     // When we find one, add a data and valid signal to the new args.
-    newArgTypes.push_back(chanTy.getInner());
+    Value data;
+    if (chanTy.hasData()) {
+      newArgTypes.push_back(chanTy.getInner());
+      newArgNames.push_back(argNameAttr);
+      data = mod.front().insertArgument(blockArgNum++, chanTy.getInner(),
+                                        mod.getArgument(argNum).getLoc());
+    }
     newArgTypes.push_back(i1);
-    newArgNames.push_back(argNameAttr);
     newArgNames.push_back(appendToRtlName(argNameAttr, "_valid"));
-    // Add the BlockArguments.
-    Value data = mod.front().insertArgument(blockArgNum, chanTy.getInner(),
-                                            mod.getArgument(argNum).getLoc());
-    Value valid = mod.front().insertArgument(blockArgNum + 1, i1,
+    Value valid = mod.front().insertArgument(blockArgNum++, i1,
                                              mod.getArgument(argNum).getLoc());
     // Build the ESI wrap operation to translate the lowered signals to what
     // they were. (A later pass takes care of eliminating the ESI ops.)
     auto wrap = modBuilder.create<WrapValidReady>(data, valid);
     // Replace uses of the old ESI port argument with the new one from the wrap.
-    mod.front()
-        .getArgument(blockArgNum + 2)
-        .replaceAllUsesWith(wrap.chanOutput());
+    mod.front().getArgument(blockArgNum).replaceAllUsesWith(wrap.chanOutput());
     // Delete the ESI port block argument.
-    mod.front().eraseArgument(blockArgNum + 2);
+    mod.front().eraseArgument(blockArgNum--);
     newReadySignals.push_back(
         std::make_pair(wrap.ready(), appendToRtlName(argNameAttr, "_ready")));
-
-    // Since we added 2 block args but erased one, there's a net increase of 1.
-    blockArgNum += 1;
     updated = true;
   }
 
@@ -493,12 +504,14 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
     Value ready = mod.front().addArgument(
         i1, modBuilder.getUnknownLoc()); // Ready block arg.
     auto unwrap = modBuilder.create<UnwrapValidReady>(oldOutputValue, ready);
-    newOutputOperands.push_back(unwrap.rawOutput());
-    newOutputOperands.push_back(unwrap.valid());
+    if (unwrap.hasData()) {
+      newOutputOperands.push_back(unwrap.getRawOutput());
+      newResultTypes.push_back(chanTy.getInner()); // Raw data.
+      newResultNames.push_back(oldResultName);
+    }
 
-    newResultTypes.push_back(chanTy.getInner()); // Raw data.
-    newResultTypes.push_back(i1);                // Valid.
-    newResultNames.push_back(oldResultName);
+    newResultTypes.push_back(i1); // Valid.
+    newOutputOperands.push_back(unwrap.valid());
     newResultNames.push_back(appendToRtlName(oldResultName, "_valid"));
 
     newArgTypes.push_back(i1); // Ready func arg.
@@ -552,7 +565,7 @@ void ESIPortsPass::updateInstance(HWModuleOp mod, InstanceOp inst) {
     auto ready = beb.get(i1);
     inputReadysToConnect.push_back(ready);
     auto unwrap = b.create<UnwrapValidReady>(operand, ready);
-    newOperands.push_back(unwrap.rawOutput());
+    newOperands.push_back(unwrap.getRawOutput());
     newOperands.push_back(unwrap.valid());
   }
 
@@ -874,7 +887,7 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   if (!chPort)
     return failure();
   Operation *symTable = stage->getParentWithTrait<OpTrait::SymbolTable>();
-  auto stageModule = builder.declareStage(symTable, chPort.getInner());
+  auto stageModule = builder.declareStage(symTable, stage);
 
   size_t width = circt::hw::getBitWidth(chPort.getInner());
 
@@ -895,17 +908,19 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
 
   // Instantiate the "ESI_PipelineStage" external module.
   circt::Backedge stageReady = back.get(rewriter.getI1Type());
-  Value operands[] = {stage.clk(), stage.rstn(), unwrap.rawOutput(),
-                      unwrap.valid(), stageReady};
+  llvm::SmallVector<Value> operands = {stage.clk(), stage.rstn()};
+  if (stage.hasData())
+    operands.push_back(unwrap.getRawOutput());
+  operands.push_back(unwrap.valid());
+  operands.push_back(stageReady);
   auto stageInst = rewriter.create<InstanceOp>(loc, stageModule, pipeStageName,
                                                operands, stageParams);
   auto stageInstResults = stageInst.getResults();
 
   // Set a_ready (from the unwrap) back edge correctly to its output from stage.
   wrapReady.setValue(stageInstResults[0]);
-
-  Value x = stageInstResults[1];
-  Value xValid = stageInstResults[2];
+  Value x = unwrap.hasData() ? stageInstResults[1] : Value();
+  Value xValid = stageInstResults[unwrap.hasData() ? 2 : 1];
 
   // Wrap up the output of the HW stage module.
   auto wrap = rewriter.create<WrapValidReady>(loc, chPort, rewriter.getI1Type(),
@@ -969,8 +984,12 @@ public:
         return rewriter.notifyMatchFailure(
             wrap, "This conversion only supports wrap-unwrap back-to-back. "
                   "Could not find 'unwrap'.");
-      data = operands[0];
-      valid = operands[1];
+
+      if (wrap.hasData()) {
+        data = operands[0];
+        valid = operands[1];
+      } else
+        valid = operands[0];
       ready = unwrap.ready();
     } else if (unwrap) {
       wrap = dyn_cast<WrapValidReady>(operands[0].getDefiningOp());
@@ -980,7 +999,8 @@ public:
             "This conversion only supports wrap-unwrap back-to-back. "
             "Could not find 'wrap'.");
       valid = wrap.valid();
-      data = wrap.rawInput();
+      if (wrap.hasData())
+        data = wrap.rawInput();
       ready = operands[1];
     } else {
       return failure();
@@ -992,7 +1012,10 @@ public:
              "Wrap didn't have exactly one use.";
       });
     rewriter.replaceOp(wrap, {nullptr, ready});
-    rewriter.replaceOp(unwrap, {data, valid});
+    if (data)
+      rewriter.replaceOp(unwrap, {data, valid});
+    else
+      rewriter.replaceOp(unwrap, {valid});
     return success();
   }
 };
@@ -1036,8 +1059,10 @@ WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
   auto loc = wrap.getLoc();
   auto validSignal = rewriter.create<ReadInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::validStr);
-  auto dataSignal = rewriter.create<ReadInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::dataStr);
+  Value dataSignal;
+  if (wrap.hasData())
+    dataSignal = rewriter.create<ReadInterfaceSignalOp>(loc, ifaceInstance,
+                                                        ESIHWBuilder::dataStr);
   auto wrapVR = rewriter.create<WrapValidReady>(loc, dataSignal, validSignal);
   rewriter.create<AssignInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::readyStr, wrapVR.ready());
@@ -1084,8 +1109,10 @@ LogicalResult UnwrapInterfaceLower::matchAndRewrite(
       rewriter.create<UnwrapValidReady>(loc, operands[0], readySignal);
   rewriter.create<AssignInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::validStr, unwrapVR.valid());
-  rewriter.create<AssignInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::dataStr, unwrapVR.rawOutput());
+
+  if (unwrap.hasData())
+    rewriter.create<AssignInterfaceSignalOp>(
+        loc, ifaceInstance, ESIHWBuilder::dataStr, unwrapVR.getRawOutput());
   rewriter.eraseOp(unwrap);
   return success();
 }
@@ -1157,8 +1184,9 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
   auto sendReady = bb.get(rewriter.getI1Type());
   UnwrapValidReady unwrapSend =
       rewriter.create<UnwrapValidReady>(loc, send, sendReady);
-  auto encodeData = rewriter.create<CapnpEncode>(
-      loc, egestBitArrayType, clk, unwrapSend.valid(), unwrapSend.rawOutput());
+  auto encodeData = rewriter.create<CapnpEncode>(loc, egestBitArrayType, clk,
+                                                 unwrapSend.valid(),
+                                                 unwrapSend.getRawOutput());
 
   // Get information necessary for injest path.
   auto recvReady = bb.get(rewriter.getI1Type());
@@ -1283,6 +1311,8 @@ void ESItoHWPass::runOnOperation() {
   if (failed(
           applyPartialConversion(top, pass1Target, std::move(pass1Patterns))))
     signalPassFailure();
+
+  top.dump();
 
   ConversionTarget pass2Target(*ctxt);
   pass2Target.addLegalDialect<CombDialect>();

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -85,18 +85,20 @@ hw.module @testIfaceWrap() {
 
 // -----
 
-// CHECK:      hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
-// CHECK-NEXT:   %0 = esi.buffer %clk, %rstn, %a  : none
-// CHECK-NEXT:   %1 = esi.stage %clk, %rstn, %0  : none
-// CHECK-NEXT:   %valid = esi.unwrap.vr %1, %ready : none
-// CHECK-NEXT:   %chanOutput, %ready = esi.wrap.vr %valid : none
-// CHECK-NEXT:   hw.output %chanOutput : !esi.channel<none>
-// CHECK-NEXT: }
+// CHECK-LABEL: hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
+// CHECK-NEXT:    %0 = esi.buffer %clk, %rstn, %a  : none
+// CHECK-NEXT:    %1 = esi.stage %clk, %rstn, %0  : none
+// CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %1, %ready : none
+// CHECK-NEXT:    %2 = esi.none : none
+// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %2, %valid : none
+// CHECK-NEXT:    hw.output %chanOutput : !esi.channel<none>
+// CHECK-NEXT:  }
 
 hw.module @NoneTyped(%a: !esi.channel<none>, %clk : i1, %rstn : i1) -> (x: !esi.channel<none>) {
   %bufferedA = esi.buffer %clk, %rstn, %a : none
   %stagedA = esi.stage %clk, %rstn, %bufferedA : none
-  %valid = esi.unwrap.vr %stagedA, %rcvrRdy : none
-  %ch, %rcvrRdy = esi.wrap.vr %valid : none
+  %none1, %valid = esi.unwrap.vr %stagedA, %rcvrRdy : none
+  %none2 = esi.none : none
+  %ch, %rcvrRdy = esi.wrap.vr %none2, %valid : none
   hw.output %ch : !esi.channel<none>
 }

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -verify-diagnostics -split-input-file | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 hw.module @Sender() -> (x: !esi.channel<i1>) {
   %0 = arith.constant 0 : i1
@@ -82,8 +82,6 @@ hw.module @testIfaceWrap() {
   // CHECK-NEXT:     %6 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   // CHECK-NEXT:     esi.unwrap.iface %3 into %6 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 }
-
-// -----
 
 // CHECK-LABEL: hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
 // CHECK-NEXT:    %0 = esi.buffer %clk, %rstn, %a  : none

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -119,7 +119,8 @@ hw.module @test_constant(%arg0: !esi.channel<i1>, %clock: i1, %reset: i1) -> (ou
 // HW:       }
 hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
   %0 = esi.buffer %clk, %rstn, %a  : none
-  %valid = esi.unwrap.vr %0, %ready : none
-  %chanOutput, %ready = esi.wrap.vr %valid : none
+  %noneValue, %valid = esi.unwrap.vr %0, %ready : none
+  %noneV2 = esi.none : none
+  %chanOutput, %ready = esi.wrap.vr %noneV2, %valid : none
   hw.output %chanOutput : !esi.channel<none>
 }

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -5,6 +5,7 @@
 hw.module.extern @Sender(%clk: i1) -> (x: !esi.channel<i4>, y: i8)
 hw.module.extern @ArrSender() -> (x: !esi.channel<!hw.array<4xi64>>)
 hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
+hw.module.extern @NoneSenderReceiver(%in: !esi.channel<none>) -> (out: !esi.channel<none>)
 
 // CHECK-LABEL: hw.module.extern @Sender(%clk: i1) -> (x: !esi.channel<i4>, y: i8)
 // CHECK-LABEL: hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
@@ -21,10 +22,15 @@ hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
 // IFACE-NEXT:    sv.interface.signal @data : !hw.array<4xi64>
 // IFACE-NEXT:    sv.interface.modport @sink  (input @ready, output @valid, output @data)
 // IFACE-NEXT:    sv.interface.modport @source  (input @valid, input @data, output @ready)
+// IFACE-LABEL: sv.interface @IValidReady_none {
+// IFACE-NEXT:    sv.interface.signal @valid : i1
+// IFACE-NEXT:    sv.interface.signal @ready : i1
+// IFACE-NEXT:    sv.interface.modport @sink (input @ready, output @valid)
+// IFACE-NEXT:    sv.interface.modport @source (input @valid, output @ready)
 // IFACE-LABEL: hw.module.extern @Sender(%clk: i1, %x: !sv.modport<@IValidReady_i4::@sink>) -> (y: i8)
 // IFACE-LABEL: hw.module.extern @ArrSender(%x: !sv.modport<@IValidReady_ArrayOf4xi64::@sink>)
 // IFACE-LABEL: hw.module.extern @Reciever(%a: !sv.modport<@IValidReady_i4::@source>, %clk: i1)
-
+// IFACE-LABEL: hw.module.extern @NoneSenderReceiver(%in: !sv.modport<@IValidReady_none::@source>, %out: !sv.modport<@IValidReady_none::@sink>)
 
 hw.module @test(%clk:i1, %rstn:i1) {
 
@@ -105,4 +111,15 @@ hw.module.extern @handshake_fork_1ins_2outs_ctrl(%in0: !esi.channel<i1>, %clock:
 hw.module @test_constant(%arg0: !esi.channel<i1>, %clock: i1, %reset: i1) -> (outCtrl: !esi.channel<i1>) {
   %handshake_fork0.out0, %handshake_fork0.out1 = hw.instance "handshake_fork0" @handshake_fork_1ins_2outs_ctrl(in0: %arg0: !esi.channel<i1>, clock: %clock: i1, reset: %reset: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>)
   hw.output %handshake_fork0.out1 : !esi.channel<i1>
+}
+
+// HW-LABEL: hw.module @NoneTyped(%a_valid: i1, %clk: i1, %rstn: i1, %x_ready: i1) -> (x_valid: i1, a_ready: i1) {
+// HW:         %pipelineStage.a_ready, %pipelineStage.x_valid = hw.instance "pipelineStage" @ESI_PipelineStage1<WIDTH: ui32 = [[DEFAULT_WIDTH:.*]]>(clk: %clk: i1, rstn: %rstn: i1, a_valid: %a_valid: i1, x_ready: %x_ready: i1) -> (a_ready: i1, x_valid: i1)
+// HW:         hw.output %pipelineStage.x_valid, %pipelineStage.a_ready : i1, i1
+// HW:       }
+hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
+  %0 = esi.buffer %clk, %rstn, %a  : none
+  %valid = esi.unwrap.vr %0, %ready : none
+  %chanOutput, %ready = esi.wrap.vr %valid : none
+  hw.output %chanOutput : !esi.channel<none>
 }


### PR DESCRIPTION
`none` typed channels imply channels which carry no data, but still transaction/handshake semantics. A new interface `ChannelOpInterface` is introduced to factor out logic for determining whether an operation carries data semantics.