### PR TITLE
[CalyxToFSM] Add FSM materialization pass

### DIFF
--- a/include/circt/Conversion/CalyxToFSM.h
+++ b/include/circt/Conversion/CalyxToFSM.h
@@ -26,11 +26,13 @@ class Pass;
 namespace circt {
 
 namespace calyxToFSM {
+// Entry and exit state names of the Calyx control program in the FSM.
 static constexpr std::string_view sEntryStateName = "fsm_entry";
 static constexpr std::string_view sExitStateName = "fsm_exit";
 } // namespace calyxToFSM
 
 std::unique_ptr<mlir::Pass> createCalyxToFSMPass();
+std::unique_ptr<mlir::Pass> createMaterializeCalyxToFSMPass();
 
 } // namespace circt
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -212,6 +212,29 @@ def CalyxToFSM : Pass<"lower-calyx-to-fsm", "calyx::ComponentOp"> {
   let dependentDialects = ["fsm::FSMDialect", "comb::CombDialect"];
 }
 
+def MaterializeCalyxToFSM : Pass<"materialize-calyx-to-fsm", "calyx::ComponentOp"> {
+  let summary = "Materializes an FSM embedded inside the control of this Calyx component.";
+  let description = [{
+    Materializes the FSM in the control of the component. This materializes the
+    top-level I/O of the FSM to receive `group_done` signals as input and
+    `group_go` signals as output, based on the `calyx.enable` operations
+    used within the states of the FSM.
+    Each transition of the FSM is predicated on the enabled groups within a
+    state being done, or, for static groups, a separate sub-FSM is instantiated
+    to await the group finishing.
+
+    Given an FSM that enables N unique groups, the top-level FSM will have N+1
+    in- and output ports, wherein:
+    * Input # 0 to N-1 are `group_done` signals
+    * Input N is the top-level `go` port
+    * Output 0 to N-1 are `group_go` signals
+    * Output N is the top-level `done` port
+  }];
+  let dependentDialects = ["comb::CombDialect", "hw::HWDialect", "fsm::FSMDialect"];
+  let constructor = "circt::createMaterializeCalyxToFSMPass()";
+}
+
+
 //===----------------------------------------------------------------------===//
 // FSMToSV
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/CalyxToFSM/CMakeLists.txt
+++ b/lib/Conversion/CalyxToFSM/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_library(CIRCTCalyxToFSM
   CalyxToFSM.cpp
+  MaterializeFSM.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/CalyxToFSM

--- a/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
@@ -26,9 +26,6 @@ using namespace fsm;
 
 namespace {
 
-// A set of group names. Use SetVector to ensure deterministic ordering.
-using GroupSet = SetVector<StringAttr>;
-
 struct MaterializeCalyxToFSMPass
     : public MaterializeCalyxToFSMBase<MaterializeCalyxToFSMPass> {
   void runOnOperation() override;
@@ -98,10 +95,13 @@ struct MaterializeCalyxToFSMPass
   }
 
   /// Maintain a set of all groups referenced within this fsm.machine.
-  GroupSet referencedGroups;
+  /// Use a SetVector to ensure a deterministic ordering - strong assumptions
+  /// are placed on the order of referenced groups wrt. the top-level I/O
+  /// created for the group done/go signals.
+  SetVector<StringAttr> referencedGroups;
 
   /// Maintain a relation between states and the groups which they enable.
-  DenseMap<fsm::StateOp, GroupSet> stateEnables;
+  DenseMap<fsm::StateOp, DenseSet<StringAttr>> stateEnables;
 
   /// A handle to the machine under transformation.
   MachineOp machineOp;

--- a/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
@@ -1,0 +1,189 @@
+//===- MaterializeCalyxToFSM.cpp - FSM Materialization Pass -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the FSM materialization pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../PassDetail.h"
+#include "circt/Conversion/CalyxToFSM.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/FSM/FSMGraph.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace circt;
+using namespace calyx;
+using namespace mlir;
+using namespace fsm;
+
+namespace {
+
+// A set of group names. Use SetVector to ensure deterministic ordering.
+using GroupSet = SetVector<StringAttr>;
+
+struct MaterializeCalyxToFSMPass
+    : public MaterializeCalyxToFSMBase<MaterializeCalyxToFSMPass> {
+  void runOnOperation() override;
+
+  /// Assigns the 'fsm.output' operation of the provided 'state' to enabled the
+  /// set of provided groups. If 'topLevelDone' is set, also asserts the
+  /// top-level done signal.
+  void assignStateOutputOperands(OpBuilder &b, StateOp stateOp,
+                                 bool topLevelDone = false) {
+    SmallVector<Value> outputOperands;
+    auto &enabledGroups = stateEnables[stateOp];
+    for (StringAttr group : referencedGroups)
+      outputOperands.push_back(
+          getOrCreateConstant(b, APInt(1, enabledGroups.contains(group))));
+
+    assert(outputOperands.size() == machineOp.getNumArguments() - 1 &&
+           "Expected exactly one value for each uniquely referenced group in "
+           "this machine");
+    outputOperands.push_back(getOrCreateConstant(b, APInt(1, topLevelDone)));
+    stateOp.ensureOutput(b);
+    auto outputOp = stateOp.getOutputOp();
+    outputOp->setOperands(outputOperands);
+  }
+
+  /// Extends every `fsm.return` guard in the transitions of this state to also
+  /// include the provided set of 'doneGuards'. 'doneGuards' is passed by value
+  /// to allow the caller to provide additional done guards apart from group
+  /// enable-generated guards.
+  void assignStateTransitionGuard(OpBuilder &b, StateOp stateOp,
+                                  SmallVector<Value> doneGuards = {}) {
+    auto &enabledGroups = stateEnables[stateOp];
+    for (auto groupIt : llvm::enumerate(referencedGroups))
+      if (enabledGroups.contains(groupIt.value()))
+        doneGuards.push_back(machineOp.getArgument(groupIt.index()));
+
+    for (auto transition : stateOp.transitions().getOps<fsm::TransitionOp>()) {
+      transition.ensureGuard(b);
+      auto guardOp = transition.getGuardReturn();
+      llvm::SmallVector<Value> guards;
+      llvm::append_range(guards, doneGuards);
+      if (guardOp.getNumOperands() != 0)
+        guards.push_back(guardOp.operand());
+
+      if (guards.empty())
+        continue;
+
+      b.setInsertionPoint(guardOp);
+      Value guardConjunction;
+      if (guards.size() == 1)
+        guardConjunction = guards.front();
+      else
+        guardConjunction = b.create<comb::AndOp>(transition.getLoc(), guards);
+      guardOp.setOperand(guardConjunction);
+    }
+  }
+
+  Value getOrCreateConstant(OpBuilder &b, APInt value) {
+    auto it = constants.find(value);
+    if (it != constants.end())
+      return it->second;
+
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPointToStart(&machineOp.getBody().front());
+    auto constantOp = b.create<hw::ConstantOp>(machineOp.getLoc(), value);
+    constants[value] = constantOp;
+    return constantOp;
+  }
+
+  /// Maintain a set of all groups referenced within this fsm.machine.
+  GroupSet referencedGroups;
+
+  /// Maintain a relation between states and the groups which they enable.
+  DenseMap<fsm::StateOp, GroupSet> stateEnables;
+
+  /// A handle to the machine under transformation.
+  MachineOp machineOp;
+
+  /// Constant cache.
+  DenseMap<APInt, Value> constants;
+};
+
+} // end anonymous namespace
+
+void MaterializeCalyxToFSMPass::runOnOperation() {
+  ComponentOp component = getOperation();
+  auto *ctx = &getContext();
+  auto b = OpBuilder(ctx);
+  auto controlOp = component.getControlOp();
+  machineOp = dyn_cast_or_null<fsm::MachineOp>(controlOp.getBody()->front());
+  if (!machineOp) {
+    controlOp.emitOpError()
+        << "expected an 'fsm.machine' operation as the top-level operation "
+           "within the control region of this component.";
+    signalPassFailure();
+    return;
+  }
+
+  // Ensure a well-formed FSM.
+  auto graph = FSMGraph(machineOp);
+  auto *entryState = graph.lookup(b.getStringAttr(calyxToFSM::sEntryStateName));
+  auto *exitState = graph.lookup(b.getStringAttr(calyxToFSM::sExitStateName));
+
+  if (!(entryState && exitState)) {
+    machineOp.emitOpError()
+        << "Expected an '" << calyxToFSM::sEntryStateName << "' and '"
+        << calyxToFSM::sExitStateName << "' state to be present in the FSM.";
+    signalPassFailure();
+    return;
+  }
+
+  // Walk the states of the machine and gather the relation between states and
+  // the groups which they enable as well as the set of all enabled states.
+  for (auto stateOp : machineOp.getOps<fsm::StateOp>()) {
+    for (auto enableOp : llvm::make_early_inc_range(
+             stateOp.output().getOps<calyx::EnableOp>())) {
+      auto groupName = enableOp.groupNameAttr().getAttr();
+      stateEnables[stateOp].insert(groupName);
+      referencedGroups.insert(groupName);
+      // Erase the enable op now that we've recorded the information.
+      enableOp.erase();
+    }
+  }
+
+  // Materialize the top-level I/O ports of the fsm.machine. We add an in- and
+  // output for every unique group referenced within the machine, as well as an
+  // additional in- and output to represent the top-level "go" input and "done"
+  // output ports.
+  SmallVector<Type> ioTypes = SmallVector<Type>(
+      referencedGroups.size() + /*top-level go/done*/ 1, b.getI1Type());
+  size_t nGroups = ioTypes.size() - 1;
+  machineOp.setType(b.getFunctionType(ioTypes, ioTypes));
+  assert(machineOp.getBody().getNumArguments() == 0 &&
+         "expected no inputs to the FSM");
+  machineOp.getBody().addArguments(
+      ioTypes, SmallVector<Location, 4>(ioTypes.size(), b.getUnknownLoc()));
+
+  // Build output assignments and transition guards in every state. We here
+  // assume that the ordering of states in referencedGroups is fixed and
+  // deterministic, since it is used as an analogue for port I/O ordering.
+  for (auto stateOp : machineOp.getOps<fsm::StateOp>()) {
+    assignStateOutputOperands(b, stateOp,
+                              /*topLevelDone=*/false);
+    assignStateTransitionGuard(b, stateOp);
+  }
+
+  // Assign top-level go guard in the transition state.
+  size_t topLevelGoIdx = nGroups;
+  assignStateTransitionGuard(b, entryState->getState(),
+                             {machineOp.getArgument(topLevelGoIdx)});
+
+  // Assign top-level done in the exit state.
+  assignStateOutputOperands(b, exitState->getState(),
+                            /*topLevelDone=*/true);
+}
+
+std::unique_ptr<mlir::Pass> circt::createMaterializeCalyxToFSMPass() {
+  return std::make_unique<MaterializeCalyxToFSMPass>();
+}

--- a/test/Conversion/CalyxToFSM/materialize-errors.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-errors.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(materialize-calyx-to-fsm))' -split-input-file -verify-diagnostics %s
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    calyx.wires {
+    }
+// expected-error @+1 {{'calyx.control' op expected an 'fsm.machine' operation as the top-level operation within the control region of this component.}}
+    calyx.control {
+      calyx.seq {}
+    }
+  }
+}
+
+
+// -----
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    calyx.wires {
+    }
+    calyx.control {
+// expected-error @+1 {{'fsm.machine' op Expected an 'fsm_entry' and 'fsm_exit' state to be present in the FSM.}}
+      fsm.machine @control() attributes {initialState = "IDLE"} {
+        fsm.state @IDLE
+      }
+    }
+  }
+}

