### PR TITLE
[ExportSystemC] Integer and port type emission

### DIFF
--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -2,4 +2,4 @@
 // RUN: circt-translate %s --export-systemc > %t.cpp
 // RUN: clang-tidy --extra-arg=-frtti %t.cpp
 
-systemc.module @module () { }
+systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>) { }

--- a/lib/Target/ExportSystemC/CMakeLists.txt
+++ b/lib/Target/ExportSystemC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_translation_library(CIRCTExportSystemC
   EmissionPrinter.cpp
   ExportSystemC.cpp
+  Patterns/HWEmissionPatterns.cpp
   Patterns/SystemCEmissionPatterns.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Target/ExportSystemC/EmissionPrinter.h
+++ b/lib/Target/ExportSystemC/EmissionPrinter.h
@@ -25,15 +25,17 @@ class EmissionPrinter {
 public:
   EmissionPrinter(mlir::raw_indented_ostream &os,
                   const FrozenOpEmissionPatternSet &opPatterns,
-                  const FrozenTypeEmissionPatternSet &typePatterns)
+                  const FrozenTypeEmissionPatternSet &typePatterns,
+                  Location loc)
       : opPatterns(opPatterns), typePatterns(typePatterns), os(os),
-        emissionFailed(false) {}
+        emissionFailed(false), currentLoc(loc) {}
 
   EmissionPrinter(mlir::raw_indented_ostream &os,
                   OpEmissionPatternSet &opPatterns,
-                  TypeEmissionPatternSet &typePatterns)
+                  TypeEmissionPatternSet &typePatterns, Location loc)
       : opPatterns(std::move(opPatterns)),
-        typePatterns(std::move(typePatterns)), os(os), emissionFailed(false) {}
+        typePatterns(std::move(typePatterns)), os(os), emissionFailed(false),
+        currentLoc(loc) {}
 
   /// Emit the given operation as a statement to the ostream associated with
   /// this printer according to the emission patterns registered. An operation
@@ -91,6 +93,7 @@ private:
   FrozenTypeEmissionPatternSet typePatterns;
   mlir::raw_indented_ostream &os;
   bool emissionFailed;
+  Location currentLoc;
 };
 
 } // namespace ExportSystemC

