### PR TITLE
[FIRRTL] Organize all existing types under FIRRTLBaseType.

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -64,11 +64,11 @@ def CMemoryType : TypeDef<CHIRRTLDialect, "CMemory"> {
     ```
   }];
 
-  let parameters = (ins "firrtl::FIRRTLType":$elementType,
+  let parameters = (ins "firrtl::FIRRTLBaseType":$elementType,
                         "uint64_t":$numElements);
 
   let builders = [
-    TypeBuilderWithInferredContext<(ins "firrtl::FIRRTLType":$elementType,
+    TypeBuilderWithInferredContext<(ins "firrtl::FIRRTLBaseType":$elementType,
                                         "uint64_t":$numElements), [{
       return $_get(elementType.getContext(), elementType, numElements);
     }]>
@@ -116,7 +116,7 @@ def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName, FNamableOp]> {
   let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind)
                          custom<CombMemOp>(attr-dict) `:` qualified(type($result))}];
   let builders = [
-    OpBuilder<(ins "firrtl::FIRRTLType":$elementType, "uint64_t":$numElements,
+    OpBuilder<(ins "firrtl::FIRRTLBaseType":$elementType, "uint64_t":$numElements,
                    "mlir::StringRef":$name, "firrtl::NameKindEnum":$nameKind,
                    "ArrayAttr":$annotations, CArg<"StringAttr", "StringAttr()">:$inner_sym)>
   ];
@@ -135,7 +135,7 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, FNamableOp]> {
   let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind) $ruw
                          custom<SeqMemOp>(attr-dict) `:` qualified(type($result))}];
   let builders = [
-    OpBuilder<(ins "firrtl::FIRRTLType":$elementType, "uint64_t":$numElements,
+    OpBuilder<(ins "firrtl::FIRRTLBaseType":$elementType, "uint64_t":$numElements,
                    "RUWAttr":$ruw, "mlir::StringRef":$name,
                    "firrtl::NameKindEnum":$nameKind, "ArrayAttr":$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>
@@ -160,7 +160,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
   let arguments = (ins CMemoryType:$memory, MemDirAttr:$direction,
                     StrAttr:$name, AnnotationArrayAttr:$annotations);
 
-  let results = (outs FIRRTLType:$data, CMemoryPortType:$port);
+  let results = (outs FIRRTLBaseType:$data, CMemoryPortType:$port);
 
   let assemblyFormat = [{
     $direction $memory custom<MemoryPortOp>(attr-dict) `:`

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -42,8 +42,8 @@ def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
 
 // Constraint that enforces types of known width
 def KnownWidth : Constraint<CPred<[{
-  $0.getType().isa<FIRRTLType>() &&
-    $0.getType().cast<FIRRTLType>().getBitWidthOrSentinel() >= 0
+  $0.getType().isa<FIRRTLBaseType>() &&
+    $0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel() >= 0
   }]>>;
 
 /// Constraint that matches a zero ConstantOp or SpecialConstantOp.
@@ -117,6 +117,6 @@ def RegResetWithZeroReset : Pat<
 // useful to pad another operation up to the width of the original operation.
 def GetWidthAsIntAttr : NativeCodeCall<
   "IntegerAttr::get(IntegerType::get($_builder.getContext(), 32, IntegerType::Signless), "
-                    "$0.getType().cast<FIRRTLType>().getBitWidthOrSentinel())">;
+                    "$0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel())">;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -121,7 +121,7 @@ def MemOp : ReferableDeclOp<"mem"> {
          PortAnnotationsAttr:$portAnnotations,
          OptionalAttr<InnerSymAttr>:$inner_sym,
          OptionalAttr<UI32Attr>:$groupID);
-  let results = (outs Variadic<FIRRTLType>:$results);
+  let results = (outs Variadic<FIRRTLBaseType>:$results);
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? custom<NameKind>($nameKind)
@@ -156,7 +156,7 @@ def MemOp : ReferableDeclOp<"mem"> {
     using NamedPort = std::pair<StringAttr, MemOp::PortKind>;
 
     /// Return the type of a port given the memory depth, type, and kind
-    static BundleType getTypeForPort(uint64_t depth, FIRRTLType dataType,
+    static BundleType getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
                                      PortKind portKind, size_t maskBits = 0);
 
     /// Return the name and kind of ports supported by this memory.
@@ -169,7 +169,7 @@ def MemOp : ReferableDeclOp<"mem"> {
     PortKind getPortKind(size_t resultNo);
 
     /// Return the data-type field of the memory, the type of each element.
-    FIRRTLType getDataType();
+    FIRRTLBaseType getDataType();
 
     /// Return the number of mask bits.
     size_t getMaskBits();
@@ -181,7 +181,7 @@ def MemOp : ReferableDeclOp<"mem"> {
     }
 
     /// Return the port type for the specified result number.
-    FIRRTLType getPortType(size_t resultNo);
+    FIRRTLBaseType getPortType(size_t resultNo);
 
     // Return the result for this instance that corresponds to the specified
     // port name.
@@ -220,7 +220,7 @@ def NodeOp : ReferableDeclOp<"node",
                        NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
@@ -353,7 +353,7 @@ def WireOp : ReferableDeclOp<"wire"> {
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -134,7 +134,7 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue",
   }];
 
   let arguments = (ins);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
 
   let hasFolder = 1;
   let assemblyFormat = "attr-dict `:` qualified(type($result))";
@@ -151,7 +151,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     }];
 
   let arguments = (ins BundleType:$input, I32Attr:$fieldIndex);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
 
   // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
@@ -199,8 +199,8 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
     ```
     }];
 
-  let arguments = (ins FIRRTLType:$input, I32Attr:$index);
-  let results = (outs FIRRTLType:$result);
+  let arguments = (ins FIRRTLBaseType:$input, I32Attr:$index);
+  let results = (outs FIRRTLBaseType:$result);
 
   // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
@@ -228,8 +228,8 @@ def SubaccessOp : FIRRTLExprOp<"subaccess", [
     ```
     }];
 
-  let arguments = (ins FIRRTLType:$input, UIntType:$index);
-  let results = (outs FIRRTLType:$result);
+  let arguments = (ins FIRRTLBaseType:$input, UIntType:$index);
+  let results = (outs FIRRTLBaseType:$result);
 
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` qualified(type($input)) `,` qualified(type($index))";
@@ -250,8 +250,8 @@ def MultibitMuxOp : FIRRTLExprOp<"multibit_mux"> {
     For the example above, if `%index` is 0, then the value is `%v_0`.
     }];
 
-  let arguments = (ins FIRRTLType:$index, Variadic<FIRRTLType>:$inputs);
-  let results = (outs FIRRTLType:$result);
+  let arguments = (ins FIRRTLBaseType:$index, Variadic<FIRRTLBaseType>:$inputs);
+  let results = (outs FIRRTLBaseType:$result);
   let hasCustomAssemblyFormat = 1;
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
@@ -406,8 +406,8 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
   let parseValidator = "impl::validateUnaryOpArguments";
 }
 
-def AsSIntPrimOp : UnaryPrimOp<"asSInt", FIRRTLType, SIntType>;
-def AsUIntPrimOp : UnaryPrimOp<"asUInt", FIRRTLType, UIntType>;
+def AsSIntPrimOp : UnaryPrimOp<"asSInt", FIRRTLBaseType, SIntType>;
+def AsUIntPrimOp : UnaryPrimOp<"asUInt", FIRRTLBaseType, UIntType>;
 def AsAsyncResetPrimOp
   : UnaryPrimOp<"asAsyncReset", OneBitCastableType, AsyncResetType>;
 def AsClockPrimOp : UnaryPrimOp<"asClock", OneBitCastableType, ClockType>;
@@ -555,7 +555,7 @@ def IsXVerifOp : FIRRTLExprOp<"verif_isX"> {
     constructs need to explicitly test for 'x.
     }];
 
-  let arguments = (ins FIRRTLType:$arg);
+  let arguments = (ins FIRRTLBaseType:$arg);
   let results = (outs UInt1Type:$result);
   let assemblyFormat =
     "$arg attr-dict `:` qualified(type($arg))";
