### PR TITLE
[FIRRTL][LowerToHW] Fix issue with backedges not being replaced

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -116,16 +116,3 @@ firrtl.circuit "Foo" attributes {annotations = [
       firrtl.instance foo sym @s1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
     }
 }
-
-// -----
-
-firrtl.circuit "UndrivenInputPort" {
-  firrtl.extmodule @Blackbox(in in : !firrtl.uint<1>)
-  firrtl.module @UndrivenInputPort() {
-    // expected-error @below {{undriven logic detected}}
-    %0 = firrtl.instance blackbox @Blackbox(in in : !firrtl.uint<1>)
-    %1 = firrtl.instance blackbox @Blackbox(in in : !firrtl.uint<1>)
-    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
-  }
-}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -116,3 +116,16 @@ firrtl.circuit "Foo" attributes {annotations = [
       firrtl.instance foo sym @s1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
     }
 }
+
+// -----
+
+firrtl.circuit "UndrivenInputPort" {
+  firrtl.extmodule @Blackbox(in in : !firrtl.uint<1>)
+  firrtl.module @UndrivenInputPort() {
+    // expected-error @below {{undriven logic detected}}
+    %0 = firrtl.instance blackbox @Blackbox(in in : !firrtl.uint<1>)
+    %1 = firrtl.instance blackbox @Blackbox(in in : !firrtl.uint<1>)
+    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1708,4 +1708,18 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.strictconnect %b_inst, %a_inst : !firrtl.uint<1>
     firrtl.strictconnect %out, %b_inst : !firrtl.uint<1>
   }
+
+  // Check that combinational cycles with no outside driver are lowered to
+  // be driven from a wire.
+  // CHECK-LABEL: hw.module @UndrivenInputPort()
+  // CHECK-NEXT:    %undriven = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT:    %0 = sv.read_inout %undriven : !hw.inout<i1>
+  // CHECK-NEXT:    hw.instance "blackbox" @Blackbox(inst: %0: i1) -> ()
+  // CHECK-NEXT:    hw.instance "blackbox" @Blackbox(inst: %0: i1) -> ()
+  firrtl.module @UndrivenInputPort() {
+    %0 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
+    %1 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
+    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1674,4 +1674,38 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %1 = arith.addf %0, %0 : f32
     builtin.unrealized_conversion_cast %1 : f32 to index
   }
+
+  // Used for testing.
+  firrtl.extmodule private @Blackbox(in inst: !firrtl.uint<1>)
+
+  // Check that the following doesn't crash, when we have a no-op cast which
+  // uses an input port.
+  // CHECK-LABEL: hw.module private @BackedgesAndNoopCasts
+  // CHECK-NEXT:    hw.instance "blackbox" @Blackbox(inst: %clock: i1) -> ()
+  // CHECK-NEXT:    hw.output %clock : i1
+  firrtl.module private @BackedgesAndNoopCasts(in %clock: !firrtl.uint<1>, out %out : !firrtl.clock) {
+    // Following comments describe why this used to crash.
+    // Blackbox input port creates a backedge.
+    %inst = firrtl.instance blackbox @Blackbox(in inst: !firrtl.uint<1>)
+    // No-op cast is removed, %cast lowered to point directly to the backedge.
+    %cast = firrtl.asClock %inst : (!firrtl.uint<1>) -> !firrtl.clock
+    // Finalize the backedge, replacing all uses with %clock.
+    firrtl.strictconnect %inst, %clock : !firrtl.uint<1>
+    // %cast accidentally still points to the back edge in the lowering table.
+    firrtl.strictconnect %out, %cast : !firrtl.clock
+  }
+  
+  // Check that when inputs are connected to other inputs, the backedges are
+  // properly resolved to the final real value.
+  // CHECK-LABEL: hw.module @ChainedBackedges
+  // CHECK-NEXT:    hw.instance "a" @Blackbox
+  // CHECK-NEXT:    hw.instance "b" @Blackbox
+  // CHECK-NEXT:    hw.output %in : i1
+  firrtl.module @ChainedBackedges(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+    %a_inst = firrtl.instance a @Blackbox(in inst: !firrtl.uint<1>)
+    %b_inst = firrtl.instance b @Blackbox(in inst: !firrtl.uint<1>)
+    firrtl.strictconnect %a_inst, %in : !firrtl.uint<1>
+    firrtl.strictconnect %b_inst, %a_inst : !firrtl.uint<1>
+    firrtl.strictconnect %out, %b_inst : !firrtl.uint<1>
+  }
 }


### PR DESCRIPTION
In LowerToHW we have a hashtable which maps every FIRRTL value to its
lowered HW value.  Some "no-op" casts, such as `asClock`, are removed
during lowering, so their result value is actually mapped to its
operand's lowered value.

For instance input ports, we lower them using backedges to take
advantage of the graph structure of the HW dialect and eliminate some
extra wires.  The port's value is mapped to the backedge, until we find
the connect operation driving it, at which point the backedge is
replaced with its true value, and the lowering table is updated.

We can have a situation where an input port is lowered to point to a
backedge, and a no-op cast of the port is also lowered to point to the
backedge.  When the backedge is replaced, the lowering table is only
updated for the input port and not the cast operation. This means that
any further uses of the cast's result will lower to uses of the
backedge, which are never fixed up.

This change delays the replacement of the backedge with its value until
all operations have been lowered.  This means that uses of the cast
which lower to uses of the backedge will be properly replaced.

This commit also addresses a related issue, when an input port is
connected to another input port.  The backedges from one port need to
"see through" the backedge that is driving it to find the real value
driving the net. We could have used equivalence classes to solve this.