### PR TITLE
Bump LLVM

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -110,7 +110,7 @@ def generate_msft_module_op(generator: Generator, spec_mod: _SpecializedModule):
 def create_msft_module_extern_op(sys, mod: _SpecializedModule, symbol):
   """Creation callback for creating a MSFTModuleExternOp."""
   paramdecl_list = [
-      hw.ParamDeclAttr.get_nodefault(i.name, mlir.ir.TypeAttr.get(i.attr.type))
+      hw.ParamDeclAttr.get_nodefault(i.name, i.attr.type)
       for i in mod.parameters
   ]
   return msft.MSFTModuleExternOp(

--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -125,10 +125,10 @@ MLIR_CAPI_EXPORTED MlirAttribute hwGlobalRefAttrGet(MlirAttribute symName);
 
 MLIR_CAPI_EXPORTED bool hwAttrIsAParamDeclAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGet(MlirStringRef name,
-                                                    MlirAttribute type,
+                                                    MlirType type,
                                                     MlirAttribute value);
 MLIR_CAPI_EXPORTED MlirStringRef hwParamDeclAttrGetName(MlirAttribute decl);
-MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGetType(MlirAttribute decl);
+MLIR_CAPI_EXPORTED MlirType hwParamDeclAttrGetType(MlirAttribute decl);
 MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGetValue(MlirAttribute decl);
 
 MLIR_CAPI_EXPORTED bool hwAttrIsAParamDeclRefAttr(MlirAttribute);

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD
 
 include "mlir/IR/EnumAttr.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Annotations Definition
@@ -35,7 +36,8 @@ def PortAnnotationsAttr : ArrayAttrBase<
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
-def InvalidValueAttr : AttrDef<FIRRTLDialect, "InvalidValue"> {
+def InvalidValueAttr : AttrDef<FIRRTLDialect, "InvalidValue",
+                               [TypedAttrInterface]> {
   let summary = "A constant value of firrtl.invalid type";
   let description = [{
     Represents an firrtl.invalidvalue value, whose type is specified by the
@@ -136,7 +138,7 @@ def AugmentedDeletedType : AugmentedType<"AugmentedDeletedType"> {
 }
 
 
-def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl"> {
+def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl", [TypedAttrInterface]> {
   let summary = "Module or instance parameter definition";
   let description = [{
     An attribute describing a module parameter, or instance parameter
@@ -149,7 +151,7 @@ def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl"> {
   /// parameter for an instance when the applied value and the default value are
   /// the same.
   let parameters = (ins "::mlir::StringAttr":$name,
-                        "::mlir::TypeAttr":$type,
+                        AttributeSelfTypeParameter<"">:$type,
                         "::mlir::Attribute":$value);
   let mnemonic = "param.decl";
 
@@ -157,19 +159,19 @@ def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl"> {
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
-                                         "::mlir::Type":$type),
+                                        "::mlir::Type":$type),
       "auto *context = type.getContext();\n"
-      "return $_get(context, name, TypeAttr::get(type), Attribute());">,
+      "return $_get(context, name, type, Attribute());">,
     AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
-                                         "::mlir::Type":$type),
+                                        "::mlir::Type":$type),
       "return get(StringAttr::get(type.getContext(), name), type);">,
 
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
-                                        "::mlir::Attribute":$value),
+                                        "::mlir::TypedAttr":$value),
       "auto *context = value.getContext();\n"
-      "return $_get(context, name, TypeAttr::get(value.getType()), value);">,
+      "return $_get(context, name, value.getType(), value);">,
     AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
-                                        "::mlir::Attribute":$value),
+                                        "::mlir::TypedAttr":$value),
       "return get(StringAttr::get(value.getContext(), name), value);">
   ];
 

