### PR TITLE
[FIRRTL] Lower RefType Operations to XMR

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -138,6 +138,7 @@ std::unique_ptr<mlir::Pass> createIMDeadCodeElimPass();
 
 std::unique_ptr<mlir::Pass> createRandomizeRegisterInitPass();
 
+std::unique_ptr<mlir::Pass> createLowerXMRPass();
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -600,4 +600,12 @@ def RandomizeRegisterInit :
   let constructor = "circt::firrtl::createRandomizeRegisterInitPass()";
 }
 
+def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
+  let summary = "Lower ref ports to XMR";
+  let description = [{
+    This pass lowers RefType ops and ports to verbatim encoded XMRs.
+  }];
+  let constructor = "circt::firrtl::createLowerXMRPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerCHIRRTL.cpp
   LowerMemory.cpp
   LowerTypes.cpp
+  LowerXMR.cpp
   MergeConnections.cpp
   MemToRegOfVec.cpp
   ModuleInliner.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -25,13 +25,11 @@ using namespace circt;
 using namespace firrtl;
 using hw::InnerRefAttr;
 
-// The LowerXMRPass, replaces every RefResolveOp with a verbatim expr op,
-// with the corresponding XMR. This also removes every RefType port from
-// the modules and corresponding instances.
-// This is a dataflow analysis over a very constrained RefType.
-// Domain of the dataflow analysis is the set of all RefSendOps.
-// Essentially every RefType value must be mapped to one and
-// only one RefSendOp.
+// The LowerXMRPass will replace every RefResolveOp with an XMR encoded within a
+// verbatim expr op. This also removes every RefType port from the modules and
+// corresponding instances. This is a dataflow analysis over a very constrained
+// RefType. Domain of the dataflow analysis is the set of all RefSendOps.
+// Essentially every RefType value must be mapped to one and only one RefSendOp.
 // The analysis propagates the dataflow from every RefSendOp to every value of
 // RefType across modules.
 // The RefResolveOp is the final leaf into which the dataflow must flow into.
@@ -46,8 +44,8 @@ using hw::InnerRefAttr;
 //  2. Get the InnerRef to the BaseType input of RefSendOp and initialize the
 //     remoteRefToXMRsymVec with it. (This is the remote op that the
 //     xmr needs to refer to)
-//  3. Set the `refSendAt` for the result RefType to this op. This map tracks
-//  the dataflow from the original
+//  3. Set the `reachingRefSendAt` for the result RefType to this op. This map
+//  tracks the dataflow from the original
 //     RefSendOp to the corresponding ref ports.
 // For every InstanceOp
 //  1. For every RefType port of the InstanceOp, get the remote RefSendOp
@@ -68,11 +66,6 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   void runOnOperation() override {
     auto &instanceGraph = getAnalysis<InstanceGraph>();
-    // Get the post order traversal of the modules in the InstanceGraph.
-    SmallVector<FModuleOp> modules(
-        llvm::map_range(llvm::post_order(&instanceGraph), [](auto *node) {
-          return cast<FModuleOp>(*node->getModule());
-        }));
     // The dataflow function, that propagates the reachable RefSendOp across
     // RefType Ops.
     auto transferFunc = [&](Operation &op) -> LogicalResult {
@@ -81,9 +74,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // Get a reference to the actual signal to which the XMR will be
             // generated.
             auto xmrDefOp = getInnerRefTo(send.getBase().getDefiningOp());
-            remoteRefToXMRsymVec[send] = {xmrDefOp};
             // Record the remote reference op, that this ref value refers to.
-            refSendAt[send.getResult()] = send;
+            reachingRefSendAt[send.getResult()] =
+                ArrayAttr::get(send.getContext(), {xmrDefOp});
             opsToRemove.push_back(send);
             return success();
           })
@@ -93,8 +86,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             if (!connect.getSrc().getType().isa<RefType>())
               return success();
             // Get the dataflow value into the src.
-            if (auto remoteOp = getRemoteRefSend(connect.getSrc(), connect))
-              refSendAt[connect.getDest()] = remoteOp;
+            if (auto remoteOpPath = getRemoteRefSend(connect.getSrc(), connect))
+              reachingRefSendAt[connect.getDest()] = remoteOpPath;
             else
               return failure();
             opsToRemove.push_back(connect);
