### PR TITLE
[LowerToHW] Delete attach op if there is single source

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -81,6 +81,29 @@ static Type lowerType(Type type) {
   return {};
 }
 
+/// Return true if the specified FIRRTL type is a sized type (Int or Analog)
+/// with zero bits.
+static bool isZeroBitFIRRTLType(Type type) {
+  return type.cast<FIRRTLType>().getPassiveType().getBitWidthOrSentinel() == 0;
+}
+
+// Return a single source value in the operands of the given attach op if
+// exists.
+static Value getSingleNonInstanceOperand(AttachOp op) {
+  Value singleSource = {};
+  for (auto operand : op.getAttached()) {
+    if (isZeroBitFIRRTLType(operand.getType()) ||
+        operand.getDefiningOp<InstanceOp>())
+      continue;
+    // If it is used by other than attach op or there is already a source
+    // value, bail out.
+    if (!operand.hasOneUse() || singleSource)
+      return {};
+    singleSource = operand;
+  }
+  return singleSource;
+}
+
 /// This verifies that the target operation has been lowered to a legal
 /// operation.  This checks that the operation recursively has no FIRRTL
 /// operations or types.
@@ -160,12 +183,6 @@ static Value castFromFIRRTLType(Value val, Type type,
       builder.create<mlir::UnrealizedConversionCastOp>(type, val).getResult(0);
 
   return val;
-}
-
-/// Return true if the specified FIRRTL type is a sized type (Int or Analog)
-/// with zero bits.
-static bool isZeroBitFIRRTLType(Type type) {
-  return type.cast<FIRRTLType>().getPassiveType().getBitWidthOrSentinel() == 0;
 }
 
 /// Move a ExtractTestCode related annotation from annotations to an attribute.
@@ -3018,6 +3035,21 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
       continue;
     }
 
+    // If the result has an analog type and is used only by attach op,
+    // try eliminating a temporary wire by directly using an attached value.
+    if (portResult.getType().isa<AnalogType>()) {
+      AttachOp attach;
+      if (portResult.hasOneUse() &&
+          (attach = dyn_cast<AttachOp>(*portResult.getUsers().begin()))) {
+        if (auto source = getSingleNonInstanceOperand(attach)) {
+          auto loweredResult = getPossiblyInoutLoweredValue(source);
+          operands.push_back(loweredResult);
+          (void)setLowering(portResult, loweredResult);
+          continue;
+        }
+      }
+    }
+
     // Create a wire for each input/inout operand, so there is
     // something to connect to.
     Value wire =
@@ -4018,6 +4050,11 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
   }
 
   if (inoutValues.size() < 2)
+    return success();
+
+  // If the op has a single source value, the value is used as a lowering result
+  // of other values. Therefore we can delete the attach op here.
+  if (getSingleNonInstanceOperand(op))
     return success();
 
   addToIfDefBlock(

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -90,7 +90,7 @@ static bool isZeroBitFIRRTLType(Type type) {
 // Return a single source value in the operands of the given attach op if
 // exists.
 static Value getSingleNonInstanceOperand(AttachOp op) {
-  Value singleSource = {};
+  Value singleSource;
   for (auto operand : op.getAttached()) {
     if (isZeroBitFIRRTLType(operand.getType()) ||
         operand.getDefiningOp<InstanceOp>())
@@ -3037,10 +3037,8 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
     // If the result has an analog type and is used only by attach op,
     // try eliminating a temporary wire by directly using an attached value.
-    if (portResult.getType().isa<AnalogType>()) {
-      AttachOp attach;
-      if (portResult.hasOneUse() &&
-          (attach = dyn_cast<AttachOp>(*portResult.getUsers().begin()))) {
+    if (portResult.getType().isa<AnalogType>() && portResult.hasOneUse()) {
+      if (auto attach = dyn_cast<AttachOp>(*portResult.getUsers().begin())) {
         if (auto source = getSingleNonInstanceOperand(attach)) {
           auto loweredResult = getPossiblyInoutLoweredValue(source);
           operands.push_back(loweredResult);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -246,15 +246,21 @@ firrtl.circuit "Simple" {
 
   // https://github.com/llvm/circt/issues/740
   // CHECK-LABEL: hw.module private @foo740(%led_0: !hw.inout<i1>) {
-  // CHECK:  %.led_0.wire = sv.wire
-  // CHECK-NEXT: sv.read_inout %.led_0.wire
-  // CHECK-NEXT:  hw.instance "fpga" @bar740(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
+  // CHECK-NEXT:  hw.instance "fpga" @bar740(led_0: %led_0: !hw.inout<i1>) -> ()
   firrtl.extmodule private @bar740(in led_0: !firrtl.analog<1>)
   firrtl.module private @foo740(in %led_0: !firrtl.analog<1>) {
     %result = firrtl.instance fpga @bar740(in led_0: !firrtl.analog<1>)
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }
-  
+
+  firrtl.extmodule private @UIntToAnalog_8(out a: !firrtl.analog<8>, out b: !firrtl.analog<8>)
+  firrtl.module @Example(out %port: !firrtl.analog<8>) {
+    // CHECK-LABEL: hw.module @Example(%port: !hw.inout<i8>)
+    // CHECK-NEXT: hw.instance "a2b" @UIntToAnalog_8(a: %port: !hw.inout<i8>, b: %port: !hw.inout<i8>)
+    %a2b_a, %a2b_b = firrtl.instance a2b  @UIntToAnalog_8(out a: !firrtl.analog<8>, out b: !firrtl.analog<8>)
+    firrtl.attach %port, %a2b_b, %a2b_a : !firrtl.analog<8>, !firrtl.analog<8>, !firrtl.analog<8>
+  }
+
   // Memory modules are lowered to plain external modules.
   // CHECK: hw.module.extern @MRead_ext(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {verilogName = "MRead_ext"}
   firrtl.memmodule @MRead_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.uint<1>, out R0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 0 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, writeLatency = 1 : ui32}


### PR DESCRIPTION
This PR implements an optimization to delete attach op if there is only a 
single source value (usually port or wire). The optimization happens in the lowering 
of instance op. If an instance result has an analog type and its user is only attach, then we try eliminating the attach op. If there is a single source value in the attached values, we use that value as a lowering result of instance port result.   
SFC implementation is  https://github.com/chipsalliance/firrtl/blob/c7403e80f965aa3c6f65b176dbb56dbb905cbb31/src/main/scala/firrtl/passes/VerilogPrep.scala#L46-L79