### PR TITLE
[HW] Added canonicalizers for aggregate operations

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -67,6 +67,8 @@ def ArrayConcatOp : HWOp<"array_concat", [NoSideEffect]> {
     // ValueRange needs to contain at least one element.
     OpBuilder<(ins "ValueRange":$inputs)>
   ];
+
+  let hasCanonicalizeMethod = 1;
 }
 
 def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
@@ -99,6 +101,7 @@ def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
   let results = (outs ArrayType:$dst);
 
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 
   let assemblyFormat = [{
     $input`[`$lowIndex`]` attr-dict `:`
@@ -137,6 +140,7 @@ def ArrayGetOp : HWOp<"array_get",
   ];
 
   let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This commit adds a batch of canonicalizers to the ops working with arrays and structures.

- Simplified chains of inject ops into struct creates if all fields set
- Eliminated injects which are overwritten by other injects
- Canonicalized concatenation of array creates into a single array create
- Converted slices of concatenations into concatenations of slices
- Pushed array gets into slices and concatenations
- Merged a slice of a slice into a single slice
- Converted single-element slices to an array creation with a single element
- Simplified slices of array creates