### PR TITLE
[HW] Added verifier for `hw.struct_create`

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -148,6 +148,7 @@ def StructCreateOp : HWOp<"struct_create", [NoSideEffect]> {
   let arguments = (ins Variadic<HWNonInOutType>:$input);
   let results = (outs StructType:$result);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 }
 
 // Extract the value of a field of a structure.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1798,6 +1798,20 @@ void StructCreateOp::print(OpAsmPrinter &printer) {
   printer << " : " << getType();
 }
 
+LogicalResult StructCreateOp::verify() {
+  auto elements = hw::type_cast<StructType>(getType()).getElements();
+
+  if (elements.size() != getInput().size())
+    return emitOpError("structure field count mismatch");
+
+  for (const auto &[field, value] : llvm::zip(elements, getInput()))
+    if (field.type != value.getType())
+      return emitOpError("structure field `")
+             << field.name << "` type does not match";
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // StructExplodeOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The verifier ensures that the types of the constituent fields match.