### PR TITLE
[FIRRTL] Support optional version in fir files

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -513,7 +513,7 @@ FIRToken FIRLexer::lexNumber(const char *tokStart) {
       ++curPtr;
   }
 
-  // If se encounter a '.' followed by a digit, again, and there was no
+  // If we encounter a '.' followed by a digit, again, and there was no
   // exponent, then this is a version literal.  Otherwise it is a floating point
   // literal.
   if (*curPtr != '.' || !llvm::isDigit(curPtr[1]) || hasE)

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -478,7 +478,7 @@ FIRToken FIRLexer::lexString(const char *tokStart, bool isRaw) {
 ///   DoubleLit ::=
 ///       ( '+' | '-' )? Digit+ '.' Digit+ ( 'E' ( '+' | '-' )? Digit+ )?
 ///   TripleLit ::=
-///       Digit+ '.' Digit+
+///       Digit+ '.' Digit+ '.' Digit+
 ///
 FIRToken FIRLexer::lexNumber(const char *tokStart) {
   assert(llvm::isDigit(curPtr[-1]) || curPtr[-1] == '+' || curPtr[-1] == '-');

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -477,6 +477,8 @@ FIRToken FIRLexer::lexString(const char *tokStart, bool isRaw) {
 ///   PosInt ::= [1-9] ([0-9])*
 ///   DoubleLit ::=
 ///       ( '+' | '-' )? Digit+ '.' Digit+ ( 'E' ( '+' | '-' )? Digit+ )?
+///   TripleLit ::=
+///       Digit+ '.' Digit+
 ///
 FIRToken FIRLexer::lexNumber(const char *tokStart) {
   assert(llvm::isDigit(curPtr[-1]) || curPtr[-1] == '+' || curPtr[-1] == '-');
@@ -501,12 +503,25 @@ FIRToken FIRLexer::lexNumber(const char *tokStart) {
   while (llvm::isDigit(*curPtr))
     ++curPtr;
 
+  bool hasE = false;
   if (*curPtr == 'E') {
+    hasE = true;
     ++curPtr;
     if (*curPtr == '+' || *curPtr == '-')
       ++curPtr;
     while (llvm::isDigit(*curPtr))
       ++curPtr;
   }
-  return formToken(FIRToken::floatingpoint, tokStart);
+
+  // If se encounter a '.' followed by a digit, again, and there was no
+  // exponent, then this is a version literal.  Otherwise it is a floating point
+  // literal.
+  if (*curPtr != '.' || !llvm::isDigit(curPtr[1]) || hasE)
+    return formToken(FIRToken::floatingpoint, tokStart);
+
+  // Lex a version literal.
+  curPtr += 2;
+  while (llvm::isDigit(*curPtr))
+    ++curPtr;
+  return formToken(FIRToken::version, tokStart);
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -228,6 +228,10 @@ struct FIRParser {
   ParseResult parseIntLit(int64_t &result, const Twine &message);
   ParseResult parseIntLit(int32_t &result, const Twine &message);
 
+  // Parse 'verLit' into specified value
+  ParseResult parseVersionLit(int32_t major, int32_t minor, int32_t patch,
+                              const Twine &message);
+
   // Parse ('<' intLit '>')? setting result to -1 if not present.
   template <typename T>
   ParseResult parseOptionalWidth(T &result);
@@ -580,6 +584,24 @@ ParseResult FIRParser::parseIntLit(int32_t &result, const Twine &message) {
   result = (int32_t)value.getLimitedValue(INT32_MAX);
   if (result != value)
     return emitError(loc, "value is too big to handle"), failure();
+  return success();
+}
+
+/// versionLit    ::= version
+/// deconstruct a version literal into parts
+ParseResult FIRParser::parseVersionLit(int32_t major, int32_t minor,
+                                       int32_t patch, const Twine &message) {
+  auto spelling = getTokenSpelling();
+  if (getToken().getKind() != FIRToken::version)
+    return emitError("expected version literal"), failure();
+  // form a.b.c
+  auto [a, d] = spelling.split(".");
+  auto [b, c] = d.split(".");
+  APInt aInt, bInt, cInt;
+  if (a.getAsInteger(10, aInt) || b.getAsInteger(10, bInt) ||
+      c.getAsInteger(10, cInt))
+    return emitError("failed to parse version string"), failure();
+  consumeToken(FIRToken::version);
   return success();
 }
 
@@ -3574,6 +3596,12 @@ ParseResult FIRCircuitParser::parseCircuit(
   StringAttr name;
   SMLoc inlineAnnotationsLoc;
   StringRef inlineAnnotations;
+
+  int32_t verMajor(1), verMinor(0), verPatch(0);
+  if (consumeIf(FIRToken::kw_FIRRTL))
+    if (parseToken(FIRToken::kw_version, "expected version after 'FIRRTL'") ||
+        parseVersionLit(verMajor, verMinor, verPatch, "expected version"))
+      return failure();
 
   // A file must contain a top level `circuit` definition.
   if (parseToken(FIRToken::kw_circuit,

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -51,6 +51,7 @@ TOK_IDENTIFIER(identifier) // foo
 TOK_LITERAL(integer)        // 42
 TOK_LITERAL(signed_integer) // -42 and +42
 TOK_LITERAL(floatingpoint)  // 42.0
+TOK_LITERAL(version)        // 1.2.3
 TOK_LITERAL(string)         // "foo"
 TOK_LITERAL(raw_string)     // 'foo'
 
@@ -91,6 +92,7 @@ TOK_KEYWORD(cmem)
 TOK_KEYWORD(defname)
 TOK_KEYWORD(else)
 TOK_KEYWORD(extmodule)
+TOK_KEYWORD(FIRRTL)
 TOK_KEYWORD(flip)
 TOK_KEYWORD(infer)
 TOK_KEYWORD(input)
@@ -113,6 +115,7 @@ TOK_KEYWORD(reset)
 TOK_KEYWORD(skip)
 TOK_KEYWORD(smem)
 TOK_KEYWORD(undefined)
+TOK_KEYWORD(version)
 TOK_KEYWORD(when)
 TOK_KEYWORD(wire)
 TOK_KEYWORD(with)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -9,6 +9,41 @@ circuit test :
 
 ;// -----
 
+FIRRTL
+; expected-error @+1 {{expected version after 'FIRRTL'}}
+circuit test :
+  module test :
+
+;// -----
+
+FIRRTL version
+; expected-error @+1 {{expected version literal}}
+circuit test :
+  module test :
+
+;// -----
+
+; expected-error @+1 {{expected version literal}}
+FIRRTL version 1
+circuit test :
+  module test :
+
+;// -----
+
+; expected-error @+1 {{expected version literal}}
+FIRRTL version 1.
+circuit test :
+  module test :
+
+;// -----
+
+; expected-error @+1 {{expected version literal}}
+FIRRTL version 1.a
+circuit test :
+  module test :
+
+;// -----
+
 circuit test test : ; expected-error {{expected ':' in circuit definition}}
 
 ;// -----

--- a/test/Dialect/FIRRTL/parse-version.fir
+++ b/test/Dialect/FIRRTL/parse-version.fir
@@ -1,0 +1,14 @@
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s | circt-opt | FileCheck %s
+FIRRTL version 1.1.0
+circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
+
+  ; CHECK-LABEL: firrtl.module @MyModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>) {
+  module MyModule :   @[FooBar.scala 369:27]
+    input in: UInt
+    output out: UInt<8>
+
+    ; CHECK: firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint
+    out <= in
+
+  ; CHECK: }
+


### PR DESCRIPTION
Firrtl spec 1.1.0 added version identifiers to the fir file.  Update the parse to parse these.  Currently nothing is done with the version after parsing.