### PR TITLE
[PyCDE] Use cocotb-test as test driver

### DIFF
--- a/frontends/PyCDE/pyproject.toml
+++ b/frontends/PyCDE/pyproject.toml
@@ -8,6 +8,8 @@ requires = [
     "numpy",
     "pybind11>=2.7.1",
     "PyYAML",
+    "cocotb>=1.6.2",
+    "cocotb-test>=0.2.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/frontends/PyCDE/test/cocotb_testbench.py
+++ b/frontends/PyCDE/test/cocotb_testbench.py
@@ -1,4 +1,4 @@
-# REQUIRES: icarus,cocotb
+# REQUIRES: iverilog,cocotb
 # RUN: %PYTHON% %s | FileCheck %s
 from pycde import Input, Output, generator, module, Clock
 from pycde.pycde_types import types

--- a/frontends/PyCDE/test/cocotb_testbench.py
+++ b/frontends/PyCDE/test/cocotb_testbench.py
@@ -1,4 +1,4 @@
-# REQUIRES: iverilog,cocotb
+# REQUIRES: icarus,cocotb
 # RUN: %PYTHON% %s | FileCheck %s
 from pycde import Input, Output, generator, module, Clock
 from pycde.pycde_types import types
@@ -44,7 +44,7 @@ class RegAdd:
     ports.out = w16Adder.out
 
 
-@cocotestbench(RegAdd, simulator="iverilog")
+@cocotestbench(RegAdd, simulator="icarus")
 class RegAddTester:
 
   @cocotest


### PR DESCRIPTION
No more custom makefile generation and 'make' commands - this is handled by cocotb-test.
Eventually, we expect support for driving cocotb from within python to be included in a future cocotb release. The support in `cocotb-test` is currently identical to the (unreleased) support in upstream `cocotb`. Hence, we use `cocotb-test` since they publish a pypi package that can be easily downloaded.