### PR TITLE
[FIRRTL] Allow annotations to be placed on PrintF ops

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -327,7 +327,7 @@ void AnnoTargetCache::gatherTargets(FModuleLike mod) {
   mod.walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
         .Case<InstanceOp, MemOp, NodeOp, RegOp, RegResetOp, WireOp, CombMemOp,
-              SeqMemOp, MemoryPortOp>([&](auto op) {
+              SeqMemOp, MemoryPortOp, PrintFOp>([&](auto op) {
           // To be safe, check attribute and non-empty name before adding.
           if (auto name = op.getNameAttr(); name && !name.getValue().empty())
             targets.insert({name, OpAnnoTarget(op)});


### PR DESCRIPTION
PrintF ops must be added to a name table to allow them to be targeted by annotations.