### PR TITLE
[FIRRTL][SFCCompat] Add support for aggregates

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -67,9 +67,10 @@ static bool isModuleScopedDrivenBy(Value val, bool lookThroughWires,
 /// the callback returns false, this function will stop walking.  Returns false
 /// if walking was broken, and true otherwise.
 using WalkDriverCallback =
-    llvm::function_ref<bool(const FieldRef &, const FieldRef &src)>;
-bool walkDrivers(Value value, bool lookThroughWires, bool lookThroughNodes,
-                 bool lookThroughCasts, WalkDriverCallback callback);
+    llvm::function_ref<bool(const FieldRef &dst, const FieldRef &src)>;
+bool walkDrivers(Value value, bool lookThroughWires,
+                 bool lookTWalkDriverCallbackhroughNodes, bool lookThroughCasts,
+                 WalkDriverCallback callback);
 
 /// Get the FieldRef from a value.  This will travel backwards to through the
 /// IR, following Subfield and Subindex to find the op which declares the

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -32,7 +32,14 @@ IntegerAttr getIntZerosAttr(Type type);
 /// Return the module-scoped driver of a value only looking through one connect.
 Value getDriverFromConnect(Value val);
 
-/// Return the module-scoped driver of a value
+/// Return the value that drives another FIRRTL value within module scope.  This
+/// is parameterized by looking through or not through certain constructs.
+Value getValueSource(Value val, bool lookThroughWires, bool lookThroughNodes,
+                     bool lookThroughCasts);
+
+/// Return the value that drives another FIRRTL value within module scope.  This
+/// is parameterized by looking through or not through certain constructs.  This
+/// assumes a single driver and should only be run after `ExpandWhens`.
 Value getModuleScopedDriver(Value val, bool lookThroughWires,
                             bool lookThroughNodes, bool lookThroughCasts);
 
@@ -54,6 +61,15 @@ static bool isModuleScopedDrivenBy(Value val, bool lookThroughWires,
 
   return isa<A, B...>(op);
 }
+
+/// Walk all the drivers of a value, passing in the connect operations drive the
+/// value. If the value is an aggregate it will find connects to subfields. If
+/// the callback returns false, this function will stop walking.  Returns false
+/// if walking was broken, and true otherwise.
+using WalkDriverCallback =
+    llvm::function_ref<bool(const FieldRef &, const FieldRef &src)>;
+bool walkDrivers(Value value, bool lookThroughWires, bool lookThroughNodes,
+                 bool lookThroughCasts, WalkDriverCallback callback);
 
 /// Get the FieldRef from a value.  This will travel backwards to through the
 /// IR, following Subfield and Subindex to find the op which declares the

--- a/include/circt/Support/FieldRef.h
+++ b/include/circt/Support/FieldRef.h
@@ -36,8 +36,23 @@ public:
   /// Get the Value which created this location.
   Value getValue() const { return value; }
 
-  /// Get the operation which defines this field.
+  /// Get the operation which defines this field.  If the field is a block
+  /// argument it will return the operation which owns the block.
   Operation *getDefiningOp() const;
+
+  /// Get the operation which defines this field and cast it to the OpTy.
+  /// Returns null if the defining operation is of a different type.
+  template <typename OpTy>
+  OpTy getDefiningOp() const {
+    return llvm::dyn_cast<OpTy>(getDefiningOp());
+  }
+
+  template <typename... Any>
+  bool isa() const {
+    auto *op = getDefiningOp();
+    assert(op && "isa<> used on a null type.");
+    return ::llvm::isa<Any...>(op);
+  }
 
   /// Get the field ID of this FieldRef, which is a unique identifier mapped to
   /// a specific field in a bundle.

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -230,20 +230,19 @@ bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
                                 bool lookThroughNodes, bool lookThroughCasts,
                                 WalkDriverCallback callback) {
   // TODO: what do we want to happen when there are flips in the type? Do we
-  // want to filter out fields which has reverse flow?
+  // want to filter out fields which have reverse flow?
   assert(val.getType().cast<FIRRTLType>().isPassive() &&
          "this code was not tested with flips");
 
   // This method keeps a stack of wires (or ports) and subfields of those that
   // it still has to process.  It keeps track of which fields in the
-  // destination are attached to which fields of the source, as well which
+  // destination are attached to which fields of the source, as well as which
   // subfield of the source we are currently investigating.  The fieldID is
   // used to filter which subfields of the current operation which we should
   // visit. As an example, the src might be an aggregate wire, but the current
-  // value might be a subfield of that wire. The src field ref will represent
-  // all subaccesses to the target, but the fieldID for the current op only
-  // needs to represent the all subaccesses between the current op and the
-  // target.
+  // value might be a subfield of that wire. The `src` FieldRef will represent
+  // all subaccesses to the target, but `fieldID` for the current op only needs
+  // to represent the all subaccesses between the current op and the target.
   struct StackElement {
     StackElement(FieldRef dst, FieldRef src, Value current,
                  Value::user_iterator it, Value::user_iterator end,
@@ -332,7 +331,7 @@ bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
         continue;
       }
 
-      //
+      // If told to look through casts, continue from the cast input.
       if (lookThroughCasts &&
           isa<AsUIntPrimOp, AsSIntPrimOp, AsClockPrimOp, AsAsyncResetPrimOp>(
               op)) {
@@ -383,10 +382,8 @@ bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
         auto index = subfield.getFieldIndex();
         auto subID = bundleType.getFieldID(index);
         // If the index of this operation doesn't match the target, skip it.
-        if (fieldID) {
-          if (index != bundleType.getIndexForFieldID(fieldID))
-            continue;
-        }
+        if (fieldID && index != bundleType.getIndexForFieldID(fieldID))
+          continue;
         auto subRef = fieldRef.getSubField(subID);
         auto subOriginal = original.getSubField(subID);
         auto value = subfield.getResult();
@@ -397,10 +394,8 @@ bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
         auto index = subindex.getIndex();
         auto subID = vectorType.getFieldID(index);
         // If the index of this operation doesn't match the target, skip it.
-        if (fieldID) {
-          if (index != vectorType.getIndexForFieldID(fieldID))
-            continue;
-        }
+        if (fieldID && index != vectorType.getIndexForFieldID(fieldID))
+          continue;
         auto subRef = fieldRef.getSubField(subID);
         auto subOriginal = original.getSubField(subID);
         auto value = subindex.getResult();

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -147,9 +147,6 @@ Value circt::firrtl::getDriverFromConnect(Value val) {
   return nullptr;
 }
 
-/// Return the value that drives another FIRRTL value within module scope.  This
-/// is parameterized by looking through or not through certain constructs.  This
-/// assumes a single driver and should only be run after `ExpandWhens`.
 Value circt::firrtl::getModuleScopedDriver(Value val, bool lookThroughWires,
                                            bool lookThroughNodes,
                                            bool lookThroughCasts) {
@@ -227,6 +224,199 @@ Value circt::firrtl::getModuleScopedDriver(Value val, bool lookThroughWires,
     break;
   };
   return val;
+}
+
+bool circt::firrtl::walkDrivers(Value val, bool lookThroughWires,
+                                bool lookThroughNodes, bool lookThroughCasts,
+                                WalkDriverCallback callback) {
+  // TODO: what do we want to happen when there are flips in the type? Do we
+  // want to filter out fields which has reverse flow?
+  assert(val.getType().cast<FIRRTLType>().isPassive() &&
+         "this code was not tested with flips");
+
+  // This method keeps a stack of wires (or ports) and subfields of those that
+  // it still has to process.  It keeps track of which fields in the
+  // destination are attached to which fields of the source, as well which
+  // subfield of the source we are currently investigating.  The fieldID is
+  // used to filter which subfields of the current operation which we should
+  // visit. As an example, the src might be an aggregate wire, but the current
+  // value might be a subfield of that wire. The src field ref will represent
+  // all subaccesses to the target, but the fieldID for the current op only
+  // needs to represent the all subaccesses between the current op and the
+  // target.
+  struct StackElement {
+    StackElement(FieldRef dst, FieldRef src, Value current,
+                 Value::user_iterator it, Value::user_iterator end,
+                 unsigned fieldID)
+        : dst(dst), src(src), current(current), it(it), end(end),
+          fieldID(fieldID) {}
+    // The elements of the destination that this refers to.
+    FieldRef dst;
+    // The elements of the source that this refers to.
+    FieldRef src;
+
+    // These next fields are tied to the value we are currently iterating. This
+    // is used so we can check if a connect op is reading or driving from this
+    // value.
+    Value current;
+    // An iterator of the users of the current value.
+    Value::user_iterator it;
+    Value::user_iterator end;
+    // A filter for which fields of the current value we care about.
+    unsigned fieldID;
+  };
+  SmallVector<StackElement> workStack;
+
+  // Helper to add record a new wire to be processed in the worklist.  This will
+  // add the wire itself to the worklist, which will lead to all subaccesses
+  // being eventually processed as well.
+  auto addToWorklist = [&](FieldRef dst, FieldRef src) {
+    auto value = src.getValue();
+    workStack.emplace_back(dst, src, value, value.user_begin(),
+                           value.user_end(), src.getFieldID());
+  };
+
+  // Create an initial fieldRef from the input value.  As a starting state, the
+  // dst and src are the same value.
+  auto original = getFieldRefFromValue(val);
+  auto fieldRef = original;
+
+  // This loop wraps the worklist, which processes wires. Initially the worklist
+  // is empty.
+  while (true) {
+    // This loop looks through simple operations like casts and nodes.  If it
+    // encounters a wire it will stop and add the wire to the worklist.
+    while (true) {
+      auto val = fieldRef.getValue();
+
+      // The value is a port.
+      if (auto blockArg = val.dyn_cast<BlockArgument>()) {
+        FModuleOp op = cast<FModuleOp>(val.getParentBlock()->getParentOp());
+        auto direction = op.getPortDirection(blockArg.getArgNumber());
+        // Base case: this is one of the module's input ports.
+        if (direction == Direction::In) {
+          if (!callback(original, fieldRef))
+            return false;
+          break;
+        }
+        addToWorklist(original, fieldRef);
+        break;
+      }
+
+      auto *op = val.getDefiningOp();
+
+      // The value is an instance port.
+      if (auto inst = dyn_cast<InstanceOp>(op)) {
+        auto resultNo = val.cast<OpResult>().getResultNumber();
+        // Base case: this is an instance's output port.
+        if (inst.getPortDirection(resultNo) == Direction::Out) {
+          if (!callback(original, fieldRef))
+            return false;
+          break;
+        }
+        addToWorklist(original, fieldRef);
+        break;
+      }
+
+      // If told to look through wires, continue from the driver of the wire.
+      if (lookThroughWires && isa<WireOp>(op)) {
+        addToWorklist(original, fieldRef);
+        break;
+      }
+
+      // If told to look through nodes, continue from the node input.
+      if (lookThroughNodes && isa<NodeOp>(op)) {
+        auto input = cast<NodeOp>(op).getInput();
+        auto next = getFieldRefFromValue(input);
+        fieldRef = next.getSubField(fieldRef.getFieldID());
+        continue;
+      }
+
+      //
+      if (lookThroughCasts &&
+          isa<AsUIntPrimOp, AsSIntPrimOp, AsClockPrimOp, AsAsyncResetPrimOp>(
+              op)) {
+        auto input = op->getOperand(0);
+        auto next = getFieldRefFromValue(input);
+        fieldRef = next.getSubField(fieldRef.getFieldID());
+        continue;
+      }
+
+      // Look through unary ops generated by emitConnect.
+      if (isa<PadPrimOp, TailPrimOp>(op)) {
+        auto input = op->getOperand(0);
+        auto next = getFieldRefFromValue(input);
+        fieldRef = next.getSubField(fieldRef.getFieldID());
+        continue;
+      }
+
+      // Base case: this is a constant/invalid or primop.
+      //
+      // TODO: If needed, this could be modified to look through unary ops which
+      // have an unambiguous single driver.  This should only be added if a need
+      // arises for it.
+      if (!callback(original, fieldRef))
+        return false;
+      break;
+    }
+
+    // Process the next element on the stack.
+    while (true) {
+      // If there is nothing left in the workstack, we are done.
+      if (workStack.empty())
+        return true;
+      auto &back = workStack.back();
+      // Pop the current element if we have processed all users.
+      if (back.it == back.end) {
+        workStack.pop_back();
+        continue;
+      }
+
+      original = back.dst;
+      fieldRef = back.src;
+      auto current = back.current;
+      auto *user = *back.it++;
+      auto fieldID = back.fieldID;
+
+      if (auto subfield = dyn_cast<SubfieldOp>(user)) {
+        auto bundleType = subfield.getInput().getType().cast<BundleType>();
+        auto index = subfield.getFieldIndex();
+        auto subID = bundleType.getFieldID(index);
+        // If the index of this operation doesn't match the target, skip it.
+        if (fieldID) {
+          if (index != bundleType.getIndexForFieldID(fieldID))
+            continue;
+        }
+        auto subRef = fieldRef.getSubField(subID);
+        auto subOriginal = original.getSubField(subID);
+        auto value = subfield.getResult();
+        workStack.emplace_back(subOriginal, subRef, value, value.user_begin(),
+                               value.user_end(), fieldID - subID);
+      } else if (auto subindex = dyn_cast<SubindexOp>(user)) {
+        auto vectorType = subindex.getInput().getType().cast<FVectorType>();
+        auto index = subindex.getIndex();
+        auto subID = vectorType.getFieldID(index);
+        // If the index of this operation doesn't match the target, skip it.
+        if (fieldID) {
+          if (index != vectorType.getIndexForFieldID(fieldID))
+            continue;
+        }
+        auto subRef = fieldRef.getSubField(subID);
+        auto subOriginal = original.getSubField(subID);
+        auto value = subindex.getResult();
+        workStack.emplace_back(subOriginal, subRef, value, value.user_begin(),
+                               value.user_end(), fieldID - subID);
+      } else if (auto connect = dyn_cast<FConnectLike>(user)) {
+        // Make sure that this connect is driving the value.
+        if (connect.getDest() != current)
+          continue;
+        // If the value is driven by a connect, we don't have to recurse,
+        // just update the current value.
+        fieldRef = getFieldRefFromValue(connect.getSrc());
+        break;
+      }
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -53,20 +53,12 @@ void SFCCompatPass::runOnOperation() {
     if (!reg)
       continue;
 
-    // Skip if the reg has an aggregate type.
-    // TODO: Support aggregate types.
-    if (reg.getType().isa<FVectorType, BundleType>()) {
-      reg.emitWarning() << "Aggregate values are not supported by SFCCompat "
-                           "pass. This may result in incorrect results";
-      continue;
-    }
-
     // If the `RegResetOp` has an invalidated initialization, then replace it
     // with a `RegOp`.
-    if (isModuleScopedDrivenBy<InvalidValueOp>(reg.getResetValue(), true, false,
-                                               false)) {
-      LLVM_DEBUG(llvm::dbgs() << "  - RegResetOp '" << reg.getName()
-                              << "' will be replaced with a RegOp\n");
+    if (walkDrivers(reg.getResetValue(), true, false, false,
+                    [](FieldRef dst, FieldRef src) {
+                      return isa<InvalidValueOp>(src.getDefiningOp());
+                    })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
           reg.getType(), reg.getClockVal(), reg.getName(), reg.getNameKind(),
@@ -82,15 +74,28 @@ void SFCCompatPass::runOnOperation() {
     // generate an error.  This implements the SFC's CheckResets pass.
     if (!reg.getResetSignal().getType().isa<AsyncResetType>())
       continue;
-    if (isModuleScopedDrivenBy<ConstantOp, InvalidValueOp, SpecialConstantOp>(
-            reg.getResetValue(), true, true, true))
+    if (walkDrivers(
+            reg.getResetValue(), true, true, true,
+            [&](FieldRef dst, FieldRef src) {
+              if (isa<ConstantOp, InvalidValueOp, SpecialConstantOp>(
+                      src.getDefiningOp()))
+                return true;
+              auto diag = emitError(reg.getLoc());
+              bool rootKnown;
+              auto fieldName = getFieldName(dst, rootKnown);
+              diag << "register " << reg.getNameAttr()
+                   << " has an async reset, but its reset value";
+              if (rootKnown)
+                diag << " \"" << fieldName << "\"";
+              diag << " is not driven with a constant value through wires, "
+                      "nodes, or connects";
+              fieldName = getFieldName(src, rootKnown);
+              diag.attachNote(src.getLoc())
+                  << "reset driver is "
+                  << (rootKnown ? ("\"" + fieldName + "\"") : "here");
+              return false;
+            }))
       continue;
-    auto resetDriver =
-        getModuleScopedDriver(reg.getResetValue(), true, true, true);
-    auto diag = reg.emitOpError()
-                << "has an async reset, but its reset value is not driven with "
-                   "a constant value through wires, nodes, or connects";
-    diag.attachNote(resetDriver.getLoc()) << "reset driver is here";
     return signalPassFailure();
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -57,7 +58,7 @@ void SFCCompatPass::runOnOperation() {
     // with a `RegOp`.
     if (walkDrivers(reg.getResetValue(), true, false, false,
                     [](FieldRef dst, FieldRef src) {
-                      return isa<InvalidValueOp>(src.getDefiningOp());
+                      return src.isa<InvalidValueOp>();
                     })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
@@ -77,8 +78,7 @@ void SFCCompatPass::runOnOperation() {
     if (walkDrivers(
             reg.getResetValue(), true, true, true,
             [&](FieldRef dst, FieldRef src) {
-              if (isa<ConstantOp, InvalidValueOp, SpecialConstantOp>(
-                      src.getDefiningOp()))
+              if (src.isa<ConstantOp, InvalidValueOp, SpecialConstantOp>())
                 return true;
               auto diag = emitError(reg.getLoc());
               bool rootKnown;


### PR DESCRIPTION
This adds support for aggregate typed registers to the SFC compat pass.
SFC Compat looks at the values which are connected to registers; if they
are all invalid the reset can be removed, and resets for async registers
require a constant reset value.

Previously, this used the function `getModuleScopedDriver` which only
handles ground types.  This creates a function `walkDrivers` which
performs a similar operation, but applies a call back when it finds
which fields of the aggregate is driven by some other value. Since the 
source value and the the destination value might both be aggregates, the 
callback uses FieldRefs to indicate the field.

As a follow up it might make sense to replace uses of
`getModuleScopedDriver` with `walkDrivers`.