### PR TITLE
[FIRRTL][RefOps] Remove downward-only constraint from RefType

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -709,8 +709,8 @@ def RefInstancePortConstraint
 // RefOps
 //===----------------------------------------------------------------------===//
 
-def RefResolveOp: FIRRTLExprOp<"ref.resolve", [RefTypeConstraint<"ref","result">,
-                                    RefInstancePortConstraint]> {
+def RefResolveOp: FIRRTLExprOp<"ref.resolve",
+                              [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL Resolve a Reference";
   let description = [{
     Resolve a remote reference for reading a remote value.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2024,24 +2024,8 @@ void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 /// ports to Instance ports.
 static LogicalResult checkRefTypeFlow(Operation *connect) {
   Value dst = connect->getOperand(0);
-  Value src = connect->getOperand(1);
 
   if (dst.getType().isa<RefType>()) {
-    if (getDeclarationKind(src) == getDeclarationKind(dst)) {
-      bool rootKnown;
-      auto diag = emitError(connect->getLoc())
-                  << "connect is invalid: the first operand ";
-      auto dstName = getFieldName(getFieldRefFromValue(dst), rootKnown);
-      if (rootKnown)
-        diag << "\"" << dstName << "\" ";
-      diag << "and second operand ";
-      auto srcName = getFieldName(getFieldRefFromValue(src), rootKnown);
-      if (rootKnown)
-        diag << "\"" << srcName << "\" ";
-      diag << "both have same port kind, expected Module port to Instance "
-              "connections only";
-      return diag;
-    }
     // RefType supports multiple readers. That is, there can be multiple
     // RefResolveOps remotely connected to a single RefSendOp.
     // But multiple RefSendOps should not be remotely connected to a single

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -905,16 +905,6 @@ firrtl.circuit "DupSymField" {
 }
 
 // -----
-// Check upward reference XMRs
-
-firrtl.circuit "func2" {
-  firrtl.module @func2(in %ref_in1: !firrtl.ref<uint<1>>, out %ref_out: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{connect is invalid: the first operand "ref_out" and second operand "ref_in1" both have same port kind, expected Module port to Instance connections only}}
-    firrtl.strictconnect %ref_out, %ref_in1 : !firrtl.ref<uint<1>>
-  }
-}
-
-// -----
 // Node ops cannot have reference type
 
 firrtl.circuit "NonRefNode" {
@@ -1025,16 +1015,6 @@ firrtl.circuit "Top" {
     %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint<2>>)
     // expected-error @+1 {{may not connect different non-base types}}
     firrtl.connect %foo_in, %in : !firrtl.ref<uint<2>>, !firrtl.ref<uint<1>>
-  }
-}
-
-// -----
-// Check upward reference XMRs
-
-firrtl.circuit "MyView_mapping" {
-  firrtl.module @MyView_mapping(in %ref_in1: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{'firrtl.ref.resolve' op failed to verify that it cannot have module port as an operand because it implies upward reference XMR, which are not supported. The reference operand must be a port from firrtl.instance}}
-    %0 = firrtl.ref.resolve %ref_in1 : !firrtl.ref<uint<1>>
   }
 }
 


### PR DESCRIPTION
This PR relaxes the downward only constraint on the RefType flow. After this change, 
- Modules can have input ports of `RefType`
- Instance ops can connect RefType input/output ports to module input/output ports according to connect semantics.
- There is no constraint to where a `ref.resolve` can occur relative to `ref.send` in the instance hierarchy

There are no additional verifiers added to constraint the `RefType` flow, but the LowerXMR pass must error out, if multiply instantiated modules with `RefType ` ports are encountered.