### PR TITLE
[FIRParser] Remove more old annotation handling code

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -14,7 +14,7 @@
 #define FIRANNOTATIONS_H
 
 #include "circt/Support/LLVM.h"
-#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace llvm {
 namespace json {
@@ -36,11 +36,11 @@ class PrintFOp;
 /// Convert a JSON value containing OMIR JSON (an array of OMNodes), convert
 /// this to an OMIRAnnotation, and add it to a mutable `annotationMap` argument.
 bool fromOMIRJSON(llvm::json::Value &value, StringRef circuitTarget,
-                  llvm::StringMap<ArrayAttr> &annotationMap,
+                  SmallVectorImpl<Attribute> &annotations,
                   llvm::json::Path path, MLIRContext *context);
 
 bool fromJSONRaw(llvm::json::Value &value, StringRef circuitTarget,
-                 SmallVectorImpl<Attribute> &attrs, llvm::json::Path path,
+                 SmallVectorImpl<Attribute> &annotations, llvm::json::Path path,
                  MLIRContext *context);
 
 ParseResult foldWhenEncodedVerifOp(PrintFOp printOp);


### PR DESCRIPTION
Since we switched to using LowerAnnotations exclusively, we no longer
attach annotations to the IR while its being generated.  This lets
us remove the `targetMap` and associated logic for attaching annotations
to FIRRTL entities from the parser.

This also changes the "raw annotation" parsing path to append all
annotations to a SmallVector instead of recording them in the
`targetMap` using the "rawAnnotations" key.