### PR TITLE
[FSMToSV] Share typescope between FSMs

### DIFF
--- a/integration_test/Dialect/FSM/simple/top.mlir
+++ b/integration_test/Dialect/FSM/simple/top.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: verilator
-// RUN: circt-opt %s --convert-fsm-to-sv --canonicalize --lower-seq-to-sv --export-verilog -o %t2.mlir > %t1.sv
-// RUN: circt-rtl-sim.py %t1.sv %S/driver.cpp --no-default-driver | FileCheck %s
+// RUN: circt-opt %s --convert-fsm-to-sv --canonicalize --lower-seq-to-sv --export-split-verilog -o %t2.mlir
+// RUN: circt-rtl-sim.py fsm_enum_typedefs.sv top.sv %S/driver.cpp --no-default-driver | FileCheck %s
 // CHECK: out: A
 // CHECK: out: B
 // CHECK: out: B

--- a/integration_test/Dialect/FSM/variable/top.mlir
+++ b/integration_test/Dialect/FSM/variable/top.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: verilator
-// RUN: circt-opt %s --convert-fsm-to-sv --canonicalize --lower-seq-to-sv --export-verilog -o %t2.mlir > %t1.sv
-// RUN: circt-rtl-sim.py %t1.sv %S/driver.cpp --no-default-driver | FileCheck %s
+// RUN: circt-opt %s --convert-fsm-to-sv --canonicalize --lower-seq-to-sv --export-split-verilog -o %t2.mlir
+// RUN: circt-rtl-sim.py fsm_enum_typedefs.sv top.sv %S/driver.cpp --no-default-driver | FileCheck %s
 
 // A simple FSM with an internal variable. The FSM counts up to 5 and then resets
 // the counter to 0, always emitting the current counter value on the output.

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -65,7 +65,8 @@ class StateEncoding {
   // values, and used as selection signals for muxes.
 
 public:
-  StateEncoding(OpBuilder &b, MachineOp machine, hw::HWModuleOp hwModule);
+  StateEncoding(OpBuilder &b, hw::TypeScopeOp typeScope, MachineOp machine,
+                hw::HWModuleOp hwModule);
 
   // Get the encoded value for a state.
   Value encode(StateOp state);
@@ -96,6 +97,9 @@ protected:
   // A mapping between an encoded value and the source value in the IR.
   SmallDenseMap<Value, Value> valueToSrcValue;
 
+  // A typescope to emit the FSM enum type within.
+  hw::TypeScopeOp typeScope;
+
   // The enum type for the states.
   Type stateType;
 
@@ -104,9 +108,9 @@ protected:
   hw::HWModuleOp hwModule;
 };
 
