### PR TITLE
[SystemC] Add SCFuncOp, MethodOp, and ThreadOp

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCDialect.td
+++ b/include/circt/Dialect/SystemC/SystemCDialect.td
@@ -31,6 +31,7 @@ def SystemCDialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
+  let useDefaultTypePrinterParser = 1;
 
   let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -38,3 +38,23 @@ def SignalOp : SystemCOp<"signal", [HasCustomSSAName, SystemCNameDeclOpInterface
     custom<ImplicitSSAName>($name) attr-dict `:` type($signal)
   }];
 }
+
+def MethodOp : SystemCOp<"method", []> {
+  let summary = "Represents the SystemC SC_METHOD macro.";
+  let description = [{
+    Represents the SC_METHOD macro as described in IEEE 1666-2011 §5.2.9.
+  }];
+
+  let arguments = (ins FuncHandleType:$funcHandle);
+  let assemblyFormat = "$funcHandle attr-dict";
+}
+
+def ThreadOp : SystemCOp<"thread", []> {
+  let summary = "Represents the SystemC SC_THREAD macro.";
+  let description = [{
+    Represents the SC_THREAD macro as described in IEEE 1666-2011 §5.2.9.
+  }];
+
+  let arguments = (ins FuncHandleType:$funcHandle);
+  let assemblyFormat = "$funcHandle attr-dict";
+}

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -92,4 +92,36 @@ def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator,
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "$body attr-dict";
+
+  let hasVerifier = true;
+}
+
+def SCFuncOp : SystemCOp<"func", [
+  HasCustomSSAName,
+  SystemCNameDeclOpInterface,
+  NoTerminator,
+  HasParent<"SCModuleOp">
+]> {
+  let summary = "A (void)->void member function of a SC_MODULE.";
+  let description = [{
+    This operation does not represent a specific SystemC construct, but a
+    regular C++ member function with no arguments and a void return type.
+    These are used to implement module-internal logic and are registered to the
+    module using the SC_METHOD, SC_THREAD, and SC_CTHREAD macros.
+  }];
+
+  let arguments = (ins StrAttr:$name);
+  let results = (outs FuncHandleType:$handle);
+  let regions = (region SizedRegion<1>:$body);
+
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name), [{
+      build($_builder, $_state,
+            FuncHandleType::get($_builder.getContext()), name);
+    }]>
+  ];
+
+  let assemblyFormat = "custom<ImplicitSSAName>($name) $body attr-dict";
+
+  let hasVerifier = true;
 }

--- a/include/circt/Dialect/SystemC/SystemCTypes.h
+++ b/include/circt/Dialect/SystemC/SystemCTypes.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_SYSTEMC_SYSTEMCTYPES_H
 #define CIRCT_DIALECT_SYSTEMC_SYSTEMCTYPES_H
 
+#include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Types.h"
 

--- a/include/circt/Dialect/SystemC/SystemCTypes.td
+++ b/include/circt/Dialect/SystemC/SystemCTypes.td
@@ -18,4 +18,11 @@ include "circt/Dialect/SystemC/SystemCDialect.td"
 class SystemCType<Pred condition, string description, string cppClassName>
   : DialectType<SystemCDialect, condition, description, cppClassName>;
 
+// A handle to refer to circt::systemc::FuncHandleType in ODS.
+def FuncHandleType : SystemCType<
+    CPred<"::circt::hw::type_isa<circt::systemc::FuncHandleType>($_self)">,
+    "FuncHandleType",
+    "::circt::hw::TypeAliasOr<circt::systemc::FuncHandleType>">,
+  BuildableType<"::circt::systemc::FuncHandleType::get($_builder.getContext())">;
+
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCTYPES

--- a/include/circt/Dialect/SystemC/SystemCTypesImpl.td
+++ b/include/circt/Dialect/SystemC/SystemCTypesImpl.td
@@ -13,3 +13,14 @@
 include "mlir/IR/EnumAttr.td"
 
 class SystemCTypeDef<string name> : TypeDef<SystemCDialect, name> { }
+
+// A handle to a systemc::SCFuncOp. Declares the systemc::FuncHandleType in C++.
+def FuncHandleTypeImpl : SystemCTypeDef<"FuncHandle"> {
+  let summary = "A function handle type";
+  let description = [{
+    Represents a handle to a SystemC module's member function that
+    can be used in places like SC_METHOD, SC_THREAD, etc.
+  }];
+
+  let mnemonic = "func_handle";
+}

