### PR TITLE
[IMDCE] Forward constant output ports to caller sides

### DIFF
--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -162,3 +162,21 @@ firrtl.circuit "DeleteEmptyModule" {
     firrtl.instance sub2 @Sub(in a: !firrtl.uint<1>)
   }
 }
+
+// -----
+
+// CHECK-LABEL: "ForwardConstant"
+firrtl.circuit "ForwardConstant" {
+  // CHECK-NOT: Zero
+  firrtl.module private @Zero(out %zero: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
+  }
+  // CHECK-LABEL: @ForwardConstant
+  firrtl.module @ForwardConstant(out %zero: !firrtl.uint<1>) {
+    // CHECK: %c0_ui1 = firrtl.constant 0
+    %sub_zero = firrtl.instance sub @Zero(out zero: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.strictconnect %zero, %c0_ui1
+    firrtl.strictconnect %zero, %sub_zero : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
This PR makes IMDCE propagate constant output ports to caller sides before
actually performing dataflow analysis so that we can eliminate constant output ports.  