### PR TITLE
[Handshake] Extend cocotb helper and add new tests

### DIFF
--- a/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
+++ b/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
@@ -1,0 +1,45 @@
+// REQUIRES: iverilog,cocotb
+
+// This test is executed with all different buffering strategies
+
+// RUN: circt-opt %s --lower-std-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv | FileCheck %s
+
+// RUN: circt-opt %s --lower-std-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv | FileCheck %s
+
+// RUN: circt-opt %s --lower-std-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv | FileCheck %s
+
+// CHECK:      ** TEST
+// CHECK-NEXT: ********************************
+// CHECK-NEXT: ** conditional_modification.oneInput
+// CHECK-NEXT: ** conditional_modification.multiple
+// CHECK-NEXT: ********************************
+// CHECK-NEXT: ** TESTS=2 PASS=2 FAIL=0 SKIP=0
+// CHECK-NEXT: ********************************
+
+module {
+  func.func @top(%n0: i32, %n1: i32, %cond: i1) -> (i32, i32) {
+    cf.cond_br %cond, ^bb1(%n0, %n1 : i32, i32), ^bb2(%n0, %n1 : i32, i32)
+  ^bb1(%t0: i32, %t1: i32):
+    %o0 = arith.addi %t0, %t1 : i32
+    %o1 = arith.subi %t0, %t1 : i32
+    cf.br ^bb2(%o0, %o1 : i32, i32)
+  ^bb2(%r0: i32, %r1: i32):
+    return %r0, %r1 : i32, i32
+  }
+}
+

--- a/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.py
+++ b/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.py
@@ -1,0 +1,87 @@
+import cocotb
+import cocotb.clock
+from cocotb.triggers import FallingEdge, RisingEdge
+
+# Hack to allow imports from parent directory
+import sys
+import os
+
+currentdir = os.path.dirname(os.path.abspath(__file__))
+parentdir = os.path.dirname(currentdir)
+sys.path.append(parentdir)
+
+from helper import HandshakePort, getPorts
+
+
+async def initDut(dut):
+  ins, outs = getPorts(dut, ["in0", "in1", "in2", "inCtrl"],
+                       ["out0", "out1", "outCtrl"])
+
+  [in0, in1, in2, inCtrl] = ins
+  [out0, out1, outCtrl] = outs
+  # Create a 10us period clock on port clock
+  clock = cocotb.clock.Clock(dut.clock, 10, units="us")
+  cocotb.start_soon(clock.start())  # Start the clock
+
+  in0.setValid(0)
+  in1.setValid(0)
+  in2.setValid(0)
+  inCtrl.setValid(0)
+
+  out0.setReady(1)
+  out1.setReady(1)
+  outCtrl.setReady(1)
+
+  # Reset
+  dut.reset.value = 1
+  await RisingEdge(dut.clock)
+  dut.reset.value = 0
+  await RisingEdge(dut.clock)
+
+  return ins, outs
+
+
+@cocotb.test()
+async def oneInput(dut):
+  [in0, in1, in2, inCtrl], [out0, out1, outCtrl] = await initDut(dut)
+
+  out0Check = cocotb.start_soon(out0.checkOutputs([18]))
+  out1Check = cocotb.start_soon(out1.checkOutputs([24]))
+
+  in0Send = cocotb.start_soon(in0.send(18))
+  in1Send = cocotb.start_soon(in1.send(24))
+  in2Send = cocotb.start_soon(in2.send(0))
+  inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+  await in0Send
+  await in1Send
+  await in2Send
+  await inCtrlSend
+
+  await out0Check
+  await out1Check
+
+
+@cocotb.test()
+async def multiple(dut):
+  [in0, in1, in2, inCtrl], [out0, out1, outCtrl] = await initDut(dut)
+
+  out0Check = cocotb.start_soon(out0.checkOutputs([18, 42, 42]))
+  # COCOTB treats all integers as unsigned, thus we have to compare with the
+  # two's complement representation
+  out1Check = cocotb.start_soon(out1.checkOutputs([24, 2**32 - 6, 42]))
+
+  inputs = [(18, 24, 0), (18, 24, 1), (42, 0, 1)]
+  for (d0, d1, cond) in inputs:
+    in0Send = cocotb.start_soon(in0.send(d0))
+    in1Send = cocotb.start_soon(in1.send(d1))
+    in2Send = cocotb.start_soon(in2.send(cond))
+    inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+    await in0Send
+    await in1Send
+    await in2Send
+    await inCtrlSend
+
+  await out0Check
+  await out1Check

