### PR TITLE
Github Actions: automatically build and upload binaries on release 

### DIFF
--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -24,9 +24,6 @@ jobs:
             cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"'
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Configure Environment
-        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
-
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get CIRCT
@@ -55,7 +52,6 @@ jobs:
         with:
           path: |
             llvm/build
-            llvm/install
           key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }} 
 
       - name: Setup Ninja Linux

--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -14,14 +14,20 @@ jobs:
             mode: release
             assert: OFF
             shared: OFF
-        os: [linux, macos]
+        runner: [ubuntu-20.04, ubuntu-18.04, macos-11]
         include:
-          - os: linux
-            runner: ubuntu-20.04
+          - runner: ubuntu-20.04
+            os: linux
             cmake-args: ''
-          - os: macos
-            runner: macos-11
+            tar: tar
+          - runner: ubuntu-18.04
+            os: linux
+            cmake-args: ''
+            tar: tar
+          - runner: macos-11
+            os: macos
             cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"'
+            tar: gtar
     runs-on: ${{ matrix.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -43,7 +49,7 @@ jobs:
 
       - name: Get workflow spec hash
         id: get-workflow-hash
-        run: echo "::set-output name=hash::$(md5sum $GITHUB_WORKSPACE/.github/workflows/uploadBinaries.yml | awk '{print $1}')"
+        run: echo "::set-output name=hash::$(shasum $GITHUB_WORKSPACE/.github/workflows/uploadBinaries.yml | awk '{print $1}')"
 
       # Try to fetch LLVM from the cache.
       - name: Cache LLVM
@@ -52,20 +58,20 @@ jobs:
         with:
           path: |
             llvm/build
-          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }} 
+          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }}
 
       - name: Setup Ninja Linux
         if: matrix.os == 'linux'
         run: sudo apt-get install ninja-build
 
-      - name: Setup Ninja Mac
+      - name: Setup Ninja and GNU Tar Mac
         if: matrix.os == 'macos'
-        run: brew install ninja
+        run: brew install ninja gnu-tar
 
       # Build LLVM if we didn't hit in the cache. Even though we build it in
       # the previous job, there is a low chance that it'll have been evicted by
       # the time we get here.
-      - name: Rebuild and Install LLVM
+      - name: Rebuild LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           mkdir -p llvm/build
@@ -111,10 +117,17 @@ jobs:
             -DLLVM_PARALLEL_LINK_JOBS=1 \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
           ninja
