### PR TITLE
[PyCDE] Add infix operator support

### DIFF
--- a/frontends/PyCDE/src/pycde/dialects/hwarith.py
+++ b/frontends/PyCDE/src/pycde/dialects/hwarith.py
@@ -1,0 +1,8 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ..value import wrap_opviews_with_values
+from circt.dialects import hwarith
+
+wrap_opviews_with_values(hwarith, __name__)

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -5,7 +5,8 @@
 from collections import OrderedDict
 
 from .value import (BitVectorValue, ChannelValue, ClockValue, ListValue,
-                    StructValue, RegularValue, InOutValue, Value)
+                    SignedBitVectorValue, UnsignedBitVectorValue, StructValue,
+                    RegularValue, InOutValue, Value)
 
 import mlir.ir
 from circt.dialects import esi, hw, sv
@@ -154,7 +155,12 @@ def Type(type: Union[mlir.ir.Type, PyCDEType]):
   if isinstance(type, hw.InOutType):
     return InOutType(type)
   if isinstance(type, mlir.ir.IntegerType):
-    return BitVectorType(type)
+    if type.is_signed:
+      return SignedBitVectorType(type)
+    elif type.is_unsigned:
+      return UnsignedBitVectorType(type)
+    else:
+      return BitVectorType(type)
   if isinstance(type, esi.ChannelType):
     return ChannelType(type)
   return PyCDEType(type)
@@ -263,6 +269,18 @@ class BitVectorType(PyCDEType):
 
   def _get_value_class(self):
     return BitVectorValue
+
+
+class SignedBitVectorType(BitVectorType):
+
+  def _get_value_class(self):
+    return SignedBitVectorValue
+
+
+class UnsignedBitVectorType(BitVectorType):
+
+  def _get_value_class(self):
+    return UnsignedBitVectorValue
 
 
 class ClockType(PyCDEType):

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -44,7 +44,7 @@ class System:
   ]
 
   PASSES = """
-    msft-lower-constructs, msft-lower-instances, {partition}
+    lower-hwarith-to-hw, msft-lower-constructs, msft-lower-instances, {partition}
     lower-msft-to-hw{{verilog-file={verilog_file}}},
     lower-esi-to-physical, lower-esi-ports, lower-esi-to-hw, convert-fsm-to-sv,
     lower-seq-to-sv, hw.module(prettify-verilog), hw.module(hw-cleanup),

--- a/frontends/PyCDE/src/pycde/testing.py
+++ b/frontends/PyCDE/src/pycde/testing.py
@@ -7,6 +7,7 @@ import inspect
 def unittestmodule(generate=True,
                    print=True,
                    run_passes=False,
+                   print_after_passes=False,
                    emit_outputs=False,
                    **kwargs):
   """
