### PR TITLE
[FIRRTL] Update port symbols to InnerSymAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -63,25 +63,20 @@ struct PortInfo {
   bool isInOut() { return !isOutput() && !isInput(); }
 
   /// Default constructors
-  PortInfo(StringAttr name, FIRRTLType type, Direction dir)
-      : name(name), type(type), direction(dir) {}
-  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName)
-      : name(name), type(type), direction(dir) {
-    sym = InnerSymAttr::get(symName);
-  };
-  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
-           Location loc)
-      : name(name), type(type), direction(dir), loc(loc) {
-    sym = InnerSymAttr::get(symName);
-  };
-  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
-           Location loc, AnnotationSet annos)
-      : name(name), type(type), direction(dir), loc(loc), annotations(annos) {
-    sym = InnerSymAttr::get(symName);
-  };
   PortInfo(StringAttr name, FIRRTLType type, Direction dir,
-           InnerSymAttr sym, Location loc, AnnotationSet annos)
-      : name(name), type(type), direction(dir), sym(symName), loc(loc),
+           StringAttr symName = {}, Optional<Location> location = {},
+           Optional<AnnotationSet> annos = {})
+      : name(name), type(type), direction(dir) {
+    if (symName)
+      sym = InnerSymAttr::get(symName);
+    if (location.hasValue())
+      loc = location.getValue();
+    if (annos.hasValue())
+      annotations = annos.getValue();
+  };
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir, InnerSymAttr sym,
+           Location loc, AnnotationSet annos)
+      : name(name), type(type), direction(dir), sym(sym), loc(loc),
         annotations(annos) {}
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -72,12 +72,12 @@ struct PortInfo {
   PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
            Location loc)
       : name(name), type(type), direction(dir), loc(loc) {
-    sym = symName ? InnerSymAttr::get(symName) : InnerSymAttr();
+    sym = InnerSymAttr::get(symName);
   };
   PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
            Location loc, AnnotationSet annos)
       : name(name), type(type), direction(dir), loc(loc), annotations(annos) {
-    sym = symName ? InnerSymAttr::get(symName) : InnerSymAttr();
+    sym = InnerSymAttr::get(symName);
   };
   PortInfo(StringAttr name, FIRRTLType type, Direction dir,
            InnerSymAttr symName, Location loc, AnnotationSet annos)

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -80,7 +80,7 @@ struct PortInfo {
     sym = InnerSymAttr::get(symName);
   };
   PortInfo(StringAttr name, FIRRTLType type, Direction dir,
-           InnerSymAttr symName, Location loc, AnnotationSet annos)
+           InnerSymAttr sym, Location loc, AnnotationSet annos)
       : name(name), type(type), direction(dir), sym(symName), loc(loc),
         annotations(annos) {}
 };

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -36,7 +36,7 @@ struct PortInfo {
   StringAttr name;
   FIRRTLType type;
   Direction direction;
-  StringAttr sym = {};
+  InnerSymAttr sym = {};
   Location loc = UnknownLoc::get(type.getContext());
   AnnotationSet annotations = AnnotationSet(type.getContext());
 
@@ -61,6 +61,28 @@ struct PortInfo {
   /// Return true if this is an inout port.  This will be true if the port
   /// contains either bi-directional signals or analog types.
   bool isInOut() { return !isOutput() && !isInput(); }
+
+  /// Default constructors
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir)
+      : name(name), type(type), direction(dir) {}
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName)
+      : name(name), type(type), direction(dir) {
+    sym = InnerSymAttr::get(symName);
+  };
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
+           Location loc)
+      : name(name), type(type), direction(dir), loc(loc) {
+    sym = symName ? InnerSymAttr::get(symName) : InnerSymAttr();
+  };
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir, StringAttr symName,
+           Location loc, AnnotationSet annos)
+      : name(name), type(type), direction(dir), loc(loc), annotations(annos) {
+    sym = symName ? InnerSymAttr::get(symName) : InnerSymAttr();
+  };
+  PortInfo(StringAttr name, FIRRTLType type, Direction dir,
+           InnerSymAttr symName, Location loc, AnnotationSet annos)
+      : name(name), type(type), direction(dir), sym(symName), loc(loc),
+        annotations(annos) {}
 };
 
 /// Verification hook for verifying module like operations.

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -147,6 +147,14 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     //===------------------------------------------------------------------===//
     // Port Symbols
     //===------------------------------------------------------------------===//
+    // Symbol conventions:
+    // 1. Every element of the ArrayAttr(portSyms) must be NON-NULL.
+    // 2. An empty string represents no symbol.
+    //    a. TODO: Update the representation to avoid storing "".
+    // 3. The Getters return null if a port sym is invalid.
+    // 4. The fixupPortSymsArray, is a utility to update a portSyms
+    //    Vector, by replacing each null entry with empty string and
+    //    clearing the array if all the elements are empty.
 
     // Getters
     InterfaceMethod<"Get the port symbols attribute",
@@ -163,29 +171,27 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     InterfaceMethod<"Get a port symbol attribute",
     "InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
       auto syms = $_op.getPortSymbols();
-      if (syms.empty())
+      if (syms.empty() ||
+          syms[portIndex].template cast<InnerSymAttr>().isSymbolInvalid())
         return InnerSymAttr();
-      return syms[portIndex].template dyn_cast_or_null<InnerSymAttr>();
+      return syms[portIndex].template cast<InnerSymAttr>();
     }]>,
 
     InterfaceMethod<"Check if port has symbol attribute",
     "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
       auto syms = $_op.getPortSymbols();
