### PR TITLE
[SystemC] Add SCModuleOp and AliasOp

### DIFF
--- a/docs/Dialects/SystemC/RationaleSystemC.md
+++ b/docs/Dialects/SystemC/RationaleSystemC.md
@@ -116,3 +116,12 @@ emission. At the same time, it is not possible to not model any C++ at all,
 because when only modeling SystemC specific constructs, the gap for
 ExportSystemC to bridge would be too big (we want the printer to be as simple
 as possible).
+
+**Q: Why does `systemc.module` have a graph region rather than a SSACFG region?**
+
+It contains a single graph region to allow flexible positioning of the fields,
+constructor and methods to support different ordering styles (fields at top
+or bottom, methods to be registered with SC_METHOD positioned after the
+constructor, etc.) without requiring any logic in ExportSystemC. Program code
+to change the emission style can thus be written as part of the lowering from
+HW, as a pre-emission transformation, or anywhere else.

--- a/include/circt/Dialect/SystemC/CMakeLists.txt
+++ b/include/circt/Dialect/SystemC/CMakeLists.txt
@@ -8,9 +8,7 @@ mlir_tablegen(SystemCEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(CIRCTSystemCEnumsIncGen)
 add_dependencies(circt-headers CIRCTSystemCEnumsIncGen)
 
-mlir_tablegen(SystemCAttributes.h.inc -gen-attrdef-decls
-  -attrdefs-dialect SystemCDialect)
-mlir_tablegen(SystemCAttributes.cpp.inc -gen-attrdef-defs
-  -attrdefs-dialect SystemCDialect)
+mlir_tablegen(SystemCAttributes.h.inc -gen-attrdef-decls)
+mlir_tablegen(SystemCAttributes.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(CIRCTSystemCAttributesIncGen)
 add_dependencies(circt-headers CIRCTSystemCAttributesIncGen)

--- a/include/circt/Dialect/SystemC/SystemC.td
+++ b/include/circt/Dialect/SystemC/SystemC.td
@@ -15,7 +15,11 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/FunctionInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 include "circt/Dialect/SystemC/SystemCDialect.td"
@@ -24,6 +28,7 @@ include "circt/Dialect/SystemC/SystemCDialect.td"
 class SystemCOp<string mnemonic, list<Trait> traits = []> :
   Op<SystemCDialect, mnemonic, traits>;
 
+include "circt/Dialect/SystemC/SystemCAttributesImpl.td"
 include "circt/Dialect/SystemC/SystemCTypesImpl.td"
 include "circt/Dialect/SystemC/SystemCTypes.td"
 include "circt/Dialect/SystemC/SystemCExpressions.td"

--- a/include/circt/Dialect/SystemC/SystemCAttributes.h
+++ b/include/circt/Dialect/SystemC/SystemCAttributes.h
@@ -1,0 +1,26 @@
+//===- SystemCAttributes.h - Declare SystemC dialect attributes --*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the attributes for the SystemC dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SYSTEMC_SYSTEMCATTRIBUTES_H
+#define CIRCT_DIALECT_SYSTEMC_SYSTEMCATTRIBUTES_H
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/APInt.h"
+
+// Include generated attributes.
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SystemC/SystemCEnums.h.inc"
+// do not reorder
+#include "circt/Dialect/SystemC/SystemCAttributes.h.inc"
+
+#endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCATTRIBUTES_H

--- a/include/circt/Dialect/SystemC/SystemCAttributesImpl.td
+++ b/include/circt/Dialect/SystemC/SystemCAttributesImpl.td
@@ -1,0 +1,73 @@
+//===- SystemCAttributesImpl.td - SystemC attribute defs ---*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Attribute definitions for the SystemC dialect.
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/EnumAttr.td"
+
+class SystemCAttrDef<string name> : AttrDef<SystemCDialect, name> { }
+
+//===----------------------------------------------------------------------===//
+// Port direction utilities
+//===----------------------------------------------------------------------===//
+
+def PortDirectionInput  : I32EnumAttrCase<"Input", 0, "sc_in">;
+def PortDirectionOutput : I32EnumAttrCase<"Output", 1, "sc_out">;
+def PortDirectionInOut  : I32EnumAttrCase<"InOut", 2, "sc_inout">;
+let cppNamespace = "circt::systemc" in
+let genSpecializedAttr = 0 in
+def PortDirection : I32EnumAttr<
+  "PortDirection",
+  "systemc.module port direction",
+  [PortDirectionInput, PortDirectionOutput, PortDirectionInOut]>;
+
+
+def PortDirectionsAttr : SystemCAttrDef<"PortDirections"> {
+  let summary = "Port directions attribute";
+  let description = [{
+  }];
+
+  let mnemonic = "port_directions";
+  let parameters = (ins "::mlir::IntegerAttr":$storage);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins
+                                   "::mlir::IntegerAttr":$storage), [{
+      return Base::get(storage.getContext(), storage);
+    }]>,
+    AttrBuilder<(ins "llvm::APInt":$storage), [{
+      return Base::get($_ctxt,
+                       IntegerAttr::get(
+                         IntegerType::get($_ctxt, storage.getBitWidth()),
+                       storage));
+    }]>,
+    AttrBuilder<(ins "llvm::ArrayRef<PortDirection>":$directions)>,
+  ];
+
+  let hasCustomAssemblyFormat = true;
+
+  let extraClassDeclaration = [{
+    bool isInput(unsigned idx) const {
+      return getDirection(idx) == PortDirection::Input;
+    }
+    bool isOutput(unsigned idx) const {
+      return getDirection(idx) == PortDirection::Output;
+    }
+    bool isInOut(unsigned idx) const {
+      return getDirection(idx) == PortDirection::InOut;
+    }
+    PortDirection getDirection(unsigned index) const;
+
+    void getPortDirections(llvm::SmallVectorImpl<PortDirection> &directions) const;
+    size_t getNumPorts() const {
+      return getStorage().getValue().getBitWidth() >> 1;
+    }
+  }];
+}