-StateEncoding::StateEncoding(OpBuilder &b, MachineOp machine,
-                             hw::HWModuleOp hwModule)
-    : b(b), machine(machine), hwModule(hwModule) {
+StateEncoding::StateEncoding(OpBuilder &b, hw::TypeScopeOp typeScope,
+                             MachineOp machine, hw::HWModuleOp hwModule)
+    : typeScope(typeScope), b(b), machine(machine), hwModule(hwModule) {
   Location loc = machine.getLoc();
   llvm::SmallVector<Attribute> stateNames;
 
@@ -118,11 +122,6 @@ StateEncoding::StateEncoding(OpBuilder &b, MachineOp machine,
       hw::EnumType::get(b.getContext(), b.getArrayAttr(stateNames));
 
   OpBuilder::InsertionGuard guard(b);
-  b.setInsertionPoint(hwModule);
-  auto typeScope = b.create<hw::TypeScopeOp>(
-      loc, b.getStringAttr(hwModule.getName() + "_enum_typedecls"));
-  typeScope.getBodyRegion().push_back(new Block());
-
   b.setInsertionPointToStart(&typeScope.getBodyRegion().front());
   auto typedeclEnumType = b.create<hw::TypedeclOp>(
       loc, b.getStringAttr(hwModule.getName() + "_state_t"),
@@ -189,8 +188,9 @@ void StateEncoding::setEncoding(StateOp state, Value v, bool wire) {
 
 class MachineOpConverter {
 public:
-  MachineOpConverter(OpBuilder &builder, MachineOp machineOp)
-      : machineOp(machineOp), b(builder) {}
+  MachineOpConverter(OpBuilder &builder, hw::TypeScopeOp typeScope,
+                     MachineOp machineOp)
+      : machineOp(machineOp), typeScope(typeScope), b(builder) {}
 
   // Converts the machine op to a hardware module.
   // 1. Creates a HWModuleOp for the machine op, with the same I/O as the FSM +
@@ -294,6 +294,9 @@ private:
   // A handle to the state register of the machine.
   seq::CompRegOp stateReg;
 
+  // A typescope to emit the FSM enum type within.
+  hw::TypeScopeOp typeScope;
+
   OpBuilder &b;
 };
 
@@ -392,7 +395,8 @@ LogicalResult MachineOpConverter::dispatch() {
   auto reset = hwModuleOp.front().getArgument(clkRstIdxs.resetIdx);
 
   // 2) Build state and variable registers.
-  encoding = std::make_unique<StateEncoding>(b, machineOp, hwModuleOp);
+  encoding =
+      std::make_unique<StateEncoding>(b, typeScope, machineOp, hwModuleOp);
   auto stateType = encoding->getStateType();
 
   auto nextStateWire =
@@ -604,12 +608,14 @@ MachineOpConverter::convertState(StateOp state) {
 
   // 3.1) Convert the output region by moving the operations into the module
   // scope and gathering the operands of the output op.
-  auto outputOpRes = moveOps(&state.output().front());
-  if (failed(outputOpRes))
-    return failure();
+  if (!state.output().empty()) {
+    auto outputOpRes = moveOps(&state.output().front());
+    if (failed(outputOpRes))
+      return failure();
 
-  OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
-  res.outputs = outputOp.getOperands(); // 3.2
+    OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
+    res.outputs = outputOp.getOperands(); // 3.2
+  }
 
   auto transitions = llvm::SmallVector<TransitionOp>(
       state.transitions().getOps<TransitionOp>());
@@ -631,9 +637,22 @@ void FSMToSVPass::runOnOperation() {
   auto b = OpBuilder(module);
   SmallVector<Operation *, 16> opToErase;
 
+  // Create a typescope shared by all of the FSMs. This typescope will be
+  // emitted in a single separate file to avoid polluting each output file with
+  // typedefs.
+  b.setInsertionPointToStart(module.getBody());
+  auto typeScope = b.create<hw::TypeScopeOp>(
+      module.getLoc(), b.getStringAttr("fsm_enum_typedecls"));
+  typeScope.getBodyRegion().push_back(new Block());
+  typeScope->setAttr(
+      "output_file",
+      hw::OutputFileAttr::get(b.getStringAttr("fsm_enum_typedefs.sv"),
+                              /*excludeFromFileList*/ b.getBoolAttr(false),
+                              /*includeReplicatedOps*/ b.getBoolAttr(false)));
+
   // Traverse all machines and convert.
   for (auto machine : llvm::make_early_inc_range(module.getOps<MachineOp>())) {
-    MachineOpConverter converter(b, machine);
+    MachineOpConverter converter(b, typeScope, machine);
 
     if (failed(converter.dispatch())) {
       signalPassFailure();

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -26,38 +26,38 @@ hw.module @top(%arg0: i1, %arg1: i1, %clk : i1, %rst : i1) -> (out: i8) {
 
 // -----
 
-// CHECK-LABEL:   hw.type_scope @top_enum_typedecls {
+// CHECK:        hw.type_scope @fsm_enum_typedecls {
 // CHECK-NEXT:     hw.typedecl @top_state_t : !hw.enum<A, B>
 // CHECK-NEXT:   }
 
 // CHECK-LABEL:  hw.module @top(%a0: i1, %a1: i1, %clk: i1, %rst: i1) -> (r0: i8, r1: i8) {
-// CHECK-NEXT:    %A = hw.enum.constant A : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %to_A = sv.wire sym @A  : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    sv.assign %to_A, %A : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %0 = sv.read_inout %to_A : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %B = hw.enum.constant B : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %to_B = sv.wire sym @B  : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    sv.assign %to_B, %B : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %1 = sv.read_inout %to_B : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %state_next = sv.reg  : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %2 = sv.read_inout %state_next : !hw.inout<typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %state_reg = seq.compreg %2, %clk, %rst, %0  : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %A = hw.enum.constant A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %to_A = sv.wire sym @A  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    sv.assign %to_A, %A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %0 = sv.read_inout %to_A : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %B = hw.enum.constant B : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %to_B = sv.wire sym @B  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    sv.assign %to_B, %B : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %1 = sv.read_inout %to_B : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %state_next = sv.reg  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %2 = sv.read_inout %state_next : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %state_reg = seq.compreg %2, %clk, %rst, %0  : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    %c42_i8 = hw.constant 42 : i8
 // CHECK-NEXT:    %c0_i8 = hw.constant 0 : i8
 // CHECK-NEXT:    %c1_i8 = hw.constant 1 : i8
 // CHECK-NEXT:    %3 = comb.and %a0, %a1 : i1
-// CHECK-NEXT:    %4 = comb.mux %3, %0, %1 : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %4 = comb.mux %3, %0, %1 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    %output_0 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    %output_1 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    sv.alwayscomb {
-// CHECK-NEXT:      sv.case %state_reg : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
-// CHECK-NEXT:        sv.bpassign %state_next, %1 : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:        sv.bpassign %state_next, %1 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:        sv.bpassign %output_0, %c0_i8 : i8
 // CHECK-NEXT:        sv.bpassign %output_1, %c42_i8 : i8
 // CHECK-NEXT:      }
 // CHECK-NEXT:      case B: {
-// CHECK-NEXT:        sv.bpassign %state_next, %4 : !hw.typealias<@top_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:        sv.bpassign %state_next, %4 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:        sv.bpassign %output_0, %c1_i8 : i8
 // CHECK-NEXT:        sv.bpassign %output_1, %c42_i8 : i8
 // CHECK-NEXT:      }
@@ -93,14 +93,14 @@ fsm.machine @top(%a0: i1, %arg1: i1) -> (i8, i8) attributes {initialState = "A",
 // CHECK:       %[[CNT_ADD_1:.*]] = comb.add %cnt_reg, %c1_i16 : i16
 // CHECK:       sv.alwayscomb {
 // CHECK-NEXT:    sv.bpassign %cnt_next, %cnt_reg : i16
-// CHECK-NEXT:    sv.case %state_reg : !hw.typealias<@FSM_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    case A: {
-// CHECK-NEXT:      sv.bpassign %state_next, %[[B:.*]] : !hw.typealias<@FSM_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.bpassign %state_next, %[[B:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      sv.bpassign %output_0, %cnt_reg : i16
 // CHECK-NEXT:    }
 // CHECK-NEXT:    case B: {
-// CHECK-NEXT:      sv.bpassign %state_next, %[[A:.*]] : !hw.typealias<@FSM_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:      sv.case %[[STATE_NEXT:.*]] : !hw.typealias<@FSM_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.bpassign %state_next, %[[A:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case %[[STATE_NEXT:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
 // CHECK-NEXT:        sv.bpassign %cnt_next, %[[CNT_ADD_1]] : i16
 // CHECK-NEXT:      }
@@ -129,5 +129,24 @@ fsm.machine @FSM(%arg0: i1, %arg1: i1) -> (i16) attributes {initialState = "A"} 
       %add1 = comb.add %cnt, %c_1 : i16
       fsm.update %cnt, %add1 : i16
     }
+  }
+}
+
+// -----
+
+// CHECK:      hw.type_scope @fsm_enum_typedecls {
+// CHECK-NEXT:   hw.typedecl @M2_state_t : !hw.enum<A, B>
+// CHECK-NEXT:   hw.typedecl @M1_state_t : !hw.enum<A, B>
+// CHECK-NEXT: } {output_file = #hw.output_file<"fsm_enum_typedefs.sv">}
+
+module {
+  fsm.machine @M1() attributes {initialState = "A"} {
+    fsm.state @A
+    fsm.state @B
+  }
+
+  fsm.machine @M2() attributes {initialState = "A"} {
+    fsm.state @A
+    fsm.state @B
   }
 }


### PR DESCRIPTION
... also emits the FSM typedefs in a separate file to avoid polluting all generated files with FSM typedefs.