### PR TITLE
[FIRRTL][RefOps] LowerXMR: Handle upward references

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -233,7 +233,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
           return refMod.emitOpError(
                      "multiply instantiated module with input RefType port '")
                  << refMod.getPortName(portNum) << "'";
-        dataFlowClasses.unionSets(refModuleArg, instanceResult);
+        dataFlowClasses.unionSets(
+            dataFlowClasses.getOrInsertLeaderValue(refModuleArg),
+            dataFlowClasses.getOrInsertLeaderValue(instanceResult));
       }
     }
     return success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -257,7 +257,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       dataflowAt[src] = getRemoteRefSend(dst).value();
       return;
     }
-    // dataflow at src exists, so merge it if an entry already exists at dest.
+    // dataflow at src exists, so merge it if an entry already exists at dst.
     auto flowAtDst = dataflowAt.find(dst);
     if (flowAtDst == dataflowAt.end()) {
       dataflowAt[dst] = flowAtSrc->getSecond();
@@ -268,7 +268,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       // If a valid dataflow already reaches the destination, emit remark.
       // This happens when multiple connects attached to an input RefType
       // port, or multiple instantiation (which is already an error).
-      dst.getDefiningOp()->emitRemark("has multipl reaching definitions");
+      dst.getDefiningOp()->emitRemark("has multiple reaching definitions");
     }
     // Dest already has an entry, make sure to update all the entries in the
     // dataflow map to point to this new entry.
@@ -318,12 +318,11 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   DenseSet<Operation *> visitedModules;
   /// Map of a reference value to an entry into refSendList. Each entry in
-  /// refSendList represents the path to RefSend is as an ArrayAttr, which is an
-  /// array of the InnerRef to InstanceOps. The path is required since there can
+  /// refSendList represents the path to RefSend, which is a vector of the
+  /// InnerRefAttr to InstanceOps. The path is required since there can
   /// be multiple paths to the RefSend and we need to identify a unique path.
-  /// Each ref value can be satically resolved to a single remote send op,
-  /// according to the constraints on the RefType. The ArrayAttr ensures that
-  /// only unique copies of the path exist.
+  /// Each ref value can be statically resolved to a single remote send op,
+  /// according to the constraints on the RefType.
   DenseMap<Value, size_t> dataflowAt;
 
   /// This is the set of all unique paths from a RefSendOp to RefResolveOps.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -159,7 +159,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                init.second; init = refSendPathList[init.second.value()])
             llvm::dbgs() << "\n path ::" << init.first << "::" << init.second;
         }
-        llvm::dbgs() << "\n Done"; // Finish set.
+        llvm::dbgs() << "\n Done\n"; // Finish set.
       }
     });
     for (auto refResolve : resolveOps)
@@ -326,7 +326,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   DenseSet<Operation *> visitedModules;
   /// Map of a reference value to an entry into refSendPathList. Each entry in
-  /// refSendPathList represents the path to RefSend. i
+  /// refSendPathList represents the path to RefSend.
   /// The path is required since there can be multiple paths to the RefSend and
   /// we need to identify a unique path.
   DenseMap<Value, size_t> dataflowAt;
@@ -334,7 +334,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   /// refSendPathList is used to construct a path to the RefSendOp. Each entry
   /// is a node, with an InnerRefAttr and a pointer to the next node in the
   /// path. The InnerRefAttr can be to an InstanceOp or to the XMR defining
-  /// op.All the nodes representing an InstanceOp, must have a valid
+  /// op. All the nodes representing an InstanceOp must have a valid
   /// nextNodeOnPath. Only the node representing the final XMR defining op has
   /// no nextNodeOnPath, which denotes a leaf node on the path.
   using nextNodeOnPath = Optional<size_t>;

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -272,9 +272,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     }
     // Dest already has an entry, make sure to update all the entries in the
     // dataflow map to point to this new entry.
-    for (auto entr : dataflowAt) {
+    for (auto &entr : dataflowAt) {
       if (entr.getSecond() == oldEntry) {
-        dataflowAt[entr.getFirst()] = flowAtSrc->getSecond();
+        entr.getSecond() = flowAtSrc->getSecond();
       }
     }
   }

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -297,9 +297,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     // Now erase all the Ops and ports of RefType.
     // This needs to be done as the last step to ensure uses are erased before
     // the def is erased.
