### PR TITLE
Bump LLVM to top-of-tree

### DIFF
--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -224,6 +224,12 @@ void InnerRefAttr::print(AsmPrinter &p) const {
   p << ">";
 }
 
+Attribute
+InnerRefAttr::replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
+                                          ArrayRef<Type> replTypes) const {
+  return get(replAttrs[0].cast<StringAttr>(), replAttrs[1].cast<StringAttr>());
+}
+
 //===----------------------------------------------------------------------===//
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
There were no changes necessary for CIRCT.

This will be updated daily and, on Friday, converted to a non-draft and merged.