--- a/lib/Dialect/SystemC/CMakeLists.txt
+++ b/lib/Dialect/SystemC/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTSystemC
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface
+  CIRCTHW
 )
 
 add_dependencies(circt-headers MLIRSystemCIncGen)

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -258,6 +258,32 @@ void SignalOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
+// CtorOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult CtorOp::verify() {
+  if (getBody().getNumArguments() != 0)
+    return emitOpError("must not have any arguments");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SCFuncOp
+//===----------------------------------------------------------------------===//
+
+void SCFuncOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getHandle(), getName());
+}
+
+LogicalResult SCFuncOp::verify() {
+  if (getBody().getNumArguments() != 0)
+    return emitOpError("must not have any arguments");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SystemC/SystemCTypes.cpp
+++ b/lib/Dialect/SystemC/SystemCTypes.cpp
@@ -12,6 +12,8 @@
 
 #include "circt/Dialect/SystemC/SystemCTypes.h"
 #include "circt/Dialect/SystemC/SystemCDialect.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace circt::systemc;

--- a/test/Conversion/HWToSystemC/errors.mlir
+++ b/test/Conversion/HWToSystemC/errors.mlir
@@ -9,3 +9,12 @@ hw.module @someModule<p1: i42 = 17, p2: i1>() -> () {}
 // expected-error @+2 {{inout arguments not supported yet}}
 // expected-error @+1 {{failed to legalize operation 'hw.module'}}
 hw.module @someModule(%in0: !hw.inout<i32>) -> () {}
+
+// -----
+
+hw.module @graphRegionToSSACFG(%in0: i32) -> () {
+    // expected-error @+1 {{operand #1 does not dominate this use}}
+    %0 = comb.add %in0, %1 : i32
+    // expected-note @+1 {{operand defined here (op in the same block)}}
+    %1 = comb.add %in0, %0 : i32
+}

--- a/test/Conversion/HWToSystemC/structure.mlir
+++ b/test/Conversion/HWToSystemC/structure.mlir
@@ -1,9 +1,34 @@
 // RUN: circt-opt --convert-hw-to-systemc --verify-diagnostics %s | FileCheck %s
 
+// CHECK-LABEL: systemc.module @emptyModule ()
+hw.module @emptyModule () -> () {}
+
+// CHECK-LABEL: systemc.module @onlyInputs (sc_in %a: i32, sc_in %b: i32)
+hw.module @onlyInputs (%a: i32, %b: i32) -> () {}
+
+// CHECK-LABEL: systemc.module @onlyOutputs (sc_out %sum: i32)
+hw.module @onlyOutputs () -> (sum: i32) {
+  // CHECK-NEXT: systemc.ctor {
+  // CHECK-NEXT:   systemc.method %innerLogic
+  // CHECK-NEXT: }
+  // CHECK-NEXT: %innerLogic = systemc.func  {
+  // CHECK-NEXT:   %c0_i32 = hw.constant 0 : i32
+  // CHECK-NEXT:   systemc.alias %sum, %c0_i32 : i32
+  // CHECK-NEXT: }
+  %0 = hw.constant 0 : i32
+  hw.output %0 : i32
+}
+
 // CHECK-LABEL: systemc.module @adder (sc_in %a: i32, sc_in %b: i32, sc_out %sum: i32)
 hw.module @adder (%a: i32, %b: i32) -> (sum: i32) {
-    // CHECK-NEXT: [[RES:%.*]] = comb.add
-    %0 = comb.add %a, %b : i32
-    // CHECK-NEXT: systemc.alias %sum, [[RES]] : i32
-    hw.output %0 : i32
+  // CHECK-NEXT: systemc.ctor {
+  // CHECK-NEXT:   systemc.method %innerLogic
+  // CHECK-NEXT: }
+  // CHECK-NEXT: %innerLogic = systemc.func  {
+  // CHECK-NEXT:   [[RES:%.*]] = comb.add %a, %b : i32
+  // CHECK-NEXT:   systemc.alias %sum, [[RES]] : i32
+  // CHECK-NEXT: }
+  %0 = comb.add %a, %b : i32
+  hw.output %0 : i32
+// CHECK-NEXT: }
 }

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -88,3 +88,33 @@ systemc.module @signalMustBeDirectChildOfModule () {
     %signal = systemc.signal : i32
   }
 }
+
+// -----
+
+systemc.module @ctorNoBlockArguments () {
+  // expected-error @+1 {{op must not have any arguments}} 
+  "systemc.ctor"() ({
+    ^bb0(%arg0: i32):
+    }) : () -> ()
+}
+
+// -----
+
+systemc.module @funcNoBlockArguments () {
+  // expected-error @+1 {{op must not have any arguments}} 
+  %0 = "systemc.func"() ({
+    ^bb0(%arg0: i32):
+    }) {name="funcname"}: () -> (!systemc.func_handle)
+}
+
+// -----
+
+// expected-note @+1 {{in module '@signalFuncNameConflict'}}
+systemc.module @signalFuncNameConflict () {
+  // expected-note @+1 {{'name' first defined here}}
+  %0 = "systemc.signal"() {name="name"} : () -> i32
+  // expected-error @+1 {{redefines name 'name'}}
+  %1 = "systemc.func"() ({
+    ^bb0:
+    }) {name="name"}: () -> (!systemc.func_handle)
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -4,12 +4,20 @@
 systemc.module @adder (sc_in %summand_a: i32, sc_in %summand_b: i32, sc_out %sum: i32) {
   //CHECK-NEXT: systemc.ctor {
   systemc.ctor {
+    // CHECK-NEXT: systemc.method %addFunc
+    systemc.method %addFunc
+    // CHECK-NEXT: systemc.thread %addFunc
+    systemc.thread %addFunc
   //CHECK-NEXT: }
   }
-  // CHECK-NEXT: [[RES:%.*]] = comb.add %summand_a, %summand_b : i32
-  %res = comb.add %summand_a, %summand_b : i32
-  // CHECK-NEXT: systemc.alias %sum, [[RES]] : i32
-  systemc.alias %sum, %res : i32
+  // CHECK-NEXT: %addFunc = systemc.func {
+  %addFunc = systemc.func {
+    // CHECK-NEXT: [[RES:%.*]] = comb.add %summand_a, %summand_b : i32
+    %res = comb.add %summand_a, %summand_b : i32
+    // CHECK-NEXT: systemc.alias %sum, [[RES]] : i32
+    systemc.alias %sum, %res : i32
+  // CHECK-NEXT: }
+  }
 // CHECK-NEXT: }
 }
 


### PR DESCRIPTION
Depends on #3614

I left two TODOs in `HWToSystemC`: I think name uniquing makes a good PR on its own implementing some utilities. Checking the graph region for invalid dominance is currently left to the verifier afterwards, but should eventually be dealt with in the lowering. However, it is likely not necessary to get a first demo running and thus I'd like to tackle that at a later point.