### PR TITLE
[ExportVerilog] Inline array element accesses

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -550,7 +550,7 @@ static bool isOkToBitSelectFrom(Value v) {
   }
 
   // Aggregate access can be inlined.
-  if (v.getDefiningOp<StructExtractOp>())
+  if (v.getDefiningOp<StructExtractOp>() || v.getDefiningOp<ArrayGetOp>())
     return true;
 
   // Interface signal can be inlined.


### PR DESCRIPTION
Allowed array indexing to be inlined in nested contexts.