-        return  (!syms.empty() &&  syms[portIndex]);
+        return  (!syms.empty() &&
+        !syms[portIndex].template cast<InnerSymAttr>().isSymbolInvalid());
     }]>,
 
     // Setters
-    InterfaceMethod<"Set the port symbols attribute", "void",
-    "setPortSymbolsAttr", (ins "ArrayAttr":$symbols), [{}], [{
-      assert(symbols.getValue().empty() ||
-             symbols.getValue().size() == $_op.getNumPorts());
-      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(), symbols);
-    }]>,
-
     InterfaceMethod<"Set the port symbols", "void",
     "setPortSymbols", (ins "ArrayRef<Attribute>":$symbols), [{}], [{
+      SmallVector<Attribute> newSyms(symbols.begin(), symbols.end());
+      FModuleLike::fixupPortSymsArray(newSyms, $_op.getContext());
       assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
-      $_op.setPortSymbolsAttr(ArrayAttr::get($_op.getContext(), symbols));
+      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
+                    ArrayAttr::get($_op.getContext(), newSyms));
     }]>,
 
     InterfaceMethod<"Set a port symbol attribute", "void",
@@ -194,7 +200,8 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
                                      $_op.getPortSymbols().end());
       if (symbols.empty()) {
-        symbols.resize($_op.getNumPorts(), InnerSymAttr());
+        symbols.resize($_op.getNumPorts(),
+                      InnerSymAttr::get(StringAttr::get($_op.getContext(),"")));
       }
       assert(symbols.size() == $_op.getNumPorts());
       symbols[portIndex] = InnerSymAttr::get(symbol);
@@ -245,6 +252,22 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     /// Get the attribute name for port symbols.
     static StringRef getPortSymbolsAttrName() {
       return "portSyms";
+    }
+
+    /// Replace NUll entries with empty string and clear array if all elements
+    /// are invalid.
+    static void fixupPortSymsArray(SmallVectorImpl<Attribute> &syms,
+                                   MLIRContext * context) {
+      bool isValid = false;
+      for (size_t i=0, e = syms.size(); i < e ; ++i)
+        if (!syms[i])
+          syms[i] = InnerSymAttr::get(StringAttr::get(context,""));
+        else
+          isValid = true;
+      // The lack of *any* port symbol is represented by an empty `portSyms`
+      // array as a shorthand.
+      if (!isValid)
+        syms.clear();
     }
   }];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -172,7 +172,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     "InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
       auto syms = $_op.getPortSymbols();
       if (syms.empty() ||
-          syms[portIndex].template cast<InnerSymAttr>().isSymbolInvalid())
+          syms[portIndex].template cast<InnerSymAttr>().empty())
         return InnerSymAttr();
       return syms[portIndex].template cast<InnerSymAttr>();
     }]>,
@@ -181,7 +181,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
       auto syms = $_op.getPortSymbols();
         return  (!syms.empty() &&
-        !syms[portIndex].template cast<InnerSymAttr>().isSymbolInvalid());
+        !syms[portIndex].template cast<InnerSymAttr>().empty());
     }]>,
 
     // Setters

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -257,9 +257,9 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     /// Replace NUll entries with empty string and clear array if all elements
     /// are invalid.
     static void fixupPortSymsArray(SmallVectorImpl<Attribute> &syms,
-                                   MLIRContext * context) {
+                                   MLIRContext *context) {
       bool isValid = false;
-      for (size_t i=0, e = syms.size(); i < e ; ++i)
+      for (size_t i = 0, e = syms.size(); i < e; ++i)
         if (!syms[i])
           syms[i] = InnerSymAttr::get(StringAttr::get(context,""));
         else

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -161,24 +161,22 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     }]>,
 
     InterfaceMethod<"Get a port symbol attribute",
-    "StringAttr", "getPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
+    "InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
       auto syms = $_op.getPortSymbols();
       if (syms.empty())
-        return StringAttr::get($_op.getContext(), "");
-      return syms[portIndex].template cast<StringAttr>();
+        return InnerSymAttr();
+      return syms[portIndex].template dyn_cast_or_null<InnerSymAttr>();
     }]>,
 
-    InterfaceMethod<"Get a port symbol",
-    "StringRef", "getPortSymbol", (ins "size_t":$portIndex), [{}], [{
-      return $_op.getPortSymbolAttr(portIndex).getValue();
+    InterfaceMethod<"Check if port has symbol attribute",
+    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
+      auto syms = $_op.getPortSymbols();
+        return  (!syms.empty() &&  syms[portIndex]);
     }]>,
 
     // Setters
     InterfaceMethod<"Set the port symbols attribute", "void",
     "setPortSymbolsAttr", (ins "ArrayAttr":$symbols), [{}], [{
-      if (llvm::all_of(symbols.getValue(), [](Attribute symbol) {
-         return symbol.cast<StringAttr>().getValue().empty(); }))
-        symbols = ArrayAttr::get($_op.getContext(), {});
       assert(symbols.getValue().empty() ||
              symbols.getValue().size() == $_op.getNumPorts());
       $_op->setAttr(FModuleLike::getPortSymbolsAttrName(), symbols);
@@ -186,9 +184,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
 
     InterfaceMethod<"Set the port symbols", "void",
     "setPortSymbols", (ins "ArrayRef<Attribute>":$symbols), [{}], [{
-      if (llvm::all_of(symbols, [](Attribute symbol) {
-         return symbol.cast<StringAttr>().getValue().empty(); }))
-        symbols = {};
       assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
       $_op.setPortSymbolsAttr(ArrayAttr::get($_op.getContext(), symbols));
     }]>,
@@ -199,11 +194,10 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
                                      $_op.getPortSymbols().end());
       if (symbols.empty()) {
-        auto emptyString = StringAttr::get($_op.getContext(), "");
-        symbols.resize($_op.getNumPorts(), emptyString);
+        symbols.resize($_op.getNumPorts(), InnerSymAttr());
       }
       assert(symbols.size() == $_op.getNumPorts());
-      symbols[portIndex] = symbol;
+      symbols[portIndex] = InnerSymAttr::get(symbol);
       $_op.setPortSymbols(symbols);
     }]>,
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -149,11 +149,11 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     //===------------------------------------------------------------------===//
     // Symbol conventions:
     // 1. Every element of the ArrayAttr(portSyms) must be NON-NULL.
