### PR TITLE
[MSFT] Introduce `LinearOp`

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTConstructs.td
+++ b/include/circt/Dialect/MSFT/MSFTConstructs.td
@@ -77,8 +77,6 @@ def LinearOp : MSFTOp<"hlc.linear", [
     Defines a feed-forward datapath which can be scheduled into a pipeline.
     Due to the feed-forwardness, the inner region is NOT a graph region.
     Internally, only combinational operations (`comb`, `msft`, `hw`) are allowed.
-    The operation expects exactly one i1-typed port to be tagged with a
-    `msft.clock` attribute.
 
     Example:
     ```mlir

--- a/include/circt/Dialect/MSFT/MSFTConstructs.td
+++ b/include/circt/Dialect/MSFT/MSFTConstructs.td
@@ -67,3 +67,48 @@ def ChannelOp: MSFTOp<"constructs.channel",
     $input $clk $sym_name `(` $defaultStages `)` attr-dict `:` type($input)
   }];
 }
+
+// Linear, pipelineable datapath.
+def LinearOp : MSFTOp<"hlc.linear", [
+    SingleBlockImplicitTerminator<"OutputOp">,
+    IsolatedFromAbove
+  ]> {
+  let summary = "Model of a linear datapath which can be arbitrarily pipelined";
+  let description = [{
+    Defines a feed-forward datapath which can be scheduled into a pipeline.
+    Due to the feed-forwardness, the inner region is NOT a graph region.
+    Internally, only combinational operations (`comb`, `msft`, `hw`) are allowed.
+    The operation expects exactly one i1-typed port to be tagged with a
+    `msft.clock` attribute.
+
+    Example:
+    ```mlir
+    msft.module @foo(%in0 : i32, %in1 : i32, %in2 : i32, %clk : i1) -> (out: i32) -> {
+      %0 = msft.hlc.linear(%a = %in0, %b = %in1, %c = %in2) clock %clk (i32, i32, i32) -> (i32) {
+        %0 = comb.mul %a, %b : i32
+        %1 = comb.add %0, %c : i32
+        msft.output %1 : i32
+      }
+    }
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$ins, I1:$clock);
+  let results = (outs Variadic<AnyType>:$outs);
+  let regions = (region SizedRegion<1>:$datapath);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name, "hw::ModulePortInfo":$ports)>
+  ];
+
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &datapath().front(); }
+
+    // Returns the functional type of this operation.
+    FunctionType getType();
+  }];
+
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}

--- a/include/circt/Dialect/MSFT/MSFTConstructs.td
+++ b/include/circt/Dialect/MSFT/MSFTConstructs.td
@@ -70,8 +70,7 @@ def ChannelOp: MSFTOp<"constructs.channel",
 
 // Linear, pipelineable datapath.
 def LinearOp : MSFTOp<"hlc.linear", [
-    SingleBlockImplicitTerminator<"OutputOp">,
-    IsolatedFromAbove
+    SingleBlockImplicitTerminator<"OutputOp">
   ]> {
   let summary = "Model of a linear datapath which can be arbitrarily pipelined";
   let description = [{
@@ -93,22 +92,14 @@ def LinearOp : MSFTOp<"hlc.linear", [
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType>:$ins, I1:$clock);
+  let arguments = (ins I1:$clock);
   let results = (outs Variadic<AnyType>:$outs);
   let regions = (region SizedRegion<1>:$datapath);
 
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "StringAttr":$name, "hw::ModulePortInfo":$ports)>
-  ];
-
   let extraClassDeclaration = [{
     Block *getBodyBlock() { return &datapath().front(); }
-
-    // Returns the functional type of this operation.
-    FunctionType getType();
   }];
 
   let hasVerifier = 1;
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{ `clock` $clock attr-dict `:` type($outs) $datapath }];
 }

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -237,7 +237,7 @@ def DesignPartitionOp : MSFTOp<"partition",
   let assemblyFormat = "$sym_name `,` $verilogName attr-dict";
 }
 
