### PR TITLE
[PyCDE] Capture guard_port name at lamba creation time

### DIFF
--- a/frontends/PyCDE/src/pycde/fsm.py
+++ b/frontends/PyCDE/src/pycde/fsm.py
@@ -313,7 +313,8 @@ def gen_fsm(transitions: dict, name: str = "MyFSM"):
       if guard_port:
         ensure_input(guard_port)
         currentStateAttr.add_transitions(
-            (nextStateAttr, lambda ports, guard_port=guard_port: getattr(ports, guard_port)))
+            (nextStateAttr,
+             lambda ports, guard_port=guard_port: getattr(ports, guard_port)))
       else:
         currentStateAttr.add_transitions((nextStateAttr,))
 

--- a/frontends/PyCDE/src/pycde/fsm.py
+++ b/frontends/PyCDE/src/pycde/fsm.py
@@ -313,7 +313,7 @@ def gen_fsm(transitions: dict, name: str = "MyFSM"):
       if guard_port:
         ensure_input(guard_port)
         currentStateAttr.add_transitions(
-            (nextStateAttr, lambda ports: getattr(ports, guard_port)))
+            (nextStateAttr, lambda ports, guard_port=guard_port: getattr(ports, guard_port)))
       else:
         currentStateAttr.add_transitions((nextStateAttr,))
 


### PR DESCRIPTION
Fixes an issue in PyCDE gen_fsm helper that causes all transitions to use the last guard. Fix captures the intended guard_port name at lamba creation time.