### PR TITLE
[IntegrationTest] Ensure correct ieee-sim selection

### DIFF
--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -149,6 +149,10 @@ if len(ieee_sims) > 1:
   warnings.warn(
       f"You have multiple ieee-sim simulators configured, choosing: {ieee_sims[-1][1]}"
   )
+  # remove all other subsitution entries
+  config.substitutions = list(
+      filter(lambda x: x[0] != '%ieee-sim' or x == ieee_sims[-1],
+             config.substitutions))
 
 # If the ieee-sim was selected to be iverilog in case no other simulators are
 # available, define a feature flag to allow tests which cannot be simulated


### PR DESCRIPTION
If multiple ieee-sims are found, only the last one should be used. As substitution considers the first match, all other substitution entries need to be dropped.