### PR TITLE
[ESI] [Integration tests] [Tests] Switch from 'rstn' to 'rst'

### DIFF
--- a/docs/Dialects/ESI/cosim.md
+++ b/docs/Dialects/ESI/cosim.md
@@ -63,7 +63,7 @@ module Cosim_Endpoint
 )
 (
    input  logic clk,
-   input  logic rstn,
+   input  logic rst,
 
    output logic DataOutValid,
    input  logic DataOutReady,

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -42,7 +42,7 @@ def ChannelBuffer : ESI_Abstract_Op<"buffer", [
     ```
   }];
 
-  let arguments = (ins I1:$clk, I1:$rstn, ChannelType:$input,
+  let arguments = (ins I1:$clk, I1:$rst, ChannelType:$input,
     OptionalAttr<Confined<I64Attr, [IntMinValue<1>]>>:$stages,
     OptionalAttr<StrAttr>:$name);
   let results = (outs ChannelType:$output);
@@ -61,7 +61,7 @@ def PipelineStage : ESI_Physical_Op<"stage", [
     late-pass latency balancing.
   }];
 
-  let arguments = (ins I1:$clk, I1:$rstn, ChannelType:$input);
+  let arguments = (ins I1:$clk, I1:$rst, ChannelType:$input);
   let results = (outs ChannelType:$output);
   let hasCustomAssemblyFormat = 1;
 }
@@ -84,12 +84,12 @@ def CosimEndpoint : ESI_Physical_Op<"cosim", []> {
     supported by the specific protocol.
   }];
 
-  let arguments = (ins I1:$clk, I1:$rstn, ChannelType:$send,
+  let arguments = (ins I1:$clk, I1:$rst, ChannelType:$send,
     I64Attr:$endpointID);
   let results = (outs ChannelType:$recv);
 
   let assemblyFormat = [{
-    $clk `,` $rstn `,` $send `,` $endpointID attr-dict
+    $clk `,` $rst `,` $send `,` $endpointID attr-dict
       `:` qualified(type($send)) `->` qualified(type($recv))
   }];
 }

--- a/include/circt/Dialect/ESI/ESIPrimitives.sv
+++ b/include/circt/Dialect/ESI/ESIPrimitives.sv
@@ -61,7 +61,7 @@ module ESI_PipelineStage # (
 
   // Register the backpressure.
   always_ff @(posedge clk)
-    x_ready_reg <= ~rst ? x_ready : 1'b0;
+    x_ready_reg <= rst ? 1'b0 : x_ready;
 
   // We are transmitting a token on this cycle.
   wire xmit = x_valid && x_ready;

--- a/include/circt/Dialect/ESI/ESIPrimitives.sv
+++ b/include/circt/Dialect/ESI/ESIPrimitives.sv
@@ -39,7 +39,7 @@ module ESI_PipelineStage # (
   int WIDTH = 8
 ) (
   input logic clk,
-  input logic rstn,
+  input logic rst,
 
   // Input LI channel.
   input logic a_valid,
@@ -61,7 +61,7 @@ module ESI_PipelineStage # (
 
   // Register the backpressure.
   always_ff @(posedge clk)
-    x_ready_reg <= rstn ? x_ready : 1'b0;
+    x_ready_reg <= ~rst ? x_ready : 1'b0;
 
   // We are transmitting a token on this cycle.
   wire xmit = x_valid && x_ready;
@@ -81,7 +81,7 @@ module ESI_PipelineStage # (
   wire a_rcv = a_ready && a_valid;
 
   always_ff @(posedge clk) begin
-    if (~rstn) begin
+    if (rst) begin
       l_valid <= 1'b0;
       x_valid_reg <= 1'b0;
     end else begin

--- a/include/circt/Dialect/ESI/cosim/Cosim_Endpoint.sv
+++ b/include/circt/Dialect/ESI/cosim/Cosim_Endpoint.sv
@@ -24,7 +24,7 @@ module Cosim_Endpoint
 )
 (
   input  logic clk,
-  input  logic rstn,
+  input  logic rst,
 
   output logic DataOutValid,
   input  logic DataOutReady,
@@ -66,7 +66,7 @@ module Cosim_Endpoint
 
   byte unsigned DataOutBuffer[RECV_TYPE_SIZE_BYTES-1:0];
   always @(posedge clk) begin
-    if (rstn && Initialized) begin
+    if (~rst && Initialized) begin
       if (DataOutValid && DataOutReady) // A transfer occurred.
         DataOutValid <= 1'b0;
 
@@ -137,7 +137,7 @@ module Cosim_Endpoint
   byte unsigned DataInBuffer[SEND_TYPE_SIZE_BYTES-1:0];
 
   always@(posedge clk) begin
-    if (rstn && Initialized) begin
+    if (~rst && Initialized) begin
       if (DataInValid) begin
         int rc;
         rc = cosim_ep_tryput(ENDPOINT_ID, DataInBuffer, SEND_TYPE_SIZE_BYTES);

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -25,25 +25,22 @@ with Context() as ctx, Location.unknown():
       reg_reset = hw.ConstantOp.create(i32, 0).result
       # CHECK: %[[INPUT_VAL:.+]] = hw.constant 45
       reg_input = hw.ConstantOp.create(i32, 45).result
-      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk, %rstn, %[[RESET_VAL]]
+      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk, %rst, %[[RESET_VAL]]
       reg = seq.CompRegOp(i32,
                           reg_input,
                           module.clk,
-                          reset=module.rstn,
+                          reset=module.rst,
                           reset_value=reg_reset,
                           name="my_reg")
 
       # CHECK: seq.compreg %[[INPUT_VAL]], %clk
       seq.reg(reg_input, module.clk)
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rstn, %{{.+}}
-      seq.reg(reg_input, module.clk, reset=module.rstn)
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rst, %{{.+}}
+      seq.reg(reg_input, module.clk, reset=module.rst)
       # CHECK: %[[RESET_VALUE:.+]] = hw.constant 123
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rstn, %[[RESET_VALUE]]
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rst, %[[RESET_VALUE]]
       custom_reset = hw.ConstantOp.create(i32, 123).result
-      seq.reg(reg_input,
-              module.clk,
-              reset=module.rstn,
-              reset_value=custom_reset)
+      seq.reg(reg_input, module.clk, reset=module.rst, reset_value=custom_reset)
       # CHECK: %FuBar = seq.compreg {{.+}}
       seq.reg(reg_input, module.clk, name="FuBar")
 
@@ -70,7 +67,7 @@ with Context() as ctx, Location.unknown():
       hw.OutputOp([reg.data])
 
     hw.HWModuleOp(name="top",
-                  input_ports=[("clk", i1), ("rstn", i1)],
+                  input_ports=[("clk", i1), ("rst", i1)],
                   output_ports=[("result", i32)],
                   body_builder=top)
 

--- a/integration_test/Dialect/Seq/registers.mlir
+++ b/integration_test/Dialect/Seq/registers.mlir
@@ -10,12 +10,11 @@
 
 sv.verbatim "`define INIT_RANDOM_PROLOG_"
 
-hw.module @top(%clk: i1, %rstn: i1) {
+hw.module @top(%clk: i1, %rst: i1) {
   %cst0 = hw.constant 0 : i32
   %cst1 = hw.constant 1 : i32
 
   %true = hw.constant 1 : i1
-  %rst = comb.xor %true, %rstn : i1
 
   %rC = seq.firreg %nextC clock %clk sym @regC reset sync %rst, %cst0 : i32
   %rB = seq.firreg %nextB clock %clk sym @regB reset sync %rst, %cst0 : i32

--- a/integration_test/ESI/cosim/basic.mlir
+++ b/integration_test/ESI/cosim/basic.mlir
@@ -8,21 +8,21 @@
 // PY: rpc.testVectorSum(25)
 // PY: rpc.testCrypto(25)
 
-hw.module.extern @IntAccNoBP(%clk: i1, %rstn: i1, %ints: !esi.channel<i32>) -> (totalOut: !esi.channel<i32>)
-hw.module.extern @IntArrSum(%clk: i1, %rstn: i1, %arr: !esi.channel<!hw.array<4 x si13>>) -> (totalOut: !esi.channel<!hw.array<2 x ui24>>)
+hw.module.extern @IntAccNoBP(%clk: i1, %rst: i1, %ints: !esi.channel<i32>) -> (totalOut: !esi.channel<i32>)
+hw.module.extern @IntArrSum(%clk: i1, %rst: i1, %arr: !esi.channel<!hw.array<4 x si13>>) -> (totalOut: !esi.channel<!hw.array<2 x ui24>>)
 
-hw.module @ints(%clk: i1, %rstn: i1) {
-  %intsIn = esi.cosim %clk, %rstn, %intsTotalBuffered, 1 {name="TestEP"} : !esi.channel<i32> -> !esi.channel<i32>
-  %intsInBuffered = esi.buffer %clk, %rstn, %intsIn {stages=2, name="intChan"} : i32
-  %intsTotal = hw.instance "acc" @IntAccNoBP(clk: %clk: i1, rstn: %rstn: i1, ints: %intsInBuffered: !esi.channel<i32>) -> (totalOut: !esi.channel<i32>)
-  %intsTotalBuffered = esi.buffer %clk, %rstn, %intsTotal {stages=2, name="totalChan"} : i32
+hw.module @ints(%clk: i1, %rst: i1) {
+  %intsIn = esi.cosim %clk, %rst, %intsTotalBuffered, 1 {name="TestEP"} : !esi.channel<i32> -> !esi.channel<i32>
+  %intsInBuffered = esi.buffer %clk, %rst, %intsIn {stages=2, name="intChan"} : i32
+  %intsTotal = hw.instance "acc" @IntAccNoBP(clk: %clk: i1, rst: %rst: i1, ints: %intsInBuffered: !esi.channel<i32>) -> (totalOut: !esi.channel<i32>)
+  %intsTotalBuffered = esi.buffer %clk, %rst, %intsTotal {stages=2, name="totalChan"} : i32
 }
 
-hw.module @array(%clk: i1, %rstn: i1) {
-  %arrIn = esi.cosim %clk, %rstn, %arrTotalBuffered, 2 {name="TestEP"} : !esi.channel<!hw.array<2 x ui24>> -> !esi.channel<!hw.array<4 x si13>>
-  %arrInBuffered = esi.buffer %clk, %rstn, %arrIn {stages=2, name="arrChan"} : !hw.array<4 x si13>
-  %arrTotal = hw.instance "acc" @IntArrSum(clk: %clk: i1, rstn: %rstn: i1, arr: %arrInBuffered: !esi.channel<!hw.array<4 x si13>>) -> (totalOut: !esi.channel<!hw.array<2 x ui24>>)
-  %arrTotalBuffered = esi.buffer %clk, %rstn, %arrTotal {stages=2, name="totalChan"} : !hw.array<2 x ui24>
+hw.module @array(%clk: i1, %rst: i1) {
+  %arrIn = esi.cosim %clk, %rst, %arrTotalBuffered, 2 {name="TestEP"} : !esi.channel<!hw.array<2 x ui24>> -> !esi.channel<!hw.array<4 x si13>>
+  %arrInBuffered = esi.buffer %clk, %rst, %arrIn {stages=2, name="arrChan"} : !hw.array<4 x si13>
+  %arrTotal = hw.instance "acc" @IntArrSum(clk: %clk: i1, rst: %rst: i1, arr: %arrInBuffered: !esi.channel<!hw.array<4 x si13>>) -> (totalOut: !esi.channel<!hw.array<2 x ui24>>)
+  %arrTotalBuffered = esi.buffer %clk, %rst, %arrTotal {stages=2, name="totalChan"} : !hw.array<2 x ui24>
 }
 
 !DataPkt = !hw.struct<encrypted: i1, blob: !hw.array<32 x i8>>
@@ -30,18 +30,18 @@ hw.module @array(%clk: i1, %rstn: i1) {
 !Config  = !hw.struct<encrypt:   i1, otp:  !hw.array<32 x i8>>
 !cfgChan = !esi.channel<!Config>
 
-hw.module.extern @Encryptor(%clk: i1, %rstn: i1, %in: !pktChan, %cfg: !cfgChan) -> (x: !pktChan)
+hw.module.extern @Encryptor(%clk: i1, %rst: i1, %in: !pktChan, %cfg: !cfgChan) -> (x: !pktChan)
 
-hw.module @structs(%clk:i1, %rstn:i1) -> () {
-  %compressedData = hw.instance "otpCryptor" @Encryptor(clk: %clk: i1, rstn: %rstn: i1, in: %inputData: !pktChan, cfg: %cfg: !cfgChan) -> (x: !pktChan)
-  %inputData = esi.cosim %clk, %rstn, %compressedData, 3 {name="CryptoData"} : !pktChan -> !pktChan
+hw.module @structs(%clk:i1, %rst:i1) -> () {
+  %compressedData = hw.instance "otpCryptor" @Encryptor(clk: %clk: i1, rst: %rst: i1, in: %inputData: !pktChan, cfg: %cfg: !cfgChan) -> (x: !pktChan)
+  %inputData = esi.cosim %clk, %rst, %compressedData, 3 {name="CryptoData"} : !pktChan -> !pktChan
   %c0 = hw.constant 0 : i1
   %null, %nullReady = esi.wrap.vr %c0, %c0 : i1
-  %cfg = esi.cosim %clk, %rstn, %null, 4 {name="CryptoConfig"} : !esi.channel<i1> -> !cfgChan
+  %cfg = esi.cosim %clk, %rst, %null, 4 {name="CryptoConfig"} : !esi.channel<i1> -> !cfgChan
 }
 
-hw.module @top(%clk: i1, %rstn: i1) {
-  hw.instance "ints" @ints (clk: %clk: i1, rstn: %rstn: i1) -> ()
-  hw.instance "array" @array(clk: %clk: i1, rstn: %rstn: i1) -> ()
-  hw.instance "structs" @structs(clk: %clk: i1, rstn: %rstn: i1) -> ()
+hw.module @top(%clk: i1, %rst: i1) {
+  hw.instance "ints" @ints (clk: %clk: i1, rst: %rst: i1) -> ()
+  hw.instance "array" @array(clk: %clk: i1, rst: %rst: i1) -> ()
+  hw.instance "structs" @structs(clk: %clk: i1, rst: %rst: i1) -> ()
 }

--- a/integration_test/ESI/cosim/cosim_only.sv
+++ b/integration_test/ESI/cosim/cosim_only.sv
@@ -10,7 +10,7 @@ import Cosim_DpiPkg::*;
 
 module top(
     input logic clk,
-    input logic rstn
+    input logic rst
 );
     localparam int TYPE_SIZE_BITS =
         (1 * 64) + // root message
@@ -37,7 +37,7 @@ module top(
 
     always@(posedge clk)
     begin
-        if (rstn)
+        if (~rst)
         begin
             if (DataOutValid && DataOutReady)
             begin

--- a/integration_test/ESI/cosim/loopback.mlir
+++ b/integration_test/ESI/cosim/loopback.mlir
@@ -9,15 +9,15 @@
 // PY: rpc.test_i32(25)
 // PY: rpc.test_keytext(25)
 
-hw.module @intLoopback(%clk:i1, %rstn:i1) -> () {
-  %cosimRecv = esi.cosim %clk, %rstn, %bufferedResp, 1 {name="IntTestEP"} : !esi.channel<i32> -> !esi.channel<i32>
-  %bufferedResp = esi.buffer %clk, %rstn, %cosimRecv {stages=1} : i32
+hw.module @intLoopback(%clk:i1, %rst:i1) -> () {
+  %cosimRecv = esi.cosim %clk, %rst, %bufferedResp, 1 {name="IntTestEP"} : !esi.channel<i32> -> !esi.channel<i32>
+  %bufferedResp = esi.buffer %clk, %rst, %cosimRecv {stages=1} : i32
 }
 
 !KeyText = !hw.struct<text: !hw.array<6xi14>, key: !hw.array<4xi8>>
-hw.module @twoListLoopback(%clk:i1, %rstn:i1) -> () {
-  %cosim = esi.cosim %clk, %rstn, %resp, 2 {name="KeyTextEP"} : !esi.channel<!KeyText> -> !esi.channel<!KeyText>
-  %resp = esi.buffer %clk, %rstn, %cosim {stages=4} : !KeyText
+hw.module @twoListLoopback(%clk:i1, %rst:i1) -> () {
+  %cosim = esi.cosim %clk, %rst, %resp, 2 {name="KeyTextEP"} : !esi.channel<!KeyText> -> !esi.channel<!KeyText>
+  %resp = esi.buffer %clk, %rst, %cosim {stages=4} : !KeyText
 }
 
 esi.service.decl @HostComms {
@@ -30,10 +30,10 @@ hw.module @TwoChanLoopback(%clk: i1) -> () {
   esi.service.req.to_server %dataIn -> <@HostComms::@Send> (["loopback_fromhw"]) : !esi.channel<i8>
 }
 
-hw.module @top(%clk:i1, %rstn:i1) -> () {
-  hw.instance "intLoopbackInst" @intLoopback(clk: %clk: i1, rstn: %rstn: i1) -> ()
-  hw.instance "twoListLoopbackInst" @twoListLoopback(clk: %clk: i1, rstn: %rstn: i1) -> ()
+hw.module @top(%clk:i1, %rst:i1) -> () {
+  hw.instance "intLoopbackInst" @intLoopback(clk: %clk: i1, rst: %rst: i1) -> ()
+  hw.instance "twoListLoopbackInst" @twoListLoopback(clk: %clk: i1, rst: %rst: i1) -> ()
 
-  esi.service.instance @HostComms impl as  "cosim" opts {EpID_start = 10} (%clk, %rstn) : (i1, i1) -> ()
+  esi.service.instance @HostComms impl as  "cosim" opts {EpID_start = 10} (%clk, %rst) : (i1, i1) -> ()
   hw.instance "TwoChanLoopback" @TwoChanLoopback(clk: %clk: i1) -> ()
 }

--- a/integration_test/ESI/primitives/primitive_tb.sv
+++ b/integration_test/ESI/primitives/primitive_tb.sv
@@ -12,7 +12,7 @@
 
 module top (
   input logic clk,
-  input logic rstn
+  input logic rst
 );
 
   logic a_valid = 0;
@@ -44,8 +44,8 @@ module top (
   end
 
   initial begin
-    // Wait until rstn is asserted.
-    while (!rstn) begin
+    // Wait until rst is asserted.
+    while (rst) begin
       @(posedge clk);
     end
 

--- a/integration_test/ESI/primitives/primitive_tb.sv
+++ b/integration_test/ESI/primitives/primitive_tb.sv
@@ -44,7 +44,7 @@ module top (
   end
 
   initial begin
-    // Wait until rst is asserted.
+    // Wait until rstn is deasserted.
     while (rst) begin
       @(posedge clk);
     end

--- a/integration_test/ESI/supplements/integers.sv
+++ b/integration_test/ESI/supplements/integers.sv
@@ -4,15 +4,15 @@
 // Produce a stream of incrementing integers.
 module IntCountProd (
   input clk,
-  input rstn,
+  input rst,
   IValidReady_i32.sink ints
 );
   logic unsigned [31:0] count;
-  assign ints.valid = rstn;
+  assign ints.valid = ~rst;
   assign ints.data = count;
 
   always@(posedge clk) begin
-    if (~rstn)
+    if (rst)
       count <= 32'h0;
     else if (ints.ready)
       count <= count + 1'h1;
@@ -23,7 +23,7 @@ endmodule
 // cycle. Output the total over a raw port.
 module IntAcc (
   input clk,
-  input rstn,
+  input rst,
   IValidReady_i32.source ints,
   output unsigned [31:0] totalOut
 );
@@ -31,11 +31,11 @@ module IntAcc (
 
   // De-assert ready randomly
   int unsigned randReady;
-  assign ints.ready = rstn && (randReady > 25);
+  assign ints.ready = ~rst && (randReady > 25);
 
   always@(posedge clk) begin
     randReady <= $urandom_range(100, 0);
-    if (~rstn) begin
+    if (rst) begin
       total <= 32'h0;
     end else begin
       $display("Total: %10d", total);
@@ -50,7 +50,7 @@ endmodule
 // over an ESI channel.
 module IntAccNoBP (
   input clk,
-  input rstn,
+  input rst,
   IValidReady_i32.source ints,
   IValidReady_i32.sink totalOut
 );
@@ -58,7 +58,7 @@ module IntAccNoBP (
   assign totalOut.data = total;
 
   always@(posedge clk) begin
-    if (~rstn) begin
+    if (rst) begin
       total <= 32'h0;
       ints.ready <= 1;
       totalOut.valid <= 0;
@@ -79,7 +79,7 @@ endmodule
 
 module IntArrSum (
   input clk,
-  input rstn,
+  input rst,
   IValidReady_ArrayOf4xsi13.source arr,
   IValidReady_ArrayOf2xui24.sink totalOut
 );
@@ -92,7 +92,7 @@ endmodule
 
 module Encryptor (
   input clk,
-  input rstn,
+  input rst,
   IValidReady_Struct.source in,
   IValidReady_Struct1.source cfg,
   IValidReady_Struct.sink x
@@ -113,7 +113,7 @@ module Encryptor (
       encrypt <= cfg.data.encrypt;
       otpValid <= 1;
     end
-    if (~rstn)
+    if (rst)
       otpValid <= 0;
   end
 endmodule

--- a/integration_test/ESI/system/basic.mlir
+++ b/integration_test/ESI/system/basic.mlir
@@ -3,12 +3,12 @@
 // RUN: circt-opt %t1.mlir -export-verilog -verify-diagnostics -o t3.mlir > %t2.sv
 // RUN: circt-rtl-sim.py %t2.sv %INC%/circt/Dialect/ESI/ESIPrimitives.sv %S/../supplements/integers.sv --cycles 150 | FileCheck %s
 
-hw.module.extern @IntCountProd(%clk: i1, %rstn: i1) -> (ints: !esi.channel<i32>)
-hw.module.extern @IntAcc(%clk: i1, %rstn: i1, %ints: !esi.channel<i32>) -> (totalOut: i32)
-hw.module @top(%clk: i1, %rstn: i1) -> (totalOut: i32) {
-  %intStream = hw.instance "prod" @IntCountProd(clk: %clk: i1, rstn: %rstn: i1) -> (ints: !esi.channel<i32>)
-  %intStreamBuffered = esi.buffer %clk, %rstn, %intStream {stages=2, name="intChan"} : i32
-  %totalOut = hw.instance "acc" @IntAcc(clk: %clk: i1, rstn: %rstn: i1, ints: %intStreamBuffered: !esi.channel<i32>) -> (totalOut: i32)
+hw.module.extern @IntCountProd(%clk: i1, %rst: i1) -> (ints: !esi.channel<i32>)
+hw.module.extern @IntAcc(%clk: i1, %rst: i1, %ints: !esi.channel<i32>) -> (totalOut: i32)
+hw.module @top(%clk: i1, %rst: i1) -> (totalOut: i32) {
+  %intStream = hw.instance "prod" @IntCountProd(clk: %clk: i1, rst: %rst: i1) -> (ints: !esi.channel<i32>)
+  %intStreamBuffered = esi.buffer %clk, %rst, %intStream {stages=2, name="intChan"} : i32
+  %totalOut = hw.instance "acc" @IntAcc(clk: %clk: i1, rst: %rst: i1, ints: %intStreamBuffered: !esi.channel<i32>) -> (totalOut: i32)
   hw.output %totalOut : i32
 }
 // CHECK:      [driver] Starting simulation

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -5,7 +5,7 @@
 module {
   // The HW dialect doesn't have any sequential constructs yet. So don't do
   // much.
-  hw.module @top(%clk: i1, %rstn: i1) {
+  hw.module @top(%clk: i1, %rst: i1) {
     %c1 = hw.instance "aaa" @AAA () -> (f: i1)
     %c1Shl = hw.instance "shl" @shl (a: %c1: i1) -> (b: i1)
     sv.always posedge %clk {

--- a/integration_test/EmitVerilog/exampleCodeGen.fir
+++ b/integration_test/EmitVerilog/exampleCodeGen.fir
@@ -28,11 +28,11 @@ circuit top :
 
   module top :
     input clk : Clock
-    input rstn : UInt<1>
+    input rst : UInt<1>
 
     inst iLFSR of LFSR @[main.scala 31:21]
     node clock = clk
-    node reset = not(rstn)
+    node reset = rst
     reg i : UInt<8>, clock with :
       reset => (UInt<1>("h0"), i) @[main.scala 32:18]
     reg golden_0 : UInt<6>, clock with :

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -17,7 +17,7 @@ module {
   hw.module.extern @Rcvr (%m: !sv.modport<@data_vr::@data_in>)
   sv.verbatim "module Rcvr (data_vr.data_in m);\nendmodule"
 
-  hw.module @top (%clk: i1, %rstn: i1) {
+  hw.module @top (%clk: i1, %rst: i1) {
     %iface = sv.interface.instance : !sv.interface<@data_vr>
 
     %ifaceInPort = sv.modport.get %iface @data_in :

--- a/integration_test/circt-rtl-sim/circt-rtl-sim-ieee-sim.sv
+++ b/integration_test/circt-rtl-sim/circt-rtl-sim-ieee-sim.sv
@@ -3,11 +3,11 @@
 
 module top(
   input clk,
-  input rstn
+  input rst
 );
 
   always@(posedge clk)
-    if (rstn)
+    if (~rst)
       $display("tock");
   // CHECK:      tock
   // CHECK-NEXT: tock

--- a/integration_test/circt-rtl-sim/circt-rtl-sim-iverilog.sv
+++ b/integration_test/circt-rtl-sim/circt-rtl-sim-iverilog.sv
@@ -3,11 +3,11 @@
 
 module top(
   input clk,
-  input rstn
+  input rst
 );
 
   always@(posedge clk)
-    if (rstn)
+    if (~rst)
       $display("tock");
   // CHECK:      tock
   // CHECK-NEXT: tock

--- a/integration_test/circt-rtl-sim/circt-rtl-sim-verilator.sv
+++ b/integration_test/circt-rtl-sim/circt-rtl-sim-verilator.sv
@@ -3,11 +3,11 @@
 
 module top(
   input clk,
-  input rstn
+  input rst
 );
 
   always@(posedge clk)
-    if (rstn)
+    if (~rst)
       $display("tock");
   // CHECK:      tock
   // CHECK-NEXT: tock

--- a/lib/Bindings/Python/circt/esi.py
+++ b/lib/Bindings/Python/circt/esi.py
@@ -40,7 +40,7 @@ class System(CppSystem):
 
   def top_module(self):
     return hw.HWModuleOp(name='top',
-                         input_ports=[('clk', self.i1), ('rstn', self.i1)],
+                         input_ports=[('clk', self.i1), ('rst', self.i1)],
                          output_ports=[],
                          body_builder=self.build_top)
 
@@ -71,14 +71,14 @@ class System(CppSystem):
     self.run_passes()
     circt.export_verilog(self.mod, out_stream)
 
-  def cosim(self, name, id, clk, rstn, recv_type=None, send=None):
+  def cosim(self, name, id, clk, rst, recv_type=None, send=None):
     if recv_type is None:
       recv_type = mlir.ir.IntegerType.get_signless(1)
     recv_type = ChannelType.get(recv_type)
     if send is None:
       send = NullSourceOp(ChannelType.get(
           mlir.ir.IntegerType.get_signless(1))).out
-    ep = CosimEndpoint(recv_type, clk, rstn, send,
+    ep = CosimEndpoint(recv_type, clk, rst, send,
                        mlir.ir.Attribute.parse(str(id)))
     ep.operation.attributes["name"] = mlir.ir.StringAttr.get(name)
     return ep

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -50,7 +50,7 @@ ParseResult ChannelBuffer::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void ChannelBuffer::print(OpAsmPrinter &p) {
-  p << " " << clk() << ", " << rstn() << ", " << input() << " ";
+  p << " " << clk() << ", " << rst() << ", " << input() << " ";
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }
@@ -84,7 +84,7 @@ ParseResult PipelineStage::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void PipelineStage::print(OpAsmPrinter &p) {
-  p << " " << clk() << ", " << rstn() << ", " << input() << " ";
+  p << " " << clk() << ", " << rst() << ", " << input() << " ";
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -66,7 +66,7 @@ public:
   const StringAttr a, aValid, aReady, x, xValid, xReady;
   const StringAttr dataOutValid, dataOutReady, dataOut, dataInValid,
       dataInReady, dataIn;
-  const StringAttr clk, rstn;
+  const StringAttr clk, rst;
   const StringAttr width;
 
   // Various identifier strings. Keep them all here in case we rename them.
@@ -106,7 +106,7 @@ ESIHWBuilder::ESIHWBuilder(Operation *top)
       dataInReady(StringAttr::get(getContext(), "DataInReady")),
       dataIn(StringAttr::get(getContext(), "DataIn")),
       clk(StringAttr::get(getContext(), "clk")),
-      rstn(StringAttr::get(getContext(), "rstn")),
+      rst(StringAttr::get(getContext(), "rst")),
       width(StringAttr::get(getContext(), "WIDTH")) {
 
   auto regions = top->getRegions();
@@ -195,7 +195,7 @@ HWModuleExternOp ESIHWBuilder::declareStage(Operation *symTable,
   size_t resn = 0;
   llvm::SmallVector<PortInfo> ports = {
       {clk, PortDirection::INPUT, getI1Type(), argn++},
-      {rstn, PortDirection::INPUT, getI1Type(), argn++}};
+      {rst, PortDirection::INPUT, getI1Type(), argn++}};
 
   if (stage.hasData())
     ports.push_back({a, PortDirection::INPUT, dataType, argn++});
@@ -229,7 +229,7 @@ HWModuleExternOp ESIHWBuilder::declareCosimEndpoint(Operation *symTable,
   // Will be refining this when we decide how to better handle parameterized
   // types and ops.
   PortInfo ports[] = {{clk, PortDirection::INPUT, getI1Type(), 0},
-                      {rstn, PortDirection::INPUT, getI1Type(), 1},
+                      {rst, PortDirection::INPUT, getI1Type(), 1},
                       {dataOutValid, PortDirection::OUTPUT, getI1Type(), 0},
                       {dataOutReady, PortDirection::INPUT, getI1Type(), 2},
                       {dataOut, PortDirection::OUTPUT, recvType, 1},
@@ -318,7 +318,7 @@ LogicalResult ChannelBufferLowering::matchAndRewrite(
   for (uint64_t i = 0; i < numStages; ++i) {
     // Create the stages, connecting them up as we build.
     auto stage = rewriter.create<PipelineStage>(loc, type, buffer.clk(),
-                                                buffer.rstn(), input);
+                                                buffer.rst(), input);
     if (bufferName) {
       SmallString<64> stageName(
           {bufferName.getValue(), "_stage", std::to_string(i)});
@@ -914,7 +914,7 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
 
   // Instantiate the "ESI_PipelineStage" external module.
   circt::Backedge stageReady = back.get(rewriter.getI1Type());
-  llvm::SmallVector<Value> operands = {stage.clk(), stage.rstn()};
+  llvm::SmallVector<Value> operands = {stage.clk(), stage.rst()};
   if (stage.hasData())
     operands.push_back(unwrap.rawOutput());
   operands.push_back(unwrap.valid());
@@ -1180,7 +1180,7 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
   auto *ctxt = rewriter.getContext();
   auto operands = adaptor.getOperands();
   Value clk = operands[0];
-  Value rstn = operands[1];
+  Value rst = operands[1];
   Value send = operands[2];
 
   circt::BackedgeBuilder bb(rewriter, loc);
@@ -1233,7 +1233,7 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
   StringAttr nameAttr = ep->getAttr("name").dyn_cast_or_null<StringAttr>();
   StringRef name = nameAttr ? nameAttr.getValue() : "cosimEndpoint";
   Value epInstInputs[] = {
-      clk, rstn, recvReady, unwrapSend.valid(), encodeData.capnpBits(),
+      clk, rst, recvReady, unwrapSend.valid(), encodeData.capnpBits(),
   };
 
   auto cosimEpModule =

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -24,21 +24,21 @@ hw.module @StructRcvr(%a: !esi.channel<!FooStruct>) {
 // CHECK:        %rawOutput, %valid = esi.unwrap.vr %a, %true : i1
 // CHECK-LABEL: hw.module @StructRcvr(%a: !esi.channel<!hw.struct<a: si4, b: !hw.array<3xui4>>>)
 
-hw.module @test(%clk: i1, %rstn: i1) {
+hw.module @test(%clk: i1, %rst: i1) {
   %esiChan = hw.instance "sender" @Sender() -> (x: !esi.channel<i1>)
-  %bufferedChan = esi.buffer %clk, %rstn, %esiChan : i1
+  %bufferedChan = esi.buffer %clk, %rst, %esiChan : i1
   hw.instance "recv" @Reciever (a: %bufferedChan: !esi.channel<i1>) -> ()
 
   // CHECK:  %sender.x = hw.instance "sender" @Sender() -> (x: !esi.channel<i1>)
-  // CHECK-NEXT:  %0 = esi.buffer %clk, %rstn, %sender.x : i1
+  // CHECK-NEXT:  %0 = esi.buffer %clk, %rst, %sender.x : i1
   // CHECK-NEXT:  hw.instance "recv" @Reciever(a: %0: !esi.channel<i1>) -> ()
 
   %esiChan2 = hw.instance "sender" @Sender() -> (x: !esi.channel<i1>)
-  %bufferedChan2 = esi.buffer %clk, %rstn, %esiChan2 { stages = 4 } : i1
+  %bufferedChan2 = esi.buffer %clk, %rst, %esiChan2 { stages = 4 } : i1
   hw.instance "recv" @Reciever (a: %bufferedChan2: !esi.channel<i1>) -> ()
 
   // CHECK-NEXT:  %sender.x_0 = hw.instance "sender" @Sender() -> (x: !esi.channel<i1>)
-  // CHECK-NEXT:  %1 = esi.buffer %clk, %rstn, %sender.x_0 {stages = 4 : i64} : i1
+  // CHECK-NEXT:  %1 = esi.buffer %clk, %rst, %sender.x_0 {stages = 4 : i64} : i1
   // CHECK-NEXT:  hw.instance "recv" @Reciever(a: %1: !esi.channel<i1>) -> ()
 
   %nullBit = esi.null : !esi.channel<i1>
@@ -83,18 +83,18 @@ hw.module @testIfaceWrap() {
   // CHECK-NEXT:     esi.unwrap.iface %3 into %6 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 }
 
-// CHECK-LABEL: hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
-// CHECK-NEXT:    %0 = esi.buffer %clk, %rstn, %a  : none
-// CHECK-NEXT:    %1 = esi.stage %clk, %rstn, %0  : none
+// CHECK-LABEL: hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rst: i1) -> (x: !esi.channel<none>) {
+// CHECK-NEXT:    %0 = esi.buffer %clk, %rst, %a  : none
+// CHECK-NEXT:    %1 = esi.stage %clk, %rst, %0  : none
 // CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %1, %ready : none
 // CHECK-NEXT:    %2 = esi.none : none
 // CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %2, %valid : none
 // CHECK-NEXT:    hw.output %chanOutput : !esi.channel<none>
 // CHECK-NEXT:  }
 
-hw.module @NoneTyped(%a: !esi.channel<none>, %clk : i1, %rstn : i1) -> (x: !esi.channel<none>) {
-  %bufferedA = esi.buffer %clk, %rstn, %a : none
-  %stagedA = esi.stage %clk, %rstn, %bufferedA : none
+hw.module @NoneTyped(%a: !esi.channel<none>, %clk : i1, %rst : i1) -> (x: !esi.channel<none>) {
+  %bufferedA = esi.buffer %clk, %rst, %a : none
+  %stagedA = esi.stage %clk, %rst, %bufferedA : none
   %none1, %valid = esi.unwrap.vr %stagedA, %rcvrRdy : none
   %none2 = esi.none : none
   %ch, %rcvrRdy = esi.wrap.vr %none2, %valid : none

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -12,21 +12,21 @@ hw.module.extern @ArrReciever(%x: !esi.channel<!hw.array<4xsi64>>)
 // CHECK-LABEL: hw.module.extern @Reciever(%a: !esi.channel<i32>)
 // CHECK-LABEL: hw.module.extern @ArrReciever(%x: !esi.channel<!hw.array<4xsi64>>)
 
-hw.module @top(%clk:i1, %rstn:i1) -> () {
+hw.module @top(%clk:i1, %rst:i1) -> () {
   hw.instance "recv" @Reciever (a: %cosimRecv: !esi.channel<i32>) -> ()
   // CHECK:  hw.instance "recv" @Reciever(a: %0: !esi.channel<i32>) -> ()
 
   %send.x = hw.instance "send" @Sender () -> (x: !esi.channel<si14>)
   // CHECK:  %send.x = hw.instance "send" @Sender() -> (x: !esi.channel<si14>)
 
-  %cosimRecv = esi.cosim %clk, %rstn, %send.x, 1 {name="TestEP"} : !esi.channel<si14> -> !esi.channel<i32>
-  // CHECK:  esi.cosim %clk, %rstn, %send.x, 1 {name = "TestEP"} : !esi.channel<si14> -> !esi.channel<i32>
+  %cosimRecv = esi.cosim %clk, %rst, %send.x, 1 {name="TestEP"} : !esi.channel<si14> -> !esi.channel<i32>
+  // CHECK:  esi.cosim %clk, %rst, %send.x, 1 {name = "TestEP"} : !esi.channel<si14> -> !esi.channel<i32>
 
   %send2.x = hw.instance "send2" @Sender () -> (x: !esi.channel<si14>)
   // CHECK:  %send2.x = hw.instance "send2" @Sender() -> (x: !esi.channel<si14>)
 
-  %cosimArrRecv = esi.cosim %clk, %rstn, %send2.x, 2 {name="ArrTestEP"} : !esi.channel<si14> -> !esi.channel<!hw.array<4xsi64>>
-  // CHECK:  esi.cosim %clk, %rstn, %send2.x, 2 {name = "ArrTestEP"} : !esi.channel<si14> -> !esi.channel<!hw.array<4xsi64>>
+  %cosimArrRecv = esi.cosim %clk, %rst, %send2.x, 2 {name="ArrTestEP"} : !esi.channel<si14> -> !esi.channel<!hw.array<4xsi64>>
+  // CHECK:  esi.cosim %clk, %rst, %send2.x, 2 {name = "ArrTestEP"} : !esi.channel<si14> -> !esi.channel<!hw.array<4xsi64>>
 
   hw.instance "arrRecv" @ArrReciever (x: %cosimArrRecv: !esi.channel<!hw.array<4 x si64>>) -> ()
 
@@ -41,7 +41,7 @@ hw.module @top(%clk:i1, %rstn:i1) -> () {
   // CAPNP: list @0 () -> (ifaces :List(EsiDpiInterfaceDesc));
   // CAPNP: open @1 [S, T] (iface :EsiDpiInterfaceDesc) -> (iface :EsiDpiEndpoint(S, T));
 
-  // COSIM: %TestEP.DataOutValid, %TestEP.DataOut, %TestEP.DataInReady = hw.instance "TestEP" @Cosim_Endpoint<ENDPOINT_ID: i32 = 1, SEND_TYPE_ID: ui64 = 11229133067582987457, SEND_TYPE_SIZE_BITS: i32 = 128, RECV_TYPE_ID: ui64 = 10578209918096690139, RECV_TYPE_SIZE_BITS: i32 = 128>(clk: %clk: i1, rstn: %rstn: i1, DataOutReady: %{{.*}}: i1, DataInValid: %{{.*}}: i1, DataIn: %encodeSi14Inst.encoded: !hw.array<128xi1>) -> (DataOutValid: i1, DataOut: !hw.array<128xi1>, DataInReady: i1)
+  // COSIM: %TestEP.DataOutValid, %TestEP.DataOut, %TestEP.DataInReady = hw.instance "TestEP" @Cosim_Endpoint<ENDPOINT_ID: i32 = 1, SEND_TYPE_ID: ui64 = 11229133067582987457, SEND_TYPE_SIZE_BITS: i32 = 128, RECV_TYPE_ID: ui64 = 10578209918096690139, RECV_TYPE_SIZE_BITS: i32 = 128>(clk: %clk: i1, rst: %rst: i1, DataOutReady: %{{.*}}: i1, DataInValid: %{{.*}}: i1, DataIn: %encodeSi14Inst.encoded: !hw.array<128xi1>) -> (DataOutValid: i1, DataOut: !hw.array<128xi1>, DataInReady: i1)
 
   // SV: assign _T.valid = TestEP_DataOutValid;
   // SV: assign _T.data = dataSection[6'h0+:32];
@@ -60,7 +60,7 @@ hw.module @top(%clk:i1, %rstn:i1) -> () {
   // SV:   .SEND_TYPE_SIZE_BITS(32'd128)
   // SV: ) TestEP (
   // SV:   .clk (clk),
-  // SV:   .rstn (rstn),
+  // SV:   .rst (rst),
   // SV:   .DataOutReady ({{.+}}.ready),
   // SV:   .DataInValid ({{.+}}.valid),
   // SV:   .DataIn ({50'h0, {{.+}}.data, {16'h0, 16'h1, 30'h0, 2'h0}})
@@ -83,7 +83,7 @@ hw.module @top(%clk:i1, %rstn:i1) -> () {
   // SV:    .SEND_TYPE_SIZE_BITS(32'd128)
   // SV:  ) ArrTestEP (
   // SV:    .clk          (clk),
-  // SV:    .rstn         (rstn),
+  // SV:    .rst         (rst),
   // SV:    .DataOutReady ({{.+}}.ready),
   // SV:    .DataInValid  ([[IF1]].valid),
   // SV:    .DataIn       ({50'h0, [[IF1]].data, {16'h0, 16'h1, 30'h0, 2'h0}}),

--- a/test/Dialect/ESI/cosim_structs.mlir
+++ b/test/Dialect/ESI/cosim_structs.mlir
@@ -7,9 +7,9 @@
 
 hw.module.extern @Compressor(%in: !esi.channel<i1>) -> (x: !pktChan)
 
-hw.module @top(%clk:i1, %rstn:i1) -> () {
+hw.module @top(%clk:i1, %rst:i1) -> () {
   %compressedData = hw.instance "compressor" @Compressor(in: %inputData: !esi.channel<i1>) -> (x: !pktChan)
-  %inputData = esi.cosim %clk, %rstn, %compressedData, 1 {name="Compressor"} : !pktChan -> !esi.channel<i1>
+  %inputData = esi.cosim %clk, %rst, %compressedData, 1 {name="Compressor"} : !pktChan -> !esi.channel<i1>
 }
 
 // CAPNP:      struct Struct{{.+}}
@@ -18,5 +18,5 @@ hw.module @top(%clk:i1, %rstn:i1) -> () {
 // CAPNP-NEXT:   blob             @2 :List(UInt8);
 
 // COSIM: hw.instance "encodeStruct{{.+}}Inst" @encodeStruct{{.+}}(clk: %clk: i1, valid: %6: i1, unencodedInput: %7: !hw.struct<encrypted: i1, compressionLevel: ui4, blob: !hw.array<32xi8>>) -> (encoded: !hw.array<448xi1>)
-// COSIM: hw.instance "Compressor" @Cosim_Endpoint<ENDPOINT_ID: i32 = 1, SEND_TYPE_ID: ui64 = 11116741711825659895, SEND_TYPE_SIZE_BITS: i32 = 448, RECV_TYPE_ID: ui64 = 17519082812652290511, RECV_TYPE_SIZE_BITS: i32 = 128>(clk: %clk: i1, rstn: %rstn: i1, {{.+}}, {{.+}}, {{.+}}) -> ({{.+}})
+// COSIM: hw.instance "Compressor" @Cosim_Endpoint<ENDPOINT_ID: i32 = 1, SEND_TYPE_ID: ui64 = 11116741711825659895, SEND_TYPE_SIZE_BITS: i32 = 448, RECV_TYPE_ID: ui64 = 17519082812652290511, RECV_TYPE_SIZE_BITS: i32 = 128>(clk: %clk: i1, rst: %rst: i1, {{.+}}, {{.+}}, {{.+}}) -> ({{.+}})
 // COSIM: hw.module @encode{{.+}}(%clk: i1, %valid: i1, %unencodedInput: !hw.struct<encrypted: i1, compressionLevel: ui4, blob: !hw.array<32xi8>>) -> (encoded: !hw.array<448xi1>)

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -86,16 +86,16 @@ hw.module @Loopback (%clk: i1) -> () {
 
 // -----
 
-hw.module @Top(%clk: i1, %rstn: i1) -> () {
+hw.module @Top(%clk: i1, %rst: i1) -> () {
   // expected-error @+2 {{'esi.service.impl_req' op incorrect type for option 'EpID_start'}}
   // expected-error @+1 {{'esi.service.instance' op failed to generate server}}
-  esi.service.instance @HostComms impl as  "cosim" opts {EpID_start = "wrong!"} (%clk, %rstn) : (i1, i1) -> ()
+  esi.service.instance @HostComms impl as  "cosim" opts {EpID_start = "wrong!"} (%clk, %rst) : (i1, i1) -> ()
 }
 
 // -----
 
-hw.module @Top(%clk: i1, %rstn: i1) -> () {
+hw.module @Top(%clk: i1, %rst: i1) -> () {
   // expected-error @+2 {{'esi.service.impl_req' op did not recognize option name "badOpt"}}
   // expected-error @+1 {{'esi.service.instance' op failed to generate server}}
-  esi.service.instance @HostComms impl as  "cosim" opts {badOpt = "wrong!"} (%clk, %rstn) : (i1, i1) -> ()
+  esi.service.instance @HostComms impl as  "cosim" opts {badOpt = "wrong!"} (%clk, %rst) : (i1, i1) -> ()
 }

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -32,26 +32,26 @@ hw.module.extern @NoneSenderReceiver(%in: !esi.channel<none>) -> (out: !esi.chan
 // IFACE-LABEL: hw.module.extern @Reciever(%a: !sv.modport<@IValidReady_i4::@source>, %clk: i1)
 // IFACE-LABEL: hw.module.extern @NoneSenderReceiver(%in: !sv.modport<@IValidReady_none::@source>, %out: !sv.modport<@IValidReady_none::@sink>)
 
-hw.module @test(%clk:i1, %rstn:i1) {
+hw.module @test(%clk:i1, %rst:i1) {
 
   %esiChan2, %0 = hw.instance "sender2" @Sender(clk: %clk: i1) -> (x: !esi.channel<i4>, y: i8)
-  %bufferedChan2 = esi.buffer %clk, %rstn, %esiChan2 { stages = 4 } : i4
+  %bufferedChan2 = esi.buffer %clk, %rst, %esiChan2 { stages = 4 } : i4
   hw.instance "recv2" @Reciever (a: %bufferedChan2: !esi.channel<i4>, clk: %clk: i1) -> ()
 
   // CHECK:      %sender2.x, %sender2.y = hw.instance "sender2" @Sender(clk: %clk: i1) -> (x: !esi.channel<i4>, y: i8)
-  // CHECK-NEXT:  %0 = esi.stage %clk, %rstn, %sender2.x : i4
-  // CHECK-NEXT:  %1 = esi.stage %clk, %rstn, %0 : i4
-  // CHECK-NEXT:  %2 = esi.stage %clk, %rstn, %1 : i4
-  // CHECK-NEXT:  %3 = esi.stage %clk, %rstn, %2 : i4
+  // CHECK-NEXT:  %0 = esi.stage %clk, %rst, %sender2.x : i4
+  // CHECK-NEXT:  %1 = esi.stage %clk, %rst, %0 : i4
+  // CHECK-NEXT:  %2 = esi.stage %clk, %rst, %1 : i4
+  // CHECK-NEXT:  %3 = esi.stage %clk, %rst, %2 : i4
   // CHECK-NEXT:  hw.instance "recv2" @Reciever(a: %3: !esi.channel<i4>, clk: %clk: i1) -> ()
 
-  // IFACE-LABEL: hw.module @test(%clk: i1, %rstn: i1) {
+  // IFACE-LABEL: hw.module @test(%clk: i1, %rst: i1) {
   // IFACE-NEXT:    %0 = sv.interface.instance {name = "i4FromSender2"} : !sv.interface<@IValidReady_i4>
   // IFACE-NEXT:    %1 = sv.modport.get %0 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
   // IFACE-NEXT:    %2 = esi.wrap.iface %1 : !sv.modport<@IValidReady_i4::@source> -> !esi.channel<i4>
   // IFACE-NEXT:    %3 = sv.modport.get %0 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
   // IFACE-NEXT:    %sender2.y = hw.instance "sender2" @Sender(clk: %clk: i1, x: %3: !sv.modport<@IValidReady_i4::@sink>) -> (y: i8)
-  // IFACE-NEXT:    %4 = esi.buffer %clk, %rstn, %2 {stages = 4 : i64} : i4
+  // IFACE-NEXT:    %4 = esi.buffer %clk, %rst, %2 {stages = 4 : i64} : i4
   // IFACE-NEXT:    %5 = sv.interface.instance {name = "i4ToRecv2"} : !sv.interface<@IValidReady_i4>
   // IFACE-NEXT:    %6 = sv.modport.get %5 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
   // IFACE-NEXT:    esi.unwrap.iface %4 into %6 : (!esi.channel<i4>, !sv.modport<@IValidReady_i4::@sink>)
@@ -78,7 +78,7 @@ hw.module @add11(%clk: i1, %ints: !esi.channel<i32>) -> (mutatedInts: !esi.chann
 
 hw.module @InternRcvr(%in: !esi.channel<!hw.array<4xi8>>) {}
 
-hw.module @test2(%clk:i1, %rstn:i1) {
+hw.module @test2(%clk:i1, %rst:i1) {
   %ints, %c4 = hw.instance "adder" @add11(clk: %clk: i1, ints: %ints: !esi.channel<i32>) -> (mutatedInts: !esi.channel<i32>, c4: i4)
 
   %nullBit = esi.null : !esi.channel<i4>
@@ -87,7 +87,7 @@ hw.module @test2(%clk:i1, %rstn:i1) {
   %nullArray = esi.null : !esi.channel<!hw.array<4xi8>>
   hw.instance "nullInternRcvr" @InternRcvr(in: %nullArray: !esi.channel<!hw.array<4xi8>>) -> ()
 }
-// HW-LABEL: hw.module @test2(%clk: i1, %rstn: i1) {
+// HW-LABEL: hw.module @test2(%clk: i1, %rst: i1) {
 // HW:   %adder.mutatedInts, %adder.mutatedInts_valid, %adder.c4, %adder.ints_ready = hw.instance "adder" @add11(clk: %clk: i1, ints: %adder.mutatedInts: i32, ints_valid: %adder.mutatedInts_valid: i1, mutatedInts_ready: %adder.ints_ready: i1) -> (mutatedInts: i32, mutatedInts_valid: i1, c4: i4, ints_ready: i1)
 // HW:   [[ZERO:%.+]] = hw.bitcast %c0_i4 : (i4) -> i4
 // HW:   sv.interface.signal.assign %1(@IValidReady_i4::@data) = [[ZERO]] : i4
@@ -113,12 +113,12 @@ hw.module @test_constant(%arg0: !esi.channel<i1>, %clock: i1, %reset: i1) -> (ou
   hw.output %handshake_fork0.out1 : !esi.channel<i1>
 }
 
-// HW-LABEL: hw.module @NoneTyped(%a_valid: i1, %clk: i1, %rstn: i1, %x_ready: i1) -> (x_valid: i1, a_ready: i1) {
-// HW:         %pipelineStage.a_ready, %pipelineStage.x_valid = hw.instance "pipelineStage" @ESI_PipelineStage1<WIDTH: ui32 = [[DEFAULT_WIDTH:.*]]>(clk: %clk: i1, rstn: %rstn: i1, a_valid: %a_valid: i1, x_ready: %x_ready: i1) -> (a_ready: i1, x_valid: i1)
+// HW-LABEL: hw.module @NoneTyped(%a_valid: i1, %clk: i1, %rst: i1, %x_ready: i1) -> (x_valid: i1, a_ready: i1) {
+// HW:         %pipelineStage.a_ready, %pipelineStage.x_valid = hw.instance "pipelineStage" @ESI_PipelineStage1<WIDTH: ui32 = [[DEFAULT_WIDTH:.*]]>(clk: %clk: i1, rst: %rst: i1, a_valid: %a_valid: i1, x_ready: %x_ready: i1) -> (a_ready: i1, x_valid: i1)
 // HW:         hw.output %pipelineStage.x_valid, %pipelineStage.a_ready : i1, i1
 // HW:       }
-hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rstn: i1) -> (x: !esi.channel<none>) {
-  %0 = esi.buffer %clk, %rstn, %a  : none
+hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rst: i1) -> (x: !esi.channel<none>) {
+  %0 = esi.buffer %clk, %rst, %a  : none
   %noneValue, %valid = esi.unwrap.vr %0, %ready : none
   %noneV2 = esi.none : none
   %chanOutput, %ready = esi.wrap.vr %noneV2, %valid : none

--- a/test/Dialect/ESI/wrapif-lowering.mlir
+++ b/test/Dialect/ESI/wrapif-lowering.mlir
@@ -8,7 +8,7 @@ sv.interface @IValidReady_i4 {
   sv.interface.modport @sink  (input @valid, input @data, output @ready)
 }
 
-hw.module @test(%clk:i1, %rstn:i1) {
+hw.module @test(%clk:i1, %rst:i1) {
 
   %0 = sv.interface.instance : !sv.interface<@IValidReady_i4>
   %1 = sv.modport.get %0 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>

--- a/tools/circt-rtl-sim/driver.cpp.in
+++ b/tools/circt-rtl-sim/driver.cpp.in
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // A fairly standard, boilerplate Verilator C++ simulation driver. Assumes the
-// top level exposes just two signals: 'clk' and 'rstn'.
+// top level exposes just two signals: 'clk' and 'rst'.
 //
 //===----------------------------------------------------------------------===//
 
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
   std::cout << "[driver] Starting simulation" << std::endl;
 
   // Reset.
-  dut.rstn = 0;
+  dut.rst = 1;
   dut.clk = 0;
 
   // Run for a few cycles with reset held.
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
   }
 
   // Take simulation out of reset.
-  dut.rstn = 1;
+  dut.rst = 0;
 
   // Run for the specified number of cycles out of reset.
   vluint64_t endTime = timeStamp + (numCyclesToRun * 2);

--- a/tools/circt-rtl-sim/driver.sv.in
+++ b/tools/circt-rtl-sim/driver.sv.in
@@ -36,13 +36,13 @@ module driver();
 
     $display("[driver] Starting simulation");
 
-    rst = 0;
+    rst = 1;
     // Hold in reset for 4 cycles.
     @(posedge clk);
     @(posedge clk);
     @(posedge clk);
     @(posedge clk);
-    rst = 1;
+    rst = 0;
 
     if ($value$plusargs ("cycles=%d", cycles)) begin
       int i;

--- a/tools/circt-rtl-sim/driver.sv.in
+++ b/tools/circt-rtl-sim/driver.sv.in
@@ -11,18 +11,18 @@
 //
 // - The testbench module is called 'top'.
 // - It exposes a pin named 'clk' (for the clock).
-// - It exposes a pin named 'rstn' (for the reset signal).
+// - It exposes a pin named 'rst' (for the reset signal).
 //
 //===----------------------------------------------------------------------===//
 
 module driver();
 
   logic clk = 0;
-  logic rstn = 0;
+  logic rst = 0;
 
   top top (
     .clk(clk),
-    .rstn(rstn)
+    .rst(rst)
   );
 
   always begin
@@ -36,13 +36,13 @@ module driver();
 
     $display("[driver] Starting simulation");
 
-    rstn = 0;
+    rst = 0;
     // Hold in reset for 4 cycles.
     @(posedge clk);
     @(posedge clk);
     @(posedge clk);
     @(posedge clk);
-    rstn = 1;
+    rst = 1;
 
     if ($value$plusargs ("cycles=%d", cycles)) begin
       int i;


### PR DESCRIPTION
Rst seems more common, but the integration tests and ESI use 'rstn'. Switch to the more common 'rst'. Mostly affects ESI, but the integration test driver affects the other integration tests as well.