### PR TITLE
[ExportVerilog] Inline logic assignments into decl in new emission mode

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3998,9 +3998,12 @@ static AssignTy getSingleAssignAndCheckUsers(Operation *op) {
   return {};
 }
 
-// Return true if `op1` dominates users of `op2`.
+/// Return true if `op1` dominates users of `op2`.
 static bool checkDominanceOfUsers(Operation *op1, Operation *op2) {
   return llvm::all_of(op2->getUsers(), [&](Operation *user) {
+    /// TODO: Use MLIR DominanceInfo.
+
+    // If the op1 and op2 are in different blocks, conservatively return false.
     if (op1->getBlock() != user->getBlock())
       return false;
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -343,7 +343,8 @@ hw.module @wires(%in4: i4, %in8: i8) -> (a: i4, b: i8, c: i8) {
   // CHECK-EMPTY:
 
   // Wires.
-  // CHECK-NEXT: wire [3:0]            myWire;
+  // NEW-NEXT: wire [3:0]            myWire = in4;
+  // OLD-NEXT: wire [3:0]            myWire;
   %myWire = sv.wire : !hw.inout<i4>
 
   // Packed arrays.
@@ -363,7 +364,7 @@ hw.module @wires(%in4: i4, %in8: i8) -> (a: i4, b: i8, c: i8) {
 
   // Wires.
 
-  // CHECK: assign myWire = in4;
+  // OLD: assign myWire = in4;
   sv.assign %myWire, %in4 : i4
   %wireout = sv.read_inout %myWire : !hw.inout<i4>
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -17,9 +17,10 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK: localparam [41:0]{{ *}} param_y = param1;
   %param_y = sv.localparam : i42 { value = #hw.param.decl.ref<"param1">: i42 }
 
-  // CHECK:       logic{{ *}} [7:0]{{ *}} logic_op;
-  // CHECK-NEXT:  struct packed {logic b; } logic_op_struct;
-  // CHECK: assign logic_op = val;
+  // OLD:        logic{{ *}} [7:0]{{ *}} logic_op;
+  // NEW:        logic{{ *}} [7:0]{{ *}} logic_op = val;
+  // CHECK-NEXT: struct packed {logic b; } logic_op_struct;
+  // OLD:        assign logic_op = val;
   %logic_op = sv.logic : !hw.inout<i8>
   %logic_op_struct = sv.logic : !hw.inout<struct<b: i1>>
   sv.assign %logic_op, %val: i8
@@ -903,10 +904,11 @@ hw.module @inlineProceduralWiresWithLongNames(%clock: i1, %in: i1) {
 // https://github.com/llvm/circt/issues/859
 // CHECK-LABEL: module oooReg(
 hw.module @oooReg(%in: i1) -> (result: i1) {
-  // CHECK: wire abc;
+  // OLD: wire abc;
+  // NEW: wire abc = in;
   %0 = sv.read_inout %abc : !hw.inout<i1>
 
-  // CHECK: assign abc = in;
+  // OLD: assign abc = in;
   sv.assign %abc, %in : i1
   %abc = sv.wire  : !hw.inout<i1>
 
@@ -1320,20 +1322,22 @@ hw.module @remoteInstDut(%i: i1, %j: i1, %z: i0) -> () {
   hw.instance "a2" sym @bindInst2 @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint=1}
   hw.instance "signed" sym @bindInst3 @extInst2(signed: %mywire_rd1 : i1, _i: %myreg_rd1 : i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint=1}
 // CHECK: wire _signed__k
-// CHECK-NEXT: wire _a2__k
-// CHECK-NEXT: wire _a1__k
+// OLD-NEXT: wire _a2__k
+// OLD-NEXT: wire _a1__k
+// NEW-NEXT: wire _a2__k = 1'h1;
+// NEW-NEXT: wire _a1__k = 1'h1;
 // CHECK-NEXT: wire mywire
 // CHECK-NEXT: myreg
 // CHECK-NEXT: wire signed_0
 // CHECK-NEXT: reg  output_1
-// CHECK: assign _a1__k = 1'h1
+// OLD:        assign _a1__k = 1'h1
 // CHECK-NEXT: /* This instance is elsewhere emitted as a bind statement
 // CHECK-NEXT:    extInst a1
-// CHECK: assign _a2__k = 1'h1
-// CHECK-NEXT: /* This instance is elsewhere emitted as a bind statement
+// OLD: assign _a2__k = 1'h1
+// CHECK: /* This instance is elsewhere emitted as a bind statement
 // CHECK-NEXT:    extInst a2
-// CHECK:  assign _signed__k = 1'h1
-// CHECK-NEXT:  /* This instance is elsewhere emitted as a bind statement
+// OLD:  assign _signed__k = 1'h1
+// CHECK:      /* This instance is elsewhere emitted as a bind statement
 // CHECK-NEXT:    extInst2 signed_2
 // CHECK-NEXT:    .signed_0 (signed_0)
 }


### PR DESCRIPTION
This implements a mechanism to inline blocking assignments into automatic logic declarations in the new emission mode. 
We can inline blocking assignment into automatic logic declrations if:
1. There exists a single blocking assignment which dominates all users of logic reads.
2. The source value of the assign can be inlined into the declaration. This is checked by  `isExpressionEmittedInlineIntoProceduralDeclaration`. 

Depends on https://github.com/llvm/circt/pull/3691