### PR TITLE
[LLHDToLLVM] Populate ArithToLLVM conversion patterns

### DIFF
--- a/lib/Conversion/LLHDToLLVM/CMakeLists.txt
+++ b/lib/Conversion/LLHDToLLVM/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_conversion_library(CIRCTLLHDToLLVM
   CIRCTLLHD
   CIRCTComb
   CIRCTHW
+  MLIRArithmeticToLLVM
   MLIRControlFlowToLLVM
   MLIRFuncToLLVM
   MLIRLLVMCommonConversion

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -17,6 +17,7 @@
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
@@ -2561,6 +2562,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
   target.addIllegalOp<InstOp>();
   target.addLegalOp<UnrealizedConversionCastOp>();
   cf::populateControlFlowToLLVMConversionPatterns(converter, patterns);
+  arith::populateArithmeticToLLVMConversionPatterns(converter, patterns);
 
   // Apply the partial conversion.
   if (failed(


### PR DESCRIPTION
Because LLHD uses operations from the cf dialect calling canonicalize creates, e.g., arith.select when control flow can be simplified. Canonicalization patterns of arith might then modify this further to arith.extui or similar. To be able to continue using the cf operations and benefit from all the control flow simplification canonicalizations, we need to add support for lowering arith operations to LLVM.