### PR TITLE
[PyCDE][NFC] Value: revert fancy __new__ dispatch method

### DIFF
--- a/frontends/PyCDE/src/pycde/behavioral.py
+++ b/frontends/PyCDE/src/pycde/behavioral.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .value import BitVectorValue, Value
+from .value import BitVectorValue, PyCDEValue, Value
 from pycde.dialects import comb
 
 import ctypes
@@ -115,7 +115,7 @@ class _IfBlock:
     new_lcls: Dict[str, Value] = {}
     for (varname, value) in s.f_locals.items():
       # Only operate on Values.
-      if not isinstance(value, Value):
+      if not isinstance(value, PyCDEValue):
         continue
       # If the value was in the original scope and it hasn't changed, don't
       # touch it.

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -11,7 +11,7 @@ from pycde.support import _obj_to_value
 from .common import (AppID, Clock, Input, Output, _PyProxy)
 from .support import (get_user_loc, _obj_to_attribute, OpOperandConnect,
                       create_type_string, create_const_zero)
-from .value import ClockValue, Value
+from .value import ClockValue, PyCDEValue, Value
 
 from circt import support
 from circt.dialects import hw, msft
@@ -581,7 +581,7 @@ class _GeneratorPortAccess:
 
     output_port = self._mod.output_ports[self._mod.output_port_lookup[name]]
     output_port_type = output_port[1]
-    if not isinstance(value, Value):
+    if not isinstance(value, PyCDEValue):
       value = _obj_to_value(value, output_port_type)
     if value.type != output_port_type:
       if value.type == output_port_type.strip:

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -79,12 +79,12 @@ def _obj_to_value(x, type, result_type=None):
   if x is None:
     raise ValueError(
         "Encountered 'None' when trying to build hardware for python value.")
-  from .value import Value
+  from .value import PyCDEValue
   from .dialects import hw
   from .pycde_types import (TypeAliasType, ArrayType, StructType, BitVectorType,
                             Type)
 
-  if isinstance(x, Value):
+  if isinstance(x, PyCDEValue):
     return x
 
   type = Type(type)
@@ -142,8 +142,8 @@ def _obj_to_value(x, type, result_type=None):
 def _infer_type(x):
   """Infer the CIRCT type from a python object. Only works on lists."""
   from .pycde_types import types
-  from .value import Value
-  if isinstance(x, Value):
+  from .value import PyCDEValue
+  if isinstance(x, PyCDEValue):
     return x.type
 
   if isinstance(x, (list, tuple)):

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -18,32 +18,40 @@ import re
 import numpy as np
 
 
-class Value:
+def Value(value, type=None):
+  from .pycde_types import Type
 
-  # Dummy __init__ as everything is done in __new__.
+  if isinstance(value, PyCDEValue):
+    return value
+
+  resvalue = support.get_value(value)
+  if resvalue is None:
+    return _obj_to_value_infer_type(value)
+
+  if type is None:
+    type = resvalue.type
+  type = Type(type)
+
+  return type._get_value_class()(resvalue, type)
+
+
+class PyCDEValue:
+  """Root of the PyCDE value (signal, in RTL terms) hierarchy."""
+
   def __init__(self, value, type=None):
-    pass
-
-  def __new__(cls, value, type=None):
     from .pycde_types import Type
 
-    if (value is None or isinstance(value, Value)) and value.__class__ is cls:
-      return value
-    resvalue = support.get_value(value)
-
-    if resvalue is None:
-      return _obj_to_value_infer_type(value)
-
-    if type is None:
-      type = resvalue.type
-    type = Type(type)
-    if cls is Value:
-      v = super().__new__(type._get_value_class())
+    if isinstance(value, ir.Value):
+      self.value = value
     else:
-      v = super().__new__(cls)
-    v.value = resvalue
-    v.type = type
-    return v
+      self.value = support.get_value(value)
+      if self.value is None:
+        self.value = _obj_to_value_infer_type(value).value
+
+    if type is not None:
+      self.type = type
+    else:
+      self.type = Type(self.value.type)
 
   _reg_name = re.compile(r"^(.*)__reg(\d+)$")
 
@@ -68,7 +76,7 @@ class Value:
     if name is None:
       basename = None
       if self.name is not None:
-        m = Value._reg_name.match(self.name)
+        m = PyCDEValue._reg_name.match(self.name)
         if m:
           basename = m.group(1)
           reg_num = m.group(2)
