### PR TITLE
[HW] Add `getReferencedModule` to `HWInstanceLike`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -79,7 +79,6 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
   let extraClassDeclaration = [{
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
-    FModuleLike getReferencedModule();
     FModuleLike getReferencedModule(SymbolTable& symtbl);
 
     /// Return the port direction for the specified result number.

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -138,6 +138,11 @@ def HWInstanceLike : OpInterface<"HWInstanceLike"> {
     "::mlir::StringAttr", "referencedModuleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
+
+    InterfaceMethod<"Get the referenced module",
+    "::mlir::Operation *", "getReferencedModule", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{}]>,
   ];
 }
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -428,7 +428,7 @@ def InstanceOp : HWOp<"instance", [
 
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
-    Operation *getReferencedModule(const HWSymbolCache *cache = nullptr);
+    Operation *getReferencedModule(const HWSymbolCache *cache);
 
     /// Get the instances's name.
     StringAttr getName() {

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -34,10 +34,6 @@ def InstanceOp : MSFTOp<"instance", [
     // determined.
     StringAttr getResultName(size_t i);
 
-    /// Lookup the module or extmodule for the symbol.  This returns null on
-    /// invalid IR.
-    Operation *getReferencedModule();
-
     /// Instance name is the same as the symbol name. This may change in the
     /// future.
     StringRef instanceName() {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1157,7 +1157,7 @@ void FMemModuleOp::getAsmBlockArgumentNames(
 
 /// Lookup the module or extmodule for the symbol.  This returns null on
 /// invalid IR.
-FModuleLike InstanceOp::getReferencedModule() {
+Operation *InstanceOp::getReferencedModule() {
   auto circuit = (*this)->getParentOfType<CircuitOp>();
   if (!circuit)
     return nullptr;

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1145,6 +1145,10 @@ Operation *InstanceOp::getReferencedModule(const HWSymbolCache *cache) {
   return topLevelModuleOp.lookupSymbol(getModuleName());
 }
 
+Operation *InstanceOp::getReferencedModule() {
+  return getReferencedModule(/*cache=*/nullptr);
+}
+
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto *module =
       symbolTable.lookupNearestSymbolFrom(*this, getModuleNameAttr());


### PR DESCRIPTION
Added a method to fetch the referenced op of any instance-like ops.