### PR TITLE
[PyCDE] Fix liveOperations bug

### DIFF
--- a/frontends/PyCDE/src/pycde/behavioral.py
+++ b/frontends/PyCDE/src/pycde/behavioral.py
@@ -117,7 +117,8 @@ class _IfBlock:
       # Only operate on Values.
       if not isinstance(value, Value):
         continue
-      # If the value was in the original scope and it hasn't changed, don't touch it.
+      # If the value was in the original scope and it hasn't changed, don't
+      # touch it.
       if varname in self._scope and self._scope[varname] is value:
         continue
 
@@ -153,7 +154,8 @@ class _IfBlock:
     ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(s), ctypes.c_int(1))
 
 
-Else = _IfBlock(False)
+def Else():
+  return _IfBlock(False)
 
 
 def EndIf():

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -181,6 +181,7 @@ class System:
     # browsing.
     gen_left = len(self._generate_queue)
     if gen_left == 0:
+      self._op_cache.release_ops()
       pm = mlir.passmanager.PassManager.parse("msft-discover-appids")
       pm.run(self.mod)
     return
@@ -206,9 +207,9 @@ class System:
     # By now, we have all the types defined so we can go through and output the
     # typedefs delcarations.
     types.declare_types(self.mod)
-    self._op_cache.release_ops()
 
     pm = mlir.passmanager.PassManager.parse(self._passes(partition))
+    self._op_cache.release_ops()
     pm.run(self.mod)
     self.passed = True
 

--- a/frontends/PyCDE/test/behavioral.py
+++ b/frontends/PyCDE/test/behavioral.py
@@ -9,12 +9,13 @@ from pycde.testing import unittestmodule
 # CHECK:         %1 = comb.mux %cond2, %a, %b {sv.namehint = "x"} : ui8
 # CHECK:         %2 = hwarith.mul %a, %1 {sv.namehint = "v_thenvalue"} : (ui8, ui8) -> ui16
 # CHECK:         %3 = hwarith.mul %2, %b {sv.namehint = "u_thenvalue"} : (ui16, ui8) -> ui24
-# CHECK:         %4 = hwarith.cast %b {sv.namehint = "v_elsevalue"} : (ui8) -> ui16
-# CHECK:         %5 = hwarith.mul %4, %a {sv.namehint = "u_elsevalue"} : (ui16, ui8) -> ui24
-# CHECK:         %6 = comb.mux %cond, %2, %4 {sv.namehint = "v"} : ui16
-# CHECK:         %7 = comb.mux %cond, %3, %5 {sv.namehint = "u"} : ui24
-# CHECK:         %8 = hwarith.add %6, %0 {sv.namehint = "v_plus_a_mul_b"} : (ui16, ui16) -> ui17
-# CHECK:         msft.output %8, %7 : ui17, ui24
+# CHECK:         %4 = comb.mux %cond2, %a, %b {sv.namehint = "p"} : ui8
+# CHECK:         %5 = hwarith.mul %b, %4 {sv.namehint = "v_elsevalue"} : (ui8, ui8) -> ui16
+# CHECK:         %6 = hwarith.mul %5, %a {sv.namehint = "u_elsevalue"} : (ui16, ui8) -> ui24
+# CHECK:         %7 = comb.mux %cond, %2, %5 {sv.namehint = "v"} : ui16
+# CHECK:         %8 = comb.mux %cond, %3, %6 {sv.namehint = "u"} : ui24
+# CHECK:         %9 = hwarith.add %7, %0 {sv.namehint = "v_plus_a_mul_b"} : (ui16, ui16) -> ui17
+# CHECK:         msft.output %9, %8 : ui17, ui24
 
 
 @unittestmodule()
@@ -39,7 +40,12 @@ class IfNestedTest:
       v = ports.a * x
       u = v * ports.b
     with Else():
-      v = ports.b.as_uint(16)
+      with If(ports.cond2):
+        p = ports.a
+      with Else():
+        p = ports.b
+      EndIf()
+      v = ports.b * p
       u = v * ports.a
     EndIf()
 

--- a/frontends/PyCDE/test/behavioral.py
+++ b/frontends/PyCDE/test/behavioral.py
@@ -33,12 +33,12 @@ class IfNestedTest:
     with If(ports.cond):
       with If(ports.cond2):
         x = ports.a
-      with Else:
+      with Else():
         x = ports.b
       EndIf()
       v = ports.a * x
       u = v * ports.b
-    with Else:
+    with Else():
       v = ports.b.as_uint(16)
       u = v * ports.a
     EndIf()


### PR DESCRIPTION
The `Else` global object was holding on to refs after __exit__. This
shouldn't have been a global object reference to begin with.

Fixes #3660 .