+      - name: Display Files
+        run: file build/bin/*
       - name: Package Binaries
         run: |
           cd build
-          tar -czf circt-bin-${{ matrix.runner }}.tar.gz bin 
+          ${{ matrix.tar }} czf circt-bin-${{ matrix.runner }}.tar.gz bin
+      - name: Show Tarball
+        run: |
+          cd build
+          ls -l circt-bin-${{ matrix.runner }}.tar.gz
+          shasum -a 256 circt-bin-${{ matrix.runner }}.tar.gz
       - name: Upload Binaries
         uses: AButler/upload-release-assets@v2.0
         with:

--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -1,0 +1,126 @@
+name: Upload Binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        compiler:
+          - cc: gcc-10
+            cxx: g++-10
+            mode: release
+            assert: OFF
+            shared: OFF
+        os: [linux, macos]
+        include:
+          - os: linux
+            runner: ubuntu-20.04
+            cmake-args: ''
+          - os: macos
+            runner: macos-11
+            cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"'
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Configure Environment
+        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
+
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      # --------
+      # Restore LLVM from cache and build if it's not in there.
+      # --------
+
+      # Extract the LLVM submodule hash for use in the cache key.
+      - name: Get LLVM Hash
+        id: get-llvm-hash
+        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+
+      - name: Get workflow spec hash
+        id: get-workflow-hash
+        run: echo "::set-output name=hash::$(md5sum $GITHUB_WORKSPACE/.github/workflows/uploadBinaries.yml | awk '{print $1}')"
+
+      # Try to fetch LLVM from the cache.
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: |
+            llvm/build
+            llvm/install
+          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }} 
+
+      - name: Setup Ninja Linux
+        if: matrix.os == 'linux'
+        run: sudo apt-get install ninja-build
+
+      - name: Setup Ninja Mac
+        if: matrix.os == 'macos'
+        run: brew install ninja
+
+      # Build LLVM if we didn't hit in the cache. Even though we build it in
+      # the previous job, there is a low chance that it'll have been evicted by
+      # the time we get here.
+      - name: Rebuild and Install LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p llvm/build
+          cd llvm/build
+          cmake -G Ninja ../llvm \
+              ${{ matrix.cmake-args }} \
+              -DCMAKE_BUILD_TYPE=${{ matrix.compiler.mode }} \
+              -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
+              -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
+              -DBUILD_SHARED_LIBS=${{ matrix.compiler.shared }} \
+              -DLLVM_BUILD_EXAMPLES=OFF \
+              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
+              -DLLVM_ENABLE_BINDINGS=OFF \
+              -DLLVM_ENABLE_OCAMLDOC=OFF \
+              -DLLVM_ENABLE_PROJECTS='mlir' \
+              -DLLVM_OPTIMIZED_TABLEGEN=ON \
+              -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+              -DLLVM_ENABLE_TERMINFO=OFF \
+              -DLLVM_PARALLEL_LINK_JOBS=1 \
+              -DLLVM_TARGETS_TO_BUILD="host"
+          ninja
+
+      # --------
+      # Build and test CIRCT
+      # --------
+
+      - name: Build and Test CIRCT
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja .. \
+            ${{ matrix.cmake-args }} \
+            -DBUILD_SHARED_LIBS=${{ matrix.compiler.shared }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.compiler.mode }} \
+            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
+            -DMLIR_DIR=`pwd`/../llvm/build/lib/cmake/mlir \
+            -DLLVM_DIR=`pwd`/../llvm/build/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
+            -DVERILATOR_DISABLE=ON \
+            -DLLVM_ENABLE_TERMINFO=OFF \
+            -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+            -DLLVM_PARALLEL_LINK_JOBS=1 \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
+          ninja
+      - name: Package Binaries
+        run: |
+          cd build
+          tar -czf circt-bin-${{ matrix.runner }}.tar.gz bin 
+      - name: Upload Binaries
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: build/circt-bin-${{ matrix.runner }}.tar.gz
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to be easily usable with Chisel soon, CIRCT should provide pre-built binaries at least for macOS and Linux. Currently pre-built Linux binaries are manually uploaded whenever a new build is made. This PR adds a Github Actions script that builds and uploads macOS and Linux binaries whenever a release (or pre-release) is made (requested in #2842). The build from scratch takes approximately 2 hours.

The generated binaries are not fully static but are portable enough to run on base versions of macOS and Ubuntu/other Linuxes. The dynamic linking ends up looking like this:

Linux:

```
$ ldd firtool
	linux-vdso.so.1 (0x00007ffc10fd1000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f19d67c3000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f19d6441000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f19d6229000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f19d5e64000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f19d7142000)
```

Mac:

```
$ otool -L firtool
firtool:
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
```

You can try out the binaries from an example release [here](https://github.com/zyedidia/circt/releases/tag/test-release-15).

The build is currently set up to use gcc/g++ instead of clang because clang includes additional dynamic dependencies on Linux (`librt.so.1`, `libdl.so.2`, and `libz.so.1`) and does not support the `-static-libstdc++` flag on mac. The build currently runs on macOS-11 and Ubuntu-20.04. Are there other versions we would like to include, like Ubuntu-18.04? (I also haven't investigated running on Windows)

Currently the uploaded package contains everything in the CIRCT `bin` directory after a build. Are there other files we would like to include as well?

Also please let me know if there are other build options that would be good to enable for this. For example, I investigated making a fully static build but wasn't successful. Let me know what you think, thanks!