### PR TITLE
[HW] Add top module inference to InstanceGraph

### DIFF
--- a/include/circt/Dialect/HW/InstanceGraphBase.h
+++ b/include/circt/Dialect/HW/InstanceGraphBase.h
@@ -198,6 +198,10 @@ public:
   /// Get the node corresponding to the top-level module of a circuit.
   virtual InstanceGraphNode *getTopLevelNode() = 0;
 
+  /// Get the node corresponding to the inferred top-level module of a circuit.
+  /// Returns failure if multiple top level modules were found.
+  FailureOr<InstanceGraphNode *> getInferredTopLevelNode();
+
   /// Return the parent under which all nodes are nested.
   Operation *getParent() { return parent; }
 
@@ -250,6 +254,9 @@ protected:
 
   /// This maps each operation to its graph node.
   llvm::DenseMap<Attribute, InstanceGraphNode *> nodeMap;
+
+  /// A caching of the inferred top level module.
+  InstanceGraphNode *inferredTopLevelNode = nullptr;
 };
 
 } // namespace hw

--- a/include/circt/Dialect/HW/InstanceGraphBase.h
+++ b/include/circt/Dialect/HW/InstanceGraphBase.h
@@ -198,9 +198,9 @@ public:
   /// Get the node corresponding to the top-level module of a circuit.
   virtual InstanceGraphNode *getTopLevelNode() = 0;
 
-  /// Get the node corresponding to the inferred top-level module of a circuit.
-  /// Returns failure if multiple top level modules were found.
-  FailureOr<InstanceGraphNode *> getInferredTopLevelNode();
+  /// Get the nodes corresponding to the inferred top-level modules of a
+  /// circuit.
+  FailureOr<llvm::ArrayRef<InstanceGraphNode *>> getInferredTopLevelNodes();
 
   /// Return the parent under which all nodes are nested.
   Operation *getParent() { return parent; }
@@ -255,8 +255,8 @@ protected:
   /// This maps each operation to its graph node.
   llvm::DenseMap<Attribute, InstanceGraphNode *> nodeMap;
 
-  /// A caching of the inferred top level module.
-  InstanceGraphNode *inferredTopLevelNode = nullptr;
+  /// A caching of the inferred top level module(s).
+  llvm::SmallVector<InstanceGraphNode *> inferredTopLevelNodes;
 };
 
 } // namespace hw

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -39,5 +39,6 @@ add_circt_library(CIRCTAnalysisTestPasses
   CIRCTControlFlowLoopAnalysis
   CIRCTDependenceAnalysis
   CIRCTSchedulingAnalysis
+  CIRCTHW
   MLIRPass
   )

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -190,14 +190,18 @@ struct InferTopModulePass
 
 void InferTopModulePass::runOnOperation() {
   circt::hw::InstanceGraph &analysis = getAnalysis<circt::hw::InstanceGraph>();
-  auto res = analysis.getInferredTopLevelNode();
+  auto res = analysis.getInferredTopLevelNodes();
   if (failed(res)) {
     signalPassFailure();
     return;
   }
 
+  llvm::SmallVector<Attribute, 4> attrs;
+  for (auto *node : res.getValue())
+    attrs.push_back(node->getModule().moduleNameAttr());
+
   analysis.getParent()->setAttr("test.top",
-                                res.getValue()->getModule().moduleNameAttr());
+                                ArrayAttr::get(&getContext(), attrs));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -13,6 +13,7 @@
 #include "circt/Analysis/ControlFlowLoopAnalysis.h"
 #include "circt/Analysis/DependenceAnalysis.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Scheduling/Problems.h"
 #include "mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -170,6 +171,36 @@ void TestControlFlowLoopAnalysisPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// InferTopModule passes.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct InferTopModulePass
+    : public PassWrapper<InferTopModulePass, OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InferTopModulePass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-infer-top-level"; }
+  StringRef getDescription() const override {
+    return "Perform top level module inference and emit results as attributes "
+           "on the enclosing module.";
+  }
+};
+} // namespace
+
+void InferTopModulePass::runOnOperation() {
+  circt::hw::InstanceGraph &analysis = getAnalysis<circt::hw::InstanceGraph>();
+  auto res = analysis.getInferredTopLevelNode();
+  if (failed(res)) {
+    signalPassFailure();
+    return;
+  }
+
+  analysis.getParent()->setAttr("test.top",
+                                res.getValue()->getModule().moduleNameAttr());
+}
+
+//===----------------------------------------------------------------------===//
 // Pass registration
 //===----------------------------------------------------------------------===//
 
@@ -184,6 +215,9 @@ void registerAnalysisTestPasses() {
   });
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestControlFlowLoopAnalysisPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<InferTopModulePass>();
   });
 }
 } // namespace test

--- a/test/Analysis/infer-top-level.mlir
+++ b/test/Analysis/infer-top-level.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-opt %s -split-input-file -test-infer-top-level -verify-diagnostics | FileCheck %s
+// RUN: circt-opt -split-input-file -test-infer-top-level -verify-diagnostics %s | FileCheck %s
 
-// CHECK: module attributes {test.top = "baz"}
+// CHECK: module attributes {test.top = ["baz"]}
 module {
   hw.module @bar() -> () {}
   hw.module @foo() -> () {
@@ -33,7 +33,7 @@ module {
 // -----
 
 // test multiple candidate top components
-// expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo).}}
+// CHECK: module attributes {test.top = ["bar", "foo"]}
 module {
   hw.module @bar() -> () {
     hw.instance "baz" @baz() -> ()

--- a/test/Analysis/infer-top-level.mlir
+++ b/test/Analysis/infer-top-level.mlir
@@ -1,0 +1,47 @@
+// RUN: circt-opt %s -split-input-file -test-infer-top-level -verify-diagnostics | FileCheck %s
+
+// CHECK: module attributes {test.top = "baz"}
+module {
+  hw.module @bar() -> () {}
+  hw.module @foo() -> () {
+    hw.instance "bar" @bar() -> ()
+  }
+  
+  hw.module @baz() -> () {
+    hw.instance "foo" @foo() -> ()
+  }
+}
+
+// -----
+
+// Test cycle through a component
+// expected-error @+1 {{'builtin.module' op cannot deduce top level module - cycle detected in instance graph (bar->baz->foo->bar).}}
+module {
+  hw.module @bar() -> () {
+    hw.instance "baz" @baz() -> ()
+  }
+
+  hw.module @foo() -> () {
+    hw.instance "bar" @bar() -> ()
+  }
+  
+  hw.module @baz() -> () {
+    hw.instance "foo" @foo() -> ()
+  }
+}
+
+// -----
+
+// test multiple candidate top components
+// expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo).}}
+module {
+  hw.module @bar() -> () {
+    hw.instance "baz" @baz() -> ()
+  }
+
+  hw.module @foo() -> () {
+    hw.instance "baz" @baz() -> ()
+  }
+  
+  hw.module @baz() -> () {}
+}


### PR DESCRIPTION
This commit adds support for inferring a top-level module in an InstanceGraph.
The implementation is based on a topological sort of the instance graph. Through this, error messages will be generated in case of a cycle in the instance graph or when multiple candidate top modules are found.