### PR TITLE
[LowerAnno][LowerTypes] Lower every dontTouch in LowerAnnotations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -208,8 +208,10 @@ def InnerSymProperties : AttrDef<FIRRTLDialect, "InnerSymProperties"> {
          DefaultValuedParameter<"::mlir::StringAttr", "public">:$sym_visibility
                      );
   let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
-      return get(sym.getContext(), sym, 0,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym,
+                                        CArg<"unsigned", "0">:$fieldID
+    ),[{
+      return get(sym.getContext(), sym, fieldID,
                         StringAttr::get(sym.getContext(), "public") );
     }]>
   ];
@@ -231,9 +233,10 @@ def InnerSymAttr : AttrDef<FIRRTLDialect, "InnerSym"> {
   let mnemonic = "innerSym";
   let parameters = (ins ArrayRefParameter<"InnerSymPropertiesAttr">:$props);
   let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym,
+                                        CArg<"unsigned", "0">:$fieldID),[{
       return get(sym.getContext(), 
-      {InnerSymPropertiesAttr::get(sym.getContext(), sym, 0,
+      {InnerSymPropertiesAttr::get(sym.getContext(), sym, fieldID,
                         StringAttr::get(sym.getContext(), "public"))});
     }]>
   ];

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -281,7 +281,7 @@ static void getDeclName(Value value, SmallString<64> &string) {
         string +=
             op.getPortName(value.cast<OpResult>().getResultNumber()).getValue();
       })
-      .Case<WireOp, RegOp, RegResetOp>(
+      .Case<WireOp, RegOp, RegResetOp, NodeOp>(
           [&](auto op) { string += op.getName(); });
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -774,7 +774,7 @@ firrtl.circuit "Foo"  attributes {
     // CHECK: firrtl.mem sym @_T_8
     %_T_8_w = firrtl.mem Undefined  {depth = 8 : i64, name = "_T_8", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>>
     %aggregate = firrtl.wire  : !firrtl.bundle<a: uint<1>>
-    // CHECK: %_T_9 = firrtl.node %aggregate {annotations = [{circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"}]}
+    // CHECK: %_T_9 = firrtl.node sym [<@_T_9.a,1,public>] %aggregate : !firrtl.bundle<a: uint<1>>
     %_T_9 = firrtl.node %aggregate  : !firrtl.bundle<a: uint<1>>
   }
 }
@@ -1200,15 +1200,9 @@ firrtl.circuit "Sub"  attributes {
 // CHECK-SAME:        {class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "sink", id = [[id]] : i64, peer = "~Top|Foo>clock", side = "local", targetId = {{[0-9]+}} : i64}
 // CHECK-NEXT:      %dataSource = firrtl.wire
 // CHECK-SAME:        {circt.fieldID = 3 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "source", id = [[id]] : i64, peer = "~Top|Foo>dataOut.p", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 3 : i32, class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        {circt.fieldID = 2 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "source", id = [[id]] : i64, peer = "~Top|Foo>dataOut.w", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 2 : i32, class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        {circt.fieldID = 1 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "source", id = [[id]] : i64, peer = "~Top|Foo>dataOut.x.y.z", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-NEXT:      %dataSink = firrtl.wire
 // CHECK-SAME:        {circt.fieldID = 3 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "sink", id = [[id]] : i64, peer = "~Top|Foo>dataIn.e", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 3 : i32, class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        {circt.fieldID = 2 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "sink", id = [[id]] : i64, peer = "~Top|Foo>dataIn.d", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 2 : i32, class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        {circt.fieldID = 1 : i32, class = "sifive.enterprise.grandcentral.SignalDriverAnnotation.target", dir = "sink", id = [[id]] : i64, peer = "~Top|Foo>dataIn.a.b.c", side = "local", targetId = {{[0-9]+}} : i64}
-// CHECK-SAME:        {circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"}


### PR DESCRIPTION
This is still quite WIP. This PR moves dontTouch Lowerings to LowerAnnotations. 

The current implementation distributes per-fields symbols to every leaf when dontTouch is on aggregate. 
The PR currently doesn't handle dontTouch on ports because it requires https://github.com/llvm/circt/pull/3582
