### PR TITLE
[COMB] Add flag to assert binary behavior.

### DIFF
--- a/docs/Dialects/Comb/RationaleComb.md
+++ b/docs/Dialects/Comb/RationaleComb.md
@@ -70,6 +70,21 @@ TODO: describe why add/xor/or are variadic
 
 TODO: describe why we have divu/divs but not addu/adds, and not sint vs uint.
 
+### Binary (2-State) logic optional per operation
+
+To keep the interpretation of comb operators local to the dialect, each
+operation where it matters has an optional flag to indicate it's semantics need
+only preserve binary (2-state) behavior.  Some users might want to preserve
+verilog or VHDL behavior, which by default comb operators will.  Other users
+don't care about these behaviors (either by analysis, design, or semantics of 
+the front-end language).  These users can opt into common binary optimizations
+on the comb dialect.
+
+This is done so as to not make the operations in comb type-dependent.
+
+This is a tradeoff in that comb operations are either 2-state or the union of 
+common backend language weirdness.  This could be refined in the future.
+
 ### No implicit extensions of operands
 
 Verilog and many other HDL's allow operators like `+` to work with

--- a/docs/Dialects/Comb/RationaleComb.md
+++ b/docs/Dialects/Comb/RationaleComb.md
@@ -73,7 +73,7 @@ TODO: describe why we have divu/divs but not addu/adds, and not sint vs uint.
 ### Binary (2-State) logic optional per operation
 
 To keep the interpretation of comb operators local to the dialect, each
-operation where it matters has an optional flag to indicate it's semantics need
+operation where it matters has an optional flag to indicate its semantics need
 only preserve binary (2-state) behavior.  Some users might want to preserve
 verilog or VHDL behavior, which by default comb operators will.  Other users
 don't care about these behaviors (either by analysis, design, or semantics of 

--- a/docs/Dialects/Comb/RationaleComb.md
+++ b/docs/Dialects/Comb/RationaleComb.md
@@ -70,18 +70,15 @@ TODO: describe why add/xor/or are variadic
 
 TODO: describe why we have divu/divs but not addu/adds, and not sint vs uint.
 
-### Binary (2-State) logic optional per operation
+### Selectable truth-table
 
 To keep the interpretation of comb operators local to the dialect, each
-operation where it matters has an optional flag to indicate its semantics need
-only preserve binary (2-state) behavior.  Some users might want to preserve
-verilog or VHDL behavior, which by default comb operators will.  Other users
-don't care about these behaviors (either by analysis, design, or semantics of 
-the front-end language).  These users can opt into common binary optimizations
-on the comb dialect.
+operation where it matters has an optional flag to indicate what semantics it needs
+to preserve.  All operations are defined in the expected way for 2-state (binary) logic.  However, comb is used for operations which have extended truth table for non-2-state logic for various target languages.  To accommodate this, operations can opt into known extended truth tables so that any transformation will preserve semantics with respect to the extended truth table.
+
+Initially, operations support 2-state or the union of 4-state (verilog) and 9-state (VHDL) behavior.  2-state is specified with the "bin" flag on operations.  In the future, explicit flags for "4state" and "9state" might be added.
 
 This is done so as to not make the operations in comb type-dependent.
-
 This is a tradeoff in that comb operations are either 2-state or the union of 
 common backend language weirdness.  This could be refined in the future.
 

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -20,24 +20,24 @@ include "mlir/IR/EnumAttr.td"
 // Base class for binary operators.
 class BinOp<string mnemonic, list<Trait> traits = []> :
       CombOp<mnemonic, traits # [NoSideEffect]> {
-  let arguments = (ins HWIntegerType:$lhs, HWIntegerType:$rhs);
+  let arguments = (ins HWIntegerType:$lhs, HWIntegerType:$rhs, UnitAttr:$twoState);
   let results = (outs HWIntegerType:$result);
 
   let assemblyFormat =
-    "$lhs `,` $rhs  attr-dict `:` functional-type($args, $results)";
+    "$lhs `,` $rhs (`bin` $twoState^)? attr-dict `:` functional-type($args, $results)";
 }
 
 // Binary operator with uniform input/result types.
 class UTBinOp<string mnemonic, list<Trait> traits = []> :
       BinOp<mnemonic,
                traits # [SameTypeOperands, SameOperandsAndResultType]> {
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "(`bin` $twoState^)? $lhs `,` $rhs attr-dict `:` qualified(type($result))";
 }
 
 // Base class for variadic operators.
 class VariadicOp<string mnemonic, list<Trait> traits = []> :
       CombOp<mnemonic, traits # [NoSideEffect]> {
-  let arguments = (ins Variadic<HWIntegerType>:$inputs);
+  let arguments = (ins Variadic<HWIntegerType>:$inputs, UnitAttr:$twoState);
   let results = (outs HWIntegerType:$result);
 }
 
@@ -49,12 +49,12 @@ class UTVariadicOp<string mnemonic, list<Trait> traits = []> :
   let hasFolder = true;
   let hasVerifier = 1;
 
-  let assemblyFormat = "$inputs attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "(`bin` $twoState^)? $inputs attr-dict `:` qualified(type($result))";
 
   let builders = [
-    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs, "bool":$twoState), [{
       return build($_builder, $_state, lhs.getType(),
-                   ValueRange{lhs, rhs}, ArrayRef<NamedAttribute>{});
+                   ValueRange{lhs, rhs}, twoState);
     }]>
   ];
 }
