### PR TITLE
[LLHDToLLVM] Add lowering support for comb.replicate

### DIFF
--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -2418,6 +2418,23 @@ struct CombConcatOpConversion : public ConvertToLLVMPattern {
 };
 } // namespace
 
+namespace {
+/// Lower an ArrayConcatOp operation to the LLVM dialect.
+struct CombReplicateOpConversion
+    : public ConvertOpToLLVMPattern<comb::ReplicateOp> {
+  using ConvertOpToLLVMPattern<comb::ReplicateOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(comb::ReplicateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    std::vector<Value> inputs(op.getMultiple(), op.getInput());
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, inputs);
+    return success();
+  }
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Memory operations
 //===----------------------------------------------------------------------===//
@@ -2511,8 +2528,8 @@ void circt::populateLLHDToLLVMConversionPatterns(LLVMTypeConverter &converter,
   // Arithmetic conversion patterns.
   patterns.add<CombAddOpConversion, CombSubOpConversion, CombMulOpConversion,
                CombDivUOpConversion, CombDivSOpConversion, CombModUOpConversion,
-               CombModSOpConversion, CombICmpOpConversion, CombMuxOpConversion>(
-      converter);
+               CombModSOpConversion, CombICmpOpConversion, CombMuxOpConversion,
+               CombReplicateOpConversion>(converter);
 
   // Unit conversion patterns.
   patterns.add<ProcOpConversion, WaitOpConversion, HaltOpConversion>(ctx,

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -2419,7 +2419,7 @@ struct CombConcatOpConversion : public ConvertToLLVMPattern {
 } // namespace
 
 namespace {
-/// Lower an ArrayConcatOp operation to the LLVM dialect.
+/// Lower a comb::ReplicateOp operation to the LLVM dialect.
 struct CombReplicateOpConversion
     : public ConvertOpToLLVMPattern<comb::ReplicateOp> {
   using ConvertOpToLLVMPattern<comb::ReplicateOp>::ConvertOpToLLVMPattern;

--- a/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
@@ -86,5 +86,21 @@ func.func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
   // CHECK: llvm.select %arg2, %arg0, %arg1 : i1, i32
   %7 = comb.mux %arg2, %arg0, %arg1 : i32
 
+  // CHECK-NEXT: %[[INIT:.*]] = llvm.mlir.constant(0 : i96) : i96
+  // CHECK-NEXT: %[[A1:.*]] = llvm.mlir.constant(64 : i96) : i96
+  // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg0 : i32 to i96
+  // CHECK-NEXT: %[[SHIFT1:.*]] = llvm.shl %[[ZEXT1]], %[[A1]]  : i96
+  // CHECK-NEXT: %[[OR1:.*]] = llvm.or %[[INIT]], %[[SHIFT1]]  : i96
+  // CHECK-NEXT: %[[A2:.*]] = llvm.mlir.constant(32 : i96) : i96
+  // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg0 : i32 to i96
+  // CHECK-NEXT: %[[SHIFT2:.*]] = llvm.shl %[[ZEXT2]], %[[A2]]  : i96
+  // CHECK-NEXT: %[[OR2:.*]] = llvm.or %[[OR1]], %[[SHIFT2]]  : i96
+  // CHECK-NEXT: %[[A3:.*]] = llvm.mlir.constant(0 : i96) : i96
+  // CHECK-NEXT: %[[ZEXT3:.*]] = llvm.zext %arg0 : i32 to i96
+  // CHECK-NEXT: %[[SHIFT3:.*]] = llvm.shl %[[ZEXT3]], %[[A3]]  : i96
+  // CHECK-NEXT: llvm.or %[[OR2]], %[[SHIFT3]]  : i96
+  %8 = comb.replicate %arg0 : (i32) -> i96
+
+  // CHECK-NEXT: return
   return %7 : i32
 }


### PR DESCRIPTION
Moore often emits concats of the same value which are canonicalized to replicate ops, i.e., canonicalizing before running LLHDToLLVM is not possible because it would fail due to the missing conversion pattern.