### PR TITLE
[Github Actions] Fix macOS build by switching to clang

### DIFF
--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - mode: release
+          - cc: clang
+            cxx: clang++
+            mode: release
             assert: OFF
             shared: OFF
         runner: [ubuntu-20.04, ubuntu-18.04, macos-11]
@@ -18,20 +20,14 @@ jobs:
             os: linux
             cmake-args: ''
             tar: tar
-            cc: gcc
-            cxx: g++
           - runner: ubuntu-18.04
             os: linux
             cmake-args: ''
             tar: tar
-            cc: gcc
-            cxx: g++
           - runner: macos-11
             os: macos
             cmake-args: ''
             tar: gtar
-            cc: clang
-            cxx: clang++
     runs-on: ${{ matrix.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -62,7 +58,7 @@ jobs:
         with:
           path: |
             llvm/build
-          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.cc }}
+          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }}
 
       - name: Setup Ninja Linux
         if: matrix.os == 'linux'
@@ -83,8 +79,8 @@ jobs:
           cmake -G Ninja ../llvm \
               ${{ matrix.cmake-args }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.compiler.mode }} \
-              -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+              -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
+              -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
               -DBUILD_SHARED_LIBS=${{ matrix.compiler.shared }} \
               -DLLVM_BUILD_EXAMPLES=OFF \
               -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
@@ -113,8 +109,8 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
             -DMLIR_DIR=`pwd`/../llvm/build/lib/cmake/mlir \
             -DLLVM_DIR=`pwd`/../llvm/build/lib/cmake/llvm \
-            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
             -DVERILATOR_DISABLE=ON \
             -DLLVM_ENABLE_TERMINFO=OFF \
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON \

--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - cc: gcc-10
-            cxx: g++-10
-            mode: release
+          - mode: release
             assert: OFF
             shared: OFF
         runner: [ubuntu-20.04, ubuntu-18.04, macos-11]
@@ -20,14 +18,20 @@ jobs:
             os: linux
             cmake-args: ''
             tar: tar
+            cc: gcc
+            cxx: g++
           - runner: ubuntu-18.04
             os: linux
             cmake-args: ''
             tar: tar
+            cc: gcc
+            cxx: g++
           - runner: macos-11
             os: macos
-            cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"'
+            cmake-args: ''
             tar: gtar
+            cc: clang
+            cxx: clang++
     runs-on: ${{ matrix.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -58,7 +62,7 @@ jobs:
         with:
           path: |
             llvm/build
-          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }}
+          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.cc }}
 
       - name: Setup Ninja Linux
         if: matrix.os == 'linux'
@@ -79,8 +83,8 @@ jobs:
           cmake -G Ninja ../llvm \
               ${{ matrix.cmake-args }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.compiler.mode }} \
-              -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
-              -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
+              -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
               -DBUILD_SHARED_LIBS=${{ matrix.compiler.shared }} \
               -DLLVM_BUILD_EXAMPLES=OFF \
               -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
@@ -109,14 +113,15 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.compiler.assert }} \
             -DMLIR_DIR=`pwd`/../llvm/build/lib/cmake/mlir \
             -DLLVM_DIR=`pwd`/../llvm/build/lib/cmake/llvm \
-            -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DVERILATOR_DISABLE=ON \
             -DLLVM_ENABLE_TERMINFO=OFF \
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
             -DLLVM_PARALLEL_LINK_JOBS=1 \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
           ninja
+          ninja check-circt
       - name: Display Files
         run: file build/bin/*
       - name: Package Binaries


### PR DESCRIPTION
While trying to use the Mac firtool pre-built binary on a larger design I noticed that it sometimes throws bogus errors, for example saying that a value is not fully initialized when in fact it is, while the Linux prebuilt binary works just fine on the same file. I did some testing and determined that these errors appear in the Mac CIRCT build if using gcc instead of clang. I'm not sure what the cause is -- I looked at the build logs using gcc and noticed there were warnings about weak symbol visibility during linking, but I'm not sure what these warnings really mean.

This PR switches the Mac build to use clang instead of gcc. Firtool now looks like this:

```
$ otool -L firtool
firtool:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.5.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1200.3.0)
```

The reason to use gcc over clang was to static link more libraries, but clearly clang must be used on Mac. Let me know if you think we should also use clang for the Linux build, but this PR just changes to clang for Mac.

I'm not sure if we want to support building with gcc on Mac, but it's good to document that it currently doesn't work, and it produces a binary that works on basic examples but not more complex ones. Sorry for not catching this earlier!