### PR TITLE
[ExportSystemC] Add InstanceDeclOp emission pattern

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -154,3 +154,46 @@ def SCFuncOp : SystemCOp<"func", [
   let hasVerifier = true;
   let skipDefaultBuilders = 1;
 }
+
+def InstanceDeclOp : SystemCOp<"instance.decl", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  DeclareOpInterfaceMethods<HWInstanceLike>,
+  HasCustomSSAName,
+  SystemCNameDeclOpInterface,
+  HasParent<"SCModuleOp">
+]> {
+  let summary = "Declares a SystemC module instance.";
+  let description = [{
+    Declares an instantiation of a SystemC module inside another SystemC module
+    by value. The instance handle returned by this operation can then be used
+    to initialize it in the constructor and to access its fields.
+    More information can be found in IEEE 1666-2011 §4.1.1.
+  }];
+
+  let arguments = (ins StrAttr:$name, FlatSymbolRefAttr:$moduleName);
+  let results = (outs ModuleType:$instanceHandle);
+
+  let assemblyFormat = [{
+    custom<ImplicitSSAName>($name) $moduleName attr-dict
+    `:` type($instanceHandle)
+  }];
+
+  let extraClassDeclaration = [{
+    /// Get the systemc::ModuleType that represents the instantiated module.
+    systemc::ModuleType getInstanceType() {
+      return getInstanceHandle().getType().cast<systemc::ModuleType>();
+    }
+
+    StringRef getInstanceName() { return getName(); }
+
+    /// Lookup the module for the symbol. This returns null on invalid IR.
+    Operation *getReferencedModule(const hw::HWSymbolCache *cache);
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// An InstanceDeclOp may not optionally define a symbol.
+    bool isOptionalSymbol() { return false; }
+  }];
+}

--- a/include/circt/Dialect/SystemC/SystemCTypes.h
+++ b/include/circt/Dialect/SystemC/SystemCTypes.h
@@ -19,7 +19,19 @@
 
 namespace circt {
 namespace systemc {
+
+namespace detail {
+/// A struct containing minimal information for a systemc module port. Thus, can
+/// be used as parameter in attributes or types.
+struct PortInfo {
+  mlir::StringAttr name;
+  mlir::Type type;
+};
+} // namespace detail
+
+/// Get the type wrapped by a signal or port (in, inout, out) type.
 Type getSignalBaseType(Type type);
+
 } // namespace systemc
 } // namespace circt
 

--- a/include/circt/Dialect/SystemC/SystemCTypes.td
+++ b/include/circt/Dialect/SystemC/SystemCTypes.td
@@ -49,4 +49,9 @@ def SignalType : SystemCType<
     "SignalType",
     "::circt::hw::TypeAliasOr<circt::systemc::SignalType>">;
 
+// A handle to refer to circt::systemc::ModuleType in ODS.
+def ModuleType : SystemCType<
+    CPred<"::circt::hw::type_isa<circt::systemc::ModuleType>($_self)">,
+    "a ModuleType", "::circt::hw::TypeAliasOr<circt::systemc::ModuleType>">;
+
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCTYPES

--- a/include/circt/Dialect/SystemC/SystemCTypesImpl.td
+++ b/include/circt/Dialect/SystemC/SystemCTypesImpl.td
@@ -78,3 +78,26 @@ def SignalTypeImpl : SignalTypesImplBase<"Signal"> {
   }];
   let mnemonic = "signal";
 }
+
+// A type to represent systemc::SCModuleOp instances.
+// Declares the systemc::ModuleType in C++.
+def ModuleTypeImpl : SystemCTypeDef<"Module"> {
+  let summary = "SystemC module type";
+  let description = [{
+    Represents a SystemC module instantiation. Example:
+    `!systemc.module<moduleName(portName1: type1, portName2: type2)>`
+  }];
+  let mnemonic = "module";
+
+  let hasCustomAssemblyFormat = 1;
+
+  let parameters = (ins
+    "mlir::StringAttr":$moduleName,
+    ArrayRefParameter<
+      "::circt::systemc::ModuleType::PortInfo", "module ports">:$ports
+  );
+
+  let extraClassDeclaration = [{
+    using PortInfo = ::circt::systemc::detail::PortInfo;
+  }];
+}

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -4,7 +4,10 @@
 
 emitc.include <"systemc">
 
