### PR TITLE
[HW][FIRRTL] Fix InnerRefAttr's subelement walk/replace.

### DIFF
--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -43,7 +43,8 @@ def InnerRefAttr : AttrDef<HWDialect, "InnerRef", [
     void walkImmediateSubElements(
         llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
         llvm::function_ref<void(mlir::Type)> walkTypesFn) {
-      walkAttrsFn(getModule());
+      walkAttrsFn(getModuleRef());
+      walkAttrsFn(getName());
     }
 
     /// Return the name of the referenced module.

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -227,7 +227,9 @@ void InnerRefAttr::print(AsmPrinter &p) const {
 Attribute
 InnerRefAttr::replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
                                           ArrayRef<Type> replTypes) const {
-  return get(replAttrs[0].cast<StringAttr>(), replAttrs[1].cast<StringAttr>());
+  assert(replAttrs.size() == 2);
+  return get(getContext(), replAttrs[0].cast<FlatSymbolRefAttr>(),
+             replAttrs[1].cast<StringAttr>());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Walk the FlatSymbolRefAttr, not the StringAttr.

cc @nandor , hopefully this fixes RAUW of symbols not updating references within InnerRefAttr's?