### PR TITLE
[FIRRTL][IST] Verify inner symbols are unique.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -71,7 +71,7 @@ class InnerSymbolOpInterface;
 LogicalResult verifyInnerSymAttr(InnerSymbolOpInterface op);
 
 namespace detail {
-LogicalResult verifyInnerRefs(Operation *op);
+LogicalResult verifyInnerRefNamespace(Operation *op);
 } // namespace detail
 
 } // namespace firrtl
@@ -95,8 +95,8 @@ public:
     if (!op->getRegion(0).hasOneBlock())
       return op->emitError("expected operation to have a single block");
 
-    // Verify all InnerRef users.
-    return ::circt::firrtl::detail::verifyInnerRefs(op);
+    // Verify all InnerSymbolTable's and InnerRef users.
+    return ::circt::firrtl::detail::verifyInnerRefNamespace(op);
   }
 };
 

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -110,7 +110,11 @@ public:
 
   /// Non-copyable
   InnerSymbolTable(const InnerSymbolTable &) = delete;
-  InnerSymbolTable &operator=(InnerSymbolTable &) = delete;
+  InnerSymbolTable &operator=(const InnerSymbolTable &) = delete;
+
+  // Moveable
+  InnerSymbolTable(InnerSymbolTable &&) = default;
+  InnerSymbolTable &operator=(InnerSymbolTable &&) = default;
 
   /// Look up a symbol with the specified name, returning empty InnerSymTarget
   /// if no such name exists. Names never include the @ on them.
@@ -142,13 +146,30 @@ public:
   /// Return the name of the attribute used for inner symbol names.
   static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
 
+  using InnerSymCallbackFn =
+      llvm::function_ref<LogicalResult(StringAttr, InnerSymTarget)>;
+
+  /// Walk the given IST operation and invoke the callback for all encountered
+  /// inner symbols.
+  static LogicalResult walkSymbols(Operation *op, InnerSymCallbackFn callback);
+
+  /// Construct an InnerSymbolTable, checking for verification failure.
+  /// Emits diagnostics describing encountered issues.
+  static FailureOr<InnerSymbolTable> get(Operation *op);
+
 private:
+  using TableTy = DenseMap<StringAttr, InnerSymTarget>;
+  /// Construct an inner symbol table for the given operation,
+  /// with pre-populated table contents.
+  explicit InnerSymbolTable(Operation *op, TableTy &&table)
+      : innerSymTblOp(op), symbolTable(table){};
+
   /// This is the operation this table is constructed for, which must have the
   /// InnerSymbolTable trait.
   Operation *innerSymTblOp;
 
-  /// This maps names to operations with that inner symbol.
-  DenseMap<StringAttr, InnerSymTarget> symbolTable;
+  /// This maps inner symbol names to their targets.
+  TableTy symbolTable;
 };
 
 /// This class represents a collection of InnerSymbolTable's.
@@ -158,10 +179,17 @@ public:
   InnerSymbolTable &getInnerSymbolTable(Operation *op);
 
   /// Populate tables in parallel for all InnerSymbolTable operations in the
-  /// given InnerRefNamespace operation.
-  void populateTables(Operation *innerRefNSOp);
+  /// given InnerRefNamespace operation, verifying each and returning
+  /// the verification result.
+  LogicalResult populateAndVerifyTables(Operation *innerRefNSOp);
 
   explicit InnerSymbolTableCollection() = default;
+  explicit InnerSymbolTableCollection(Operation *innerRefNSOp) {
+    // Caller is not interested in verification, no way to report it upwards.
+    auto result = populateAndVerifyTables(innerRefNSOp);
+    (void)result;
+    assert(succeeded(result));
+  }
   InnerSymbolTableCollection(const InnerSymbolTableCollection &) = delete;
   InnerSymbolTableCollection &
   operator=(const InnerSymbolTableCollection &) = delete;