-def OutputOp : MSFTOp<"output", [Terminator, HasParent<"MSFTModuleOp">,
+def OutputOp : MSFTOp<"output", [Terminator, ParentOneOf<["MSFTModuleOp", "LinearOp"]>,
                                 NoSideEffect, ReturnLike]> {
   let summary = "termination operation";
 

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -983,94 +983,16 @@ void SystolicArrayOp::print(OpAsmPrinter &p) {
 // LinearOp
 //===----------------------------------------------------------------------===//
 
-ParseResult LinearOp::parse(OpAsmParser &parser, OperationState &result) {
-  llvm::SmallVector<OpAsmParser::Argument> regionArgs;
-  llvm::SmallVector<OpAsmParser::UnresolvedOperand> opInputs;
-
-  if (parser.parseLParen())
-    return failure();
-
-  // Parse the input values and inner region argument defs.
-  if (failed(parser.parseOptionalRParen())) {
-    do {
-      regionArgs.resize(regionArgs.size() + 1);
-      opInputs.resize(opInputs.size() + 1);
-      if (parser.parseArgument(regionArgs.back()) || parser.parseEqual() ||
-          parser.parseOperand(opInputs.back()))
-        return failure();
-    } while (!parser.parseOptionalComma());
-    if (parser.parseRParen())
-      return failure();
-  }
-
-  // Parse clock signal.
-  opInputs.resize(opInputs.size() + 1);
-  if (parser.parseKeyword("clock") || parser.parseOperand(opInputs.back()))
-    return failure();
-
-  // Parse the optional attribute list.
-  if (parser.parseOptionalAttrDict(result.attributes))
-    return failure();
-
-  // Parse the type.
-  FunctionType type;
-  if (failed(parser.parseColonType(type)))
-    return failure();
-
-  for (auto it : llvm::enumerate(type.getInputs())) {
-    if (failed(parser.resolveOperand(opInputs[it.index()], it.value(),
-                                     result.operands)))
-      return failure();
-    regionArgs[it.index()].type = it.value();
-  }
-  if (failed(parser.resolveOperand(
-          opInputs.back(), parser.getBuilder().getI1Type(), result.operands)))
-    return failure();
-  if (parser.addTypesToList(type.getResults(), result.types))
-    return failure();
-
-  // Parse the inner region.
-  Region *region = result.addRegion();
-  if (parser.parseRegion(*region, regionArgs))
-    return failure();
-
-  return success();
-}
-
-void LinearOp::print(OpAsmPrinter &p) {
-  p << "(";
-
-  for (int i = 0, e = ins().size(); i < e; i++) {
-    p << getBody()->getArgument(i) << " = " << ins()[i];
-    if (i != e - 1)
-      p << ", ";
-  }
-
-  p << ") clock " << clock();
-  p.printOptionalAttrDict(getOperation()->getAttrs());
-  p << " : " << getType() << " ";
-  p.printRegion(datapath(), /*printEntryBlockArgs=*/false);
-}
-
 LogicalResult LinearOp::verify() {
 
   for (auto &op : *getBodyBlock()) {
     if (!isa<hw::HWDialect, comb::CombDialect, msft::MSFTDialect>(
             op.getDialect()))
-      return op.emitOpError() << "expected only hw, comb, and msft dialect ops "
-                                 "inside the msft.hlc.linear datapath.";
+      return emitOpError() << "expected only hw, comb, and msft dialect ops "
+                              "inside the datapath.";
   }
 
   return success();
-}
-
-FunctionType LinearOp::getType() {
-  llvm::SmallVector<Type, 4> inTypes, outTypes;
-  llvm::transform(ins(), std::back_inserter(inTypes),
-                  [](Value v) { return v.getType(); });
-  llvm::transform(outs(), std::back_inserter(outTypes),
-                  [](Value v) { return v.getType(); });
-  return FunctionType::get(getContext(), inTypes, outTypes);
 }
 
 #define GET_OP_CLASSES

--- a/test/Dialect/MSFT/constructs.mlir
+++ b/test/Dialect/MSFT/constructs.mlir
@@ -63,16 +63,16 @@ msft.module @ChannelExample {} (%clk: i1, %a : i8) -> (out: i8) {
 }
 
 // CHECK-LABEL: msft.module @foo {} (%in0: i32, %in1: i32, %in2: i32, %clk: i1) -> (out: i32) {
-// CHECK:       %0 = msft.hlc.linear(%arg0 = %in0, %arg1 = %in1, %arg2 = %in2) clock %clk : (i32, i32, i32) -> i32 {
-// CHECK:         %1 = comb.mul %arg0, %arg1 : i32
-// CHECK:         %2 = comb.add %1, %arg2 : i32
+// CHECK:       %0 = msft.hlc.linear clock %clk : i32 {
+// CHECK:         %1 = comb.mul %in0, %in1 : i32
+// CHECK:         %2 = comb.add %1, %in2 : i32
 // CHECK:         msft.output %2 : i32
 // CHECK:       }
 // CHECK:       msft.output %0 : i32
 msft.module @foo {} (%in0 : i32, %in1 : i32, %in2 : i32, %clk : i1) -> (out: i32) {
-  %0 = msft.hlc.linear(%arg0 = %in0, %arg1 = %in1, %arg2 = %in2) clock %clk : (i32, i32, i32) -> (i32) {
-    %0 = comb.mul %arg0, %arg1 : i32
-    %1 = comb.add %0, %arg2 : i32
+  %0 = msft.hlc.linear clock %clk : i32 {
+    %0 = comb.mul %in0, %in1 : i32
+    %1 = comb.add %0, %in2 : i32
     msft.output %1 : i32
   }
   msft.output %0 : i32

--- a/test/Dialect/MSFT/constructs.mlir
+++ b/test/Dialect/MSFT/constructs.mlir
@@ -61,3 +61,19 @@ msft.module @ChannelExample {} (%clk: i1, %a : i8) -> (out: i8) {
   %out = msft.constructs.channel %a %clk "chEx" (2) : i8
   msft.output %out : i8
 }
+
+// CHECK-LABEL: msft.module @foo {} (%in0: i32, %in1: i32, %in2: i32, %clk: i1) -> (out: i32) {
+// CHECK:       %0 = msft.hlc.linear(%arg0 = %in0, %arg1 = %in1, %arg2 = %in2) clock %clk : (i32, i32, i32) -> i32 {
+// CHECK:         %1 = comb.mul %arg0, %arg1 : i32
+// CHECK:         %2 = comb.add %1, %arg2 : i32
+// CHECK:         msft.output %2 : i32
+// CHECK:       }
+// CHECK:       msft.output %0 : i32
+msft.module @foo {} (%in0 : i32, %in1 : i32, %in2 : i32, %clk : i1) -> (out: i32) {
+  %0 = msft.hlc.linear(%arg0 = %in0, %arg1 = %in1, %arg2 = %in2) clock %clk : (i32, i32, i32) -> (i32) {
+    %0 = comb.mul %arg0, %arg1 : i32
+    %1 = comb.add %0, %arg2 : i32
+    msft.output %1 : i32
+  }
+  msft.output %0 : i32
+}

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -45,3 +45,15 @@ msft.module @M {} (%x : i32) {
   comb.add %x, %x {msft.appid=#msft.appid<"add"[0]>} : i32
   msft.output
 }
+
+// -----
+
+msft.module @foo {} (%in0 : i32, %clk : i1) -> (out: i32) {
+  %0 = msft.hlc.linear(%a = %in0) clock %clk : (i32) -> (i32) {
+    %c1_i1 = hw.constant 1 : i1
+// expected-error @+1 {{'seq.compreg' op expected only hw, comb, and msft dialect ops inside the msft.hlc.linear datapath.}}
+    %0 = seq.compreg %a, %c1_i1 : i32
+    msft.output %0 : i32
+  }
+  msft.output %0 : i32
+}

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -49,10 +49,10 @@ msft.module @M {} (%x : i32) {
 // -----
 
 msft.module @foo {} (%in0 : i32, %clk : i1) -> (out: i32) {
-  %0 = msft.hlc.linear(%a = %in0) clock %clk : (i32) -> (i32) {
+// expected-error @+1 {{'msft.hlc.linear' op expected only hw, comb, and msft dialect ops inside the datapath.}}
+  %0 = msft.hlc.linear clock %clk : i32 {
     %c1_i1 = hw.constant 1 : i1
-// expected-error @+1 {{'seq.compreg' op expected only hw, comb, and msft dialect ops inside the msft.hlc.linear datapath.}}
-    %0 = seq.compreg %a, %c1_i1 : i32
+    %0 = seq.compreg %in0, %c1_i1 : i32
     msft.output %0 : i32
   }
   msft.output %0 : i32


### PR DESCRIPTION
The `msft.hlc.linear` operation defines a linear datapath. It serves as a container for `hw`, `comb` and `msft` operations, with the following restrictions:
- Not graph-like - only SSA def-use chains are allowed.
- `seq` ops are not allowed.
- Exactly one port must be an `i1` signal tagged with a `msft.clock` `UnitAttr`. This signal will be required during lowering.