@@ -127,10 +127,10 @@ def ICmpOp : CombOp<"icmp", [NoSideEffect, SameTypeOperands]> {
   }];
 
   let arguments = (ins ICmpPredicate:$predicate,
-                   HWIntegerType:$lhs, HWIntegerType:$rhs);
+                   HWIntegerType:$lhs, HWIntegerType:$rhs, UnitAttr:$twoState);
   let results = (outs I1:$result);
 
-  let assemblyFormat = "$predicate $lhs `,` $rhs  attr-dict `:` qualified(type($lhs))";
+  let assemblyFormat = "(`bin` $twoState^)? $predicate $lhs `,` $rhs attr-dict `:` qualified(type($lhs))";
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
@@ -164,11 +164,11 @@ def ICmpOp : CombOp<"icmp", [NoSideEffect, SameTypeOperands]> {
 // Base class for unary reduction operations that produce an i1.
 class UnaryI1ReductionOp<string mnemonic, list<Trait> traits = []> :
       CombOp<mnemonic, traits # [NoSideEffect]> {
-  let arguments = (ins HWIntegerType:$input);
+  let arguments = (ins HWIntegerType:$input, UnitAttr:$twoState);
   let results = (outs I1:$result);
   let hasFolder = 1;
 
-  let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
+  let assemblyFormat = "(`bin` $twoState^)? $input attr-dict `:` qualified(type($input))";
 }
 
 def ParityOp : UnaryI1ReductionOp<"parity">;
@@ -275,11 +275,11 @@ def MuxOp : CombOp<"mux",
   }];
 
   let arguments = (ins I1:$cond, AnyType:$trueValue,
-                       AnyType:$falseValue);
+                       AnyType:$falseValue, UnitAttr:$twoState);
   let results = (outs AnyType:$result);
 
   let assemblyFormat =
-    "$cond `,` $trueValue `,` $falseValue attr-dict `:` qualified(type($result))";
+    "(`bin` $twoState^)? $cond `,` $trueValue `,` $falseValue  attr-dict `:` qualified(type($result))";
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -203,12 +203,14 @@ def ExtractOp : CombOp<"extract", [NoSideEffect]> {
 //===----------------------------------------------------------------------===//
 // Other Operations
 //===----------------------------------------------------------------------===//
-
-def ConcatOp : VariadicOp<"concat", [InferTypeOpInterface]> {
+def ConcatOp : CombOp<"concat", [InferTypeOpInterface, NoSideEffect]> {
   let summary = "Concatenate a variadic list of operands together.";
   let description = [{
     See the comb rationale document for details on operand ordering.
   }];
+
+  let arguments = (ins Variadic<HWIntegerType>:$inputs);
+  let results = (outs HWIntegerType:$result);
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -139,7 +139,7 @@ struct ConvertAssignOp : public OpConversionPattern<calyx::AssignOp> {
     if (auto guard = adaptor.guard()) {
       auto zero =
           rewriter.create<hw::ConstantOp>(assign.getLoc(), src.getType(), 0);
-      src = rewriter.create<MuxOp>(assign.getLoc(), guard, src, zero);
+      src = rewriter.create<MuxOp>(assign.getLoc(), guard, src, zero, false);
     }
 
     rewriter.replaceOpWithNewOp<sv::AssignOp>(assign, dest, src);
@@ -282,7 +282,7 @@ private:
           auto in = wireIn(op.in(), op.instanceName(), op.portName(op.in()), b);
           auto one = b.create<hw::ConstantOp>(op.in().getType(), 0);
 
-          auto xorOp = b.create<XorOp>(in, one);
+          auto xorOp = b.create<XorOp>(in, one, false);
 
           auto out =
               wireOut(xorOp, op.instanceName(), op.portName(op.out()), b);
@@ -319,7 +319,7 @@ private:
     auto right =
         wireIn(op.right(), op.instanceName(), op.portName(op.right()), b);
 
-    auto add = b.create<ResultTy>(left, right);
+    auto add = b.create<ResultTy>(left, right, false);
 
     auto out = wireOut(add, op.instanceName(), op.portName(op.out()), b);
     wires.append({left.getInput(), right.getInput(), out});
@@ -333,7 +333,7 @@ private:
     auto right =
         wireIn(op.right(), op.instanceName(), op.portName(op.right()), b);
 
-    auto add = b.create<ICmpOp>(pred, left, right);
+    auto add = b.create<ICmpOp>(pred, left, right, false);
 
     auto out = wireOut(add, op.instanceName(), op.portName(op.out()), b);
     wires.append({left.getInput(), right.getInput(), out});
@@ -352,7 +352,7 @@ private:
     wires.append({clk.getInput(), reset.getInput(), go.getInput(),
                   left.getInput(), right.getInput()});
 
-    auto targetOp = b.create<TargetOpTy>(left, right);
+    auto targetOp = b.create<TargetOpTy>(left, right, false);
     for (auto &&[targetRes, sourceRes] :
          llvm::zip(targetOp->getResults(), op.getOutputPorts())) {
       auto portName = op.portName(sourceRes);

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -345,7 +345,8 @@ static Operation *rewriteAddWithNegativeConstant(comb::AddOp add,
 
   // Get the positive constant.
   auto negCst = builder.create<hw::ConstantOp>(-rhsCst.getValue());
-  auto sub = builder.create<comb::SubOp>(add.getOperand(0), negCst);
+  auto sub =
+      builder.create<comb::SubOp>(add.getOperand(0), negCst, add.getTwoState());
   add.getResult().replaceAllUsesWith(sub);
   add.erase();
   if (rhsCst.use_empty())

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -589,7 +589,7 @@ MachineOpConverter::convertTransitions( // NOLINT(misc-no-recursion)
       if (failed(otherNextState))
         return failure();
       comb::MuxOp nextStateMux = b.create<comb::MuxOp>(
-          transition.getLoc(), guard, nextState, *otherNextState);
+          transition.getLoc(), guard, nextState, *otherNextState, false);
       nextState = nextStateMux;
     }
   }

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -120,10 +120,10 @@ struct DivOpLowering : public OpConversionPattern<DivOp> {
 
     Value divResult;
     if (signedDivision)
-      divResult = rewriter.create<comb::DivSOp>(loc, lhsValue, rhsValue)
+      divResult = rewriter.create<comb::DivSOp>(loc, lhsValue, rhsValue, false)
                       ->getOpResult(0);
     else
-      divResult = rewriter.create<comb::DivUOp>(loc, lhsValue, rhsValue)
+      divResult = rewriter.create<comb::DivUOp>(loc, lhsValue, rhsValue, false)
                       ->getOpResult(0);
 
     // finally truncate back to the expected result size!
@@ -222,7 +222,8 @@ struct ICmpOpLowering : public OpConversionPattern<ICmpOp> {
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.rhs(), cmpWidth,
                                      rhsType.isSigned());
 
-    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, combPred, lhsValue, rhsValue);
+    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, combPred, lhsValue, rhsValue,
+                                              false);
 
     return success();
   }
@@ -252,7 +253,7 @@ struct BinaryOpLowering : public OpConversionPattern<BinOp> {
                                      targetWidth, isLhsTypeSigned);
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.inputs()[1],
                                      targetWidth, isRhsTypeSigned);
-    rewriter.replaceOpWithNewOp<ReplaceOp>(op, lhsValue, rhsValue);
+    rewriter.replaceOpWithNewOp<ReplaceOp>(op, lhsValue, rhsValue, false);
     return success();
   }
 };

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -48,12 +48,12 @@ static Value adjustIntegerWidth(OpBuilder &builder, Value value,
                                              intWidth - targetWidth);
   Value zero = builder.create<hw::ConstantOp>(
       loc, builder.getIntegerType(intWidth - targetWidth), 0);