--- a/test/Conversion/CalyxToFSM/materialize-errors.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-errors.mlir
@@ -1,28 +1,25 @@
-// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(materialize-calyx-to-fsm))' -split-input-file -verify-diagnostics %s
+// RUN: circt-opt -pass-pipeline='calyx.component(materialize-calyx-to-fsm)' -split-input-file -verify-diagnostics %s
 
-calyx.program "main" {
-  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
-    calyx.wires {
-    }
+calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+  calyx.wires {
+  }
 // expected-error @+1 {{'calyx.control' op expected an 'fsm.machine' operation as the top-level operation within the control region of this component.}}
-    calyx.control {
-      calyx.seq {}
-    }
+  calyx.control {
+    calyx.seq {}
   }
 }
 
 
+
 // -----
 
-calyx.program "main" {
-  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
-    calyx.wires {
-    }
-    calyx.control {
+calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+  calyx.wires {
+  }
+  calyx.control {
 // expected-error @+1 {{'fsm.machine' op Expected an 'fsm_entry' and 'fsm_exit' state to be present in the FSM.}}
-      fsm.machine @control() attributes {initialState = "IDLE"} {
-        fsm.state @IDLE
-      }
+    fsm.machine @control() attributes {initialState = "IDLE"} {
+      fsm.state @IDLE
     }
   }
 }

--- a/test/Conversion/CalyxToFSM/materialize-fsm.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-fsm.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(materialize-calyx-to-fsm))' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='calyx.component(materialize-calyx-to-fsm)' %s | FileCheck %s
 
 // CHECK: fsm.machine @control(%[[A_DONE:.*]]: i1, %[[B_DONE:.*]]: i1, %[[COND_DONE:.*]]: i1, %[[TOP_LEVEL_GO:.*]]: i1) -> (i1, i1, i1, i1) attributes {compiledGroups = [@A, @B, @cond], initialState = "[[FSM_ENTRY:.*]]"} {
 // CHECK-NEXT:   %[[C1:.*]] = hw.constant true
