### PR TITLE
Update llvm::{Optional,FailureOr} uses to new methods (NFCI). 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -161,7 +161,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
       auto bundleType = input.getType().cast<BundleType>();
       auto fieldIndex = bundleType.getElementIndex(fieldName);
-      assert(fieldIndex.hasValue() && "subfield operation to unknown field");
+      assert(fieldIndex.has_value() && "subfield operation to unknown field");
       return build($_builder, $_state, input, *fieldIndex);
     }]>
   ];

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -201,13 +201,10 @@ public:
   }
 
   /// Return the width of this type, or -1 if it has none specified.
-  int32_t getWidthOrSentinel() {
-    auto width = getWidth();
-    return width.hasValue() ? width.getValue() : -1;
-  }
+  int32_t getWidthOrSentinel() { return getWidth().value_or(-1); }
 
   /// Return true if this type has a known width.
-  bool hasWidth() { return getWidth().hasValue(); }
+  bool hasWidth() { return getWidth().has_value(); }
 
   /// Return a new type with the width changed to a different value.
   ConcreteType changeWidth(int32_t width) {
@@ -231,16 +228,13 @@ public:
   bool isUnsigned() { return isa<UIntType>(); }
 
   /// Return true if this integer type has a known width.
-  bool hasWidth() { return getWidth().hasValue(); }
+  bool hasWidth() { return getWidth().has_value(); }
 
   /// Return the bitwidth of this type or None if unknown.
   Optional<int32_t> getWidth();
 
   /// Return the width of this type, or -1 if it has none specified.
-  int32_t getWidthOrSentinel() {
-    auto width = getWidth();
-    return width.hasValue() ? width.getValue() : -1;
-  }
+  int32_t getWidthOrSentinel() { return getWidth().value_or(-1); }
 
   static bool classof(Type type) {
     return type.isa<SIntType>() || type.isa<UIntType>();

--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -280,7 +280,7 @@ def LLHD_RegOp : LLHD_Op<"reg", [
     static RegMode getRegModeByName(StringRef name) {
       llvm::Optional<RegMode> optional =  symbolizeRegMode(name);
       assert(optional && "Invalid RegMode string.");
-      return optional.getValue();
+      return optional.value();
     }
 
     bool hasGate(unsigned index) {

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -72,7 +72,7 @@ void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
       // assumes outer loops execute sequentially, i.e. one iteration of the
       // inner loop completes before the next iteration is initiated. With
       // proper analysis and lowerings, this can be relaxed.
-      unsigned distance = memoryDep.dependenceComponents.back().lb.getValue();
+      unsigned distance = memoryDep.dependenceComponents.back().lb.value();
       if (distance > 0)
         problem.setDistance(dep, distance);
     }

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -60,10 +60,10 @@ void TestDependenceAnalysisPass::runOnOperation() {
       SmallVector<Attribute> comps;
       for (auto comp : dep.dependenceComponents) {
         SmallVector<Attribute> vector;
-        vector.push_back(IntegerAttr::get(IntegerType::get(context, 64),
-                                          comp.lb.getValue()));
-        vector.push_back(IntegerAttr::get(IntegerType::get(context, 64),
-                                          comp.ub.getValue()));
+        vector.push_back(
+            IntegerAttr::get(IntegerType::get(context, 64), comp.lb.value()));
+        vector.push_back(
+            IntegerAttr::get(IntegerType::get(context, 64), comp.ub.value()));
         comps.push_back(ArrayAttr::get(context, vector));
       }
 
@@ -197,7 +197,7 @@ void InferTopModulePass::runOnOperation() {
   }
 
   llvm::SmallVector<Attribute, 4> attrs;
-  for (auto *node : res.getValue())
+  for (auto *node : *res)
     attrs.push_back(node->getModule().moduleNameAttr());
 
   analysis.getParent()->setAttr("test.top",

--- a/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
+++ b/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
@@ -363,8 +363,7 @@ LogicalResult AffineToStaticLogic::createStaticLogicPipeline(
   // iter arg is created for the induction variable.
   TypeRange resultTypes = innerLoop.getResultTypes();
 
-  auto ii =
-      builder.getI64IntegerAttr(problem.getInitiationInterval().getValue());
+  auto ii = builder.getI64IntegerAttr(problem.getInitiationInterval().value());
 
   SmallVector<Value> iterArgs;
   iterArgs.push_back(lowerBound);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1509,13 +1509,13 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   // TODO: This could try harder to omit redundant casts like the mainline
   // expression emitter.
   auto emitOperand = [&](Attribute operand) -> bool {
-    if (operandSign.hasValue())
-      os << (operandSign.getValue() == IsSigned ? "$signed(" : "$unsigned(");
+    if (operandSign.has_value())
+      os << (operandSign.value() == IsSigned ? "$signed(" : "$unsigned(");
     auto signedness =
         printParamValue(operand, os, subprecedence, emitError).signedness;
-    if (operandSign.hasValue()) {
+    if (operandSign.has_value()) {
       os << ')';
-      signedness = operandSign.getValue();
+      signedness = operandSign.value();
     }
     return signedness == IsSigned;
   };

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -987,7 +987,7 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
 
   StringRef verilogName;
   if (auto defName = oldModule.getDefname())
-    verilogName = defName.getValue();
+    verilogName = defName.value();
 
   // Build the new hw.module op.
   auto builder = OpBuilder::atBlockEnd(topLevelModule);
@@ -1260,10 +1260,8 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
     auto elemIndex =
         fieldAccess.getInput().getType().cast<BundleType>().getElementIndex(
             field);
-    if (elemIndex.hasValue() &&
-        fieldAccess.getFieldIndex() == elemIndex.getValue()) {
+    if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
-    }
   }
   return accesses;
 }
@@ -3251,10 +3249,10 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
   // lowering it to a random value, we should see if this is what we need to
   // do.
   if (auto bitwidth = firrtl::getBitWidth(op.getType().cast<FIRRTLType>())) {
-    if (bitwidth.getValue() == 0) // Let the caller handle zero width values.
+    if (bitwidth.value() == 0) // Let the caller handle zero width values.
       return failure();
 
-    auto constant = getOrCreateIntConstant(bitwidth.getValue(), 0);
+    auto constant = getOrCreateIntConstant(bitwidth.value(), 0);
     // If the result is an aggregate value, we have to bitcast the constant.
     if (!resultTy.isa<IntegerType>())
       constant = builder.create<hw::BitcastOp>(resultTy, constant);

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -439,9 +439,9 @@ LogicalResult MachineOpConverter::dispatch() {
     if (failed(stateConvRes))
       return failure();
 
-    stateConvResults[state] = stateConvRes.getValue();
+    stateConvResults[state] = *stateConvRes;
     orderedStates.push_back(state);
-    nextStateFromState[state] = {stateConvRes.getValue().nextState};
+    nextStateFromState[state] = {stateConvRes->nextState};
   }
 
   // 4/5) Create next-state assignments for each output.
@@ -608,7 +608,7 @@ MachineOpConverter::convertState(StateOp state) {
   if (failed(outputOpRes))
     return failure();
 
-  OutputOp outputOp = cast<fsm::OutputOp>(outputOpRes.getValue());
+  OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
   res.outputs = outputOp.getOperands(); // 3.2
 
   auto transitions = llvm::SmallVector<TransitionOp>(
@@ -618,7 +618,7 @@ MachineOpConverter::convertState(StateOp state) {
   auto nextStateRes = convertTransitions(state, transitions);
   if (failed(nextStateRes))
     return failure();
-  res.nextState = nextStateRes.getValue();
+  res.nextState = *nextStateRes;
   return res;
 }
 

--- a/lib/Conversion/StandardToHandshake/InsertMergeBlocks.cpp
+++ b/lib/Conversion/StandardToHandshake/InsertMergeBlocks.cpp
@@ -208,11 +208,11 @@ static LogicalResult buildMergeBlocks(Block *currBlock, SplitInfo &splitInfo,
 
     // Update info for the newly created block.
     Block *splitIn = splitInfo.in.lookup(splitBlock);
-    splitInfo.in.try_emplace(mergeBlock.getValue(), splitIn);
+    splitInfo.in.try_emplace(*mergeBlock, splitIn);
     // By construction, this block has only one successor, therefore, out == in.
-    splitInfo.out.try_emplace(mergeBlock.getValue(), splitIn);
+    splitInfo.out.try_emplace(*mergeBlock, splitIn);
 
-    preds.push_back(mergeBlock.getValue());
+    preds.push_back(*mergeBlock);
   }
   if (predsToConsider.size() != 0)
     return currBlock->getParentOp()->emitError(

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -1013,14 +1013,10 @@ class BuildPipelineGroups : public calyx::FuncOpPartialLoweringPattern {
     if (isStageWithNoPipelinedValues) {
       // Covers the case where there are no values that need to be passed
       // through to the next stage, e.g., some intermediary store.
-      for (auto &op : stage.getBodyBlock()) {
-        Optional<calyx::GroupOp> group =
-            getState<ComponentLoweringState>()
-                .getNonPipelinedGroupFrom<calyx::GroupOp>(&op);
-        if (!group.hasValue())
-          continue;
-        updatePrologueAndEpilogue(*group);
-      }
+      for (auto &op : stage.getBodyBlock())
+        if (auto group = getState<ComponentLoweringState>()
+                             .getNonPipelinedGroupFrom<calyx::GroupOp>(&op))
+          updatePrologueAndEpilogue(*group);
     }
 
     for (auto &operand : operands) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -97,7 +97,7 @@ public:
         auto libraryName = getLibraryFor(&op);
         if (failed(libraryName))
           return WalkResult::interrupt();
-        usedLibraries.insert(libraryName.getValue());
+        usedLibraries.insert(*libraryName);
       }
       return WalkResult::advance();
     });
@@ -190,7 +190,7 @@ struct Emitter {
     if (failed(libraryNames))
       return failure();
 
-    for (StringRef library : libraryNames.getValue())
+    for (StringRef library : *libraryNames)
       emitImport(library);
 
     return success();
@@ -465,8 +465,8 @@ private:
             indent() << prependAttributes(op, "while ");
             emitValue(op.cond(), /*isIndented=*/false);
 
-            if (auto groupName = op.groupName(); groupName.hasValue())
-              os << " with " << groupName.getValue();
+            if (auto groupName = op.groupName())
+              os << " with " << *groupName;
 
             emitCalyxBody([&]() { emitCalyxControl(op.getBody()); });
           })
@@ -474,8 +474,8 @@ private:
             indent() << prependAttributes(op, "if ");
             emitValue(op.cond(), /*isIndented=*/false);
 
-            if (auto groupName = op.groupName(); groupName.hasValue())
-              os << " with " << groupName.getValue();
+            if (auto groupName = op.groupName())
+              os << " with " << *groupName;
 
             emitCalyxBody([&]() { emitCalyxControl(op.getThenBody()); });
             if (op.elseBodyExists())
@@ -658,8 +658,7 @@ void Emitter::emitLibraryPrimTypedByFirstOutputPort(
   StringRef opName = op->getName().getStringRef();
   indent() << getAttributes(op) << cell.instanceName() << space() << equals()
            << space()
-           << (calyxLibName.hasValue() ? *calyxLibName
-                                       : removeCalyxPrefix(opName))
+           << (calyxLibName ? *calyxLibName : removeCalyxPrefix(opName))
            << LParen() << bitWidth << RParen() << semicolonEndL();
 }
 

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -44,11 +44,11 @@ void appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
         rewriter.getNamedAttr("id", rewriter.getI32IntegerAttr(memoryID)),
         // "tag" denotes the function of this signal.
         rewriter.getNamedAttr("tag", rewriter.getStringAttr(tag))};
-    if (addrIdx.hasValue())
+    if (addrIdx.has_value())
       // "addr_idx" denotes the address index of this signal, for
       // multi-dimensional memory interfaces.
       attrs.push_back(rewriter.getNamedAttr(
-          "addr_idx", rewriter.getI32IntegerAttr(addrIdx.getValue())));
+          "addr_idx", rewriter.getI32IntegerAttr(*addrIdx)));
 
     return rewriter.getNamedAttr("mem", rewriter.getDictionaryAttr(attrs));
   };
@@ -582,7 +582,7 @@ RewriteMemoryAccesses::partiallyLower(calyx::AssignOp assignOp,
   auto *state = cls.getState(assignOp->getParentOfType<calyx::ComponentOp>());
 
   Value dest = assignOp.dest();
-  if (!state->isInputPortOfMemory(dest).hasValue())
+  if (!state->isInputPortOfMemory(dest))
     return success();
 
   Value src = assignOp.src();

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -33,7 +33,7 @@ ServiceGeneratorDispatcher ServiceGeneratorDispatcher::defaultDispatcher() {
 
 LogicalResult ServiceGeneratorDispatcher::generate(ServiceImplementReqOp req) {
   // Create the lookup table lazily.
-  if (!lookupTable.hasValue())
+  if (!lookupTable)
     lookupTable = create(req.getContext());
 
   // Lookup based on 'impl_type' attribute and pass through the generate request

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -90,7 +90,7 @@ static ParseResult parseNameKind(OpAsmParser &parser,
   if (!parser.parseOptionalKeyword(&keyword,
                                    {"interesting_name", "droppable_name"})) {
     auto kind = symbolizeNameKindEnum(keyword);
-    result = NameKindEnumAttr::get(parser.getContext(), kind.getValue());
+    result = NameKindEnumAttr::get(parser.getContext(), kind.value());
     return success();
   }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -729,9 +729,8 @@ void Emitter::emitAttribute(RUWAttr attr) {
 /// Emit a FIRRTL type into the output.
 void Emitter::emitType(Type type) {
   auto emitWidth = [&](Optional<int32_t> width) {
-    if (!width.hasValue())
-      return;
-    os << "<" << *width << ">";
+    if (width)
+      os << "<" << *width << ">";
   };
   TypeSwitch<Type>(type)
       .Case<ClockType>([&](auto) { os << "Clock"; })

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -65,7 +65,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       // Get the width of individual aggregate leaf elements.
       for (auto f : flatMemType) {
         LLVM_DEBUG(llvm::dbgs() << "\n field type:" << f);
-        memWidths.push_back(f.getWidth().getValue());
+        memWidths.push_back(f.getWidth().value());
       }
       maskGran = memWidths[0];
       size_t memFlatWidth = 0;
@@ -141,9 +141,8 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
             auto oldFieldBitWidth = getBitWidth(oldField.getType());
             // Following condition is true, if a data field is 0 bits. Then
             // newFieldType is of smaller bits than old.
-            if (getBitWidth(newFieldType) != oldFieldBitWidth.getValue())
-              newFieldType =
-                  UIntType::get(context, oldFieldBitWidth.getValue());
+            if (getBitWidth(newFieldType) != oldFieldBitWidth.value())
+              newFieldType = UIntType::get(context, oldFieldBitWidth.value());
             realOldField = builder.create<BitCastOp>(newFieldType, oldField);
             // Mask bits require special handling, since some of the mask bits
             // need to be repeated, direct bitcasting wouldn't work. Depending
@@ -200,7 +199,7 @@ private:
           })
           .Case<IntType>([&](auto iType) {
             results.push_back({iType});
-            return iType.getWidth().hasValue();
+            return iType.getWidth().has_value();
           })
           .Default([&](auto) { return false; });
     };

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -476,7 +476,7 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
     port.append("target", StringAttr::get(context, canonTarget));
     state.addToWorklistFn(DictionaryAttr::get(context, port));
 
-    auto blackboxTarget = tokenizePath(canonTarget).getValue();
+    auto blackboxTarget = tokenizePath(canonTarget).value();
     blackboxTarget.name = {};
     blackboxTarget.component.clear();
     auto blackboxTargetStr = blackboxTarget.str();
@@ -826,11 +826,10 @@ void GrandCentralTapsPass::runOnOperation() {
           }
 
           auto relative = stripCommonPrefix(prefixWithNLA, path);
-          if (!shortestPrefix.hasValue() ||
-              relative.size() < shortestPrefix->size())
+          if (!shortestPrefix || relative.size() < shortestPrefix->size())
             shortestPrefix.emplace(relative.begin(), relative.end());
         }
-        if (!shortestPrefix.hasValue()) {
+        if (!shortestPrefix) {
           LLVM_DEBUG(llvm::dbgs() << "  - Has no prefix, skipping\n");
           continue;
         }
@@ -860,7 +859,7 @@ void GrandCentralTapsPass::runOnOperation() {
         // Concatenate the prefix into a proper full hierarchical name.
         addSymbol(
             FlatSymbolRefAttr::get(SymbolTable::getSymbolName(rootModule)));
-        for (auto inst : shortestPrefix.getValue())
+        for (auto inst : *shortestPrefix)
           addSymbol(getInnerRefTo(inst));
 
         if (port.target.getOp()) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1663,8 +1663,8 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
       instanceGraph->replaceInstance(instOp, newInstOp);
       instOp->erase();
       instOp = newInstOp;
-    } else if (domain.existingPort.hasValue()) {
-      auto idx = domain.existingPort.getValue();
+    } else if (domain.existingPort.has_value()) {
+      auto idx = domain.existingPort.value();
       instReset = instOp.getResult(idx);
       LLVM_DEBUG(llvm::dbgs() << "  - Using result #" << idx << " as reset\n");
     }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -157,12 +157,12 @@ struct IdExpr : public ExprBase<IdExpr, Expr::Kind::Id> {
 /// A known constant value.
 struct KnownExpr : public ExprBase<KnownExpr, Expr::Kind::Known> {
   KnownExpr(int32_t value) : ExprBase() { solution = value; }
-  void print(llvm::raw_ostream &os) const { os << solution.getValue(); }
+  void print(llvm::raw_ostream &os) const { os << solution.value(); }
   bool operator==(const KnownExpr &other) const {
-    return solution.getValue() == other.solution.getValue();
+    return solution.value() == other.solution.value();
   }
   llvm::hash_code hash_value() const {
-    return llvm::hash_combine(Expr::hash_value(), solution.getValue());
+    return llvm::hash_combine(Expr::hash_value(), solution.value());
   }
 };
 
@@ -1948,7 +1948,7 @@ FIRRTLType InferenceTypeUpdate::updateType(FieldRef fieldRef, FIRRTLType type) {
   auto value = fieldRef.getValue();
   // Get the inferred width.
   Expr *expr = mapping.getExprOrNull(fieldRef);
-  if (!expr || !expr->solution.hasValue()) {
+  if (!expr || !expr->solution) {
     // It should not be possible to arrive at an uninferred width at this point.
     // In case the constraints are not resolvable, checks before the calls to
     // `updateType` must have already caught the issues and aborted the pass
@@ -1957,7 +1957,7 @@ FIRRTLType InferenceTypeUpdate::updateType(FieldRef fieldRef, FIRRTLType type) {
     mlir::emitError(value.getLoc(), "width should have been inferred");
     return type;
   }
-  int32_t solution = expr->solution.getValue();
+  int32_t solution = *expr->solution;
   assert(solution >= 0); // The solver infers variables to be 0 or greater.
   return resizeType(type, solution);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -310,10 +310,8 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
     auto elemIndex =
         fieldAccess.getInput().getType().cast<BundleType>().getElementIndex(
             field);
-    if (elemIndex.hasValue() &&
-        fieldAccess.getFieldIndex() == elemIndex.getValue()) {
+    if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
-    }
   }
   return accesses;
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -508,7 +508,7 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(MLIRContext *ctxt,
           updateAnnotationFieldID(ctxt, opAttr, field.fieldID, cache.i64ty));
       continue;
     }
-    auto fieldID = maybeFieldID.getValue();
+    auto fieldID = maybeFieldID.value();
     // Check whether the annotation falls into the range of the current field.
     if (fieldID != 0 &&
         !(fieldID >= field.fieldID &&
@@ -1064,7 +1064,7 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
     // Loop over the leaf aggregates and concat each of them to get a UInt.
     // Bitcast the fields to handle nested aggregate types.
     for (const auto &field : llvm::enumerate(fields)) {
-      auto fieldBitwidth = getBitWidth(field.value().type).getValue();
+      auto fieldBitwidth = getBitWidth(field.value().type).value();
       // Ignore zero width fields, like empty bundles.
       if (fieldBitwidth == 0)
         continue;
@@ -1091,7 +1091,7 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
     auto clone = [&](const FlatBundleFieldEntry &field,
                      ArrayAttr attrs) -> Operation * {
       // All the fields must have valid bitwidth, a requirement for BitCastOp.
-      auto fieldBits = getBitWidth(field.type).getValue();
+      auto fieldBits = getBitWidth(field.type).value();
       // If empty field, then it doesnot have any use, so replace it with an
       // invalid op, which should be trivially removed.
       if (fieldBits == 0)

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -124,7 +124,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
 
   Value getMask(ImplicitLocOpBuilder &builder, Value bundle) {
     auto bType = bundle.getType().cast<FIRRTLType>().cast<BundleType>();
-    if (bType.getElement("mask").hasValue())
+    if (bType.getElement("mask"))
       return builder.create<SubfieldOp>(bundle, "mask");
     return builder.create<SubfieldOp>(bundle, "wmask");
   }
@@ -132,9 +132,9 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
   Value getData(ImplicitLocOpBuilder &builder, Value bundle,
                 bool getWdata = false) {
     auto bType = bundle.getType().cast<FIRRTLType>().cast<BundleType>();
-    if (bType.getElement("data").hasValue())
+    if (bType.getElement("data"))
       return builder.create<SubfieldOp>(bundle, "data");
-    if (bType.getElement("rdata").hasValue() && !getWdata)
+    if (bType.getElement("rdata") && !getWdata)
       return builder.create<SubfieldOp>(bundle, "rdata");
     return builder.create<SubfieldOp>(bundle, "wdata");
   }
@@ -335,7 +335,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
           })
           .Case<IntType>([&](auto iType) {
             results.push_back({reg, input, mask});
-            return iType.getWidth().hasValue();
+            return iType.getWidth().has_value();
           })
           .Default([&](auto) { return false; });
     };

--- a/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
@@ -80,7 +80,7 @@ bool MergeConnection::peelConnect(StrictConnectOp connect) {
   // connections.
   LLVM_DEBUG(llvm::dbgs() << "Visiting " << connect << "\n");
   auto destTy = connect.getDest().getType().cast<FIRRTLType>();
-  if (!destTy.isPassive() || !firrtl::getBitWidth(destTy).hasValue())
+  if (!destTy.isPassive() || !firrtl::getBitWidth(destTy).has_value())
     return false;
 
   auto destFieldRef = getFieldRefFromValue(connect.getDest());

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -360,8 +360,7 @@ void PrefixModulesPass::renameExtModule(FExtModuleOp extModule) {
                                          StringRef prefix) {
     extModule.setName((prefix + extModule.getName()).str());
     if (auto defname = extModule.getDefname())
-      extModule->setAttr("defname",
-                         builder.getStringAttr(prefix + defname.getValue()));
+      extModule->setAttr("defname", builder.getStringAttr(prefix + *defname));
   };
 
   // Duplicate the external module if there is more than one prefix.

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -53,15 +53,15 @@ StateOp MachineOp::getInitialStateOp() {
 }
 
 StringAttr MachineOp::getArgName(size_t i) {
-  if (argNames())
-    return argNames().getValue()[i].cast<StringAttr>();
+  if (auto args = argNames())
+    return (*args)[i].cast<StringAttr>();
   else
     return StringAttr::get(getContext(), "in" + std::to_string(i));
 }
 
 StringAttr MachineOp::getResName(size_t i) {
-  if (resNames())
-    return resNames().getValue()[i].cast<StringAttr>();
+  if (auto resNameAttrs = resNames())
+    return (*resNameAttrs)[i].cast<StringAttr>();
   else
     return StringAttr::get(getContext(), "out" + std::to_string(i));
 }
@@ -138,21 +138,21 @@ LogicalResult MachineOp::verify() {
     return emitOpError("initial state '" + initialState() +
                        "' was not defined in the machine");
 
-  if (argNames() && argNames().getValue().size() != getArgumentTypes().size())
+  if (argNames() && argNames()->size() != getArgumentTypes().size())
     return emitOpError() << "number of machine arguments ("
                          << getArgumentTypes().size()
                          << ") does "
                             "not match the provided number "
                             "of argument names ("
-                         << argNames().getValue().size() << ")";
+                         << argNames()->size() << ")";
 
-  if (resNames() && resNames().getValue().size() != getResultTypes().size())
+  if (resNames() && resNames()->size() != getResultTypes().size())
     return emitOpError() << "number of machine results ("
                          << getResultTypes().size()
                          << ") does "
                             "not match the provided number "
                             "of result names ("
-                         << resNames().getValue().size() << ")";
+                         << resNames()->size() << ")";
 
   return success();
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1201,9 +1201,9 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
         diag << "failed to resolve parametric input of instantiated module";
       });
     auto operandType = getOperand(i).getType();
-    if (operandType != expectedType.getValue()) {
+    if (operandType != *expectedType) {
       return emitError([&](auto &diag) {
-        diag << "operand type #" << i << " must be " << expectedType.getValue()
+        diag << "operand type #" << i << " must be " << *expectedType
              << ", but got " << operandType;
       });
     }
@@ -1240,9 +1240,9 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
         diag << "failed to resolve parametric input of instantiated module";
       });
     auto resultType = getResult(i).getType();
-    if (resultType != expectedType.getValue())
+    if (resultType != *expectedType)
       return emitError([&](auto &diag) {
-        diag << "result type #" << i << " must be " << expectedType.getValue()
+        diag << "result type #" << i << " must be " << *expectedType
              << ", but got " << resultType;
       });
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -346,7 +346,7 @@ void EnumType::print(AsmPrinter &p) const {
 }
 
 bool EnumType::contains(mlir::StringRef field) {
-  return indexOf(field).hasValue();
+  return indexOf(field).has_value();
 }
 
 Optional<size_t> EnumType::indexOf(mlir::StringRef field) {

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1006,12 +1006,12 @@ void handshake::TerminatorOp::build(OpBuilder &builder, OperationState &result,
 LogicalResult BufferOp::verify() {
   // Verify that exactly 'size' number of initial values have been provided, if
   // an initializer list have been provided.
-  if (initValues().hasValue()) {
+  if (auto initVals = initValues()) {
     if (!isSequential())
       return emitOpError()
              << "only bufferType buffers are allowed to have initial values.";
 
-    auto nInits = initValues().getValue().size();
+    auto nInits = initVals->size();
     if (nInits != size())
       return emitOpError() << "expected " << size() << " init values but got "
                            << nInits << ".";

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -852,7 +852,7 @@ ParseResult llhd::RegOp::parse(OpAsmParser &parser, OperationState &result) {
     if (!attrOptional)
       return parser.emitError(parser.getCurrentLocation(),
                               "invalid string attribute");
-    modesArray.push_back(static_cast<int64_t>(attrOptional.getValue()));
+    modesArray.push_back(static_cast<int64_t>(*attrOptional));
     if (parser.parseOperand(trigger))
       return failure();
     if (parser.parseKeyword("after") || parser.parseOperand(delay))
@@ -919,8 +919,8 @@ void llhd::RegOp::print(OpAsmPrinter &printer) {
       return;
     }
     printer << ", (" << getValues()[i] << ", \""
-            << llhd::stringifyRegMode(mode.getValue()) << "\" "
-            << getTriggers()[i] << " after " << getDelays()[i];
+            << llhd::stringifyRegMode(*mode) << "\" " << getTriggers()[i]
+            << " after " << getDelays()[i];
     if (hasGate(i))
       printer << " if " << getGateAt(i);
     printer << " : " << getValues()[i].getType() << ")";

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -363,7 +363,7 @@ void PlacementDB::walkPlacements(
   // right data structure.
 
   auto maybeSort = [](auto &container, auto direction) {
-    if (!direction.hasValue())
+    if (!direction.has_value())
       return;
     if (*direction == Direction::NONE)
       return;

--- a/lib/Dialect/Moore/MooreTypes.cpp
+++ b/lib/Dialect/Moore/MooreTypes.cpp
@@ -476,9 +476,9 @@ Optional<IntType::Kind> IntType::getKindFromDomainAndSize(Domain domain,
 }
 
 IntType IntType::get(MLIRContext *context, Kind kind, Optional<Sign> sign) {
-  return Base::get(
-      context, detail::IntTypeStorage::pack(
-                   kind, sign.value_or(getDefaultSign(kind)), sign.hasValue()));
+  return Base::get(context, detail::IntTypeStorage::pack(
+                                kind, sign.value_or(getDefaultSign(kind)),
+                                sign.has_value()));
 }
 
 IntType::Kind IntType::getKind() const { return getImpl()->kind; }
@@ -1121,7 +1121,7 @@ PackedStructType PackedStructType::get(StructKind kind,
          "packed struct members must be packed");
   return Base::get(loc.getContext(),
                    detail::StructTypeStorage::pack(
-                       kind, sign.value_or(Sign::Unsigned), sign.hasValue()),
+                       kind, sign.value_or(Sign::Unsigned), sign.has_value()),
                    members, name, loc);
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -504,9 +504,9 @@ static ParseResult parseEventList(
   if (!p.parseOptionalKeyword(&keyword)) {
     while (1) {
       auto kind = symbolizeEventControl(keyword);
-      if (!kind.hasValue())
+      if (!kind.has_value())
         return p.emitError(loc, "expected 'posedge', 'negedge', or 'edge'");
-      auto eventEnum = static_cast<int32_t>(kind.getValue());
+      auto eventEnum = static_cast<int32_t>(*kind);
       events.push_back(p.getBuilder().getI32IntegerAttr(eventEnum));
 
       clocksOperands.push_back({});
@@ -736,7 +736,7 @@ ParseResult CaseOp::parse(OpAsmParser &parser, OperationState &result) {
   StringRef keyword;
   if (!parser.parseOptionalKeyword(&keyword, {"case", "casex", "casez"})) {
     auto kind = symbolizeCaseStmtType(keyword);
-    auto caseEnum = static_cast<int32_t>(kind.getValue());
+    auto caseEnum = static_cast<int32_t>(kind.value());
     result.addAttribute("caseStyle", builder.getI32IntegerAttr(caseEnum));
   }
 
@@ -746,7 +746,7 @@ ParseResult CaseOp::parse(OpAsmParser &parser, OperationState &result) {
     auto kind = symbolizeValidationQualifierTypeEnum(keyword);
     result.addAttribute("validationQualifier",
                         ValidationQualifierTypeEnumAttr::get(
-                            builder.getContext(), kind.getValue()));
+                            builder.getContext(), kind.value()));
   }
 
   if (parser.parseOperand(condOperand) || parser.parseColonType(condType) ||
@@ -1475,7 +1475,7 @@ static Op findInstanceSymbolInBlock(StringAttr name, Block *body) {
   for (auto &op : llvm::reverse(body->getOperations())) {
     if (auto instance = dyn_cast<Op>(op)) {
       if (instance.getInnerSym() &&
-          instance.getInnerSym().getValue() == name.getValue())
+          instance.getInnerSym().value() == name.getValue())
         return instance;
     }
 

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -33,8 +33,8 @@ using namespace circt;
 struct HWExportModuleHierarchyPass
     : public sv::HWExportModuleHierarchyBase<HWExportModuleHierarchyPass> {
   HWExportModuleHierarchyPass(Optional<std::string> directory) {
-    if (directory.hasValue())
-      directoryName = directory.getValue();
+    if (directory)
+      directoryName = *directory;
   }
   void runOnOperation() override;
 };
@@ -114,7 +114,7 @@ void HWExportModuleHierarchyPass::runOnOperation() {
         return;
       }
 
-      extractHierarchyFromTop(op, symbolTable.getValue(), outputFile->os());
+      extractHierarchyFromTop(op, *symbolTable, outputFile->os());
 
       outputFile->keep();
     }

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -339,10 +339,10 @@ void SVExtractTestCodeImplPass::runOnOperation() {
     // verifications. See FIRParserAsserts for more details.
     if (auto error = dyn_cast<ErrorOp>(op)) {
       if (auto message = error.getMessage())
-        return message.getValue().startswith("assert:") ||
-               message.getValue().startswith("Assertion failed") ||
-               message.getValue().startswith("assertNotX:") ||
-               message.getValue().contains("[verif-library-assert]");
+        return message->startswith("assert:") ||
+               message->startswith("Assertion failed") ||
+               message->startswith("assertNotX:") ||
+               message->contains("[verif-library-assert]");
       return false;
     }
 

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -98,10 +98,10 @@ ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void CompRegOp::print(::mlir::OpAsmPrinter &p) {
   SmallVector<StringRef> elidedAttrs;
-  if (getSymName().hasValue()) {
+  if (auto sym = getSymName()) {
     elidedAttrs.push_back("sym_name");
     p << ' ' << "sym ";
-    p.printSymbolName(*getSymName());
+    p.printSymbolName(*sym);
   }
 
   p << ' ' << getInput() << ", " << getClk();

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -54,7 +54,7 @@ public:
 
     // If the seq::CompRegOp has an inner_sym attribute, set this for the
     // sv::RegOp inner_sym attribute.
-    if (reg.getSymName().hasValue())
+    if (reg.getSymName().has_value())
       svReg.setInnerSymAttr(reg.getSymNameAttr());
 
     if (auto attribute = circt::sv::getSVAttributes(reg))

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -494,7 +494,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (outputFormat == OutputParseOnly) {
     mlir::ModuleOp theModule = module.release();
     auto outputTimer = ts.nest("Print .mlir output");
-    theModule->print(outputFile.getValue()->os());
+    theModule->print(outputFile.value()->os());
     return success();
   }
 
@@ -703,7 +703,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     default:
       llvm_unreachable("can't reach this");
     case OutputVerilog:
-      exportPm.addPass(createExportVerilogPass(outputFile.getValue()->os()));
+      exportPm.addPass(createExportVerilogPass(outputFile.value()->os()));
       break;
     case OutputSplitVerilog:
       exportPm.addPass(createExportSplitVerilogPass(outputFilename));
@@ -730,7 +730,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (outputFormat == OutputIRFir || outputFormat == OutputIRHW ||
       outputFormat == OutputIRSV || outputFormat == OutputIRVerilog) {
     auto outputTimer = ts.nest("Print .mlir output");
-    module->print(outputFile.getValue()->os());
+    module->print(outputFile.value()->os());
   }
 
   // If requested, print the final MLIR into mlirOutFile.
@@ -838,7 +838,7 @@ static LogicalResult executeFirtool(MLIRContext &context) {
   if (outputFormat != OutputSplitVerilog) {
     // Create an output file.
     outputFile.emplace(openOutputFile(outputFilename, &errorMessage));
-    if (!outputFile.getValue()) {
+    if (!outputFile.value()) {
       llvm::errs() << errorMessage << "\n";
       return failure();
     }
@@ -866,8 +866,8 @@ static LogicalResult executeFirtool(MLIRContext &context) {
     return failure();
 
   // If the result succeeded and we're emitting a file, close it.
-  if (outputFile.hasValue())
-    outputFile.getValue()->keep();
+  if (outputFile.has_value())
+    outputFile.value()->keep();
 
   return success();
 }

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -790,7 +790,7 @@ HandshakeExecuter::HandshakeExecuter(
 
   // Initialize the value map for buffers with initial values.
   for (auto bufferOp : func.getOps<handshake::BufferOp>()) {
-    if (bufferOp.initValues().hasValue()) {
+    if (bufferOp.initValues().has_value()) {
       auto initValues = bufferOp.getInitValues();
       assert(initValues.size() == 1 &&
              "Handshake-runner only supports buffer initialization with a "


### PR DESCRIPTION
Primarily:

getValue -> value
hasValue -> has_value

Value accesses not dominated by a presence check use 'value'.
(only use 'operator *' when clearly dominated by check)

"operator bool" and "operator *" used only when meaning was clear
(if variable looks like an integer, like getBitWidth(),
don't use operator bool unless the code already does so;
if returning result of a presence check prefer has_value, etc.)

Few places are slightly simplified, such as: using value_or,
avoiding calling same method for presence check and for the value,
and X.getValue().y -> X->y.

Fixes #3552.
(LLVM will be deprecating the old method names)