--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -10,6 +10,7 @@
 #define CIRCT_DIALECT_HW_ATTRIBUTES_H
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
 namespace circt {

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 include "mlir/IR/EnumAttr.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 /// An attribute to indicate the output file an operation should be emitted to.
 def OutputFileAttr : AttrDef<HWDialect, "OutputFile"> {
@@ -125,7 +126,7 @@ def FileListAttr : AttrDef<HWDialect, "FileList"> {
 
 }
 
-def ParamDeclAttr : AttrDef<HWDialect, "ParamDecl"> {
+def ParamDeclAttr : AttrDef<HWDialect, "ParamDecl", [TypedAttrInterface]> {
   let summary = "Module or instance parameter definition";
   let description = [{
     An attribute describing a module parameter, or instance parameter
@@ -138,7 +139,7 @@ def ParamDeclAttr : AttrDef<HWDialect, "ParamDecl"> {
   /// parameter for an instance when the applied value and the default value are
   /// the same.
   let parameters = (ins "::mlir::StringAttr":$name,
-                        "::mlir::TypeAttr":$type,
+                        AttributeSelfTypeParameter<"">:$type,
                         "::mlir::Attribute":$value);
   let mnemonic = "param.decl";
 
@@ -146,19 +147,19 @@ def ParamDeclAttr : AttrDef<HWDialect, "ParamDecl"> {
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
-                                         "::mlir::Type":$type),
+                                        "::mlir::Type":$type),
       "auto *context = type.getContext();\n"
-      "return $_get(context, name, TypeAttr::get(type), Attribute());">,
+      "return $_get(context, name, type, Attribute());">,
     AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
-                                         "::mlir::Type":$type),
+                                        "::mlir::Type":$type),
       "return get(StringAttr::get(type.getContext(), name), type);">,
 
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
-                                        "::mlir::Attribute":$value),
+                                        "::mlir::TypedAttr":$value),
       "auto *context = value.getContext();\n"
-      "return $_get(context, name, TypeAttr::get(value.getType()), value);">,
+      "return $_get(context, name, value.getType(), value);">,
     AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
-                                        "::mlir::Attribute":$value),
+                                        "::mlir::TypedAttr":$value),
       "return get(StringAttr::get(value.getContext(), name), value);">
   ];
 
@@ -179,7 +180,8 @@ def ParamDeclArrayAttr
 /// This attribute models a reference to a named parameter within a module body.
 /// The type of the ParamDeclRefAttr must always be the same as the type of the
 /// parameter being referenced.