-  Value isZero =
-      builder.create<comb::ICmpOp>(loc, comb::ICmpPredicate::eq, hi, zero);
+  Value isZero = builder.create<comb::ICmpOp>(loc, comb::ICmpPredicate::eq, hi,
+                                              zero, false);
   Value lo = builder.create<comb::ExtractOp>(loc, value, 0, targetWidth);
   Value max = builder.create<hw::ConstantOp>(
       loc, builder.getIntegerType(targetWidth), -1);
-  return builder.create<comb::MuxOp>(loc, isZero, lo, max);
+  return builder.create<comb::MuxOp>(loc, isZero, lo, max, false);
 }
 
 //===----------------------------------------------------------------------===//
@@ -203,7 +203,7 @@ struct ShlOpConversion : public OpConversionPattern<ShlOp> {
         adjustIntegerWidth(rewriter, adaptor.getAmount(),
                            resultType.getIntOrFloatBitWidth(), op->getLoc());
     rewriter.replaceOpWithNewOp<comb::ShlOp>(op, resultType, adaptor.getValue(),
-                                             amount);
+                                             amount, false);
     return success();
   }
 };
@@ -227,13 +227,13 @@ struct ShrOpConversion : public OpConversionPattern<ShrOp> {
                            resultType.getIntOrFloatBitWidth(), op->getLoc());
 
     if (adaptor.getArithmetic() && hasSignedResultType) {
-      rewriter.replaceOpWithNewOp<comb::ShrSOp>(op, resultType,
-                                                adaptor.getValue(), amount);
+      rewriter.replaceOpWithNewOp<comb::ShrSOp>(
+          op, resultType, adaptor.getValue(), amount, false);
       return success();
     }
 
-    rewriter.replaceOpWithNewOp<comb::ShrUOp>(op, resultType,
-                                              adaptor.getValue(), amount);
+    rewriter.replaceOpWithNewOp<comb::ShrUOp>(
+        op, resultType, adaptor.getValue(), amount, false);
     return success();
   }
 };

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -108,25 +108,26 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
     // and source.
     auto guard = groupOp.getDoneOp().guard();
     auto source = groupOp.getDoneOp().src();
-    auto doneOpValue =
-        !guard ? source
-               : builder.create<comb::AndOp>(wires->getLoc(), guard, source);
+    auto doneOpValue = !guard ? source
+                              : builder.create<comb::AndOp>(
+                                    wires->getLoc(), guard, source, false);
 
     // Build the Guard for the `go` signal of the current group being walked.
     // The group should begin when:
     // (1) the current step in the fsm is reached, and
     // (2) the done signal of this group is not high.
-    auto eqCmp = builder.create<comb::ICmpOp>(
-        wires->getLoc(), comb::ICmpPredicate::eq, fsmOut, fsmCurrentState);
+    auto eqCmp =
+        builder.create<comb::ICmpOp>(wires->getLoc(), comb::ICmpPredicate::eq,
+                                     fsmOut, fsmCurrentState, false);
     auto notDone = comb::createOrFoldNot(wires->getLoc(), doneOpValue, builder);
     auto groupGoGuard =