+systemc.module @submodule (%in0: !systemc.in<i32>, %in1: !systemc.in<i32>, %out0: !systemc.out<i32>) {}
+
 systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>, %port4: !systemc.out<i1>) {
+  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
   %sig = systemc.signal : !systemc.signal<i64>
   systemc.ctor {
     systemc.method %add

--- a/lib/Dialect/SystemC/SystemCTypes.cpp
+++ b/lib/Dialect/SystemC/SystemCTypes.cpp
@@ -26,6 +26,69 @@ Type systemc::getSignalBaseType(Type type) {
       .Default([](auto ty) { return Type(); });
 }
 
+namespace circt {
+namespace systemc {
+namespace detail {
+bool operator==(const PortInfo &a, const PortInfo &b) {
+  return a.name == b.name && a.type == b.type;
+}
+// NOLINTNEXTLINE(readability-identifier-naming)
+llvm::hash_code hash_value(const PortInfo &pi) {
+  return llvm::hash_combine(pi.name, pi.type);
+}
+} // namespace detail
+} // namespace systemc
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// ModuleType
+//===----------------------------------------------------------------------===//
+
+/// Parses a systemc::ModuleType of the format:
+/// !systemc.module<moduleName(portName1: type1, portName2: type2)>
+Type ModuleType::parse(AsmParser &odsParser) {
+  if (odsParser.parseLess())
+    return Type();
+
+  StringRef moduleName;
+  if (odsParser.parseKeyword(&moduleName))
+    return Type();
+
+  SmallVector<ModuleType::PortInfo> ports;
+
+  if (odsParser.parseCommaSeparatedList(
+          AsmParser::Delimiter::Paren, [&]() -> ParseResult {
+            StringRef name;
+            PortInfo port;
+            if (odsParser.parseKeyword(&name) || odsParser.parseColon() ||
+                odsParser.parseType(port.type))
+              return failure();
+
+            port.name = StringAttr::get(odsParser.getContext(), name);
+            ports.push_back(port);
+
+            return success();
+          }))
+    return Type();
+
+  if (odsParser.parseGreater())
+    return Type();
+
+  return ModuleType::getChecked(
+      UnknownLoc::get(odsParser.getContext()), odsParser.getContext(),
+      StringAttr::get(odsParser.getContext(), moduleName), ports);
+}
+
+/// Prints a systemc::ModuleType in the format:
+/// !systemc.module<moduleName(portName1: type1, portName2: type2)>
+void ModuleType::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << '<' << getModuleName().getValue() << '(';
+  llvm::interleaveComma(getPorts(), odsPrinter, [&](auto port) {
+    odsPrinter << port.name.getValue() << ": " << port.type;
+  });
+  odsPrinter << ")>";
+}
+
 //===----------------------------------------------------------------------===//
 // Generated logic
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -154,3 +154,92 @@ systemc.module @invalidSignalOpReturnType () {
   // expected-error @+1 {{invalid kind of type specified}}
   %signal0 = systemc.signal : i32
 }
+
+// -----
+
+systemc.module @m1() {}
+
+// expected-note @+1 {{in module '@instanceDeclNameConflict'}}
+systemc.module @instanceDeclNameConflict () {
+  // expected-note @+1 {{'name' first defined here}}
+  %0 = "systemc.signal"() {name="name"} : () -> !systemc.signal<i32>
+  // expected-error @+1 {{redefines name 'name'}}
+  %1 = "systemc.instance.decl"() {name="name", moduleName=@m1} : () -> !systemc.module<m1()>
+}
+
+// -----
+
+systemc.module @m1() {}
+
+systemc.module @instanceDeclNameNotEmpty () {
+  // expected-error @+1 {{'name' attribute must not be empty}}
+  %0 = "systemc.instance.decl"() {name = "", moduleName=@m1} : () -> !systemc.module<m1()>
+}
+
+// -----
+
+systemc.module @submodule (%in0: !systemc.in<i32>) {}
+
+systemc.module @instanceDeclMustBeDirectChildOfModule () {
+  systemc.ctor {
+    // expected-error @+1 {{expects parent op 'systemc.module'}}
+    %instance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>)>
+  }
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32>, %sum: !systemc.out<i32>) {}
+
+systemc.module @instanceDeclTypeMismatch () {
+  // expected-error @+1 {{port type #1 must be '!systemc.in<i32>', but got '!systemc.in<i1>'}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i1>, sum: !systemc.out<i32>)>
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32>, %sum: !systemc.out<i32>) {}
+
+systemc.module @instanceDeclPortNameMismatch () {
+  // expected-error @+1 {{port name #1 must be "summand_b", but got "summand"}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand: !systemc.in<i32>, sum: !systemc.out<i32>)>
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32>, %sum: !systemc.out<i32>) {}
+
+systemc.module @instanceDeclPortNumMismatch () {
+  // expected-error @+1 {{has a wrong number of ports; expected 3 but got 2}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>)>
+}
+
+// -----
+
+systemc.module @instanceDeclNonExistentModule () {
+  // expected-error @+1 {{cannot find module definition 'adder'}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>)>
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module @adder () -> () {}
+
+systemc.module @instanceDeclDoesNotReferenceSystemCModule () {
+  // expected-error @+1 {{symbol reference 'adder' isn't a systemc module}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<adder()>
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32>, %sum: !systemc.out<i32>) {}
+
+systemc.module @instanceDeclPortNumMismatch () {
+  // expected-error @+1 {{module names must match; expected 'adder' but got 'wrongname'}}
+  %moduleInstance = systemc.instance.decl @adder : !systemc.module<wrongname(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>)>
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -63,3 +63,11 @@ systemc.module @argAttrs (%port0: !systemc.in<i32> {hw.attrname = "sometext"}, %
 
 // CHECK-LABEL: systemc.module @resultAttrs (%port0: !systemc.in<i32>, %out0: !systemc.out<i32> {hw.attrname = "sometext"})
 systemc.module @resultAttrs (%port0: !systemc.in<i32>, %out0: !systemc.out<i32> {hw.attrname = "sometext"}) {}
+
+// CHECK-LABEL: systemc.module @instanceDecl
+systemc.module @instanceDecl () {
+  // CHECK-NEXT: %moduleInstance0 = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>
+  %moduleInstance0 = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>
+  // CHECK-NEXT: %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
+  %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
+}

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -11,6 +11,15 @@ emitc.include <"systemc">
 emitc.include "nosystemheader"
 
 // CHECK-EMPTY:
+// CHECK-LABEL: SC_MODULE(submodule) {
+systemc.module @submodule (%in0: !systemc.in<i32>, %in1: !systemc.in<i32>, %out0: !systemc.out<i32>) {
+// CHECK-NEXT: sc_core::sc_in<sc_dt::sc_uint<32>> in0;
+// CHECK-NEXT: sc_core::sc_in<sc_dt::sc_uint<32>> in1;
+// CHECK-NEXT: sc_core::sc_out<sc_dt::sc_uint<32>> out0;
+// CHECK-NEXT: };
+}
+
+// CHECK-EMPTY:
 // CHECK-LABEL: SC_MODULE(basic) {
 systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>, %port4: !systemc.out<i1>) {
   // CHECK-NEXT: sc_core::sc_in<bool> port0;
@@ -20,6 +29,8 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %po
   // CHECK-NEXT: sc_core::sc_out<bool> port4;
   // CHECK-NEXT: sc_core::sc_signal<sc_dt::sc_uint<64>> sig;
   %sig = systemc.signal : !systemc.signal<i64>
+  // CHECK-NEXT: submodule submoduleInstance;
+  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
   // CHECK-EMPTY: 
   // CHECK-NEXT: SC_CTOR(basic) {
   systemc.ctor {


### PR DESCRIPTION
The plan is to use the more modern constructor that does not take the instance name as a string argument for initialization. This means we only have to connect the ports in the SC_CTOR (in a later PR).