-    // 2. An empty string represents no symbol.
-    //    a. TODO: Update the representation to avoid storing "".
+    // 2. An empty array represents no symbol.
+    //    a. TODO: Update the representation to avoid storing it.
     // 3. The Getters return null if a port sym is invalid.
     // 4. The fixupPortSymsArray, is a utility to update a portSyms
-    //    Vector, by replacing each null entry with empty string and
+    //    Vector, by replacing each null entry with empty array and
     //    clearing the array if all the elements are empty.
 
     // Getters
@@ -201,7 +201,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
                                      $_op.getPortSymbols().end());
       if (symbols.empty()) {
         symbols.resize($_op.getNumPorts(),
-                      InnerSymAttr::get(StringAttr::get($_op.getContext(),"")));
+                      InnerSymAttr::get($_op.getContext()));
       }
       assert(symbols.size() == $_op.getNumPorts());
       symbols[portIndex] = InnerSymAttr::get(symbol);
@@ -254,14 +254,14 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       return "portSyms";
     }
 
-    /// Replace NUll entries with empty string and clear array if all elements
+    /// Replace NUll entries with invalid sym and clear array if all elements
     /// are invalid.
     static void fixupPortSymsArray(SmallVectorImpl<Attribute> &syms,
                                    MLIRContext *context) {
       bool isValid = false;
       for (size_t i = 0, e = syms.size(); i < e; ++i)
         if (!syms[i])
-          syms[i] = InnerSymAttr::get(StringAttr::get(context,""));
+          syms[i] = InnerSymAttr::get(context);
         else
           isValid = true;
       // The lack of *any* port symbol is represented by an empty `portSyms`

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -182,6 +182,30 @@ public:
   /// A successful walk with no failures returns success.
   static LogicalResult walkSymbols(Operation *op, InnerSymCallbackFn callback);
 
+  /// Get the sym name from the InnerSymPropertiesAttr.
+  static StringAttr getInnerSymName(const InnerSymPropertiesAttr p) {
+    return p.getName();
+  }
+
+  /// Get the iterator for all the symbol names for an InnerSymAttr.
+  static auto getSymNamesBegin(InnerSymAttr isa) {
+    return llvm::map_iterator(isa.begin(), getInnerSymName);
+  }
+
+  /// Get the iterator for all the symbol names for an InnerSymAttr.
+  static auto getSymNamesEnd(InnerSymAttr isa) {
+    return llvm::map_iterator(isa.end(), getInnerSymName);
+  }
+
+  /// Get all the symbol names for an Operation.
+  static auto getSymNames(Operation *op) {
+    InnerSymAttr isa =
+        op->getAttrOfType<InnerSymAttr>(getInnerSymbolAttrName());
+    if (isa)
+      llvm::make_range(getSymNamesBegin(isa), getSymNamesEnd(isa));
+    return StringAttr{};
+  }
+
 private:
   using TableTy = DenseMap<StringAttr, InnerSymTarget>;
   /// Construct an inner symbol table for the given operation,

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -182,30 +182,6 @@ public:
   /// A successful walk with no failures returns success.
   static LogicalResult walkSymbols(Operation *op, InnerSymCallbackFn callback);
 
-  /// Get the sym name from the InnerSymPropertiesAttr.
-  static StringAttr getInnerSymName(const InnerSymPropertiesAttr p) {
-    return p.getName();
-  }
-
-  /// Get the iterator for all the symbol names for an InnerSymAttr.
-  static auto getSymNamesBegin(InnerSymAttr isa) {
-    return llvm::map_iterator(isa.begin(), getInnerSymName);
-  }
-
-  /// Get the iterator for all the symbol names for an InnerSymAttr.
-  static auto getSymNamesEnd(InnerSymAttr isa) {
-    return llvm::map_iterator(isa.end(), getInnerSymName);
-  }
-
-  /// Get all the symbol names for an Operation.
-  static auto getSymNames(Operation *op) {
-    InnerSymAttr isa =
-        op->getAttrOfType<InnerSymAttr>(getInnerSymbolAttrName());
-    if (isa)
-      llvm::make_range(getSymNamesBegin(isa), getSymNamesEnd(isa));
-    return StringAttr{};
-  }
-
 private:
   using TableTy = DenseMap<StringAttr, InnerSymTarget>;
   /// Construct an inner symbol table for the given operation,

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -53,19 +53,21 @@ struct ModuleNamespace : public Namespace {
   void addPorts(FModuleLike module) {
     for (auto portSymbol : module.getPortSymbolsAttr())
       if (portSymbol)
-        portSymbol.cast<InnerSymAttr>().forAllSymNames([&](StringAttr sName) {
-          nextIndex.insert({sName.getValue(), 0});
-          return true;
-        });
+        static_cast<void>(
+            portSymbol.cast<InnerSymAttr>().walkSymbols([&](StringAttr sName) {
+              nextIndex.insert({sName.getValue(), 0});
+              return success();
+            }));
   }
 
   void addPorts(ArrayRef<PortInfo> ports) {
     for (auto port : ports)
       if (port.sym)
-        port.sym.cast<InnerSymAttr>().forAllSymNames([&](StringAttr symName) {
-          nextIndex.insert({symName.getValue(), 0});
-          return true;
-        });
+        static_cast<void>(
+            port.sym.cast<InnerSymAttr>().walkSymbols([&](StringAttr symName) {
+              nextIndex.insert({symName.getValue(), 0});
+              return success();
+            }));
   }
 
   /// Populate the namespace with the body of a module-like operation.

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -51,15 +51,17 @@ struct ModuleNamespace : public Namespace {
 
   /// Populate the namespace with the ports of a module-like operation.
   void addPorts(FModuleLike module) {
-    for (auto portSymbol : module.getPortSymbolsAttr().getAsRange<StringAttr>())
-      if (!portSymbol.getValue().empty())
-        nextIndex.insert({portSymbol.getValue(), 0});
+    for (auto portSymbol : module.getPortSymbolsAttr())
+      if (portSymbol)
+        for (auto symName : portSymbol.cast<InnerSymAttr>().getAllSymNames())
+          nextIndex.insert({symName.getValue(), 0});
   }
 
   void addPorts(ArrayRef<PortInfo> ports) {
     for (auto port : ports)
       if (port.sym)
-        nextIndex.insert({port.sym.getValue(), 0});
+        for (auto symName : port.sym.cast<InnerSymAttr>().getAllSymNames())
+          nextIndex.insert({symName.getValue(), 0});
   }
 
   /// Populate the namespace with the body of a module-like operation.

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -53,15 +53,19 @@ struct ModuleNamespace : public Namespace {
   void addPorts(FModuleLike module) {
     for (auto portSymbol : module.getPortSymbolsAttr())
       if (portSymbol)
-        for (auto symName : portSymbol.cast<InnerSymAttr>().getAllSymNames())
-          nextIndex.insert({symName.getValue(), 0});
+        portSymbol.cast<InnerSymAttr>().forAllSymNames([&](StringAttr sName) {
+          nextIndex.insert({sName.getValue(), 0});
+          return true;
+        });
   }
 
   void addPorts(ArrayRef<PortInfo> ports) {
     for (auto port : ports)
       if (port.sym)
-        for (auto symName : port.sym.cast<InnerSymAttr>().getAllSymNames())
+        port.sym.cast<InnerSymAttr>().forAllSymNames([&](StringAttr symName) {
           nextIndex.insert({symName.getValue(), 0});
+          return true;
+        });
   }
 
   /// Populate the namespace with the body of a module-like operation.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -915,6 +915,15 @@ LogicalResult FIRRTLModuleLowering::lowerPorts(
     hw::PortInfo hwPort;
     hwPort.name = firrtlPort.name;
     hwPort.type = lowerType(firrtlPort.type);
+    if (firrtlPort.sym)
+      if (firrtlPort.sym.numSymbols() > 1 ||
+          (firrtlPort.sym.numSymbols() == 1 && !firrtlPort.sym.getSymName())) {
+        moduleOp->emitError("cannot lower aggregate port `" +
+                            firrtlPort.name.getValue() +
+                            "` with field sensitive symbols, HW dialect does  "
+                            "not support per field symbols yet.");
+        return failure();
+      }
     hwPort.sym = firrtlPort.sym ? firrtlPort.sym.getSymName()
                                 : StringAttr::get(moduleOp->getContext(), "");
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -916,8 +916,8 @@ LogicalResult FIRRTLModuleLowering::lowerPorts(
     hwPort.name = firrtlPort.name;
     hwPort.type = lowerType(firrtlPort.type);
     if (firrtlPort.sym)
-      if (firrtlPort.sym.numSymbols() > 1 ||
-          (firrtlPort.sym.numSymbols() == 1 && !firrtlPort.sym.getSymName())) {
+      if (firrtlPort.sym.size() > 1 ||
+          (firrtlPort.sym.size() == 1 && !firrtlPort.sym.getSymName())) {
         moduleOp->emitError("cannot lower aggregate port `" +
                             firrtlPort.name.getValue() +
                             "` with field sensitive symbols, HW dialect does  "

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -915,7 +915,8 @@ LogicalResult FIRRTLModuleLowering::lowerPorts(
     hw::PortInfo hwPort;
     hwPort.name = firrtlPort.name;
     hwPort.type = lowerType(firrtlPort.type);
-    hwPort.sym = firrtlPort.sym;
+    hwPort.sym = firrtlPort.sym ? firrtlPort.sym.getSymName()
+                                : StringAttr::get(moduleOp->getContext(), "");
 
     // We can't lower all types, so make sure to cleanly reject them.
     if (!hwPort.type) {

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -81,9 +81,10 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
     return module.emitOpError("requires valid port symbols");
   if (!portSymbols.empty() && portSymbols.size() != numPorts)
     return module.emitOpError("requires ") << numPorts << " port symbols";
-  if (llvm::any_of(portSymbols.getValue(),
-                   [](Attribute attr) { return !attr.isa<StringAttr>(); }))
-    return module.emitOpError("port symbols should all be string attributes");
+  if (llvm::any_of(portSymbols.getValue(), [](Attribute attr) {
+        return attr && !attr.isa<InnerSymAttr>();
+      }))
+    return module.emitOpError("port symbols should all be InnerSym attributes");
 
   // Verify the body.
   if (module->getNumRegions() != 1)

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -82,7 +82,7 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   if (!portSymbols.empty() && portSymbols.size() != numPorts)
     return module.emitOpError("requires ") << numPorts << " port symbols";
   if (llvm::any_of(portSymbols.getValue(), [](Attribute attr) {
-        return attr && !attr.isa<InnerSymAttr>();
+        return !attr || !attr.isa<InnerSymAttr>();
       }))
     return module.emitOpError("port symbols should all be InnerSym attributes");
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -179,7 +179,7 @@ bool firrtl::hasDontTouch(Value value) {
     return hasDontTouch(op);
   auto arg = value.dyn_cast<BlockArgument>();
   auto module = cast<FModuleOp>(arg.getOwner()->getParentOp());
-  return (!module.getPortSymbolAttr(arg.getArgNumber())) ||
+  return (module.getPortSymbolAttr(arg.getArgNumber())) ||
          AnnotationSet::forPort(module, arg.getArgNumber()).hasDontTouch();
 }
 
@@ -774,7 +774,7 @@ static bool printModulePorts(OpAsmPrinter &p, Block *block,
 
     // Print the optional port symbol.
     if (!portSyms.empty()) {
-      if (!portSyms[i].cast<InnerSymAttr>().isSymbolInvalid()) {
+      if (!portSyms[i].cast<InnerSymAttr>().empty()) {
         p << " sym ";
         portSyms[i].cast<InnerSymAttr>().print(p);
       }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -205,12 +205,6 @@ void getAsmBlockArgumentNamesImpl(Operation *op, mlir::Region &region,
   }
 }
 
-static bool hasPortNamed(FModuleLike op, StringAttr name) {
-  return llvm::any_of(op.getPortSymbols(), [name](Attribute pname) {
-    return pname && pname.cast<InnerSymAttr>().hasSymNamed(name);
-  });
-}
-
 /// A forward declaration for `NameKind` attribute parser.
 static ParseResult parseNameKind(OpAsmParser &parser,
                                  firrtl::NameKindEnumAttr &result);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -179,7 +179,7 @@ bool firrtl::hasDontTouch(Value value) {
     return hasDontTouch(op);
   auto arg = value.dyn_cast<BlockArgument>();
   auto module = cast<FModuleOp>(arg.getOwner()->getParentOp());
-  return (!module.getPortSymbol(arg.getArgNumber()).empty()) ||
+  return (!module.getPortSymbolAttr(arg.getArgNumber())) ||
          AnnotationSet::forPort(module, arg.getArgNumber()).hasDontTouch();
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -390,8 +390,8 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
 
   auto attr = mod.getPortSymbolAttr(portIdx);
-  if (attr && !attr.getValue().empty())
-    return attr;
+  if (attr)
+    return attr.getSymName();
   if (nameHint.empty()) {
     if (auto name = mod.getPortNameAttr(portIdx))
       nameHint = name;
@@ -399,9 +399,9 @@ StringAttr circt::firrtl::getOrAddInnerSym(
       nameHint = "sym";
   }
   auto name = getNamespace(mod).newName(nameHint);
-  attr = StringAttr::get(mod.getContext(), name);
-  mod.setPortSymbolAttr(portIdx, attr);
-  return attr;
+  auto sAttr = StringAttr::get(mod.getContext(), name);
+  mod.setPortSymbolAttr(portIdx, sAttr);
+  return sAttr;
 }
 
 /// Obtain an inner reference to a port, possibly adding an `inner_sym`

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3503,7 +3503,8 @@ FIRCircuitParser::parseModuleBody(DeferredModuleToParse &deferredModule) {
     PortInfo &port = std::get<0>(tuple);
     llvm::SMLoc loc = std::get<1>(tuple);
     BlockArgument portArg = std::get<2>(tuple);
-    modNameSpace.newName(port.sym.getValue());
+    if (port.sym)
+      modNameSpace.newName(port.sym.getSymName().getValue());
     if (moduleContext.addSymbolEntry(port.getName(), portArg, loc))
       return failure();
   }

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -98,9 +98,8 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
            if (auto mod = dyn_cast<FModuleLike>(curOp)) {
              for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i)
                if (InnerSymAttr symAttr = mod.getPortSymbolAttr(i))
-               if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
-                 return WalkResult::interrupt();
-             
+                 if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
+                   return WalkResult::interrupt();
            }
            return WalkResult::advance();
          }).wasInterrupted());

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -150,7 +150,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
     // Workaround quirk with empty string for no symbol on ports.
     if (!sym)
       return {};
-    return sym.getSymName();
+    return sym.getSymIfExists(target.getField());
   }
 
   // InnerSymbols only supported if op implements the interface.

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -96,12 +96,11 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
            // Check for ports
            // TODO: Add fields per port, once they work that way (use addSyms)
            if (auto mod = dyn_cast<FModuleLike>(curOp)) {
-             for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i) {
-               auto sym = mod.getPortSymbolAttr(i);
-               if (sym && !sym.getValue().empty())
-                 if (failed(walkSym(sym, InnerSymTarget(i, curOp))))
-                   return WalkResult::interrupt();
-             }
+             for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i)
+               if (InnerSymAttr symAttr = mod.getPortSymbolAttr(i))
+               if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
+                 return WalkResult::interrupt();
+             
            }
            return WalkResult::advance();
          }).wasInterrupted());
@@ -149,9 +148,9 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
     // TODO: update this when ports support per-field symbols
     auto sym = mod.getPortSymbolAttr(target.getPort());
     // Workaround quirk with empty string for no symbol on ports.
-    if (sym && sym.getValue().empty())
+    if (!sym)
       return {};
-    return sym;
+    return sym.getSymName();
   }
 
   // InnerSymbols only supported if op implements the interface.

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -940,32 +940,33 @@ private:
     // Create an array of new port symbols for the "to" operation, copy in the
     // old symbols if it has any, create an empty symbol array if it doesn't.
     SmallVector<Attribute> newPortSyms;
-    auto emptyString = StringAttr::get(context, "");
     if (toPortSyms.empty())
-      newPortSyms.assign(portCount, emptyString);
+      newPortSyms.assign(portCount, InnerSymAttr());
     else
       newPortSyms.assign(toPortSyms.begin(), toPortSyms.end());
 
     for (unsigned portNo = 0; portNo < portCount; ++portNo) {
       // If this fromPort doesn't have a symbol, move on to the next one.
-      auto fromSym = fromPortSyms[portNo].cast<StringAttr>();
-      if (fromSym.getValue().empty())
+      if (!fromPortSyms[portNo])
         continue;
+      auto fromSym = fromPortSyms[portNo].cast<InnerSymAttr>();
 
       // If this toPort doesn't have a symbol, assign one.
-      auto toSym = newPortSyms[portNo].cast<StringAttr>();
-      if (toSym == emptyString) {
+      InnerSymAttr toSym;
+      if (!newPortSyms[portNo]) {
         // Get a reasonable base name for the port.
         StringRef symName = "inner_sym";
         if (portNames)
           symName = portNames[portNo].cast<StringAttr>().getValue();
         // Create the symbol and store it into the array.
-        toSym = StringAttr::get(context, moduleNamespace.newName(symName));
+        toSym = InnerSymAttr::get(
+            StringAttr::get(context, moduleNamespace.newName(symName)));
         newPortSyms[portNo] = toSym;
-      }
+      } else
+        toSym = newPortSyms[portNo].cast<InnerSymAttr>();
 
       // Record the renaming.
-      renameMap[fromSym] = toSym;
+      renameMap[fromSym.getSymName()] = toSym.getSymName();
     }
 
     // Commit the new symbol attribute.

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -970,7 +970,7 @@ private:
     }
 
     // Commit the new symbol attribute.
-    to->setAttr("portSyms", ArrayAttr::get(context, newPortSyms));
+    cast<FModuleLike>(to).setPortSymbols(newPortSyms);
   }
 
   /// Recursively merge two operations.

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2195,20 +2195,6 @@ void GrandCentralPass::runOnOperation() {
   markAnalysesPreserved<NLATable>();
 }
 
