### PR TITLE
[FIRRTL/IMCP] Move constants to be trailing operands

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -492,17 +492,6 @@ OpFoldResult AndPrimOp::fold(ArrayRef<Attribute> operands) {
       return getLhs();
   }
 
-  if (auto lhsCst = getConstant(operands[0])) {
-    /// and(0, x) -> 0
-    if (lhsCst->isZero() && getLhs().getType() == getType())
-      return getIntZerosAttr(getType());
-
-    /// and(-1, x) -> x
-    if (lhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getRhs();
-  }
-
   /// and(x, x) -> x
   if (getLhs() == getRhs() && getRhs().getType() == getType())
     return getRhs();
@@ -522,17 +511,6 @@ OpFoldResult OrPrimOp::fold(ArrayRef<Attribute> operands) {
     if (rhsCst->isAllOnes() && getRhs().getType() == getType() &&
         getLhs().getType() == getType())
       return getRhs();
-  }
-
-  if (auto lhsCst = getConstant(operands[0])) {
-    /// or(0, x) -> x
-    if (lhsCst->isZero() && getRhs().getType() == getType())
-      return getRhs();
-
-    /// or(-1, x) -> -1
-    if (lhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getLhs();
   }
 
   /// or(x, x) -> x

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -671,6 +671,14 @@ void IMConstPropPass::visitOperation(Operation *op) {
       operandConstants.push_back({});
   }
 
+  // If this is a commutative operation, move constants to be trailing
+  // operands.
+  if (op->getNumOperands() >= 2 && op->hasTrait<OpTrait::IsCommutative>()) {
+    auto isUndefined = [](Attribute attr) { return !attr; };
+    auto *firstConstantIt = llvm::find_if_not(operandConstants, isUndefined);
+    std::stable_partition(firstConstantIt, operandConstants.end(), isUndefined);
+  }
+
   // Simulate the result of folding this operation to a constant. If folding
   // fails or was an in-place fold, mark the results as overdefined.
   SmallVector<OpFoldResult, 8> foldResults;

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -554,3 +554,15 @@ firrtl.circuit "Issue3372"  {
     firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
   }
 }
+
+// -----
+
+// CHECK-LABEL: "LhsConstant"
+firrtl.circuit "LhsConstant"  {
+  firrtl.module @LhsConstant(in %reset: !firrtl.uint<1>, out %value: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %c = firrtl.xor %c0_ui1, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %value, %reset : !firrtl.uint<1>
+    firrtl.strictconnect %value, %c: !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
If op is a commutative operation, MLIR moves constants to be training
operands just before folder invocations[1]. IMCP has  used a folder method
but currently doesn't move operands in such way. This commit implements
similar reordering for `operandsConstants` so that we can get more
optimal results in IMCP. This also removes commutative folders which I previously
implemented to try fixing the same problem. 

[1] https://github.com/llvm/llvm-project/blob/b395c0f0cdbf60bb86cb30bd403ac82227d0f2da/mlir/lib/Transforms/Utils/FoldUtils.cpp#L231-L242
 
