### PR TITLE
[MSFT][CAPI] Fix library dependencies

### DIFF
--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -38,6 +38,7 @@ add_mlir_public_c_api_library(CIRCTCAPIMSFT
   MLIRCAPIIR
   MLIRTransforms
   CIRCTMSFT
+  CIRCTMSFTTransforms
 )
 
 add_mlir_public_c_api_library(CIRCTCAPIHW


### PR DESCRIPTION
The CIRCTCAPIMSFT library depends on MSFTTransforms, and is currently
failing to link when creating shared libraries.
```
ld: tools/circt/lib/CAPI/Dialect/CMakeFiles/obj.CIRCTCAPIMSFT.dir/MSFT.cpp.o: in function `operator()':
/circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:373: undefined reference to `circt::msft::createDiscoverAppIDsPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:383: undefined reference to `circt::msft::createExportTclPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:393: undefined reference to `circt::msft::createLowerConstructsPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:403: undefined reference to `circt::msft::createLowerInstancesPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:413: undefined reference to `circt::msft::createLowerToHWPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:423: undefined reference to `circt::msft::createPartitionPass()'
ld: /circt/build-release/tools/circt/include/circt/Dialect/MSFT/MSFTPasses.h.inc:433: undefined reference to `circt::msft::createWireCleanupPass()
```