### PR TITLE
[PyCDE] Add new API to import existing HW modules into a System.

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -409,7 +409,8 @@ def import_hw_module(hw_module: hw.HWModuleOp):
   # would wrap.
   cls = type(name, (object,), ports)
 
-  # Creation callback that just returns the already build module.
+  # Creation callback that just moves the already build module into the System's
+  # ModuleOp and returns it.
   def create_cb(sys: System, mod: _SpecializedModule, symbol: str):
     sys.mod.body.append(hw_module)
     return hw_module

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -394,6 +394,30 @@ def externmodule(to_be_wrapped, extern_name=None):
                                create_cb=create_msft_module_extern_op)
 
 
+def import_hw_module(hw_module: hw.HWModuleOp):
+  # Get the module name to use in the generated class and as the external name.
+  name = mlir.ir.StringAttr(hw_module.name).value
+
+  # Collect input and output ports as named Inputs and Outputs.
+  ports = {}
+  for input_name, block_arg in hw_module.inputs().items():
+    ports[input_name] = Input(block_arg.type, input_name)
+  for output_name, output_type in hw_module.outputs().items():
+    ports[output_name] = Output(output_type, output_name)
+
+  # Use the name and ports to construct a class object like what externmodule
+  # would wrap.
+  cls = type(name, (object,), ports)
+
+  # Creation callback that just returns the already build module.
+  def create_cb(sys: System, mod: _SpecializedModule, symbol: str):
+    sys.mod.body.append(hw_module)
+    return hw_module
+
+  # Hand off the class, external name, and create callback to _module_base.
+  return _module_base(cls, name, create_cb)
+
+
 def _module_base(cls,
                  extern_name: str,
                  create_cb: Optional[builtins.function] = None,

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -2,6 +2,8 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations
+
 from pycde.devicedb import (EntityExtern, PlacementDB, PrimitiveDB,
                             PhysicalRegion)
 
@@ -90,19 +92,14 @@ class System:
   def set_debug():
     ir._GlobalDebug.flag = True
 
-  def import_hw_modules(self, path: Path):
-    # Parse the MLIR Module at path.
-    mlir_module = ir.Module.parse(open(path).read())
-
-    # Construct PyCDE modules wrapping each HW module, and call their `create`
-    # method to import the IR into the PyCDE System ModuleOp. Also add them to
-    # the list of top-level modules so later emission stages know about them.
+  def import_modules(self, modules: list[_SpecializedModule]):
+    # Call the imported modules' `create` methods to import the IR into the
+    # PyCDE System ModuleOp. Also add them to the list of top-level modules so
+    # later emission stages know about them.
     with self:
-      for op in mlir_module.body:
-        if isinstance(op, hw.HWModuleOp):
-          hw_module = import_hw_module(op)
-          hw_module._pycde_mod.create()
-          self.top_modules.append(hw_module)
+      for module in modules:
+        module._pycde_mod.create()
+        self.top_modules.append(module)
 
   def create_physical_region(self, name: str = None):
     with self._get_ip():

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -8,7 +8,7 @@ from pycde.devicedb import (EntityExtern, PlacementDB, PrimitiveDB,
                             PhysicalRegion)
 
 from .common import _PyProxy
-from .module import _SpecializedModule, import_hw_module
+from .module import _SpecializedModule
 from .pycde_types import types
 from .instance import Instance, InstanceHierarchyRoot
 
@@ -26,7 +26,6 @@ from contextvars import ContextVar
 import gc
 import os
 import sys
-from pathlib import Path
 from typing import Callable, Dict, Set, Tuple
 
 _current_system = ContextVar("current_pycde_system")

--- a/frontends/PyCDE/test/test_import_hw_modules.py
+++ b/frontends/PyCDE/test/test_import_hw_modules.py
@@ -1,0 +1,34 @@
+# RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pycde.system import System
+
+tmp = NamedTemporaryFile()
+tmp.write(b"""
+hw.module @add(%a: i1, %b: i1) -> (out: i1) {
+  %0 = comb.add %a, %b : i1
+  hw.output %0 : i1
+}
+
+hw.module @and(%a: i1, %b: i1) -> (out: i1) {
+  %0 = comb.and %a, %b : i1
+  hw.output %0 : i1
+}
+""")
+tmp.flush()
+
+system = System.import_hw_modules(tmp.name)
+system.generate()
+
+# CHECK: hw.module @add(%a: i1, %b: i1) -> (out: i1)
+# CHECK:   %0 = comb.add %a, %b : i1
+# CHECK:   hw.output %0 : i1
+
+# CHECK: hw.module @and(%a: i1, %b: i1) -> (out: i1)
+# CHECK:   %0 = comb.and %a, %b : i1
+# CHECK:   hw.output %0 : i1
+
+system.print()
+tmp.close()

--- a/frontends/PyCDE/test/test_import_hw_modules.py
+++ b/frontends/PyCDE/test/test_import_hw_modules.py
@@ -19,7 +19,8 @@ hw.module @and(%a: i1, %b: i1) -> (out: i1) {
 """)
 tmp.flush()
 
-system = System.import_hw_modules(tmp.name)
+system = System([])
+system.import_hw_modules(tmp.name)
 system.generate()
 
 # CHECK: hw.module @add(%a: i1, %b: i1) -> (out: i1)

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -336,6 +336,14 @@ class HWModuleOp(ModuleLike):
       ret[name] = self.entry_block.arguments[idx]
     return ret
 
+  def outputs(self) -> dict[str:Type]:
+    result_names = [
+        StringAttr(name).value
+        for name in ArrayAttr(self.attributes["resultNames"])
+    ]
+    result_types = self.type.results
+    return dict(zip(result_names, result_types))
+
   def add_entry_block(self):
     if not self.is_external:
       raise IndexError('The module already has an entry block')


### PR DESCRIPTION
This can be used to load HW modules from an MLIR file on disk, and
insert them into a fresh System.