### PR TITLE
[ESI] Bidirectional channel requests and Cosim support

### DIFF
--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -54,6 +54,17 @@ def ToClientOp : ESI_Op<"service.to_client",
   }];
 }
 
+def ServiceDeclInOutOp : ESI_Op<"service.inout",
+                        [HasParent<"::circt::esi::ServiceDeclOp">]> {
+  let summary = "An ESI service port headed to a particular client";
+
+  let arguments = (ins SymbolNameAttr:$inner_sym,
+                       TypeAttr:$inType, TypeAttr:$outType);
+  let assemblyFormat = [{
+    $inner_sym attr-dict `:` qualified($inType) `->` qualified($outType)
+  }];
+}
+
 def ServiceInstanceOp : ESI_Op<"service.instance"> {
   let summary = "Instantiate a server module";
   let description = [{
@@ -132,5 +143,20 @@ def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
   let assemblyFormat = [{
     $servicePort `(` $clientNamePath `)`
       attr-dict `:` qualified(type($receiving))
+  }];
+}
+
+def RequestInOutChannelOp : ESI_Op<"service.req.inout", [
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Request a bidirectional channel";
+
+  let arguments = (ins HWInnerRefAttr:$servicePort,
+                       ChannelType:$sending,
+                       StrArrayAttr:$clientNamePath);
+  let results = (outs ChannelType:$receiving);
+
+  let assemblyFormat = [{
+    $sending `->` $servicePort `(` $clientNamePath `)` attr-dict `:`
+      qualified(type($sending)) `->` qualified(type($receiving))
   }];
 }

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -242,7 +242,6 @@ static OpType getServicePortDecl(Operation *op,
   StringAttr modName = servicePort.getModule();
   ServiceDeclOp serviceDeclOp = topSyms.lookup<ServiceDeclOp>(modName);
   if (!serviceDeclOp) {
-    op->emitOpError("Cannot find module ") << modName;
     return {};
   }
 
@@ -250,7 +249,6 @@ static OpType getServicePortDecl(Operation *op,
   for (auto portDecl : serviceDeclOp.getOps<OpType>())
     if (portDecl.inner_symAttr() == innerSym)
       return portDecl;
-  op->emitOpError("Cannot find port named ") << innerSym;
   return {};
 }
 
@@ -259,17 +257,34 @@ static OpType getServicePortDecl(Operation *op,
 template <class PortTypeOp, class OpType>
 static LogicalResult
 reqPortMatches(OpType op, SymbolTableCollection &symbolTable, Type t) {
-  auto portDecl =
-      getServicePortDecl<PortTypeOp>(op, symbolTable, op.servicePort());
-  if (!portDecl)
-    return failure();
+  hw::InnerRefAttr port = op.servicePort();
+  auto portDecl = getServicePortDecl<PortTypeOp>(op, symbolTable, port);
+  auto inoutPortDecl =
+      getServicePortDecl<ServiceDeclInOutOp>(op, symbolTable, port);
+  if (!portDecl && !inoutPortDecl)
+    return op.emitOpError("Could not find service port declaration ")
+           << port.getModuleRef() << "::" << port.getName().getValue();
 
   auto *ctxt = op.getContext();
-  if (portDecl.type() != t &&
-      portDecl.type() != ChannelType::get(ctxt, AnyType::get(ctxt)))
-    return op.emitOpError("Request type does not match port type ")
-           << portDecl.type();
+  auto anyChannelType = ChannelType::get(ctxt, AnyType::get(ctxt));
+  if (portDecl) {
+    if (portDecl.type() != t && portDecl.type() != anyChannelType)
+      return op.emitOpError("Request type does not match port type ")
+             << portDecl.type();
+    return success();
+  }
 
+  assert(inoutPortDecl);
+  if (isa<ToClientOp>(op)) {
+    if (inoutPortDecl.inType() != t && inoutPortDecl.inType() != anyChannelType)
+      return op.emitOpError("Request type does not match port type ")
+             << inoutPortDecl.inType();
+  } else if (isa<ToServerOp>(op)) {
+    if (inoutPortDecl.outType() != t &&
+        inoutPortDecl.outType() != anyChannelType)
+      return op.emitOpError("Request type does not match port type ")
+             << inoutPortDecl.outType();
+  }
   return success();
 }
 
@@ -281,6 +296,28 @@ LogicalResult RequestToClientConnectionOp::verifySymbolUses(
 LogicalResult RequestToServerConnectionOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
   return reqPortMatches<ToServerOp>(*this, symbolTable, sending().getType());
+}
+
+LogicalResult
+RequestInOutChannelOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto portDecl = getServicePortDecl<ServiceDeclInOutOp>(
+      this->getOperation(), symbolTable, servicePort());
+  if (!portDecl)
+    return emitOpError("Could not find inout service port declaration.");
+
+  auto *ctxt = getContext();
+  auto anyChannelType = ChannelType::get(ctxt, AnyType::get(ctxt));
+  if (portDecl.inType() != sending().getType() &&
+      portDecl.inType() != anyChannelType)
+    return emitOpError("Request to_server type does not match port type ")
+           << portDecl.inType();
+
+  if (portDecl.outType() != receiving().getType() &&
+      portDecl.outType() != anyChannelType)
+    return emitOpError("Request to_client type does not match port type ")
+           << portDecl.outType();
+
+  return success();
 }
 
 #define GET_OP_CLASSES

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -63,7 +63,7 @@ esi.service.decl @HostComms {
 }
 
 hw.module @Loopback (%clk: i1) -> () {
-  // expected-error @+1 {{'esi.service.req.to_client' op Cannot find port named "Recv"}}
+  // expected-error @+1 {{'esi.service.req.to_client' op Could not find service port declaration @HostComms::Recv}}
   %dataIn = esi.service.req.to_client <@HostComms::@Recv> (["loopback_tohw"]) : !esi.channel<i32>
 }
 // -----
@@ -79,8 +79,30 @@ hw.module @Loopback (%clk: i1) -> () {
 
 // -----
 
+esi.service.decl @HostComms {
+  esi.service.inout @ReqResp : !esi.channel<i8> -> !esi.channel<i16>
+}
+
+hw.module @Loopback (%clk: i1, %s: !esi.channel<i16>) -> () {
+  // expected-error @+1 {{'esi.service.req.inout' op Request to_server type does not match port type '!esi.channel<i8>'}}
+  %dataIn = esi.service.req.inout %s -> <@HostComms::@ReqResp> (["loopback_tohw"]) : !esi.channel<i16> -> !esi.channel<i16>
+}
+
+// -----
+
+esi.service.decl @HostComms {
+  esi.service.inout @ReqResp : !esi.channel<i8> -> !esi.channel<i16>
+}
+
+hw.module @Loopback (%clk: i1, %s: !esi.channel<i8>) -> () {
+  // expected-error @+1 {{'esi.service.req.inout' op Request to_client type does not match port type '!esi.channel<i16>'}}
+  %dataIn = esi.service.req.inout %s -> <@HostComms::@ReqResp> (["loopback_tohw"]) : !esi.channel<i8> -> !esi.channel<i8>
+}
+
+// -----
+
 hw.module @Loopback (%clk: i1) -> () {
-  // expected-error @+1 {{Cannot find module "HostComms"}}
+  // expected-error @+1 {{'esi.service.req.to_client' op Could not find service port declaration @HostComms::Recv}}
   %dataIn = esi.service.req.to_client <@HostComms::@Recv> (["loopback_tohw"]) : !esi.channel<i32>
 }
 


### PR DESCRIPTION
Allow users to request bidirectional channels (InOut). Decomposes into
one `to_server` and one `to_client` request. Cosim will detect that and
wire them up to the same endpoint.