### PR TITLE
[ESI] Creating capnp generation pass

### DIFF
--- a/include/circt/Dialect/ESI/ESIPasses.td
+++ b/include/circt/Dialect/ESI/ESIPasses.td
@@ -22,6 +22,16 @@ def ESIConnectServices : Pass<"esi-connect-services", "mlir::ModuleOp"> {
   let dependentDialects = ["circt::hw::HWDialect"];
 }
 
+def ESICreateCapnpSchema: Pass<"esi-create-capnp-schema", "mlir::ModuleOp"> {
+  let summary = "Create a Cap'nProto schema";
+  let constructor = "circt::esi::createESICreateCapnpSchemaPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+  let options = [
+    Option<"schemaFile", "schema-file", "std::string",
+           "", "File to output capnp schema into">
+  ];
+}
+
 def LowerESIToPhysical: Pass<"lower-esi-to-physical", "mlir::ModuleOp"> {
   let summary = "Lower ESI abstract Ops to ESI physical ops.";
   let constructor = "circt::esi::createESIPhysicalLoweringPass()";

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1384,6 +1384,7 @@ void ESICreateCapnpSchemaPass::runOnOperation() {
   if (!cosimWalk.wasInterrupted())
     return;
 
+  // Generate the schema
   std::string schemaStrBuffer;
   llvm::raw_string_ostream os(schemaStrBuffer);
   if (failed(exportCosimSchema(mod, os))) {
@@ -1391,10 +1392,10 @@ void ESICreateCapnpSchemaPass::runOnOperation() {
     return;
   }
 
+  // And stuff if in a verbatim op with a filename, optionally.
   OpBuilder b = OpBuilder::atBlockEnd(mod.getBody());
   auto verbatim = b.create<sv::VerbatimOp>(b.getUnknownLoc(),
                                            StringAttr::get(ctxt, os.str()));
-
   if (!schemaFile.empty()) {
     auto outputFileAttr = OutputFileAttr::getFromFilename(ctxt, schemaFile);
     verbatim->setAttr("output_file", outputFileAttr);

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1361,8 +1361,51 @@ void ESItoHWPass::runOnOperation() {
     signalPassFailure();
 }
 
+//===----------------------------------------------------------------------===//
+// Create Cap'n Proto schema pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Run all the physical lowerings.
+struct ESICreateCapnpSchemaPass
+    : public ESICreateCapnpSchemaBase<ESICreateCapnpSchemaPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void ESICreateCapnpSchemaPass::runOnOperation() {
+  ModuleOp mod = getOperation();
+  auto *ctxt = &getContext();
+
+  // Check for cosim endpoints in the design. If the design doesn't have any we
+  // don't need a schema.
+  WalkResult cosimWalk =
+      mod.walk([](CosimEndpointOp _) { return WalkResult::interrupt(); });
+  if (!cosimWalk.wasInterrupted())
+    return;
+
+  std::string schemaStrBuffer;
+  llvm::raw_string_ostream os(schemaStrBuffer);
+  if (failed(exportCosimSchema(mod, os))) {
+    signalPassFailure();
+    return;
+  }
+
+  OpBuilder b = OpBuilder::atBlockEnd(mod.getBody());
+  auto verbatim = b.create<sv::VerbatimOp>(b.getUnknownLoc(),
+                                           StringAttr::get(ctxt, os.str()));
+
+  if (!schemaFile.empty()) {
+    auto outputFileAttr = OutputFileAttr::getFromFilename(ctxt, schemaFile);
+    verbatim->setAttr("output_file", outputFileAttr);
+  }
+}
+
 namespace circt {
 namespace esi {
+std::unique_ptr<OperationPass<ModuleOp>> createESICreateCapnpSchemaPass() {
+  return std::make_unique<ESICreateCapnpSchemaPass>();
+}
 std::unique_ptr<OperationPass<ModuleOp>> createESIPhysicalLoweringPass() {
   return std::make_unique<ESIToPhysicalPass>();
 }


### PR DESCRIPTION
Do this in a pass which creates a VerbatimOp block. More consistent with
how other parts of CIRCT generate aux files.