-def ParamDeclRefAttr : AttrDef<HWDialect, "ParamDeclRef"> {
+def ParamDeclRefAttr : AttrDef<HWDialect, "ParamDeclRef",
+                               [TypedAttrInterface]> {
   let summary = "Is a reference to a parameter value.";
   let parameters = (ins "::mlir::StringAttr":$name,
                         AttributeSelfTypeParameter<"">:$type);
@@ -195,7 +197,8 @@ def ParamDeclRefAttr : AttrDef<HWDialect, "ParamDeclRef"> {
   let hasCustomAssemblyFormat = 1;
 }
 
-def ParamVerbatimAttr : AttrDef<HWDialect, "ParamVerbatim"> {
+def ParamVerbatimAttr : AttrDef<HWDialect, "ParamVerbatim",
+                                [TypedAttrInterface]> {
   let summary =
     "Represents text to emit directly to SystemVerilog for a parameter";
   let parameters = (ins "::mlir::StringAttr":$value,
@@ -238,10 +241,10 @@ def PEOAttr  : I32EnumAttr<"PEO", "Parameter Expression Opcode",
                             PEO_CLog2, PEO_StrConcat]>;
 }
 
-def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {
+def ParamExprAttr : AttrDef<HWDialect, "ParamExpr", [TypedAttrInterface]> {
   let summary = "Parameter expression combining operands";
   let parameters = (ins "PEO":$opcode,
-                        ArrayRefParameter<"::mlir::Attribute">:$operands,
+                        ArrayRefParameter<"::mlir::TypedAttr">:$operands,
                         AttributeSelfTypeParameter<"">:$type);
   let mnemonic = "param.expr";
 
@@ -252,11 +255,13 @@ def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {
   let extraClassDeclaration = [{
     /// Build a parameter expression.  This automatically canonicalizes and
     /// folds, so it may not necessarily return a ParamExprAttr.
-    static Attribute get(PEO opcode, mlir::ArrayRef<mlir::Attribute> operands);
+    static mlir::TypedAttr get(PEO opcode,
+                               mlir::ArrayRef<mlir::TypedAttr> operands);
 
     /// Build a binary parameter expression for convenience.
-    static Attribute get(PEO opcode, mlir::Attribute lhs, mlir::Attribute rhs) {
-      Attribute operands[] = { lhs, rhs };
+    static mlir::TypedAttr get(PEO opcode, mlir::TypedAttr lhs,
+                                           mlir::TypedAttr rhs) {
+      mlir::TypedAttr operands[] = { lhs, rhs };
       return get(opcode, operands);
     }
   }];

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -27,7 +27,7 @@ def IntTypeImpl : HWType<"Int"> {
   }];
 
   let mnemonic = "int";
-  let parameters = (ins "::mlir::Attribute":$width);
+  let parameters = (ins "::mlir::TypedAttr":$width);
 
   let hasCustomAssemblyFormat = 1;
 
@@ -36,7 +36,7 @@ def IntTypeImpl : HWType<"Int"> {
   let extraClassDeclaration = [{
     /// Get an integer type for the specified width.  Note that this may return
     /// a builtin integer type if the width is a known-constant value.
-    static Type get(::mlir::Attribute width);
+    static Type get(::mlir::TypedAttr width);
   }];
 }
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -13,6 +13,7 @@
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/BuiltinTypes.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 // This is almost exactly like a standard FuncOp, except that it has some
 // extra verification conditions.  In particular, each Value must
@@ -594,15 +595,15 @@ def ConstantOp : Handshake_Op<"constant", [
     ```
   }];
 
-  let arguments = (ins AnyAttr:$value, NoneType:$ctrl);
+  let arguments = (ins TypedAttrInterface:$value, NoneType:$ctrl);
   let results = (outs AnyType : $result);
 
-  let builders = [OpBuilder<(ins "Attribute":$value, "Value":$ctrl)>];
+  let builders = [OpBuilder<(ins "mlir::TypedAttr":$value, "Value":$ctrl)>];
   let skipDefaultBuilders = 1;
 
   let hasCanonicalizer = 1;
   let extraClassDeclaration = [{
-    Attribute getValue() { return (*this)->getAttr("value"); }
+    mlir::TypedAttr getValue() { return value(); }
   }];
   let assemblyFormat = [{ $ctrl attr-dict `:` qualified(type($result))}];
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
 def GenerateOp : SVOp<"generate",
                       [SingleBlock, NoTerminator, NoRegionArguments]> {
   let summary = "A generate block";
@@ -28,6 +30,12 @@ class MaxSizedRegion<int numBlocks> : Region<
   CPred<"::llvm::hasNItemsOrLess($_self, " # numBlocks # ")">,
   "region with at most " # numBlocks # " blocks">;
 
+/// An array of case patterns. This is either a typed attribute of some kind,
+/// an integer constant or a parameter expression for example, or a `unit` attr
+/// that indicates the `default` case.
+def PatternArrayAttr : TypedArrayAttrBase<
+  AnyAttrOf<[TypedAttrInterface, UnitAttr]>, "case pattern array">;
+
 def GenerateCaseOp : SVOp<"generate.case",
                           [SingleBlock, NoTerminator, NoRegionArguments,
                            HasParent<"GenerateOp">]> {
@@ -36,11 +44,11 @@ def GenerateCaseOp : SVOp<"generate.case",
   let description = "See SystemVerilog 2017 27.5.";
 
   let regions = (region VariadicRegion<SizedRegion<1>>:$caseRegions);
-  let arguments = (ins AnyAttr:$cond,
-                       ArrayAttr:$casePatterns, ArrayAttr:$caseNames);
+  let arguments = (ins TypedAttrInterface:$cond,
+                       PatternArrayAttr:$casePatterns, StrArrayAttr:$caseNames);
 
   let assemblyFormat = [{
-    $cond attr-dict `[`
+    $cond attr-dict ` ` `[`
       custom<CaseRegions>($casePatterns, $caseNames, $caseRegions)
     `]`
   }];

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -74,12 +74,11 @@ with Context() as ctx, Location.unknown():
   print(typeAlias.scope)
   print(typeAlias.name)
 
-  pdecl = hw.ParamDeclAttr.get("param1", TypeAttr.get(i32),
-                               IntegerAttr.get(i32, 13))
+  pdecl = hw.ParamDeclAttr.get("param1", i32, IntegerAttr.get(i32, 13))
   # CHECK: #hw.param.decl<"param1": i32 = 13 : i32>
   print(pdecl)
 
-  pdecl = hw.ParamDeclAttr.get_nodefault("param2", TypeAttr.get(i32))
+  pdecl = hw.ParamDeclAttr.get_nodefault("param2", i32)
   # CHECK: #hw.param.decl<"param2": i32>
   print(pdecl)
 

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -48,8 +48,7 @@ with Context() as ctx, Location.unknown():
         name="one_input",
         input_ports=[("a", i32)],
         parameters=[
-            hw.ParamDeclAttr.get("BANKS", TypeAttr.get(i32),
-                                 IntegerAttr.get(i32, 5))
+            hw.ParamDeclAttr.get("BANKS", i32, IntegerAttr.get(i32, 5))
         ],
         body_builder=lambda m: hw.OutputOp([]),
     )

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -130,18 +130,17 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "ParamDeclAttr", hwAttrIsAParamDeclAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, std::string name, MlirAttribute type,
+          [](py::object cls, std::string name, MlirType type,
              MlirAttribute value) {
             return cls(hwParamDeclAttrGet(
                 mlirStringRefCreateFromCString(name.c_str()), type, value));
           })
-      .def_classmethod(
-          "get_nodefault",
-          [](py::object cls, std::string name, MlirAttribute type) {
-            return cls(
-                hwParamDeclAttrGet(mlirStringRefCreateFromCString(name.c_str()),
-                                   type, MlirAttribute{nullptr}));
-          })
+      .def_classmethod("get_nodefault",
+                       [](py::object cls, std::string name, MlirType type) {
+                         return cls(hwParamDeclAttrGet(
+                             mlirStringRefCreateFromCString(name.c_str()), type,
+                             MlirAttribute{nullptr}));
+                       })
       .def_property_readonly(
           "value",
           [](MlirAttribute self) { return hwParamDeclAttrGetValue(self); })

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -109,7 +109,7 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
   @property
   def parameters(self):
     return [
-        hw.ParamDeclAttr.get(p.name, _ir.TypeAttr.get(p.attr.type), p.attr)
+        hw.ParamDeclAttr.get(p.name, p.attr.type, p.attr)
         for p in _ir.DictAttr(self.attributes["parameters"])
     ]
 

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -176,9 +176,9 @@ MLIR_CAPI_EXPORTED bool hwAttrIsAParamDeclAttr(MlirAttribute attr) {
   return unwrap(attr).isa<ParamDeclAttr>();
 }
 MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGet(MlirStringRef cName,
-                                                    MlirAttribute cType,
+                                                    MlirType cType,
                                                     MlirAttribute cValue) {
-  TypeAttr type = unwrap(cType).cast<TypeAttr>();
+  auto type = unwrap(cType);
   auto name = StringAttr::get(type.getContext(), unwrap(cName));
   return wrap(
       ParamDeclAttr::get(type.getContext(), name, type, unwrap(cValue)));
@@ -186,7 +186,7 @@ MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGet(MlirStringRef cName,
 MLIR_CAPI_EXPORTED MlirStringRef hwParamDeclAttrGetName(MlirAttribute decl) {
   return wrap(unwrap(decl).cast<ParamDeclAttr>().getName().getValue());
 }
-MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGetType(MlirAttribute decl) {
+MLIR_CAPI_EXPORTED MlirType hwParamDeclAttrGetType(MlirAttribute decl) {
   return wrap(unwrap(decl).cast<ParamDeclAttr>().getType());
 }
 MLIR_CAPI_EXPORTED MlirAttribute hwParamDeclAttrGetValue(MlirAttribute decl) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -976,7 +976,7 @@ static ArrayAttr getHWParameters(FExtModuleOp module, bool ignoreValues) {
   SmallVector<Attribute> newParams;
   for (const ParamDeclAttr &entry : params) {
     auto name = entry.getName();
-    auto type = TypeAttr::get(entry.getValue().getType());
+    auto type = entry.getType();
     auto value = ignoreValues ? Attribute() : entry.getValue();
     auto paramAttr =
         hw::ParamDeclAttr::get(builder.getContext(), name, type, value);

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1448,8 +1448,7 @@ static ParseResult parseParameterList(OpAsmParser &parser,
 
         auto &builder = parser.getBuilder();
         parameters.push_back(hw::ParamDeclAttr::get(
-            builder.getContext(), builder.getStringAttr(name),
-            TypeAttr::get(type), value));
+            builder.getContext(), builder.getStringAttr(name), type, value));
         return success();
       });
 }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -639,8 +639,19 @@ static Attribute constFoldAssociativeOp(ArrayRef<Attribute> operands,
     return {};
 
   // This will fold to a simple constant if all operands are constant.
-  if (llvm::all_of(operands.drop_front(2), [&](Attribute in) { return !!in; }))
-    return hw::ParamExprAttr::get(paramOpcode, operands);
+  if (llvm::all_of(operands.drop_front(2),
+                   [&](Attribute in) { return !!in; })) {
+    SmallVector<mlir::TypedAttr> typedOperands;
+    typedOperands.reserve(operands.size());
+    for (auto operand : operands) {
+      if (auto typedOperand = operand.dyn_cast<mlir::TypedAttr>())
+        typedOperands.push_back(typedOperand);
+      else
+        break;
+    }
+    if (typedOperands.size() == operands.size())
+      return hw::ParamExprAttr::get(paramOpcode, typedOperands);
+  }
 
   return {};
 }

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -172,8 +172,7 @@ StringAttr ESIHWBuilder::constructInterfaceName(ChannelType port) {
 /// Return a parameter list for the stage module with the specified value.
 ArrayAttr ESIHWBuilder::getStageParameterList(Attribute value) {
   auto type = IntegerType::get(width.getContext(), 32, IntegerType::Unsigned);
-  auto widthParam =
-      ParamDeclAttr::get(width.getContext(), width, TypeAttr::get(type), value);
+  auto widthParam = ParamDeclAttr::get(width.getContext(), width, type, value);
   return ArrayAttr::get(width.getContext(), widthParam);
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -976,9 +976,8 @@ parseOptionalParameters(OpAsmParser &parser,
         }
 
         auto &builder = parser.getBuilder();
-        parameters.push_back(ParamDeclAttr::get(builder.getContext(),
-                                                builder.getStringAttr(name),
-                                                TypeAttr::get(type), value));
+        parameters.push_back(ParamDeclAttr::get(
+            builder.getContext(), builder.getStringAttr(name), type, value));
         return success();
       });
 }

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -188,7 +188,7 @@ static void printHWElementType(Type element, AsmPrinter &p) {
 // Int Type
 //===----------------------------------------------------------------------===//
 
-Type IntType::get(Attribute width) {
+Type IntType::get(mlir::TypedAttr width) {
   // The width expression must always be a 32-bit wide integer type itself.
   auto widthWidth = width.getType().dyn_cast<IntegerType>();
   assert(widthWidth && widthWidth.getWidth() == 32 &&
@@ -206,7 +206,7 @@ Type IntType::parse(AsmParser &p) {
   // The bitwidth of the parameter size is always 32 bits.
   auto int32Type = p.getBuilder().getIntegerType(32);
 
-  Attribute width;
+  mlir::TypedAttr width;
   if (p.parseLess() || p.parseAttribute(width, int32Type) || p.parseGreater())
     return Type();
   return get(width);

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -975,15 +975,20 @@ void SourceOp::print(OpAsmPrinter &p) {
 
 LogicalResult ConstantOp::verify() {
   // Verify that the type of the provided value is equal to the result type.
-  if ((*this)->getAttr("value").getType() != getResult().getType())
-    return emitOpError()
-           << "constant value type differs from operation result type.";
+  auto typedValue = value().dyn_cast<mlir::TypedAttr>();
+  if (!typedValue)
+    return emitOpError("constant value must be a typed attribute; value is ")
+           << value();
+  if (typedValue.getType() != getResult().getType())
+    return emitOpError() << "constant value type " << typedValue.getType()
+                         << " differs from operation result type "
+                         << getResult().getType();
 
   return success();
 }
 
 void handshake::ConstantOp::build(OpBuilder &builder, OperationState &result,
-                                  Attribute value, Value operand) {
+                                  mlir::TypedAttr value, Value operand) {
   result.addOperands(operand);
 
   auto type = value.getType();

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -71,10 +71,6 @@ static Attribute constFoldTernaryOp(ArrayRef<Attribute> operands,
   assert(operands.size() == 3 && "ternary op takes three operands");
   if (!operands[0] || !operands[1] || !operands[2])
     return {};
-  if (operands[0].getType() != operands[1].getType())
-    return {};
-  if (operands[0].getType() != operands[2].getType())
-    return {};
 
   if (operands[0].isa<AttrElementT>() && operands[1].isa<AttrElementT>() &&
       operands[2].isa<AttrElementT>()) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -26,6 +26,7 @@
 
 using namespace circt;
 using namespace sv;
+using mlir::TypedAttr;
 
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {

--- a/test/Conversion/ExportVerilog/verilog-errors.mlir
+++ b/test/Conversion/ExportVerilog/verilog-errors.mlir
@@ -15,7 +15,7 @@ module attributes {circt.loweringOptions = "badOption,anotherOne"} {}
 hw.module.extern @A<width: none> ()
 
 hw.module @B() {
-  // expected-error @+1 {{op invalid parameter value @Foo}}
+  // expected-error @+1 {{should have a typed value; has value @Foo}}
   hw.instance "foo" @A<width: none = @Foo>() -> ()
 }
 

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -230,7 +230,7 @@ hw.module @Use(%a: i8) -> (xx: i8) {
 hw.module.extern @p<p1: i42 = 17, p2: i1>(%arg0: i8) -> (out: i8)
 
 hw.module @Use(%a: i8) -> (xx: i8) {
-  // expected-error @+1 {{op parameter "p2" should have type i1 but has type i2}}
+  // expected-error @+1 {{op parameter "p2" should have type 'i1' but has type 'i2'}}
   %r0 = hw.instance "inst1" @p<p1: i42 = 4, p2: i2 = 0>(arg0: %a: i8) -> (out: i8)
   hw.output %r0: i8
 }
@@ -284,7 +284,7 @@ hw.module @Use<xx: i41>() {
 
 // -----
 
-// expected-error @+1 {{parameter #hw.param.decl<"xx": i41> has the same name as a previous parameter}}
+// expected-error @+1 {{parameter #hw.param.decl<"xx": i41> : i41 has the same name as a previous parameter}}
 hw.module @Use<xx: i41, xx: i41>() {
 }
 

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -164,7 +164,7 @@ handshake.func @invalid_type_resnames(%a : i32, %b : none) -> none attributes {r
 // -----
 
 handshake.func @invalid_constant_value(%ctrl : none) -> none {
-  // expected-error @+1 {{'handshake.constant' op constant value type differs from operation result type.}}
+  // expected-error @+1 {{'handshake.constant' op constant value type 'i31' differs from operation result type 'i32'}}
   %0 = constant %ctrl {value = 1 : i31} : i32
   return %ctrl : none
 }

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -12,7 +12,7 @@ hw.module @PrintPath<> () -> () {
 hw.module @Case1<NUM : i8> () -> () {
   %fd = hw.constant 0x80000002 : i32
   sv.generate "foo_case": {
-    sv.generate.case #hw.param.decl.ref<"NUM"> [
+    sv.generate.case #hw.param.decl.ref<"NUM"> : i8 [
       case (0, "case0") {
         sv.initial {
           sv.fwrite %fd, "case 0\n"
@@ -21,7 +21,7 @@ hw.module @Case1<NUM : i8> () -> () {
       case (1 : i64, "case1") {
         hw.instance "print1" @PrintPath() -> ()
       }
-      case (none, "dflt") {
+      case (unit, "dflt") {
         hw.instance "printDflt" @PrintPath() -> ()
       }
     ]
@@ -31,7 +31,7 @@ hw.module @Case1<NUM : i8> () -> () {
 // CHECK-LABEL: hw.module @Case1
 // CHECK-NEXT:    [[FD:%.+]] = hw.constant -2147483646 : i32
 // CHECK-NEXT:    sv.generate "foo_case" : {
-// CHECK-NEXT:      sv.generate.case #hw.param.decl.ref<"NUM">[
+// CHECK-NEXT:      sv.generate.case #hw.param.decl.ref<"NUM"> : i8 [
 // CHECK-NEXT:        case (0 : i64, "case0") {
 // CHECK-NEXT:          sv.initial {
 // CHECK-NEXT:            sv.fwrite [[FD]], "case 0\0A"
@@ -40,7 +40,7 @@ hw.module @Case1<NUM : i8> () -> () {
 // CHECK-NEXT:        case (1 : i64, "case1") {
 // CHECK-NEXT:          hw.instance "print1" @PrintPath() -> ()
 // CHECK-NEXT:        }
-// CHECK-NEXT:        case (none, "dflt") {
+// CHECK-NEXT:        case (unit, "dflt") {
 // CHECK-NEXT:          hw.instance "printDflt" @PrintPath() -> ()
 // CHECK-NEXT:        }
 // CHECK-NEXT:        ]
@@ -68,7 +68,7 @@ hw.module @Case1<NUM : i8> () -> () {
 
 hw.module @CaseNoDefault<NUM : i8> () -> () {
   sv.generate "bar": {
-    sv.generate.case #hw.param.decl.ref<"NUM"> [
+    sv.generate.case #hw.param.decl.ref<"NUM"> : i8 [
       case (0 : i64, "bar0") { }
     ]
   }
@@ -76,7 +76,7 @@ hw.module @CaseNoDefault<NUM : i8> () -> () {
 
 // CHECK-LABEL: hw.module @CaseNoDefault
 // CHECK:         sv.generate "bar" : {
-// CHECK:           sv.generate.case #hw.param.decl.ref<"NUM">[
+// CHECK:           sv.generate.case #hw.param.decl.ref<"NUM"> : i8 [
 // CHECK:             case (0 : i64, "bar0") {
 // CHECK:             }
 // CHECK:           ]


### PR DESCRIPTION
Bump LLVM to the current top-of-tree.

This requires changing a few `Attribute`s to the new `TypedAttr` interface, since attributes no longer carry a type by default. We rely on this type in quite a few places in the CIRCT codebase, which required a switch over to `TypedAttr`.

See: https://reviews.llvm.org/D130092

*Note:* Keeping this in draft mode until Aug 5 in order to gobble up additional upstream changes. If you need the LLVM bump before that, feel free to hit merge.