@@ -48,73 +48,71 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-calyx.program "main" {
-  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
-    %false = hw.constant false
-    %true = hw.constant true
-    %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
-    %t.in, %t.write_en, %t.clk, %t.reset, %t.out, %t.done = calyx.register @t : i1, i1, i1, i1, i1, i1
-    %f.in, %f.write_en, %f.clk, %f.reset, %f.out, %f.done = calyx.register @f : i1, i1, i1, i1, i1, i1
-    %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i1, i1, i1
-    calyx.wires {
-      %0 = calyx.undef : i1
-      calyx.group @A {
-        %A.go = calyx.group_go %0 : i1
-        calyx.assign %t.in = %A.go ? %true : i1
-        calyx.assign %t.write_en = %A.go ? %true : i1
-        calyx.group_done %t.done : i1
-      }
-      calyx.group @B {
-        %B.go = calyx.group_go %0 : i1
-        calyx.assign %f.in = %B.go ? %true : i1
-        calyx.assign %f.write_en = %B.go ? %true : i1
-        calyx.group_done %f.done : i1
-      }
-      calyx.group @cond {
-        %cond.go = calyx.group_go %0 : i1
-        calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
-        calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
-        calyx.assign %lt.left = %cond.go ? %true : i1
-        calyx.assign %lt.right = %cond.go ? %false : i1
-        calyx.group_done %lt_reg.done ? %true : i1
-      }
+calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
+  %t.in, %t.write_en, %t.clk, %t.reset, %t.out, %t.done = calyx.register @t : i1, i1, i1, i1, i1, i1
+  %f.in, %f.write_en, %f.clk, %f.reset, %f.out, %f.done = calyx.register @f : i1, i1, i1, i1, i1, i1
+  %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i1, i1, i1
+  calyx.wires {
+    %0 = calyx.undef : i1
+    calyx.group @A {
+      %A.go = calyx.group_go %0 : i1
+      calyx.assign %t.in = %A.go ? %true : i1
+      calyx.assign %t.write_en = %A.go ? %true : i1
+      calyx.group_done %t.done : i1
     }
-    calyx.control {
-      fsm.machine @control() attributes {compiledGroups = [@A, @B, @cond], initialState = "fsm_entry"} {
-        fsm.state @fsm_entry transitions {
-          fsm.transition @seq_0_cond
-        }
+    calyx.group @B {
+      %B.go = calyx.group_go %0 : i1
+      calyx.assign %f.in = %B.go ? %true : i1
+      calyx.assign %f.write_en = %B.go ? %true : i1
+      calyx.group_done %f.done : i1
+    }
+    calyx.group @cond {
+      %cond.go = calyx.group_go %0 : i1
+      calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
+      calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
+      calyx.assign %lt.left = %cond.go ? %true : i1
+      calyx.assign %lt.right = %cond.go ? %false : i1
+      calyx.group_done %lt_reg.done ? %true : i1
+    }
+  }
+  calyx.control {
+    fsm.machine @control() attributes {compiledGroups = [@A, @B, @cond], initialState = "fsm_entry"} {
+      fsm.state @fsm_entry transitions {
+        fsm.transition @seq_0_cond
+      }
 
-        fsm.state @fsm_exit
+      fsm.state @fsm_exit
 
-        fsm.state @seq_1_if transitions {
-          fsm.transition @seq_1_if_then_seq_0_A guard {
-            fsm.return %lt_reg.out
-          }
-          fsm.transition @seq_1_if_else_seq_0_B guard {
-            %true_0 = hw.constant true
-            %0 = comb.xor %lt_reg.out, %true_0 : i1
-            fsm.return %0
-          }
+      fsm.state @seq_1_if transitions {
+        fsm.transition @seq_1_if_then_seq_0_A guard {
+          fsm.return %lt_reg.out
         }
-        fsm.state @seq_1_if_then_seq_0_A output {
-          calyx.enable @A
-          fsm.output
-        } transitions {
-          fsm.transition @fsm_exit
+        fsm.transition @seq_1_if_else_seq_0_B guard {
+          %true_0 = hw.constant true
+          %0 = comb.xor %lt_reg.out, %true_0 : i1
+          fsm.return %0
         }
-        fsm.state @seq_1_if_else_seq_0_B output {
-          calyx.enable @B
-          fsm.output
-        } transitions {
-          fsm.transition @fsm_exit
-        }
-        fsm.state @seq_0_cond output {
-          calyx.enable @cond
-          fsm.output
-        } transitions {
-          fsm.transition @seq_1_if
-        }
+      }
+      fsm.state @seq_1_if_then_seq_0_A output {
+        calyx.enable @A
+        fsm.output
+      } transitions {
+        fsm.transition @fsm_exit
+      }
+      fsm.state @seq_1_if_else_seq_0_B output {
+        calyx.enable @B
+        fsm.output
+      } transitions {
+        fsm.transition @fsm_exit
+      }
+      fsm.state @seq_0_cond output {
+        calyx.enable @cond
+        fsm.output
+      } transitions {
+        fsm.transition @seq_1_if
       }
     }
   }

--- a/test/Conversion/CalyxToFSM/materialize-fsm.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-fsm.mlir
@@ -1,0 +1,121 @@
+// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(materialize-calyx-to-fsm))' %s | FileCheck %s
+
+// CHECK: fsm.machine @control(%[[A_DONE:.*]]: i1, %[[B_DONE:.*]]: i1, %[[COND_DONE:.*]]: i1, %[[TOP_LEVEL_GO:.*]]: i1) -> (i1, i1, i1, i1) attributes {compiledGroups = [@A, @B, @cond], initialState = "[[FSM_ENTRY:.*]]"} {
+// CHECK-NEXT:   %[[C1:.*]] = hw.constant true
+// CHECK-NEXT:   %[[C0:.*]] = hw.constant false
+// CHECK-NEXT:   fsm.state @[[FSM_ENTRY]] output {
+// CHECK-NEXT:     fsm.output %[[C0]], %[[C0]], %[[C0]], %[[C0]] : i1, i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @[[SEQ_0_COND:.*]] guard {
+// CHECK-NEXT:       fsm.return %[[TOP_LEVEL_GO]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state @[[FSM_EXIT:.*]] output {
+// CHECK-NEXT:     fsm.output %[[C0]], %[[C0]], %[[C0]], %[[C1]] : i1, i1, i1, i1
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state @[[SEQ_1_IF:.*]] output {
+// CHECK-NEXT:     fsm.output %[[C0]], %[[C0]], %[[C0]], %[[C0]] : i1, i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @[[SEQ_1_IF_THEN_A:.*]] guard {
+// CHECK-NEXT:       fsm.return %lt_reg.out
+// CHECK-NEXT:     }
+// CHECK-NEXT:     fsm.transition @[[SEQ_1_IF_ELSE_B:.*]] guard {
+// CHECK-NEXT:       %true_2 = hw.constant true
+// CHECK-NEXT:       %0 = comb.xor %lt_reg.out, %true_2 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state @[[SEQ_1_IF_THEN_A]] output {
+// CHECK-NEXT:     fsm.output %[[C1]], %[[C0]], %[[C0]], %[[C0]] : i1, i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @[[FSM_EXIT]] guard {
+// CHECK-NEXT:       fsm.return %[[A_DONE]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state @[[SEQ_1_IF_ELSE_B]] output {
+// CHECK-NEXT:     fsm.output %[[C0]], %[[C1]], %[[C0]], %[[C0]] : i1, i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @[[FSM_EXIT]] guard {
+// CHECK-NEXT:       fsm.return %[[B_DONE]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state @[[SEQ_0_COND]] output {
+// CHECK-NEXT:     fsm.output %[[C0]], %[[C0]], %[[C1]], %[[C0]] : i1, i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @[[SEQ_1_IF]] guard {
+// CHECK-NEXT:       fsm.return %[[COND_DONE]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    %false = hw.constant false
+    %true = hw.constant true
+    %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
+    %t.in, %t.write_en, %t.clk, %t.reset, %t.out, %t.done = calyx.register @t : i1, i1, i1, i1, i1, i1
+    %f.in, %f.write_en, %f.clk, %f.reset, %f.out, %f.done = calyx.register @f : i1, i1, i1, i1, i1, i1
+    %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i1, i1, i1
+    calyx.wires {
+      %0 = calyx.undef : i1
+      calyx.group @A {
+        %A.go = calyx.group_go %0 : i1
+        calyx.assign %t.in = %A.go ? %true : i1
+        calyx.assign %t.write_en = %A.go ? %true : i1
+        calyx.group_done %t.done : i1
+      }
+      calyx.group @B {
+        %B.go = calyx.group_go %0 : i1
+        calyx.assign %f.in = %B.go ? %true : i1
+        calyx.assign %f.write_en = %B.go ? %true : i1
+        calyx.group_done %f.done : i1
+      }
+      calyx.group @cond {
+        %cond.go = calyx.group_go %0 : i1
+        calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
+        calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
+        calyx.assign %lt.left = %cond.go ? %true : i1
+        calyx.assign %lt.right = %cond.go ? %false : i1
+        calyx.group_done %lt_reg.done ? %true : i1
+      }
+    }
+    calyx.control {
+      fsm.machine @control() attributes {compiledGroups = [@A, @B, @cond], initialState = "fsm_entry"} {
+        fsm.state @fsm_entry transitions {
+          fsm.transition @seq_0_cond
+        }
+
+        fsm.state @fsm_exit
+
+        fsm.state @seq_1_if transitions {
+          fsm.transition @seq_1_if_then_seq_0_A guard {
+            fsm.return %lt_reg.out
+          }
+          fsm.transition @seq_1_if_else_seq_0_B guard {
+            %true_0 = hw.constant true
+            %0 = comb.xor %lt_reg.out, %true_0 : i1
+            fsm.return %0
+          }
+        }
+        fsm.state @seq_1_if_then_seq_0_A output {
+          calyx.enable @A
+          fsm.output
+        } transitions {
+          fsm.transition @fsm_exit
+        }
+        fsm.state @seq_1_if_else_seq_0_B output {
+          calyx.enable @B
+          fsm.output
+        } transitions {
+          fsm.transition @fsm_exit
+        }
+        fsm.state @seq_0_cond output {
+          calyx.enable @cond
+          fsm.output
+        } transitions {
+          fsm.transition @seq_1_if
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
(continuation of #3214)

In materializing a Calyx control FSM we:
* Gather up all of the `calyx.group`s referenced in the FSM
* Create an in- and output for each group, representing `done` (FSM input) and `go` (FSM output) signals
* Iterate over all states in the FSM and
  * replace `calyx.enable`s with an `fsm.output` bitvector asserting the corresponding `go` outputs
  * Extend the guards of all transitions from the state with a conjunction of the `done` signals of the enabled groups in the given state.

After FSM materialization, the FSM no longer contains any referenced to Calyx groups, and can be safely outlined.
The materialization does not consider how to materialize static groups. However, this should be fairly easy to implement/hook into when iterating over states and detecting `calyx.group`s with `static` attributes.

The materialization does **_not_** outline the FSM to `module` scope and replace it with a `fsm.hwinstance`. Personally, i think this should be done during the `remove-groups` pass. Why? It is in this pass where `calyx.group_go` ops will be replaced with FSM outputs and `calyx.group_done` ops will define FSM inputs needed for the `fsm.hwinstance` op (@cgyurgyik LMKWYT).