### PR TITLE
[PrepareForEmission] Use inferStructuralNameForTemporary

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -853,11 +853,6 @@ public:
   /// the value is empty.
   void emitComment(StringAttr comment);
 
-  /// Given an expression that is spilled into a temporary wire, try to
-  /// synthesize a better name than "_T_42" based on the structure of the
-  /// expression.
-  StringAttr inferStructuralNameForTemporary(Value expr);
-
 private:
   void operator=(const EmitterBase &) = delete;
   EmitterBase(const EmitterBase &) = delete;
@@ -1028,7 +1023,7 @@ void EmitterBase::emitComment(StringAttr comment) {
 
 /// Given an expression that is spilled into a temporary wire, try to synthesize
 /// a better name than "_T_42" based on the structure of the expression.
-StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
+StringAttr ExportVerilog::inferStructuralNameForTemporary(Value expr) {
   StringAttr result;
   bool addPrefixUnderScore = true;
 
@@ -1071,7 +1066,7 @@ StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
           })
 
           // If this is an extract from a namable object, derive a name from it.
-          .Case([&result, this](ExtractOp extract) {
+          .Case([&result](ExtractOp extract) {
             if (auto operandName =
                     inferStructuralNameForTemporary(extract.getInput())) {
               unsigned numBits = extract.getType().getWidth();
@@ -2523,7 +2518,7 @@ void NameCollector::collectNames(Block &block) {
         // Get an explicitly set name or try to infer a name from the structure
         // of the expression.
         names.addName(result,
-                      moduleEmitter.inferStructuralNameForTemporary(result));
+                      ExportVerilog::inferStructuralNameForTemporary(result));
 
         // Don't measure or emit wires that are emitted inline (i.e. the wire
         // definition is emitted on the line of the expression instead of a

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -30,6 +30,11 @@ bool isSimpleReadOrPort(Value v);
 /// for instances this is `instanceName`, etc.
 StringAttr getDeclarationName(Operation *op);
 
+/// Given an expression that is spilled into a temporary wire, try to
+/// synthesize a better name than "_T_42" based on the structure of the
+/// expression.
+StringAttr inferStructuralNameForTemporary(Value expr);
+
 /// This class keeps track of global names at the module/interface level.
 /// It is built in a global pass over the entire design and then frozen to allow
 /// concurrent accesses.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -274,13 +274,10 @@ static void lowerUsersToTemporaryWire(Operation &op) {
     connect->moveAfter(&op);
   };
 
-  // If the op has a single result and a namehint, give the name to its
-  // temporary wire.
+  // If the op has a single result, infer a meaningfull name from the
+  // value.
   if (op.getNumResults() == 1) {
-    auto namehint = op.getAttrOfType<StringAttr>("sv.namehint");
-    // Remove a namehint from the op because the name is moved to the wire.
-    if (namehint)
-      op.removeAttr("sv.namehint");
+    auto namehint = inferStructuralNameForTemporary(op.getResult(0));
     createWireForResult(op.getResult(0), namehint);
     return;
   }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -59,13 +59,13 @@ module attributes {circt.loweringOptions = "disallowLocalVariables,spillWiresAtP
 
   // CHECK-LABEL: @SpillTemporaryWireForMultipleUseExpression
   hw.module @SpillTemporaryWireForMultipleUseExpression(%a: i4, %b: i4) -> (c: i4, d: i4) {
-    // CHECK-NEXT: %0 = sv.wire
-    // CHECK-NEXT: %1 = comb.add %a, %b
-    // CHECK-NEXT: sv.assign %0, %1
-    // CHECK-NEXT: %2 = sv.read_inout %0
-    // CHECK-NEXT: %3 = sv.read_inout %0
-    // CHECK-NEXT: hw.output %3, %2
-    %0 = comb.add %a, %b : i4
+    // CHECK-NEXT: %bar = sv.wire
+    // CHECK-NEXT: %0 = comb.add %a, %b
+    // CHECK-NEXT: sv.assign %bar, %0
+    // CHECK-NEXT: %1 = sv.read_inout %bar
+    // CHECK-NEXT: %2 = sv.read_inout %bar
+    // CHECK-NEXT: hw.output %2, %1
+    %0 = comb.add %a, %b {sv.namehint = "bar"}: i4
     hw.output %0, %0 : i4, i4
   }
 }


### PR DESCRIPTION
This commit changes PrepareForEmission to use `inferStructuralNameForTemporary` 
function to infer names of temporary wires. `inferStructuralNameForTemporary` is moved 
to`ExportVerilogInternals.h` so that we can use it from PrepareForEmission as well. 