@@ -104,8 +97,14 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
               [&](auto resolve) { return handleRefResolve(resolve); })
           .Default([&](auto) { return success(); });
     };
+
+    DenseSet<Operation *> visitedModules;
     // Traverse the modules in post order.
-    for (auto module : modules) {
+    for (auto node : llvm::post_order(&instanceGraph)) {
+      auto module = cast<FModuleOp>(*node->getModule());
+      if (!visitedModules.insert(module).second)
+        continue;
+
       LLVM_DEBUG(llvm::dbgs()
                  << "\n Traversing module:" << module.moduleNameAttr());
 
@@ -118,6 +117,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         if (module.getPortType(portNum).isa<RefType>())
           refPortsToRemoveMap[module].push_back(portNum);
     }
+
     // Now erase all the Ops and ports of RefType.
     // This needs to be done as the last step to ensure uses are erased before
     // the def is erased.
@@ -133,46 +133,41 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       }
   }
 
-  Operation *getRemoteRefSend(Value val, Operation *op) {
-    auto iter = refSendAt.find(val);
-    if (iter != refSendAt.end())
+  ArrayAttr getRemoteRefSend(Value val, Operation *op) {
+    auto iter = reachingRefSendAt.find(val);
+    if (iter != reachingRefSendAt.end())
       return iter->getSecond();
     // The referenced module must have already been analyzed, error out if the
     // dataflow at the child module is not resolved.
     op->emitOpError(
         "reference dataflow cannot be traced back to the remote read op");
-    return nullptr;
+    return {};
   }
   //
   // Replace the RefResolveOp with verbatim op representing the XMR.
   LogicalResult handleRefResolve(RefResolveOp resolve) {
     opsToRemove.push_back(resolve);
-    auto remoteOp = getRemoteRefSend(resolve.getRef(), resolve);
-    if (!remoteOp)
+    auto remoteOpPath = getRemoteRefSend(resolve.getRef(), resolve);
+    if (!remoteOpPath)
       return failure();
+    auto xmrSize = remoteOpPath.size();
+    SmallVector<Attribute> xmrHierPath(xmrSize);
+    SmallString<128> xmrString;
+    for (auto instanceRef : llvm::enumerate(remoteOpPath)) {
+      xmrHierPath[xmrSize - instanceRef.index() - 1] = instanceRef.value();
+      ("{{" + Twine(instanceRef.index()) + "}}").toVector(xmrString);
+      if (instanceRef.index() < xmrSize - 1)
+        xmrString += '.';
+    }
 
     // The source of the dataflow for this RefResolveOp is established. So
     // replace the RefResolveOp with the coresponding VerbatimExpr to
     // generate the XMR.
-    SmallVector<Attribute> xmrHierPath(remoteRefToXMRsymVec[remoteOp].rbegin(),
-                                       remoteRefToXMRsymVec[remoteOp].rend());
-    SmallString<128> xmrString;
-    for (unsigned id = 0, e = xmrHierPath.size(); id < e; ++id) {
-      ("{{" + Twine(id) + "}}").toVector(xmrString);
-      if (id < e - 1)
-        xmrString += '.';
-    }
     ImplicitLocOpBuilder builder(resolve.getLoc(), resolve);
     auto xmrVerbatim =
         builder.create<VerbatimExprOp>(resolve.getType().cast<FIRRTLType>(),
                                        xmrString, ValueRange{}, xmrHierPath);
     resolve.getResult().replaceAllUsesWith(xmrVerbatim);
-    LLVM_DEBUG({
-      llvm::dbgs() << "\n The get op:" << resolve
-                   << "\n is connected to :" << remoteOp;
-      for (auto attr : remoteRefToXMRsymVec[remoteOp])
-        llvm::dbgs() << ":" << attr;
-    });
     return success();
   }
 
@@ -193,13 +188,14 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         continue;
       auto refModuleArg = refMod.getArgument(portNum);
       // Get the remote RefSendOp, that flows through the module ports.
-      if (auto remoteOp = getRemoteRefSend(refModuleArg, inst)) {
-        // This instance op must participate in the XMR hierarchical path, so
-        // record the innerRef to it.
-        remoteRefToXMRsymVec[remoteOp].push_back(getInnerRefTo(inst));
-        refSendAt[instanceResult] = remoteOp;
-      } else
+      auto remoteOpPath = getRemoteRefSend(refModuleArg, inst);
+      if (!remoteOpPath)
         return failure();
+
+      auto pathToRefSend = remoteOpPath.getValue().vec();
+      pathToRefSend.push_back(getInnerRefTo(inst));
+      reachingRefSendAt[instanceResult] =
+          ArrayAttr::get(inst.getContext(), pathToRefSend);
     }
     return success();
   }
