### PR TITLE
[ESI][NFC] Rename Ops and Types to include those suffixes

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -67,7 +67,7 @@ class _RequestToServerConn(_RequestConnection):
 
   def __call__(self, chan: ChannelValue, chan_name: str):
     decl_sym = self.decl._materialize_service_decl()
-    raw_esi.RequestToServerConnection(
+    raw_esi.RequestToServerConnectionOp(
         hw.InnerRefAttr.get(ir.StringAttr.get(decl_sym), self._name),
         chan.value, ir.ArrayAttr.get([ir.StringAttr.get(chan_name)]))
 
@@ -78,7 +78,7 @@ class _RequestToClientConn(_RequestConnection):
     decl_sym = self.decl._materialize_service_decl()
     if not isinstance(type, ChannelType):
       type = types.channel(type)
-    req_op = raw_esi.RequestToClientConnection(
+    req_op = raw_esi.RequestToClientConnectionOp(
         type, hw.InnerRefAttr.get(ir.StringAttr.get(decl_sym), self._name),
         ir.ArrayAttr.get([ir.StringAttr.get(chan_name)]))
     return ChannelValue(req_op)

--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -19,7 +19,7 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
   let methods = [
     InterfaceMethod<
       [{"Returns the channel type of this operation."}],
-      "circt::esi::ChannelPort", "channelType"
+      "circt::esi::ChannelType", "channelType"
     >,
     InterfaceMethod<
         "Returns true if this channel carries data.",

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def ChannelBuffer : ESI_Abstract_Op<"buffer", [
+def ChannelBufferOp : ESI_Abstract_Op<"buffer", [
     NoSideEffect,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
@@ -49,7 +49,7 @@ def ChannelBuffer : ESI_Abstract_Op<"buffer", [
   let hasCustomAssemblyFormat = 1;
 }
 
-def PipelineStage : ESI_Physical_Op<"stage", [
+def PipelineStageOp : ESI_Physical_Op<"stage", [
     NoSideEffect,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
@@ -66,7 +66,7 @@ def PipelineStage : ESI_Physical_Op<"stage", [
   let hasCustomAssemblyFormat = 1;
 }
 
-def CosimEndpoint : ESI_Physical_Op<"cosim", []> {
+def CosimEndpointOp : ESI_Physical_Op<"cosim", []> {
   let summary = "Co-simulation endpoint";
   let description = [{
     A co-simulation endpoint is a connection from the simulation to some
@@ -94,14 +94,14 @@ def CosimEndpoint : ESI_Physical_Op<"cosim", []> {
   }];
 }
 
-def RtlBitArray : Type<CPred<"$_self.isa<::circt::hw::ArrayType>()"
+def RtlBitArrayType : Type<CPred<"$_self.isa<::circt::hw::ArrayType>()"
  " && $_self.cast<::circt::hw::ArrayType>().getElementType() =="
  "   ::mlir::IntegerType::get($_self.getContext(), 1)">, "an HW bit array">;
 
-def CapnpDecode : ESI_Physical_Op<"decode.capnp", [NoSideEffect]> {
+def CapnpDecodeOp : ESI_Physical_Op<"decode.capnp", [NoSideEffect]> {
   let summary = "Translate bits in Cap'nProto messages to HW typed data";
 
-  let arguments = (ins I1:$clk, I1:$valid, RtlBitArray:$capnpBits);
+  let arguments = (ins I1:$clk, I1:$valid, RtlBitArrayType:$capnpBits);
   let results = (outs AnyType:$decodedData);
 
   let assemblyFormat = [{
@@ -110,11 +110,11 @@ def CapnpDecode : ESI_Physical_Op<"decode.capnp", [NoSideEffect]> {
   }];
 }
 
-def CapnpEncode : ESI_Physical_Op<"encode.capnp", [NoSideEffect]> {
+def CapnpEncodeOp : ESI_Physical_Op<"encode.capnp", [NoSideEffect]> {
   let summary = "Translate HW typed data to Cap'nProto";
 
   let arguments = (ins I1:$clk, I1:$valid, AnyType:$dataToEncode);
-  let results = (outs RtlBitArray:$capnpBits);
+  let results = (outs RtlBitArrayType:$capnpBits);
 
   let assemblyFormat = [{
     $clk $valid $dataToEncode attr-dict `:` qualified(type($dataToEncode))

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -14,11 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-class ESI_Port<string name> : TypeDef<ESI_Dialect, name> {
-  let cppClassName = name # "Port";
-}
+class ESI_Port<string name> : TypeDef<ESI_Dialect, name> {}
 
-def Channel : ESI_Port<"Channel"> {
+def ChannelType : ESI_Port<"Channel"> {
   let summary = "An ESI-compatible channel port";
   let description = [{
     An ESI port kind which models a latency-insensitive, unidirectional,
@@ -48,14 +46,10 @@ def Channel : ESI_Port<"Channel"> {
 
 }
 
-def ChannelType :
-  Type<CPred<"$_self.isa<::circt::esi::ChannelPort>()">, "">;
-
-
 //=========
 // Operations on ports.
 
-def WrapValidReady : ESI_Op<"wrap.vr", [
+def WrapValidReadyOp : ESI_Op<"wrap.vr", [
     NoSideEffect,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
@@ -76,7 +70,7 @@ def WrapValidReady : ESI_Op<"wrap.vr", [
   ];
 }
 
-def UnwrapValidReady : ESI_Op<"unwrap.vr", [
+def UnwrapValidReadyOp : ESI_Op<"unwrap.vr", [
     NoSideEffect,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
@@ -99,7 +93,7 @@ def UnwrapValidReady : ESI_Op<"unwrap.vr", [
 def ModportType:
   Type<CPred<"$_self.isa<::circt::sv::ModportType>()">, "sv.interface">;
 
-def WrapSVInterface: ESI_Op<"wrap.iface", [
+def WrapSVInterfaceOp: ESI_Op<"wrap.iface", [
     NoSideEffect,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
@@ -120,7 +114,7 @@ def WrapSVInterface: ESI_Op<"wrap.iface", [
   let hasVerifier = 1;
 }
 
-def UnwrapSVInterface : ESI_Op<"unwrap.iface", [
+def UnwrapSVInterfaceOp : ESI_Op<"unwrap.iface", [
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "Unwrap an SV interface from an ESI port";

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -110,7 +110,7 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [NoTerminator]> {
   }];
 }
 
-def RequestToServerConnection : ESI_Op<"service.req.to_server", [
+def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to send data";
 
@@ -118,11 +118,11 @@ def RequestToServerConnection : ESI_Op<"service.req.to_server", [
                        ChannelType:$sending, StrArrayAttr:$clientNamePath);
   let assemblyFormat = [{
     $sending `->` $servicePort `(` $clientNamePath `)`
-      attr-dict `:` type($sending)
+      attr-dict `:` qualified(type($sending))
   }];
 }
 
-def RequestToClientConnection : ESI_Op<"service.req.to_client", [
+def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to receive data";
 
@@ -130,6 +130,7 @@ def RequestToClientConnection : ESI_Op<"service.req.to_client", [
                        StrArrayAttr:$clientNamePath);
   let results = (outs ChannelType:$receiving);
   let assemblyFormat = [{
-    $servicePort `(` $clientNamePath `)` attr-dict `:` type($receiving)
+    $servicePort `(` $clientNamePath `)`
+      attr-dict `:` qualified(type($receiving))
   }];
 }

--- a/lib/Bindings/Python/circt/esi.py
+++ b/lib/Bindings/Python/circt/esi.py
@@ -78,8 +78,8 @@ class System(CppSystem):
     if send is None:
       send = NullSourceOp(ChannelType.get(
           mlir.ir.IntegerType.get_signless(1))).out
-    ep = CosimEndpoint(recv_type, clk, rstn, send,
-                       mlir.ir.Attribute.parse(str(id)))
+    ep = CosimEndpointOp(recv_type, clk, rstn, send,
+                         mlir.ir.Attribute.parse(str(id)))
     ep.operation.attributes["name"] = mlir.ir.StringAttr.get(name)
     return ep
 

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -28,16 +28,16 @@ MlirLogicalResult circtESIExportCosimSchema(MlirModule module,
 }
 
 bool circtESITypeIsAChannelType(MlirType type) {
-  return unwrap(type).isa<ChannelPort>();
+  return unwrap(type).isa<ChannelType>();
 }
 
 MlirType circtESIChannelTypeGet(MlirType inner) {
   auto cppInner = unwrap(inner);
-  return wrap(ChannelPort::get(cppInner.getContext(), cppInner));
+  return wrap(ChannelType::get(cppInner.getContext(), cppInner));
 }
 
 MlirType circtESIChannelGetInner(MlirType channelType) {
-  return wrap(unwrap(channelType).cast<ChannelPort>().getInner());
+  return wrap(unwrap(channelType).cast<ChannelType>().getInner());
 }
 
 bool circtESITypeIsAnAnyType(MlirType type) {

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -56,7 +56,7 @@ static std::string getCallName(Operation *op) {
 /// assume that opType itself is the data-carrying type.
 static Type getOperandDataType(Value op) {
   auto opType = op.getType();
-  if (auto channelType = opType.dyn_cast<esi::ChannelPort>())
+  if (auto channelType = opType.dyn_cast<esi::ChannelType>())
     return channelType.getInner();
   return opType;
 }
@@ -90,7 +90,7 @@ static DiscriminatingTypes getHandshakeDiscriminatingTypes(Operation *op) {
       });
 }
 
-// Wraps a type into an ESI ChannelPort type. The inner type is converted to
+// Wraps a type into an ESI ChannelType type. The inner type is converted to
 // ensure comprehensability by the RTL dialects.
 static Type esiWrapper(Type t) {
   // Translate none- and index types to something HW understands.
@@ -99,7 +99,7 @@ static Type esiWrapper(Type t) {
   else if (t.isa<IndexType>())
     t = IntegerType::get(t.getContext(), 64);
 
-  return esi::ChannelPort::get(t.getContext(), t);
+  return esi::ChannelType::get(t.getContext(), t);
 }
 
 /// Get type name. Currently we only support integer or index types.

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -220,7 +220,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
 
     hw::PortInfo newPort = port;
     if (dataPortMap.find(port.name.getValue()) != dataPortMap.end())
-      newPort.type = esi::ChannelPort::get(ctxt, port.type);
+      newPort.type = esi::ChannelType::get(ctxt, port.type);
 
     if (port.isOutput()) {
       newPort.argNum = outputPortMap.size();
@@ -277,7 +277,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
 
     Backedge ready = bb.get(modBuilder.getI1Type());
     backedges.insert(std::make_pair(esiPort->second.ready.argNum, ready));
-    auto unwrap = modBuilder.create<UnwrapValidReady>(arg, ready);
+    auto unwrap = modBuilder.create<UnwrapValidReadyOp>(arg, ready);
     pearlOperands[esiPort->second.data.argNum] = unwrap.rawOutput();
     pearlOperands[esiPort->second.valid.argNum] = unwrap.valid();
   }
@@ -294,7 +294,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
 
     Backedge data = bb.get(esiPort->second.data.type);
     Backedge valid = bb.get(modBuilder.getI1Type());
-    auto wrap = modBuilder.create<WrapValidReady>(data, valid);
+    auto wrap = modBuilder.create<WrapValidReadyOp>(data, valid);
     backedges.insert(std::make_pair(esiPort->second.data.argNum, data));
     backedges.insert(std::make_pair(esiPort->second.valid.argNum, valid));
     outputs[port.argNum] = wrap.chanOutput();

--- a/lib/Dialect/ESI/ESIFolds.cpp
+++ b/lib/Dialect/ESI/ESIFolds.cpp
@@ -14,8 +14,8 @@
 using namespace circt;
 using namespace circt::esi;
 
-LogicalResult WrapValidReady::fold(ArrayRef<Attribute> operands,
-                                   SmallVectorImpl<OpFoldResult> &results) {
+LogicalResult WrapValidReadyOp::fold(ArrayRef<Attribute> operands,
+                                     SmallVectorImpl<OpFoldResult> &results) {
   if (!chanOutput().getUsers().empty())
     return failure();
   results.push_back(mlir::UnitAttr::get(getContext()));

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -23,10 +23,11 @@ using namespace circt;
 using namespace circt::esi;
 
 //===----------------------------------------------------------------------===//
-// ChannelBuffer functions.
+// ChannelBufferOp functions.
 //===----------------------------------------------------------------------===//
 
-ParseResult ChannelBuffer::parse(OpAsmParser &parser, OperationState &result) {
+ParseResult ChannelBufferOp::parse(OpAsmParser &parser,
+                                   OperationState &result) {
   llvm::SMLoc inputOperandsLoc = parser.getCurrentLocation();
 
   llvm::SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
@@ -39,7 +40,7 @@ ParseResult ChannelBuffer::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(innerOutputType))
     return failure();
   auto outputType =
-      ChannelPort::get(parser.getBuilder().getContext(), innerOutputType);
+      ChannelType::get(parser.getBuilder().getContext(), innerOutputType);
   result.addTypes({outputType});
 
   auto i1 = IntegerType::get(result.getContext(), 1);
@@ -49,21 +50,22 @@ ParseResult ChannelBuffer::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-void ChannelBuffer::print(OpAsmPrinter &p) {
+void ChannelBufferOp::print(OpAsmPrinter &p) {
   p << " " << clk() << ", " << rstn() << ", " << input() << " ";
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }
 
-circt::esi::ChannelPort ChannelBuffer::channelType() {
-  return input().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType ChannelBufferOp::channelType() {
+  return input().getType().cast<circt::esi::ChannelType>();
 }
 
 //===----------------------------------------------------------------------===//
-// PipelineStage functions.
+// PipelineStageOp functions.
 //===----------------------------------------------------------------------===//
 
-ParseResult PipelineStage::parse(OpAsmParser &parser, OperationState &result) {
+ParseResult PipelineStageOp::parse(OpAsmParser &parser,
+                                   OperationState &result) {
   llvm::SMLoc inputOperandsLoc = parser.getCurrentLocation();
 
   SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
@@ -73,7 +75,7 @@ ParseResult PipelineStage::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(innerOutputType))
     return failure();
   auto type =
-      ChannelPort::get(parser.getBuilder().getContext(), innerOutputType);
+      ChannelType::get(parser.getBuilder().getContext(), innerOutputType);
   result.addTypes({type});
 
   auto i1 = IntegerType::get(result.getContext(), 1);
@@ -83,21 +85,22 @@ ParseResult PipelineStage::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-void PipelineStage::print(OpAsmPrinter &p) {
+void PipelineStageOp::print(OpAsmPrinter &p) {
   p << " " << clk() << ", " << rstn() << ", " << input() << " ";
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }
 
-circt::esi::ChannelPort PipelineStage::channelType() {
-  return input().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType PipelineStageOp::channelType() {
+  return input().getType().cast<circt::esi::ChannelType>();
 }
 
 //===----------------------------------------------------------------------===//
 // Wrap / unwrap.
 //===----------------------------------------------------------------------===//
 
-ParseResult WrapValidReady::parse(OpAsmParser &parser, OperationState &result) {
+ParseResult WrapValidReadyOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
   llvm::SMLoc inputOperandsLoc = parser.getCurrentLocation();
 
   llvm::SmallVector<OpAsmParser::UnresolvedOperand, 2> opList;
@@ -109,7 +112,7 @@ ParseResult WrapValidReady::parse(OpAsmParser &parser, OperationState &result) {
 
   auto boolType = parser.getBuilder().getI1Type();
   auto outputType =
-      ChannelPort::get(parser.getBuilder().getContext(), innerOutputType);
+      ChannelType::get(parser.getBuilder().getContext(), innerOutputType);
   result.addTypes({outputType, boolType});
   if (parser.resolveOperands(opList, {innerOutputType, boolType},
                              inputOperandsLoc, result.operands))
@@ -117,20 +120,20 @@ ParseResult WrapValidReady::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-void WrapValidReady::print(OpAsmPrinter &p) {
+void WrapValidReadyOp::print(OpAsmPrinter &p) {
   p << " " << rawInput() << ", " << valid();
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }
 
-void WrapValidReady::build(OpBuilder &b, OperationState &state, Value data,
-                           Value valid) {
-  build(b, state, ChannelPort::get(state.getContext(), data.getType()),
+void WrapValidReadyOp::build(OpBuilder &b, OperationState &state, Value data,
+                             Value valid) {
+  build(b, state, ChannelType::get(state.getContext(), data.getType()),
         b.getI1Type(), data, valid);
 }
 
-ParseResult UnwrapValidReady::parse(OpAsmParser &parser,
-                                    OperationState &result) {
+ParseResult UnwrapValidReadyOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
   llvm::SMLoc inputOperandsLoc = parser.getCurrentLocation();
 
   llvm::SmallVector<OpAsmParser::UnresolvedOperand, 2> opList;
@@ -141,7 +144,7 @@ ParseResult UnwrapValidReady::parse(OpAsmParser &parser,
     return failure();
 
   auto inputType =
-      ChannelPort::get(parser.getBuilder().getContext(), outputType);
+      ChannelType::get(parser.getBuilder().getContext(), outputType);
 
   auto boolType = parser.getBuilder().getI1Type();
 
@@ -152,24 +155,24 @@ ParseResult UnwrapValidReady::parse(OpAsmParser &parser,
   return success();
 }
 
-void UnwrapValidReady::print(OpAsmPrinter &p) {
+void UnwrapValidReadyOp::print(OpAsmPrinter &p) {
   p << " " << chanInput() << ", " << ready();
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << rawOutput().getType();
 }
 
-circt::esi::ChannelPort WrapValidReady::channelType() {
-  return chanOutput().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType WrapValidReadyOp::channelType() {
+  return chanOutput().getType().cast<circt::esi::ChannelType>();
 }
 
-void UnwrapValidReady::build(OpBuilder &b, OperationState &state, Value inChan,
-                             Value ready) {
-  auto inChanType = inChan.getType().cast<ChannelPort>();
+void UnwrapValidReadyOp::build(OpBuilder &b, OperationState &state,
+                               Value inChan, Value ready) {
+  auto inChanType = inChan.getType().cast<ChannelType>();
   build(b, state, inChanType.getInner(), b.getI1Type(), inChan, ready);
 }
 
-circt::esi::ChannelPort UnwrapValidReady::channelType() {
-  return chanInput().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType UnwrapValidReadyOp::channelType() {
+  return chanInput().getType().cast<circt::esi::ChannelType>();
 }
 
 /// If 'iface' looks like an ESI interface, return the inner data type.
@@ -190,7 +193,7 @@ static Type getEsiDataType(circt::sv::InterfaceOp iface) {
 /// the chan type's inner data type.
 static LogicalResult verifySVInterface(Operation *op,
                                        circt::sv::ModportType modportType,
-                                       ChannelPort chanType) {
+                                       ChannelType chanType) {
   auto modport =
       SymbolTable::lookupNearestSymbolFrom<circt::sv::InterfaceModportOp>(
           op, modportType.getModport());
@@ -208,24 +211,24 @@ static LogicalResult verifySVInterface(Operation *op,
   return success();
 }
 
-LogicalResult WrapSVInterface::verify() {
+LogicalResult WrapSVInterfaceOp::verify() {
   auto modportType = interfaceSink().getType().cast<circt::sv::ModportType>();
-  auto chanType = output().getType().cast<ChannelPort>();
+  auto chanType = output().getType().cast<ChannelType>();
   return verifySVInterface(*this, modportType, chanType);
 }
 
-circt::esi::ChannelPort WrapSVInterface::channelType() {
-  return output().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType WrapSVInterfaceOp::channelType() {
+  return output().getType().cast<circt::esi::ChannelType>();
 }
 
-LogicalResult UnwrapSVInterface::verify() {
+LogicalResult UnwrapSVInterfaceOp::verify() {
   auto modportType = interfaceSource().getType().cast<circt::sv::ModportType>();
-  auto chanType = chanInput().getType().cast<ChannelPort>();
+  auto chanType = chanInput().getType().cast<ChannelType>();
   return verifySVInterface(*this, modportType, chanType);
 }
 
-circt::esi::ChannelPort UnwrapSVInterface::channelType() {
-  return chanInput().getType().cast<circt::esi::ChannelPort>();
+circt::esi::ChannelType UnwrapSVInterfaceOp::channelType() {
+  return chanInput().getType().cast<circt::esi::ChannelType>();
 }
 
 /// Get the port declaration op for the specified service decl, port name.
@@ -263,19 +266,19 @@ reqPortMatches(OpType op, SymbolTableCollection &symbolTable, Type t) {
 
   auto *ctxt = op.getContext();
   if (portDecl.type() != t &&
-      portDecl.type() != ChannelPort::get(ctxt, AnyType::get(ctxt)))
+      portDecl.type() != ChannelType::get(ctxt, AnyType::get(ctxt)))
     return op.emitOpError("Request type does not match port type ")
            << portDecl.type();
 
   return success();
 }
 
-LogicalResult RequestToClientConnection::verifySymbolUses(
+LogicalResult RequestToClientConnectionOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
   return reqPortMatches<ToClientOp>(*this, symbolTable, receiving().getType());
 }
 
-LogicalResult RequestToServerConnection::verifySymbolUses(
+LogicalResult RequestToServerConnectionOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
   return reqPortMatches<ToServerOp>(*this, symbolTable, sending().getType());
 }

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -54,13 +54,13 @@ public:
 
   ArrayAttr getStageParameterList(Attribute value);
 
-  HWModuleExternOp declareStage(Operation *symTable, PipelineStage);
+  HWModuleExternOp declareStage(Operation *symTable, PipelineStageOp);
   // Will be unused when CAPNP is undefined
-  HWModuleExternOp declareCosimEndpoint(Operation *symTable, Type sendType,
-                                        Type recvType) LLVM_ATTRIBUTE_UNUSED;
+  HWModuleExternOp declareCosimEndpointOp(Operation *symTable, Type sendType,
+                                          Type recvType) LLVM_ATTRIBUTE_UNUSED;
 
-  InterfaceOp getOrConstructInterface(ChannelPort);
-  InterfaceOp constructInterface(ChannelPort);
+  InterfaceOp getOrConstructInterface(ChannelType);
+  InterfaceOp constructInterface(ChannelType);
 
   // A bunch of constants for use in various places below.
   const StringAttr a, aValid, aReady, x, xValid, xReady;
@@ -77,10 +77,11 @@ public:
 private:
   /// Construct a type-appropriate name for the interface, making sure it's not
   /// taken in the symbol table.
-  StringAttr constructInterfaceName(ChannelPort);
+  StringAttr constructInterfaceName(ChannelType);
 
   llvm::DenseMap<Type, HWModuleExternOp> declaredStage;
-  llvm::DenseMap<std::pair<Type, Type>, HWModuleExternOp> declaredCosimEndpoint;
+  llvm::DenseMap<std::pair<Type, Type>, HWModuleExternOp>
+      declaredCosimEndpointOp;
   llvm::DenseMap<Type, InterfaceOp> portTypeLookup;
 };
 } // anonymous namespace
@@ -141,7 +142,7 @@ static StringAttr constructUniqueSymbol(Operation *tableOp,
   return StringAttr::get(tableOp->getContext(), proposedName);
 }
 
-StringAttr ESIHWBuilder::constructInterfaceName(ChannelPort port) {
+StringAttr ESIHWBuilder::constructInterfaceName(ChannelType port) {
   Operation *tableOp =
       getInsertionPoint()->getParentWithTrait<mlir::OpTrait::SymbolTable>();
 
@@ -181,7 +182,7 @@ ArrayAttr ESIHWBuilder::getStageParameterList(Attribute value) {
 /// implementation is double-buffered and fully pipelines the reverse-flow ready
 /// signal.
 HWModuleExternOp ESIHWBuilder::declareStage(Operation *symTable,
-                                            PipelineStage stage) {
+                                            PipelineStageOp stage) {
   Type dataType = stage.innerType();
   HWModuleExternOp &stageMod = declaredStage[dataType];
   if (stageMod)
@@ -217,11 +218,11 @@ HWModuleExternOp ESIHWBuilder::declareStage(Operation *symTable,
 /// Write an 'ExternModuleOp' to use a hand-coded SystemVerilog module. Said
 /// module contains a bi-directional Cosimulation DPI interface with valid/ready
 /// semantics.
-HWModuleExternOp ESIHWBuilder::declareCosimEndpoint(Operation *symTable,
-                                                    Type sendType,
-                                                    Type recvType) {
+HWModuleExternOp ESIHWBuilder::declareCosimEndpointOp(Operation *symTable,
+                                                      Type sendType,
+                                                      Type recvType) {
   HWModuleExternOp &endpoint =
-      declaredCosimEndpoint[std::make_pair(sendType, recvType)];
+      declaredCosimEndpointOp[std::make_pair(sendType, recvType)];
   if (endpoint)
     return endpoint;
   // Since this module has parameterized widths on the a input and x output,
@@ -253,7 +254,7 @@ HWModuleExternOp ESIHWBuilder::declareCosimEndpoint(Operation *symTable,
 /// Return the InterfaceType which corresponds to an ESI port type. If it
 /// doesn't exist in the cache, build the InterfaceOp and the corresponding
 /// type.
-InterfaceOp ESIHWBuilder::getOrConstructInterface(ChannelPort t) {
+InterfaceOp ESIHWBuilder::getOrConstructInterface(ChannelType t) {
   auto ifaceIter = portTypeLookup.find(t);
   if (ifaceIter != portTypeLookup.end())
     return ifaceIter->second;
@@ -262,7 +263,7 @@ InterfaceOp ESIHWBuilder::getOrConstructInterface(ChannelPort t) {
   return iface;
 }
 
-InterfaceOp ESIHWBuilder::constructInterface(ChannelPort chan) {
+InterfaceOp ESIHWBuilder::constructInterface(ChannelType chan) {
   return create<InterfaceOp>(constructInterfaceName(chan).getValue(), [&]() {
     create<InterfaceSignalOp>(validStr, getI1Type());
     create<InterfaceSignalOp>(readyStr, getI1Type());
@@ -286,21 +287,21 @@ InterfaceOp ESIHWBuilder::constructInterface(ChannelPort chan) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Lower `ChannelBuffer`s, breaking out the various options. For now, just
+/// Lower `ChannelBufferOp`s, breaking out the various options. For now, just
 /// replace with the specified number of pipeline stages (since that's the only
 /// option).
-struct ChannelBufferLowering : public OpConversionPattern<ChannelBuffer> {
+struct ChannelBufferLowering : public OpConversionPattern<ChannelBufferOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ChannelBuffer buffer, OpAdaptor adaptor,
+  matchAndRewrite(ChannelBufferOp buffer, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult ChannelBufferLowering::matchAndRewrite(
-    ChannelBuffer buffer, OpAdaptor adaptor,
+    ChannelBufferOp buffer, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = buffer.getLoc();
 
@@ -317,8 +318,8 @@ LogicalResult ChannelBufferLowering::matchAndRewrite(
   StringAttr bufferName = buffer.nameAttr();
   for (uint64_t i = 0; i < numStages; ++i) {
     // Create the stages, connecting them up as we build.
-    auto stage = rewriter.create<PipelineStage>(loc, type, buffer.clk(),
-                                                buffer.rstn(), input);
+    auto stage = rewriter.create<PipelineStageOp>(loc, type, buffer.clk(),
+                                                  buffer.rstn(), input);
     if (bufferName) {
       SmallString<64> stageName(
           {bufferName.getValue(), "_stage", std::to_string(i)});
@@ -343,7 +344,7 @@ void ESIToPhysicalPass::runOnOperation() {
   // Set up a conversion and give it a set of laws.
   ConversionTarget target(getContext());
   target.addLegalDialect<ESIDialect>();
-  target.addIllegalOp<ChannelBuffer>();
+  target.addIllegalOp<ChannelBufferOp>();
 
   // Add all the conversion patterns.
   RewritePatternSet patterns(&getContext());
@@ -418,7 +419,7 @@ static StringAttr appendToRtlName(StringAttr base, StringRef suffix) {
   return StringAttr::get(context, base.getValue().str() + suffix.str());
 }
 
-/// Convert all input and output ChannelPorts into valid/ready wires. Try not to
+/// Convert all input and output ChannelTypes into valid/ready wires. Try not to
 /// change the order and materialize ops in reasonably intuitive locations.
 bool ESIPortsPass::updateFunc(HWModuleOp mod) {
   auto funcType = mod.getFunctionType();
@@ -446,7 +447,7 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
     Type argTy = funcType.getInput(argNum);
     auto argNameAttr = getModuleArgumentNameAttr(mod, argNum);
 
-    auto chanTy = argTy.dyn_cast<ChannelPort>();
+    auto chanTy = argTy.dyn_cast<ChannelType>();
     if (!chanTy) {
       // If not ESI, pass through.
       newArgTypes.push_back(argTy);
@@ -474,7 +475,7 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
     ++blockArgNum;
     // Build the ESI wrap operation to translate the lowered signals to what
     // they were. (A later pass takes care of eliminating the ESI ops.)
-    auto wrap = modBuilder.create<WrapValidReady>(data, valid);
+    auto wrap = modBuilder.create<WrapValidReadyOp>(data, valid);
     // Replace uses of the old ESI port argument with the new one from the wrap.
     mod.front().getArgument(blockArgNum).replaceAllUsesWith(wrap.chanOutput());
     // Delete the ESI port block argument.
@@ -495,7 +496,7 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
   for (size_t resNum = 0, numRes = funcType.getNumResults(); resNum < numRes;
        ++resNum) {
     Type resTy = funcType.getResult(resNum);
-    auto chanTy = resTy.dyn_cast<ChannelPort>();
+    auto chanTy = resTy.dyn_cast<ChannelType>();
     Value oldOutputValue = outOp.getOperand(resNum);
     auto oldResultName = getModuleResultNameAttr(mod, resNum);
     if (!chanTy) {
@@ -509,7 +510,7 @@ bool ESIPortsPass::updateFunc(HWModuleOp mod) {
     // Lower the output, adding ready signals directly to the arg list.
     Value ready = mod.front().addArgument(
         i1, modBuilder.getUnknownLoc()); // Ready block arg.
-    auto unwrap = modBuilder.create<UnwrapValidReady>(oldOutputValue, ready);
+    auto unwrap = modBuilder.create<UnwrapValidReadyOp>(oldOutputValue, ready);
     if (unwrap.hasData()) {
       newOutputOperands.push_back(unwrap.rawOutput());
       newResultTypes.push_back(chanTy.getInner()); // Raw data.
@@ -563,14 +564,14 @@ void ESIPortsPass::updateInstance(HWModuleOp mod, InstanceOp inst) {
   // doubles as a count of `i1`s to append to the existing results.
   SmallVector<Backedge, 8> inputReadysToConnect;
   for (auto operand : inst.getOperands()) {
-    if (!operand.getType().isa<ChannelPort>()) {
+    if (!operand.getType().isa<ChannelType>()) {
       newOperands.push_back(operand);
       continue;
     }
 
     auto ready = beb.get(i1);
     inputReadysToConnect.push_back(ready);
-    auto unwrap = b.create<UnwrapValidReady>(operand, ready);
+    auto unwrap = b.create<UnwrapValidReadyOp>(operand, ready);
     newOperands.push_back(unwrap.rawOutput());
     newOperands.push_back(unwrap.valid());
   }
@@ -583,7 +584,7 @@ void ESIPortsPass::updateInstance(HWModuleOp mod, InstanceOp inst) {
   // 'wrap' ops.
   SmallVector<Backedge, 8> outputReadysToConnect;
   for (auto resTy : inst.getResultTypes()) {
-    auto cpTy = resTy.dyn_cast<ChannelPort>();
+    auto cpTy = resTy.dyn_cast<ChannelType>();
     if (!cpTy) {
       resTypes.push_back(resTy);
       continue;
@@ -610,15 +611,15 @@ void ESIPortsPass::updateInstance(HWModuleOp mod, InstanceOp inst) {
   size_t newInstResNum = 0;
   size_t readyIdx = 0;
   for (auto res : inst.getResults()) {
-    auto cpTy = res.getType().dyn_cast<ChannelPort>();
+    auto cpTy = res.getType().dyn_cast<ChannelType>();
     if (!cpTy) {
       res.replaceAllUsesWith(newInst.getResult(newInstResNum));
       newInstResNum++;
       continue;
     }
 
-    auto wrap = b.create<WrapValidReady>(newInst.getResult(newInstResNum),
-                                         newInst.getResult(newInstResNum + 1));
+    auto wrap = b.create<WrapValidReadyOp>(
+        newInst.getResult(newInstResNum), newInst.getResult(newInstResNum + 1));
     newInstResNum += 2;
     res.replaceAllUsesWith(wrap.chanOutput());
     outputReadysToConnect[readyIdx].setValue(wrap.ready());
@@ -634,7 +635,7 @@ void ESIPortsPass::updateInstance(HWModuleOp mod, InstanceOp inst) {
   inst.erase();
 }
 
-/// Convert all input and output ChannelPorts into SV Interfaces. For inputs,
+/// Convert all input and output ChannelTypes into SV Interfaces. For inputs,
 /// just switch the type to `ModportType`. For outputs, append a `ModportType`
 /// to the inputs and remove the output channel from the results. Returns true
 /// if 'mod' was updated. Delay updating the instances to amortize the IR walk
@@ -651,7 +652,7 @@ bool ESIPortsPass::updateFunc(HWModuleExternOp mod) {
   SmallVector<Type, 16> newArgTypes;
   size_t nextArgNo = 0;
   for (auto argTy : mod.getArgumentTypes()) {
-    auto chanTy = argTy.dyn_cast<ChannelPort>();
+    auto chanTy = argTy.dyn_cast<ChannelType>();
     newArgNames.push_back(getModuleArgumentNameAttr(mod, nextArgNo++));
 
     if (!chanTy) {
@@ -675,7 +676,7 @@ bool ESIPortsPass::updateFunc(HWModuleExternOp mod) {
   for (size_t resNum = 0, numRes = mod.getNumResults(); resNum < numRes;
        ++resNum) {
     Type resTy = funcType.getResult(resNum);
-    auto chanTy = resTy.dyn_cast<ChannelPort>();
+    auto chanTy = resTy.dyn_cast<ChannelType>();
     auto resNameAttr = getModuleResultNameAttr(mod, resNum);
     if (!chanTy) {
       newResultTypes.push_back(resTy);
@@ -759,7 +760,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
   // Fill the new operand list with old plain operands and mutated ones.
   std::string nameStringBuffer; // raw_string_ostream uses std::string.
   for (auto op : inst.getOperands()) {
-    auto instChanTy = op.getType().dyn_cast<ChannelPort>();
+    auto instChanTy = op.getType().dyn_cast<ChannelType>();
     if (!instChanTy) {
       newOperands.push_back(op);
       ++opNum;
@@ -771,7 +772,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
     auto iface = build->getOrConstructInterface(instChanTy);
     if (iface.getModportType(ESIHWBuilder::sourceStr) !=
         funcTy.getInput(opNum)) {
-      inst.emitOpError("ESI ChannelPort (operand #")
+      inst.emitOpError("ESI ChannelType (operand #")
           << opNum << ") doesn't match module!";
       ++opNum;
       newOperands.push_back(op);
@@ -790,7 +791,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
                         constructInstanceName(op, iface, nameStringBuffer)));
     GetModportOp sinkModport =
         instBuilder.create<GetModportOp>(ifaceInst, ESIHWBuilder::sinkStr);
-    instBuilder.create<UnwrapSVInterface>(op, sinkModport);
+    instBuilder.create<UnwrapSVInterfaceOp>(op, sinkModport);
     GetModportOp sourceModport =
         instBuilder.create<GetModportOp>(ifaceInst, ESIHWBuilder::sourceStr);
     // Finally, add the correct modport to the list of operands.
@@ -804,7 +805,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
   for (size_t resNum = 0, numRes = inst.getNumResults(); resNum < numRes;
        ++resNum) {
     Value res = inst.getResult(resNum);
-    auto instChanTy = res.getType().dyn_cast<ChannelPort>();
+    auto instChanTy = res.getType().dyn_cast<ChannelType>();
     if (!instChanTy) {
       newResults.push_back(res);
       newResultTypes.push_back(res.getType());
@@ -815,7 +816,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
     // being used in the module.
     auto iface = build->getOrConstructInterface(instChanTy);
     if (iface.getModportType(ESIHWBuilder::sinkStr) != funcTy.getInput(opNum)) {
-      inst.emitOpError("ESI ChannelPort (result #")
+      inst.emitOpError("ESI ChannelType (result #")
           << resNum << ", operand #" << opNum << ") doesn't match module!";
       ++opNum;
       newResults.push_back(res);
@@ -837,7 +838,7 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
     GetModportOp sourceModport =
         instBuilder.create<GetModportOp>(ifaceInst, ESIHWBuilder::sourceStr);
     auto newChannel =
-        instBuilder.create<WrapSVInterface>(res.getType(), sourceModport);
+        instBuilder.create<WrapSVInterfaceOp>(res.getType(), sourceModport);
     // Connect all the old users of the output channel with the newly
     // wrapped replacement channel.
     res.replaceAllUsesWith(newChannel);
@@ -867,17 +868,17 @@ void ESIPortsPass::updateInstance(HWModuleExternOp mod, InstanceOp inst) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Lower PipelineStage ops to an HW implementation. Unwrap and re-wrap
+/// Lower PipelineStageOp ops to an HW implementation. Unwrap and re-wrap
 /// appropriately. Another conversion will take care merging the resulting
 /// adjacent wrap/unwrap ops.
-struct PipelineStageLowering : public OpConversionPattern<PipelineStage> {
+struct PipelineStageLowering : public OpConversionPattern<PipelineStageOp> {
 public:
   PipelineStageLowering(ESIHWBuilder &builder, MLIRContext *ctxt)
       : OpConversionPattern(ctxt), builder(builder) {}
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(PipelineStage stage, OpAdaptor adaptor,
+  matchAndRewrite(PipelineStageOp stage, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 
 private:
@@ -886,10 +887,10 @@ private:
 } // anonymous namespace
 
 LogicalResult PipelineStageLowering::matchAndRewrite(
-    PipelineStage stage, OpAdaptor adaptor,
+    PipelineStageOp stage, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = stage.getLoc();
-  auto chPort = stage.input().getType().dyn_cast<ChannelPort>();
+  auto chPort = stage.input().getType().dyn_cast<ChannelType>();
   if (!chPort)
     return failure();
   Operation *symTable = stage->getParentWithTrait<OpTrait::SymbolTable>();
@@ -906,7 +907,7 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   circt::BackedgeBuilder back(rewriter, loc);
   circt::Backedge wrapReady = back.get(rewriter.getI1Type());
   auto unwrap =
-      rewriter.create<UnwrapValidReady>(loc, stage.input(), wrapReady);
+      rewriter.create<UnwrapValidReadyOp>(loc, stage.input(), wrapReady);
 
   StringRef pipeStageName = "pipelineStage";
   if (auto name = stage->getAttrOfType<StringAttr>("name"))
@@ -937,8 +938,8 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   }
 
   // Wrap up the output of the HW stage module.
-  auto wrap = rewriter.create<WrapValidReady>(loc, chPort, rewriter.getI1Type(),
-                                              x, xValid);
+  auto wrap = rewriter.create<WrapValidReadyOp>(
+      loc, chPort, rewriter.getI1Type(), x, xValid);
   // Set the stages x_ready backedge correctly.
   stageReady.setValue(wrap.ready());
 
@@ -961,7 +962,7 @@ public:
 LogicalResult NullSourceOpLowering::matchAndRewrite(
     NullSourceOp nullop, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  auto innerType = nullop.out().getType().cast<ChannelPort>().getInner();
+  auto innerType = nullop.out().getType().cast<ChannelType>().getInner();
   Location loc = nullop.getLoc();
   int64_t width = hw::getBitWidth(innerType);
   if (width == -1)
@@ -972,7 +973,7 @@ LogicalResult NullSourceOpLowering::matchAndRewrite(
   auto zero =
       rewriter.create<hw::ConstantOp>(loc, rewriter.getIntegerType(width), 0);
   auto typedZero = rewriter.create<hw::BitcastOp>(loc, innerType, zero);
-  auto wrap = rewriter.create<WrapValidReady>(loc, typedZero, valid);
+  auto wrap = rewriter.create<WrapValidReadyOp>(loc, typedZero, valid);
   wrap->setAttr("name", rewriter.getStringAttr("nullsource"));
   rewriter.replaceOp(nullop, {wrap.chanOutput()});
   return success();
@@ -1009,11 +1010,11 @@ public:
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     Value valid, ready, data;
-    WrapValidReady wrap = dyn_cast<WrapValidReady>(op);
-    UnwrapValidReady unwrap = dyn_cast<UnwrapValidReady>(op);
+    WrapValidReadyOp wrap = dyn_cast<WrapValidReadyOp>(op);
+    UnwrapValidReadyOp unwrap = dyn_cast<UnwrapValidReadyOp>(op);
     if (wrap) {
       if (!wrap.chanOutput().hasOneUse() ||
-          !(unwrap = dyn_cast<UnwrapValidReady>(
+          !(unwrap = dyn_cast<UnwrapValidReadyOp>(
                 wrap.chanOutput().use_begin()->getOwner())))
         return rewriter.notifyMatchFailure(
             wrap, "This conversion only supports wrap-unwrap back-to-back. "
@@ -1023,7 +1024,7 @@ public:
       valid = operands[1];
       ready = unwrap.ready();
     } else if (unwrap) {
-      wrap = dyn_cast<WrapValidReady>(operands[0].getDefiningOp());
+      wrap = dyn_cast<WrapValidReadyOp>(operands[0].getDefiningOp());
       if (!wrap)
         return rewriter.notifyMatchFailure(
             operands[0].getDefiningOp(),
@@ -1057,18 +1058,18 @@ struct ESItoHWPass : public LowerESItoHWBase<ESItoHWPass> {
 namespace {
 /// Lower a `wrap.iface` to `wrap.vr` by extracting the wires then feeding the
 /// new `wrap.vr`.
-struct WrapInterfaceLower : public OpConversionPattern<WrapSVInterface> {
+struct WrapInterfaceLower : public OpConversionPattern<WrapSVInterfaceOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
+  matchAndRewrite(WrapSVInterfaceOp wrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult
-WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
+WrapInterfaceLower::matchAndRewrite(WrapSVInterfaceOp wrap, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
   auto operands = adaptor.getOperands();
   if (operands.size() != 1)
@@ -1095,7 +1096,7 @@ WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
     // to feed into wrapvr.
     dataSignal = rewriter.create<esi::NoneSourceOp>(loc);
   }
-  auto wrapVR = rewriter.create<WrapValidReady>(loc, dataSignal, validSignal);
+  auto wrapVR = rewriter.create<WrapValidReadyOp>(loc, dataSignal, validSignal);
   rewriter.create<AssignInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::readyStr, wrapVR.ready());
   rewriter.replaceOp(wrap, {wrapVR.chanOutput()});
@@ -1105,19 +1106,19 @@ WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
 namespace {
 /// Lower an unwrap interface to just extract the wires and feed them into an
 /// `unwrap.vr`.
-struct UnwrapInterfaceLower : public OpConversionPattern<UnwrapSVInterface> {
+struct UnwrapInterfaceLower : public OpConversionPattern<UnwrapSVInterfaceOp> {
 public:
   UnwrapInterfaceLower(MLIRContext *ctxt) : OpConversionPattern(ctxt) {}
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(UnwrapSVInterface wrap, OpAdaptor adaptor,
+  matchAndRewrite(UnwrapSVInterfaceOp wrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult UnwrapInterfaceLower::matchAndRewrite(
-    UnwrapSVInterface unwrap, OpAdaptor adaptor,
+    UnwrapSVInterfaceOp unwrap, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto operands = adaptor.getOperands();
   if (operands.size() != 2)
@@ -1138,7 +1139,7 @@ LogicalResult UnwrapInterfaceLower::matchAndRewrite(
   auto readySignal = rewriter.create<ReadInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::readyStr);
   auto unwrapVR =
-      rewriter.create<UnwrapValidReady>(loc, operands[0], readySignal);
+      rewriter.create<UnwrapValidReadyOp>(loc, operands[0], readySignal);
   rewriter.create<AssignInterfaceSignalOp>(
       loc, ifaceInstance, ESIHWBuilder::validStr, unwrapVR.valid());
 
@@ -1150,9 +1151,9 @@ LogicalResult UnwrapInterfaceLower::matchAndRewrite(
 }
 
 namespace {
-/// Lower `CosimEndpoint` ops to a SystemVerilog extern module and a Capnp
+/// Lower `CosimEndpointOp` ops to a SystemVerilog extern module and a Capnp
 /// gasket op.
-struct CosimLowering : public OpConversionPattern<CosimEndpoint> {
+struct CosimLowering : public OpConversionPattern<CosimEndpointOp> {
 public:
   CosimLowering(ESIHWBuilder &b)
       : OpConversionPattern(b.getContext(), 1), builder(b) {}
@@ -1160,7 +1161,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CosimEndpoint, OpAdaptor operands,
+  matchAndRewrite(CosimEndpointOp, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const final;
 
 private:
@@ -1169,7 +1170,7 @@ private:
 } // anonymous namespace
 
 LogicalResult
-CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
+CosimLowering::matchAndRewrite(CosimEndpointOp ep, OpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter) const {
 #ifndef CAPNP
   (void)builder;
@@ -1214,9 +1215,9 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
   ArrayType egestBitArrayType =
       ArrayType::get(rewriter.getI1Type(), sendTypeSchema.size());
   auto sendReady = bb.get(rewriter.getI1Type());
-  UnwrapValidReady unwrapSend =
-      rewriter.create<UnwrapValidReady>(loc, send, sendReady);
-  auto encodeData = rewriter.create<CapnpEncode>(
+  UnwrapValidReadyOp unwrapSend =
+      rewriter.create<UnwrapValidReadyOp>(loc, send, sendReady);
+  auto encodeData = rewriter.create<CapnpEncodeOp>(
       loc, egestBitArrayType, clk, unwrapSend.valid(), unwrapSend.rawOutput());
 
   // Get information necessary for injest path.
@@ -1226,12 +1227,12 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
 
   // Build or get the cached Cosim Endpoint module parameterization.
   Operation *symTable = ep->getParentWithTrait<OpTrait::SymbolTable>();
-  HWModuleExternOp endpoint = builder.declareCosimEndpoint(
+  HWModuleExternOp endpoint = builder.declareCosimEndpointOp(
       symTable, egestBitArrayType, ingestBitArrayType);
 
   // Create replacement Cosim_Endpoint instance.
   StringAttr nameAttr = ep->getAttr("name").dyn_cast_or_null<StringAttr>();
-  StringRef name = nameAttr ? nameAttr.getValue() : "cosimEndpoint";
+  StringRef name = nameAttr ? nameAttr.getValue() : "CosimEndpointOp";
   Value epInstInputs[] = {
       clk, rstn, recvReady, unwrapSend.valid(), encodeData.capnpBits(),
   };
@@ -1245,13 +1246,13 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
   Value recvDataFromCosim = cosimEpModule.getResult(1);
   Value recvValidFromCosim = cosimEpModule.getResult(0);
   auto decodeData =
-      rewriter.create<CapnpDecode>(loc, recvTypeSchema.getType(), clk,
-                                   recvValidFromCosim, recvDataFromCosim);
-  WrapValidReady wrapRecv = rewriter.create<WrapValidReady>(
+      rewriter.create<CapnpDecodeOp>(loc, recvTypeSchema.getType(), clk,
+                                     recvValidFromCosim, recvDataFromCosim);
+  WrapValidReadyOp wrapRecv = rewriter.create<WrapValidReadyOp>(
       loc, decodeData.decodedData(), recvValidFromCosim);
   recvReady.setValue(wrapRecv.ready());
 
-  // Replace the CosimEndpoint op.
+  // Replace the CosimEndpointOp op.
   rewriter.replaceOp(ep, wrapRecv.chanOutput());
 
   return success();
@@ -1260,12 +1261,12 @@ CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor adaptor,
 
 namespace {
 /// Lower the encode gasket to SV/HW.
-struct EncoderLowering : public OpConversionPattern<CapnpEncode> {
+struct EncoderLowering : public OpConversionPattern<CapnpEncodeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CapnpEncode enc, OpAdaptor adaptor,
+  matchAndRewrite(CapnpEncodeOp enc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
 #ifndef CAPNP
     return rewriter.notifyMatchFailure(enc,
@@ -1288,12 +1289,12 @@ public:
 
 namespace {
 /// Lower the decode gasket to SV/HW.
-struct DecoderLowering : public OpConversionPattern<CapnpDecode> {
+struct DecoderLowering : public OpConversionPattern<CapnpDecodeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CapnpDecode dec, OpAdaptor adaptor,
+  matchAndRewrite(CapnpDecodeOp dec, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
 #ifndef CAPNP
     return rewriter.notifyMatchFailure(dec,
@@ -1323,12 +1324,12 @@ void ESItoHWPass::runOnOperation() {
   pass1Target.addLegalDialect<CombDialect>();
   pass1Target.addLegalDialect<HWDialect>();
   pass1Target.addLegalDialect<SVDialect>();
-  pass1Target.addLegalOp<WrapValidReady, UnwrapValidReady>();
-  pass1Target.addLegalOp<CapnpDecode, CapnpEncode>();
+  pass1Target.addLegalOp<WrapValidReadyOp, UnwrapValidReadyOp>();
+  pass1Target.addLegalOp<CapnpDecodeOp, CapnpEncodeOp>();
   pass1Target.addLegalOp<NoneSourceOp>();
 
-  pass1Target.addIllegalOp<WrapSVInterface, UnwrapSVInterface>();
-  pass1Target.addIllegalOp<PipelineStage>();
+  pass1Target.addIllegalOp<WrapSVInterfaceOp, UnwrapSVInterfaceOp>();
+  pass1Target.addIllegalOp<PipelineStageOp>();
 
   // Add all the conversion patterns.
   ESIHWBuilder esiBuilder(top);

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -58,7 +58,7 @@ struct ExportCosimSchema {
 
   /// Collect the types for which we need to emit a schema. Output some metadata
   /// comments.
-  LogicalResult visitEndpoint(CosimEndpoint);
+  LogicalResult visitEndpoint(CosimEndpointOp);
 
 private:
   ModuleOp module;
@@ -73,7 +73,7 @@ private:
 };
 } // anonymous namespace
 
-LogicalResult ExportCosimSchema::visitEndpoint(CosimEndpoint ep) {
+LogicalResult ExportCosimSchema::visitEndpoint(CosimEndpointOp ep) {
   capnp::TypeSchema sendTypeSchema(ep.send().getType());
   if (!sendTypeSchema.isSupported())
     return ep.emitOpError("Type ") << ep.send().getType() << " not supported.";
@@ -119,7 +119,7 @@ LogicalResult ExportCosimSchema::emit() {
      << "#########################################################\n";
 
   // Walk and collect the type data.
-  auto walkResult = module.walk([this](CosimEndpoint ep) {
+  auto walkResult = module.walk([this](CosimEndpointOp ep) {
     if (failed(visitEndpoint(ep)))
       return mlir::WalkResult::interrupt();
     return mlir::WalkResult::advance();

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -1229,7 +1229,7 @@ llvm::SmallDenseMap<Type, hw::HWModuleOp>
     circt::esi::capnp::TypeSchema::encImplMods;
 
 circt::esi::capnp::TypeSchema::TypeSchema(Type type) {
-  circt::esi::ChannelPort chan = type.dyn_cast<circt::esi::ChannelPort>();
+  circt::esi::ChannelType chan = type.dyn_cast<circt::esi::ChannelType>();
   if (chan) // Unwrap the channel if it's a channel.
     type = chan.getInner();
   s = std::make_shared<detail::TypeSchemaImpl>(type);


### PR DESCRIPTION
Update the ESI class names to standard naming conventions. Mechanical search and replace.