### PR TITLE
[LLHDToLLVM] Generalize signal init expression support

### DIFF
--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -518,39 +518,57 @@ static Value adjustBitWidth(Location loc, ConversionPatternRewriter &rewriter,
   return value;
 }
 
+static unsigned getIndexOfOperandResult(Operation *op, Value result) {
+  for (unsigned j = 0, e = op->getNumResults(); j < e; ++j) {
+    if (result == result.getDefiningOp()->getResult(j))
+      return j;
+  }
+  llvm_unreachable(
+      "no way to recurse to an operation that does not return any value");
+}
+
 /// Recursively clone the init origin of a sig operation into the init function,
 /// up to the initial constant value(s). This is required to clone the
-/// initialization of array and struct signals, where the init operant cannot
-/// originate from a constant operation. Integer constants are currently assumed
-/// to come from a constant operation.
-static Operation *recursiveCloneInit(OpBuilder &initBuilder, Operation *op) {
-  if (auto arrayCreateOp = dyn_cast<hw::ArrayCreateOp>(op)) {
-    auto def =
-        cast<hw::ArrayCreateOp>(initBuilder.insert(arrayCreateOp.clone()));
-    initBuilder.setInsertionPoint(def.getOperation());
-    for (size_t i = 0, e = def.getInputs().size(); i < e; ++i) {
-      auto clone =
-          recursiveCloneInit(initBuilder, def.getInputs()[i].getDefiningOp());
-      def.setOperand(i, clone->getResult(0));
+/// initialization of array and struct signals, where the init operand cannot
+/// originate from a constant operation.
+static Value recursiveCloneInit(OpBuilder &initBuilder,
+                                BlockAndValueMapping &mapping, Value init) {
+  SmallVector<Value> clonedOperands;
+  Operation *initOp = init.getDefiningOp();
+
+  // If we end up at a value that we get via BlockArgument or as a result of a
+  // llhd.prb op, return a nullptr to signal that something went wrong, because
+  // these cases are not supported.
+  if (!initOp || isa<llhd::PrbOp>(initOp))
+    return nullptr;
+
+  for (size_t i = 0, e = initOp->getNumOperands(); i < e; ++i) {
+    Value operand = initOp->getOperand(i);
+
+    // If we have some value that is used multiple times (e.g., broadcasted to
+    // an array) then don't emit the ops to create this value several times,
+    // but instead remember the cloned value and use it again.
+    if (auto memorizedOperand = mapping.lookupOrNull(operand)) {
+      clonedOperands.push_back(memorizedOperand);
+      continue;
     }
-    initBuilder.setInsertionPointAfter(def.getOperation());
-    return def;
+
+    // Recursively follow operands.
+    Value clonedOperand = recursiveCloneInit(initBuilder, mapping, operand);
+    if (!clonedOperand)
+      return nullptr;
+
+    mapping.map(operand, clonedOperand);
+    clonedOperands.push_back(clonedOperand);
   }
 
-  if (auto structCreateOp = dyn_cast<hw::StructCreateOp>(op)) {
-    auto def =
-        cast<hw::StructCreateOp>(initBuilder.insert(structCreateOp.clone()));
-    initBuilder.setInsertionPoint(def.getOperation());
-    for (size_t i = 0, e = def.getInput().size(); i < e; ++i) {
-      auto clone =
-          recursiveCloneInit(initBuilder, def.getInput()[i].getDefiningOp());
-      def.setOperand(i, clone->getResult(0));
-    }
-    initBuilder.setInsertionPointAfter(def.getOperation());
-    return def;
-  }
+  Operation *clone = initOp->clone();
+  clone->setOperands(clonedOperands);
 
-  return initBuilder.insert(op->clone());
+  // If we have cloned an operation that returns several values, we have to
+  // find the result value of the cloned operation we want to return.
+  unsigned index = getIndexOfOperandResult(initOp, init);
+  return initBuilder.insert(clone)->getResult(index);
 }
 
 /// Check if the given type is either of LLHD's ArrayType, StructType, or LLVM
@@ -1165,7 +1183,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
       // Index of the signal in the entity's signal table.
       int initCounter = 0;
       // Walk over the entity and generate mallocs for each one of its signals.
-      child.walk([&](SigOp op) -> void {
+      WalkResult sigWalkResult = child.walk([&](SigOp op) -> WalkResult {
         // if (auto sigOp = dyn_cast<SigOp>(op)) {
         auto underlyingTy = typeConverter->convertType(op.getInit().getType());
         // Get index constant of the signal in the entity's signal table.
@@ -1175,8 +1193,12 @@ struct InstOpConversion : public ConvertToLLVMPattern {
 
         // Clone and insert the operation that defines the signal's init
         // operand (assmued to be a constant/array op)
-        auto defOp = op.getInit().getDefiningOp();
-        auto initDef = recursiveCloneInit(initBuilder, defOp)->getResult(0);
+        BlockAndValueMapping mapping;
+        Value initDef = recursiveCloneInit(initBuilder, mapping, op.getInit());
+
+        if (!initDef)
+          return WalkResult::interrupt();
+
         Value initDefCast = typeConverter->materializeTargetConversion(
             initBuilder, initDef.getLoc(),
             typeConverter->convertType(initDef.getType()), initDef);
@@ -1287,7 +1309,12 @@ struct InstOpConversion : public ConvertToLLVMPattern {
                     {initStatePtr, sigIndex, elemToInt, elemSizeToInt}));
           }
         }
+        return WalkResult::advance();
       });
+
+      if (sigWalkResult.wasInterrupted())
+        return failure();
+
     } else if (auto proc = module.lookupSymbol<ProcOp>(instOp.getCallee())) {
       // Handle process instantiation.
       auto sensesPtrTy = LLVM::LLVMPointerType::get(

--- a/test/Conversion/LLHDToLLVM/signal-init-error.mlir
+++ b/test/Conversion/LLHDToLLVM/signal-init-error.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s --convert-llhd-to-llvm --verify-diagnostics --split-input-file
+
+llhd.entity @root() -> () {
+  // expected-error @+1 {{failed to legalize operation 'llhd.inst'}}
+  llhd.inst "inst" @initUsesProbedValue () -> () : () -> ()
+}
+
+llhd.entity @initUsesProbedValue () -> () {
+  // expected-error @+1 {{failed to legalize operation 'hw.constant'}}
+  %0 = hw.constant 0 : i1
+  %1 = llhd.sig "sig" %0 : i1
+  %2 = llhd.prb %1 : !llhd.sig<i1>
+  %3 = hw.array_create %2, %2 : i1
+  %4 = llhd.sig "sig1" %3 : !hw.array<2xi1>
+}
+
+// TODO: add testcase where the init value of llhd.sig comes from a block argument

--- a/test/Conversion/LLHDToLLVM/signal-init.mlir
+++ b/test/Conversion/LLHDToLLVM/signal-init.mlir
@@ -1,0 +1,67 @@
+// RUN: circt-opt %s --convert-llhd-to-llvm | FileCheck %s
+
+// CHECK-LABEL: llvm.func @llhd_init
+// CHECK: llvm.mlir.constant(false) : i1
+llhd.entity @root() -> () {
+  llhd.inst "inst1" @initArraySig () -> () : () -> ()
+  llhd.inst "inst2" @initStructSig () -> () : () -> ()
+  llhd.inst "inst3" @initPartiallyLowered () -> () : () -> ()
+  llhd.inst "inst4" @initMultipleResults () -> () : () -> ()
+}
+
+// CHECK: [[ZERO:%.+]] = llvm.mlir.constant(false) : i1
+// CHECK: [[A1:%.+]] = llvm.mlir.undef : !llvm.array<2 x i1>
+// CHECK: [[A2:%.+]] = llvm.insertvalue [[ZERO]], [[A1]][0 : i32] : !llvm.array<2 x i1>
+// CHECK: [[A3:%.+]] = llvm.insertvalue [[ZERO]], [[A2]][1 : i32] : !llvm.array<2 x i1>
+// CHECK: llvm.store [[A3]], {{%.+}} : !llvm.ptr<array<2 x i1>>
+llhd.entity @initArraySig () -> () {
+  %init = hw.constant 0 : i1
+  %initArr = hw.array_create %init, %init : i1
+  %0 = llhd.sig "sig" %initArr : !hw.array<2xi1>
+}
+
+// CHECK: llvm.mlir.constant(false) : i1
+
+// CHECK: [[FALSE:%.+]] = llvm.mlir.constant(false) : i1
+// CHECK: [[THREE:%.+]] = llvm.mlir.constant(3 : i5) : i5
+// CHECK: [[S1:%.+]] = llvm.mlir.undef : !llvm.struct<(i5, i1)>
+// CHECK: [[S2:%.+]] = llvm.insertvalue [[THREE]], [[S1]][0 : i32] : !llvm.struct<(i5, i1)>
+// CHECK: [[S3:%.+]] = llvm.insertvalue [[FALSE]], [[S2]][1 : i32] : !llvm.struct<(i5, i1)>
+// CHECK: llvm.store [[S3]], {{%.+}} : !llvm.ptr<struct<(i5, i1)>>
+llhd.entity @initStructSig () -> () {
+  %init = hw.constant 0 : i1
+  %init1 = hw.constant 3 : i5
+  %initStruct = hw.struct_create (%init, %init1) : !hw.struct<f1: i1, f2: i5>
+  %0 = llhd.sig "sig" %initStruct : !hw.struct<f1: i1, f2: i5>
+}
+
+// CHECK: [[B1:%.+]] = llvm.mlir.undef : !llvm.array<2 x i1>
+// CHECK: [[FALSE1:%.+]] = llvm.mlir.constant(false) : i1
+// CHECK: [[B2:%.+]] = llvm.insertvalue [[FALSE1]], [[B1]][0 : i32] : !llvm.array<2 x i1>
+// CHECK: [[B3:%.+]] = llvm.insertvalue [[FALSE1]], [[B2]][1 : i32] : !llvm.array<2 x i1>
+// CHECK: llvm.store [[B3]], {{%.+}} : !llvm.ptr<array<2 x i1>>
+llhd.entity @initPartiallyLowered () -> () {
+  %0 = llvm.mlir.constant(false) : i1
+  %1 = llvm.mlir.undef : !llvm.array<2 x i1>
+  %2 = llvm.insertvalue %0, %1[0 : i32] : !llvm.array<2 x i1>
+  %3 = llvm.insertvalue %0, %2[1 : i32] : !llvm.array<2 x i1>
+  %4 = builtin.unrealized_conversion_cast %3 : !llvm.array<2 x i1> to !hw.array<2xi1>
+  %5 = llhd.sig "sig" %4 : !hw.array<2xi1>
+}
+
+func.func @getInitValue() -> (i32, i32, i32) {
+  %0 = hw.constant 0 : i32
+  return %0, %0, %0 : i32, i32, i32
+}
+
+// CHECK: [[RETURN:%.+]] = llvm.call @getInitValue() : () -> !llvm.struct<(i32, i32, i32)>
+// CHECK: [[E1:%.+]] = llvm.extractvalue [[RETURN]][0] : !llvm.struct<(i32, i32, i32)>
+// CHECK: [[E2:%.+]] = llvm.extractvalue [[RETURN]][1] : !llvm.struct<(i32, i32, i32)>
+// CHECK: [[E3:%.+]] = llvm.extractvalue [[RETURN]][2] : !llvm.struct<(i32, i32, i32)>
+// CHECK: llvm.store [[E2]], {{%.+}} : !llvm.ptr<i32>
+llhd.entity @initMultipleResults () -> () {
+  %0, %1, %2 = func.call @getInitValue() : () -> (i32, i32, i32)
+  %3 = llhd.sig "sig" %1 : i32
+}
+
+// CHECK: }


### PR DESCRIPTION
Currently, `LLHDToLLVM` accepts a very limited number of expressions for the `llhd.sig` init value. In particular, it fails when first partially lowering only the HW operations in the following IR

```mlir
llhd.entity @snitch_tb () -> () {
  llhd.inst "i_snitch" @snitch.param1() -> () : () -> ()
}
llhd.entity @snitch.param1 () -> () {
  %c0_i5_17 = hw.constant 0 : i5
  %c0_i5_18 = hw.constant 0 : i5
  %21 = hw.array_create %c0_i5_17, %c0_i5_18 : i5
  %22 = llhd.sig "gpr_raddr" %21 : !hw.array<2xi5>
}
```

to

```mlir
llhd.entity @snitch_tb () -> () {
  llhd.inst "i_snitch" @snitch.param1() -> () : () -> ()
}
llhd.entity @snitch.param1 () -> () {
  %0 = llvm.mlir.constant(0 : i5) : i5
  %1 = llvm.mlir.undef : !llvm.array<2 x i5>
  %2 = llvm.insertvalue %0, %1[0 : i32] : !llvm.array<2 x i5>
  %3 = llvm.insertvalue %0, %2[1 : i32] : !llvm.array<2 x i5>
  %4 = builtin.unrealized_conversion_cast %3 : !llvm.array<2 x i5> to !hw.array<2xi5>
  %5 = llhd.sig "gpr_raddr" %4 : !hw.array<2xi5>
}
```

and afterwards lowering the LLHD operations. This is because the current implementation just clones the `builtin.unrealized_conversion_cast` and does not clone the operands recursively. As a result the operand value is not defined which the verifier then complains about:

```
snitch_tb_lowered.mlir:201:11: error: 'llvm.store' op using value defined outside the region
    %22 = llhd.sig "gpr_raddr" %21 : !hw.array<2xi5>
          ^
snitch_tb_lowered.mlir:201:11: note: see current operation: "llvm.store"(<<UNKNOWN SSA VALUE>>, %270) : (!llvm.array<2 x i5>, !llvm.ptr<array<2 x i5>>) -> ()
snitch_tb_lowered.mlir:151:5: note: required by region isolation constraints
    llhd.inst "i_snitch" @snitch.param1(%0, %1, %36, %3, %5, %38, %39, %40, %41, %42, %12, %13, %14, %15, %43, %45) -> (%2, %4, %46, %47, %48, %49, %50, %51, %52, %53, %6, %7, %8, %9, %10, %11, %16, %54, %56) : (!llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i32>, !llhd.sig<i32>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i64>, !llhd.sig<i5>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i64>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<!hw.struct<NV: i1, DZ: i1, OF: i1, UF: i1, NX: i1>>) -> (!llhd.sig<i32>, !llhd.sig<i1>, !llhd.sig<i32>, !llhd.sig<i5>, !llhd.sig<i32>, !llhd.sig<i64>, !llhd.sig<i64>, !llhd.sig<i64>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i32>, !llhd.sig<i1>, !llhd.sig<i4>, !llhd.sig<i64>, !llhd.sig<i8>, !llhd.sig<i1>, !llhd.sig<i1>, !llhd.sig<i3>, !llhd.sig<!hw.struct<issue_fpu: i1, issue_fpu_seq: i1, issue_core_to_fpu: i1, retired_insts: i1>>)
    ^
```

The same happens for other expressions other than the currently hardcoded ones.

This implementation still has two limitations:
* When a value in the expression is a block argument: cannot happen in entities, not trivial to add support for it
* When a value in the expression is probed from a signal: this is an artificial limitation put in place to avoid cycles in a graph region of the form

```mlir
%0 = hw.constant 0 : i32
%1 = llhd.sig "signame" %2 : i32
%2 = llhd.prb %1 : !llhd.sig<i32> 
```
It also does not really make sense to allow the init value of a signal depend on the value driven to another signal, I think.

Maybe it would even be sufficient to only allow specifying the signal init value using an attribute?