### PR TITLE
[Docs] Fix hw, comb and sv dialect links

### DIFF
--- a/docs/Charter.md
+++ b/docs/Charter.md
@@ -167,7 +167,7 @@ Calyx currently serves as the compilation target for [Dahlia](https://capra.cs.c
 and several other domain-specific architectures (systolic array, number 
 theoretic transform unit).
 
-### [Dataflow/handshake](Dialects/Handshake.md)
+### [Dataflow/handshake](Dialects/Handshake/RationaleHandshake.md)
 
 Dataflow models have long been used to represent parallel computation.
 Typically these models include components representing independent

--- a/docs/Dialects/Comb/RationaleComb.md
+++ b/docs/Dialects/Comb/RationaleComb.md
@@ -2,7 +2,7 @@
 
 This document describes various design points of the Comb dialect, a common
 dialect that is typically used in conjunction with the `hw` and `sv` dialects.
-Please see the [`hw` Dialect Rationale](RationaleHW.md) for high level insight
+Please see the [`hw` Dialect Rationale](../HW/RationaleHW.md) for high level insight
 on how these work together.  This follows in the spirit of
 other [MLIR Rationale docs](https://mlir.llvm.org/docs/Rationale/).
 

--- a/docs/Dialects/HW/RationaleHW.md
+++ b/docs/Dialects/HW/RationaleHW.md
@@ -5,8 +5,8 @@ global perspective on the `hw`, `comb`, and `sv` dialects, why
 they are the way they are, and current status.  This follows in the spirit of
 other [MLIR Rationale docs](https://mlir.llvm.org/docs/Rationale/).  For more
 information about the other dialects, please see the
-[Comb Dialect Rationale](RationaleComb.md) and [SV Dialect
-Rationale](RationaleSV.md).
+[Comb Dialect Rationale](../Comb/RationaleComb.md) and [SV Dialect
+Rationale](../SV/RationaleSV.md).
 
 - [HW Dialect Rationale](#hw-dialect-rationale)
   - [General Introduction](#general-introduction)
@@ -139,7 +139,7 @@ notable differences: for example:
    analysis from the `hw.output` which is useful for inter-module analyses.
  - We allow arbitrary types for module ports.  The `hw` dialect is generally
    designed to be extensible by other dialects, and thus being permissive here
-   is useful.  That said, the [Verilog exporter](VerilogGeneration.md) does not
+   is useful.  That said, the [Verilog exporter](../../VerilogGeneration.md) does not
    support arbitrary user-defined types.
  - The `comb` dialect in particular does not use signed integer types, its
    operators do not support zero-width integer types.  Modules in the `hw` dialect,

--- a/docs/Dialects/SV/RationaleSV.md
+++ b/docs/Dialects/SV/RationaleSV.md
@@ -2,7 +2,7 @@
 
 This document describes various design points of the `sv` dialect, a common
 dialect that is typically used in conjunction with the `hw` and `comb` dialects.
-Please see the [HW Dialect Rationale](RationaleHW.md) for high level insight
+Please see the [HW Dialect Rationale](../HW/RationaleHW.md) for high level insight
 on how these work together.  This follows in the spirit of
 other [MLIR Rationale docs](https://mlir.llvm.org/docs/Rationale/).
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -136,7 +136,7 @@ dependencies are installed on your system. They are:
 7) **Install Cap'nProto** (optional, affects ESI dialect only)
 
 Some of the ESI dialect code requires [libcapnp](https://capnproto.org/), 0.9.1 or newer.
-(Specifically, the [cosimulation](ESI/cosim.md) component.) Most of
+(Specifically, the [cosimulation](Dialects/ESI/cosim.md) component.) Most of
 the ESI cosim integration tests also require the python bindings: pycapnp.
 The `utils/get-capnp.sh` script downloads, compiles, and installs a known
 good version to a directory within the circt source code. It optionally


### PR DESCRIPTION
Seems like these links were not updated when the corresponding files were moved into separate subfolders.