### PR TITLE
[PrettifyVerilog] No longer remove self-assignments to whole names

### DIFF
--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -475,13 +475,17 @@ void PrettifyVerilogPass::processPostOrder(Block &body) {
 
     // Simplify assignments involving structures and arrays.
     if (auto assign = dyn_cast<sv::PAssignOp>(op)) {
-      OpBuilder builder(assign);
-      if (splitAssignment(builder, assign.getDest(), assign.getSrc())) {
-        anythingChanged = true;
-        toDelete.insert(assign.getSrc().getDefiningOp());
-        toDelete.insert(assign.getDest().getDefiningOp());
-        assign.erase();
-        continue;
+      auto dst = assign.getDest();
+      auto src = assign.getSrc();
+      if (!isSelfWrite(dst, src)) {
+        OpBuilder builder(assign);
+        if (splitAssignment(builder, dst, src)) {
+          anythingChanged = true;
+          toDelete.insert(src.getDefiningOp());
+          toDelete.insert(dst.getDefiningOp());
+          assign.erase();
+          continue;
+        }
       }
     }
 

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -564,3 +564,23 @@ hw.module private @ConnectNestedFieldsAndIndices(%clock: i1, %reset: i1, %value:
   // VERILOG:      always @(posedge clock)
   // VERILOG-NEXT:   r[3'h1].a[2'h1].b <= value;
 }
+
+
+// CHECK-LABEL: hw.module private @SelfConnect
+hw.module private @SelfConnect(%clock: i1, %reset: i1) -> () {
+  %r = sv.reg : !hw.inout<i2>
+  %val = sv.read_inout %r : !hw.inout<i2>
+  sv.always posedge %clock {
+    sv.passign %r, %val : i2
+  }
+
+  // CHECK: %r = sv.reg  : !hw.inout<i2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[READ:%.+]] = sv.read_inout %r : !hw.inout<i2>
+  // CHECK:   sv.passign %r, [[READ]] : i2
+  // CHECK: }
+
+  //VERILOG: reg [1:0] r;
+  //VERILOG: always @(posedge clock)
+  //VERILOG:   r <= r;
+}


### PR DESCRIPTION
Removing self-assignments leaves registers unassigned, resulting in errors in verification tools. This change preserves them.