-        builder.create<comb::AndOp>(wires->getLoc(), eqCmp, notDone);
+        builder.create<comb::AndOp>(wires->getLoc(), eqCmp, notDone, false);
 
     // Guard for the `in` and `write_en` signal of the fsm register. These are
     // driven when the group has completed.
     builder.setInsertionPoint(seqGroup);
     auto groupDoneGuard =
-        builder.create<comb::AndOp>(wires->getLoc(), eqCmp, doneOpValue);
+        builder.create<comb::AndOp>(wires->getLoc(), eqCmp, doneOpValue, false);
 
     // Directly update the GroupGoOp of the current group being walked.
     auto goOp = groupOp.getGoOp();
@@ -149,7 +150,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
   // defined by the fsm's final state.
   builder.setInsertionPoint(seqGroup);
   auto isFinalState = builder.create<comb::ICmpOp>(
-      wires->getLoc(), comb::ICmpPredicate::eq, fsmOut, fsmNextState);
+      wires->getLoc(), comb::ICmpPredicate::eq, fsmOut, fsmNextState, false);
 
   // Insert the respective GroupDoneOp.
   builder.setInsertionPointToEnd(seqGroup.getBody());

--- a/lib/Dialect/Calyx/Transforms/PassDetails.h
+++ b/lib/Dialect/Calyx/Transforms/PassDetails.h
@@ -34,8 +34,8 @@ static void updateGroupAssignmentGuards(OpBuilder &builder, GroupOp &group,
     if (assign.guard())
       // If the assignment is guarded already, take the bitwise & of the current
       // guard and the group's go signal.
-      assign->setOperand(
-          2, builder.create<comb::AndOp>(group.getLoc(), assign.guard(), op));
+      assign->setOperand(2, builder.create<comb::AndOp>(
+                                group.getLoc(), assign.guard(), op, false));
     else
       // Otherwise, just insert it as the guard.
       assign->insertOperands(2, {op});

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2393,7 +2393,7 @@ static LogicalResult matchAndRewriteCompareConcat(ICmpOp op, Operation *lhs,
     if (sameElement)
       return rewriter.createOrFold<ReplicateOp>(loc, sameElement,
                                                 operands.size());
-    return rewriter.createOrFold<ConcatOp>(loc, operands, false);
+    return rewriter.createOrFold<ConcatOp>(loc, operands);
   };
 
   auto replaceWith = [&](ICmpPredicate predicate, Value lhs,

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -47,7 +47,7 @@ Value comb::createOrFoldSExt(Value value, Type destTy,
 
 Value comb::createOrFoldNot(Location loc, Value value, OpBuilder &builder) {
   auto allOnes = builder.create<hw::ConstantOp>(loc, value.getType(), -1);
-  return builder.createOrFold<XorOp>(loc, value, allOnes);
+  return builder.createOrFold<XorOp>(loc, value, allOnes, false);
 }
 
 Value comb::createOrFoldNot(Value value, ImplicitLocOpBuilder &builder) {

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -10,7 +10,7 @@ firrtl.circuit "ifElseFatalToSVA" {
     firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "ifElseFatal"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond 
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -147,7 +147,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: [[ARG:%.+]]: i1) -> (out: i8)
     %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
-    // CHECK: [[ADD:%.+]] = comb.add %0, %1
+    // CHECK: [[ADD:%.+]] = comb.add bin %0, %1
 
     // Calculation of input (the firrtl.add + firrtl.eq) happens after the
     // instance.
@@ -155,7 +155,7 @@ firrtl.circuit "Simple" {
 
     // Multiple uses of the add.
     %a = firrtl.eq %0, %arg2 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    // CHECK-NEXT: [[ARG]] = comb.icmp eq [[ADD]], %arg2 : i3
+    // CHECK-NEXT: [[ARG]] = comb.icmp bin eq [[ADD]], %arg2 : i3
     firrtl.connect %myext#0, %a : !firrtl.uint<1>, !firrtl.uint<1>
 
     firrtl.connect %out0, %myext#1 : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -55,33 +55,33 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %out5, %tmp1 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: [[ZEXT:%.+]] = comb.concat %false, %in1 : i1, i4
-    // CHECK: [[ADD:%.+]] = comb.add %c12_i5, [[ZEXT]] : i5
+    // CHECK: [[ADD:%.+]] = comb.add bin %c12_i5, [[ZEXT]] : i5
     %0 = firrtl.add %c12_ui4, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
     %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
 
     // CHECK: [[ZEXT1:%.+]] = comb.concat %false, [[ADD]] : i1, i5
     // CHECK: [[ZEXT2:%.+]] = comb.concat %c0_i2, %in1 : i2, i4
-    // CHECK-NEXT: [[SUB:%.+]] = comb.sub [[ZEXT1]], [[ZEXT2]] : i6
+    // CHECK-NEXT: [[SUB:%.+]] = comb.sub bin [[ZEXT1]], [[ZEXT2]] : i6
     %2 = firrtl.sub %0, %1 : (!firrtl.uint<5>, !firrtl.uint<4>) -> !firrtl.uint<6>
 
     %in2s = firrtl.asSInt %in2 : (!firrtl.uint<2>) -> !firrtl.sint<2>
 
     // CHECK: [[PADRES_SIGN:%.+]] = comb.extract %in2 from 1 : (i2) -> i1
-    // CHECK: [[PADRES:%.+]] = comb.concat  [[PADRES_SIGN]], %in2 : i1, i2
+    // CHECK: [[PADRES:%.+]] = comb.concat [[PADRES_SIGN]], %in2 : i1, i2
     %3 = firrtl.pad %in2s, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
 
     // CHECK: [[PADRES2:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
     %4 = firrtl.pad %in2, 4 : (!firrtl.uint<2>) -> !firrtl.uint<4>
 
     // CHECK: [[IN2EXT:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
-    // CHECK: [[XOR:%.+]] = comb.xor [[IN2EXT]], [[PADRES2]] : i4
+    // CHECK: [[XOR:%.+]] = comb.xor bin [[IN2EXT]], [[PADRES2]] : i4
     %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
-    // CHECK: comb.and [[XOR]]
+    // CHECK: comb.and bin [[XOR]]
     %and = firrtl.and %5, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
-    // CHECK: comb.or [[XOR]]
+    // CHECK: comb.or bin [[XOR]]
     %or = firrtl.or %5, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
     // CHECK: [[CONCAT1:%.+]] = comb.concat [[PADRES2]], [[XOR]] : i4, i4
@@ -135,29 +135,29 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: = comb.parity [[CONCAT1]] : i8
     %15 = firrtl.xorr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: = comb.icmp eq  {{.*}}, %c-1_i8 : i8
+    // CHECK-NEXT: = comb.icmp bin eq  {{.*}}, %c-1_i8 : i8
     %16 = firrtl.andr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: = comb.icmp ne {{.*}}, %c0_i8 : i8
+    // CHECK-NEXT: = comb.icmp bin ne {{.*}}, %c0_i8 : i8
     %17 = firrtl.orr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[ZEXTC1:%.+]] = comb.concat %c0_i6, [[CONCAT1]] : i6, i8
     // CHECK-NEXT: [[ZEXT2:%.+]] = comb.concat %c0_i8, [[SUB]] : i8, i6
-    // CHECK-NEXT: [[VAL18:%.+]] = comb.mul  [[ZEXTC1]], [[ZEXT2]] : i14
+    // CHECK-NEXT: [[VAL18:%.+]] = comb.mul bin [[ZEXTC1]], [[ZEXT2]] : i14
     %18 = firrtl.mul %6, %2 : (!firrtl.uint<8>, !firrtl.uint<6>) -> !firrtl.uint<14>
 
     // CHECK: [[IN3SEXT:%.+]] = comb.concat {{.*}}, %in3 : i1, i8
     // CHECK: [[PADRESSEXT:%.+]] = comb.concat {{.*}}, [[PADRES]] : i6, i3
-    // CHECK-NEXT: = comb.divs [[IN3SEXT]], [[PADRESSEXT]] : i9
+    // CHECK-NEXT: = comb.divs bin [[IN3SEXT]], [[PADRESSEXT]] : i9
     %19 = firrtl.div %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.sint<9>
 
     // CHECK: [[IN3EX:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
-    // CHECK-NEXT: [[MOD1:%.+]] = comb.mods %in3, [[IN3EX]] : i8
+    // CHECK-NEXT: [[MOD1:%.+]] = comb.mods bin %in3, [[IN3EX]] : i8
     // CHECK-NEXT: = comb.extract [[MOD1]] from 0 : (i8) -> i3
     %20 = firrtl.rem %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.sint<3>
 
     // CHECK: [[IN4EX:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
-    // CHECK-NEXT: [[MOD2:%.+]] = comb.mods [[IN4EX]], %in3 : i8
+    // CHECK-NEXT: [[MOD2:%.+]] = comb.mods bin [[IN4EX]], %in3 : i8
     // CHECK-NEXT: = comb.extract [[MOD2]] from 0 : (i8) -> i3
     %21 = firrtl.rem %3, %in3 : (!firrtl.sint<3>, !firrtl.sint<8>) -> !firrtl.sint<3>
 
@@ -186,59 +186,59 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // Will be dropped, here because this triggered a crash
     %s23 = firrtl.cvt %in3 : (!firrtl.sint<8>) -> !firrtl.sint<8>
 
-    // CHECK-NEXT: [[XOR:%.+]] = comb.xor [[CVT]], %c-1_i3 : i3
+    // CHECK-NEXT: [[XOR:%.+]] = comb.xor bin [[CVT]], %c-1_i3 : i3
     %24 = firrtl.not %23 : (!firrtl.sint<3>) -> !firrtl.uint<3>
 
     %s24 = firrtl.asSInt %24 : (!firrtl.uint<3>) -> !firrtl.sint<3>
 
     // CHECK: [[SEXT:%.+]] = comb.concat {{.*}}, [[XOR]] : i1, i3
-    // CHECK-NEXT: [[SUB:%.+]] = comb.sub %c0_i4, [[SEXT]] : i4
+    // CHECK-NEXT: [[SUB:%.+]] = comb.sub bin %c0_i4, [[SEXT]] : i4
     %25 = firrtl.neg %s24 : (!firrtl.sint<3>) -> !firrtl.sint<4>
 
     // CHECK: [[CVT4:%.+]] = comb.concat {{.*}}, [[CVT]] : i1, i3
-    // CHECK-NEXT: comb.mux {{.*}}, [[CVT4]], [[SUB]] : i4
+    // CHECK-NEXT: comb.mux bin {{.*}}, [[CVT4]], [[SUB]] : i4
     %26 = firrtl.mux(%17, %23, %25) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
 
-    // CHECK-NEXT: = comb.icmp eq  {{.*}}, %c-1_i14 : i14
+    // CHECK-NEXT: = comb.icmp bin eq {{.*}}, %c-1_i14 : i14
     %28 = firrtl.andr %18 : (!firrtl.uint<14>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: = comb.icmp ceq {{.*}}, %x_i1
+    // CHECK-NEXT: = comb.icmp bin ceq {{.*}}, %x_i1
     %x28 = firrtl.verif_isX %28 : !firrtl.uint<1>
 
     // CHECK-NEXT: [[XOREXT:%.+]] = comb.concat %c0_i11, [[XOR]]
-    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shru [[XOREXT]], [[VAL18]] : i14
+    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shru bin [[XOREXT]], [[VAL18]] : i14
     // CHECK-NEXT: [[DSHR:%.+]] = comb.extract [[SHIFT]] from 0 : (i14) -> i3
     %29 = firrtl.dshr %24, %18 : (!firrtl.uint<3>, !firrtl.uint<14>) -> !firrtl.uint<3>
 
     // CHECK-NEXT: = comb.concat %c0_i5, {{.*}} : i5, i3
-    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs %in3, {{.*}} : i8
+    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs bin %in3, {{.*}} : i8
     %a29 = firrtl.dshr %in3, %9 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<8>
 
     // CHECK: = comb.concat {{.*}}, %in3 : i7, i8
     // CHECK-NEXT: = comb.concat %c0_i12, [[DSHR]]
-    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shl {{.*}}, {{.*}} : i15
+    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shl bin {{.*}}, {{.*}} : i15
     %30 = firrtl.dshl %in3, %29 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<15>
 
-    // CHECK-NEXT: = comb.shl [[DSHR]], [[DSHR]] : i3
+    // CHECK-NEXT: = comb.shl bin [[DSHR]], [[DSHR]] : i3
     %dshlw = firrtl.dshlw %29, %29 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
 
     // Issue #367: https://github.com/llvm/circt/issues/367
     // CHECK: = comb.concat {{.*}} : i10, i4
-    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs {{.*}}, {{.*}} : i14
+    // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs bin {{.*}}, {{.*}} : i14
     // CHECK-NEXT: = comb.extract [[SHIFT]] from 0 : (i14) -> i4
     %31 = firrtl.dshr %25, %18 : (!firrtl.sint<4>, !firrtl.uint<14>) -> !firrtl.sint<4>
 
-    // CHECK-NEXT: comb.icmp ule {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin ule {{.*}}, {{.*}} : i4
     %41 = firrtl.leq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT: comb.icmp ult {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin ult {{.*}}, {{.*}} : i4
     %42 = firrtl.lt %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT: comb.icmp uge {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin uge {{.*}}, {{.*}} : i4
     %43 = firrtl.geq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT: comb.icmp ugt {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin ugt {{.*}}, {{.*}} : i4
     %44 = firrtl.gt %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT: comb.icmp eq {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin eq {{.*}}, {{.*}} : i4
     %45 = firrtl.eq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT: comb.icmp ne {{.*}}, {{.*}} : i4
+    // CHECK-NEXT: comb.icmp bin ne {{.*}}, {{.*}} : i4
     %46 = firrtl.neq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
 
     // Noop
@@ -251,10 +251,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: [[VERB3READ:%.+]] = sv.read_inout [[VERB3]]
     // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : i1, i42
     // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : i11, i32
-    // CHECK: [[ADD:%.+]] = comb.add [[VERB1EXT]], [[VERB2EXT]] : i43
+    // CHECK: [[ADD:%.+]] = comb.add bin [[VERB1EXT]], [[VERB2EXT]] : i43
     // CHECK: [[VERB3EXT:%.+]] = comb.concat {{%.+}}, [[VERB3READ]] : i12, i32
     // CHECK: [[ADDEXT:%.+]] = comb.concat {{%.+}}, [[ADD]] : i1, i43
-    // CHECK: = comb.add [[VERB3EXT]], [[ADDEXT]] : i44
+    // CHECK: = comb.add bin [[VERB3EXT]], [[ADDEXT]] : i44
     %56 = firrtl.verbatim.expr "MAGIC_CONSTANT" : () -> !firrtl.uint<42>
     %57 = firrtl.verbatim.expr "$bits({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
     %58 = firrtl.verbatim.wire "$size({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
@@ -263,12 +263,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // Issue #353
     // CHECK: [[PADRES_EXT:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
-    // CHECK: = comb.and %in3, [[PADRES_EXT]] : i8
+    // CHECK: = comb.and bin %in3, [[PADRES_EXT]] : i8
     %49 = firrtl.and %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.uint<8>
 
     // Issue #355: https://github.com/llvm/circt/issues/355
     // CHECK: [[IN1:%.+]] = comb.concat %c0_i6, %in1 : i6, i4
-    // CHECK: [[DIV:%.+]] = comb.divu [[IN1]], %c306_i10 : i10
+    // CHECK: [[DIV:%.+]] = comb.divu bin [[IN1]], %c306_i10 : i10
     // CHECK: = comb.extract [[DIV]] from 0 : (i10) -> i4
     %c306_ui10 = firrtl.constant 306 : !firrtl.uint<10>
     %50 = firrtl.div %in1, %c306_ui10 : (!firrtl.uint<4>, !firrtl.uint<10>) -> !firrtl.uint<4>
@@ -277,11 +277,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
     // https://github.com/llvm/circt/issues/821
     // CHECK: [[CONCAT:%.+]] = comb.concat %false, %in1 : i1, i4
-    // CHECK:  = comb.sub %c0_i5, [[CONCAT]] : i5
+    // CHECK:  = comb.sub bin %c0_i5, [[CONCAT]] : i5
     %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
     %53 = firrtl.neg %in4 : (!firrtl.uint<0>) -> !firrtl.sint<1>
     // CHECK: [[SEXT:%.+]] = comb.concat {{.*}}, %in3 : i1, i8
-    // CHECK: = comb.sub %c0_i9, [[SEXT]] : i9
+    // CHECK: = comb.sub bin %c0_i9, [[SEXT]] : i9
     %54 = firrtl.neg %in3 : (!firrtl.sint<8>) -> !firrtl.sint<9>
     firrtl.connect %out1, %53 : !firrtl.sint<1>, !firrtl.sint<1>
     %55 = firrtl.neg %in5 : (!firrtl.sint<0>) -> !firrtl.sint<1>
@@ -295,8 +295,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-SAME: (%[[WIRE]], %[[ARRAY_GET]])
     // CHECK-NEXT: %[[READ_WIRE:.+]] = sv.read_inout %[[WIRE]] : !hw.inout<i1>
     // CHECK-NEXT: %[[ARRAY_ZEROTH:.+]] = hw.array_get %[[ARRAY]][%c0_i2]
-    // CHECK-NEXT: %[[IS_OOB:.+]] = comb.icmp uge %[[ZEXT_INDEX]], %c-1_i2
-    // CHECK-NEXT: %[[GUARDED:.+]] = comb.mux %[[IS_OOB]], %[[ARRAY_ZEROTH]], %[[READ_WIRE]]
+    // CHECK-NEXT: %[[IS_OOB:.+]] = comb.icmp bin uge %[[ZEXT_INDEX]], %c-1_i2
+    // CHECK-NEXT: %[[GUARDED:.+]] = comb.mux bin %[[IS_OOB]], %[[ARRAY_ZEROTH]], %[[READ_WIRE]]
     // CHECK: hw.output %false, %[[GUARDED]] : i1, i1
     firrtl.connect %out2, %61 : !firrtl.sint<1>, !firrtl.sint<1>
   }
@@ -318,13 +318,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: } else  {
     // CHECK-NEXT:   sv.always posedge %clock {
     // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref< "PRINTF_COND_"> : i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and %PRINTF_COND_, %reset
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND_, %reset
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
     // CHECK-NEXT:       sv.fwrite [[FD]], "No operands!\0A"
     // CHECK-NEXT:     }
     // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref< "PRINTF_COND_"> : i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and %PRINTF_COND__0, %reset : i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__0, %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
     // CHECK-NEXT:       sv.fwrite [[FD]], "Hi %x %x\0A"(%2, %b) : i5, i4
@@ -358,7 +358,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge %clock1 {
     // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref< "STOP_COND_"> : i1
-    // CHECK-NEXT:     %0 = comb.and %STOP_COND_, %reset : i1
+    // CHECK-NEXT:     %0 = comb.and bin %STOP_COND_, %reset : i1
     // CHECK-NEXT:     sv.if %0 {
     // CHECK-NEXT:       sv.fatal
     // CHECK-NEXT:     }
@@ -367,7 +367,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK-NEXT:   sv.always posedge %clock2 {
     // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref< "STOP_COND_"> : i1
-    // CHECK-NEXT:     %0 = comb.and %STOP_COND_, %reset : i1
+    // CHECK-NEXT:     %0 = comb.and bin %STOP_COND_, %reset : i1
     // CHECK-NEXT:     sv.if %0 {
     // CHECK-NEXT:       sv.finish
     // CHECK-NEXT:     }
@@ -402,16 +402,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %aEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %aCond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP3:%.+]] = comb.xor %aEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP4:%.+]] = comb.or [[TMP3]], %aCond
+    // CHECK-NEXT: [[TMP4:%.+]] = comb.or bin [[TMP3]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP4]] label "assert__assert_0" message "assert0"
     // CHECK-NEXT: [[SAMPLED:%.+]] =  sv.system.sampled %value : i42
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP5:%.+]] = comb.xor %aEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP6:%.+]] = comb.or [[TMP5]], %aCond
+    // CHECK-NEXT: [[TMP6:%.+]] = comb.or bin [[TMP5]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP6]] message "assert0"([[SAMPLED]]) : i42
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
@@ -423,25 +423,25 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %bCond
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %bCond
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] label "assume__assume_0" message "assume0"
     // CHECK-NEXT: [[SAMPLED:%.+]] = sv.system.sampled %value
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %bCond
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"([[SAMPLED]]) : i42
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover__cover_0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
     firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
     firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
@@ -493,16 +493,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:   sv.ifdef "WORLD" {
     // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
-    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:     sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
     // CHECK-NEXT:     sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:       sv.assume.concurrent posedge %clock, [[TMP2]]
     // CHECK-NEXT:     }
     // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
-    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:     sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"
-    // CHECK-NEXT:     [[TMP:%.+]] = comb.and %enable, %cond
+    // CHECK-NEXT:     [[TMP:%.+]] = comb.and bin %enable, %cond
     // CHECK-NEXT:     sv.cover.concurrent posedge %clock, [[TMP]]
     // CHECK-NOT:      label
     // CHECK-NEXT:   }
@@ -519,7 +519,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "sva"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
@@ -527,7 +527,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assert %clock, %cond, %enable, "assert1"(%value) : !firrtl.uint<42> {isConcurrent = true, format = "ifElseFatal"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cond, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.and %enable, [[TMP1]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.and bin %enable, [[TMP1]]
     // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge %clock {
@@ -593,7 +593,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %tmp48 = firrtl.wire : !firrtl.uint<27>
 
     // CHECK-NEXT: %0 = comb.concat %c0_i38, %inp_2 : i38, i27
-    // CHECK-NEXT: %1 = comb.divu %0, %inpi : i65
+    // CHECK-NEXT: %1 = comb.divu bin %0, %inpi : i65
     %0 = firrtl.div %inp_2, %inpi : (!firrtl.uint<27>, !firrtl.uint<65>) -> !firrtl.uint<27>
     // CHECK-NEXT: %2 = comb.extract %1 from 0 : (i65) -> i27
     // CHECK-NEXT: sv.assign %tmp48, %2 : i27
@@ -682,8 +682,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
     %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-  // CHECK: %[[v1:.+]] = comb.and %true, %inpred : i1
-  // CHECK: %[[v2:.+]] = comb.and %inpred, %true : i1
+  // CHECK: %[[v1:.+]] = comb.and bin %true, %inpred : i1
+  // CHECK: %[[v2:.+]] = comb.and bin %inpred, %true : i1
   // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @_M_combMem_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %[[v1]]: i1, RW0_wdata: %1: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK: hw.output %_M_ext.R0_data, %_M_ext.RW0_rdata : i42, i42
 
@@ -1262,8 +1262,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-SAME: (%1, %2)
     // CHECK-NEXT: %3 = sv.read_inout %1 : !hw.inout<i1>
     // CHECK-NEXT: %4 = hw.array_get %0[%c0_i2]
-    // CHECK-NEXT: %5 = comb.icmp uge %index, %c-1_i2
-    // CHECK-NEXT: %6 = comb.mux %5, %4, %3
+    // CHECK-NEXT: %5 = comb.icmp bin uge %index, %c-1_i2
+    // CHECK-NEXT: %6 = comb.mux bin %5, %4, %3
     // CHECK-NEXT: hw.output %6 : i1
   }
 
@@ -1289,7 +1289,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %0, %wData : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK-LABEL: hw.module private @inferUnmaskedMemory
-  // CHECK-NEXT:   %[[v0:.+]] = comb.and %rEn, %wMask : i1
+  // CHECK-NEXT:   %[[v0:.+]] = comb.and bin %rEn, %wMask : i1
   // CHECK-NEXT:   %tbMemoryKind1_ext.R0_data = hw.instance "tbMemoryKind1_ext" @tbMemoryKind1_combMem(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
   // CHECK-NEXT:   hw.output %tbMemoryKind1_ext.R0_data : i8
 

--- a/test/Conversion/FIRRTLToHW/zero-width.mlir
+++ b/test/Conversion/FIRRTLToHW/zero-width.mlir
@@ -25,7 +25,7 @@ firrtl.circuit "Arithmetic" {
     // CHECK-DAG: %c0_i4 = hw.constant 0 : i4
     // CHECK-DAG: %false = hw.constant false
     // CHECK-NEXT: [[UIN3EXT:%.+]] = comb.concat %false, %uin3c : i1, i3
-    // CHECK-NEXT: [[ADDRES:%.+]] = comb.add %c0_i4, [[UIN3EXT]] : i4
+    // CHECK-NEXT: [[ADDRES:%.+]] = comb.add bin %c0_i4, [[UIN3EXT]] : i4
     %1 = firrtl.add %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<4>
     firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -213,7 +213,7 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; MLIRLOWER-NEXT:    %0 = comb.extract %inp_2 from 4 : (i5) -> i1
 ; MLIRLOWER-NEXT:    %1 = comb.concat %0, %inp_2 : i1, i5
 ; MLIRLOWER-NEXT:    %2 = comb.concat %c0_i5, %inp_1 : i5, i1
-; MLIRLOWER-NEXT:    %3 = comb.shl %1, %2 : i6
+; MLIRLOWER-NEXT:    %3 = comb.shl bin %1, %2 : i6
 ; MLIRLOWER-NEXT:    %4 = comb.extract %3 from 0 : (i6) -> i3
 ; MLIRLOWER-NEXT:    %5 = comb.extract %inp_2 from 0 : (i5) -> i3
 ; MLIRLOWER-NEXT:    hw.output %4, %5 : i3, i3


### PR DESCRIPTION
Comb exists in a place where it might or might not need to deal with Verilog or VHDL weirdness.  Some transformations which are desirable might not be semantic preserving with respect to concepts such as 'x'.  This is overly strong for a number of languages.  An "bin" flag is added to most operations to allow flagging the comb operation as only requiring binary semantics.  Frontends by construction, or by analysis can enable this flag to enable richer comb-level optimizations.