### PR TITLE
[ESI] Make service generators registerable in Python

### DIFF
--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -40,6 +40,11 @@ MLIR_CAPI_EXPORTED void circtESIAppendMlirFile(MlirModule,
 MLIR_CAPI_EXPORTED MlirOperation circtESILookup(MlirModule,
                                                 MlirStringRef symbol);
 
+typedef MlirLogicalResult (*CirctESIServiceGeneratorFunc)(
+    MlirOperation serviceImplementReqOp, void *userData);
+MLIR_CAPI_EXPORTED void circtESIRegisterGlobalServiceImplementor(
+    MlirStringRef impl_type, CirctESIServiceGeneratorFunc, void *userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -42,7 +42,7 @@ MLIR_CAPI_EXPORTED MlirOperation circtESILookup(MlirModule,
 
 typedef MlirLogicalResult (*CirctESIServiceGeneratorFunc)(
     MlirOperation serviceImplementReqOp, void *userData);
-MLIR_CAPI_EXPORTED void circtESIRegisterGlobalServiceImplementor(
+MLIR_CAPI_EXPORTED void circtESIRegisterGlobalServiceGenerator(
     MlirStringRef impl_type, CirctESIServiceGeneratorFunc, void *userData);
 
 #ifdef __cplusplus

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -73,7 +73,7 @@ def ServiceInstanceOp : ESI_Op<"service.instance"> {
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$service_symbol,
-                       AnyAttr:$impl_type,
+                       StrAttr:$impl_type,
                        OptionalAttr<DictionaryAttr>:$impl_opts,
                        Variadic<AnyType>:$inputs);
   let results = (outs Variadic<AnyType>);
@@ -97,7 +97,7 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [NoTerminator]> {
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$service_symbol,
-                       AnyAttr:$impl_type,
+                       StrAttr:$impl_type,
                        OptionalAttr<DictionaryAttr>:$impl_opts,
                        Variadic<AnyType>:$inputs);
   let results = (outs Variadic<AnyType>:$outputs);

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -72,7 +72,7 @@ static MlirLogicalResult serviceGenFunc(MlirOperation reqOp, void *userData) {
 void registerServiceGenerator(std::string name, py::object genFunc) {
   std::string *n = new std::string(name);
   serviceGenFuncLookup[n] = genFunc;
-  circtESIRegisterGlobalServiceImplementor(wrap(*n), serviceGenFunc, n);
+  circtESIRegisterGlobalServiceGenerator(wrap(*n), serviceGenFunc, n);
 }
 
 using namespace mlir::python::adaptors;

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -15,6 +15,7 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include "PybindUtils.h"
@@ -57,6 +58,23 @@ private:
   MlirModule cModuleOp;
 };
 
+// Mapping from unique identifier to python callback. We use std::string
+// pointers since we also need to allocate memory for the string.
+llvm::DenseMap<std::string *, py::object> serviceGenFuncLookup;
+static MlirLogicalResult serviceGenFunc(MlirOperation reqOp, void *userData) {
+  std::string *name = static_cast<std::string *>(userData);
+  py::object genFunc = serviceGenFuncLookup[name];
+  py::object rc = genFunc(reqOp);
+  return rc.cast<bool>() ? mlirLogicalResultSuccess()
+                         : mlirLogicalResultFailure();
+}
+
+void registerServiceGenerator(std::string name, py::object genFunc) {
+  std::string *n = new std::string(name);
+  serviceGenFuncLookup[n] = genFunc;
+  circtESIRegisterGlobalServiceImplementor(wrap(*n), serviceGenFunc, n);
+}
+
 using namespace mlir::python::adaptors;
 
 void circt::python::populateDialectESISubmodule(py::module &m) {
@@ -74,6 +92,10 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
       "Construct an ESI wrapper around HW module 'op' given a list of "
       "latency-insensitive ports.",
       py::arg("op"), py::arg("name_list"));
+
+  m.def("registerServiceGenerator", registerServiceGenerator,
+        "Register a service generator for a given service name.",
+        py::arg("impl_type"), py::arg("generator"));
 
   py::class_<System>(m, "CppSystem")
       .def(py::init<MlirModule>())

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -78,7 +78,7 @@ MlirOperation circtESILookup(MlirModule mod, MlirStringRef symbol) {
   return wrap(SymbolTable::lookupSymbolIn(unwrap(mod), unwrap(symbol)));
 }
 
-void circtESIRegisterGlobalServiceImplementor(
+void circtESIRegisterGlobalServiceGenerator(
     MlirStringRef impl_type, CirctESIServiceGeneratorFunc genFunc,
     void *userData) {
   ServiceGeneratorDispatcher::globalDispatcher().registerGenerator(

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -3,6 +3,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt-c/Dialect/ESI.h"
+#include "circt/Dialect/ESI/ESIServices.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
@@ -75,4 +76,13 @@ void circtESIAppendMlirFile(MlirModule cMod, MlirStringRef filename) {
 }
 MlirOperation circtESILookup(MlirModule mod, MlirStringRef symbol) {
   return wrap(SymbolTable::lookupSymbolIn(unwrap(mod), unwrap(symbol)));
+}
+
+void circtESIRegisterGlobalServiceImplementor(
+    MlirStringRef impl_type, CirctESIServiceGeneratorFunc genFunc,
+    void *userData) {
+  ServiceGeneratorDispatcher::globalDispatcher().registerGenerator(
+      unwrap(impl_type), [genFunc, userData](ServiceImplementReqOp req) {
+        return unwrap(genFunc(wrap(req), userData));
+      });
 }


### PR DESCRIPTION
Enables writing service generators in Python. Also switches to
string-base 'impl_types' (from Attributes) since Attributes are tied to
a context whereas Passes are not. Simplifies things by not having to
create a registry for each context.