### PR TITLE
[HWArith][HWArithToHW] Implement ICmp

### DIFF
--- a/include/circt/Dialect/HWArith/CMakeLists.txt
+++ b/include/circt/Dialect/HWArith/CMakeLists.txt
@@ -2,3 +2,6 @@ add_circt_dialect(HWArith hwarith)
 add_circt_dialect_doc(HWArith hwarith)
 
 set(LLVM_TARGET_DEFINITIONS HWArith.td)
+mlir_tablegen(HWArithEnums.h.inc -gen-enum-decls)
+mlir_tablegen(HWArithEnums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(MLIRHWArithEnumsIncGen)

--- a/include/circt/Dialect/HWArith/HWArithDialect.h
+++ b/include/circt/Dialect/HWArith/HWArithDialect.h
@@ -19,4 +19,7 @@
 // Pull in the Dialect definition.
 #include "circt/Dialect/HWArith/HWArithDialect.h.inc"
 
+// Pull in all enum type definitions and utility function declarations.
+#include "circt/Dialect/HWArith/HWArithEnums.h.inc"
+
 #endif // CIRCT_DIALECT_HWARITH_HWARITHDIALECT_H

--- a/include/circt/Dialect/HWArith/HWArithOps.h
+++ b/include/circt/Dialect/HWArith/HWArithOps.h
@@ -22,4 +22,13 @@
 #define GET_OP_CLASSES
 #include "circt/Dialect/HWArith/HWArith.h.inc"
 
+namespace circt {
+namespace hwarith {
+
+unsigned inferAddResultType(IntegerType::SignednessSemantics &signedness,
+                            IntegerType lhs, IntegerType rhs);
+
+} // namespace hwarith
+} // namespace circt
+
 #endif // CIRCT_DIALECT_HWARITH_OPS_H

--- a/include/circt/Dialect/HWArith/HWArithOps.h
+++ b/include/circt/Dialect/HWArith/HWArithOps.h
@@ -25,6 +25,8 @@
 namespace circt {
 namespace hwarith {
 
+// Infer the bitwidth as well as the signedness that is required to store the
+// sum of two given integer types without over- or underflowing.
 unsigned inferAddResultType(IntegerType::SignednessSemantics &signedness,
                             IntegerType lhs, IntegerType rhs);
 

--- a/include/circt/Dialect/HWArith/HWArithOps.td
+++ b/include/circt/Dialect/HWArith/HWArithOps.td
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_HWARITH_HWARITHOPS_TD
 #define CIRCT_DIALECT_HWARITH_HWARITHOPS_TD
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -199,6 +200,55 @@ def HWArith_CastOp : HWArithOp<"cast", [NoSideEffect]> {
   let assemblyFormat = "$in attr-dict `:` functional-type($in, $out)";
 
   let hasVerifier = 1;
+}
+
+// Comparison predicates
+// `==` and `!=`
+def ICmpPredicateEQ  : I64EnumAttrCase<"eq", 0b000>;
+def ICmpPredicateNE  : I64EnumAttrCase<"ne", 0b001>;
+// `<` and `>=`
+def ICmpPredicateLT : I64EnumAttrCase<"lt", 0b010>;
+def ICmpPredicateGE : I64EnumAttrCase<"ge", 0b011>;
+// `<=` and `>`
+def ICmpPredicateLE : I64EnumAttrCase<"le", 0b100>;
+def ICmpPredicateGT : I64EnumAttrCase<"gt", 0b101>;
+
+let cppNamespace = "circt::hwarith" in
+def ICmpPredicate : I64EnumAttr<
+    "ICmpPredicate",
+    "hwarith.icmp comparison predicate",
+    [ICmpPredicateEQ, ICmpPredicateNE, ICmpPredicateLT,
+     ICmpPredicateGE, ICmpPredicateLE, ICmpPredicateGT]>;
+
+def ICmpOp : HWArithOp<"icmp", [NoSideEffect]> {
+  let summary = "Sign- and bitwidth-aware integer comparison.";
+  let description = [{
+    The `icmp` operation compares two integers using a predicate. If the
+    predicate is true, returns 1, otherwise returns 0. This operation always
+    returns a one bit wide result of type `ui1`. Both operand types may be
+    signed or unsigned scalar integer types of arbitrary bitwidth.
+
+    | LHS type | RHS type | Comparison type                          | Result type |
+    | :------- | :------- | :--------------------------------------- | :---------- |
+    | `ui<a>`  | `ui<b>`  | `ui<r>`, *r* = max(*a*, *b*)             | `ui1`       |
+    | `si<a>`  | `si<b>`  | `si<r>`, *r* = max(*a*, *b*)             | `ui1`       |
+    | `ui<a>`  | `si<b>`  | `si<r>`, *r* = *a* + 1 **if** *a* ≥ *b*  | `ui1`       |
+    |          |          | `si<r>`, *r* = *b* **if** *a* < *b*      | `ui1`       |
+    | `si<a>`  | `ui<b>`  | Same as `ui<b> si<a>`                    | `ui1`       |
+
+    Examples:
+    ```mlir
+    %0 = hwarith.icmp lt %10, %11 : ui5, ui6
+    %1 = hwarith.icmp lt %12, %13 : si3, si4
+    %2 = hwarith.icmp lt %12, %11 : si3, ui6
+    ```
+  }];
+
+  let arguments = (ins ICmpPredicate:$predicate,
+                   HWArithIntegerType:$lhs, HWArithIntegerType:$rhs);
+  let results = (outs UI1:$result);
+
+  let assemblyFormat = "$predicate $lhs `,` $rhs  attr-dict `:` type($lhs) `,` type($rhs)";
 }
 
 #endif // CIRCT_DIALECT_HWARITH_HWARITHOPS_TD

--- a/include/circt/Dialect/HWArith/HWArithTypes.h
+++ b/include/circt/Dialect/HWArith/HWArithTypes.h
@@ -19,6 +19,8 @@
 namespace circt {
 namespace hwarith {
 
+// Check whether a specified type satisfies the constraints for the
+// HWArithIntegerType
 bool isHWArithIntegerType(::mlir::Type type);
 
 } // namespace hwarith

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -168,6 +168,10 @@ struct CastOpLowering : public OpConversionPattern<CastOp> {
 } // namespace
 
 namespace {
+
+// Utility lowering function that maps a hwarith::ICmpPredicate predicate and
+// the information whether the comparison contains signed values to the
+// corresponding comb::ICmpPredicate.
 static comb::ICmpPredicate lowerPredicate(ICmpPredicate pred, bool isSigned) {
 #define _CREATE_HWARITH_ICMP_CASE(x)                                           \
   case ICmpPredicate::x:                                                       \

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -167,6 +167,61 @@ struct CastOpLowering : public OpConversionPattern<CastOp> {
 };
 } // namespace
 
+namespace {
+static comb::ICmpPredicate lowerPredicate(ICmpPredicate pred, bool isSigned) {
+#define _CREATE_HWARITH_ICMP_CASE(x)                                           \
+  case ICmpPredicate::x:                                                       \
+    return isSigned ? comb::ICmpPredicate::s##x : comb::ICmpPredicate::u##x
+
+  switch (pred) {
+  case ICmpPredicate::eq:
+    return comb::ICmpPredicate::eq;
+
+  case ICmpPredicate::ne:
+    return comb::ICmpPredicate::ne;
+
+    _CREATE_HWARITH_ICMP_CASE(lt);
+    _CREATE_HWARITH_ICMP_CASE(ge);
+    _CREATE_HWARITH_ICMP_CASE(le);
+    _CREATE_HWARITH_ICMP_CASE(gt);
+  }
+
+#undef _CREATE_HWARITH_ICMP_CASE
+
+  llvm_unreachable(
+      "Missing hwarith::ICmpPredicate to comb::ICmpPredicate lowering");
+  return comb::ICmpPredicate::eq;
+}
+
+struct ICmpOpLowering : public OpConversionPattern<ICmpOp> {
+  using OpConversionPattern<ICmpOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ICmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto lhsType = op.lhs().getType().cast<IntegerType>();
+    auto rhsType = op.rhs().getType().cast<IntegerType>();
+    IntegerType::SignednessSemantics cmpSignedness;
+    const unsigned cmpWidth =
+        inferAddResultType(cmpSignedness, lhsType, rhsType) - 1;
+
+    ICmpPredicate pred = op.predicate();
+    comb::ICmpPredicate combPred = lowerPredicate(
+        pred, cmpSignedness == IntegerType::SignednessSemantics::Signed);
+
+    const auto loc = op.getLoc();
+    Value lhsValue = extendTypeWidth(rewriter, loc, adaptor.lhs(), cmpWidth,
+                                     lhsType.isSigned());
+    Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.rhs(), cmpWidth,
+                                     rhsType.isSigned());
+
+    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, combPred, lhsValue, rhsValue);
+
+    return success();
+  }
+};
+} // namespace
+
 // Templated patterns
 
 namespace {
@@ -212,7 +267,7 @@ public:
     target.addIllegalDialect<HWArithDialect>();
     target.addLegalDialect<comb::CombDialect, hw::HWDialect>();
 
-    patterns.add<ConstantOpLowering, CastOpLowering,
+    patterns.add<ConstantOpLowering, CastOpLowering, ICmpOpLowering,
                  BinaryOpLowering<AddOp, comb::AddOp>,
                  BinaryOpLowering<SubOp, comb::SubOp>,
                  BinaryOpLowering<MulOp, comb::MulOp>, DivOpLowering>(

--- a/lib/Dialect/HWArith/CMakeLists.txt
+++ b/lib/Dialect/HWArith/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTHWArith
 
     DEPENDS
     MLIRHWArithIncGen
+    MLIRHWArithEnumsIncGen
     MLIRIR
 
     LINK_COMPONENTS

--- a/lib/Dialect/HWArith/HWArithDialect.cpp
+++ b/lib/Dialect/HWArith/HWArithDialect.cpp
@@ -29,4 +29,7 @@ void HWArithDialect::initialize() {
       >();
 }
 
+// Provide implementations for the enums we use.
+#include "circt/Dialect/HWArith/HWArithEnums.cpp.inc"
+
 #include "circt/Dialect/HWArith/HWArithDialect.cpp.inc"

--- a/lib/Dialect/HWArith/HWArithOps.cpp
+++ b/lib/Dialect/HWArith/HWArithOps.cpp
@@ -75,32 +75,6 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 // AddOp
 //===----------------------------------------------------------------------===//
 
-static unsigned inferAddResultType(IntegerType::SignednessSemantics &signedness,
-                                   IntegerType lhs, IntegerType rhs) {
-  // the result width is never less than max(w1, w2) + 1
-  unsigned resultWidth = std::max(lhs.getWidth(), rhs.getWidth()) + 1;
-
-  if (lhs.getSignedness() == rhs.getSignedness()) {
-    // max(w1, w2) + 1 in case both operands use the same signedness
-    // the signedness is also identical to the operands
-    signedness = lhs.getSignedness();
-  } else {
-    // For mixed signedness the result is always signed
-    signedness = IntegerType::Signed;
-
-    // Regarding the result width two case need to be considered:
-    if ((lhs.isUnsigned() && lhs.getWidth() >= rhs.getWidth()) ||
-        (rhs.isUnsigned() && rhs.getWidth() >= lhs.getWidth())) {
-      // 1. the unsigned width is >= the signed width,
-      // then the width needs to be increased by 1
-      ++resultWidth;
-    }
-    // 2. the unsigned width is < the signed width,
-    // then no further adjustment is needed
-  }
-  return resultWidth;
-}
-
 LogicalResult AddOp::inferReturnTypes(MLIRContext *context,
                                       Optional<Location> loc,
                                       ValueRange operands, DictionaryAttr attrs,
@@ -199,6 +173,32 @@ LogicalResult DivOp::inferReturnTypes(MLIRContext *context,
 
 namespace circt {
 namespace hwarith {
+
+unsigned inferAddResultType(IntegerType::SignednessSemantics &signedness,
+                                   IntegerType lhs, IntegerType rhs) {
+  // the result width is never less than max(w1, w2) + 1
+  unsigned resultWidth = std::max(lhs.getWidth(), rhs.getWidth()) + 1;
+
+  if (lhs.getSignedness() == rhs.getSignedness()) {
+    // max(w1, w2) + 1 in case both operands use the same signedness
+    // the signedness is also identical to the operands
+    signedness = lhs.getSignedness();
+  } else {
+    // For mixed signedness the result is always signed
+    signedness = IntegerType::Signed;
+
+    // Regarding the result width two case need to be considered:
+    if ((lhs.isUnsigned() && lhs.getWidth() >= rhs.getWidth()) ||
+        (rhs.isUnsigned() && rhs.getWidth() >= lhs.getWidth())) {
+      // 1. the unsigned width is >= the signed width,
+      // then the width needs to be increased by 1
+      ++resultWidth;
+    }
+    // 2. the unsigned width is < the signed width,
+    // then no further adjustment is needed
+  }
+  return resultWidth;
+}
 
 static LogicalResult verifyBinOp(Operation *binOp) {
   auto ops = binOp->getOperands();

--- a/lib/Dialect/HWArith/HWArithOps.cpp
+++ b/lib/Dialect/HWArith/HWArithOps.cpp
@@ -175,7 +175,7 @@ namespace circt {
 namespace hwarith {
 
 unsigned inferAddResultType(IntegerType::SignednessSemantics &signedness,
-                                   IntegerType lhs, IntegerType rhs) {
+                            IntegerType lhs, IntegerType rhs) {
   // the result width is never less than max(w1, w2) + 1
   unsigned resultWidth = std::max(lhs.getWidth(), rhs.getWidth()) + 1;
 

--- a/test/Conversion/HWArithToHW/test_basic.mlir
+++ b/test/Conversion/HWArithToHW/test_basic.mlir
@@ -179,14 +179,14 @@ hw.module @div(%op0: i32, %op1: i32) -> (sisi: i32, siui: i32, uisi: i32, uiui: 
   %op1Unsigned = hwarith.cast %op1 : (i32) -> ui32
 
 // CHECK:   %[[SIGN_BIT_OP0:.*]] = comb.extract %op0 from 31 : (i32) -> i1
-// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %0, %op0 : i1, i32
+// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP0]], %op0 : i1, i32
 // CHECK:   %[[SIGN_BIT_OP1:.*]] = comb.extract %op1 from 31 : (i32) -> i1
-// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %2, %op1 : i1, i32
+// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP1]], %op1 : i1, i32
 // CHECK:   %[[SISI_RES:.*]] = comb.divs %[[OP0_PADDED]], %[[OP1_PADDED]] : i33
   %sisi = hwarith.div %op0Signed, %op1Signed : (si32, si32) -> si33
 
 // CHECK:   %[[SIGN_BIT_OP0:.*]] = comb.extract %op0 from 31 : (i32) -> i1
-// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %5, %op0 : i1, i32
+// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP0]], %op0 : i1, i32
 // CHECK:   %[[ZERO_EXTEND:.*]] = hw.constant false
 // CHECK:   %[[OP1_PADDED:.*]] = comb.concat %[[ZERO_EXTEND]], %op1 : i1, i32
 // CHECK:   %[[SIUI_RES_IMM:.*]] = comb.divs %[[OP0_PADDED]], %[[OP1_PADDED]] : i33
@@ -196,7 +196,7 @@ hw.module @div(%op0: i32, %op1: i32) -> (sisi: i32, siui: i32, uisi: i32, uiui: 
 // CHECK:   %[[ZERO_EXTEND:.*]] = hw.constant false
 // CHECK:   %[[OP0_PADDED:.*]] = comb.concat %[[ZERO_EXTEND]], %op0 : i1, i32
 // CHECK:   %[[SIGN_BIT_OP1:.*]] = comb.extract %op1 from 31 : (i32) -> i1
-// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %11, %op1 : i1, i32
+// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP1]], %op1 : i1, i32
 // CHECK:   %[[UISI_RES:.*]] = comb.divs %[[OP0_PADDED]], %[[OP1_PADDED]] : i33
   %uisi = hwarith.div %op0Unsigned, %op1Signed : (ui32, si32) -> si33
 
@@ -212,4 +212,42 @@ hw.module @div(%op0: i32, %op1: i32) -> (sisi: i32, siui: i32, uisi: i32, uiui: 
 
 // CHECK:   hw.output %[[SISI_OUT]], %[[SIUI_RES]], %[[UISI_OUT]], %[[UIUI_RES]] : i32, i32, i32, i32
   hw.output %sisiOut, %siuiOut, %uisiOut, %uiuiOut : i32, i32, i32, i32
+}
+
+// -----
+
+// CHECK: hw.module @icmp(%op0: i32, %op1: i32) -> (sisi: i1, siui: i1, uisi: i1, uiui: i1) {
+hw.module @icmp(%op0: i32, %op1: i32) -> (sisi: i1, siui: i1, uisi: i1, uiui: i1) {
+  %op0Signed = hwarith.cast %op0 : (i32) -> si32
+  %op0Unsigned = hwarith.cast %op0 : (i32) -> ui32
+  %op1Signed = hwarith.cast %op1 : (i32) -> si32
+  %op1Unsigned = hwarith.cast %op1 : (i32) -> ui32
+
+// CHECK:   %[[SISI_OUT:.*]] = comb.icmp slt %op0, %op1 : i32
+  %sisi = hwarith.icmp lt %op0Signed, %op1Signed : si32, si32
+
+// CHECK:   %[[SIGN_BIT_OP0:.*]] = comb.extract %op0 from 31 : (i32) -> i1
+// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP0]], %op0 : i1, i32
+// CHECK:   %[[ZERO_EXTEND:.*]] = hw.constant false
+// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %[[ZERO_EXTEND]], %op1 : i1, i32
+// CHECK:   %[[SIUI_OUT:.*]] = comb.icmp slt %[[OP0_PADDED]], %[[OP1_PADDED]] : i33
+  %siui = hwarith.icmp lt %op0Signed, %op1Unsigned : si32, ui32
+
+// CHECK:   %[[ZERO_EXTEND:.*]] = hw.constant false
+// CHECK:   %[[OP0_PADDED:.*]] = comb.concat %[[ZERO_EXTEND]], %op0 : i1, i32
+// CHECK:   %[[SIGN_BIT_OP1:.*]] = comb.extract %op1 from 31 : (i32) -> i1
+// CHECK:   %[[OP1_PADDED:.*]] = comb.concat %[[SIGN_BIT_OP1]], %op1 : i1, i32
+// CHECK:   %[[UISI_OUT:.*]] = comb.icmp slt %[[OP0_PADDED]], %[[OP1_PADDED]] : i33
+  %uisi = hwarith.icmp lt %op0Unsigned, %op1Signed : ui32, si32
+
+// CHECK:   %[[UIUI_OUT:.*]] = comb.icmp ult %op0, %op1 : i32
+  %uiui = hwarith.icmp lt %op0Unsigned, %op1Unsigned : ui32, ui32
+
+  %sisiOut = hwarith.cast %sisi : (ui1) -> i1
+  %siuiOut = hwarith.cast %siui : (ui1) -> i1
+  %uisiOut = hwarith.cast %uisi : (ui1) -> i1
+  %uiuiOut = hwarith.cast %uiui : (ui1) -> i1
+
+// CHECK:   hw.output %[[SISI_OUT]], %[[SIUI_OUT]], %[[UISI_OUT]], %[[UIUI_OUT]] : i1, i1, i1, i1
+  hw.output %sisiOut, %siuiOut, %uisiOut, %uiuiOut : i1, i1, i1, i1
 }

--- a/test/Dialect/HWArith/basic.mlir
+++ b/test/Dialect/HWArith/basic.mlir
@@ -31,4 +31,8 @@ hw.module @test1() {
   %11 = hwarith.add %10, %6 : (si9, ui3) -> si10
   // CHECK: %12 = hwarith.cast %11 : (si10) -> i9
   %12 = hwarith.cast %11 : (si10) -> i9
+  // CHECK: %13 = hwarith.icmp eq %5, %10 : ui2, si9
+  %13 = hwarith.icmp eq %5, %10 : ui2, si9
+  // CHECK: %14 = hwarith.cast %13 : (ui1) -> i1
+  %14 = hwarith.cast %13 : (ui1) -> i1
 }


### PR DESCRIPTION
This PR adds the missing comparison operator (https://github.com/llvm/circt/issues/3549) as well as implements the lowering to `comb`. I can also split this PR into two separate ones, if preferred.