--- a/lib/Target/ExportSystemC/ExportSystemC.cpp
+++ b/lib/Target/ExportSystemC/ExportSystemC.cpp
@@ -50,7 +50,7 @@ static LogicalResult emitFile(Operation *op, StringRef filePath,
   registerAllOpEmitters(opPatterns, op->getContext());
   TypeEmissionPatternSet typePatterns;
   registerAllTypeEmitters(typePatterns);
-  EmissionPrinter printer(ios, opPatterns, typePatterns);
+  EmissionPrinter printer(ios, opPatterns, typePatterns, op->getLoc());
 
   printer << "// " << filePath << "\n";
   std::string macroname = pathToMacroName(filePath);

--- a/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
@@ -1,0 +1,62 @@
+//===- HWEmissionPatterns.cpp - HW Dialect Emission Patterns --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This implements the emission patterns for the HW dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "HWEmissionPatterns.h"
+#include "../EmissionPrinter.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+using namespace circt;
+using namespace circt::ExportSystemC;
+
+//===----------------------------------------------------------------------===//
+// Type emission patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Emit integer types. There are several datatypes to represent integers in
+/// SystemC. In contrast to HW and Comb, SystemC chooses the signedness
+/// semantics of operations not by the operation itself, but by the type of the
+/// operands. We generally map the signless integers of HW to unsigned integers
+/// in SystemC and cast to/from signed integers whenever needed. SystemC also
+/// uses different types depending on the bit-width of the integer. For 1-bit
+/// integers it simply uses 'bool', for integers with up to 64 bits it uses
+/// 'sc_uint<>' which maps to native C types for performance reasons. For bigger
+/// integers 'sc_biguint<>' is used. However, often a limit of 512 bits is
+/// configured for this datatype to improve performance. In that case, we have
+/// to fall back to 'sc_bv' bit-vectors which have the disadvantage that many
+/// operations such as arithmetics are not supported.
+struct IntegerTypeEmitter : TypeEmissionPattern<IntegerType> {
+  void emitType(IntegerType type, EmissionPrinter &p) override {
+    unsigned bitWidth = type.getIntOrFloatBitWidth();
+    if (bitWidth == 1)
+      p << "bool";
+    else if (bitWidth <= 64)
+      p << "sc_dt::sc_uint<" << bitWidth << ">";
+    else if (bitWidth <= 512)
+      p << "sc_dt::sc_biguint<" << bitWidth << ">";
+    else
+      p << "sc_dt::sc_bv<" << bitWidth << ">";
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Register Operation and Type emission patterns.
+//===----------------------------------------------------------------------===//
+
+void circt::ExportSystemC::populateHWEmitters(OpEmissionPatternSet &patterns,
+                                              MLIRContext *context) {}
+
+void circt::ExportSystemC::populateHWTypeEmitters(
+    TypeEmissionPatternSet &patterns) {
+  patterns.add<IntegerTypeEmitter>();
+}

--- a/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.h
+++ b/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.h
@@ -1,0 +1,25 @@
+//===- HWEmissionPatterns.h - HW Dialect Emission Patterns ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This exposes the emission patterns of the HW dialect for registration.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H
+#define CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H
+
+#include "../EmissionPatternSupport.h"
+
+namespace circt {
+namespace ExportSystemC {
+void populateHWEmitters(OpEmissionPatternSet &patterns, MLIRContext *context);
+void populateHWTypeEmitters(TypeEmissionPatternSet &patterns);
+} // namespace ExportSystemC
+} // namespace circt
+
+#endif // CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -71,6 +71,23 @@ struct BuiltinModuleEmitter : OpEmissionPattern<ModuleOp> {
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// Type emission patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Emit SystemC signal and port types according to the specification listed in
+/// their ODS description.
+template <typename Ty, const char Mn[]>
+struct SignalTypeEmitter : public TypeEmissionPattern<Ty> {
+  void emitType(Ty type, EmissionPrinter &p) override {
+    p << "sc_core::" << Mn << "<";
+    p.emitType(type.getBaseType());
+    p << ">";
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // Register Operation and Type emission patterns.
 //===----------------------------------------------------------------------===//
 
@@ -80,4 +97,14 @@ void circt::ExportSystemC::populateSystemCOpEmitters(
 }
 
 void circt::ExportSystemC::populateSystemCTypeEmitters(
-    TypeEmissionPatternSet &patterns) {}
+    TypeEmissionPatternSet &patterns) {
+  static constexpr const char in[] = "sc_in";
+  static constexpr const char inout[] = "sc_inout";
+  static constexpr const char out[] = "sc_out";
+
+  // clang-format off
+  patterns.add<SignalTypeEmitter<InputType, in>, 
+               SignalTypeEmitter<InOutType, inout>,
+               SignalTypeEmitter<OutputType, out>>();
+  // clang-format on
+}

--- a/lib/Target/ExportSystemC/RegisterAllEmitters.h
+++ b/lib/Target/ExportSystemC/RegisterAllEmitters.h
@@ -14,6 +14,7 @@
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_REGISTERALLEMITTERS_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_REGISTERALLEMITTERS_H
 
+#include "Patterns/HWEmissionPatterns.h"
 #include "Patterns/SystemCEmissionPatterns.h"
 
 namespace circt {
@@ -21,12 +22,14 @@ namespace ExportSystemC {
 
 /// Collects the operation emission patterns of all supported dialects.
 inline void registerAllOpEmitters(OpEmissionPatternSet &patterns,
-                                  mlir::MLIRContext *context) {
+                                  MLIRContext *context) {
+  populateHWEmitters(patterns, context);
   populateSystemCOpEmitters(patterns, context);
 }
 
 /// Collects the type emission patterns of all supported dialects.
 inline void registerAllTypeEmitters(TypeEmissionPatternSet &patterns) {
+  populateHWTypeEmitters(patterns);
   populateSystemCTypeEmitters(patterns);
 }
 

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -7,7 +7,11 @@
 // CHECK: #include <systemc>
 
 // CHECK-LABEL: SC_MODULE(basic) {
+// CHECK-NEXT: sc_core::sc_in<bool> port0;
+// CHECK-NEXT: sc_core::sc_inout<sc_dt::sc_uint<64>> port1;
+// CHECK-NEXT: sc_core::sc_out<sc_dt::sc_biguint<512>> port2;
+// CHECK-NEXT: sc_core::sc_out<sc_dt::sc_bv<1024>> port3;
 // CHECK-NEXT: };
-systemc.module @basic () { }
+systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>) { }
 
 // CHECK: #endif // STDOUT_H

--- a/test/Target/ExportSystemC/errors.mlir
+++ b/test/Target/ExportSystemC/errors.mlir
@@ -1,5 +1,11 @@
-// RUN: circt-translate %s --export-systemc --verify-diagnostics | FileCheck %s
+// RUN: circt-translate %s --export-systemc --verify-diagnostics --split-input-file | FileCheck %s
 
 // CHECK: <<UNSUPPORTED OPERATION (hw.module)>>
 // expected-error @+1 {{no emission pattern found for 'hw.module'}}
 hw.module @notSupported () -> () { }
+
+// -----
+
+// CHECK: <<UNSUPPORTED TYPE (!hw.inout<i2>)>>
+// expected-error @+1 {{no emission pattern found for type '!hw.inout<i2>'}}
+systemc.module @invalidType (%port0: !systemc.in<!hw.inout<i2>>) {}


### PR DESCRIPTION
Add emission patterns for `!systemc.in`, `!systemc.out`, `!systemc.inout`, and HW integers which map to different unsigned types in SystemC depending on the bit-width. I couldn't find any information on the max bit-width of each SystemC type in the IEEE spec, but it becomes clear what they are doing when reading the SystemC implementation (so I couldn't link a spec section in the emission pattern).

Also improves the error reporting in the emission printer a bit.