### PR TITLE
[HWArithToHW] Add type conversions for 'other' ops

### DIFF
--- a/lib/Conversion/HWArithToHW/CMakeLists.txt
+++ b/lib/Conversion/HWArithToHW/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_conversion_library(CIRCTHWArithToHW
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTSeq
   CIRCTHW
   CIRCTHWArith
   MLIRTransforms

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -324,8 +324,6 @@ static bool hasSignednessSemantics(TypeRange types) {
 
 /// A helper type converter class that automatically populates the relevant
 /// materializations and type conversions for converting HWArith to HW.
-/// Source/target materialization patterns are strictly for materializing
-/// intermediate conversions - all of these will eventually canonicalize out.
 struct HWArithToHWTypeConverter : public TypeConverter {
   HWArithToHWTypeConverter();
 };
@@ -334,14 +332,6 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
   // Pass any type through the signedness remover.
   addConversion([](Type type) { return removeSignedness(type); });
 }
-
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// Pass driver
-//===----------------------------------------------------------------------===//
-
-namespace {
 
 // Adds the ArgResOpConversion for 'TOp' to the set of conversion patterns, as
 // well as a legality check on the conversion status of the op's operands and
@@ -364,6 +354,14 @@ static void addOperandConversion(ConversionTarget &target,
   addOperandConversion<TOp>(target, patterns, typeConverter);
   addOperandConversion<TOp2, OpTs...>(target, patterns, typeConverter);
 }
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Pass driver
+//===----------------------------------------------------------------------===//
+
+namespace {
 
 class HWArithToHWPass : public HWArithToHWBase<HWArithToHWPass> {
 public:
@@ -388,8 +386,8 @@ public:
           return legalResults && legalArgs;
         });
 
-    // Generic conversion and legalization patterns for operations that may have
-    // their operands modified from signedness to signless.
+    // Generic conversion and legalization patterns for operations that we
+    // expect to be using in conjunction with the signedness values of hwarith.
     addOperandConversion<
         hw::OutputOp, comb::MuxOp, seq::CompRegOp, hw::ArrayCreateOp,
         hw::ArrayGetOp, hw::ArrayConcatOp, hw::ArraySliceOp, hw::StructCreateOp,

--- a/test/Conversion/HWArithToHW/test_basic.mlir
+++ b/test/Conversion/HWArithToHW/test_basic.mlir
@@ -307,3 +307,17 @@ hw.module @sigAndOps(%a: ui8, %b: ui8, %cond: i1, %clk : i1) -> (out: ui8)  {
     %1 = seq.compreg %0, %clk: ui8
     hw.output %1 : ui8
 }
+
+// -----
+
+// Type conversions of struct and array ops.
+// CHECK:      hw.module @structAndArrays(%a: i8, %b: i8) -> (out: !hw.struct<foo: !hw.array<2xi8>>) {
+// CHECK-NEXT:   %[[ARRAY:.*]] = hw.array_create %a, %b : i8
+// CHECK-NEXT:   %[[STRUCT:.*]] = hw.struct_create (%[[ARRAY]]) : !hw.struct<foo: !hw.array<2xi8>>
+// CHECK-NEXT:   hw.output %[[STRUCT]] : !hw.struct<foo: !hw.array<2xi8>>
+// CHECK-NEXT: }
+hw.module @structAndArrays(%a: ui8, %b: ui8) -> (out: !hw.struct<foo: !hw.array<2xui8>>)  {
+    %2 = hw.array_create %a, %b : ui8
+    %3 = hw.struct_create (%2) : !hw.struct<foo: !hw.array<2xui8>>
+    hw.output %3 : !hw.struct<foo: !hw.array<2xui8>>
+}

--- a/test/Conversion/HWArithToHW/test_basic.mlir
+++ b/test/Conversion/HWArithToHW/test_basic.mlir
@@ -293,3 +293,17 @@ hw.module @icmp_mixed_width(%op0: i5, %op1: i7) -> (sisi: i1, siui: i1, uisi: i1
 // CHECK:   hw.output %[[SISI_OUT]], %[[SIUI_OUT]], %[[UISI_OUT]], %[[UIUI_OUT]] : i1, i1, i1, i1
   hw.output %sisiOut, %siuiOut, %uisiOut, %uiuiOut : i1, i1, i1, i1
 }
+
+// -----
+
+// Signature conversion and other-dialect operations using signedness values.
+// CHECK:      hw.module @sigAndOps(%a: i8, %b: i8, %cond: i1, %clk: i1) -> (out: i8) {
+// CHECK-NEXT:   %[[MUX_OUT:.*]] = comb.mux %cond, %a, %b : i8
+// CHECK-NEXT:   %[[REG_OUT:.*]] = seq.compreg %[[MUX_OUT]], %clk : i8
+// CHECK-NEXT:   hw.output %[[REG_OUT]] : i8
+// CHECK-NEXT: }
+hw.module @sigAndOps(%a: ui8, %b: ui8, %cond: i1, %clk : i1) -> (out: ui8)  {
+    %0 = comb.mux %cond, %a, %b : ui8
+    %1 = seq.compreg %0, %clk: ui8
+    hw.output %1 : ui8
+}


### PR DESCRIPTION
Fixes #3635. Adds signature conversion for `hw::HWModuleOp,hw:HWExternalModuleOp` (`mlir::populateFunctionOpInterfaceTypeConversionPattern` unfortunately can't be provided an interface, i.e. `HWModuleLike`) as well as conversions for 'other' operations which we expect to be mixed in with `hwarith` operations.

Let me know if I've missed any ops for the `ArgResOpConversion` pattern. Any operation which we expect to be used in conjunction with the `ui/si` types of the `hwarith` operations must (unfortunately) be explicitly mentioned. 