### PR TITLE
[FIRRTL][Dedup] Simplify printing of dedup failure of instances

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/None.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Format.h"
@@ -420,17 +421,13 @@ struct Equivalence {
     // sub module did not dedupliate. This code recursively checks the child
     // module.
     if (aName != bName) {
-      diag.attachNote(a->getLoc()) << "first instance targets module " << aName;
-      diag.attachNote(b->getLoc())
-          << "second instance targets module " << bName;
-      diag.report();
       auto aModule = instanceGraph.getReferencedModule(a);
       auto bModule = instanceGraph.getReferencedModule(b);
       // Create a new error for the submodule.
-      auto newDiag = emitError(aModule->getLoc())
-                     << "module " << aName << " not deduplicated with "
-                     << bName;
-      check(newDiag, aModule, bModule);
+      diag.attachNote(llvm::None)
+          << "in instance " << a.getNameAttr() << " of " << aName
+          << ", and instance " << b.getNameAttr() << " of " << bName;
+      check(diag, aModule, bModule);
       return failure();
     }
     return success();

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -56,7 +56,8 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
 
 // -----
 
-// expected-error@below {{module "Mid1" not deduplicated with "Mid0"}}
+// expected-error@+2 {{module "Mid1" not deduplicated with "Mid0"}}
+// expected-note@+1 {{in instance "test0" of "Test0", and instance "test1" of "Test1"}}
 firrtl.circuit "MustDedup" attributes {annotations = [{
       class = "firrtl.transforms.MustDeduplicateAnnotation",
       modules = ["~MustDedup|Mid0", "~MustDedup|Mid1"]
@@ -66,14 +67,11 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
     firrtl.instance mid1 @Mid1()
   }
   firrtl.module @Mid0() {
-    // expected-note@below {{first instance targets module "Test0"}}
     firrtl.instance test0 @Test0()
   }
   firrtl.module @Mid1() {
-    // expected-note@below {{second instance targets module "Test1"}}
     firrtl.instance test1 @Test1()
   }
-  // expected-error@below {{module "Test0" not deduplicated with "Test1"}}
   firrtl.module @Test0() {
     // expected-note@below {{first operation is a firrtl.wire}}
     %w = firrtl.wire : !firrtl.uint<8>


### PR DESCRIPTION
When printing the error message for deduplication failure, the error
printed for a stack of error messages is quite large and hard to read.
This makes an incremental improvement to the stack of error messages.
The most important improvement is that it prints as a single diagnostic
with a single `error:` emitted.

Before:
```
design.fir:1:1: error: module "Top0" not deduplicated with "Top1"
circuit Top :
^
design.scala:135:24: note: first instance targets module "Mid0"
design.scala:135:24: note: second instance targets module "Mid1"
design.fir:4395809:10: error: module "Mid0" not deduplicated with "MId1"
  module Mid0:
         ^
design.scala:64:9: note: first operation has attribute 'message' with value "Assertion failed: 0"
design.scala:64:9: note: second operation has value "Assertion failed: 1"
```

After:
```
design.fir:1:1: error: module "Top0" not deduplicated with "Top1"
circuit Top :
^
design.fir:1:1: note: in instance "mid0" of "Mid0", and instance "mid1" of "Mid1"
design.scala:64:9: note: first operation has attribute 'message' with value "Assertion failed: 0"
design.scala:64:9: note: second operation has value "Assertion failed: 1"
```