@@ -34,6 +35,8 @@ def unittestmodule(generate=True,
         sys.print()
       if run_passes:
         sys.run_passes()
+      if print_after_passes:
+        sys.print()
       if emit_outputs:
         sys.emit_outputs()
 

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -258,6 +258,127 @@ class BitVectorValue(Value):
   def __len__(self):
     return self.type.width
 
+  #  === Casting ===
+
+  def _exec_cast(self, targetValueType, type_getter, width: int = None):
+    from .dialects import hwarith
+    if type(self) is targetValueType:
+      return self
+    if width is None:
+      width = self.type.width
+    return hwarith.CastOp(self.value, type_getter(width))
+
+  def asInt(self, width: int = None):
+    """
+    Returns this value as a signless integer. If 'width' is provided, this value
+    will be truncated to that width.
+    """
+    return self._exec_cast(BitVectorValue, ir.IntegerType.get_signless, width)
+
+  def asSInt(self, width: int = None):
+    """
+    Returns this value as a a signed integer. If 'width' is provided, this value
+    will be truncated or sign-extended to that width.
+    """
+    return self._exec_cast(SignedBitVectorValue, ir.IntegerType.get_signed,
+                           width)
+
+  def asUInt(self, width: int = None):
+    """
+    Returns this value as an unsigned integer. If 'width' is provided, this value
+    will be truncated or zero-padded to that width.
+    """
+    return self._exec_cast(UnsignedBitVectorValue, ir.IntegerType.get_unsigned,
+                           width)
+
+  #  === Infix operators ===
+
+  # Signless operations. These will all return signless values - a user is
+  # expected to reapply signedness semantics if needed.
+  def __eq__(self, other):
+    from .dialects import comb
+    return comb.EqOp(self.asInt(), other.asInt())
+
+  def __ne__(self, other):
+    from .dialects import comb
+    return comb.NeOp(self.asInt(), other.asInt())
+
+  def __and__(self, other):
+    from .dialects import comb
+    return comb.AndOp(self.asInt(), other.asInt())
+
+  def __or__(self, other):
+    from .dialects import comb
+    return comb.OrOp(self.asInt(), other.asInt())
+
+  def __xor__(self, other):
+    from .dialects import comb
+    return comb.XorOp(self.asInt(), other.asInt())
+
+  def __invert__(self):
+    from .dialects import comb
+    from .pycde_types import types
+    return self.asInt() ^ types.int(self.type.width)(-1)
+
+  # Generalized function for executing sign-aware binary operations. Performs
+  # a check to ensure that the operands have signedness semantics, and then calls
+  # the provided operator.
+  def __exec_signedness_binop__(self, other, op, op_symbol):
+    signlessOperand = None
+    if type(self) is BitVectorValue:
+      signlessOperand = "LHS"
+    elif type(other) is BitVectorValue:
+      signlessOperand = "RHS"
+
+    if signlessOperand is not None:
+      raise TypeError(
+          f"Operator '{op_symbol}' is not supported on signless values. {signlessOperand} operand should be cast .asSInt()/.asUInt()."
+      )
+
+    return op(self, other)
+
+  def __add__(self, other):
+    from .dialects import hwarith
+    return self.__exec_signedness_binop__(other, hwarith.AddOp, "+")
+
+  def __sub__(self, other):
+    from .dialects import hwarith
+    return self.__exec_signedness_binop__(other, hwarith.SubOp, "-")
+
+  def __mul__(self, other):
+    from .dialects import hwarith
+    return self.__exec_signedness_binop__(other, hwarith.MulOp, "*")
+
+  def __truediv__(self, other):
+    from .dialects import hwarith
+    return self.__exec_signedness_binop__(other, hwarith.DivOp, "/")
+
+
+class WidthExtendingBitVectorValue(BitVectorValue):
+  # TODO: This class will contain comparison operators (<, >, <=, >=)
+  pass
+
+  def __lt__(self, other):
+    assert (False, "Unimplemented")
+
+  def __le__(self, other):
+    assert (False, "Unimplemented")
+
+  def __ge__(self, other):
+    assert (False, "Unimplemented")
+
+
+class UnsignedBitVectorValue(WidthExtendingBitVectorValue):
+  pass
+
+
+class SignedBitVectorValue(WidthExtendingBitVectorValue):
+
+  def __neg__(self):
+    from .dialects import comb
+    from .pycde_types import types
+    return self * types.int(self.type.width)(-1).asSInt()
+
 
 class ListValue(Value):
 

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -65,3 +65,30 @@ t.generate()
 inst = t.get_instance(Test)
 # CHECK: reg[8] not found
 inst.reg[8]
+
+# -----
+
+
+@unittestmodule()
+class OperatorError:
+  a = Input(types.i32)
+  b = Input(types.si32)
+
+  @generator
+  def build(ports):
+    # CHECK: Operator '+' is not supported on signless values. LHS operand should be cast .asSInt()/.asUInt().
+    ports.a + ports.b
+
+
+# -----
+
+
+@unittestmodule()
+class OperatorError2:
+  a = Input(types.i32)
+  b = Input(types.si32)
+
+  @generator
+  def build(ports):
+    # CHECK: Operator '+' is not supported on signless values. RHS operand should be cast .asSInt()/.asUInt().
+    ports.b + ports.a

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -76,7 +76,7 @@ class OperatorError:
 
   @generator
   def build(ports):
-    # CHECK: Operator '+' is not supported on signless values. LHS operand should be cast .asSInt()/.asUInt().
+    # CHECK: Operator '+' is not supported on signless values. LHS operand should be cast .as_sint()/.as_uint().
     ports.a + ports.b
 
 
@@ -90,5 +90,19 @@ class OperatorError2:
 
   @generator
   def build(ports):
-    # CHECK: Operator '+' is not supported on signless values. RHS operand should be cast .asSInt()/.asUInt().
+    # CHECK: Operator '+' is not supported on signless values. RHS operand should be cast .as_sint()/.as_uint().
     ports.b + ports.a
+
+
+# -----
+
+
+@unittestmodule()
+class OperatorError2:
+  a = Input(types.i32)
+  b = Input(types.si32)
+
+  @generator
+  def build(ports):
+    # CHECK: Operator '==' requires LHS to be cast .as_int().
+    ports.b == ports.a

--- a/frontends/PyCDE/test/test_hwarith.py
+++ b/frontends/PyCDE/test/test_hwarith.py
@@ -72,7 +72,7 @@ class InfixLogic:
 # CHECK-NEXT:    msft.output
 @unittestmodule(run_passes=False)
 class InfixComparison:
-  in0 = Input(types.si16)
+  in0 = Input(types.i16)
   in1 = Input(types.i16)
 
   @generator
@@ -98,7 +98,7 @@ class Multiple:
 
   @generator
   def construct(ports):
-    ports.out0 = (ports.in0 + ports.in1 + ports.in0 + ports.in1).asInt(16)
+    ports.out0 = (ports.in0 + ports.in1 + ports.in0 + ports.in1).as_int(16)
 
 
 # -----
@@ -111,6 +111,7 @@ class Multiple:
 # CHECK-NEXT:    %3 = hwarith.cast %in0 : (i16) -> si8
 # CHECK-NEXT:    %4 = hwarith.cast %in0 : (i16) -> ui8
 # CHECK-NEXT:    %5 = hwarith.cast %0 : (si16) -> i8
+# CHECK-NEXT:    %6 = hwarith.cast %0 : (si16) -> si24
 # CHECK-NEXT:    msft.output
 @unittestmodule(run_passes=False)
 class Casting:
@@ -118,12 +119,13 @@ class Casting:
 
   @generator
   def construct(ports):
-    in0s = ports.in0.asSInt()
-    in0u = ports.in0.asUInt()
-    in0s_i = in0s.asInt()
-    in0s8 = ports.in0.asSInt(8)
-    in0u8 = ports.in0.asUInt(8)
-    in0s_i8 = in0s.asInt(8)
+    in0s = ports.in0.as_sint()
+    in0u = ports.in0.as_uint()
+    in0s_i = in0s.as_int()
+    in0s8 = ports.in0.as_sint(8)
+    in0u8 = ports.in0.as_uint(8)
+    in0s_i8 = in0s.as_int(8)
+    in0s_s24 = in0s.as_sint(24)
 
 
 # -----
@@ -145,4 +147,4 @@ class Lowering:
 
   @generator
   def construct(ports):
-    ports.out0 = (ports.in0.asSInt() + ports.in1.asSInt()).asInt(16)
+    ports.out0 = (ports.in0.as_sint() + ports.in1.as_sint()).as_int(16)

--- a/frontends/PyCDE/test/test_hwarith.py
+++ b/frontends/PyCDE/test/test_hwarith.py
@@ -98,7 +98,6 @@ class Multiple:
 
   @generator
   def construct(ports):
-    o = Multiple.out0
     ports.out0 = (ports.in0 + ports.in1 + ports.in0 + ports.in1).asInt(16)
 
 

--- a/frontends/PyCDE/test/test_hwarith.py
+++ b/frontends/PyCDE/test/test_hwarith.py
@@ -1,0 +1,149 @@
+# RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
+
+from math import fabs
+from yaml import emit
+from pycde import Input, Output, generator
+from pycde.testing import unittestmodule
+from pycde.dialects import comb
+from pycde.pycde_types import dim, types
+
+
+# CHECK-LABEL: msft.module @InfixArith {} (%in0: si16, %in1: ui16)
+# CHECK-NEXT:   %0 = hwarith.add %in0, %in1 : (si16, ui16) -> si18
+# CHECK-NEXT:   %1 = hwarith.sub %in0, %in1 : (si16, ui16) -> si18
+# CHECK-NEXT:   %2 = hwarith.mul %in0, %in1 : (si16, ui16) -> si32
+# CHECK-NEXT:   %3 = hwarith.div %in0, %in1 : (si16, ui16) -> si16
+# CHECK-NEXT:   %c-1_i16 = hw.constant -1 : i16
+# CHECK-NEXT:   %4 = hwarith.cast %c-1_i16 : (i16) -> si16
+# CHECK-NEXT:   %5 = hwarith.mul %in0, %4 : (si16, si16) -> si32
+# CHECK-NEXT:   msft.output
+@unittestmodule(run_passes=False)
+class InfixArith:
+  in0 = Input(types.si16)
+  in1 = Input(types.ui16)
+
+  @generator
+  def construct(ports):
+    add = ports.in0 + ports.in1
+    sub = ports.in0 - ports.in1
+    mul = ports.in0 * ports.in1
+    div = ports.in0 / ports.in1
+    neg = -ports.in0
+
+
+# -----
+
+
+# CHECK-LABEL: msft.module @InfixLogic {} (%in0: si16, %in1: ui16)
+# CHECK-NEXT:  %0 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:  %1 = hwarith.cast %in1 : (ui16) -> i16
+# CHECK-NEXT:  %2 = comb.and %0, %1 : i16
+# CHECK-NEXT:  %3 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:  %4 = hwarith.cast %in1 : (ui16) -> i16
+# CHECK-NEXT:  %5 = comb.or %3, %4 : i16
+# CHECK-NEXT:  %6 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:  %7 = hwarith.cast %in1 : (ui16) -> i16
+# CHECK-NEXT:  %8 = comb.xor %6, %7 : i16
+# CHECK-NEXT:  %9 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:  %c-1_i16 = hw.constant -1 : i16
+# CHECK-NEXT:  %10 = comb.xor %9, %c-1_i16 : i16
+# CHECK-NEXT:  msft.output
+@unittestmodule(run_passes=False)
+class InfixLogic:
+  in0 = Input(types.si16)
+  in1 = Input(types.ui16)
+
+  @generator
+  def construct(ports):
+    and_ = ports.in0 & ports.in1
+    or_ = ports.in0 | ports.in1
+    xor = ports.in0 ^ ports.in1
+    inv = ~ports.in0
+
+
+# -----
+
+
+# CHECK-LABEL: msft.module @InfixComparison {} (%in0: si16, %in1: i16)
+# CHECK-NEXT:    %0 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:    %1 = comb.icmp eq %0, %in1 : i16
+# CHECK-NEXT:    %2 = hwarith.cast %in0 : (si16) -> i16
+# CHECK-NEXT:    %3 = comb.icmp ne %2, %in1 : i16
+# CHECK-NEXT:    msft.output
+@unittestmodule(run_passes=False)
+class InfixComparison:
+  in0 = Input(types.si16)
+  in1 = Input(types.i16)
+
+  @generator
+  def construct(ports):
+    eq = ports.in0 == ports.in1
+    neq = ports.in0 != ports.in1
+
+
+# -----
+
+
+# CHECK-LABEL:  msft.module @Multiple {} (%in0: si16, %in1: si16) -> (out0: i16)
+# CHECK-NEXT:    %0 = hwarith.add %in0, %in1 : (si16, si16) -> si17
+# CHECK-NEXT:    %1 = hwarith.add %0, %in0 : (si17, si16) -> si18
+# CHECK-NEXT:    %2 = hwarith.add %1, %in1 : (si18, si16) -> si19
+# CHECK-NEXT:    %3 = hwarith.cast %2 : (si19) -> i16
+# CHECK-NEXT:    msft.output %3 : i16
+@unittestmodule(run_passes=False)
+class Multiple:
+  in0 = Input(types.si16)
+  in1 = Input(types.si16)
+  out0 = Output(types.i16)
+
+  @generator
+  def construct(ports):
+    o = Multiple.out0
+    ports.out0 = (ports.in0 + ports.in1 + ports.in0 + ports.in1).asInt(16)
+
+
+# -----
+
+
+# CHECK-LABEL:  msft.module @Casting {} (%in0: i16)
+# CHECK-NEXT:    %0 = hwarith.cast %in0 : (i16) -> si16
+# CHECK-NEXT:    %1 = hwarith.cast %in0 : (i16) -> ui16
+# CHECK-NEXT:    %2 = hwarith.cast %0 : (si16) -> i16
+# CHECK-NEXT:    %3 = hwarith.cast %in0 : (i16) -> si8
+# CHECK-NEXT:    %4 = hwarith.cast %in0 : (i16) -> ui8
+# CHECK-NEXT:    %5 = hwarith.cast %0 : (si16) -> i8
+# CHECK-NEXT:    msft.output
+@unittestmodule(run_passes=False)
+class Casting:
+  in0 = Input(types.i16)
+
+  @generator
+  def construct(ports):
+    in0s = ports.in0.asSInt()
+    in0u = ports.in0.asUInt()
+    in0s_i = in0s.asInt()
+    in0s8 = ports.in0.asSInt(8)
+    in0u8 = ports.in0.asUInt(8)
+    in0s_i8 = in0s.asInt(8)
+
+
+# -----
+
+
+# CHECK-LABEL: hw.module @Lowering<__INST_HIER: none = "INSTANTIATE_WITH_INSTANCE_PATH">(%in0: i16, %in1: i16) -> (out0: i16)
+# CHECK-NEXT:    %0 = comb.extract %in0 from 15 : (i16) -> i1
+# CHECK-NEXT:    %1 = comb.concat %0, %in0 : i1, i16
+# CHECK-NEXT:    %2 = comb.extract %in1 from 15 : (i16) -> i1
+# CHECK-NEXT:    %3 = comb.concat %2, %in1 : i1, i16
+# CHECK-NEXT:    %4 = comb.add %1, %3 : i17
+# CHECK-NEXT:    %5 = comb.extract %4 from 0 : (i17) -> i16
+# CHECK-NEXT:    hw.output %5 : i16
+@unittestmodule(generate=True, run_passes=True, print_after_passes=True)
+class Lowering:
+  in0 = Input(types.i16)
+  in1 = Input(types.i16)
+  out0 = Output(types.i16)
+
+  @generator
+  def construct(ports):
+    ports.out0 = (ports.in0.asSInt() + ports.in1.asSInt()).asInt(16)

--- a/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
@@ -42,3 +42,10 @@ class AddOp:
 @BinaryOp
 class MulOp:
   pass
+
+
+class CastOp:
+
+  @classmethod
+  def create(cls, value, result_type):
+    return cls(result_type, value)


### PR DESCRIPTION
This commit adds support for infix operations on PyCDE bit vector values. Arithmetic operators are implemented through `hwarith` operation, logic operators through `comb`.