### PR TITLE
[FIRRTL] Add RefType, first non-base type.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -58,6 +58,9 @@ struct PortInfo {
                      .Case<FIRRTLBaseType>([](auto base) {
                        return base.getRecursiveTypeProperties();
                      })
+                     .Case<RefType>([](auto ref) {
+                       return ref.getType().getRecursiveTypeProperties();
+                     })
                      .Default([](auto) {
                        llvm_unreachable("unsupported type");
                        return RecursiveTypeProperties{};

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -49,7 +49,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
     ```
     }];
 
-  let arguments = (ins SizedType:$dest, SizedType:$src);
+  let arguments = (ins SizedBaseOrRefType:$dest, SizedBaseOrRefType:$src);
   let results = (outs);
   let hasCanonicalizeMethod = true;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -438,6 +438,9 @@ public:
 
   /// Return the underlying type.
   FIRRTLBaseType getType();
+
+  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitErrorFn,
+                              FIRRTLBaseType base);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -24,6 +24,7 @@ struct WidthTypeStorage;
 struct BundleTypeStorage;
 struct VectorTypeStorage;
 struct CMemoryTypeStorage;
+struct RefTypeStorage;
 } // namespace detail.
 
 class ClockType;
@@ -34,6 +35,7 @@ class UIntType;
 class AnalogType;
 class BundleType;
 class FVectorType;
+class RefType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -109,7 +111,7 @@ public:
 
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
-    return llvm::isa<FIRRTLDialect>(type.getDialect());
+    return llvm::isa<FIRRTLDialect>(type.getDialect()) && !type.isa<RefType>();
   }
 
   /// Return true if this is a valid "reset" type.
@@ -422,6 +424,20 @@ public:
   /// of the type.  Essentially maps a fieldID to a fieldID after a subfield op.
   /// Returns the new id and whether the id is in the given child.
   std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
+};
+
+//===----------------------------------------------------------------------===//
+// Reference Type
+//===----------------------------------------------------------------------===//
+
+class RefType
+    : public FIRRTLType::TypeBase<RefType, FIRRTLType, detail::RefTypeStorage> {
+public:
+  using Base::Base;
+  static RefType get(FIRRTLBaseType type);
+
+  /// Return the underlying type.
+  FIRRTLBaseType getType();
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -100,9 +100,21 @@ def PassiveType : FIRRTLDialectType<
   CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isPassive()">,
   "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
-def RefType : DialectType<FIRRTLDialect,
+def RefType : FIRRTLDialectType<
    CPred<"$_self.isa<RefType>()">,
-  "reference type", "::circt::firrtl::RefType">;
+  "reference type", "::circt::firrtl::RefType", [{
+    A reference type, such as `firrtl.ref<uint<1>>`.
+
+    Used for remote reads and writes of the wrapped base type.
+
+    Parameterized over the referenced base type,
+    which must be passive and for now must also be ground.
+
+    Not a base type.
+
+    Values of this type are used to capture dataflow paths,
+    and do not represent a circuit element or entity.
+  }]>;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -70,10 +70,14 @@ def ConnectableType : FIRRTLDialectType<
     Currently this is any base type or ref type.
   }]>;
 
-def SizedType : FIRRTLDialectType<
+def SizedBaseOrRefType : FIRRTLDialectType<
+  Or<[
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "!$_self.cast<FIRRTLBaseType>().hasUninferredWidth()">,
-    "a sized type (contains no unifered widths)", "::circt::firrtl::FIRRTLType">;
+    CPred<"$_self.isa<RefType>() && "
+          "!$_self.cast<RefType>().getType().hasUninferredWidth()">,
+    ]>,
+  "a sized base or ref type (contains no uninferred widths)", "::circt::firrtl::FIRRTLType">;
 
 def UInt1Type : FIRRTLDialectType<
     CPred<"$_self.isa<UIntType>() && "

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -61,10 +61,13 @@ def FVectorType : FIRRTLDialectType<CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
 def ConnectableType : FIRRTLDialectType<
+  Or<[
     CPred<"$_self.isa<FIRRTLBaseType>()">,
-    "a connectable type (base type)", "::circt::firrtl::FIRRTLType", [{
+    CPred<"$_self.isa<RefType>()">,
+    ]>,
+    "a connectable type (base or ref type)", "::circt::firrtl::FIRRTLType", [{
     Any type that is valid for use in connect statements.
-    Currently this is any base type.
+    Currently this is any base type or ref type.
   }]>;
 
 def SizedType : FIRRTLDialectType<
@@ -93,6 +96,10 @@ def PassiveType : FIRRTLDialectType<
   CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isPassive()">,
   "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
+def RefType : DialectType<FIRRTLDialect,
+   CPred<"$_self.isa<RefType>()">,
+  "reference type", "::circt::firrtl::RefType">;
+
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//
@@ -110,7 +117,7 @@ def AnyResetType : FIRRTLDialectType<
 def AnyRegisterType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "$_self.cast<FIRRTLBaseType>().isRegisterType()">,
-    "a passive type that does not contain analog",
+    "a passive base type that does not contain analog",
     "::circt::firrtl::FIRRTLBaseType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -350,15 +350,13 @@ LogicalResult CircuitOp::verify() {
             .attachNote(collidingExtModule.getLoc())
             .append("previous extmodule definition occurred here");
 
-      if (!aType.isa<FIRRTLBaseType>() || !bType.isa<FIRRTLBaseType>())
-        return extModule.emitOpError().append(
-            "with 'defname' attribute ", defname,
-            " has a port that is of unsupported type, must be base type.");
-
       if (!extModule.getParameters().empty() ||
           !collidingExtModule.getParameters().empty()) {
-        aType = aType.cast<FIRRTLBaseType>().getWidthlessType();
-        bType = bType.cast<FIRRTLBaseType>().getWidthlessType();
+        // Compare base types as widthless, others must match.
+        if (auto base = aType.dyn_cast<FIRRTLBaseType>())
+          aType = base.getWidthlessType();
+        if (auto base = bType.dyn_cast<FIRRTLBaseType>())
+          bType = base.getWidthlessType();
       }
       if (aType != bType)
         return extModule.emitOpError()

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2028,20 +2028,16 @@ static LogicalResult checkRefTypeFlow(Operation *connect) {
 
   if (dst.getType().isa<RefType>()) {
     if (getDeclarationKind(src) == getDeclarationKind(dst)) {
-      auto srcRef = getFieldRefFromValue(src);
       bool rootKnown;
-      auto srcName = getFieldName(srcRef, rootKnown);
       auto diag = emitError(connect->getLoc())
-                  << "connect has invalid flow for ref type ports: the source "
-                     "expression ";
+                  << "connect is invalid: the first operand ";
+      auto dstName = getFieldName(getFieldRefFromValue(dst), rootKnown);
+      if (rootKnown)
+        diag << "\"" << dstName << "\" ";
+      diag << "and second operand ";
+      auto srcName = getFieldName(getFieldRefFromValue(src), rootKnown);
       if (rootKnown)
         diag << "\"" << srcName << "\" ";
-      diag << "and destination expression ";
-      auto dstRef = getFieldRefFromValue(dst);
-      bool dstRootKnown;
-      auto dstName = getFieldName(dstRef, dstRootKnown);
-      if (dstRootKnown)
-        diag << "\"" << dstName << "\" ";
       diag << "both have same port kind, expected Module port to Instance "
               "connections only";
       return diag;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2032,7 +2032,7 @@ static LogicalResult checkRefTypeFlow(Operation *connect) {
       bool rootKnown;
       auto srcName = getFieldName(srcRef, rootKnown);
       auto diag = emitError(connect->getLoc())
-                  << "connect has invalid flow for Ref type ports: the source "
+                  << "connect has invalid flow for ref type ports: the source "
                      "expression ";
       if (rootKnown)
         diag << "\"" << srcName << "\" ";

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2048,7 +2048,8 @@ static LogicalResult checkRefTypeFlow(Operation *connect) {
               "connections only";
       return diag;
     }
-    if (!src.hasOneUse() || !dst.hasOneUse()) {
+    if ((src.getType().isa<RefType>() && !src.hasOneUse()) ||
+        (dst.getType().isa<RefType>() && !dst.hasOneUse())) {
       auto diag = emitError(connect->getLoc());
       diag << "connect operands of ref type cannot be reused";
       return diag;

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1144,7 +1144,6 @@ llvm::Optional<int64_t> firrtl::getBitWidth(FIRRTLBaseType type) {
             return llvm::Optional<int64_t>(None);
         })
         .Case<ClockType, ResetType, AsyncResetType>([](Type) { return 1; })
-        .Case<RefType>([&](RefType ref) { return getBitWidth(ref.getType()); })
         .Default([&](auto t) { return llvm::Optional<int64_t>(None); });
   };
   return getWidth(type);

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1146,12 +1146,15 @@ private:
 static bool hasUninferredWidth(Type type) {
   return TypeSwitch<Type, bool>(type)
       .Case<FIRRTLBaseType>([](auto base) { return base.hasUninferredWidth(); })
+      .Case<RefType>(
+          [](auto ref) { return ref.getType().hasUninferredWidth(); })
       .Default([](auto) { return false; });
 }
 
 static FIRRTLBaseType getBaseType(FIRRTLType type) {
   return TypeSwitch<FIRRTLType, FIRRTLBaseType>(type)
       .Case<FIRRTLBaseType>([](auto base) { return base; })
+      .Case<RefType>([](auto ref) { return ref.getType(); })
       .Default([](auto) {
         llvm_unreachable("unexpected FIRRTLType");
         return FIRRTLBaseType();
@@ -1940,6 +1943,8 @@ bool InferenceTypeUpdate::updateValue(Value value) {
   auto update = [&](FIRRTLType ftype) {
     return TypeSwitch<FIRRTLType, FIRRTLType>(type)
         .Case<FIRRTLBaseType>([&](auto base) { return updateBase(base); })
+        .Case<RefType>(
+            [&](auto ref) { return RefType::get(updateBase(ref.getType())); })
         .Default([](auto) {
           llvm_unreachable("unsupported type");
           return FIRRTLType();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -97,6 +97,7 @@ static bool hasZeroBitWidth(FIRRTLType type) {
       .Case<FIRRTLBaseType>([](auto groundType) {
         return firrtl::getBitWidth(groundType).value_or(0) == 0;
       })
+      .Case<RefType>([](auto) { return false; })
       .Default([](auto) { return false; });
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -97,7 +97,7 @@ static bool hasZeroBitWidth(FIRRTLType type) {
       .Case<FIRRTLBaseType>([](auto groundType) {
         return firrtl::getBitWidth(groundType).value_or(0) == 0;
       })
-      .Case<RefType>([](auto) { return false; })
+      .Case<RefType>([](auto ref) { return hasZeroBitWidth(ref.getType()); })
       .Default([](auto) { return false; });
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -782,7 +782,7 @@ firrtl.circuit "Top"   {
 firrtl.circuit "Top" {
   firrtl.module @Top (in %in : !firrtl.uint) {
     %a = firrtl.wire : !firrtl.uint
-    // expected-error @+1 {{op operand #0 must be a sized type}}
+    // expected-error @+1 {{op operand #0 must be a sized base or ref type}}
     firrtl.strictconnect %a, %in : !firrtl.uint
   }
 }
@@ -909,9 +909,8 @@ firrtl.circuit "DupSymField" {
 
 firrtl.circuit "func2" {
   firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
-    // TODO: Support use in strictconnect ?
     // expected-error @+1 {{connect has invalid flow for Ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
-    firrtl.connect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    firrtl.strictconnect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>
   }
 }
 
@@ -1001,5 +1000,17 @@ firrtl.circuit "BitcastRef" {
   firrtl.module @BitcastRef(in %a: !firrtl.ref<uint<1>>) {
     // expected-error @+1 {{'firrtl.bitcast' op operand #0 must be a base type, but got '!firrtl.ref<uint<1>>}}
     %0 = firrtl.bitcast %a : (!firrtl.ref<uint<1>>) -> (!firrtl.ref<uint<1>>)
+  }
+}
+
+// -----
+// Cannot strictconnect unsized types, even when ref's.
+
+firrtl.circuit "Top" {
+  firrtl.module @Foo (in %in: !firrtl.ref<uint>) {}
+  firrtl.module @Top (in %in : !firrtl.ref<uint>) {
+    %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint>)
+    // expected-error @+1 {{op operand #0 must be a sized base or ref type}}
+    firrtl.strictconnect %foo_in, %in : !firrtl.ref<uint>
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -909,7 +909,7 @@ firrtl.circuit "DupSymField" {
 
 firrtl.circuit "func2" {
   firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{connect has invalid flow for Ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
+    // expected-error @+1 {{connect has invalid flow for ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
     firrtl.strictconnect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -926,6 +926,7 @@ firrtl.module @NonRefNode(in %in1 : !firrtl.ref<uint<8>>) {
 }
 
 // -----
+// Registers cannot be reference type.
 
 firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -791,7 +791,7 @@ firrtl.circuit "Top" {
 
 firrtl.circuit "AnalogRegister" {
   firrtl.module @AnalogRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive type that does not contain analog, but got '!firrtl.analog'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.analog'}}
     %r = firrtl.reg %clock : !firrtl.analog
   }
 }
@@ -800,7 +800,7 @@ firrtl.circuit "AnalogRegister" {
 
 firrtl.circuit "AnalogVectorRegister" {
   firrtl.module @AnalogVectorRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
     %r = firrtl.reg %clock : !firrtl.vector<analog, 2>
   }
 }
@@ -901,5 +901,105 @@ firrtl.circuit "DupSymField" {
     %w1 = firrtl.wire sym @x : !firrtl.uint<2>
     // expected-error @+1 {{redefinition of inner symbol named 'x'}}
     %w3 = firrtl.wire sym [<@x,1,public>] : !firrtl.vector<uint<1>,1>
+  }
+}
+
+// -----
+// Check upward reference XMRs
+
+firrtl.circuit "func2" {
+  firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
+    // TODO: Support use in strictconnect ?
+    // expected-error @+1 {{connect has invalid flow for Ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
+    firrtl.connect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Node ops cannot have reference type
+
+firrtl.circuit "NonRefNode" {
+firrtl.module @NonRefNode(in %in1 : !firrtl.ref<uint<8>>) {
+  // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive base type (contain no flips), but got '!firrtl.ref<uint<8>>'}}
+  %n1 = firrtl.node %in1 : !firrtl.ref<uint<8>>
+  %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+}
+}
+
+// -----
+
+firrtl.circuit "NonRefRegister" {
+  firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
+    %r = firrtl.reg %clock : !firrtl.ref<uint<8>>
+  }
+}
+
+// -----
+// Wire ops cannot have reference type
+
+firrtl.circuit "MyView" {
+  firrtl.module @MyView() {
+  // expected-error @+1 {{'firrtl.wire' op result #0 must be a base type, but got '!firrtl.ref<uint<1>>'}}
+    %ref_in1 = firrtl.wire : !firrtl.ref<uint<1>>
+    %in1 = firrtl.wire : !firrtl.uint<1>
+  }
+}
+
+// -----
+// Ref types must be ground
+
+firrtl.circuit "RefBundle" {
+  // expected-error @+1 {{reference type must be ground}}
+  firrtl.module @RefBundle(in %in1 : !firrtl.ref<bundle<valid: uint<1>>>) {
+  }
+}
+
+// -----
+// Ref types cannot be ref
+
+firrtl.circuit "RefRef" {
+  // expected-error @+1 {{expected base type, found '!firrtl.ref<uint<1>>'}}
+  firrtl.module @RefRef(in %in1 : !firrtl.ref<ref<uint<1>>>) {
+  }
+}
+
+// -----
+// No ref in bundle
+
+firrtl.circuit "RefField" {
+  // expected-error @+1 {{expected base type, found '!firrtl.ref<uint<1>>'}}
+  firrtl.module @RefField(in %in1 : !firrtl.bundle<r: ref<uint<1>>>) {
+  }
+}
+
+// -----
+// Invalid
+
+firrtl.circuit "InvalidRef" {
+  firrtl.module @InvalidRef() {
+    // expected-error @+1 {{'firrtl.invalidvalue' op result #0 must be a base type, but got '!firrtl.ref<uint<1>>'}}
+    %0 = firrtl.invalidvalue : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Mux ref
+
+firrtl.circuit "MuxRef" {
+  firrtl.module @MuxRef(in %a: !firrtl.ref<uint<1>>, in %b: !firrtl.ref<uint<1>>,
+                          in %cond: !firrtl.uint<1>) {
+    // expected-error @+1 {{'firrtl.mux' op operand #1 must be a passive base type (contain no flips), but got '!firrtl.ref<uint<1>>'}}
+    %a_or_b = firrtl.mux(%cond, %a, %b) : (!firrtl.uint<1>, !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>) -> !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Bitcast ref
+
+firrtl.circuit "BitcastRef" {
+  firrtl.module @BitcastRef(in %a: !firrtl.ref<uint<1>>) {
+    // expected-error @+1 {{'firrtl.bitcast' op operand #0 must be a base type, but got '!firrtl.ref<uint<1>>}}
+    %0 = firrtl.bitcast %a : (!firrtl.ref<uint<1>>) -> (!firrtl.ref<uint<1>>)
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -909,7 +909,7 @@ firrtl.circuit "DupSymField" {
 
 firrtl.circuit "func2" {
   firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{connect has invalid flow for ref type ports: the source expression "ref_in1" and destination expression "ref_out" both have same port kind, expected Module port to Instance connections only}}
+    // expected-error @+1 {{connect is invalid: the first operand "ref_out" and second operand "ref_in1" both have same port kind, expected Module port to Instance connections only}}
     firrtl.strictconnect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1014,3 +1014,15 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %foo_in, %in : !firrtl.ref<uint>
   }
 }
+
+// -----
+// Cannot connect different ref types
+
+firrtl.circuit "Top" {
+  firrtl.module @Foo (in %in: !firrtl.ref<uint<2>>) {}
+  firrtl.module @Top (in %in: !firrtl.ref<uint<1>>) {
+    %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint<2>>)
+    // expected-error @+1 {{may not connect different non-base types}}
+    firrtl.connect %foo_in, %in : !firrtl.ref<uint<2>>, !firrtl.ref<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -950,7 +950,7 @@ firrtl.circuit "MyView" {
 // Ref types must be ground
 
 firrtl.circuit "RefBundle" {
-  // expected-error @+1 {{reference type must be ground}}
+  // expected-error @+1 {{reference base type must be ground}}
   firrtl.module @RefBundle(in %in1 : !firrtl.ref<bundle<valid: uint<1>>>) {
   }
 }


### PR DESCRIPTION
Add `firrtl.ref<T>` as new FIRRTLType, first type that's not a base type (see #3666).
Part of XMR effort, see #3566 for details and motivation.

----
BaseType:

Existing FIRRTL operations are closed under FIRRTLBaseType, keeping this new type separate makes it straightforward to ensure it's not used in unexpected ways or places.  Only a few places are allowed to use non-base types such as module ports.

FIRRTLBaseType's describe circuit entities and their types, where as "RefType" captures data-flow (to a remote value), and should not be used in most places.  Can't use it as a register's type, so on.  This approach also avoids the need to give "hopefully conservatively correct" answers to FIRRTLType helper methods querying, e.g., bitwidth and whether it is a ground or passive type-- as any generic code reasoning about this for a RefType is unlikely to do the right thing without also knowing that it's dealing with a RefType.  This changes forces the issue across the codebase.