@@ -145,14 +153,14 @@ class Value:
     self.value.owner.attributes[AppID.AttributeName] = appid._appid
 
 
-class RegularValue(Value):
+class RegularValue(PyCDEValue):
   pass
 
 
 _current_clock_context = ContextVar("current_clock_context")
 
 
-class ClockValue(Value):
+class ClockValue(PyCDEValue):
   """A clock signal."""
 
   __slots__ = ["_old_token"]
@@ -170,7 +178,7 @@ class ClockValue(Value):
     return _current_clock_context.get(None)
 
 
-class InOutValue(Value):
+class InOutValue(PyCDEValue):
   # Maintain a caching of the read value.
   read_value = None
 
@@ -210,7 +218,7 @@ def get_slice_bounds(size, idxOrSlice: Union[int, slice]):
   return idxs[0], idxs[1]
 
 
-class BitVectorValue(Value):
+class BitVectorValue(PyCDEValue):
 
   @singledispatchmethod
   def __getitem__(self, idxOrSlice: Union[int, slice]) -> BitVectorValue:
@@ -225,7 +233,7 @@ class BitVectorValue(Value):
         ret.name = f"{self.name}_{lo}upto{hi}"
       return ret
 
-  @__getitem__.register(Value)
+  @__getitem__.register(PyCDEValue)
   def __get_item__value(self, idx: BitVectorValue) -> BitVectorValue:
     """Get the single bit at `idx`."""
     return self.slice(idx, 1)
@@ -314,7 +322,7 @@ class BitVectorValue(Value):
 
   def __exec_signless_binop_nocast__(self, other, op, op_symbol: str,
                                      op_name: str):
-    if not isinstance(other, Value):
+    if not isinstance(other, PyCDEValue):
       # Fall back to the default implementation in cases where we're not dealing
       # with PyCDE value comparison.
       return super().__eq__(other)
@@ -426,10 +434,10 @@ class SignedBitVectorValue(WidthExtendingBitVectorValue):
     return self * types.int(self.type.width)(-1).as_sint()
 
 
-class ListValue(Value):
+class ListValue(PyCDEValue):
 
   @singledispatchmethod
-  def __getitem__(self, idx: Union[int, BitVectorValue]) -> Value:
+  def __getitem__(self, idx: Union[int, BitVectorValue]) -> PyCDEValue:
     _validate_idx(self.type.size, idx)
     from .dialects import hw
     with get_user_loc():
@@ -454,7 +462,8 @@ class ListValue(Value):
         ret.name = f"{self.name}_{idxs[0]}upto{idxs[1]}"
       return ret
 
-  def slice(self, low_idx: Union[int, BitVectorValue], num_elems: int) -> Value:
+  def slice(self, low_idx: Union[int, BitVectorValue],
+            num_elems: int) -> PyCDEValue:
     """Get an array slice starting at `low_idx` and ending at `low_idx +
     num_elems`."""
     _validate_idx(self.type.size, low_idx)
@@ -518,7 +527,7 @@ class ListValue(Value):
     return np.roll(NDArray(from_value=self), shift=shift, axis=axis).to_circt()
 
 
-class StructValue(Value):
+class StructValue(PyCDEValue):
 
   def __getitem__(self, sub):
     if sub not in [name for name, _ in self.type.strip.fields]:
@@ -539,7 +548,7 @@ class StructValue(Value):
     raise AttributeError(f"'Value' object has no attribute '{attr}'")
 
 
-class ChannelValue(Value):
+class ChannelValue(PyCDEValue):
 
   def reg(self, clk, rst=None, name=None):
     raise TypeError("Cannot register a channel")
@@ -570,9 +579,9 @@ def wrap_opviews_with_values(dialect, module_name, excluded=[]):
 
         def create(*args, **kwargs):
           # If any of the arguments are Value objects, we need to convert them.
-          args = [v.value if isinstance(v, Value) else v for v in args]
+          args = [v.value if isinstance(v, PyCDEValue) else v for v in args]
           kwargs = {
-              k: v.value if isinstance(v, Value) else v
+              k: v.value if isinstance(v, PyCDEValue) else v
               for k, v in kwargs.items()
           }
           # Create the OpView.


### PR DESCRIPTION
Using `__new__` to redirect construction to a specialized class had too
many side-effects. Trying to get around them led to convoluted code.
Move back to a function-based dispatch method.