@@ -214,6 +210,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   InnerRefAttr getInnerRefTo(Operation *op) {
+
     return ::getInnerRefTo(op, "xmr_sym",
                            [&](FModuleOp mod) -> ModuleNamespace & {
                              return getModuleNamespace(mod);
@@ -222,17 +219,17 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   /// Cached module namespaces.
   DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
 
-  /// Map of a reference value to the RefSend op. Each ref value can be
+  /// Map of a reference value to the path to the RefSend op. The path to
+  /// RefSend is represented as an ArrayAttr, which is an array of the InnerRef
+  /// to InstanceOps. The path is required since there can be multiple paths to
+  /// the RefSend and we need to identify a unique path. Each ref value can be
   /// satically resolved to a single remote send op, according to the
-  /// constraints on the RefType.
-  DenseMap<Value, Operation *> refSendAt;
-  /// Map of the remote RefSend op, to the sequence of the InnerRef symbols that
-  /// represents the Final XMR. Each of the intermediary symbol is an instance
-  /// op, and the final symbol represents the leaf operation corresponding to
-  /// the XMR. The symbol sequence can represent a hierarchical path to the
-  /// operation, for which the XMR needs to be constructed.
-  DenseMap<Operation *, SmallVector<Attribute>> remoteRefToXMRsymVec;
+  /// constraints on the RefType. The ArrayAttr ensures that only unique copies
+  /// of the path exist.
+  DenseMap<Value, ArrayAttr> reachingRefSendAt;
+
   SmallVector<Operation *> opsToRemove;
+
   // Instance and module ref ports that needs to be removed.
   DenseMap<Operation *, SmallVector<unsigned>> refPortsToRemoveMap;
 };

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -1,0 +1,242 @@
+//===- LowerXMR.cpp - FIRRTL Lower to XMR -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements FIRRTL XMR Lowering.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-lower-xmr"
+
+using namespace circt;
+using namespace firrtl;
+using hw::InnerRefAttr;
+
+// The LowerXMRPass, replaces every RefResolveOp with a verbatim expr op,
+// with the corresponding XMR. This also removes every RefType port from
+// the modules and corresponding instances.
+// This is a dataflow analysis over a very constrained RefType.
+// Domain of the dataflow analysis is the set of all RefSendOps.
+// Essentially every RefType value must be mapped to one and
+// only one RefSendOp.
+// The analysis propagates the dataflow from every RefSendOp to every value of
+// RefType across modules.
+// The RefResolveOp is the final leaf into which the dataflow must flow into.
+//
+// Algorithm:
+// Due to the downward only reference constraint on XMRs, the post order
+//  traversal ensures that the RefSendOp will be encountered before any
+//  RefResolveOp.
+// For every RefSendOp
+//  0. The BaseType input is the value to which the final XMR should refer to.
+//  1. create a new entry into the `remoteRefToXMRsymVec`.
+//  2. Get the InnerRef to the BaseType input of RefSendOp and initialize the
+//     remoteRefToXMRsymVec with it. (This is the remote op that the
+//     xmr needs to refer to)
+//  3. Set the `refSendAt` for the result RefType to this op. This map tracks
+//  the dataflow from the original
+//     RefSendOp to the corresponding ref ports.
+// For every InstanceOp
+//  1. For every RefType port of the InstanceOp, get the remote RefSendOp
+//     that flows into the corresponding port of the Referenced module.
+//     Because of the order of traversal and the constraints on the ref
+//     ports, the Referenced module ref ports must already be resolved.
+//  2. Update the `remoteRefToXMRsymVec` for the corresponding RefSendOp,
+//    with an InnerRef to this InstanceOp. This denotes that the final
+//    XMR must include this InstanceOp.
+// For every ConnectLike op
+//  1. Copy the dataflow of the src to the dest.
+// For every RefResolveOp,
+//  1. Replace the op result with a VerbatimExpr, representing the XMR.
+//       The InnerRef sequence of symbols from remoteRefToXMRsymVec is
+//       used to construct the symbol list for the verbatim.
+//
+class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
+
+  void runOnOperation() override {
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    // Get the post order traversal of the modules in the InstanceGraph.
+    SmallVector<FModuleOp> modules(
+        llvm::map_range(llvm::post_order(&instanceGraph), [](auto *node) {
+          return cast<FModuleOp>(*node->getModule());
+        }));
+    // The dataflow function, that propagates the reachable RefSendOp across
+    // RefType Ops.
+    auto transferFunc = [&](Operation &op) -> LogicalResult {
+      return TypeSwitch<Operation *, LogicalResult>(&op)
+          .Case<RefSendOp>([&](auto send) {
+            // Get a reference to the actual signal to which the XMR will be
+            // generated.
+            auto xmrDefOp = getInnerRefTo(send.getBase().getDefiningOp());
+            remoteRefToXMRsymVec[send] = {xmrDefOp};
+            // Record the remote reference op, that this ref value refers to.
+            refSendAt[send.getResult()] = send;
+            opsToRemove.push_back(send);
+            return success();
+          })
+          .Case<InstanceOp>([&](auto inst) { return handleInstanceOp(inst); })
+          .Case<FConnectLike>([&](FConnectLike connect) {
+            // Ignore BaseType.
+            if (!connect.getSrc().getType().isa<RefType>())
+              return success();
+            // Get the dataflow value into the src.
+            if (auto remoteOp = getRemoteRefSend(connect.getSrc(), connect))
+              refSendAt[connect.getDest()] = remoteOp;
+            else
+              return failure();
+            opsToRemove.push_back(connect);
+            return success();
+          })
+          .Case<RefResolveOp>(
+              [&](auto resolve) { return handleRefResolve(resolve); })
+          .Default([&](auto) { return success(); });
+    };
+    // Traverse the modules in post order.
+    for (auto module : modules) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "\n Traversing module:" << module.moduleNameAttr());
+
+      for (Operation &op : module.getBodyBlock()->getOperations())
+        if (transferFunc(op).failed())
+          return signalPassFailure();
+
+      // Record all the RefType ports to be removed later.
+      for (size_t portNum = 0, e = module.getNumPorts(); portNum < e; ++portNum)
+        if (module.getPortType(portNum).isa<RefType>())
+          refPortsToRemoveMap[module].push_back(portNum);
+    }
+    // Now erase all the Ops and ports of RefType.
+    // This needs to be done as the last step to ensure uses are erased before
+    // the def is erased.
+    for (auto op : llvm::reverse(opsToRemove))
+      op->erase();
+    for (auto iter : refPortsToRemoveMap)
+      if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
+        mod.erasePorts(iter.getSecond());
+      else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
+        ImplicitLocOpBuilder b(inst.getLoc(), inst);
+        inst.erasePorts(b, iter.getSecond());
+        inst.erase();
+      }
+  }
+
+  Operation *getRemoteRefSend(Value val, Operation *op) {
+    auto iter = refSendAt.find(val);
+    if (iter != refSendAt.end())
+      return iter->getSecond();
+    // The referenced module must have already been analyzed, error out if the
+    // dataflow at the child module is not resolved.
+    op->emitOpError(
+        "reference dataflow cannot be traced back to the remote read op");
+    return nullptr;
+  }
+  //
+  // Replace the RefResolveOp with verbatim op representing the XMR.
+  LogicalResult handleRefResolve(RefResolveOp resolve) {
+    opsToRemove.push_back(resolve);
+    auto remoteOp = getRemoteRefSend(resolve.getRef(), resolve);
+    if (!remoteOp)
+      return failure();
+
+    // The source of the dataflow for this RefResolveOp is established. So
+    // replace the RefResolveOp with the coresponding VerbatimExpr to
+    // generate the XMR.
+    SmallVector<Attribute> xmrHierPath(remoteRefToXMRsymVec[remoteOp].rbegin(),
+                                       remoteRefToXMRsymVec[remoteOp].rend());
+    SmallString<128> xmrString;
+    for (unsigned id = 0, e = xmrHierPath.size(); id < e; ++id) {
+      ("{{" + Twine(id) + "}}").toVector(xmrString);
+      if (id < e - 1)
+        xmrString += '.';
+    }
+    ImplicitLocOpBuilder builder(resolve.getLoc(), resolve);
+    auto xmrVerbatim =
+        builder.create<VerbatimExprOp>(resolve.getType().cast<FIRRTLType>(),
+                                       xmrString, ValueRange{}, xmrHierPath);
+    resolve.getResult().replaceAllUsesWith(xmrVerbatim);
+    LLVM_DEBUG({
+      llvm::dbgs() << "\n The get op:" << resolve
+                   << "\n is connected to :" << remoteOp;
+      for (auto attr : remoteRefToXMRsymVec[remoteOp])
+        llvm::dbgs() << ":" << attr;
+    });
+    return success();
+  }
+
+  // Propagate the reachable RefSendOp across modules.
+  LogicalResult handleInstanceOp(InstanceOp inst) {
+    auto refMod = dyn_cast<FModuleOp>(inst.getReferencedModule());
+    for (size_t portNum = 0, e = inst.getNumResults(); portNum < e; ++portNum) {
+      auto instanceResult = inst.getResult(portNum);
+      if (!instanceResult.getType().isa<RefType>())
+        continue;
+      if (!refMod) {
+        return inst.emitOpError("cannot lower ext modules with RefType ports");
+      }
+      // Reference ports must be removed.
+      refPortsToRemoveMap[inst].push_back(portNum);
+      // Drop dead instance ports.
+      if (instanceResult.use_empty())
+        continue;
+      auto refModuleArg = refMod.getArgument(portNum);
+      // Get the remote RefSendOp, that flows through the module ports.
+      if (auto remoteOp = getRemoteRefSend(refModuleArg, inst)) {
+        // This instance op must participate in the XMR hierarchical path, so
+        // record the innerRef to it.
+        remoteRefToXMRsymVec[remoteOp].push_back(getInnerRefTo(inst));
+        refSendAt[instanceResult] = remoteOp;
+      } else
+        return failure();
+    }
+    return success();
+  }
+
+  /// Get the cached namespace for a module.
+  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+    auto it = moduleNamespaces.find(module);
+    if (it != moduleNamespaces.end())
+      return it->second;
+    return moduleNamespaces.insert({module, ModuleNamespace(module)})
+        .first->second;
+  }
+
+  InnerRefAttr getInnerRefTo(Operation *op) {
+    return ::getInnerRefTo(op, "xmr_sym",
+                           [&](FModuleOp mod) -> ModuleNamespace & {
+                             return getModuleNamespace(mod);
+                           });
+  }
+  /// Cached module namespaces.
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+
+  /// Map of a reference value to the RefSend op. Each ref value can be
+  /// satically resolved to a single remote send op, according to the
+  /// constraints on the RefType.
+  DenseMap<Value, Operation *> refSendAt;
+  /// Map of the remote RefSend op, to the sequence of the InnerRef symbols that
+  /// represents the Final XMR. Each of the intermediary symbol is an instance
+  /// op, and the final symbol represents the leaf operation corresponding to
+  /// the XMR. The symbol sequence can represent a hierarchical path to the
+  /// operation, for which the XMR needs to be constructed.
+  DenseMap<Operation *, SmallVector<Attribute>> remoteRefToXMRsymVec;
+  SmallVector<Operation *> opsToRemove;
+  // Instance and module ref ports that needs to be removed.
+  DenseMap<Operation *, SmallVector<unsigned>> refPortsToRemoveMap;
+};
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerXMRPass() {
+  return std::make_unique<LowerXMRPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -182,9 +182,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       auto instanceResult = inst.getResult(portNum);
       if (!instanceResult.getType().isa<RefType>())
         continue;
-      if (!refMod) {
+      if (!refMod) 
         return inst.emitOpError("cannot lower ext modules with RefType ports");
-      }
       // Reference ports must be removed.
       refPortsToRemoveMap[inst].push_back(portNum);
       // Drop dead instance ports.
@@ -220,6 +219,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                              return getModuleNamespace(mod);
                            });
   }