-StringAttr GrandCentralPass::getOrAddInnerSym(FModuleLike module,
-                                              size_t portIdx) {
-  auto attr = module.getPortSymbolAttr(portIdx);
-  if (attr && !attr.getValue().empty())
-    return attr;
-  StringRef nameHint = "gct_sym";
-  if (auto attr = module.getPortNameAttr(portIdx))
-    nameHint = attr.getValue();
-  auto name = getModuleNamespace(module).newName(nameHint);
-  attr = StringAttr::get(module.getContext(), name);
-  module.setPortSymbolAttr(portIdx, attr);
-  return attr;
-}
-
 hw::InnerRefAttr GrandCentralPass::getInnerRefTo(Operation *op) {
   return ::getInnerRefTo(op, "", [&](FModuleOp mod) -> ModuleNamespace & {
     return getModuleNamespace(mod);
@@ -2217,8 +2203,10 @@ hw::InnerRefAttr GrandCentralPass::getInnerRefTo(Operation *op) {
 
 hw::InnerRefAttr GrandCentralPass::getInnerRefTo(FModuleLike module,
                                                  size_t portIdx) {
-  return hw::InnerRefAttr::get(SymbolTable::getSymbolName(module),
-                               getOrAddInnerSym(module, portIdx));
+  return ::getInnerRefTo(module, portIdx, "",
+                         [&](FModuleLike mod) -> ModuleNamespace & {
+                           return getModuleNamespace(mod);
+                         });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -208,8 +208,8 @@ void InjectDUTHierarchy::runOnOperation() {
   }
   for (size_t i = 0, e = dut.getNumPorts(); i != e; ++i) {
     auto portSym = dut.getPortSymbolAttr(i);
-    if (portSym && !portSym.getValue().empty())
-      dutPortSyms.insert(portSym);
+    if (portSym)
+      dutPortSyms.insert(portSym.getSymName());
     for (auto anno : AnnotationSet::forPort(dut, i)) {
       auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
       if (sym)

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -133,7 +133,8 @@ LowerMemoryPass::getMemoryModulePorts(const FirMemory &mem) {
   SmallVector<PortInfo> ports;
   auto addPort = [&](const Twine &name, FIRRTLType type, Direction direction) {
     auto nameAttr = StringAttr::get(context, name);
-    ports.push_back({nameAttr, type, direction, {}, loc, annotations});
+    ports.push_back(
+        {nameAttr, type, direction, InnerSymAttr{}, loc, annotations});
   };
 
   auto makePortCommon = [&](StringRef prefix, size_t idx, FIRRTLType addrType) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1273,90 +1273,10 @@ void LowerTypesPass::runOnOperation() {
     return LogicalResult::failure(tl.isFailed());
   };
 
-<<<<<<< HEAD
   auto result = failableParallelForEach(&getContext(), ops.begin(), ops.end(),
                                         lowerModules);
   if (failed(result))
     signalPassFailure();
-=======
-      // Split the old hierarchical path into one hierarchical path for each new
-      // InnerRefAttr.  Update the symbols in any NLAs which use the old
-      // InnerRefAttr to the correct new InnerRefAttr.
-      auto namepath = path.getNamepath().getValue();
-      // Grab the old namepath.  We reuse all but the last element of this.
-      SmallVector<Attribute> newNamepath{namepath.begin(), namepath.end()};
-      ImplicitLocOpBuilder builder(path.getLoc(), path);
-      builder.setInsertionPointAfter(path);
-      StringAttr oldSym;
-      assert(!newRefs.empty() && "LowerTypes should not delete InnerRefAttrs");
-      for (auto &target : newRefs) {
-        // Drop the last part of the namepath so we can replace it.
-        newNamepath.pop_back();
-
-        // Re-use the old hierarchical path symbol for the first new
-        // hierarchical path.  Generate a new symbol for any later paths.
-        StringAttr newSym;
-        if (!oldSym) {
-          oldSym = path.getNameAttr();
-          newSym = oldSym;
-          // Delete the old hierarchical path from the NLA and symbol tables.
-          nlaTable->erase(path, &symTbl);
-        } else
-          newSym =
-              builder.getStringAttr(circtNamespace.newName(oldSym.getValue()));
-
-        // This is the new annotation sequence.  Put the update method into a
-        // lambda to enable reuse for operation and port annotations.
-        SmallVector<Annotation> newAnnotations;
-        auto updateNLASymbol = [&](Annotation anno) -> bool {
-          auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
-          if (!sym || sym.getAttr() != oldSym)
-            return false;
-          anno.setMember("circt.nonlocal", FlatSymbolRefAttr::get(newSym));
-          newAnnotations.push_back(anno);
-          return true;
-        };
-
-        // Update annotations the operation or on the port.
-        HierPathOp newPath;
-        TypeSwitch<AnnoTarget>(target)
-            .Case<OpAnnoTarget>([&](OpAnnoTarget target) {
-              auto *op = target.getOp();
-              newNamepath.push_back(hw::InnerRefAttr::get(
-                  target.getModule().moduleNameAttr(), getInnerSymName(op)));
-              newPath = builder.create<HierPathOp>(
-                  newSym, builder.getArrayAttr(newNamepath));
-              AnnotationSet annotations(op);
-              annotations.removeAnnotations(updateNLASymbol);
-              annotations.addAnnotations(newAnnotations);
-              annotations.applyToOperation(op);
-            })
-            .Case<PortAnnoTarget>([&](PortAnnoTarget target) {
-              auto op = cast<FModuleLike>(target.getOp());
-              auto portIdx = target.getPortNo();
-              newNamepath.push_back(hw::InnerRefAttr::get(
-                  target.getModule().moduleNameAttr(),
-                  // getPortSymbolAttr can return null,
-                  // but here it must exist.
-                  op.getPortSymbolAttr(portIdx).getSymName()));
-              newPath = builder.create<HierPathOp>(
-                  newSym, builder.getArrayAttr(newNamepath));
-              auto annotations = AnnotationSet::forPort(op, portIdx);
-              annotations.removeAnnotations(updateNLASymbol);
-              annotations.addAnnotations(newAnnotations);
-              annotations.applyToPort(op, portIdx);
-            })
-            .Default([](auto) {
-              llvm_unreachable("match on unkonwn AnnoTarget type");
-            });
-
-        // Add the new hierarchical path to the NLA Table and Symbol Table.
-        nlaTable->addNLA(newPath);
-        symTbl.insert(newPath);
-      }
-    }
-  }
->>>>>>> 65052de05... [FIRRTL] Handle ports symbols as InnrtSymAttr and null attribute instead of empty string
 }
 
 /// This is the pass constructor.

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -668,9 +668,11 @@ Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b,
 
     // Compute a unique symbol if needed
     StringAttr newSym;
-    StringAttr oldSym = portInfo[i].sym;
-    if (!oldSym.getValue().empty())
+    StringAttr oldSym;
+    if (portInfo[i].sym) {
+      oldSym = portInfo[i].sym.getSymName();
       newSym = b.getStringAttr(moduleNamespace.newName(oldSym.getValue()));
+    }
 
     SmallVector<Attribute> newAnnotations;
     for (auto anno : AnnotationSet::forPort(target, i)) {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -98,7 +98,7 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{requires one region}}
 "firrtl.module"() ( { }, { })
    {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
 
@@ -109,7 +109,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry:
 }) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
 // -----
@@ -119,7 +119,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry(%a: i1):
 }) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
 // -----

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -163,10 +163,7 @@ firrtl.circuit "DontTouchAggregate" {
 
 firrtl.circuit "OutPortTop" {
   // Check that we don't propagate througth it.
-  firrtl.module @OutPortChild(out %out: !firrtl.vector<uint<1>, 2>) attributes {
-    portAnnotations = [[]],
-    portSyms = ["dntSym"]
-  }
+  firrtl.module @OutPortChild(out %out: !firrtl.vector<uint<1>, 2> sym @dntSym)
   {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.subindex %out[0] : !firrtl.vector<uint<1>, 2>
@@ -196,9 +193,9 @@ firrtl.circuit "InputPortTop"  {
     firrtl.strictconnect %2, %3 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @InputPortChild
-  firrtl.module @InputPortChild(in %in0: !firrtl.bundle<v: uint<1>>, in %in1: !firrtl.bundle<v: uint<1>>, out %out: !firrtl.bundle<v: uint<1>>) attributes {
-    portAnnotations = [[], [], []], portSyms = ["", "dntSym", ""]
-  }
+  firrtl.module @InputPortChild(in %in0: !firrtl.bundle<v: uint<1>>,
+    in %in1: !firrtl.bundle<v: uint<1>> sym @dntSym,
+    out %out: !firrtl.bundle<v: uint<1>>)
   {
     %0 = firrtl.subfield %in1(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
     %1 = firrtl.subfield %in0(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
@@ -385,7 +382,7 @@ firrtl.circuit "dntOutput"  {
     %2 = firrtl.mux(%c, %1, %c2_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.strictconnect %0, %2 : !firrtl.uint<3>
   }
-  firrtl.module @foo(out %b: !firrtl.bundle<v: uint<3>>) attributes {portSyms = ["dntSym1"] }{
+  firrtl.module @foo(out %b: !firrtl.bundle<v: uint<3>> sym @dntSym1){
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
     %0 = firrtl.subfield %b(0) : (!firrtl.bundle<v: uint<3>>) -> !firrtl.uint<3>
     firrtl.strictconnect %0, %c1_ui3 : !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -174,10 +174,8 @@ firrtl.circuit "Issue1188"  {
 // DontTouch annotation should block constant propagation.
 firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module private @blockProp
-  firrtl.module private @blockProp1(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [],[]],
-    portSyms = ["", "dntSym", ""]
-  }{
+  firrtl.module private @blockProp1(in %clock: !firrtl.clock,
+    in %a: !firrtl.uint<1> sym @dntSym, out %b: !firrtl.uint<1>){
     //CHECK: %c = firrtl.reg
     %c = firrtl.reg %clock : !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -229,7 +227,7 @@ firrtl.circuit "testDontTouch"  {
 // -----
 
 firrtl.circuit "OutPortTop" {
-    firrtl.module private @OutPortChild1(out %out: !firrtl.uint<1>)  attributes {portSyms = ["dntSym"]}{
+    firrtl.module private @OutPortChild1(out %out: !firrtl.uint<1> sym @dntSym1) {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     } 
@@ -263,9 +261,8 @@ firrtl.circuit "InputPortTop"   {
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @InputPortChild
-  firrtl.module private @InputPortChild(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [], []], portSyms = ["", "dntSym", ""]
-  } {
+  firrtl.module private @InputPortChild(in %in0: !firrtl.uint<1>,
+    in %in1 : !firrtl.uint<1> sym @dntSym1, out %out: !firrtl.uint<1>) {
     // CHECK: %0 = firrtl.and %in0, %in1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -507,7 +504,7 @@ firrtl.circuit "dntOutput" {
     %m = firrtl.mux(%c, %int_b, %const) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.connect %b, %m : !firrtl.uint<3>, !firrtl.uint<3>
   }
-  firrtl.module private @foo(out %b: !firrtl.uint<3> ) attributes {portSyms = ["dntSym1"] } {
+  firrtl.module private @foo(out %b: !firrtl.uint<3>  sym @dntSym1) {
     %const = firrtl.constant 1 : !firrtl.uint<3>
     firrtl.connect %b, %const : !firrtl.uint<3>, !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -49,8 +49,8 @@ firrtl.circuit "Top"   {
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
   // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym2)
-  firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym2"]}
+  firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1> sym @dntSym2) attributes {
+    portAnnotations = [[], [{a = "a"}], []]}
   {
     // CHECK: firrtl.connect %c, %{{invalid_ui1.*}}
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
@@ -120,8 +120,8 @@ firrtl.circuit "Top"   {
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
   // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym2)
-  firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
-    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym2"]}
+  firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1> sym @dntSym2) attributes {
+    portAnnotations = [[], [{a = "a"}], []]}
   {
     // CHECK: firrtl.strictconnect %c, %{{invalid_ui1.*}}
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>


### PR DESCRIPTION
This PR updates ports to use `InnerSymAttr` for inner symbols instead of `StringAttr`.
`InnerSymAttr` makes it possible to add symbols per field.
This PR also updates the default symbol to `null` instead of an empty string name.
Before this PR, empty string was used to represent a port with no symbols, 
` portSyms = ["", "@sym1"]`
But this PR updates it to use `null` attribute instead:
` portSyms = [<<NULL ATTRIBUTE>>, [#firrtl<innerSym@sym1>]`
I am not sure if it is a good idea to add `null` attribute instead of the empty string in the IR.