### PR TITLE
[FIRRTL][RefOps] NoSideEffects, InferTypeOpInterface, asm result names

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -709,7 +709,7 @@ class RefInstancePortConstraint
 // RefOps
 //===----------------------------------------------------------------------===//
 
-def RefResolveOp: FIRRTLOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
+def RefResolveOp: FIRRTLExprOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
                                     RefInstancePortConstraint<>]> {
   let summary = "FIRRTL Resolve a Reference";
   let description = [{
@@ -724,7 +724,7 @@ def RefResolveOp: FIRRTLOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }
 
-def RefSendOp: FIRRTLOp<"ref.send", [RefResultTypeConstraint<"base", "result">]> {
+def RefSendOp: FIRRTLExprOp<"ref.send", [RefResultTypeConstraint<"base", "result">]> {
   let summary = "FIRRTL Send through Reference";
   let description = [{
     Endpoint of a remote reference. Send a value through a reference

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -699,7 +699,7 @@ class RefResultTypeConstraint<string base, string ref>
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>())">;
 
-class RefInstancePortConstraint
+def RefInstancePortConstraint
   : PredOpTrait<"it cannot have module port as an operand because it implies"
   " upward reference XMR, which are not supported."
   " The reference operand must be a port from firrtl.instance",
@@ -710,7 +710,7 @@ class RefInstancePortConstraint
 //===----------------------------------------------------------------------===//
 
 def RefResolveOp: FIRRTLExprOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
-                                    RefInstancePortConstraint<>]> {
+                                    RefInstancePortConstraint]> {
   let summary = "FIRRTL Resolve a Reference";
   let description = [{
     Resolve a remote reference for reading a remote value.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3960,6 +3960,47 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
+// RefOps
+//===----------------------------------------------------------------------===//
+
+FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
+                                       ArrayRef<NamedAttribute> attrs,
+                                       Optional<Location> loc) {
+  auto inType = operands[0].getType();
+  auto inRefType = inType.dyn_cast<RefType>();
+  if (!inRefType) {
+    if (loc)
+      mlir::emitError(*loc, "ref.resolve operand must be ref type, not ")
+          << inType;
+    return {};
+  }
+  return inRefType.getType();
+}
+
+FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
+                                       ArrayRef<NamedAttribute> attrs,
+                                       Optional<Location> loc) {
+  auto inType = operands[0].getType();
+  auto inBaseType = inType.dyn_cast<FIRRTLBaseType>();
+  if (!inBaseType) {
+    if (loc)
+      mlir::emitError(*loc, "ref.send operand must be base type, not ")
+          << inType;
+    return {};
+  }
+  return RefType::get(inBaseType);
+}
+
+void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3964,8 +3964,8 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 //===----------------------------------------------------------------------===//
 
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
-                                       ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                         ArrayRef<NamedAttribute> attrs,
+                                         Optional<Location> loc) {
   auto inType = operands[0].getType();
   auto inRefType = inType.dyn_cast<RefType>();
   if (!inRefType) {
@@ -3978,8 +3978,8 @@ FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
 }
 
 FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
-                                       ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                      ArrayRef<NamedAttribute> attrs,
+                                      Optional<Location> loc) {
   auto inType = operands[0].getType();
   auto inBaseType = inType.dyn_cast<FIRRTLBaseType>();
   if (!inBaseType) {
@@ -3998,7 +3998,6 @@ void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
-
 
 //===----------------------------------------------------------------------===//
 // TblGen Generated Logic.


### PR DESCRIPTION
Make these more like other expressions.

~NoSideEffects seems to be used to mean something like "only modifies state reachable through operands", so I think is fitting here.~
EDIT: NoSideEffects is used to see if an op can be deleted if its result is unused.  This is not the same as what I suggested above, but I think is still appropriate for these ops.

Type inference is especially used by InferResets to update the result type after inferring the operand type (and to propagate changed types).  Implement this so these operations are updated properly without special handling on those paths.

Result naming came along by using `FIRRTLExprOp` (`HasCustomSSAName`), can drop if this is not desired but doesn't seem problematic and neater to include.

Keep type constraints although not needed in order to parse now with InferTypeOpInterface, but might as well ensure the types match as specified.

IMDCE will know how to delete these ops with this change, so ensure that is working properly (#3716 or so).