### PR TITLE
Fix -Wreturn-stack-address warnings

### DIFF
--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1568,7 +1568,8 @@ void MSFTPassCommon::dedupInputs(MSFTModuleOp mod) {
   // loopbacks for all the instances.
   if (instantiations.size() != 1)
     return;
-  InstanceOp inst = dyn_cast<InstanceOp>(instantiations[0]);
+  InstanceOp inst =
+      dyn_cast<InstanceOp>(static_cast<Operation *>(instantiations[0]));
   if (!inst)
     return;
 
@@ -1619,7 +1620,8 @@ void MSFTPassCommon::sinkWiresDown(MSFTModuleOp mod) {
   // loopbacks for all the instances.
   if (instantiations.size() != 1)
     return;
-  InstanceOp inst = dyn_cast<InstanceOp>(instantiations[0]);
+  InstanceOp inst =
+      dyn_cast<InstanceOp>(static_cast<Operation *>(instantiations[0]));
   if (!inst)
     return;
 

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -72,7 +72,8 @@ static llvm::Optional<firrtl::FModuleOp>
 findInstantiatedModule(firrtl::InstanceOp instOp, SymbolCache &symbols) {
   auto *tableOp = SymbolTable::getNearestSymbolTable(instOp);
   auto moduleOp = dyn_cast<firrtl::FModuleOp>(
-      instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
+      instOp.getReferencedModule(symbols.getSymbolTable(tableOp))
+          .getOperation());
   return moduleOp ? llvm::Optional(moduleOp)
                   : llvm::Optional<firrtl::FModuleOp>();
 }
@@ -1031,7 +1032,7 @@ struct EagerInliner : public Reduction {
       return 0;
     auto tableOp = SymbolTable::getNearestSymbolTable(instOp);
     auto moduleOp = instOp.getReferencedModule(symbols.getSymbolTable(tableOp));
-    if (!isa<firrtl::FModuleOp>(moduleOp))
+    if (!isa<firrtl::FModuleOp>(moduleOp.getOperation()))
       return 0;
     return symbols.getSymbolUserMap(tableOp).getUsers(moduleOp).size() == 1;
   }
@@ -1054,7 +1055,8 @@ struct EagerInliner : public Reduction {
     }
     auto tableOp = SymbolTable::getNearestSymbolTable(instOp);
     auto moduleOp = cast<firrtl::FModuleOp>(
-        instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
+        instOp.getReferencedModule(symbols.getSymbolTable(tableOp))
+            .getOperation());
     for (auto &op : llvm::make_early_inc_range(*moduleOp.getBodyBlock())) {
       op.remove();
       builder.insert(&op);


### PR DESCRIPTION
Not great that this is necessary, but checking the underlying operation makes the warnings go away.
(Cast check from `Operation *` instead of `FModuleLike`/`HWModuleLike`).

In MSFTPasses used `static_cast` to get the `Operation *` because apparently `getOperation()` isn't const :disappointed: .

Fixes #3615.