### PR TITLE
[FIRRTL][firtool] Add support for reading/writing bytecode

### DIFF
--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -1,7 +1,11 @@
-// RUN: firtool %s --format=mlir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
-// RUN: firtool %s --format=mlir -verilog |           FileCheck %s --check-prefix=VERILOG
+// RUN: firtool %s --format=mlir --ir-fir | circt-opt | FileCheck %s --check-prefix=MLIR
+// RUN: firtool %s --format=mlir --ir-fir --emit-bytecode | circt-opt | FileCheck %s --check-prefix=MLIR
+// RUN: circt-opt %s --emit-bytecode | firtool --ir-fir | circt-opt | FileCheck %s --check-prefix=MLIR
+// RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
 // RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.bc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
+// RUN: circt-opt %t.bc | FileCheck %s --check-prefix=VERILOG-WITH-MLIR-OUT
 
 firrtl.circuit "Top" {
   firrtl.module @Top(in %in : !firrtl.uint<8>,

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -3,9 +3,10 @@
 // RUN: circt-opt %s --emit-bytecode | firtool --ir-fir | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
 // RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
-// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.bc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.mlirbc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
-// RUN: circt-opt %t.bc | FileCheck %s --check-prefix=VERILOG-WITH-MLIR-OUT
+// RUN: circt-opt %t.mlirbc | FileCheck %s --check-prefix=VERILOG-WITH-MLIR-OUT
+// RUN: not diff %t %t.mlirbc
 
 firrtl.circuit "Top" {
   firrtl.module @Top(in %in : !firrtl.uint<8>,

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTSVTransforms
   CIRCTTransforms
 
+  MLIRBytecodeWriter
   MLIRParser
   MLIRSupport
   MLIRIR

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTSVTransforms
   CIRCTTransforms
 
+  MLIRBytecodeReader
   MLIRBytecodeWriter
   MLIRParser
   MLIRSupport

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -64,10 +64,10 @@ static cl::OptionCategory mainCategory("firtool Options");
 
 static cl::opt<InputFormatKind> inputFormat(
     "format", cl::desc("Specify input file format:"),
-    cl::values(clEnumValN(InputUnspecified, "autodetect",
-                          "Autodetect input format"),
-               clEnumValN(InputFIRFile, "fir", "Parse as .fir file"),
-               clEnumValN(InputMLIRFile, "mlir", "Parse as .mlir or .bc file")),
+    cl::values(
+        clEnumValN(InputUnspecified, "autodetect", "Autodetect input format"),
+        clEnumValN(InputFIRFile, "fir", "Parse as .fir file"),
+        clEnumValN(InputMLIRFile, "mlir", "Parse as .mlir or .mlirbc file")),
     cl::init(InputUnspecified), cl::cat(mainCategory));
 
 static cl::opt<std::string> inputFilename(cl::Positional,
@@ -872,7 +872,7 @@ static LogicalResult executeFirtool(MLIRContext &context) {
     if (StringRef(inputFilename).endswith(".fir"))
       inputFormat = InputFIRFile;
     else if (StringRef(inputFilename).endswith(".mlir") ||
-             StringRef(inputFilename).endswith(".bc") ||
+             StringRef(inputFilename).endswith(".mlirbc") ||
              mlir::isBytecode(*input))
       inputFormat = InputMLIRFile;
     else {


### PR DESCRIPTION
Upstream MLIR has recently introduced bytecode serialization support: [commit](https://github.com/llvm/llvm-project/commit/f3acb54c1b7b7721cea5c07f64194151dddd3c4b) , [RFC](https://discourse.llvm.org/t/rfc-a-binary-serialization-format-for-mlir/63518).

This PR bumps LLVM to include the new bytecode support and adds support for it to firtool.

`circt-opt` already knows how to handle this, and can emit it via `-emit-bytecode` flag.

firtool modifications:
* Support emitting bytecode via new `-emit-bytecode` flag.
  * Use the `-f` flag to force printing to terminal.
*  Support reading bytecode -- MLIR parser handles this for us, but also autodetect if ends with ".mlirbc" or if has the requisite magic bytes (`mlir::isBytecode`).  (maybe we could detect FIR > 1.1.0 this way as well in the future?).

Add test (see for some usage examples).