### PR TITLE
[FIRRTL] Extend register randomization to split up large registers.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -586,10 +586,10 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
 }
 
 def RandomizeRegisterInit :
-    Pass<"firrtl-randomize-register-init", "firrtl::CircuitOp"> {
+    Pass<"firrtl-randomize-register-init", "firrtl::FModuleOp"> {
   let summary = "Randomize register initialization.";
   let description = [{
-    This pass eagerly creates a large vector of randomized bits for initializing
+    This pass eagerly creates large vectors of randomized bits for initializing
     registers, and marks each register with attributes indicating which bits to
     read. If the registers survive until LowerToHW, their initialization logic
     will pick up the correct bits.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1064,8 +1064,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
     newModule.setCommentAttr(comment);
 
   // Pass along the number of random initialization bits needed for this module.
-  if (auto randomWidth =
-          oldModule->getAttrOfType<IntegerAttr>("firrtl.random_init_width"))
+  if (auto randomWidth = oldModule->getAttr("firrtl.random_init_width"))
     newModule->setAttr("firrtl.random_init_width", randomWidth);
 
   // If the circuit has an entry point, set all other modules private.
@@ -2604,6 +2603,8 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
                                            op.getNameAttr(), symName);
 
   // Pass along the start and end random initialization bits for this register.
+  if (auto randomRegister = op->getAttr("firrtl.random_init_register"))
+    reg->setAttr("firrtl.random_init_register", randomRegister);
   if (auto randomStart = op->getAttr("firrtl.random_init_start"))
     reg->setAttr("firrtl.random_init_start", randomStart);
   if (auto randomEnd = op->getAttr("firrtl.random_init_end"))
@@ -2644,6 +2645,8 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
                                     resetSignal, resetValue, symName, isAsync);
 
   // Pass along the start and end random initialization bits for this register.
+  if (auto randomRegister = op->getAttr("firrtl.random_init_register"))
+    reg->setAttr("firrtl.random_init_register", randomRegister);
   if (auto randomStart = op->getAttr("firrtl.random_init_start"))
     reg->setAttr("firrtl.random_init_start", randomStart);
   if (auto randomEnd = op->getAttr("firrtl.random_init_end"))

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -6,7 +6,11 @@ circuit Foo:
   module Foo:
     input clock: Clock
     input d: UInt<33>
+    input d0: UInt<60000>
+    input d1: UInt<120000>
     output q: UInt<33>
+    output q0: UInt<60000>
+    output q1: UInt<120000>
 
     ; ALL:   reg [127:0] _RANDOM;
     ; ALL:   _RANDOM = {`RANDOM,`RANDOM,`RANDOM,`RANDOM};
@@ -36,3 +40,40 @@ circuit Foo:
     s <= d
 
     q <= s
+
+    inst i0 of TwoLargeRegisters
+    i0.clock <= clock
+    i0.d <= d0
+    q0 <= i0.q
+
+    inst i1 of OneReallyLargeRegister
+    i1.clock <= clock
+    i1.d <= d1
+    q1 <= i1.q
+
+  module TwoLargeRegisters:
+    input clock: Clock
+    input d: UInt<60000>
+    output q: UInt<60000>
+
+    ; ALL: reg [59999:0] _RANDOM;
+    ; ALL: reg [59999:0] _RANDOM_0;
+
+    reg r0: UInt<60000>, clock
+    reg r1: UInt<60000>, clock
+
+    r0 <= d
+    r1 <= r0
+    q <= r1
+
+  module OneReallyLargeRegister:
+    input clock: Clock
+    input d: UInt<120000>
+    output q: UInt<120000>
+
+    ; ALL: reg [119999:0] _RANDOM;
+
+    reg r: UInt<120000>, clock
+
+    r <= d
+    q <= r

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -565,7 +565,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   // implementation assumes it can run at a time where every register is
   // currently in the final module it will be emitted in, all registers have
   // been created, and no registers have yet been removed.
-  pm.nest<firrtl::CircuitOp>().addPass(
+  pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createRandomizeRegisterInitPass());
 
   if (checkCombCycles)


### PR DESCRIPTION
This now tracks when randomized registers exceed a threshold, and
splits them up into multiple registers. This is intended to work
around register size limits in simulators that may be exceeded by
using a single large register to hold all of the random bits for each
module.