### PR TITLE
[Pipeline] Add retimeable pipeline operation

### DIFF
--- a/include/circt/Dialect/Pipeline/Pipeline.h
+++ b/include/circt/Dialect/Pipeline/Pipeline.h
@@ -25,6 +25,7 @@
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -123,6 +123,27 @@ def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
 
 
 def PipelineStageOp : Op<Pipeline_Dialect, "stage", [
+    HasParent<"PipelineOp">
+  ]> {
+  let summary = "Pipeline pipeline stage.";
+  let description = [{
+    The `pipeline.stage` operation represents a stage separating register
+    in a pipeline. The stage does not define any explicit registers, but solely
+    defines a cut of a dataflow graph based on its lexical position in the
+    pipeline. Pipeline registers are made explicit through the register
+    materialization pass, wherein this op is replaced by
+    `pipeline.stage.register` operations.
+  }];
+
+  let arguments = (ins I1:$when);
+  let results = (outs I1:$valid);
+
+  let assemblyFormat = [{
+    `when` $when attr-dict
+  }];
+}
+
+def PipelineStageRegisterOp : Op<Pipeline_Dialect, "stage.register", [
     HasParent<"PipelineOp">,
     RangedTypesMatchWith<"result type matches operand", "regIns", "regOuts",
                          "llvm::make_range($_self.begin(), $_self.end())">
@@ -130,7 +151,11 @@ def PipelineStageOp : Op<Pipeline_Dialect, "stage", [
   let summary = "Pipeline pipeline stage.";
   let description = [{
     The `pipeline.stage` operation represents a stage separating register
-    in a pipeline.
+    in a pipeline with materialized register values. `pipeline.stage` and
+    `pipeline.stage.register` operations are not allowed to co-exist in the
+    same pipeline body. This is because, once register values are materialized,
+    all delays as well as knowledge about multicycle paths have been lowered
+    away.
   }];
 
   let arguments = (ins Variadic<AnyType>:$regIns, I1:$when);

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -14,19 +14,143 @@
 #else
 #define PIPELINE_OPS
 
-#ifdef OP_BASE
-#else
-include "mlir/IR/OpBase.td"
-#endif // OP_BASE
 
+include "mlir/IR/OpBase.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/IR/EnumAttr.td"
 
 def Pipeline_Dialect : Dialect {
   let name = "pipeline";
   let cppNamespace = "::circt::pipeline";
+}
+
+def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
+    IsolatedFromAbove,
+    NoSideEffect,
+    SingleBlockImplicitTerminator<"ReturnOp">,
+    RegionKindInterface,
+    HasOnlyGraphRegion 
+  ]> {
+  let summary = "pipeline operation";
+  let description = [{
+    The "pipeline.pipeline" operation represents a retimeable pipeline.
+    The pipeline contains a single block representing a graph region. Pipeline
+    stages are represented by `pipeline.rt.register` operations. Semantics
+    of values crossing register boundaries are defined by lowering passes.
+    The pipeline representation is centered around providing latency insensitive
+    values (valid signals between stages). Such signals can either be removed
+    (in the feedforward, statically scheduled case), used to control stalling
+    (feedback, statically scheduled case) or in conjunction with handshake signals
+    for dynamically scheduled pipelines.
+    A pipelines' latency sensitivity is based on the I/O of the pipeline - if
+    any in- or output port is an ESI channel, all ports are expected to be ESI
+    channels, and the pipeline is considered latency sensitive.
+    The internal representation of the pipeline is agnostic to the latency
+    insensitivity of the I/O. This is by design - allowing us a single source
+    of truth for lowering either latency sensitive or latency insensitive pipelines.
+
+    A typical flow would go like this:
+
+    An untimed datapath is defined:
+    ```
+    pipeline.pipeline(%in0 : i32, %in1 : i32) -> (i32) {
+      ^bb0:(%arg0 : i32, %arg1: i32):
+        %add0 = comb.add %arg0, %arg1 : i32
+        %add1 = comb.add %add0, %arg0 : i32
+        %add2 = comb.add %add1, %arg1 : i32
+        pipeline.return %add2 : i32
+    }
+    ```
+    The datapath is scheduled:
+    ```
+    pipeline.pipeline(%in0 : i32, %in1 : i32) -> (i32) {
+      ^bb0:(%arg0 : i32, %arg1: i32, %go : i1):
+        %add0 = comb.add %arg0, %arg1 : i32
+
+        %s0_valid = pipeline.stage when %go
+        %add1 = comb.add %add0, %arg0 : i32
+  
+        %s1_valid = pipeline.stage when %g1
+        %add2 = comb.add %add1, %arg1 : i32
+
+        pipeline.return %add2 valid %s1_valid : i32
+    }
+    ```
+
+    Stage-crossing dependencies are made explicit through registers.
+    ```
+    pipeline.pipeline(%in0 : i32, %in1 : i32) -> (i32) {
+      ^bb0:(%arg0 : i32, %arg1: i32):
+        %add0 = comb.add %arg0, %arg1 : i32
+
+        %s0_valid, %add0_r = pipeline.stage when %go regs (%add0: i32)
+        %add1 = comb.add %add0_r, %arg0 : i32
+  
+        %s1_valid, %add1_r = pipeline.stage when %g1 regs (%add1: i32)
+        %add2 = comb.add %add1_r, %arg1 : i32
+
+        pipeline.return %add2 valid %s1_valid : i32
+    }
+    ```
+
+    This representation can then be lowered to statically or dynamically scheduled
+    pipelines.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset
+  );
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region SizedRegion<1>: $body);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `(` $inputs `)` `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
+  }];
+
+  let extraClassDeclaration = [{
+    // Returns true if this pipeline has a latency-insensitive interface.
+    // Latency sensitivity is defined based on whether _any_ `$input` is an 
+    // ESI channel.
+    bool isLatencyInsensitive(); 
+    bool isLatencySensitive() { return !isLatencyInsensitive(); }
+  }];
+}
+
+
+def PipelineStageOp : Op<Pipeline_Dialect, "stage", [
+    HasParent<"PipelineOp">,
+    RangedTypesMatchWith<"result type matches operand", "regIns", "regOuts",
+                         "llvm::make_range($_self.begin(), $_self.end())">
+  ]> {
+  let summary = "Pipeline pipeline stage.";
+  let description = [{
+    The `pipeline.stage` operation represents a stage separating register
+    in a pipeline.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$regIns, I1:$when);
+  let results = (outs Variadic<AnyType>:$regOuts, I1:$valid);
+
+  let assemblyFormat = [{
+    `when` $when (`regs` $regIns^)? attr-dict (`:` type($regIns)^)?
+  }];
+}
+
+def ReturnOp : Op<Pipeline_Dialect, "return", [Terminator]> {
+  let summary = "Pipeline dialect return.";
+  let description = [{
+    The "return" operation represents a terminator of a `pipeline.pipeline`.
+  }];
+
+  let hasVerifier = 1;
+  let arguments = (ins Variadic<AnyType>: $operands, I1:$valid);
+  let builders = [OpBuilder<(ins), [{ return; }]>];
+  let assemblyFormat = [{ ($operands^)? `valid` $valid attr-dict (`:` type($operands)^)? }];
 }
 
 def PipelineWhileOp : Op<Pipeline_Dialect, "while", []> {

--- a/lib/Dialect/Pipeline/CMakeLists.txt
+++ b/lib/Dialect/Pipeline/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTPipelineOps
   ${PROJECT_BINARY_DIR}/include
 
   LINK_LIBS PUBLIC
+  CIRCTESI
   MLIRArithmeticDialect
   MLIRFuncDialect
   MLIRIR

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -58,12 +58,12 @@ LogicalResult PipelineOp::verify() {
   }
 
   // Check mixing of `pipeline.stage` and `pipeline.stage.register` ops.
-  bool hasStageOps = getOps<PipelineStageOp>().size() > 0;
-  bool hasStageRegOps = getOps<PipelineStageRegisterOp>().size() > 0;
-  if (!(hasStageOps ^ hasStageRegOps))
-    return emitOpError(
-        "expected either `pipeline.stage` or "
-        "`pipeline.stage.register` ops in the pipeline, but not both.");
+  bool hasStageOps = !getOps<PipelineStageOp>().empty();
+  bool hasStageRegOps = !getOps<PipelineStageRegisterOp>().empty();
+
+  if (hasStageOps && hasStageRegOps)
+    return emitOpError("mixing `pipeline.stage` and `pipeline.stage.register` "
+                       "ops is illegal.");
 
   return success();
 }

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -57,6 +57,14 @@ LogicalResult PipelineOp::verify() {
              << ".";
   }
 
+  // Check mixing of `pipeline.stage` and `pipeline.stage.register` ops.
+  bool hasStageOps = getOps<PipelineStageOp>().size() > 0;
+  bool hasStageRegOps = getOps<PipelineStageRegisterOp>().size() > 0;
+  if (!(hasStageOps ^ hasStageRegOps))
+    return emitOpError(
+        "expected either `pipeline.stage` or "
+        "`pipeline.stage.register` ops in the pipeline, but not both.");
+
   return success();
 }
 

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/ESI/ESITypes.h"
 #include "circt/Dialect/Pipeline/Pipeline.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -21,6 +22,78 @@ using namespace circt;
 using namespace circt::pipeline;
 
 #include "circt/Dialect/Pipeline/PipelineDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// PipelineOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult PipelineOp::verify() {
+  bool anyInputIsAChannel = llvm::any_of(inputs(), [](Value operand) {
+    return operand.getType().isa<esi::ChannelType>();
+  });
+  bool anyOutputIsAChannel = llvm::any_of(
+      getResultTypes(), [](Type type) { return type.isa<esi::ChannelType>(); });
+
+  if ((anyInputIsAChannel || anyOutputIsAChannel) && !isLatencyInsensitive()) {
+    return emitOpError("if any port of this pipeline is an ESI channel, all "
+                       "ports must be ESI channels.");
+  }
+
+  if (getBody()->getNumArguments() != inputs().size())
+    return emitOpError("expected ")
+           << inputs().size() << " arguments in the pipeline body block, got "
+           << getBody()->getNumArguments() << ".";
+
+  for (size_t i = 0; i < inputs().size(); i++) {
+    Type expectedInArg = inputs()[i].getType();
+    Type bodyArg = getBody()->getArgument(i).getType();
+
+    if (isLatencyInsensitive())
+      expectedInArg = expectedInArg.cast<esi::ChannelType>().getInner();
+
+    if (expectedInArg != bodyArg)
+      return emitOpError("expected body block argument ")
+             << i << " to have type " << expectedInArg << ", got " << bodyArg
+             << ".";
+  }
+
+  return success();
+}
+
+bool PipelineOp::isLatencyInsensitive() {
+  bool allInputsAreChannels = llvm::all_of(inputs(), [](Value operand) {
+    return operand.getType().isa<esi::ChannelType>();
+  });
+  bool allOutputsAreChannels = llvm::all_of(
+      getResultTypes(), [](Type type) { return type.isa<esi::ChannelType>(); });
+  return allInputsAreChannels && allOutputsAreChannels;
+}
+
+//===----------------------------------------------------------------------===//
+// ReturnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ReturnOp::verify() {
+  PipelineOp parent = getOperation()->getParentOfType<PipelineOp>();
+  if (operands().size() != parent.results().size())
+    return emitOpError("expected ")
+           << parent.results().size() << " return values, got "
+           << operands().size() << ".";
+
+  bool isLatencyInsensitive = parent.isLatencyInsensitive();
+  for (size_t i = 0; i < parent.results().size(); i++) {
+    Type expectedType = parent.getResultTypes()[i];
+    Type actualType = getOperandTypes()[i];
+    if (isLatencyInsensitive)
+      expectedType = expectedType.cast<esi::ChannelType>().getInner();
+    if (expectedType != actualType)
+      return emitOpError("expected argument ")
+             << i << " to have type " << expectedType << ", got " << actualType
+             << ".";
+  }
+
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // PipelineWhileOp

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -278,6 +278,7 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
 // -----
 
 hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.pipeline' op mixing `pipeline.stage` and `pipeline.stage.register` ops is illegal.}}
   %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -213,3 +213,64 @@ func.func @non_monotonic_start1() {
   }
   return
 }
+
+// -----
+
+hw.module @mixed_ports(%arg0 : !esi.channel<i32>, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.pipeline' op if any port of this pipeline is an ESI channel, all ports must be ESI channels.}}
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (!esi.channel<i32>, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %valid = hw.constant 1 : i1
+    pipeline.return %a0 valid %valid : i32
+  }
+  hw.output %0 : i32
+}
+
+
+// -----
+
+hw.module @body_argn(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.pipeline' op expected 2 arguments in the pipeline body block, got 1.}}
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32):
+    %valid = hw.constant 1 : i1
+    pipeline.return %a0 valid %valid : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @res_argn(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %valid = hw.constant 1 : i1
+    // expected-error @+1 {{'pipeline.return' op expected 1 return values, got 0.}}
+    pipeline.return valid %valid
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @body_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.pipeline' op expected body block argument 0 to have type 'i32', got 'i31'.}}
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i31, %a1 : i32):
+    %valid = hw.constant 1 : i1
+    pipeline.return %a1 valid %valid : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i31) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i31) {
+   ^bb0(%a0 : i32, %a1 : i32):
+    %valid = hw.constant 1 : i1
+    // expected-error @+1 {{'pipeline.return' op expected argument 0 to have type 'i31', got 'i32'.}}
+    pipeline.return %a0 valid %valid  : i32
+  }
+  hw.output %0 : i31
+}

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -274,3 +274,17 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
   }
   hw.output %0 : i31
 }
+
+// -----
+
+hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %0 = comb.add %a0, %a1 : i32
+    %c1_i1 = hw.constant 1 : i1
+    %r_0, %s0_valid = pipeline.stage.register when %c1_i1 regs %0 : i32
+    %s1_valid = pipeline.stage when %s0_valid
+    pipeline.return %0 valid %s0_valid : i32
+  }
+  hw.output %0 : i32
+}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -214,7 +214,7 @@ hw.module @retimeable2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant 1 : i1
-    %r_0, %s0_valid = pipeline.stage when %c1_i1 regs %0 : i32
+    %r_0, %s0_valid = pipeline.stage.register when %c1_i1 regs %0 : i32
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : i32

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -197,3 +197,36 @@ func.func @trip_count_attr() {
   }
   return
 }
+
+hw.module @retimeable1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %0 = comb.add %a0, %a1 : i32
+    %c1_i1 = hw.constant 1 : i1
+    %s0_valid = pipeline.stage when %c1_i1
+    pipeline.return %0 valid %s0_valid : i32
+  }
+  hw.output %0 : i32
+}
+
+hw.module @retimeable2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %0 = comb.add %a0, %a1 : i32
+    %c1_i1 = hw.constant 1 : i1
+    %r_0, %s0_valid = pipeline.stage when %c1_i1 regs %0 : i32
+    pipeline.return %0 valid %s0_valid : i32
+  }
+  hw.output %0 : i32
+}
+
+hw.module @retimeable3(%arg0 : !esi.channel<i32>, %arg1 : !esi.channel<i32>, %clk : i1, %rst: i1) -> (out: !esi.channel<i32>) {
+  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (!esi.channel<i32>, !esi.channel<i32>) -> (!esi.channel<i32>) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %0 = comb.add %a0, %a1 : i32
+    %c1_i1 = hw.constant 1 : i1
+    %s0_valid = pipeline.stage when %c1_i1
+    pipeline.return %0 valid %s0_valid : i32
+  }
+  hw.output %0 : !esi.channel<i32>
+}


### PR DESCRIPTION
The `pipeline.rtp` operation represents a retimeable pipeline.
The pipeline contains a single block representing a graph region. Pipeline stages are represented by `pipeline.rt.register` operations. Semantics of values crossing register boundaries are defined by lowering passes.
The pipeline representation is centered around providing latency insensitive values (valid signals between stages). Such signals can either be removed (in the feedforward, statically scheduled case), used to control stalling (feedback, statically scheduled case) or in conjunction with handshake signals for dynamically scheduled pipelines.

Alongside this, some old, unused code (StandardToStaticLogic) is pruned to remove a maintenance burden associated with this change.

A typical flow would go like this:

An untimed datapath is defined:
```mlir
pipeline.rtp(%in0 : i32, %in1 : i32,  %go : i1) -> (i32) {
    ^bb0:(%arg0 : i32, %arg1: i32, %go : i1):
    %add0 = comb.add %arg0, %arg1 : i32
    %add1 = comb.add %add0, %arg0 : i32
    %add2 = comb.add %add1, %arg1 : i32
    pipeline.rtp.return %add2 valid %go : i32
}
```
The datapath is scheduled (future pass). At this point, stage separating registers can be inserted at arbitrary points in the datapath. In future commits, delays will always be specified relative to the op that produces it - either by `pipeline.delay %0 by N` operations that can delay an arbitrary SSA value across the next `N` stages, or annotating that some values take multiple cycles to produce (pipelined operators).
```mlir
pipeline.rtp(%in0 : i32, %in1 : i32, %go : i1) -> (i32) {
    ^bb0:(%arg0 : i32, %arg1: i32, %go : i1):
    %add0 = comb.add %arg0, %arg1 : i32

    %s0_valid = pipeline.stage when %go
    %add1 = comb.add %add0, %arg0 : i32

    %s1_valid = pipeline.stage when %s0_valid
    %add2 = comb.add %add1, %arg1 : i32

    pipeline.rtp.return %add2 valid %s1_valid : i32
}
```

Stage-crossing dependencies are made explicit through registers (future pass). At this point, `pipeline.stage` operations are illegal, and the pipeline has been timed.
```mlir
pipeline.rtp(%in0 : i32, %in1 : i32,  %go : i1) -> (i32) {
    ^bb0:(%arg0 : i32, %arg1: i32,  %go : i1):
    %add0 = comb.add %arg0, %arg1 : i32

    %s0_valid, %add0_r = pipeline.stage.register when %go regs (%add0: i32)
    %add1 = comb.add %add0_r, %arg0 : i32

    %s1_valid, %add1_r = pipeline.stage.register when %s0_valid regs (%add1: i32)
    %add2 = comb.add %add1_r, %arg1 : i32

    pipeline.rtp.return %add2 valid %s1_valid : i32
}
```

This representation can then be lowered to statically or dynamically scheduled pipelines.