### PR TITLE
[SSP] Add SSP <-> circt::scheduling conversion utilities.

### DIFF
--- a/docs/Dialects/SSP/RationaleSSP.md
+++ b/docs/Dialects/SSP/RationaleSSP.md
@@ -166,3 +166,26 @@ cannot be statically downcasted to the concrete class due to the use of virtual
 multiple inheritance in the problem class hierarchy. If the inheritance model
 were to change in the scheduling infrastructure, the use of attribute interfaces
 should be reconsidered.
+
+## Import/export
+
+The `circt/Dialect/SSP/Utilities.h` header defines methods to convert between
+`ssp.InstanceOp`s and `circt::scheduling::Problem` instances. These utilities
+use template parameters for the problem class and the property attribute
+classes, allowing client code to load/save an instance of a certain problem
+class with the given properties (but ignoring others). Incompatible properties
+(e.g. `distance` on a base `Problem`, or `initiationInterval` on an operation)
+will be caught at compile time as errors in the template instantiation. Note
+that convenience versions that simply load/save all properties known in the
+given problem class are provided as well.
+
+## Extensibility
+
+A key feature of the scheduling infrastructure is its extensibility. New problem
+definitions in out-of-tree projects have to define attributes inheriting from
+the property base classes in one of their own dialects. Due to the heavy use of
+templates in the import/export utilities, these additional attributes are
+supported uniformly alongside the built-in property attributes. The only
+difference is that the SSP dialect provides short-form pretty printing for its
+own properties, whereas externally-defined properties fall back to the generic
+dialect attribute syntax.

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -1,0 +1,437 @@
+//===- Utilities.h - SSP <-> circt::scheduling infra conversion -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides utilities for the conversion between SSP IR and the
+// extensible problem model in the scheduling infrastructure.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SSP_SSPUTILITIES_H
+#define CIRCT_DIALECT_SSP_SSPUTILITIES_H
+
+#include "circt/Dialect/SSP/SSPAttributes.h"
+#include "circt/Dialect/SSP/SSPOps.h"
+#include "circt/Scheduling/Problems.h"
+#include "circt/Support/ValueMapper.h"
+
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <functional>
+
+namespace circt {
+namespace ssp {
+
+using OperatorType = scheduling::Problem::OperatorType;
+using Dependence = scheduling::Problem::Dependence;
+
+//===----------------------------------------------------------------------===//
+// ssp.InstanceOp -> circt::scheduling::Problem (or subclasses)
+//===----------------------------------------------------------------------===//
+
+template <typename ProblemT>
+void loadOperationProperties(ProblemT &, Operation *, ArrayAttr) {}
+template <typename ProblemT, typename OperationPropertyT,
+          typename... OperationPropertyTs>
+void loadOperationProperties(ProblemT &prob, Operation *op, ArrayAttr props) {
+  if (!props)
+    return;
+  for (auto prop : props) {
+    TypeSwitch<Attribute>(prop)
+        .Case<OperationPropertyT, OperationPropertyTs...>(
+            [&](auto p) { p.setInProblem(prob, op); });
+  }
+}
+
+template <typename ProblemT>
+void loadOperatorTypeProperties(ProblemT &, OperatorType, ArrayAttr) {}
+template <typename ProblemT, typename OperatorTypePropertyT,
+          typename... OperatorTypePropertyTs>
+void loadOperatorTypeProperties(ProblemT &prob, OperatorType opr,
+                                ArrayAttr props) {
+  if (!props)
+    return;
+  for (auto prop : props) {
+    TypeSwitch<Attribute>(prop)
+        .Case<OperatorTypePropertyT, OperatorTypePropertyTs...>(
+            [&](auto p) { p.setInProblem(prob, opr); });
+  }
+}
+
+template <typename ProblemT>
+void loadDependenceProperties(ProblemT &, Dependence, ArrayAttr) {}
+template <typename ProblemT, typename DependencePropertyT,
+          typename... DependencePropertyTs>
+void loadDependenceProperties(ProblemT &prob, Dependence dep, ArrayAttr props) {
+  if (!props)
+    return;
+  for (auto prop : props) {
+    TypeSwitch<Attribute>(prop)
+        .Case<DependencePropertyT, DependencePropertyTs...>(
+            [&](auto p) { p.setInProblem(prob, dep); });
+  }
+}
+
+template <typename ProblemT>
+void loadInstanceProperties(ProblemT &, ArrayAttr) {}
+template <typename ProblemT, typename InstancePropertyT,
+          typename... InstancePropertyTs>
+void loadInstanceProperties(ProblemT &prob, ArrayAttr props) {
+  if (!props)
+    return;
+  for (auto prop : props) {
+    TypeSwitch<Attribute>(prop).Case<InstancePropertyT, InstancePropertyTs...>(
+        [&](auto p) { p.setInProblem(prob); });
+  }
+}
+
+/// Construct an instance of \p ProblemT from \p instOp, and attempt to set
+/// properties from the given attribute classes. The attribute tuples are used
+/// solely for grouping/inferring the template parameter packs. The tuple
+/// elements may therefore be unitialized objects. The template instantiation
+/// fails if properties are incompatible with \p ProblemT.
+///
+/// Example: To load an instance of the `circt::scheduling::CyclicProblem` with
+/// all its input and solution properties, call this as follows:
+///
+/// ```
+/// loadProblem<CyclicProblem>(instOp,
+///   std::make_tuple(LinkedOperatorTypeAttr(), StartTimeAttr()),
+///   std::make_tuple(LatencyAttr()),
+///   std::make_tuple(DistanceAttr()),
+///   std::make_tuple(InitiationIntervalAttr()));
+/// ```
+template <typename ProblemT, typename... OperationPropertyTs,
+          typename... OperatorTypePropertyTs, typename... DependencePropertyTs,
+          typename... InstancePropertyTs>
+ProblemT loadProblem(InstanceOp instOp,
+                     std::tuple<OperationPropertyTs...> opProps,
+                     std::tuple<OperatorTypePropertyTs...> oprProps,
+                     std::tuple<DependencePropertyTs...> depProps,
+                     std::tuple<InstancePropertyTs...> instProps) {
+  auto prob = ProblemT::get(instOp);
+
+  loadInstanceProperties<ProblemT, InstancePropertyTs...>(
+      prob, instOp.getPropertiesAttr());
+
+  instOp.getOperatorLibrary().walk([&](OperatorTypeOp oprOp) {
+    OperatorType opr = oprOp.getNameAttr();
+    prob.insertOperatorType(opr);
+    loadOperatorTypeProperties<ProblemT, OperatorTypePropertyTs...>(
+        prob, opr, oprOp.getPropertiesAttr());
+  });
+
+  // Register all operations first, in order to retain their original order.
+  auto graphOp = instOp.getDependenceGraph();
+  graphOp.walk([&](OperationOp opOp) {
+    prob.insertOperation(opOp);
+    loadOperationProperties<ProblemT, OperationPropertyTs...>(
+        prob, opOp, opOp.getPropertiesAttr());
+  });
+
+  // Then walk them again, and load auxiliary dependences as well as any
+  // dependence properties.
+  graphOp.walk([&](OperationOp opOp) {
+    ArrayAttr depsAttr = opOp.getDependencesAttr();
+    if (!depsAttr)
+      return;
+
+    for (auto depAttr : depsAttr.getAsRange<DependenceAttr>()) {
+      Dependence dep;
+      if (FlatSymbolRefAttr sourceRef = depAttr.getSourceRef()) {
+        Operation *sourceOp = SymbolTable::lookupSymbolIn(graphOp, sourceRef);
+        assert(sourceOp);
+        dep = Dependence(sourceOp, opOp);
+        LogicalResult res = prob.insertDependence(dep);
+        assert(succeeded(res));
+        (void)res;
+      } else
+        dep = Dependence(&opOp->getOpOperand(depAttr.getOperandIdx()));
+
+      loadDependenceProperties<ProblemT, DependencePropertyTs...>(
+          prob, dep, depAttr.getProperties());
+    }
+  });
+
+  return prob;
+}
+
+//===----------------------------------------------------------------------===//
+// circt::scheduling::Problem (or subclasses) -> ssp.InstanceOp
+//===----------------------------------------------------------------------===//
+
+template <typename ProblemT, typename... OperationPropertyTs>
+ArrayAttr saveOperationProperties(ProblemT &prob, Operation *op,
+                                  ImplicitLocOpBuilder &b) {
+  SmallVector<Attribute> props;
+  Attribute prop;
+  ((prop = OperationPropertyTs::getFromProblem(prob, op, b.getContext()),
+    prop ? props.push_back(prop) : (void)prop),
+   ...);
+  return props.empty() ? ArrayAttr() : b.getArrayAttr(props);
+}
+
+template <typename ProblemT, typename... OperatorTypePropertyTs>
+ArrayAttr saveOperatorTypeProperties(ProblemT &prob, OperatorType opr,
+                                     ImplicitLocOpBuilder &b) {
+  SmallVector<Attribute> props;
+  Attribute prop;
+  ((prop = OperatorTypePropertyTs::getFromProblem(prob, opr, b.getContext()),
+    prop ? props.push_back(prop) : (void)prop),
+   ...);
+  return props.empty() ? ArrayAttr() : b.getArrayAttr(props);
+}
+
+template <typename ProblemT, typename... DependencePropertyTs>
+ArrayAttr saveDependenceProperties(ProblemT &prob, Dependence dep,
+                                   ImplicitLocOpBuilder &b) {
+  SmallVector<Attribute> props;
+  Attribute prop;
+  ((prop = DependencePropertyTs::getFromProblem(prob, dep, b.getContext()),
+    prop ? props.push_back(prop) : (void)prop),
+   ...);
+  return props.empty() ? ArrayAttr() : b.getArrayAttr(props);
+}
+
+template <typename ProblemT, typename... InstancePropertyTs>
+ArrayAttr saveInstanceProperties(ProblemT &prob, ImplicitLocOpBuilder &b) {
+  SmallVector<Attribute> props;
+  Attribute prop;
+  ((prop = InstancePropertyTs::getFromProblem(prob, b.getContext()),
+    prop ? props.push_back(prop) : (void)prop),
+   ...);
+  return props.empty() ? ArrayAttr() : b.getArrayAttr(props);
+}
+
+/// Construct an `InstanceOp` from a given \p ProblemT instance, and
+/// create/attach attributes of the given classes for the corresponding
+/// properties on the scheduling problem. The returned `InstanceOp` uses the
+/// given \p instanceName and \p problemName. `OperationOp`s are created
+/// unnamed, unless they represent the source operation in an auxiliary
+/// dependence, or the \p operationNameFn callback returns a non-null
+/// `StringAttr` with the desired name. The attribute tuples are used
+/// solely for grouping/inferring the template parameter packs. The tuple
+/// elements may therefore be unitialized objects. The template instantiation
+/// fails if properties are incompatible with \p ProblemT.
+///
+/// Example: To save an instance of the `circt::scheduling::CyclicProblem` with
+/// all its input and solution properties, and reyling on default operation
+/// names, call this as follows:
+///
+/// ```
+/// saveProblem<CyclicProblem>(prob,
+///   builder.getStringAttr("my_instance"),
+///   builder.getStringAttr("CyclicProblem"),
+///   [](Operation *) { return StringAttr(); },
+///   std::make_tuple(LinkedOperatorTypeAttr(), StartTimeAttr()),
+///   std::make_tuple(LatencyAttr()),
+///   std::make_tuple(DistanceAttr()),
+///   std::make_tuple(InitiationIntervalAttr()),
+///   builder);
+/// ```
+template <typename ProblemT, typename... OperationPropertyTs,
+          typename... OperatorTypePropertyTs, typename... DependencePropertyTs,
+          typename... InstancePropertyTs>
+InstanceOp
+saveProblem(ProblemT &prob, StringAttr instanceName, StringAttr problemName,
+            std::function<StringAttr(Operation *)> operationNameFn,
+            std::tuple<OperationPropertyTs...> opProps,
+            std::tuple<OperatorTypePropertyTs...> oprProps,
+            std::tuple<DependencePropertyTs...> depProps,
+            std::tuple<InstancePropertyTs...> instProps, OpBuilder &builder) {
+  ImplicitLocOpBuilder b(builder.getUnknownLoc(), builder);
+
+  // Set up instance.
+  auto instOp = b.create<InstanceOp>(
+      instanceName, problemName,
+      saveInstanceProperties<ProblemT, InstancePropertyTs...>(prob, b));
+
+  // Emit operator types.
+  b.setInsertionPointToEnd(instOp.getBodyBlock());
+  auto libraryOp = b.create<OperatorLibraryOp>();
+  b.setInsertionPointToStart(libraryOp.getBodyBlock());
+
+  for (auto opr : prob.getOperatorTypes())
+    b.create<OperatorTypeOp>(
+        opr, saveOperatorTypeProperties<ProblemT, OperatorTypePropertyTs...>(
+                 prob, opr, b));
+
+  // Determine which operations act as source ops for auxiliary dependences, and
+  // therefore need a name. Also, honor names provided by the client.
+  DenseMap<Operation *, StringAttr> opNames;
+  for (auto *op : prob.getOperations()) {
+    if (StringAttr providedName = operationNameFn(op))
+      opNames[op] = providedName;
+
+    for (auto &dep : prob.getDependences(op)) {
+      Operation *src = dep.getSource();
+      if (!dep.isAuxiliary() || opNames.count(src))
+        continue;
+      if (StringAttr providedName = operationNameFn(src)) {
+        opNames[src] = providedName;
+        continue;
+      }
+      opNames[src] = b.getStringAttr(Twine("Op") + Twine(opNames.size()));
+    }
+  }
+
+  // Construct operations and model their dependences.
+  b.setInsertionPointToEnd(instOp.getBodyBlock());
+  auto graphOp = b.create<DependenceGraphOp>();
+  b.setInsertionPointToStart(graphOp.getBodyBlock());
+
+  BackedgeBuilder backedgeBuilder(b, b.getLoc());
+  ValueMapper v(&backedgeBuilder);
+  for (auto *op : prob.getOperations()) {
+    // Construct the `dependences attribute`. It contains `DependenceAttr` for
+    // def-use deps _with_ properties, and all aux deps.
+    ArrayAttr dependences;
+    SmallVector<Attribute> depAttrs;
+    unsigned auxOperandIdx = op->getNumOperands();
+    for (auto &dep : prob.getDependences(op)) {
+      ArrayAttr depProps =
+          saveDependenceProperties<ProblemT, DependencePropertyTs...>(prob, dep,
+                                                                      b);
+      if (dep.isDefUse() && depProps) {
+        auto depAttr = b.getAttr<DependenceAttr>(*dep.getDestinationIndex(),
+                                                 FlatSymbolRefAttr(), depProps);
+        depAttrs.push_back(depAttr);
+        continue;
+      }
+
+      if (!dep.isAuxiliary())
+        continue;
+
+      auto sourceOpName = opNames.lookup(dep.getSource());
+      assert(sourceOpName);
+      auto sourceRef = b.getAttr<FlatSymbolRefAttr>(sourceOpName);
+      auto depAttr =
+          b.getAttr<DependenceAttr>(auxOperandIdx, sourceRef, depProps);
+      depAttrs.push_back(depAttr);
+      ++auxOperandIdx;
+    }
+    if (!depAttrs.empty())
+      dependences = b.getArrayAttr(depAttrs);
+
+    // Delegate to helper to construct the `properties` attribute.
+    ArrayAttr properties =
+        saveOperationProperties<ProblemT, OperationPropertyTs...>(prob, op, b);
+
+    // Finally, create the `OperationOp` and inform the value mapper.
+    // NB: sym_name, dependences and properties are optional attributes, so
+    // passing potentially unitialized String/ArrayAttrs is intentional here.
+    auto opOp =
+        b.create<OperationOp>(op->getNumResults(), v.get(op->getOperands()),
+                              opNames.lookup(op), dependences, properties);
+    v.set(op->getResults(), opOp->getResults());
+  }
+
+  return instOp;
+}
+
+/// Dummy struct to query a problem's default properties (i.e. all input and
+/// solution properties). Specializations shall provide the following
+/// definitions:
+///
+/// ```
+/// static constexpr auto operationProperties = std::make_tuple(...);
+/// static constexpr auto operatorTypeProperties = std::make_tuple(...);
+/// static constexpr auto dependenceProperties = std::make_tuple(...);
+/// static constexpr auto instanceProperties = std::make_tuple(...);
+/// ```
+template <typename ProblemT>
+struct Default {};
+
+/// Construct an instance of \p ProblemT from \p instOp, and attempt to set all
+/// of the problem class' properties.
+///
+/// Relies on the specialization of template `circt::ssp::Default` for \p
+/// ProblemT.
+template <typename ProblemT>
+ProblemT loadProblem(InstanceOp instOp) {
+  return loadProblem<ProblemT>(instOp, Default<ProblemT>::operationProperties,
+                               Default<ProblemT>::operatorTypeProperties,
+                               Default<ProblemT>::dependenceProperties,
+                               Default<ProblemT>::instanceProperties);
+}
+
+/// Construct an `InstanceOp` from a given \p ProblemT instance, and
+/// create/attach attributes for all of the problem class' properties.
+///
+/// Relies on the specialization of template `circt::ssp::Default` for \p
+/// ProblemT.
+template <typename ProblemT>
+InstanceOp saveProblem(ProblemT &prob, StringAttr instanceName,
+                       StringAttr problemName,
+                       std::function<StringAttr(Operation *)> operationNameFn,
+                       OpBuilder &builder) {
+  return saveProblem<ProblemT>(prob, instanceName, problemName, operationNameFn,
+                               Default<ProblemT>::operationProperties,
+                               Default<ProblemT>::operatorTypeProperties,
+                               Default<ProblemT>::dependenceProperties,
+                               Default<ProblemT>::instanceProperties, builder);
+}
+
+//===----------------------------------------------------------------------===//
+// Default property tuples for the built-in problems
+//===----------------------------------------------------------------------===//
+
+template <>
+struct Default<scheduling::Problem> {
+  static constexpr auto operationProperties =
+      std::make_tuple(LinkedOperatorTypeAttr(), StartTimeAttr());
+  static constexpr auto operatorTypeProperties = std::make_tuple(LatencyAttr());
+  static constexpr auto dependenceProperties = std::make_tuple();
+  static constexpr auto instanceProperties = std::make_tuple();
+};
+
+template <>
+struct Default<scheduling::CyclicProblem> {
+  static constexpr auto operationProperties =
+      Default<scheduling::Problem>::operationProperties;
+  static constexpr auto operatorTypeProperties =
+      Default<scheduling::Problem>::operatorTypeProperties;
+  static constexpr auto dependenceProperties =
+      std::tuple_cat(Default<scheduling::Problem>::dependenceProperties,
+                     std::make_tuple(DistanceAttr()));
+  static constexpr auto instanceProperties =
+      std::tuple_cat(Default<scheduling::Problem>::instanceProperties,
+                     std::make_tuple(InitiationIntervalAttr()));
+};
+
+template <>
+struct Default<scheduling::SharedOperatorsProblem> {
+  static constexpr auto operationProperties =
+      Default<scheduling::Problem>::operationProperties;
+  static constexpr auto operatorTypeProperties =
+      std::tuple_cat(Default<scheduling::Problem>::operatorTypeProperties,
+                     std::make_tuple(LimitAttr()));
+  static constexpr auto dependenceProperties =
+      Default<scheduling::Problem>::dependenceProperties;
+  static constexpr auto instanceProperties =
+      Default<scheduling::Problem>::instanceProperties;
+};
+
+template <>
+struct Default<scheduling::ModuloProblem> {
+  static constexpr auto operationProperties =
+      Default<scheduling::Problem>::operationProperties;
+  static constexpr auto operatorTypeProperties =
+      Default<scheduling::SharedOperatorsProblem>::operatorTypeProperties;
+  static constexpr auto dependenceProperties =
+      Default<scheduling::CyclicProblem>::dependenceProperties;
+  static constexpr auto instanceProperties =
+      Default<scheduling::CyclicProblem>::instanceProperties;
+};
+
+} // namespace ssp
+} // namespace circt
+
+#endif // CIRCT_DIALECT_SSP_SSPUTILITIES_H

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -172,6 +172,8 @@ ArrayAttr saveOperationProperties(ProblemT &prob, Operation *op,
                                   ImplicitLocOpBuilder &b) {
   SmallVector<Attribute> props;
   Attribute prop;
+  // Fold expression: Expands to a `getFromProblem` and a conditional
+  // `push_back` call for each of the `OperationPropertyTs`.
   ((prop = OperationPropertyTs::getFromProblem(prob, op, b.getContext()),
     prop ? props.push_back(prop) : (void)prop),
    ...);
@@ -183,6 +185,8 @@ ArrayAttr saveOperatorTypeProperties(ProblemT &prob, OperatorType opr,
                                      ImplicitLocOpBuilder &b) {
   SmallVector<Attribute> props;
   Attribute prop;
+  // Fold expression: Expands to a `getFromProblem` and a conditional
+  // `push_back` call for each of the `OperatorTypePropertyTs`.
   ((prop = OperatorTypePropertyTs::getFromProblem(prob, opr, b.getContext()),
     prop ? props.push_back(prop) : (void)prop),
    ...);
@@ -194,6 +198,8 @@ ArrayAttr saveDependenceProperties(ProblemT &prob, Dependence dep,
                                    ImplicitLocOpBuilder &b) {
   SmallVector<Attribute> props;
   Attribute prop;
+  // Fold expression: Expands to a `getFromProblem` and a conditional
+  // `push_back` call for each of the `DependencePropertyTs`.
   ((prop = DependencePropertyTs::getFromProblem(prob, dep, b.getContext()),
     prop ? props.push_back(prop) : (void)prop),
    ...);
@@ -204,6 +210,8 @@ template <typename ProblemT, typename... InstancePropertyTs>
 ArrayAttr saveInstanceProperties(ProblemT &prob, ImplicitLocOpBuilder &b) {
   SmallVector<Attribute> props;
   Attribute prop;
+  // Fold expression: Expands to a `getFromProblem` and a conditional
+  // `push_back` call for each of the `InstancePropertyTs`.
   ((prop = InstancePropertyTs::getFromProblem(prob, b.getContext()),
     prop ? props.push_back(prop) : (void)prop),
    ...);

--- a/lib/Dialect/SSP/CMakeLists.txt
+++ b/lib/Dialect/SSP/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SSP_Srcs
 
 set(SSP_LinkLibs
   CIRCTScheduling
+  CIRCTSupport
   MLIRIR
   )
 

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -43,6 +43,7 @@ add_circt_library(CIRCTSchedulingTestPasses
 
   LINK_LIBS PUBLIC
   CIRCTScheduling
+  CIRCTSSP
   MLIRPass
   )
 

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -10,15 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/SSP/Utilities.h"
 #include "circt/Scheduling/Algorithms.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 using namespace mlir;
 using namespace circt;
 using namespace circt::scheduling;
+using namespace circt::ssp;
 
 //===----------------------------------------------------------------------===//
 // Construction helper methods
@@ -558,6 +561,64 @@ void TestSimplexSchedulerPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// Import/export via SSP dialect
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestSSPRoundtripPass
+    : public PassWrapper<TestSSPRoundtripPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestSSPRoundtripPass)
+
+  TestSSPRoundtripPass() = default;
+  TestSSPRoundtripPass(const TestSSPRoundtripPass &) {}
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-ssp-roundtrip"; }
+  StringRef getDescription() const override {
+    return "Roundtrip SSP -> circt::scheduling -> SSP";
+  }
+};
+} // anonymous namespace
+
+template <typename ProblemT>
+void roundtrip(InstanceOp instOp) {
+  auto prob = loadProblem<ProblemT>(instOp);
+
+  OpBuilder builder(instOp);
+  saveProblem<ProblemT>(
+      prob, instOp.getInstanceNameAttr(), instOp.getProblemNameAttr(),
+      [&](Operation *op) {
+        if (auto opOp = dyn_cast<OperationOp>(op))
+          return opOp.getSymNameAttr();
+        return StringAttr();
+      },
+      builder);
+}
+
+void TestSSPRoundtripPass::runOnOperation() {
+  ModuleOp module = getOperation();
+  SmallVector<InstanceOp> instanceOps;
+  module.walk([&](ssp::InstanceOp op) { instanceOps.push_back(op); });
+
+  for (auto op : instanceOps) {
+    StringRef probName = op.getProblemName();
+    if (probName.equals("Problem"))
+      roundtrip<Problem>(op);
+    else if (probName.equals("CyclicProblem"))
+      roundtrip<CyclicProblem>(op);
+    else if (probName.equals("SharedOperatorsProblem"))
+      roundtrip<SharedOperatorsProblem>(op);
+    else if (probName.equals("ModuloProblem"))
+      roundtrip<ModuloProblem>(op);
+    else {
+      op->emitError("Unhandled problem class: ") << probName;
+      return signalPassFailure();
+    }
+  }
+
+  llvm::for_each(instanceOps, [](InstanceOp op) { op.erase(); });
+}
+
+//===----------------------------------------------------------------------===//
 // LPScheduler
 //===----------------------------------------------------------------------===//
 
@@ -657,6 +718,9 @@ void registerSchedulingTestPasses() {
   });
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestSimplexSchedulerPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestSSPRoundtripPass>();
   });
 #ifdef SCHEDULING_OR_TOOLS
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -1,4 +1,8 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
+// RUN: circt-opt %s -test-ssp-roundtrip | circt-opt | FileCheck %s
+
+// 1) tests the plain parser/printer roundtrip.
+// 2) roundtrips via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
 
 // CHECK: ssp.instance "no properties" of "Problem" {
 // CHECK:   library {  


### PR DESCRIPTION
This PR adds the missing pieces to link the SSP dialect to the scheduling infra.

NB: It's debatable whether the `-ssp-roundtrip` pass should live with the other scheduling test passes. I mostly put it in there because SSP doesn't have the pass boilerplate yet. However, my current plan is to rework all of this anyways, and replace the test passes with a (public) `-schedule` pass to operate on SSP IR.