+  
   /// Cached module namespaces.
   DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
 
@@ -232,6 +232,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   /// of the path exist.
   DenseMap<Value, ArrayAttr> reachingRefSendAt;
 
+  /// RefResolve, RefSend, and Connects involving them that will be removed.
   SmallVector<Operation *> opsToRemove;
 
   // Instance and module ref ports that needs to be removed.

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -16,56 +16,52 @@ firrtl.circuit "xmr" {
 
 // -----
 
-// Test for hierarchichal lowering
-// CHECK-LABEL: firrtl.circuit "ForwardToInstance" {
-firrtl.circuit "ForwardToInstance" {
-  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
-    // CHECK: firrtl.module @Bar2() {
+// Test for multiple readers and multiple instances
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.instance bar sym @xmr_sym  @Bar2()
-    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
-  }
-  firrtl.module @ForwardToInstance() {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
+    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-  }
-}
-
-// -----
-
-// Test for multiple readers
-// CHECK-LABEL: firrtl.circuit "ForwardToInstance" {
-firrtl.circuit "ForwardToInstance" {
-  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
-    // CHECK: firrtl.module @Bar2() {
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
-    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.instance bar sym @xmr_sym  @Bar2()
-    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %bar_2 : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
+    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
-  firrtl.module @ForwardToInstance() {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Top() {
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @bar  @Bar()
+    // CHECK:  firrtl.instance foo sym @foo  @Foo()
+    // CHECK:  firrtl.instance xmr sym @xmr  @XmrSrcMod()
     %a = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.wire : !firrtl.uint<1>
+    %c = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %1 = firrtl.ref.resolve %foo_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %2 = firrtl.ref.resolve %xmr_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %2 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.strictconnect %b, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %c, %2 : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -1,0 +1,71 @@
+// RUN: circt-opt %s  --firrtl-lower-xmr -split-input-file |  FileCheck %s
+
+// Test for same module lowering
+// CHECK-LABEL: firrtl.circuit "xmr"
+firrtl.circuit "xmr" {
+  firrtl.module @xmr(out %o: !firrtl.uint<2>) {
+    %w = firrtl.wire : !firrtl.uint<2>
+    %1 = firrtl.ref.send %w : !firrtl.uint<2>
+    %x = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
+    firrtl.strictconnect %o, %x : !firrtl.uint<2>
+    // CHECK:  %w = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}" : () -> !firrtl.uint<2> {symbols = [#hw.innerNameRef<@xmr::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %o, %0 : !firrtl.uint<2>
+  }
+}
+
+// -----
+
+// Test for hierarchichal lowering
+// CHECK-LABEL: firrtl.circuit "ForwardToInstance" {
+firrtl.circuit "ForwardToInstance" {
+  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @Bar2() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @xmr_sym  @Bar2()
+    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @ForwardToInstance() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Test for multiple readers
+// CHECK-LABEL: firrtl.circuit "ForwardToInstance" {
+firrtl.circuit "ForwardToInstance" {
+  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @Bar2() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @xmr_sym  @Bar2()
+    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_2 : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    %a = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+  firrtl.module @ForwardToInstance() {
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@ForwardToInstance::@xmr_sym>, #hw.innerNameRef<@Bar::@xmr_sym>, #hw.innerNameRef<@Bar2::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
The `LowerXMRPass`  replaces every `RefResolveOp` with a verbatim expr op encoding the corresponding XMR.
 The pass also removes every value of `RefType` and its uses from the circuit.

This is a dataflow analysis over a very constrained `RefType`. Domain of the dataflow analysis is the set of all `RefSendOp`.
Essentially every `RefType` value must be mapped to one and only one `RefSendOp`.
The analysis propagates the reachable `RefSendOp` to every value of `RefType` across modules.
The `RefResolveOp` is the final leaf into which the dataflow must flow into.

 Due to the downward only reference constraint on XMRs, the post order traversal ensures that the `RefSendOp` will be encountered before any user of the `RefType` value. The pass fails and errors out if every "live" `RefType` value is not mapped to a unique `RefSendOp`.