--- a/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
+++ b/include/circt/Dialect/FIRRTL/InnerSymbolTable.h
@@ -141,7 +141,7 @@ public:
   static StringAttr getInnerSymbol(Operation *op);
 
   /// Get InnerSymbol for a target.
-  static StringAttr getInnerSymbol(InnerSymTarget target);
+  static StringAttr getInnerSymbol(const InnerSymTarget &target);
 
   /// Return the name of the attribute used for inner symbol names.
   static StringRef getInnerSymbolAttrName() { return "inner_sym"; }
@@ -151,13 +151,14 @@ public:
   static FailureOr<InnerSymbolTable> get(Operation *op);
 
   using InnerSymCallbackFn =
-      llvm::function_ref<LogicalResult(StringAttr, InnerSymTarget)>;
+      llvm::function_ref<LogicalResult(StringAttr, const InnerSymTarget &)>;
 
   /// Walk the given IST operation and invoke the callback for all encountered
   /// inner symbols.
   /// This variant is used for callbacks that return LogicalResult.
   template <typename FuncTy,
-            typename RetTy = typename std::invoke_result<FuncTy, StringAttr, InnerSymTarget>::type>
+            typename RetTy = typename std::invoke_result<
+                FuncTy, StringAttr, const InnerSymTarget &>::type>
   static typename std::enable_if<std::is_same<LogicalResult, RetTy>::value,
                                  RetTy>::type
   walkSymbols(Operation *op, FuncTy &&callback) {
@@ -169,11 +170,11 @@ public:
   /// This variant is used for callbacks that return void.
   template <typename FuncTy,
             typename RetTy = typename std::invoke_result<
-                FuncTy, StringAttr, InnerSymTarget>::type>
+                FuncTy, StringAttr, const InnerSymTarget &>::type>
   static typename std::enable_if<std::is_void<RetTy>::value, RetTy>::type
   walkSymbols(Operation *op, FuncTy &&callback) {
     (void)InnerSymbolTable::walkSymbols(
-        op, [&](StringAttr name, InnerSymTarget target) {
+        op, [&](StringAttr name, const InnerSymTarget &target) {
           std::invoke(std::forward<FuncTy>(callback), name, target);
           return success();
         });

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -31,11 +31,10 @@ InnerSymbolTable::InnerSymbolTable(Operation *op) {
   // Save the operation this table is for.
   this->innerSymTblOp = op;
 
-  (void)walkSymbols(op, [&](StringAttr name, InnerSymTarget target) {
+  walkSymbols(op, [&](StringAttr name, InnerSymTarget target) {
     auto it = symbolTable.insert({name, target});
     (void)it;
     assert(it.second && "repeated symbol found");
-    return success();
   });
 }
 

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -26,54 +26,87 @@ namespace firrtl {
 //===----------------------------------------------------------------------===//
 // InnerSymbolTable
 //===----------------------------------------------------------------------===//
-
 InnerSymbolTable::InnerSymbolTable(Operation *op) {
-  using llvm::dbgs;
-  LLVM_DEBUG(dbgs() << "===----- InnerSymbolTable -----===\n";
-             dbgs() << "Constructing table for @"
-                    << SymbolTable::getSymbolName(op) << "\n");
-  assert(op->hasTrait<OpTrait::InnerSymbolTable>() &&
-         "expected operation to have InnerSymbolTable trait");
+  assert(op->hasTrait<OpTrait::InnerSymbolTable>());
   // Save the operation this table is for.
   this->innerSymTblOp = op;
 
+  (void)walkSymbols(op, [&](StringAttr name, InnerSymTarget target) {
+    auto it = symbolTable.insert({name, target});
+    (void)it;
+    assert(it.second && "repeated symbol found");
+    return success();
+  });
+}
+
+FailureOr<InnerSymbolTable> InnerSymbolTable::get(Operation *op) {
+  assert(op);
+  if (!op->hasTrait<OpTrait::InnerSymbolTable>())
+    return op->emitError("expected operation to have InnerSymbolTable trait");
+
+  TableTy table;
+  auto result = walkSymbols(
+      op, [&](StringAttr name, InnerSymTarget target) -> LogicalResult {
+        auto it = table.insert({name, target});
+        if (it.second)
+          return success();
+        auto existing = it.first->second;
+        return target.getOp()
+            ->emitError()
+            .append("redefinition of inner symbol named '", name.strref(), "'")
+            .attachNote(existing.getOp()->getLoc())
+            .append("see existing inner symbol definition here");
+      });
+  if (failed(result))
+    return failure();
+  return InnerSymbolTable(op, std::move(table));
+};
+
+LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
+                                            InnerSymCallbackFn callback) {
+  using llvm::dbgs;
+  LLVM_DEBUG(dbgs() << "===----- InnerSymbolTable -----===\n";
+             dbgs() << "Walking inner symbols for @"
+                    << SymbolTable::getSymbolName(op) << "\n");
   auto addSym = [&](StringAttr name, InnerSymTarget target) {
     LLVM_DEBUG(dbgs() << " - @" << name << " -> " << target << "\n");
     assert(name && !name.getValue().empty());
-    auto it = symbolTable.insert({name, target});
-    if (!it.second) {
-      auto orig = symbolTable.lookup(name);
-      (target.getOp()->emitError("duplicate symbol @") << name << " found")
-              .attachNote(orig.getOp()->getLoc())
-          << " symbol also found within this operation";
-      // TODO: rework so can indicate failure to caller, for use in verif/etc?
-    }
-    assert(it.second && "repeated symbol found");
+    return callback(name, target);
   };
-  auto addSyms = [&](InnerSymAttr symAttr, InnerSymTarget baseTarget) {
+
+  auto addSyms = [&](InnerSymAttr symAttr,
+                     InnerSymTarget baseTarget) -> LogicalResult {
     if (!symAttr)
-      return;
+      return success();
     assert(baseTarget.getField() == 0);
     for (const auto &symProp : symAttr.getProps()) {
-      addSym(symProp.getName(), InnerSymTarget::getTargetForSubfield(
-                                    baseTarget, symProp.getFieldID()));
+      if (failed(
+              addSym(symProp.getName(), InnerSymTarget::getTargetForSubfield(
+                                            baseTarget, symProp.getFieldID()))))
+        return failure();
     }
+    return success();
   };
 
   // Walk the operation and add InnerSymbolTarget's to the table.
-  op->walk([&](Operation *curOp) {
-    if (auto symOp = dyn_cast<InnerSymbolOpInterface>(curOp))
-      addSyms(symOp.getInnerSymAttr(), InnerSymTarget(symOp));
+  return success(
+      !op->walk<mlir::WalkOrder::PreOrder>([&](Operation *curOp) -> WalkResult {
+           if (auto symOp = dyn_cast<InnerSymbolOpInterface>(curOp))
+             if (failed(
+                     addSyms(symOp.getInnerSymAttr(), InnerSymTarget(symOp))))
+               return WalkResult::interrupt();
 
-    // Check for ports
-    // TODO: investigate why/confirm ports having empty-string symbols is normal
-    // TODO: Add fields per port, once they work that way (use addSyms)
-    if (auto mod = dyn_cast<FModuleLike>(curOp)) {
-      for (const auto &p : llvm::enumerate(mod.getPorts()))
-        if (auto sym = p.value().sym; sym && !sym.getValue().empty())
-          addSym(p.value().sym, InnerSymTarget(p.index(), curOp));
-    }
-  });
+           // Check for ports
+           // TODO: Add fields per port, once they work that way (use addSyms)
+           if (auto mod = dyn_cast<FModuleLike>(curOp)) {
+             for (const auto &p : llvm::enumerate(mod.getPorts()))
+               if (auto sym = p.value().sym; sym && !sym.getValue().empty())
+                 if (failed(addSym(p.value().sym,
+                                   InnerSymTarget(p.index(), curOp))))
+                   return WalkResult::interrupt();
+           }
+           return WalkResult::advance();
+         }).wasInterrupted());
 }
 
 /// Look up a symbol with the specified name, returning empty InnerSymTarget if
@@ -144,14 +177,12 @@ InnerSymbolTableCollection::getInnerSymbolTable(Operation *op) {
   return *it.first->second;
 }
 
-void InnerSymbolTableCollection::populateTables(Operation *innerRefNSOp) {
-  // Gather top-level operations.
-  SmallVector<Operation *> childOps(
-      llvm::make_pointer_range(innerRefNSOp->getRegion(0).front()));
-
-  // Filter these to those that have the InnerSymbolTable trait.
-  SmallVector<Operation *> innerSymTableOps(
-      llvm::make_filter_range(childOps, [&](Operation *op) {
+LogicalResult
+InnerSymbolTableCollection::populateAndVerifyTables(Operation *innerRefNSOp) {
+  // Gather top-level operations that have the InnerSymbolTable trait.
+  SmallVector<Operation *> innerSymTableOps(llvm::make_filter_range(
+      llvm::make_pointer_range(innerRefNSOp->getRegion(0).front()),
+      [&](Operation *op) {
         return op->hasTrait<OpTrait::InnerSymbolTable>();
       }));
 
@@ -160,12 +191,18 @@ void InnerSymbolTableCollection::populateTables(Operation *innerRefNSOp) {
                  [&](auto *op) { symbolTables.try_emplace(op, nullptr); });
 
   // Construct the tables in parallel (if context allows it).
-  mlir::parallelForEach(
+  return mlir::failableParallelForEach(
       innerRefNSOp->getContext(), innerSymTableOps, [&](auto *op) {
         auto it = symbolTables.find(op);
         assert(it != symbolTables.end());
-        if (!it->second)
-          it->second = ::std::make_unique<InnerSymbolTable>(op);
+        if (!it->second) {
+          auto result = InnerSymbolTable::get(op);
+          if (failed(result))
+            return failure();
+          it->second = std::make_unique<InnerSymbolTable>(std::move(*result));
+          return success();
+        }
+        return failure();
       });
 }
 
@@ -186,17 +223,19 @@ Operation *InnerRefNamespace::lookupOp(hw::InnerRefAttr inner) {
 }
 
 //===----------------------------------------------------------------------===//
-// InnerRef verification
+// InnerRefNamespace verification
 //===----------------------------------------------------------------------===//
 
 namespace detail {
 
-LogicalResult verifyInnerRefs(Operation *op) {
+LogicalResult verifyInnerRefNamespace(Operation *op) {
   // Construct the symbol tables.
   InnerSymbolTableCollection innerSymTables;
   SymbolTable symbolTable(op);
   InnerRefNamespace ns{symbolTable, innerSymTables};
-  innerSymTables.populateTables(op);
+
+  if (failed(innerSymTables.populateAndVerifyTables(op)))
+    return failure();
 
   // Conduct parallel walks of the top-level children of this
   // InnerRefNamespace, verifying all InnerRefUserOp's discovered within.

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -228,11 +228,11 @@ namespace detail {
 LogicalResult verifyInnerRefNamespace(Operation *op) {
   // Construct the symbol tables.
   InnerSymbolTableCollection innerSymTables;
-  SymbolTable symbolTable(op);
-  InnerRefNamespace ns{symbolTable, innerSymTables};
-
   if (failed(innerSymTables.populateAndVerifyTables(op)))
     return failure();
+
+  SymbolTable symbolTable(op);
+  InnerRefNamespace ns{symbolTable, innerSymTables};
 
   // Conduct parallel walks of the top-level children of this
   // InnerRefNamespace, verifying all InnerRefUserOp's discovered within.

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -96,11 +96,12 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
            // Check for ports
            // TODO: Add fields per port, once they work that way (use addSyms)
            if (auto mod = dyn_cast<FModuleLike>(curOp)) {
-             for (const auto &p : llvm::enumerate(mod.getPorts()))
-               if (auto sym = p.value().sym; sym && !sym.getValue().empty())
-                 if (failed(walkSym(p.value().sym,
-                                    InnerSymTarget(p.index(), curOp))))
+             for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i) {
+               auto sym = mod.getPortSymbolAttr(i);
+               if (sym && !sym.getValue().empty())
+                 if (failed(walkSym(sym, InnerSymTarget(i, curOp))))
                    return WalkResult::interrupt();
+             }
            }
            return WalkResult::advance();
          }).wasInterrupted());

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -75,8 +75,6 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
 
   auto walkSyms = [&](InnerSymAttr symAttr,
                       const InnerSymTarget &baseTarget) -> LogicalResult {
-    if (!symAttr)
-      return success();
     assert(baseTarget.getField() == 0);
     for (const auto &symProp : symAttr.getProps()) {
       if (failed(walkSym(symProp.getName(),
@@ -91,9 +89,9 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
   return success(
       !op->walk<mlir::WalkOrder::PreOrder>([&](Operation *curOp) -> WalkResult {
            if (auto symOp = dyn_cast<InnerSymbolOpInterface>(curOp))
-             if (failed(
-                     walkSyms(symOp.getInnerSymAttr(), InnerSymTarget(symOp))))
-               return WalkResult::interrupt();
+             if (auto symAttr = symOp.getInnerSymAttr())
+               if (failed(walkSyms(symAttr, InnerSymTarget(symOp))))
+                 return WalkResult::interrupt();
 
            // Check for ports
            // TODO: Add fields per port, once they work that way (use addSyms)

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -579,8 +579,7 @@ void GrandCentralTapsPass::runOnOperation() {
   LLVM_DEBUG(llvm::dbgs() << "Running the GCT Data Taps pass\n");
   SymbolTable symtbl(circuitOp);
   circuitSymbols = &symtbl;
-  InnerSymbolTableCollection innerSymTblCol;
-  innerSymTblCol.populateTables(circuitOp);
+  InnerSymbolTableCollection innerSymTblCol(circuitOp);
   InnerRefNamespace innerRefNS{symtbl, innerSymTblCol};
 
   // Here's a rough idea of what the Scala code is doing:

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -871,3 +871,35 @@ firrtl.circuit "Foo"   {
     %bar_a, %bar_b, %bar_c = firrtl.instance bar sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [{circt.fieldID = 1 : i32, two}], out c: !firrtl.uint<1> [{four}])
   }
 }
+
+// -----
+
+firrtl.circuit "DupSyms" {
+  firrtl.module @DupSyms() {
+    // expected-note @+1 {{see existing inner symbol definition here}}
+    %w1 = firrtl.wire sym @x : !firrtl.uint<2>
+    // expected-error @+1 {{redefinition of inner symbol named 'x'}}
+    %w2 = firrtl.wire sym @x : !firrtl.uint<2>
+  }
+}
+
+// -----
+
+firrtl.circuit "DupSymPort" {
+  // expected-note @+1 {{see existing inner symbol definition here}}
+  firrtl.module @DupSymPort(in %a : !firrtl.uint<1> sym @x) {
+    // expected-error @+1 {{redefinition of inner symbol named 'x'}}
+    %w1 = firrtl.wire sym @x : !firrtl.uint<2>
+  }
+}
+
+// -----
+
+firrtl.circuit "DupSymField" {
+  firrtl.module @DupSymField() {
+    // expected-note @+1 {{see existing inner symbol definition here}}
+    %w1 = firrtl.wire sym @x : !firrtl.uint<2>
+    // expected-error @+1 {{redefinition of inner symbol named 'x'}}
+    %w3 = firrtl.wire sym [<@x,1,public>] : !firrtl.vector<uint<1>,1>
+  }
+}


### PR DESCRIPTION
Split construction into verification paths.

Do verification as part of circuit-level inner symbol verification, which is building all the IST's already (and is required to be parent of any IST).

Add some tests for duplicate symbol errors.

Fixes #3531.