### PR TITLE
[SystemC] Don't hardcode includes

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -351,7 +351,7 @@ def ConvertHWToSystemC : Pass<"convert-hw-to-systemc", "mlir::ModuleOp"> {
     This pass translates a HW design into an equivalent SystemC design.
   }];
   let constructor = "circt::createConvertHWToSystemCPass()";
-  let dependentDialects = ["systemc::SystemCDialect"];
+  let dependentDialects = ["systemc::SystemCDialect", "mlir::emitc::EmitCDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -2,4 +2,6 @@
 // RUN: circt-translate %s --export-systemc > %t.cpp
 // RUN: clang-tidy --extra-arg=-frtti %t.cpp
 
+emitc.include <"systemc">
+
 systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>) { }

--- a/lib/Conversion/HWToSystemC/CMakeLists.txt
+++ b/lib/Conversion/HWToSystemC/CMakeLists.txt
@@ -11,5 +11,6 @@ add_circt_conversion_library(CIRCTHWToSystemC
   CIRCTSystemC
   CIRCTHW
   CIRCTComb
+  MLIREmitCDialect
   MLIRTransforms
 )

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -39,6 +39,10 @@ namespace func {
 class FuncDialect;
 class FuncOp;
 } // namespace func
+
+namespace emitc {
+class EmitCDialect;
+} // namespace emitc
 } // namespace mlir
 
 namespace circt {

--- a/lib/Target/ExportSystemC/CMakeLists.txt
+++ b/lib/Target/ExportSystemC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_translation_library(CIRCTExportSystemC
   EmissionPrinter.cpp
   ExportSystemC.cpp
+  Patterns/EmitCEmissionPatterns.cpp
   Patterns/HWEmissionPatterns.cpp
   Patterns/SystemCEmissionPatterns.cpp
 
@@ -14,6 +15,7 @@ add_circt_translation_library(CIRCTExportSystemC
   CIRCTHW
   CIRCTSystemC
   CIRCTSupport
+  MLIREmitCDialect
   MLIRIR
   MLIRTranslateLib
 )

--- a/lib/Target/ExportSystemC/EmissionPattern.h
+++ b/lib/Target/ExportSystemC/EmissionPattern.h
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPATTERN_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPATTERN_H
 

--- a/lib/Target/ExportSystemC/EmissionPatternSupport.h
+++ b/lib/Target/ExportSystemC/EmissionPatternSupport.h
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPATTERNSUPPORT_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPATTERNSUPPORT_H
 

--- a/lib/Target/ExportSystemC/EmissionPrinter.h
+++ b/lib/Target/ExportSystemC/EmissionPrinter.h
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPRINTER_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_EMISSIONPRINTER_H
 

--- a/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.cpp
@@ -1,0 +1,43 @@
+//===- EmitCEmissionPatterns.cpp - EmitC Dialect Emission Patterns --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This implements the emission patterns for the emitc dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EmitCEmissionPatterns.h"
+#include "../EmissionPrinter.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+
+using namespace mlir::emitc;
+using namespace circt;
+using namespace circt::ExportSystemC;
+
+//===----------------------------------------------------------------------===//
+// Operation emission patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Emit emitc.include operations.
+struct IncludeEmitter : OpEmissionPattern<IncludeOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+  void emitStatement(IncludeOp op, EmissionPrinter &p) override {
+    p << "#include " << (op.getIsStandardInclude() ? "<" : "\"")
+      << op.getInclude() << (op.getIsStandardInclude() ? ">" : "\"") << "\n";
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Register Operation and Type emission patterns.
+//===----------------------------------------------------------------------===//
+
+void circt::ExportSystemC::populateEmitCOpEmitters(
+    OpEmissionPatternSet &patterns, MLIRContext *context) {
+  patterns.add<IncludeEmitter>(context);
+}

--- a/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.h
+++ b/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.h
@@ -1,4 +1,4 @@
-//===- HWEmissionPatterns.h - HW Dialect Emission Patterns ----------------===//
+//===- EmitCEmissionPatterns.h - EmitC Dialect Emission Patterns ----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,21 +6,24 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This exposes the emission patterns of the HW dialect for registration.
+// This exposes the emission patterns of the emitc dialect for registration.
 //
 //===----------------------------------------------------------------------===//
 
 // NOLINTNEXTLINE(llvm-header-guard)
-#ifndef CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H
-#define CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H
+#ifndef CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_EMITCEMISSIONPATTERNS_H
+#define CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_EMITCEMISSIONPATTERNS_H
 
 #include "../EmissionPatternSupport.h"
 
 namespace circt {
 namespace ExportSystemC {
-void populateHWEmitters(OpEmissionPatternSet &patterns, MLIRContext *context);
-void populateHWTypeEmitters(TypeEmissionPatternSet &patterns);
+
+/// Register EmitC operation emission patterns.
+void populateEmitCOpEmitters(OpEmissionPatternSet &patterns,
+                             MLIRContext *context);
+
 } // namespace ExportSystemC
 } // namespace circt
 
-#endif // CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_HWEMISSIONPATTERNS_H
+#endif // CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_EMITCEMISSIONPATTERNS_H

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.h
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.h
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_SYSTEMCEMISSIONPATTERNS_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_PATTERNS_SYSTEMCEMISSIONPATTERNS_H
 

--- a/lib/Target/ExportSystemC/RegisterAllEmitters.h
+++ b/lib/Target/ExportSystemC/RegisterAllEmitters.h
@@ -11,9 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_TARGET_EXPORTSYSTEMC_REGISTERALLEMITTERS_H
 #define CIRCT_TARGET_EXPORTSYSTEMC_REGISTERALLEMITTERS_H
 
+#include "Patterns/EmitCEmissionPatterns.h"
 #include "Patterns/HWEmissionPatterns.h"
 #include "Patterns/SystemCEmissionPatterns.h"
 
@@ -25,6 +27,7 @@ inline void registerAllOpEmitters(OpEmissionPatternSet &patterns,
                                   MLIRContext *context) {
   populateHWEmitters(patterns, context);
   populateSystemCOpEmitters(patterns, context);
+  populateEmitCOpEmitters(patterns, context);
 }
 
 /// Collects the type emission patterns of all supported dialects.

--- a/test/Conversion/HWToSystemC/structure.mlir
+++ b/test/Conversion/HWToSystemC/structure.mlir
@@ -1,5 +1,7 @@
 // RUN: circt-opt --convert-hw-to-systemc --verify-diagnostics %s | FileCheck %s
 
+// CHECK: emitc.include <"systemc">
+
 // CHECK-LABEL: systemc.module @emptyModule ()
 hw.module @emptyModule () -> () {}
 

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -5,6 +5,10 @@
 // CHECK-NEXT: #define STDOUT_H
 
 // CHECK: #include <systemc>
+// CHECK: #include "nosystemheader"
+
+emitc.include <"systemc">
+emitc.include "nosystemheader"
 
 // CHECK-LABEL: SC_MODULE(basic) {
 // CHECK-NEXT: sc_core::sc_in<bool> port0;


### PR DESCRIPTION
Use the emitc.include operation to add includes during lowering or transformations instead of hardcoding them in the printer. Add basic support in HWToSystemC and ExportSystemC.