### PR TITLE
[SSP] Define first batch of operations.

### DIFF
--- a/docs/Dialects/SSP/RationaleSSP.md
+++ b/docs/Dialects/SSP/RationaleSSP.md
@@ -121,3 +121,17 @@ problem instances?
 
   No, you're right. However, the SSP dialect uses the same terminology as the
   scheduling infrastructure, so any changes would have to originate there.
+
+## Rationale for selected design points
+
+### Use of container-like operations instead of regions in `InstanceOp`
+
+This dialect defines the `OperatorLibraryOp` and `DependenceGraphOp` to
+serve exclusively as the first and second operation in an `InstanceOp`'s region. 
+The alternative of using two regions on the `InstanceOp` is not applicable,
+because the `InstanceOp` then needs to provide a symbol table, but the upstream
+`SymbolTable` trait enforces single-region ops. Lastly, we also considered using
+a single graph region to hold both `OperatorTypeOp`s and `OperationOp`s, but
+discarded that design because it cannot be safely roundtripped via a
+`circt::scheduling::Problem` (internally, registered operator types and
+operations are separate lists).

--- a/include/circt/Dialect/SSP/SSP.td
+++ b/include/circt/Dialect/SSP/SSP.td
@@ -31,7 +31,7 @@ def SSPDialect : Dialect {
   let cppNamespace = "::circt::ssp";
   let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 
-  let useDefaultAttributePrinterParser = 0;
+  let useDefaultAttributePrinterParser = true;
   let extraClassDeclaration = [{
     /// Register all SSP attributes.
     void registerAttributes();

--- a/include/circt/Dialect/SSP/SSPAttributes.h
+++ b/include/circt/Dialect/SSP/SSPAttributes.h
@@ -26,7 +26,7 @@ namespace ssp {
 
 /// Parse an array of attributes while recognizing the properties of the SSP
 /// dialect even without a `#ssp.` prefix. Any attributes supplied in \p
-/// alreadParsed are prepended to the parsed ones.
+/// alreadyParsed are prepended to the parsed ones.
 mlir::OptionalParseResult
 parseOptionalPropertyArray(ArrayAttr &attr, AsmParser &parser,
                            ArrayRef<Attribute> alreadyParsed = {});

--- a/include/circt/Dialect/SSP/SSPAttributes.h
+++ b/include/circt/Dialect/SSP/SSPAttributes.h
@@ -14,10 +14,30 @@
 #define CIRCT_DIALECT_SSP_SSPATTRIBUTES_H
 
 #include "circt/Dialect/SSP/SSPDialect.h"
+#include "circt/Support/LLVM.h"
 
 #include "mlir/IR/OpImplementation.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/SSP/SSPAttributes.h.inc"
+
+namespace circt {
+namespace ssp {
+
+/// Parse an array of attributes while recognizing the properties of the SSP
+/// dialect even without a `#ssp.` prefix. Any attributes supplied in \p
+/// alreadParsed are prepended to the parsed ones.
+mlir::OptionalParseResult
+parseOptionalPropertyArray(ArrayAttr &attr, AsmParser &parser,
+                           ArrayRef<Attribute> alreadyParsed = {});
+
+/// Print an array attribute, suppressing the `#ssp.` prefix for properties
+/// defined in the SSP dialect. Attributes mentioned in \p alreadyPrinted are
+/// skipped.
+void printPropertyArray(ArrayAttr attr, AsmPrinter &p,
+                        ArrayRef<Attribute> alreadyPrinted = {});
+
+} // namespace ssp
+} // namespace circt
 
 #endif // CIRCT_DIALECT_SSP_SSPATTRIBUTES_H

--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -9,3 +9,12 @@
 // This file defines the SSP (static scheduling problem) dialect attributes.
 //
 //===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Dialect attributes
+//===----------------------------------------------------------------------===//
+
+def DummyAttr : AttrDef<SSPDialect, "Dummy"> {
+  let summary = "Trigger generation of dialect attribute parser & printer.";
+  let mnemonic = "dummy";
+}

--- a/include/circt/Dialect/SSP/SSPOps.h
+++ b/include/circt/Dialect/SSP/SSPOps.h
@@ -16,6 +16,8 @@
 #include "circt/Dialect/SSP/SSPDialect.h"
 
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/RegionKindInterface.h"
+#include "mlir/IR/SymbolTable.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/SSP/SSP.h.inc"

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -10,7 +10,138 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
+
 class SSPOp<string mnemonic, list<Trait> traits = []> :
   Op<SSPDialect, mnemonic, traits>;
 
-def DummyOp : SSPOp<"dummy">;
+def InstanceOp : SSPOp<"instance",
+    [NoRegionArguments, SingleBlock, NoTerminator,
+     IsolatedFromAbove, OpAsmOpInterface]> {
+  let summary = "Instance of a static scheduling problem.";
+  let description = [{
+    This operation represents an instance of a static scheduling problem,
+    comprised of an operator library (`OperatorLibraryOp`, a container for
+    `OperatorTypeOp`s) and the dependence graph (`DependenceGraphOp`, a
+    container for `OperationOp`s). The instance and its components (operations,
+    operator types and dependences) can carry properties, i.e. special MLIR
+    attributes inheriting from the TableGen classes in `PropertyBase.td`. The
+    `ssp` dialect provides attribute definitions (and short-form
+    pretty-printing) for CIRCT's built-in scheduling problems.
+    
+    **Example**
+    ```mlir
+    ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
+      library {
+        operator_type @MemPort [latency<1>, limit<1>]
+        operator_type @Add [latency<1>]
+      }
+      graph {
+        %0 = operation<@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
+        %1 = operation<@MemPort> @load_B() [t<0>]
+        %2 = operation<@Add> @add(%0, %1) [t<3>]
+        operation<@MemPort> @store_A(%2) [t<4>]
+      }
+    }
+    ```
+  }];
+
+  let arguments = (ins StrAttr:$instanceName, StrAttr:$problemName,
+                       OptionalAttr<ArrayAttr>:$properties);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $instanceName `of` $problemName custom<Properties>($properties) $body attr-dict
+  }];
+  
+  let hasVerifier = true;
+
+  let extraClassDeclaration = [{
+    // OpAsmOpInterface
+    static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
+
+    // Convenience
+    ::mlir::Block *getBodyBlock() {
+      return &getBody().getBlocks().front();
+    }
+
+    // Access to container ops
+    ::circt::ssp::OperatorLibraryOp getOperatorLibrary();
+    ::circt::ssp::DependenceGraphOp getDependenceGraph();
+  }];
+
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins "::mlir::StringAttr":$instanceName,
+                   "::mlir::StringAttr":$problemName,
+                   CArg<"::mlir::ArrayAttr", "::mlir::ArrayAttr()">:$properties), [{
+      $_state.addAttribute($_builder.getStringAttr("instanceName"), instanceName);
+      $_state.addAttribute($_builder.getStringAttr("problemName"), problemName);
+      if (properties)
+        $_state.addAttribute($_builder.getStringAttr("properties"), properties);
+      ::mlir::Region* region = $_state.addRegion();
+      region->push_back(new ::mlir::Block());
+    }]>
+  ];
+}
+
+class ContainerOp<string mnemonic, list<Trait> traits = []>
+    : SSPOp<mnemonic, traits # [NoRegionArguments, SingleBlock, NoTerminator,
+     SymbolTable, OpAsmOpInterface, HasParent<"InstanceOp">]> {
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "$body attr-dict";
+
+  let extraClassDeclaration = [{
+    // OpAsmOpInterface
+    static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
+
+    // Convenience
+    ::mlir::Block *getBodyBlock() {
+      return &getBody().getBlocks().front();
+    }
+  }];
+
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins ), [{
+      ::mlir::Region* region = $_state.addRegion();
+      region->push_back(new ::mlir::Block());
+    }]>
+  ];
+}
+
+def OperatorLibraryOp : ContainerOp<"library"> {
+  let summary = "Container for operator types.";
+  let description = [{
+    The operator library abstracts the characteristics of the target
+    architecture/IR (onto which the source graph is scheduled), represented by
+    the individual `OperatorTypeOp`s.
+  }];
+}
+
+def DependenceGraphOp : ContainerOp<"graph",
+    [RegionKindInterface, HasOnlyGraphRegion]> {
+  let summary = "Container for (scheduling) operations.";
+  let description = [{
+    The dependence graph is spanned by `OperationOp`s (vertices) and a
+    combination of MLIR value uses and symbol references (edges).
+  }];
+}
+
+def OperatorTypeOp : SSPOp<"operator_type",
+    [Symbol, HasParent<"OperatorLibraryOp">]> {
+  let summary = "Element of the target architecture/IR.";
+  let description = [{
+    This operation represents an operator type, which can be augmented with a
+    set of problem-specific properties, and is identified through a unique name.
+
+    **Example**
+    ```mlir
+    operator_type @MemPort [latency<1>, limit<1>]
+    ```
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name, OptionalAttr<ArrayAttr>:$properties);
+  let assemblyFormat = "$sym_name custom<Properties>($properties) attr-dict";
+}

--- a/lib/Dialect/SSP/SSPAttributes.cpp
+++ b/lib/Dialect/SSP/SSPAttributes.cpp
@@ -66,10 +66,11 @@ ssp::parseOptionalPropertyArray(ArrayAttr &attr, AsmParser &parser,
     auto parseShortformAttrResult =
         generatedAttributeParser(parser, &mnemonic, Type(), elem);
 
-    if (!parseShortformAttrResult.hasValue())
+    if (!parseShortformAttrResult.hasValue()) {
       return parser.emitError(parser.getCurrentLocation(),
                               "carries unknown shortform property: ")
              << mnemonic;
+    }
 
     if (failed(*parseShortformAttrResult))
       return failure();

--- a/lib/Dialect/SSP/SSPAttributes.cpp
+++ b/lib/Dialect/SSP/SSPAttributes.cpp
@@ -12,10 +12,12 @@
 
 #include "circt/Dialect/SSP/SSPAttributes.h"
 #include "circt/Dialect/SSP/SSPDialect.h"
-#include "circt/Support/LLVM.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace ssp;
@@ -28,4 +30,76 @@ void SSPDialect::registerAttributes() {
 #define GET_ATTRDEF_LIST
 #include "circt/Dialect/SSP/SSPAttributes.cpp.inc"
       >();
+}
+
+mlir::OptionalParseResult
+ssp::parseOptionalPropertyArray(ArrayAttr &attr, AsmParser &parser,
+                                ArrayRef<Attribute> alreadyParsed) {
+  auto &builder = parser.getBuilder();
+
+  if (parser.parseOptionalLSquare()) {
+    if (!alreadyParsed.empty()) {
+      attr = builder.getArrayAttr(alreadyParsed);
+      return success();
+    }
+    return {};
+  }
+
+  SmallVector<Attribute> elements;
+  elements.append(alreadyParsed.begin(), alreadyParsed.end());
+
+  auto parseListResult = parser.parseCommaSeparatedList([&]() -> ParseResult {
+    Attribute elem;
+
+    // Try to parse a generic attribute.
+    auto parseGenericAttrResult = parser.parseOptionalAttribute(elem);
+    if (parseGenericAttrResult.hasValue()) {
+      if (failed(*parseGenericAttrResult))
+        return failure();
+
+      elements.push_back(elem);
+      return success();
+    }
+
+    // Try to parse one of the built-in SSP property attributes.
+    StringRef mnemonic;
+    auto parseShortformAttrResult =
+        generatedAttributeParser(parser, &mnemonic, Type(), elem);
+
+    if (!parseShortformAttrResult.hasValue())
+      return parser.emitError(parser.getCurrentLocation(),
+                              "carries unknown shortform property: ")
+             << mnemonic;
+
+    if (failed(*parseShortformAttrResult))
+      return failure();
+
+    elements.push_back(elem);
+    return success();
+  });
+
+  if (parseListResult || parser.parseRSquare())
+    return failure();
+
+  attr = builder.getArrayAttr(elements);
+  return success();
+}
+
+void ssp::printPropertyArray(ArrayAttr attr, AsmPrinter &p,
+                             ArrayRef<Attribute> alreadyPrinted) {
+  auto elementsToPrint =
+      llvm::make_filter_range(attr.getAsRange<Attribute>(), [&](Attribute a) {
+        return !llvm::is_contained(alreadyPrinted, a);
+      });
+  if (elementsToPrint.empty())
+    return;
+
+  p << '[';
+  llvm::interleaveComma(elementsToPrint, p, [&](Attribute elem) {
+    // Try to emit the shortform for the built-in SSP property attributes, and
+    // if that fails, fall back to the generic form.
+    if (failed(generatedAttributePrinter(elem, p)))
+      p.printAttribute(attr);
+  });
+  p << ']';
 }

--- a/lib/Dialect/SSP/SSPOps.cpp
+++ b/lib/Dialect/SSP/SSPOps.cpp
@@ -20,6 +20,47 @@ using namespace circt;
 using namespace circt::ssp;
 
 //===----------------------------------------------------------------------===//
+// InstanceOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult InstanceOp::verify() {
+  auto &ops = getBodyBlock()->getOperations();
+  auto it = ops.begin();
+  if (ops.size() != 2 || !isa<OperatorLibraryOp>(*it) ||
+      !isa<DependenceGraphOp>(*(++it)))
+    return emitOpError()
+           << "must contain exactly one 'library' op and one 'graph' op";
+
+  return success();
+}
+
+// The verifier checks that exactly one of each of the container ops is present.
+OperatorLibraryOp InstanceOp::getOperatorLibrary() {
+  return *getOps<OperatorLibraryOp>().begin();
+}
+
+DependenceGraphOp InstanceOp::getDependenceGraph() {
+  return *getOps<DependenceGraphOp>().begin();
+}
+
+//===----------------------------------------------------------------------===//
+// Wrappers for the `custom<Properties>` ODS directive.
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseProperties(OpAsmParser &parser, ArrayAttr &attr) {
+  auto result = parseOptionalPropertyArray(attr, parser);
+  if (!result.hasValue() || succeeded(*result))
+    return success();
+  return failure();
+}
+
+static void printProperties(OpAsmPrinter &p, Operation *op, ArrayAttr attr) {
+  if (!attr)
+    return;
+  printPropertyArray(attr, p);
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'ed code
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SSP/errors.mlir
+++ b/test/Dialect/SSP/errors.mlir
@@ -5,7 +5,7 @@ ssp.instance "error0a" of "Problem" {}
 
 // -----
 
-// expected-error @+1 {{must contain exactly one 'library' op and one 'graph' op}}
+// expected-error @+1 {{must contain the 'library' op followed by the 'graph' op}}
 ssp.instance "error0b" of "Problem" {
   graph {}
   library {}

--- a/test/Dialect/SSP/errors.mlir
+++ b/test/Dialect/SSP/errors.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// expected-error @+1 {{must contain exactly one 'library' op and one 'graph' op}}
+ssp.instance "error0a" of "Problem" {}
+
+// -----
+
+// expected-error @+1 {{must contain exactly one 'library' op and one 'graph' op}}
+ssp.instance "error0b" of "Problem" {
+  graph {}
+  library {}
+}


### PR DESCRIPTION
This follow-up PR to #3558 adds the "mostly boring" operations of the SSP dialect; the `OperationOp` requires lots of custom printing/parsing/verification code and will be added in the next PR. Also, the attributes representing scheduling properties (latency, start time, etc.) are still excluded here as well.