### PR TITLE
 [FIRRTL][IMDCE] Test deleting code w/ref's. Avoid temp ref wire. 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -396,6 +396,10 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
       if (!deadOutputPortAtAnyInstantiation)
         continue;
 
+      // RefType can't be a wire, especially if it won't be erased.  Skip.
+      if (argument.getType().isa<RefType>())
+        continue;
+
       // Ok, this port is used only within its defined module. So we can replace
       // the port with a wire.
       WireOp wire = builder.create<WireOp>(argument.getType());


### PR DESCRIPTION
Note: when deleting dead ports, IMDCE introduces temporary wires
for the ports (inside the module) and at points of instantiation.
These are invalid for ref type, which isn't ideal, but they will be erased.

In one case this is not temporary, which this checks for,
the case where an output ref port is alive but not used by instantiators.

I'm not sure this can be constructed presently, given limitations
on uses and use-count of ref ports.