--- a/integration_test/Dialect/Handshake/helper.py
+++ b/integration_test/Dialect/Handshake/helper.py
@@ -126,8 +126,7 @@ def _findPort(dut, name):
   if hasData:
     return HandshakeDataPort(dut, ready, valid, data)
 
-  isTuple = hasattr(dut, f"{name}_data_field0")
-  isCtrl = not isTuple and not hasData
+  isCtrl = not hasattr(dut, f"{name}_data_field0")
 
   if (isCtrl):
     return HandshakePort(dut, ready, valid)

--- a/integration_test/Dialect/Handshake/helper.py
+++ b/integration_test/Dialect/Handshake/helper.py
@@ -6,11 +6,10 @@ class HandshakePort:
   Helper class that encapsulates a handshake port from the DUT.
   """
 
-  def __init__(self, dut, rdy, val, data=None):
+  def __init__(self, dut, rdy, val):
     self.dut = dut
     self.ready = rdy
     self.valid = val
-    self.data = data
 
   def isReady(self):
     return self.ready.value.is_resolvable and self.ready.value == 1
@@ -49,10 +48,28 @@ class HandshakePort:
       await RisingEdge(self.dut.clock)
 
   async def send(self, val=None):
-    if (val is not None):
-      self.data.value = val
     self.setValid(1)
     await self.awaitHandshake()
+
+  async def awaitNOutputs(self, n):
+    assert (self.isReady())
+    for _ in range(n):
+      await self.waitUntilValid()
+      await RisingEdge(self.dut.clock)
+
+
+class HandshakeDataPort(HandshakePort):
+  """
+  A handshaked port with a data field.
+  """
+
+  def __init__(self, dut, rdy, val, data):
+    super().__init__(dut, rdy, val)
+    self.data = data
+
+  async def send(self, val):
+    self.data.value = val
+    await super().send()
 
   async def checkOutputs(self, results):
     assert (self.isReady())
@@ -62,34 +79,72 @@ class HandshakePort:
       await RisingEdge(self.dut.clock)
 
 
+class HandshakeTuplePort(HandshakePort):
+  """
+  A handshaked port that sends a tuple.
+  """
+
+  def __init__(self, dut, rdy, val, fields):
+    super().__init__(dut, rdy, val)
+    self.fields = fields
+
+  async def send(self, val):
+    assert (len(list(val)) == len(self.fields))
+    for (f, v) in zip(self.fields, list(val)):
+      f.value = v
+
+    await super().send()
+
+  async def checkOutputs(self, results):
+    assert (self.isReady())
+    for res in results:
+      await self.waitUntilValid()
+
+      assert (len(list(res)) == len(self.fields))
+      for (f, r) in zip(self.fields, list(res)):
+        assert (f.value == r)
+      await RisingEdge(self.dut.clock)
+
+
+def _findPort(dut, name):
+  """
+  Checks if dut has a port of the provided name. Either throws an exception or
+  returns a HandshakePort that encapsulates the dut's interface.
+  """
+  readyName = f"{name}_ready"
+  validName = f"{name}_valid"
+  dataName = f"{name}_data"
+  if (not hasattr(dut, readyName) or not hasattr(dut, validName)):
+    raise Exception(f"dut does not have a port named {n}")
+
+  ready = getattr(dut, readyName)
+  valid = getattr(dut, validName)
+  data = getattr(dut, dataName, None)
+
+  # Needed, as it otherwise would try to resolve the value
+  hasData = not isinstance(data, type(None))
+  if hasData:
+    return HandshakeDataPort(dut, ready, valid, data)
+
+  isTuple = hasattr(dut, f"{name}_data_field0")
+  isCtrl = not isTuple and not hasData
+
+  if (isCtrl):
+    return HandshakePort(dut, ready, valid)
+
+  fields = []
+  i = 0
+  while hasattr(dut, f"{name}_data_field{i}"):
+    fields.append(getattr(dut, f"{name}_data_field{i}"))
+    i += 1
+
+  return HandshakeTuplePort(dut, ready, valid, fields)
+
+
 def getPorts(dut, inNames, outNames):
   """
   Helper function to produce in and out ports for the provided dut.
   """
-  ins = []
-  outs = []
-
-  for inName in inNames:
-    readyName = f"{inName}_ready"
-    validName = f"{inName}_valid"
-    dataName = f"{inName}_data"
-    if (not hasattr(dut, readyName) or not hasattr(dut, validName)):
-      raise Exception(f"dut does not have the input {i}")
-
-    ready = getattr(dut, readyName)
-    valid = getattr(dut, validName)
-
-    ins.append(HandshakePort(dut, ready, valid, getattr(dut, dataName, None)))
-
-  for outName in outNames:
-    readyName = f"{outName}_ready"
-    validName = f"{outName}_valid"
-    dataName = f"{outName}_data"
-    if (not hasattr(dut, readyName) or not hasattr(dut, validName)):
-      raise Exception(f"dut does not have the output {i}")
-
-    ready = getattr(dut, readyName)
-    valid = getattr(dut, validName)
-
-    outs.append(HandshakePort(dut, ready, valid, getattr(dut, dataName, None)))
+  ins = [_findPort(dut, name) for name in inNames]
+  outs = [_findPort(dut, name) for name in outNames]
   return ins, outs

--- a/integration_test/Dialect/Handshake/lit.local.cfg.py
+++ b/integration_test/Dialect/Handshake/lit.local.cfg.py
@@ -1,5 +1,7 @@
 config.excludes.add('driver.sv')
 config.excludes.add('driver_with_input.sv')
 config.excludes.add('task_pipelining.py')
+config.excludes.add('tuple_packing.py')
+config.excludes.add('conditional_modification.py')
 config.excludes.add('cocotb_driver.py')
 config.excludes.add('helper.py')

--- a/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
+++ b/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
@@ -1,0 +1,42 @@
+// REQUIRES: iverilog,cocotb
+
+// This test is executed with all different buffering strategies
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder=%S %t.sv | FileCheck %s
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder=%S %t.sv | FileCheck %s
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder=%S %t.sv | FileCheck %s
+
+// CHECK:      ** TEST
+// CHECK-NEXT: ********************************
+// CHECK-NEXT: ** tuple_packing.oneInput
+// CHECK-NEXT: ********************************
+// CHECK-NEXT: ** TESTS=1 PASS=1 FAIL=0 SKIP=0
+// CHECK-NEXT: ********************************
+
+module {
+  handshake.func @top(%arg0: tuple<i32, i32>, %arg1: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
+    %res:2 = handshake.unpack %arg0 : tuple<i32, i32>
+
+    %sum = arith.addi %res#0, %res#1 : i32
+
+    return %sum, %arg1 : i32, none
+  }
+}
+

--- a/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
+++ b/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
@@ -33,9 +33,7 @@
 module {
   handshake.func @top(%arg0: tuple<i32, i32>, %arg1: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
     %res:2 = handshake.unpack %arg0 : tuple<i32, i32>
-
     %sum = arith.addi %res#0, %res#1 : i32
-
     return %sum, %arg1 : i32, none
   }
 }

--- a/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.py
+++ b/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.py
@@ -1,0 +1,45 @@
+import cocotb
+import cocotb.clock
+from cocotb.triggers import FallingEdge, RisingEdge
+
+# Hack to allow imports from parent directory
+import sys
+import os
+
+currentdir = os.path.dirname(os.path.abspath(__file__))
+parentdir = os.path.dirname(currentdir)
+sys.path.append(parentdir)
+
+from helper import HandshakePort, getPorts
+
+
+@cocotb.test()
+async def oneInput(dut):
+  [in0, inCtrl], [out0, outCtrl] = getPorts(dut, ["in0", "inCtrl"],
+                                            ["out0", "outCtrl"])
+
+  # Create a 10us period clock on port clock
+  clock = cocotb.clock.Clock(dut.clock, 10, units="us")
+  cocotb.start_soon(clock.start())  # Start the clock
+
+  in0.setValid(0)
+  inCtrl.setValid(0)
+
+  out0.setReady(1)
+  outCtrl.setReady(1)
+
+  # Reset
+  dut.reset.value = 1
+  await RisingEdge(dut.clock)
+  dut.reset.value = 0
+  await RisingEdge(dut.clock)
+
+  resCheck = cocotb.start_soon(out0.checkOutputs([42]))
+
+  in0Send = cocotb.start_soon(in0.send((24, 18)))
+  inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+  await in0Send
+  await inCtrlSend
+
+  await resCheck


### PR DESCRIPTION
This patch adds additional functionality to handshakes COCOTB helper. 
Pushing the task pipelining transformations into a stable state will require additional test, and this lays the foundation for that. 