-    for (auto op : llvm::reverse(opsToRemove)) {
+    for (auto op : llvm::reverse(opsToRemove))
       op->erase();
-    }
     for (auto iter : refPortsToRemoveMap)
       if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -297,7 +297,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     // Now erase all the Ops and ports of RefType.
     // This needs to be done as the last step to ensure uses are erased before
     // the def is erased.
-    for (auto op : llvm::reverse(opsToRemove))
+    for (Operation *op : llvm::reverse(opsToRemove))
       op->erase();
     for (auto iter : refPortsToRemoveMap)
       if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))

--- a/test/Dialect/FIRRTL/lowerXMR-error.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-error.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt %s  --firrtl-lower-xmr -split-input-file -verify-diagnostics
+
+// Test for same module lowering
+// CHECK-LABEL: firrtl.circuit "xmr"
+firrtl.circuit "xmr" {
+  // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port 'a'}}
+  firrtl.module @xmr(in %a: !firrtl.ref<uint<2>>) {
+    %x = firrtl.ref.resolve %a : !firrtl.ref<uint<2>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+  }
+  // expected-error @+1 {{op multiply instantiated module with input RefType port '0'}}
+  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  }
+  // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port '_a'}}
+  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -29,7 +29,7 @@ firrtl.circuit "Top" {
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
   }
-  // expected-error @+1 {{op multiply instantiated module with input RefType port '0'}}
+  // expected-error @+1 {{op multiply instantiated module with input RefType port '_a'}}
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
   }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -23,7 +23,7 @@ firrtl.circuit "Top" {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK:  %0 = firrtl.node sym @xmr_sym interesting_name %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -76,7 +76,7 @@ firrtl.circuit "Top" {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0
-    // CHECK:  %0 = firrtl.node sym @xmr_sym interesting_name %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -129,7 +129,7 @@ firrtl.circuit "Top" {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0
-    // CHECK:  %0 = firrtl.node sym @xmr_sym interesting_name %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -128,7 +128,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK:   %c0_ui1 = firrtl.constant 0
+    // CHECK:  %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -117,3 +117,138 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %c, %2 : !firrtl.uint<1>
   }
 }
+
+// -----
+
+// Check for downward reference
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @XmrSrcMod() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1> {inner_sym = #firrtl<innerSym@xmr_sym>}
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
+    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @bar  @Bar()
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+  }
+
+}
+
+// -----
+
+// Check for downward reference to port
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
+    // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
+    %1 = firrtl.ref.send %pa : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
+    // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
+    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.instance bar sym @bar  @Bar()
+    %a = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL: %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+  }
+}
+
+// -----
+
+// Test for multiple paths and downward reference.
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %c_a, %c_b = firrtl.instance child @Child2p(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
+    // CHECK:  firrtl.instance child  @Child2p()
+    firrtl.strictconnect %c_a, %foo_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child2p(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+  }
+}
+
+
+// -----
+
+// Test for multiple children paths
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.ref.send %zero : !firrtl.uint<1>
+    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Top() {
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+  }
+  // CHECK-LABEL: firrtl.module @Child1() {
+  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
+    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+    %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
+    firrtl.strictconnect %c3 , %_a : !firrtl.ref<uint<1>>
+  }
+  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+  }
+  firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+  }
+}

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "xmr" {
     %x = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:  %w = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}" : () -> !firrtl.uint<2> {symbols = [#hw.innerNameRef<@xmr::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<2> {symbols = [@xmr, #hw.innerNameRef<@xmr::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %o, %0 : !firrtl.uint<2>
   }
 }
@@ -37,7 +37,7 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -62,7 +62,7 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL: %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -85,7 +85,7 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
     firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Foo, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
@@ -94,7 +94,7 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
     firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Bar, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
@@ -109,11 +109,11 @@ firrtl.circuit "Top" {
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %foo_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %2 = firrtl.ref.resolve %xmr_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %2 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     firrtl.strictconnect %b, %1 : !firrtl.uint<1>
     firrtl.strictconnect %c, %2 : !firrtl.uint<1>
@@ -143,14 +143,14 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 
 }
@@ -175,14 +175,14 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL: %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }
 
@@ -210,9 +210,9 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2p(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }
 
@@ -234,7 +234,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -243,15 +243,15 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }
 
@@ -273,7 +273,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -282,15 +282,15 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }
 
@@ -317,7 +317,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -326,14 +326,14 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK-LITERAL:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }


### PR DESCRIPTION
This PR updates the `LowerXMR`  to remove the `RefType` constraint of downward only reference.
The algorithm now requires a second pass over the modules, to propagate the reference from top to bottom. The first pass propagates the `ref.send` from bottom to top.