@@ -583,7 +583,7 @@ def VerbatimExprOp : FIRRTLOp<"verbatim.expr",
 
   let arguments = (ins StrAttr:$text, Variadic<AnyType>:$substitutions,
                        DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
   let assemblyFormat = [{
     $text (`(` $substitutions^ `)`)?
     `:` functional-type($substitutions, $result) attr-dict
@@ -617,7 +617,7 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 
   let arguments = (ins StrAttr:$text, Variadic<AnyType>:$substitutions,
                        DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs FIRRTLBaseType:$result);
   let assemblyFormat = [{
     $text (`(` $substitutions^ `)`)?
     `:` functional-type($substitutions, $result) attr-dict
@@ -655,8 +655,8 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
     potentially different type. This op is lowered to hw::BitCastOp.
   }];
 
-  let arguments = (ins FIRRTLType:$input);
-  let results = (outs FIRRTLType:$result);
+  let arguments = (ins FIRRTLBaseType:$input);
+  let results = (outs FIRRTLBaseType:$result);
   let hasVerifier = 1;
   let hasFolder = 1;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -24,6 +24,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
 
 namespace circt {
@@ -44,23 +45,25 @@ struct PortInfo {
 
   /// Return true if this is a simple output-only port.  If you want the
   /// direction of the port, use the \p direction parameter.
-  bool isOutput() {
-    auto flags = type.getRecursiveTypeProperties();
-    return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Out;
-  }
+  bool isOutput() { return !isInOut() && direction == Direction::Out; }
 
   /// Return true if this is a simple input-only port.  If you want the
   /// direction of the port, use the \p direction parameter.
-  bool isInput() {
-    auto flags = type.getRecursiveTypeProperties();
-    return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::In;
-  }
+  bool isInput() { return !isInOut() && direction == Direction::In; }
 
   /// Return true if this is an inout port.  This will be true if the port
   /// contains either bi-directional signals or analog types.
-  bool isInOut() { return !isOutput() && !isInput(); }
+  bool isInOut() {
+    auto flags = TypeSwitch<FIRRTLType, RecursiveTypeProperties>(type)
+                     .Case<FIRRTLBaseType>([](auto base) {
+                       return base.getRecursiveTypeProperties();
+                     })
+                     .Default([](auto) {
+                       llvm_unreachable("unsupported type");
+                       return RecursiveTypeProperties{};
+                     });
+    return !flags.isPassive || flags.containsAnalog;
+  }
 
   /// Default constructors
   PortInfo(StringAttr name, FIRRTLType type, Direction dir,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -45,11 +45,11 @@ struct PortInfo {
 
   /// Return true if this is a simple output-only port.  If you want the
   /// direction of the port, use the \p direction parameter.
-  bool isOutput() { return !isInOut() && direction == Direction::Out; }
+  bool isOutput() { return direction == Direction::Out && !isInOut(); }
 
   /// Return true if this is a simple input-only port.  If you want the
   /// direction of the port, use the \p direction parameter.
-  bool isInput() { return !isInOut() && direction == Direction::In; }
+  bool isInput() { return direction == Direction::In && !isInOut(); }
 
   /// Return true if this is an inout port.  This will be true if the port
   /// contains either bi-directional signals or analog types.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -63,7 +63,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$formatString,
-                       Variadic<FIRRTLType>:$substitutions, StrAttr:$name);
+                       Variadic<FIRRTLBaseType>:$substitutions, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -199,7 +199,7 @@ def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
 def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
   let summary = "Force procedural statement";
   let description = "Maps to the corresponding `sv.force` operation.";
-  let arguments = (ins FIRRTLType:$dest, FIRRTLType:$src);
+  let arguments = (ins FIRRTLBaseType:$dest, FIRRTLBaseType:$src);
   let results = (outs);
   let assemblyFormat =
     "$dest `,` $src attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
@@ -210,7 +210,7 @@ def ProbeOp : FIRRTLOp<"probe"> {
   let description = [{
     Captures values without binding to any accidental name.
   }];
-  let arguments = (ins SymbolNameAttr:$inner_sym, Variadic<FIRRTLType>:$captured);
+  let arguments = (ins SymbolNameAttr:$inner_sym, Variadic<FIRRTLBaseType>:$captured);
   let results = (outs);
 
   let assemblyFormat = "$inner_sym attr-dict ( `,` $captured^  `:` qualified(type($captured)))?";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -30,7 +30,7 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
     ```
     }];
 
-  let arguments = (ins FIRRTLType:$dest, FIRRTLType:$src);
+  let arguments = (ins ConnectableType:$dest, ConnectableType:$src);
   let results = (outs);
 
   let assemblyFormat =

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -60,6 +60,13 @@ def BundleType : FIRRTLDialectType<CPred<"$_self.isa<BundleType>()">,
 def FVectorType : FIRRTLDialectType<CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
+def ConnectableType : FIRRTLDialectType<
+    CPred<"$_self.isa<FIRRTLBaseType>()">,
+    "a connectable type (base type)", "::circt::firrtl::FIRRTLType", [{
+    Any type that is valid for use in connect statements.
+    Currently this is any base type.
+  }]>;
+
 def SizedType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "!$_self.cast<FIRRTLBaseType>().hasUninferredWidth()">,

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -19,6 +19,10 @@ include "mlir/IR/EnumAttr.td"
 def FIRRTLType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FIRRTLType>()">,
   "FIRRTLType", "::circt::firrtl::FIRRTLType">;
 
+def FIRRTLBaseType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<FIRRTLBaseType>()">,
+  "a base type", "::circt::firrtl::FIRRTLBaseType">;
+
 def ClockType : DialectType<FIRRTLDialect, CPred<"$_self.isa<ClockType>()">,
     "clock", "::circt::firrtl::ClockType">,
   BuildableType<"ClockType::get($_builder.getContext())">;
@@ -42,8 +46,8 @@ def FVectorType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
 def SizedType : DialectType<FIRRTLDialect,
-    CPred<"$_self.isa<FIRRTLType>() && "
-          "!$_self.cast<FIRRTLType>().hasUninferredWidth()">,
+    CPred<"$_self.isa<FIRRTLBaseType>() && "
+          "!$_self.cast<FIRRTLBaseType>().hasUninferredWidth()">,
     "a sized type (contains no unifered widths)", "::circt::firrtl::FIRRTLType">;
 
 def UInt1Type : DialectType<FIRRTLDialect,
@@ -64,8 +68,8 @@ def ResetType : DialectType<FIRRTLDialect,
   BuildableType<"ResetType::get($_builder.getContext())">;
 
 def PassiveType : DialectType<FIRRTLDialect,
-  CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
-  "a passive type (contain no flips)", "::circt::firrtl::FIRRTLType">;
+  CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isPassive()">,
+  "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
@@ -74,26 +78,27 @@ def PassiveType : DialectType<FIRRTLDialect,
 def OneBitType : DialectType<FIRRTLDialect,
  CPred<"($_self.isa<IntType>() && $_self.cast<IntType>().getWidth() == 1) || "
    "($_self.isa<AnalogType>() && $_self.cast<AnalogType>().getWidth() == 1)">,
- "UInt<1>, SInt<1>, or Analog<1>", "::circt::firrtl::FIRRTLType">;
+ "UInt<1>, SInt<1>, or Analog<1>", "::circt::firrtl::FIRRTLBaseType">;
+
 
 def AnyResetType : DialectType<FIRRTLDialect,
-    CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
-    "Reset", "::circt::firrtl::FIRRTLType">;
+    CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isResetType()">,
+    "Reset", "::circt::firrtl::FIRRTLBaseType">;
 
 def AnyRegisterType : DialectType<FIRRTLDialect,
-    CPred<"$_self.isa<FIRRTLType>() && "
-          "$_self.cast<FIRRTLType>().isRegisterType()">,
+    CPred<"$_self.isa<FIRRTLBaseType>() && "
+          "$_self.cast<FIRRTLBaseType>().isRegisterType()">,
     "a passive type that does not contain analog",
-    "::circt::firrtl::FIRRTLType">;
+    "::circt::firrtl::FIRRTLBaseType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock",
-                                  "::circt::firrtl::FIRRTLType">;
+                                  "::circt::firrtl::FIRRTLBaseType">;
 
 def OneBitCastableType : AnyTypeOf<
   [OneBitType, AnyResetType, AsyncResetType, ClockType],
   "1-bit uint/sint/analog, reset, asyncreset, or clock",
-                                  "::circt::firrtl::FIRRTLType">;
+                                  "::circt::firrtl::FIRRTLBaseType">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Enum Definitions

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -16,58 +16,73 @@ include "mlir/IR/EnumAttr.td"
 // FIRRTL Types Definitions
 //===----------------------------------------------------------------------===//
 
-def FIRRTLType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FIRRTLType>()">,
-  "FIRRTLType", "::circt::firrtl::FIRRTLType">;
+class FIRRTLDialectType<Pred pred, string summary, string cpp, string desc = "">
+  : DialectType<FIRRTLDialect,pred, summary, cpp> {
+  let description = desc;
+}
 
-def FIRRTLBaseType : DialectType<FIRRTLDialect,
+def FIRRTLType : FIRRTLDialectType<CPred<"$_self.isa<FIRRTLType>()">,
+  "FIRRTLType", "::circt::firrtl::FIRRTLType", [{
+    Any FIRRTL dialect type, represented by FIRRTLType.
+  }]>;
+
+def FIRRTLBaseType : FIRRTLDialectType<
   CPred<"$_self.isa<FIRRTLBaseType>()">,
-  "a base type", "::circt::firrtl::FIRRTLBaseType">;
+  "a base type", "::circt::firrtl::FIRRTLBaseType", [{
+    A base FIRRTL type, such as a clock, integer, or wire.
 
-def ClockType : DialectType<FIRRTLDialect, CPred<"$_self.isa<ClockType>()">,
+    Base types represent circuit elements and constructs,
+    examples include ClockType, IntType, or BundleType.
+    Nearly all FIRRTL types are base types.
+
+    All base types are FIRRTLType's, and inherit from FIRRTLBaseType.
+  }]>;
+
+def ClockType : FIRRTLDialectType<CPred<"$_self.isa<ClockType>()">,
     "clock", "::circt::firrtl::ClockType">,
   BuildableType<"ClockType::get($_builder.getContext())">;
 
-def IntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<IntType>()">,
+def IntType : FIRRTLDialectType<CPred<"$_self.isa<IntType>()">,
  "sint or uint type", "::circt::firrtl::IntType">;
 
-def SIntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<SIntType>()">,
+def SIntType : FIRRTLDialectType<CPred<"$_self.isa<SIntType>()">,
  "sint type", "::circt::firrtl::SIntType">;
 
-def UIntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<UIntType>()">,
+def UIntType : FIRRTLDialectType<CPred<"$_self.isa<UIntType>()">,
  "uint type", "::circt::firrtl::UIntType">;
 
-def AnalogType : DialectType<FIRRTLDialect, CPred<"$_self.isa<AnalogType>()">,
+def AnalogType : FIRRTLDialectType<CPred<"$_self.isa<AnalogType>()">,
  "analog type", "::circt::firrtl::AnalogType">;
 
-def BundleType : DialectType<FIRRTLDialect, CPred<"$_self.isa<BundleType>()">,
+def BundleType : FIRRTLDialectType<CPred<"$_self.isa<BundleType>()">,
  "BundleType", "::circt::firrtl::BundleType">;
 
-def FVectorType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FVectorType>()">,
+def FVectorType : FIRRTLDialectType<CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
-def SizedType : DialectType<FIRRTLDialect,
+def SizedType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "!$_self.cast<FIRRTLBaseType>().hasUninferredWidth()">,
     "a sized type (contains no unifered widths)", "::circt::firrtl::FIRRTLType">;
 
-def UInt1Type : DialectType<FIRRTLDialect,
+def UInt1Type : FIRRTLDialectType<
     CPred<"$_self.isa<UIntType>() && "
           "($_self.cast<UIntType>().getWidth() == 1 ||"
           " $_self.cast<UIntType>().getWidth() == None)">,
     "UInt<1> or UInt", "::circt::firrtl::UIntType">,
   BuildableType<"UIntType::get($_builder.getContext(), 1)">;
 
-def AsyncResetType : DialectType<FIRRTLDialect,
+def AsyncResetType : FIRRTLDialectType<
     CPred<"$_self.isa<AsyncResetType>()">,
     "AsyncReset", "::circt::firrtl::AsyncResetType">,
   BuildableType<"AsyncResetType::get($_builder.getContext())">;
 
-def ResetType : DialectType<FIRRTLDialect,
+def ResetType : FIRRTLDialectType<
     CPred<"$_self.isa<ResetType>()">,
     "Reset", "::circt::firrtl::ResetType">,
   BuildableType<"ResetType::get($_builder.getContext())">;
 
-def PassiveType : DialectType<FIRRTLDialect,
+def PassiveType : FIRRTLDialectType<
   CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isPassive()">,
   "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
@@ -75,17 +90,17 @@ def PassiveType : DialectType<FIRRTLDialect,
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//
 
-def OneBitType : DialectType<FIRRTLDialect,
+def OneBitType : FIRRTLDialectType<
  CPred<"($_self.isa<IntType>() && $_self.cast<IntType>().getWidth() == 1) || "
    "($_self.isa<AnalogType>() && $_self.cast<AnalogType>().getWidth() == 1)">,
  "UInt<1>, SInt<1>, or Analog<1>", "::circt::firrtl::FIRRTLBaseType">;
 
 
-def AnyResetType : DialectType<FIRRTLDialect,
+def AnyResetType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isResetType()">,
     "Reset", "::circt::firrtl::FIRRTLBaseType">;
 
-def AnyRegisterType : DialectType<FIRRTLDialect,
+def AnyRegisterType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "$_self.cast<FIRRTLBaseType>().isRegisterType()">,
     "a passive type that does not contain analog",

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2636,8 +2636,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     auto fieldName = storeIdentifier(i);
     auto memBundle = memOp.getPortNamed(fieldName);
-    auto memType =
-        memBundle.getType().cast<FIRRTLBaseType>().cast<BundleType>();
+    auto memType = memBundle.getType().cast<BundleType>();
 
     // Get the clock out of the bundle and connect it.
     auto memClock = rewriter.create<SubfieldOp>(

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -108,8 +108,8 @@ static FIRRTLBaseType portInfosToBundleType(MLIRContext *ctx,
 static FIRRTLBaseType getBundleType(Type type) {
   // If the input is already converted to a bundle type elsewhere, itself will
   // be returned after cast.
-  if (auto firrtlBaseType = type.dyn_cast<FIRRTLBaseType>())
-    return firrtlBaseType;
+  if (auto bundleType = type.dyn_cast<BundleType>())
+    return bundleType;
 
   MLIRContext *context = type.getContext();
   using BundleElement = BundleType::BundleElement;

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -55,10 +55,10 @@ static size_t getNumIndexBits(uint64_t numValues) {
 /// Get the corresponding FIRRTL type given the built-in data type. Current
 /// supported data types are integer (signed, unsigned, and signless), index,
 /// and none.
-static FIRRTLType getFIRRTLType(Type type) {
+static FIRRTLBaseType getFIRRTLType(Type type) {
   MLIRContext *context = type.getContext();
-  return TypeSwitch<Type, FIRRTLType>(type)
-      .Case<IntegerType>([&](IntegerType integerType) -> FIRRTLType {
+  return TypeSwitch<Type, FIRRTLBaseType>(type)
+      .Case<IntegerType>([&](IntegerType integerType) -> FIRRTLBaseType {
         unsigned width = integerType.getWidth();
 
         switch (integerType.getSignedness()) {
@@ -73,12 +73,12 @@ static FIRRTLType getFIRRTLType(Type type) {
         }
         llvm_unreachable("invalid IntegerType");
       })
-      .Case<IndexType>([&](IndexType indexType) -> FIRRTLType {
+      .Case<IndexType>([&](IndexType indexType) -> FIRRTLBaseType {
         // Currently we consider index type as 64-bits unsigned integer.
         unsigned width = indexType.kInternalStorageBitWidth;
         return UIntType::get(context, width);
       })
-      .Case<TupleType>([&](TupleType tupleType) -> FIRRTLType {
+      .Case<TupleType>([&](TupleType tupleType) -> FIRRTLBaseType {
         using BundleElement = BundleType::BundleElement;
         llvm::SmallVector<BundleElement> elements;
         for (auto it : llvm::enumerate(tupleType.getTypes()))
@@ -87,28 +87,29 @@ static FIRRTLType getFIRRTLType(Type type) {
               false, getFIRRTLType(it.value())));
         return BundleType::get(elements, context);
       })
-      .Default([&](Type) { return FIRRTLType(); });
+      .Default([&](Type) { return FIRRTLBaseType(); });
 }
 
 /// Creates a new FIRRTL bundle type based on an array of port infos.
-static FIRRTLType portInfosToBundleType(MLIRContext *ctx,
-                                        ArrayRef<PortInfo> ports) {
+static FIRRTLBaseType portInfosToBundleType(MLIRContext *ctx,
+                                            ArrayRef<PortInfo> ports) {
   using BundleElement = BundleType::BundleElement;
   llvm::SmallVector<BundleElement, 4> elements;
   for (auto &port : ports) {
-    elements.push_back(
-        BundleElement(port.name, port.direction == Direction::Out, port.type));
+    elements.push_back(BundleElement(port.name,
+                                     port.direction == Direction::Out,
+                                     port.type.cast<FIRRTLBaseType>()));
   }
   return BundleType::get(elements, ctx);
 }
 
 /// Return a FIRRTL bundle type (with data, valid, and ready subfields) given a
 /// standard data type.
-static FIRRTLType getBundleType(Type type) {
+static FIRRTLBaseType getBundleType(Type type) {
   // If the input is already converted to a bundle type elsewhere, itself will
   // be returned after cast.
-  if (auto firrtlType = type.dyn_cast<FIRRTLType>())
-    return firrtlType;
+  if (auto firrtlBaseType = type.dyn_cast<FIRRTLBaseType>())
+    return firrtlBaseType;
 
   MLIRContext *context = type.getContext();
   using BundleElement = BundleType::BundleElement;
@@ -226,8 +227,8 @@ getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op) {
 /// Returns the bundle type associated with an external memory (memref
 /// input argument). The bundle type is deduced from the handshake.extmemory
 /// operator which references the memref input argument.
-static FIRRTLType getMemrefBundleType(ConversionPatternRewriter &rewriter,
-                                      Value blockArg, bool flip) {
+static FIRRTLBaseType getMemrefBundleType(ConversionPatternRewriter &rewriter,
+                                          Value blockArg, bool flip) {
   assert(blockArg.getType().isa<MemRefType>() &&
          "expected blockArg to be a memref");
 
@@ -253,7 +254,7 @@ static FIRRTLType getMemrefBundleType(ConversionPatternRewriter &rewriter,
   return portInfosToBundleType(rewriter.getContext(), extmemPortInfo);
 }
 
-static Value createConstantOp(FIRRTLType opType, APInt value,
+static Value createConstantOp(FIRRTLBaseType opType, APInt value,
                               Location insertLoc, OpBuilder &builder) {
   assert(opType.isa<IntType>() && "can only create constants from IntTypes");
   if (auto intOpType = opType.dyn_cast<firrtl::IntType>()) {
@@ -268,7 +269,7 @@ static Value createConstantOp(FIRRTLType opType, APInt value,
 
 /// Creates a Value that has an assigned zero value. For bundles, this
 /// corresponds to assigning zero to each element recursively.
-static Value createZeroDataConst(FIRRTLType dataType, Location insertLoc,
+static Value createZeroDataConst(FIRRTLBaseType dataType, Location insertLoc,
                                  OpBuilder &builder) {
   return TypeSwitch<Type, Value>(dataType)
       .Case<IntType>([&](auto dataType) {
@@ -525,7 +526,7 @@ static Value createOneHotMuxTree(ArrayRef<Value> inputs, Value select,
          "one-hot select can't mux inputs");
 
   // Start the mux tree with zero value.
-  auto inputType = inputs[0].getType().cast<FIRRTLType>();
+  auto inputType = inputs[0].getType().cast<FIRRTLBaseType>();
   auto inputWidth = inputType.getBitWidthOrSentinel();
   auto muxValue =
       createConstantOp(inputType, APInt(inputWidth, 0), insertLoc, rewriter);
@@ -639,7 +640,7 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
   // Add all inputs of funcOp.
   for (auto &arg : llvm::enumerate(funcOp.getArguments())) {
     auto portName = funcOp.getArgName(arg.index());
-    FIRRTLType bundlePortType;
+    FIRRTLBaseType bundlePortType;
     if (arg.value().getType().isa<MemRefType>())
       bundlePortType =
           getMemrefBundleType(rewriter, arg.value(), /*flip=*/true);
@@ -769,7 +770,7 @@ static ValueVectorList extractSubfields(FModuleOp subModuleOp,
   ValueVectorList portList;
   for (auto &arg : subModuleOp.getArguments()) {
     ValueVector subfields;
-    auto type = arg.getType().cast<FIRRTLType>();
+    auto type = arg.getType().cast<FIRRTLBaseType>();
     if (auto bundleType = type.dyn_cast<BundleType>()) {
       // Extract all subfields of all bundle ports.
       for (size_t i = 0, e = bundleType.getNumElements(); i < e; ++i) {
@@ -948,8 +949,9 @@ bool StdExprBuilder::visitStdExpr(arith::TruncIOp op) {
 }
 
 bool StdExprBuilder::visitStdExpr(arith::IndexCastOp op) {
-  FIRRTLType sourceType = getFIRRTLType(getOperandDataType(op.getOperand()));
-  FIRRTLType targetType = getFIRRTLType(getOperandDataType(op.getResult()));
+  FIRRTLBaseType sourceType =
+      getFIRRTLType(getOperandDataType(op.getOperand()));
+  FIRRTLBaseType targetType = getFIRRTLType(getOperandDataType(op.getResult()));
   unsigned targetBits = targetType.getBitWidthOrSentinel();
   unsigned sourceBits = sourceType.getBitWidthOrSentinel();
   return (targetBits < sourceBits ? buildTruncateOp(targetBits)
@@ -981,11 +983,11 @@ void StdExprBuilder::buildBinaryLogic() {
 
   // Carry out the binary operation.
   Value resultDataOp = rewriter.create<OpType>(insertLoc, arg0Data, arg1Data);
-  auto resultTy = resultDataOp.getType().cast<FIRRTLType>();
+  auto resultTy = resultDataOp.getType().cast<FIRRTLBaseType>();
 
   // Truncate the result type down if needed.
   auto resultWidth = resultData.getType()
-                         .cast<FIRRTLType>()
+                         .cast<FIRRTLBaseType>()
                          .getPassiveType()
                          .getBitWidthOrSentinel();
 
@@ -1091,7 +1093,7 @@ bool HandshakeBuilder::visitHandshake(SinkOp op) {
   Value argReady = argSubfields[1];
 
   // A Sink operation is always ready to accept tokens.
-  auto signalType = argValid.getType().cast<FIRRTLType>();
+  auto signalType = argValid.getType().cast<FIRRTLBaseType>();
   Value highSignal =
       createConstantOp(signalType, APInt(1, 1), insertLoc, rewriter);
   rewriter.create<ConnectOp>(insertLoc, argReady, highSignal);
@@ -1116,7 +1118,7 @@ bool HandshakeBuilder::visitHandshake(SourceOp op) {
   Value argReady = argSubfields[1];
 
   // A Source operation is always ready to provide tokens.
-  auto signalType = argValid.getType().cast<FIRRTLType>();
+  auto signalType = argValid.getType().cast<FIRRTLBaseType>();
   Value highSignal =
       createConstantOp(signalType, APInt(1, 1), insertLoc, rewriter);
   rewriter.create<ConnectOp>(insertLoc, argValid, highSignal);
@@ -1257,7 +1259,7 @@ bool HandshakeBuilder::visitHandshake(MuxOp op) {
   // width used to index into the decoder.
   size_t bitsNeeded = getNumIndexBits(argValid.size());
   size_t selectBits =
-      selectData.getType().cast<FIRRTLType>().getBitWidthOrSentinel();
+      selectData.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel();
 
   if (selectBits > bitsNeeded) {
     auto tailAmount = selectBits - bitsNeeded;
@@ -1849,7 +1851,7 @@ bool HandshakeBuilder::visitHandshake(handshake::ConstantOp op) {
   Value resultReady = resultSubfields[1];
   Value resultData = resultSubfields[2];
 
-  auto constantType = resultData.getType().cast<FIRRTLType>();
+  auto constantType = resultData.getType().cast<FIRRTLBaseType>();
   auto constantValue = op->getAttrOfType<IntegerAttr>("value").getValue();
 
   rewriter.create<ConnectOp>(insertLoc, resultValid, controlValid);
@@ -1904,7 +1906,7 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
 
   // Add same logic for the data path if necessary.
   if (predData) {
-    auto dataType = predData.getType().cast<FIRRTLType>();
+    auto dataType = predData.getType().cast<FIRRTLBaseType>();
     auto ctrlDataRegWire =
         rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire");
 
@@ -1953,7 +1955,7 @@ void HandshakeBuilder::buildDataBufferLogic(Value predValid, Value validReg,
 
   // If data is not nullptr, create data logic.
   if (predData && dataReg) {
-    auto dataType = predData.getType().cast<FIRRTLType>();
+    auto dataType = predData.getType().cast<FIRRTLBaseType>();
 
     // Create a mux that drives the date register.
     auto dataRegMux = rewriter.create<MuxPrimOp>(
@@ -1978,7 +1980,7 @@ static void connectSrcToAllElements(ImplicitLocOpBuilder &builder, Value dest,
 
 FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
                          unsigned depth, bool isControl,
-                         FIRRTLType dataType = FIRRTLType()) {
+                         FIRRTLBaseType dataType = FIRRTLBaseType()) {
   ImplicitLocOpBuilder builder(circuit.getLoc(), circuit.getContext());
   SmallVector<PortInfo> ports;
   auto bitType = UIntType::get(builder.getContext(), 1);
@@ -2041,7 +2043,7 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
   /// Returns a constant value 'value' width a width equal to that of
   /// 'refValue'.
   auto getConstantOfEqWidth = [&](uint64_t value, Value refValue) {
-    FIRRTLType type = refValue.getType().cast<FIRRTLType>();
+    FIRRTLBaseType type = refValue.getType().cast<FIRRTLBaseType>();
     return createConstantOp(type, APInt(type.getBitWidthOrSentinel(), value),
                             loc, builder);
   };
@@ -2065,9 +2067,9 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
       builder.create<RegResetOp>(depthType, clk, rst, zeroConst, "count_reg");
 
   // Function for truncating results to a given types' width.
-  auto trunc = [&](Value v, FIRRTLType toType) {
+  auto trunc = [&](Value v, FIRRTLBaseType toType) {
     unsigned truncBits =
-        v.getType().cast<FIRRTLType>().getBitWidthOrSentinel() -
+        v.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel() -
         toType.getBitWidthOrSentinel();
     return builder.create<TailPrimOp>(v, truncBits);
   };
@@ -2119,10 +2121,11 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
 
     // Extract the port bundles.
     auto readBundle = memOp.getPortNamed("read");
-    auto readType = readBundle.getType().cast<FIRRTLType>().cast<BundleType>();
+    auto readType =
+        readBundle.getType().cast<FIRRTLBaseType>().cast<BundleType>();
     auto writeBundle = memOp.getPortNamed("write");
     auto writeType =
-        writeBundle.getType().cast<FIRRTLType>().cast<BundleType>();
+        writeBundle.getType().cast<FIRRTLBaseType>().cast<BundleType>();
 
     // Get the clock out of the bundle and connect them.
     auto readClock = builder.create<SubfieldOp>(
@@ -2217,10 +2220,10 @@ bool HandshakeBuilder::buildFIFOBufferLogic(int64_t numStage,
   auto inputValid = inputSubfields[0];
   auto inputReady = inputSubfields[1];
   Value inputData = nullptr;
-  FIRRTLType dataType = nullptr;
+  FIRRTLBaseType dataType = nullptr;
   if (!isControl) {
     inputData = inputSubfields[2];
-    dataType = inputData.getType().cast<FIRRTLType>();
+    dataType = inputData.getType().cast<FIRRTLBaseType>();
   }
 
   auto outputSubfields = *output;
@@ -2332,7 +2335,7 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
   auto trueConst = createConstantOp(bitType, APInt(1, 1), insertLoc, rewriter);
 
   // Create useful value and type for data signal.
-  FIRRTLType dataType = nullptr;
+  FIRRTLBaseType dataType = nullptr;
   Value zeroDataConst = nullptr;
 
   // Temporary values for storing the valid, ready, and data signals in the
@@ -2345,7 +2348,7 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
   if (!isControl) {
     auto inputData = inputSubfields[2];
 
-    dataType = inputData.getType().cast<FIRRTLType>();
+    dataType = inputData.getType().cast<FIRRTLBaseType>();
 
     zeroDataConst = createZeroDataConst(dataType, insertLoc, rewriter);
     currentData = inputData;
@@ -2501,7 +2504,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
   uint32_t writeLatency = 1;
   RUWAttr ruw = RUWAttr::Old;
   uint64_t depth = type.getNumElements();
-  FIRRTLType dataType = getFIRRTLType(elementType);
+  FIRRTLBaseType dataType = getFIRRTLType(elementType);
   auto name = "mem" + std::to_string(op.id());
 
   // Helpers to get port identifiers.
@@ -2579,8 +2582,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Since addresses coming from Handshake are IndexType and have a hardcoded
     // 64-bit width in this pass, we may need to truncate down to the actual
     // size of the address port used by the FIRRTL memory.
-    auto memAddrType = memAddr.getType().cast<FIRRTLType>();
-    auto loadAddrType = loadAddrData.getType().cast<FIRRTLType>();
+    auto memAddrType = memAddr.getType().cast<FIRRTLBaseType>();
+    auto loadAddrType = loadAddrData.getType().cast<FIRRTLBaseType>();
     if (memAddrType != loadAddrType) {
       auto memAddrPassiveType = memAddrType.getPassiveType();
       auto tailAmount = loadAddrType.getBitWidthOrSentinel() -
@@ -2633,7 +2636,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     auto fieldName = storeIdentifier(i);
     auto memBundle = memOp.getPortNamed(fieldName);
-    auto memType = memBundle.getType().cast<FIRRTLType>().cast<BundleType>();
+    auto memType =
+        memBundle.getType().cast<FIRRTLBaseType>().cast<BundleType>();
 
     // Get the clock out of the bundle and connect it.
     auto memClock = rewriter.create<SubfieldOp>(
@@ -2648,7 +2652,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // 64-bit width in this pass, we may need to truncate down to the actual
     // size of the address port used by the FIRRTL memory.
     auto memAddrType = memAddr.getType();
-    auto storeAddrType = storeAddrData.getType().cast<FIRRTLType>();
+    auto storeAddrType = storeAddrData.getType().cast<FIRRTLBaseType>();
     if (memAddrType != storeAddrType) {
       auto memAddrPassiveType = memAddrType.getPassiveType();
       auto tailAmount = storeAddrType.getBitWidthOrSentinel() -

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -196,7 +196,7 @@ static void printCombMemOp(OpAsmPrinter &p, Operation *op,
 }
 
 void CombMemOp::build(OpBuilder &builder, OperationState &result,
-                      FIRRTLType elementType, uint64_t numElements,
+                      FIRRTLBaseType elementType, uint64_t numElements,
                       StringRef name, NameKindEnum nameKind,
                       ArrayAttr annotations, StringAttr innerSym) {
   build(builder, result,
@@ -224,8 +224,8 @@ static void printSeqMemOp(OpAsmPrinter &p, Operation *op, DictionaryAttr attr) {
 }
 
 void SeqMemOp::build(OpBuilder &builder, OperationState &result,
-                     FIRRTLType elementType, uint64_t numElements, RUWAttr ruw,
-                     StringRef name, NameKindEnum nameKind,
+                     FIRRTLBaseType elementType, uint64_t numElements,
+                     RUWAttr ruw, StringRef name, NameKindEnum nameKind,
                      ArrayAttr annotations, StringAttr innerSym) {
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), ruw,
@@ -293,9 +293,9 @@ void CMemoryType::print(AsmPrinter &printer) const {
 }
 
 Type CMemoryType::parse(AsmParser &parser) {
-  FIRRTLType elementType;
+  FIRRTLBaseType elementType;
   uint64_t numElements;
-  if (parser.parseLess() || firrtl::parseNestedType(elementType, parser) ||
+  if (parser.parseLess() || firrtl::parseNestedBaseType(elementType, parser) ||
       parser.parseComma() || parser.parseInteger(numElements) ||
       parser.parseGreater())
     return {};
@@ -303,7 +303,7 @@ Type CMemoryType::parse(AsmParser &parser) {
 }
 
 LogicalResult CMemoryType::verify(function_ref<InFlightDiagnostic()> emitError,
-                                  FIRRTLType elementType,
+                                  FIRRTLBaseType elementType,
                                   uint64_t numElements) {
   if (!elementType.isPassive()) {
     return emitError() << "behavioral memory element type must be passive";

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -245,7 +245,7 @@ static LogicalResult canonicalizePrimOp(
   // Can only operate on FIRRTL primitive operations.
   if (op->getNumResults() != 1)
     return failure();
-  auto type = op->getResult(0).getType().dyn_cast<FIRRTLType>();
+  auto type = op->getResult(0).getType().dyn_cast<FIRRTLBaseType>();
   if (!type)
     return failure();
 
@@ -280,7 +280,8 @@ static LogicalResult canonicalizePrimOp(
     resultValue = result.get<Value>();
 
   // Insert a pad if the type widths disagree.
-  if (width != resultValue.getType().cast<FIRRTLType>().getBitWidthOrSentinel())
+  if (width !=
+      resultValue.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel())
     resultValue = rewriter.create<PadPrimOp>(op->getLoc(), resultValue, width);
 
   // Insert a cast if this is a uint vs. sint or vice versa.
@@ -1078,7 +1079,7 @@ OpFoldResult BitCastOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult BitsPrimOp::fold(ArrayRef<Attribute> operands) {
-  auto inputType = getInput().getType().cast<FIRRTLType>();
+  auto inputType = getInput().getType().cast<FIRRTLBaseType>();
   // If we are extracting the entire input, then return it.
   if (inputType == getType() && getType().hasWidth())
     return getInput();
@@ -1177,7 +1178,7 @@ static LogicalResult canonicalizeMux(MuxPrimOp op, PatternRewriter &rewriter) {
 
   auto pad = [&](Value input) {
     auto inputWidth =
-        input.getType().cast<FIRRTLType>().getBitWidthOrSentinel();
+        input.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel();
     if (inputWidth < 0 || width == inputWidth)
       return input;
     return rewriter.create<PadPrimOp>(op.getLoc(), op.getType(), input, width)
@@ -1403,7 +1404,7 @@ LogicalResult MultibitMuxOp::canonicalize(MultibitMuxOp op,
 
   // TODO: Handle even when `index` doesn't have uint<1>.
   auto uintType =
-      op.getIndex().getType().cast<FIRRTLType>().dyn_cast<UIntType>();
+      op.getIndex().getType().cast<FIRRTLBaseType>().dyn_cast<UIntType>();
   if (!uintType || uintType.getBitWidthOrSentinel() != 1)
     return failure();
 
@@ -1523,9 +1524,14 @@ static LogicalResult canonicalizeIntTypeConnect(ConnectOp op,
                                                 PatternRewriter &rewriter) {
   // If a connect exists from a shorter int to a longer int, simplify
   // to an extend and strict connect.
+
+  // Base types only
+  if (!op.getOperand(0).getType().isa<FIRRTLBaseType>())
+    return failure();
+
   auto destType =
-      op.getOperand(0).getType().cast<FIRRTLType>().getPassiveType();
-  auto srcType = op.getOperand(1).getType().cast<FIRRTLType>();
+      op.getOperand(0).getType().cast<FIRRTLBaseType>().getPassiveType();
+  auto srcType = op.getOperand(1).getType().cast<FIRRTLBaseType>();
   if (destType == srcType)
     return failure();
 
@@ -1551,7 +1557,8 @@ static LogicalResult canonicalizeIntTypeConnect(ConnectOp op,
 static LogicalResult
 canonicalizeMatchingTypeConnect(ConnectOp op, PatternRewriter &rewriter) {
   if (op.getSrc().getType() != op.getDest().getType() ||
-      op.getSrc().getType().cast<FIRRTLType>().hasUninferredWidth())
+      !op.getSrc().getType().isa<FIRRTLBaseType>() ||
+      op.getSrc().getType().cast<FIRRTLBaseType>().hasUninferredWidth())
     return failure();
   rewriter.create<StrictConnectOp>(op.getLoc(), op.getDest(), op.getSrc());
   if (auto *srcOp = op.getSrc().getDefiningOp())

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -128,7 +128,10 @@ LogicalResult circt::firrtl::verifyInnerSymAttr(InnerSymbolOpInterface op) {
     }
     return success();
   }
-  auto maxFields = op->getResultTypes()[0].cast<FIRRTLType>().getMaxFieldID();
+  auto resultType = op->getResultTypes()[0].dyn_cast<FIRRTLBaseType>();
+  if (!resultType)
+    return op->emitOpError("cannot attach symbols to non-base types");
+  auto maxFields = resultType.getMaxFieldID();
   SmallBitVector indices(maxFields + 1);
   SmallPtrSet<Attribute, 8> symNames;
   // Ensure fieldID and symbol names are unique.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2018,11 +2018,7 @@ void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // Statements
 //===----------------------------------------------------------------------===//
 
-/// Check if the source and sink are of appropriate flow.
-/// The disallowOutputPortSink flag can be enabled to disallow reads from
-/// module/instance output ports.
-static LogicalResult checkConnectFlow(Operation *connect,
-                                      bool disallowOutputPortSink = false) {
+static LogicalResult checkConnectFlow(Operation *connect) {
   Value dst = connect->getOperand(0);
   Value src = connect->getOperand(1);
 
@@ -2031,8 +2027,7 @@ static LogicalResult checkConnectFlow(Operation *connect,
   if (foldFlow(src) == Flow::Sink) {
     // A sink that is a port output or instance input used as a source is okay.
     auto kind = getDeclarationKind(src);
-    if (disallowOutputPortSink ||
-        (kind != DeclKind::Port && kind != DeclKind::Instance)) {
+    if (kind != DeclKind::Port && kind != DeclKind::Instance) {
       auto srcRef = getFieldRefFromValue(src);
       bool rootKnown;
       auto srcName = getFieldName(srcRef, rootKnown);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2078,8 +2078,6 @@ LogicalResult ConnectOp::verify() {
   auto dstBaseType = dstType.dyn_cast<FIRRTLBaseType>();
   auto srcBaseType = srcType.dyn_cast<FIRRTLBaseType>();
   if (!dstBaseType || !srcBaseType) {
-    if (dstBaseType || srcBaseType)
-      return emitError("type mismatch with base/non-base");
     if (dstType != srcType)
       return emitError("may not connect different non-base types");
   } else {

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -28,16 +28,24 @@ void circt::firrtl::emitConnect(OpBuilder &builder, Location loc, Value dst,
 /// Emit a connect between two values.
 void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
                                 Value src) {
-  auto dstType = dst.getType().cast<FIRRTLType>();
-  auto srcType = src.getType().cast<FIRRTLType>();
+  auto dstFType = dst.getType().cast<FIRRTLType>();
+  auto srcFType = src.getType().cast<FIRRTLType>();
+  auto dstType = dstFType.dyn_cast<FIRRTLBaseType>();
+  auto srcType = srcFType.dyn_cast<FIRRTLBaseType>();
 
   // If the types are the exact same we can just connect them.
-  if (dstType == srcType) {
+  if (dstFType == srcFType) {
     // Strict connect does not allow uninferred widths.
-    if (dstType.hasUninferredWidth())
+    if (dstType && dstType.hasUninferredWidth())
       builder.create<ConnectOp>(dst, src);
     else
       builder.create<StrictConnectOp>(dst, src);
+    return;
+  }
+
+  // Non-base types don't need special handling.
+  if (!srcType || !dstType) {
+    builder.create<ConnectOp>(dst, src);
     return;
   }
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -239,7 +239,7 @@ bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
                                 WalkDriverCallback callback) {
   // TODO: what do we want to happen when there are flips in the type? Do we
   // want to filter out fields which have reverse flow?
-  assert(val.getType().cast<FIRRTLType>().isPassive() &&
+  assert(val.getType().cast<FIRRTLBaseType>().isPassive() &&
          "this code was not tested with flips");
 
   // This method keeps a stack of wires (or ports) and subfields of those that

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -352,7 +352,9 @@ void AddSeqMemPortsPass::runOnOperation() {
             context, userPort.direction == Direction::In ? "input" : "output"));
     attrs.emplace_back(
         StringAttr::get(context, "width"),
-        IntegerAttr::get(ui32Type, userPort.type.getBitWidthOrSentinel()));
+        IntegerAttr::get(
+            ui32Type,
+            userPort.type.cast<FIRRTLBaseType>().getBitWidthOrSentinel()));
     extraPorts.push_back(DictionaryAttr::get(context, attrs));
   }
   extraPortsAttr = ArrayAttr::get(context, extraPorts);

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -916,7 +916,8 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
     jsonStream.attribute("name", "ports");
     jsonStream.attributeArray("value", [&] {
       for (const auto &port : llvm::enumerate(module.getPorts())) {
-        if (port.value().type.getBitWidthOrSentinel() == 0)
+        auto portType = port.value().type.dyn_cast<FIRRTLBaseType>();
+        if (!portType || portType.getBitWidthOrSentinel() == 0)
           continue;
         jsonStream.object([&] {
           // Emit the `ref` field.
@@ -940,8 +941,7 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
 
           // Emit the `width` field.
           buf.assign("OMBigInt:");
-          Twine::utohexstr(port.value().type.getBitWidthOrSentinel())
-              .toVector(buf);
+          Twine::utohexstr(portType.getBitWidthOrSentinel()).toVector(buf);
           jsonStream.attribute("width", buf);
         });
       }

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -137,7 +137,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
           } else {
             // Cast the input aggregate write data to flat type.
             // Cast the input aggregate write data to flat type.
-            auto newFieldType = newField.getType().cast<FIRRTLType>();
+            auto newFieldType = newField.getType().cast<FIRRTLBaseType>();
             auto oldFieldBitWidth = getBitWidth(oldField.getType());
             // Following condition is true, if a data field is 0 bits. Then
             // newFieldType is of smaller bits than old.

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1166,7 +1166,7 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         auto builder = OpBuilder::atBlockEnd(
             companionIDMap.lookup(id).companion.getBodyBlock());
 
-        FIRRTLType tpe = leafValue.getType().cast<FIRRTLType>();
+        auto tpe = leafValue.getType().cast<FIRRTLBaseType>();
 
         // If the type is zero-width then do not emit an XMR.
         if (!tpe.getBitWidthOrSentinel())
@@ -1341,8 +1341,9 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
             FieldRef fieldRef = leafMap.lookup(ground.getID()).field;
             auto value = fieldRef.getValue();
             auto fieldID = fieldRef.getFieldID();
-            auto tpe = value.getType().cast<FIRRTLType>().getFinalTypeByFieldID(
-                fieldID);
+            auto tpe =
+                value.getType().cast<FIRRTLBaseType>().getFinalTypeByFieldID(
+                    fieldID);
             if (!tpe.isGround()) {
               value.getDefiningOp()->emitOpError()
                   << "cannot be added to interface with id '"

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -78,7 +78,7 @@ struct SignalMapping {
   /// The reference target of the thing we are forcing or probing.
   StringAttr remoteTarget;
   /// The type of the signal being mapped.
-  FIRRTLType type;
+  FIRRTLBaseType type;
   /// The block argument or result that interacts with the remote target, either
   /// by forcing it or by reading from it through a connect.
   Value localValue;
@@ -344,8 +344,9 @@ void ModuleSignalMappings::run() {
 /// `SignalMapping` information and adds an entry to the `mappings` array, to be
 /// later consumed when the mappings module is constructed.
 void ModuleSignalMappings::addTarget(Value value, Annotation anno) {
-  // Ignore the target if it is zero width.
-  if (!value.getType().cast<FIRRTLType>().getBitWidthOrSentinel())
+  // Ignore the target if it is zero width or not a base type.
+  auto targetType = value.getType().dyn_cast<FIRRTLBaseType>();
+  if (!targetType || !targetType.getBitWidthOrSentinel())
     return;
 
   SignalMapping mapping;
@@ -354,7 +355,7 @@ void ModuleSignalMappings::addTarget(Value value, Annotation anno) {
                     : MappingDirection::DriveRemote;
   mapping.remoteTarget = anno.getMember<StringAttr>("peer");
   mapping.localValue = value;
-  mapping.type = value.getType().cast<FIRRTLType>();
+  mapping.type = targetType;
   mapping.isLocal = anno.getMember<StringAttr>("side").getValue() == "local";
   mapping.nlaSym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -509,6 +509,7 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
     assert(!tappedPorts.count(key) && "ambiguous tap annotation");
     auto portWidth = cast<FModuleLike>(port.first)
                          .getPortType(port.second)
+                         .cast<FIRRTLBaseType>()
                          .getBitWidthOrSentinel();
     // If the port width is non-zero, process it normally.  Otherwise, record it
     // as being zero-width.
@@ -526,8 +527,10 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
     // If the port width is targeting a module (e.g., a blackbox) or if it has a
     // non-zero width, process it normally.  Otherwise, record it as being
     // zero-width.
-    if (isa<FModuleLike>(op) ||
-        op->getResult(0).getType().cast<FIRRTLType>().getBitWidthOrSentinel())
+    if (isa<FModuleLike>(op) || op->getResult(0)
+                                    .getType()
+                                    .cast<FIRRTLBaseType>()
+                                    .getBitWidthOrSentinel())
       tappedOps.insert({key, op});
     else
       zeroWidthTaps.insert(key);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -256,7 +256,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   /// Return the lattice value for the specified SSA value, extended to the
   /// width of the specified destType.  If allowTruncation is true, then this
   /// allows truncating the lattice value to the specified type.
-  LatticeValue getExtendedLatticeValue(Value value, FIRRTLType destType,
+  LatticeValue getExtendedLatticeValue(Value value, FIRRTLBaseType destType,
                                        bool allowTruncation = false);
 
   /// Mark the given block as executable.
@@ -335,7 +335,7 @@ void IMConstPropPass::runOnOperation() {
 /// of the specified destType.  If allowTruncation is true, then this allows
 /// truncating the lattice value to the specified type.
 LatticeValue IMConstPropPass::getExtendedLatticeValue(Value value,
-                                                      FIRRTLType destType,
+                                                      FIRRTLBaseType destType,
                                                       bool allowTruncation) {
   // If 'value' hasn't been computed yet, then it is unknown.
   auto it = latticeValues.find(value);
@@ -401,7 +401,7 @@ void IMConstPropPass::markWireRegOp(Operation *wireOrReg) {
   // handle, mark it as overdefined.
   // TODO: Eventually add a field-sensitive model.
   auto resultValue = wireOrReg->getResult(0);
-  if (!resultValue.getType().cast<FIRRTLType>().getPassiveType().isGround())
+  if (!resultValue.getType().cast<FIRRTLBaseType>().getPassiveType().isGround())
     return markOverdefined(resultValue);
 
   // Otherwise, this starts out as InvalidValue and is upgraded by connects.
@@ -463,7 +463,8 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
     if (fModule.getPortDirection(resultNo) == Direction::In)
       continue;
     // We only support simple values so far.
-    if (!instancePortVal.getType().cast<FIRRTLType>().isGround()) {
+    auto portType = instancePortVal.getType().dyn_cast<FIRRTLBaseType>();
+    if (portType && !portType.isGround()) {
       // TODO: Add field sensitivity.
       markOverdefined(instancePortVal);
       continue;
@@ -487,8 +488,12 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
 
 // We merge the value from the RHS into the value of the LHS.
 void IMConstPropPass::visitConnect(ConnectOp connect) {
-  auto destType =
-      connect.getDest().getType().cast<FIRRTLType>().getPassiveType();
+  auto connectDestType = connect.getDest().getType().dyn_cast<FIRRTLBaseType>();
+  if (!connectDestType) {
+    connect.emitError("connect of non-base types unhandled by IMConstProp");
+    return;
+  }
+  auto destType = connectDestType.getPassiveType();
 
   // Handle implicit extensions.
   auto srcValue = getExtendedLatticeValue(connect.getSrc(), destType);
@@ -540,8 +545,12 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
 
 // We merge the value from the RHS into the value of the LHS.
 void IMConstPropPass::visitStrictConnect(StrictConnectOp connect) {
-  auto destType =
-      connect.getDest().getType().cast<FIRRTLType>().getPassiveType();
+  auto connectDestType = connect.getDest().getType().dyn_cast<FIRRTLBaseType>();
+  if (!connectDestType) {
+    connect.emitError("connect of non-base types unhandled by IMConstProp");
+    return;
+  }
+  auto destType = connectDestType.getPassiveType();
 
   // Handle implicit extensions.
   auto srcValue = getExtendedLatticeValue(connect.getSrc(), destType);
@@ -606,12 +615,12 @@ void IMConstPropPass::visitRegResetOp(RegResetOp regReset) {
 
   // The reset value may be known - if so, merge it in if the enable is greater
   // than invalid.
-  auto srcValue = getExtendedLatticeValue(regReset.getResetValue(),
-                                          regReset.getType().cast<FIRRTLType>(),
-                                          /*allowTruncation=*/true);
+  auto srcValue = getExtendedLatticeValue(
+      regReset.getResetValue(), regReset.getType().cast<FIRRTLBaseType>(),
+      /*allowTruncation=*/true);
   auto enable = getExtendedLatticeValue(
       regReset.getResetSignal(),
-      regReset.getResetSignal().getType().cast<FIRRTLType>(),
+      regReset.getResetSignal().getType().cast<FIRRTLBaseType>(),
       /*allowTruncation=*/true);
   if (enable.isOverdefined() ||
       (enable.isConstant() && !enable.getConstant().getValue().isZero()))

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -489,9 +489,10 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
 // We merge the value from the RHS into the value of the LHS.
 void IMConstPropPass::visitConnect(ConnectOp connect) {
   auto connectDestType = connect.getDest().getType().dyn_cast<FIRRTLBaseType>();
+  // Only base types are handled for now, mark non-base overdefined.
   if (!connectDestType) {
-    connect.emitError("connect of non-base types unhandled by IMConstProp");
-    return;
+    markOverdefined(connect.getSrc());
+    return markOverdefined(connect.getDest());
   }
   auto destType = connectDestType.getPassiveType();
 
@@ -546,9 +547,10 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
 // We merge the value from the RHS into the value of the LHS.
 void IMConstPropPass::visitStrictConnect(StrictConnectOp connect) {
   auto connectDestType = connect.getDest().getType().dyn_cast<FIRRTLBaseType>();
+  // Only base types are handled for now, mark non-base overdefined.
   if (!connectDestType) {
-    connect.emitError("connect of non-base types unhandled by IMConstProp");
-    return;
+    markOverdefined(connect.getSrc());
+    return markOverdefined(connect.getDest());
   }
   auto destType = connectDestType.getPassiveType();
 

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -317,7 +317,7 @@ private:
             // Already 1 bit, nothing to do.
             if (sf.getResult()
                     .getType()
-                    .cast<FIRRTLType>()
+                    .cast<FIRRTLBaseType>()
                     .getBitWidthOrSentinel() == 1)
               continue;
             // Check what is the mask field directly connected to.

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1144,9 +1144,18 @@ private:
 
 /// Check if a type contains any FIRRTL type with uninferred widths.
 static bool hasUninferredWidth(Type type) {
-  if (auto ftype = type.dyn_cast<FIRRTLType>())
-    return ftype.hasUninferredWidth();
-  return false;
+  return TypeSwitch<Type, bool>(type)
+      .Case<FIRRTLBaseType>([](auto base) { return base.hasUninferredWidth(); })
+      .Default([](auto) { return false; });
+}
+
+static FIRRTLBaseType getBaseType(FIRRTLType type) {
+  return TypeSwitch<FIRRTLType, FIRRTLBaseType>(type)
+      .Case<FIRRTLBaseType>([](auto base) { return base; })
+      .Default([](auto) {
+        llvm_unreachable("unexpected FIRRTLType");
+        return FIRRTLBaseType();
+      });
 }
 
 LogicalResult InferenceMapping::map(CircuitOp op) {
@@ -1522,7 +1531,7 @@ void InferenceMapping::declareVars(Value value, Location loc) {
   // Declare a variable for every unknown width in the type. If this is a Bundle
   // type or a FVector type, we will have to potentially create many variables.
   unsigned fieldID = 0;
-  std::function<void(FIRRTLType)> declare = [&](FIRRTLType type) {
+  std::function<void(FIRRTLBaseType)> declare = [&](FIRRTLBaseType type) {
     auto width = type.getBitWidthOrSentinel();
     if (width >= 0) {
       // Known width integer create a known expression.
@@ -1550,7 +1559,7 @@ void InferenceMapping::declareVars(Value value, Location loc) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  declare(ftype);
+  declare(getBaseType(ftype));
 }
 
 /// Assign the constraint expressions of the fields in the `result` argument as
@@ -1559,7 +1568,7 @@ void InferenceMapping::declareVars(Value value, Location loc) {
 void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
   // Recurse to every leaf element and set larger >= smaller.
   auto fieldID = 0;
-  std::function<void(FIRRTLType)> maximize = [&](FIRRTLType type) {
+  std::function<void(FIRRTLBaseType)> maximize = [&](FIRRTLBaseType type) {
     if (auto bundleType = type.dyn_cast<BundleType>()) {
       fieldID++;
       for (auto &element : bundleType.getElements())
@@ -1581,7 +1590,7 @@ void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
     }
   };
   auto type = result.getType().cast<FIRRTLType>();
-  maximize(type);
+  maximize(getBaseType(type));
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
@@ -1594,8 +1603,8 @@ void InferenceMapping::constrainTypes(Value larger, Value smaller) {
   // Recurse to every leaf element and set larger >= smaller.
   auto type = larger.getType().cast<FIRRTLType>();
   auto fieldID = 0;
-  std::function<void(FIRRTLType, Value, Value)> constrain =
-      [&](FIRRTLType type, Value larger, Value smaller) {
+  std::function<void(FIRRTLBaseType, Value, Value)> constrain =
+      [&](FIRRTLBaseType type, Value larger, Value smaller) {
         if (auto bundleType = type.dyn_cast<BundleType>()) {
           fieldID++;
           for (auto &element : bundleType.getElements()) {
@@ -1622,7 +1631,7 @@ void InferenceMapping::constrainTypes(Value larger, Value smaller) {
         }
       };
 
-  constrain(type, larger, smaller);
+  constrain(getBaseType(type), larger, smaller);
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
@@ -1652,7 +1661,7 @@ void InferenceMapping::unifyTypes(FieldRef lhs, FieldRef rhs, FIRRTLType type) {
   // Co-iterate the two field refs, recurring into every leaf element and set
   // them equal.
   auto fieldID = 0;
-  std::function<void(FIRRTLType)> unify = [&](FIRRTLType type) {
+  std::function<void(FIRRTLBaseType)> unify = [&](FIRRTLBaseType type) {
     if (type.isGround()) {
       // Leaf element, unify the fields!
       FieldRef lhsFieldRef(lhs.getValue(), lhs.getFieldID() + fieldID);
@@ -1681,12 +1690,12 @@ void InferenceMapping::unifyTypes(FieldRef lhs, FieldRef rhs, FIRRTLType type) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  unify(type);
+  unify(getBaseType(type));
 }
 
 /// Get the constraint expression for a value.
 Expr *InferenceMapping::getExpr(Value value) {
-  assert(value.getType().cast<FIRRTLType>().isGround());
+  assert(getBaseType(value.getType().cast<FIRRTLType>()).isGround());
   // A field ID of 0 indicates the entire value.
   return getExpr(FieldRef(value, 0));
 }
@@ -1705,7 +1714,7 @@ Expr *InferenceMapping::getExprOrNull(FieldRef fieldRef) {
 
 /// Associate a constraint expression with a value.
 void InferenceMapping::setExpr(Value value, Expr *expr) {
-  assert(value.getType().cast<FIRRTLType>().isGround());
+  assert(getBaseType(value.getType().cast<FIRRTLType>()).isGround());
   // A field ID of 0 indicates the entire value.
   setExpr(FieldRef(value, 0), expr);
 }
@@ -1735,7 +1744,7 @@ public:
   LogicalResult update(CircuitOp op);
   bool updateOperation(Operation *op);
   bool updateValue(Value value);
-  FIRRTLType updateType(FieldRef fieldRef, FIRRTLType type);
+  FIRRTLBaseType updateType(FieldRef fieldRef, FIRRTLBaseType type);
 
 private:
   bool anyFailed;
@@ -1790,28 +1799,32 @@ bool InferenceTypeUpdate::updateOperation(Operation *op) {
   if (auto con = dyn_cast<ConnectOp>(op)) {
     auto lhs = con.getDest();
     auto rhs = con.getSrc();
-    auto lhsType = lhs.getType().cast<FIRRTLType>();
-    auto rhsType = rhs.getType().cast<FIRRTLType>();
+    auto lhsFType = lhs.getType().cast<FIRRTLType>();
+    auto rhsFType = rhs.getType().cast<FIRRTLType>();
+    auto lhsType = lhsFType.dyn_cast<FIRRTLBaseType>();
+    auto rhsType = rhsFType.dyn_cast<FIRRTLBaseType>();
 
-    // If the source is an InvalidValue of unknown width, infer the type to be
-    // the same as the destination.
-    if (dyn_cast_or_null<InvalidValueOp>(rhs.getDefiningOp()) &&
-        hasUninferredWidth(rhs.getType()))
-      rhs.setType(lhsType);
+    if (lhsType && rhsType) {
+      // If the source is an InvalidValue of unknown width, infer the type to be
+      // the same as the destination.
+      if (dyn_cast_or_null<InvalidValueOp>(rhs.getDefiningOp()) &&
+          hasUninferredWidth(rhs.getType()))
+        rhs.setType(lhsType);
 
-    auto lhsWidth = lhsType.getBitWidthOrSentinel();
-    auto rhsWidth = rhsType.getBitWidthOrSentinel();
-    if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
-      OpBuilder builder(op);
-      auto trunc = builder.createOrFold<TailPrimOp>(con.getLoc(), con.getSrc(),
-                                                    rhsWidth - lhsWidth);
-      if (rhsType.isa<SIntType>())
-        trunc =
-            builder.createOrFold<AsSIntPrimOp>(con.getLoc(), lhsType, trunc);
+      auto lhsWidth = lhsType.getBitWidthOrSentinel();
+      auto rhsWidth = rhsType.getBitWidthOrSentinel();
+      if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
+        OpBuilder builder(op);
+        auto trunc = builder.createOrFold<TailPrimOp>(
+            con.getLoc(), con.getSrc(), rhsWidth - lhsWidth);
+        if (rhsType.isa<SIntType>())
+          trunc =
+              builder.createOrFold<AsSIntPrimOp>(con.getLoc(), lhsType, trunc);
 
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Truncating RHS to " << lhsType << " in " << con << "\n");
-      con->replaceUsesOfWith(con.getSrc(), trunc);
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Truncating RHS to " << lhsType << " in " << con << "\n");
+        con->replaceUsesOfWith(con.getSrc(), trunc);
+      }
     }
   }
 
@@ -1839,9 +1852,9 @@ bool InferenceTypeUpdate::updateOperation(Operation *op) {
 }
 
 /// Resize a `uint`, `sint`, or `analog` type to a specific width.
-static FIRRTLType resizeType(FIRRTLType type, uint32_t newWidth) {
+static FIRRTLBaseType resizeType(FIRRTLBaseType type, uint32_t newWidth) {
   auto *context = type.getContext();
-  return TypeSwitch<FIRRTLType, FIRRTLType>(type)
+  return TypeSwitch<FIRRTLBaseType, FIRRTLBaseType>(type)
       .Case<UIntType>(
           [&](auto type) { return UIntType::get(context, newWidth); })
       .Case<SIntType>(
@@ -1886,7 +1899,8 @@ bool InferenceTypeUpdate::updateValue(Value value) {
   // Recreate the type, substituting the solved widths.
   auto context = type.getContext();
   unsigned fieldID = 0;
-  std::function<FIRRTLType(FIRRTLType)> update = [&](FIRRTLType type) {
+  std::function<FIRRTLBaseType(FIRRTLBaseType)> updateBase =
+      [&](FIRRTLBaseType type) -> FIRRTLBaseType {
     auto width = type.getBitWidthOrSentinel();
     if (width >= 0) {
       // Known width integers return themselves.
@@ -1903,7 +1917,7 @@ bool InferenceTypeUpdate::updateValue(Value value) {
       llvm::SmallVector<BundleType::BundleElement, 3> elements;
       for (auto &element : bundleType) {
         elements.emplace_back(element.name, element.isFlip,
-                              update(element.type));
+                              updateBase(element.type));
       }
       return BundleType::get(elements, context);
     } else if (auto vecType = type.dyn_cast<FVectorType>()) {
@@ -1912,7 +1926,7 @@ bool InferenceTypeUpdate::updateValue(Value value) {
       // TODO: this should recurse into the element type of 0 length vectors and
       // set any unknown width to 0.
       if (vecType.getNumElements() > 0) {
-        auto newType = FVectorType::get(update(vecType.getElementType()),
+        auto newType = FVectorType::get(updateBase(vecType.getElementType()),
                                         vecType.getNumElements());
         fieldID = save + vecType.getMaxFieldID();
         return newType;
@@ -1921,6 +1935,14 @@ bool InferenceTypeUpdate::updateValue(Value value) {
       return type;
     }
     llvm_unreachable("Unknown type inside a bundle!");
+  };
+  auto update = [&](FIRRTLType ftype) {
+    return TypeSwitch<FIRRTLType, FIRRTLType>(type)
+        .Case<FIRRTLBaseType>([&](auto base) { return updateBase(base); })
+        .Default([](auto) {
+          llvm_unreachable("unsupported type");
+          return FIRRTLType();
+        });
   };
 
   // Update the type.
@@ -1933,7 +1955,7 @@ bool InferenceTypeUpdate::updateValue(Value value) {
   // the value, but may be larger. This can trip up the verifier.
   if (auto op = value.getDefiningOp<ConstantOp>()) {
     auto k = op.getValue();
-    auto bitwidth = op.getType().cast<FIRRTLType>().getBitWidthOrSentinel();
+    auto bitwidth = op.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel();
     if (k.getBitWidth() > unsigned(bitwidth))
       k = k.trunc(bitwidth);
     op->setAttr("value", IntegerAttr::get(op.getContext(), k));
@@ -1943,7 +1965,8 @@ bool InferenceTypeUpdate::updateValue(Value value) {
 }
 
 /// Update a type.
-FIRRTLType InferenceTypeUpdate::updateType(FieldRef fieldRef, FIRRTLType type) {
+FIRRTLBaseType InferenceTypeUpdate::updateType(FieldRef fieldRef,
+                                               FIRRTLBaseType type) {
   assert(type.isGround() && "Can only pass in ground types.");
   auto value = fieldRef.getValue();
   // Get the inferred width.

--- a/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
@@ -79,8 +79,9 @@ bool MergeConnection::peelConnect(StrictConnectOp connect) {
   // partial connect. Also ignore non-passive connections or non-integer
   // connections.
   LLVM_DEBUG(llvm::dbgs() << "Visiting " << connect << "\n");
-  auto destTy = connect.getDest().getType().cast<FIRRTLType>();
-  if (!destTy.isPassive() || !firrtl::getBitWidth(destTy).has_value())
+  auto destTy = connect.getDest().getType().dyn_cast<FIRRTLBaseType>();
+  if (!destTy || !destTy.isPassive() ||
+      !firrtl::getBitWidth(destTy).has_value())
     return false;
 
   auto destFieldRef = getFieldRefFromValue(connect.getDest());
@@ -210,7 +211,7 @@ bool MergeConnection::peelConnect(StrictConnectOp connect) {
         subConnections[e.index()].erase();
       auto value = e.value();
       auto bitwidth =
-          firrtl::getBitWidth(value.getType().template cast<FIRRTLType>());
+          firrtl::getBitWidth(value.getType().template cast<FIRRTLBaseType>());
       assert(bitwidth &&
              "it should be checked at the beginning of `peelConnect`");
       value = builder->createOrFold<BitCastOp>(


### PR DESCRIPTION
Leave FIRRTLType parent, for including non-base types in the future.

(split off from #3653)