### PR TITLE
[CI] Fix invocation of clang-tidy.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -276,7 +276,7 @@ jobs:
         if: ${{ always() }}
         run: |
           git diff -U0 $DIFF_COMMIT...HEAD | \
-            clang-tidy-diff -path build_clang -p1 -fix
+            clang-tidy-diff -path build -p1 -fix -j$(nproc)
           git clang-format $DIFF_COMMIT
           git diff --ignore-submodules > clang-tidy.patch
           if [ -s clang-tidy.patch ]; then


### PR DESCRIPTION
Has been silently failing for some time, pointed at non-existent
directory to find the compilation database.

While visiting, let clang-tidy operate in parallel as it can take
a small but non-trivial amount of time to process each file.