--- a/include/circt/Dialect/SystemC/SystemCAttributesImpl.td
+++ b/include/circt/Dialect/SystemC/SystemCAttributesImpl.td
@@ -32,6 +32,7 @@ def PortDirection : I32EnumAttr<
 def PortDirectionsAttr : SystemCAttrDef<"PortDirections"> {
   let summary = "Port directions attribute";
   let description = [{
+    An attribute to store an array of PortDirection.
   }];
 
   let mnemonic = "port_directions";

--- a/include/circt/Dialect/SystemC/SystemCDialect.td
+++ b/include/circt/Dialect/SystemC/SystemCDialect.td
@@ -15,18 +15,24 @@
 
 def SystemCDialect : Dialect {
   let name = "systemc";
+  let cppNamespace = "::circt::systemc";
 
   let summary = "Types and operations for the SystemC dialect";
   let description = [{
     This dialect defines the `systemc` dialect, which represents various
     constructs of the SystemC library (IEEE 1666-2011) useful for emission.
   }];
-  let cppNamespace = "::circt::systemc";
+
   let extraClassDeclaration = [{
+    /// Register all SystemC attributes.
+    void registerAttributes();
     /// Register all SystemC types.
     void registerTypes();
   }];
-  int emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
+
+  let useDefaultAttributePrinterParser = 1;
+
+  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }
 
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCDIALECT

--- a/include/circt/Dialect/SystemC/SystemCOps.h
+++ b/include/circt/Dialect/SystemC/SystemCOps.h
@@ -13,13 +13,15 @@
 #ifndef CIRCT_DIALECT_SYSTEMC_SYSTEMCOPS_H
 #define CIRCT_DIALECT_SYSTEMC_SYSTEMCOPS_H
 
+#include "circt/Dialect/SystemC/SystemCAttributes.h"
 #include "circt/Dialect/SystemC/SystemCDialect.h"
 #include "circt/Dialect/SystemC/SystemCTypes.h"
-#include "mlir/IR/OpImplementation.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 
 #define GET_OP_CLASSES
-#include "circt/Dialect/SystemC/SystemCEnums.h.inc"
-// Clang format shouldn't reorder these headers.
 #include "circt/Dialect/SystemC/SystemC.h.inc"
 
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCOPS_H

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -10,3 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+def AliasOp : SystemCOp<"alias", [SameTypeOperands]> {
+  let summary = "Declare two SSA values equivalent.";
+  let description = [{
+    This operation does not model a specific construct in the SystemC spec, but
+    is required to 'connect' an SSA value to a module output SSA value. It can,
+    however, also be used to declare any two SSA values to be aliases which
+    means that ExportSystemC will generate at most one variable name for all
+    SSA values in the alias set.
+  }];
+
+  let arguments = (ins AnyType:$lhs, AnyType:$rhs);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
+}

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -38,7 +38,9 @@ def SCModuleOp : SystemCOp<"module", [
 
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
-    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
+    static RegionKind getRegionKind(unsigned index) { 
+      return RegionKind::Graph;
+    }
 
     /// Returns the type of this function.
     mlir::FunctionType getFunctionType() {

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -11,8 +11,72 @@
 //
 //===----------------------------------------------------------------------===//
 
+def SCModuleOp : SystemCOp<"module", [
+    Symbol,
+    FunctionOpInterface,
+    IsolatedFromAbove,
+    SingleBlock,
+    NoTerminator,
+    RegionKindInterface,
+    DeclareOpInterfaceMethods<CallableOpInterface>,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
+    HasParent<"mlir::ModuleOp">
+  ]> {
+  let summary = "Define a SystemC SC_MODULE.";
+  let description = [{
+    Represents the SC_MODULE macro as described in IEEE 1666-2011 §5.2.5.
+    Models input, output and inout ports as module arguments (as opposed to
+    `sc_signal`s which are modeled by a separate `systemc.signal` operation),
+    but are nonetheless emitted as regular struct fields.
+  }];
 
-def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator]> {
+  let arguments = (ins PortDirectionsAttr:$portDirections, StrArrayAttr:$portNames);
+  let regions = (region SizedRegion<1>: $body);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
+
+    /// Returns the type of this function.
+    mlir::FunctionType getFunctionType() {
+      return getFunctionTypeAttr().getValue().cast<mlir::FunctionType>();
+    }
+
+    /// Returns the argument types of this function.
+    ArrayRef<mlir::Type> getArgumentTypes() {
+      return getFunctionType().getInputs();
+    }
+
+    /// Returns the result types of this function.
+    ArrayRef<mlir::Type> getResultTypes() {
+      return getFunctionType().getResults();
+    }
+
+    // Use FunctionOpInterface traits's getBody method.
+    using mlir::detail::FunctionOpInterfaceTrait<SCModuleOp>::getBody;
+
+    /// Return the block corresponding to the region.
+    Block *getBodyBlock() { return &getBody().front(); }
+
+    void getPortsOfDirection(PortDirection direction,
+                             llvm::SmallVector<Value> &values);
+    void getInputs(llvm::SmallVector<Value> &inputs) {
+      getPortsOfDirection(PortDirection::Input, inputs);
+    }
+    void getOutputs(llvm::SmallVector<Value> &outputs) {
+      getPortsOfDirection(PortDirection::Output, outputs);
+    }
+    void getInOuts(llvm::SmallVector<Value> &inouts) {
+      getPortsOfDirection(PortDirection::InOut, inouts);
+    }
+  }];
+}
+
+def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator,
+                                HasParent<"SCModuleOp">]> {
   let summary = "A constructor definition.";
   let description = [{
     Represents the SC_CTOR macro as described in IEEE 1666-2011 §5.2.7.

--- a/lib/Conversion/HWToSystemC/CMakeLists.txt
+++ b/lib/Conversion/HWToSystemC/CMakeLists.txt
@@ -10,5 +10,6 @@ add_circt_conversion_library(CIRCTHWToSystemC
   LINK_LIBS PUBLIC
   CIRCTSystemC
   CIRCTHW
+  CIRCTComb
   MLIRTransforms
 )

--- a/lib/Conversion/HWToSystemC/HWToSystemC.cpp
+++ b/lib/Conversion/HWToSystemC/HWToSystemC.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Conversion/HWToSystemC.h"
 #include "../PassDetail.h"
+#include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SystemC/SystemCOps.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -21,6 +22,112 @@
 using namespace mlir;
 using namespace circt;
 using namespace hw;
+using namespace systemc;
+
+//===----------------------------------------------------------------------===//
+// Operation Conversion Patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// This works on each HW module, creates corresponding SystemC modules, moves
+/// the body of the module into the new SystemC module by splitting up the body
+/// into field declarations, initializations done in a newly added systemc.ctor,
+/// and internal methods to be registered in the constructor.
+struct ConvertHWModule : public OpConversionPattern<HWModuleOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(HWModuleOp module, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Collect the HW module's port types.
+    FunctionType moduleType = module.getFunctionType();
+    TypeRange moduleInputs = moduleType.getInputs();
+    TypeRange moduleOutputs = moduleType.getResults();
+
+    // SystemC module port types are all expressed as block arguments to the op,
+    // so collect all of the types and add them as arguments to the SystemC
+    // module.
+    SmallVector<Type, 4> portTypes(moduleInputs);
+    portTypes.append(moduleOutputs.begin(), moduleOutputs.end());
+
+    // Collect all the port directions.
+    SmallVector<systemc::PortDirection> directions;
+    for (auto port : module.getAllPorts()) {
+      if (port.isInput())
+        directions.push_back(systemc::PortDirection::Input);
+      else if (port.isOutput())
+        directions.push_back(systemc::PortDirection::Output);
+      else
+        directions.push_back(systemc::PortDirection::InOut);
+    }
+    PortDirectionsAttr portDirections =
+        PortDirectionsAttr::get(rewriter.getContext(), directions);
+
+    // Collect all the port names (inputs and outputs).
+    SmallVector<Attribute> portNames;
+    ArrayRef<Attribute> args = module.getArgNames().getValue();
+    ArrayRef<Attribute> results = module.getResultNames().getValue();
+    portNames.append(args.begin(), args.end());
+    portNames.append(results.begin(), results.end());
+
+    // Create the SystemC module. Note that no parameterized modules are
+    // supported yet.
+    auto scModule = rewriter.create<SCModuleOp>(
+        module.getLoc(), portDirections,
+        ArrayAttr::get(rewriter.getContext(), portNames));
+
+    // Inline the HW module body into the SystemC module body.
+    Region &scModuleBodyRegion = scModule.getBodyRegion();
+    rewriter.inlineRegionBefore(module.getBodyRegion(), scModuleBodyRegion,
+                                scModuleBodyRegion.end());
+
+    // Set the SCModule type and name attributes. Add block arguments for each
+    // output.
+    auto scModuleType = rewriter.getFunctionType(portTypes, {});
+    rewriter.updateRootInPlace(scModule, [&] {
+      scModule->setAttr(scModule.getTypeAttrName(),
+                        TypeAttr::get(scModuleType));
+      scModule.setName(module.getName());
+      scModuleBodyRegion.addArguments(
+          moduleOutputs, SmallVector<Location, 4>(moduleOutputs.size(),
+                                                  rewriter.getUnknownLoc()));
+    });
+
+    // Erase the HW module.
+    rewriter.eraseOp(module);
+
+    return success();
+  }
+};
+
+/// Convert output operations to alias operations connecting the result SSA
+/// values to the output block arguments.
+struct ConvertOutput : public OpConversionPattern<OutputOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OutputOp outputOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    SmallVector<Value> moduleOutputs;
+    if (auto scModule = dyn_cast<SCModuleOp>(outputOp->getParentOp())) {
+      scModule.getOutputs(moduleOutputs);
+      for (auto args : llvm::zip(moduleOutputs, outputOp.getOperands())) {
+        rewriter.create<AliasOp>(outputOp->getLoc(), std::get<0>(args),
+                                 std::get<1>(args));
+      }
+
+      // Erase the HW OutputOp.
+      rewriter.eraseOp(outputOp);
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Conversion Infrastructure
@@ -30,6 +137,11 @@ static void populateLegality(ConversionTarget &target) {
   target.addIllegalDialect<HWDialect>();
   target.addLegalDialect<mlir::BuiltinDialect>();
   target.addLegalDialect<systemc::SystemCDialect>();
+  target.addLegalDialect<comb::CombDialect>();
+}
+
+static void populateOpConversion(RewritePatternSet &patterns) {
+  patterns.add<ConvertHWModule, ConvertOutput>(patterns.getContext());
 }
 
 //===----------------------------------------------------------------------===//
@@ -56,6 +168,7 @@ void HWToSystemCPass::runOnOperation() {
   TypeConverter typeConverter;
   RewritePatternSet patterns(&context);
   populateLegality(target);
+  populateOpConversion(patterns);
 
   if (failed(applyFullConversion(module, target, std::move(patterns))))
     signalPassFailure();

--- a/lib/Dialect/SystemC/CMakeLists.txt
+++ b/lib/Dialect/SystemC/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTSystemC
+  SystemCAttributes.cpp
   SystemCDialect.cpp
   SystemCTypes.cpp
   SystemCOps.cpp

--- a/lib/Dialect/SystemC/SystemCAttributes.cpp
+++ b/lib/Dialect/SystemC/SystemCAttributes.cpp
@@ -1,0 +1,108 @@
+//===- SystemCAttributes.cpp - SystemC attribute code defs ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation for SystemC attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/SystemC/SystemCAttributes.h"
+#include "circt/Dialect/SystemC/SystemCDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt::systemc;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// PortDirectionsAttr
+//===----------------------------------------------------------------------===//
+
+PortDirection PortDirectionsAttr::getDirection(unsigned idx) const {
+  return symbolizePortDirection(
+             getStorage().getValue().extractBitsAsZExtValue(2, 2 * idx))
+      .value();
+}
+
+void PortDirectionsAttr::getPortDirections(
+    SmallVectorImpl<PortDirection> &directions) const {
+  for (unsigned i = 0, e = getStorage().getValue().getBitWidth() >> 1; i < e;
+       ++i) {
+    directions.push_back(getDirection(i));
+  }
+}
+
+PortDirectionsAttr PortDirectionsAttr::get(MLIRContext *context,
+                                           ArrayRef<PortDirection> directions) {
+  APInt storage(2 * directions.size(), 0);
+  for (size_t i = 0; i < directions.size(); ++i) {
+    storage.insertBits(APInt(2, static_cast<uint32_t>(directions[i])), 2 * i);
+  }
+  return get(context, storage);
+}
+
+Attribute PortDirectionsAttr::parse(AsmParser &p, Type odsType) {
+  if (p.parseLess())
+    return {};
+
+  SmallVector<PortDirection> directions;
+
+  auto parsePortDirection = [&]() -> ParseResult {
+    if (succeeded(p.parseOptionalKeyword(
+            stringifyPortDirection(PortDirection::InOut)))) {
+      directions.push_back(PortDirection::InOut);
+      return success();
+    }
+    if (succeeded(p.parseOptionalKeyword(
+            stringifyPortDirection(PortDirection::Input)))) {
+      directions.push_back(PortDirection::Input);
+      return success();
+    }
+    if (succeeded(p.parseOptionalKeyword(
+            stringifyPortDirection(PortDirection::Output)))) {
+      directions.push_back(PortDirection::Output);
+      return success();
+    }
+    return failure();
+  };
+
+  if (p.parseCommaSeparatedList(OpAsmParser::Delimiter::Square,
+                                parsePortDirection))
+    return {};
+
+  if (p.parseGreater())
+    return {};
+
+  return PortDirectionsAttr::get(p.getContext(), directions);
+}
+
+void PortDirectionsAttr::print(AsmPrinter &p) const {
+  p << "<[";
+  for (size_t i = 0, e = getNumPorts(); i < e; ++i) {
+    if (i > 0)
+      p << ", ";
+
+    p << stringifyPortDirection(getDirection(i));
+  }
+  p << "]>";
+}
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SystemC/SystemCAttributes.cpp.inc"
+#include "circt/Dialect/SystemC/SystemCEnums.cpp.inc"
+
+void SystemCDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/SystemC/SystemCAttributes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/SystemC/SystemCDialect.cpp
+++ b/lib/Dialect/SystemC/SystemCDialect.cpp
@@ -21,6 +21,7 @@ using namespace circt::systemc;
 
 void SystemCDialect::initialize() {
   // Register types.
+  registerAttributes();
   registerTypes();
 
   // Register operations.

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -17,10 +17,166 @@ using namespace circt;
 using namespace circt::systemc;
 
 //===----------------------------------------------------------------------===//
+// SCModuleOp
+//===----------------------------------------------------------------------===//
+
+void SCModuleOp::getPortsOfDirection(PortDirection direction,
+                                     SmallVector<Value> &outputs) {
+  for (int i = 0, e = getNumArguments(); i < e; ++i) {
+    if (getPortDirections().getDirection(i) == direction)
+      outputs.push_back(getArgument(i));
+  }
+}
+
+mlir::Region *SCModuleOp::getCallableRegion() { return &getBody(); }
+
+ArrayRef<mlir::Type> SCModuleOp::getCallableResults() {
+  return getResultTypes();
+}
+
+/// Parse an argument list of a systemc.module operation.
+static ParseResult parseArgumentList(
+    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::Argument> &args,
+    SmallVectorImpl<Type> &argTypes, SmallVectorImpl<Attribute> &argNames,
+    SmallVectorImpl<PortDirection> &argDirection) {
+  auto parseElt = [&]() -> ParseResult {
+    // Parse port direction.
+    PortDirection dir = PortDirection::Input;
+    if (succeeded(parser.parseOptionalKeyword(
+            stringifyPortDirection(PortDirection::InOut))))
+      dir = PortDirection::InOut;
+    else if (succeeded(parser.parseOptionalKeyword(
+                 stringifyPortDirection(PortDirection::Output))))
+      dir = PortDirection::Output;
+    else if (failed(parser.parseKeyword(
+                 stringifyPortDirection(PortDirection::Input),
+                 ", 'sc_out', or 'sc_inout'")))
+      return failure();
+
+    OpAsmParser::Argument argument;
+    auto optArg = parser.parseOptionalArgument(argument);
+    if (optArg.hasValue()) {
+      if (succeeded(optArg.getValue())) {
+        Type argType;
+        if (!argument.ssaName.name.empty() &&
+            succeeded(parser.parseColonType(argType))) {
+          args.push_back(argument);
+          argTypes.push_back(argType);
+          args.back().type = argType;
+          argDirection.push_back(dir);
+          argNames.push_back(StringAttr::get(
+              parser.getContext(), argument.ssaName.name.drop_front()));
+        }
+      }
+    }
+    return success();
+  };
+
+  return parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren,
+                                        parseElt);
+}
+
+ParseResult SCModuleOp::parse(OpAsmParser &parser, OperationState &result) {
+  StringAttr entityName;
+  SmallVector<OpAsmParser::Argument, 4> args;
+  SmallVector<Type, 4> argTypes;
+  SmallVector<Attribute> argNames;
+  SmallVector<PortDirection> argDirection;
+
+  if (parser.parseSymbolName(entityName, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  if (failed(parseArgumentList(parser, args, argTypes, argNames, argDirection)))
+    return failure();
+
+  result.addAttribute("portDirections", PortDirectionsAttr::get(
+                                            parser.getContext(), argDirection));
+  result.addAttribute("portNames",
+                      ArrayAttr::get(parser.getContext(), argNames));
+
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
+    return failure();
+
+  auto type = parser.getBuilder().getFunctionType(argTypes, llvm::None);
+  result.addAttribute(SCModuleOp::getTypeAttrName(), TypeAttr::get(type));
+
+  auto &body = *result.addRegion();
+  if (parser.parseRegion(body, args))
+    return failure();
+  if (body.empty())
+    body.push_back(std::make_unique<Block>().release());
+
+  return success();
+}
+
+static void printArgumentList(OpAsmPrinter &printer,
+                              ArrayRef<BlockArgument> args,
+                              ArrayRef<PortDirection> directions) {
+  printer << "(";
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i > 0)
+      printer << ", ";
+    printer << stringifyPortDirection(directions[i]) << " " << args[i] << ": "
+            << args[i].getType();
+  }
+  printer << ")";
+}
+
+void SCModuleOp::print(OpAsmPrinter &printer) {
+  auto moduleName =
+      (*this)
+          ->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
+  printer << " ";
+  printer.printSymbolName(moduleName);
+  printer << " ";
+  SmallVector<PortDirection> directions;
+  getPortDirections().getPortDirections(directions);
+  printArgumentList(printer, getArguments(), directions);
+  printer.printOptionalAttrDictWithKeyword(
+      (*this)->getAttrs(),
+      /*elidedAttrs =*/{SymbolTable::getSymbolAttrName(),
+                        SCModuleOp::getTypeAttrName(), "portNames",
+                        "portDirections"});
+  printer << " ";
+  printer.printRegion(getBody(), false, false);
+}
+
+void SCModuleOp::getAsmBlockArgumentNames(mlir::Region &region,
+                                          mlir::OpAsmSetValueNameFn setNameFn) {
+  if (region.empty())
+    return;
+
+  ArrayAttr portNames = getPortNames();
+  for (size_t i = 0, e = getNumArguments(); i != e; ++i) {
+    auto str = portNames[i].cast<StringAttr>().getValue();
+    setNameFn(getArgument(i), str);
+  }
+}
+
+LogicalResult SCModuleOp::verify() {
+  if (getFunctionType().getNumResults() != 0)
+    return emitOpError(
+        "incorrect number of function results (always has to be 0)");
+  if (getPortNames().size() != getFunctionType().getNumInputs())
+    return emitOpError("incorrect number of port names");
+  if (getPortDirections().getNumPorts() != getFunctionType().getNumInputs())
+    return emitOpError("incorrect number of port directions");
+
+  ArrayAttr portNames = getPortNames();
+  for (auto *iter = portNames.begin(); iter != portNames.end(); ++iter) {
+    if (iter->cast<StringAttr>().getValue().empty())
+      return emitOpError("port name must not be empty");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 
 // Provide the autogenerated implementation guts for the Op classes.
 #define GET_OP_CLASSES
 #include "circt/Dialect/SystemC/SystemC.cpp.inc"
-#include "circt/Dialect/SystemC/SystemCEnums.cpp.inc"

--- a/test/Conversion/HWToSystemC/errors.mlir
+++ b/test/Conversion/HWToSystemC/errors.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt --convert-hw-to-systemc --verify-diagnostics --split-input-file %s
+
+// expected-error @+2 {{module parameters not supported yet}}
+// expected-error @+1 {{failed to legalize operation 'hw.module'}}
+hw.module @someModule<p1: i42 = 17, p2: i1>() -> () {}
+
+// -----
+
+// expected-error @+2 {{inout arguments not supported yet}}
+// expected-error @+1 {{failed to legalize operation 'hw.module'}}
+hw.module @someModule(%in0: !hw.inout<i32>) -> () {}

--- a/test/Conversion/HWToSystemC/structure.mlir
+++ b/test/Conversion/HWToSystemC/structure.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --convert-hw-to-systemc --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: systemc.module @adder (sc_in %a: i32, sc_in %b: i32, sc_out %sum: i32)
+hw.module @adder (%a: i32, %b: i32) -> (sum: i32) {
+    // CHECK-NEXT: [[RES:%.*]] = comb.add
+    %0 = comb.add %a, %b : i32
+    // CHECK-NEXT: systemc.alias %sum, [[RES]] : i32
+    hw.output %0 : i32
+}

--- a/test/Dialect/SystemC/module-attributes.mlir
+++ b/test/Dialect/SystemC/module-attributes.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-opt %s --mlir-print-op-generic | circt-opt --mlir-print-op-generic | FileCheck %s
+
+// CHECK-LABEL: "systemc.module"
+// CHECK: ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+// CHECK: function_type = (i4, i32, i4, i8) -> (),
+// CHECK: portDirections = #systemc.port_directions<[sc_out, sc_in, sc_out, sc_inout]>,
+// CHECK: portNames = ["port0", "port1", "port2", "port3"],
+systemc.module @mixedPorts (sc_out %port0: i4, sc_in %port1: i32, sc_out %port2: i4, sc_inout %port3: i8) {}

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+// expected-error @+1 {{entry block must have 3 arguments to match function signature}}
+"systemc.module"() ({
+  ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+  }) {function_type = (i4, i32, i4) -> (), portDirections = #systemc.port_directions<[sc_out, sc_in, sc_out, sc_inout]>, portNames = ["port0", "port1", "port2", "port3"], sym_name = "verifierTest"} : () -> ()
+
+// -----
+
+// expected-error @+1 {{incorrect number of port directions}}
+"systemc.module"() ({
+  ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+  }) {function_type = (i4, i32, i4, i8) -> (), portDirections = #systemc.port_directions<[sc_in, sc_out, sc_inout]>, portNames = ["port0", "port1", "port2", "port3"], sym_name = "verifierTest"} : () -> ()
+
+// -----
+
+// expected-error @+1 {{incorrect number of port names}}
+"systemc.module"() ({
+  ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+  }) {function_type = (i4, i32, i4, i8) -> (), portDirections = #systemc.port_directions<[sc_out, sc_in, sc_out, sc_inout]>, portNames = ["port0", "port1", "port2"], sym_name = "verifierTest"} : () -> ()
+
+// -----
+
+// expected-error @+1 {{incorrect number of function results (always has to be 0)}}
+"systemc.module"() ({
+  ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+  }) {function_type = (i4, i32, i4, i8) -> (i1), portDirections = #systemc.port_directions<[sc_out, sc_in, sc_out, sc_inout]>, portNames = ["port0", "port1", "port2", "port3"], sym_name = "verifierTest"} : () -> ()
+
+// -----
+
+// expected-error @+1 {{port name must not be empty}}
+"systemc.module"() ({
+  ^bb0(%arg0: i4, %arg1: i32, %arg2: i4, %arg3: i8):
+  }) {function_type = (i4, i32, i4, i8) -> (), portDirections = #systemc.port_directions<[sc_out, sc_in, sc_out, sc_inout]>, portNames = ["port0", "port1", "port2", ""], sym_name = "verifierTest"} : () -> ()
+
+// -----
+
+// expected-error @+1 {{expected 'sc_in', 'sc_out', or 'sc_inout'}}
+systemc.module @parserTest (sc_invalid %arg: i32) { }

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -1,9 +1,17 @@
 // RUN: circt-opt %s | FileCheck %s
 
-// CHECK-LABEL: @ctor
-hw.module @ctor () {
+// CHECK: systemc.module @adder (sc_in %summand_a: i32, sc_in %summand_b: i32, sc_out %sum: i32) {
+systemc.module @adder (sc_in %summand_a: i32, sc_in %summand_b: i32, sc_out %sum: i32) {
   //CHECK-NEXT: systemc.ctor {
   systemc.ctor {
   //CHECK-NEXT: }
   }
+  // CHECK-NEXT: [[RES:%.*]] = comb.add %summand_a, %summand_b : i32
+  %res = comb.add %summand_a, %summand_b : i32
+  // CHECK-NEXT: systemc.alias %sum, [[RES]] : i32
+  systemc.alias %sum, %res : i32
+// CHECK-NEXT: }
 }
+
+// CHECK: systemc.module @mixedPorts (sc_out %port0: i4, sc_in %port1: i32, sc_out %port2: i4, sc_inout %port3: i8)
+systemc.module @mixedPorts (sc_out %port0: i4, sc_in %port1: i32, sc_out %port2: i4, sc_inout %port3: i8) {}


### PR DESCRIPTION
Includes the `systemc.module` and `systemc.alias` operation definitions as well as a basic lowering from HW. The lowering will be extended in another PR once other necessary operations such as `systemc.func` and `systemc.method` are added.