### PR TITLE
[PrepareForEmission] Don't create localparam as a temporary wire

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -279,13 +279,6 @@ static void lowerUsersToTemporaryWire(Operation &op,
   bool isProceduralRegion = op.getParentOp()->hasTrait<ProceduralRegion>();
 
   auto createWireForResult = [&](Value result, StringAttr name) {
-    // For constant, use local param op.
-    if (auto constantOp = result.getDefiningOp<ConstantOp>()) {
-      auto localparam = builder.create<LocalParamOp>(
-          constantOp.getType(), constantOp.getValueAttr(), "");
-      result.replaceAllUsesWith(localparam);
-      return;
-    }
     Value newWire;
     // If the op is in a procedural region, use logic op.
     if (isProceduralRegion)

--- a/test/Conversion/ExportVerilog/sv-always-wire.mlir
+++ b/test/Conversion/ExportVerilog/sv-always-wire.mlir
@@ -6,7 +6,9 @@ hw.module @AlwaysSpill(%port: i1) {
   %true = hw.constant true
   %awire = sv.wire : !hw.inout<i1>
 
-  // CHECK: wire {{ *}} awire;
+  // CHECK: wire [[TMP1:.+]] = 1'h0;
+  // CHECK: wire [[TMP2:.+]] = 1'h1;
+  // CHECK: wire{{ *}}awire;
   %awire2 = sv.read_inout %awire : !hw.inout<i1>
 
   // Existing simple names should not cause additional spill.
@@ -20,11 +22,9 @@ hw.module @AlwaysSpill(%port: i1) {
   sv.alwaysff(posedge %awire2) {}
 
   // Constant values should cause a spill.
-  // CHECK: assign [[TMP:.+]] =
-  // CHECK-NEXT: always @(posedge [[TMP]])
+  // CHECK: always @(posedge [[TMP1]])
   sv.always posedge %false {}
-  // CHECK: assign [[TMP:.+]] =
-  // CHECK-NEXT: always_ff @(posedge [[TMP]])
+  // CHECK: always_ff @(posedge [[TMP2]])
   sv.alwaysff(posedge %true) {}
 }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -602,7 +602,7 @@ hw.module @exprInlineTestIssue439(%clk: i1) {
     %c = hw.constant 0 : i32
 
     // OLD: localparam [31:0] _GEN = 32'h0;
-    // NEW: localparam [31:0] _GEN = 0;
+    // NEW: automatic logic [31:0] _GEN = 32'h0;
     %e = comb.extract %c from 0 : (i32) -> i16
     %f = comb.add %e, %e : i16
     sv.fwrite %fd, "%d"(%f) : i16
@@ -947,7 +947,7 @@ hw.module @ConstResetValueMustBeInlined(%clock: i1, %reset: i1, %d: i42) -> (q: 
 // CHECK-LABEL: module OutOfLineConstantsInAlwaysSensitivity
 hw.module @OutOfLineConstantsInAlwaysSensitivity() {
   // OLD-NEXT: localparam _GEN = 1'h0;
-  // NEW-NEXT: localparam _GEN = 0;
+  // NEW-NEXT: wire _GEN = 1'h0;
   // CHECK-NEXT: always_ff @(posedge _GEN)
   %clock = hw.constant 0 : i1
   sv.alwaysff(posedge %clock) {}


### PR DESCRIPTION
Previously if a temporary wire is required for a constant, localparam op is created. However sometimes we truly want to have wires for constants, for example when we want to create wires for sensitivity lists. In such cases the output verilog looks weird because we create an additional temporary wire for localparam. Therefore this PR stops creating a localparam op for constants in the first place. 