### PR TITLE
[FIRRTL] Backport IMDCE updates to sifive 1.5

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -40,6 +40,7 @@ struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
   void rewriteModuleSignature(FModuleOp module);
   void rewriteModuleBody(FModuleOp module);
   void eraseEmptyModule(FModuleOp module);
+  void forwardConstantOutputPort(FModuleOp module);
 
   void markAlive(Value value) {
     //  If the value is already in `liveSet`, skip it.
@@ -179,11 +180,57 @@ void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
   }
 }
 
+void IMDeadCodeElimPass::forwardConstantOutputPort(FModuleOp module) {
+  // This tracks constant values of output ports.
+  SmallVector<std::pair<unsigned, APSInt>> constantPortIndicesAndValues;
+  auto ports = module.getPorts();
+  auto *instanceGraphNode = instanceGraph->lookup(module);
+
+  for (const auto &e : llvm::enumerate(ports)) {
+    unsigned index = e.index();
+    auto port = e.value();
+    auto arg = module.getArgument(index);
+
+    // If the port has don't touch, don't propagate the constant value.
+    if (!port.isOutput() || hasDontTouch(arg))
+      continue;
+
+    // Remember the index and constant value connected to an output port.
+    if (auto connect = getSingleConnectUserOf(arg))
+      if (auto constant = connect.src().getDefiningOp<ConstantOp>())
+        constantPortIndicesAndValues.push_back({index, constant.value()});
+  }
+
+  // If there is no constant port, abort.
+  if (constantPortIndicesAndValues.empty())
+    return;
+
+  // Rewrite all uses.
+  for (auto *use : instanceGraphNode->uses()) {
+    auto instance = cast<InstanceOp>(*use->getInstance());
+    ImplicitLocOpBuilder builder(instance.getLoc(), instance);
+    for (auto [index, constant] : constantPortIndicesAndValues) {
+      auto result = instance.getResult(index);
+      assert(ports[index].isOutput() && "must be an output port");
+
+      // Replace the port with the constant.
+      result.replaceAllUsesWith(builder.create<ConstantOp>(constant));
+    }
+  }
+}
+
 void IMDeadCodeElimPass::runOnOperation() {
   LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----==="
                           << "\n");
   auto circuit = getOperation();
   instanceGraph = &getAnalysis<InstanceGraph>();
+
+  // Forward constant output ports to caller sides so that we can eliminate
+  // constant outputs.
+  for (auto *node : llvm::post_order(instanceGraph))
+    if (auto module = dyn_cast_or_null<FModuleOp>(*node->getModule()))
+      forwardConstantOutputPort(module);
+
   for (auto module : circuit.getBody()->getOps<FModuleOp>()) {
     // Mark the ports of public modules as alive.
     if (module.isPublic()) {

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
+#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -38,6 +39,7 @@ struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
 
   void rewriteModuleSignature(FModuleOp module);
   void rewriteModuleBody(FModuleOp module);
+  void eraseEmptyModule(FModuleOp module);
 
   void markAlive(Value value) {
     //  If the value is already in `liveSet`, skip it.
@@ -204,6 +206,19 @@ void IMDeadCodeElimPass::runOnOperation() {
   mlir::parallelForEach(circuit.getContext(),
                         circuit.getBody()->getOps<FModuleOp>(),
                         [&](auto op) { rewriteModuleBody(op); });
+
+  // Erase empty modules. To erase empty modules transitively, it is necessary
+  // to visit modules in the post order of instance graph.
+  // FIXME: We copy the list of modules into a vector first to avoid iterator
+  // invalidation while we mutate the instance graph. See issue 3387.
+  SmallVector<FModuleOp, 0> modules(llvm::make_filter_range(
+      llvm::map_range(
+          llvm::post_order(instanceGraph),
+          [](auto *node) { return dyn_cast<FModuleOp>(*node->getModule()); }),
+      [](auto module) { return module; }));
+
+  for (auto module : modules)
+    eraseEmptyModule(module);
 }
 
 void IMDeadCodeElimPass::visitValue(Value value) {
@@ -397,6 +412,42 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
   }
 
   numRemovedPorts += deadPortIndexes.size();
+}
+
+void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
+  // Public modules cannot be erased.
+  if (module.isPublic())
+    return;
+
+  // If the module doesn't have arguments, operations or annotations, we
+  // consider it to be dead.
+  if (!module.getBody()->args_empty() || !module.getBody()->empty() ||
+      !module.annotations().empty())
+    return;
+
+  // Ok, the module is empty. Delete instances unless they have symbols.
+  LLVM_DEBUG(llvm::dbgs() << "Erase " << module.getName() << "\n");
+
+  InstanceGraphNode *instanceGraphNode =
+      instanceGraph->lookup(module.moduleNameAttr());
+
+  bool existsInstanceWithSymbol = false;
+  for (auto *use : llvm::make_early_inc_range(instanceGraphNode->uses())) {
+    auto instance = cast<InstanceOp>(use->getInstance());
+    if (instance.inner_sym()) {
+      existsInstanceWithSymbol = true;
+      continue;
+    }
+    use->erase();
+    instance.erase();
+  }
+
+  // If there is an instance with a symbol, we don't delete the module itself.
+  if (existsInstanceWithSymbol)
+    return;
+
+  instanceGraph->erase(instanceGraphNode);
+  module.erase();
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createIMDeadCodeElimPass() {

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -162,3 +162,21 @@ firrtl.circuit "DeleteEmptyModule" {
     firrtl.instance sub2 @Sub(in a: !firrtl.uint<1>)
   }
 }
+
+// -----
+
+// CHECK-LABEL: "ForwardConstant"
+firrtl.circuit "ForwardConstant" {
+  // CHECK-NOT: Zero
+  firrtl.module private @Zero(out %zero: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
+  }
+  // CHECK-LABEL: @ForwardConstant
+  firrtl.module @ForwardConstant(out %zero: !firrtl.uint<1>) {
+    // CHECK: %c0_ui1 = firrtl.constant 0
+    %sub_zero = firrtl.instance sub @Zero(out zero: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.strictconnect %zero, %c0_ui1
+    firrtl.strictconnect %zero, %sub_zero : !firrtl.uint<1>
+  }
+}

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -118,7 +118,6 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.instance unusedPortsMod interesting_name @UnusedPortsMod()
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod
 ; ANNOTATIONS-SAME: info = "a ModuleTarget Annotation"
@@ -173,7 +172,6 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-NEXT:     .sel (b),
 ; VERILOG-NEXT:     .b   (out_multibitMux)
 ; VERILOG-NEXT:    );
-; VERILOG-NEXT:    UnusedPortsMod unusedPortsMod ();
 ; VERILOG:       endmodule
 
 ; Check that we canonicalize the HW output of lowering.
@@ -273,4 +271,3 @@ circuit test_mod : %[[{"a": "a"}]]
     input in : UInt<1>
     output out : UInt<1>
     out is invalid
-; VERILOG-LABEL: module UnusedPortsMod();


### PR DESCRIPTION
This PR backports #3378 and #3688 into sifive-1.5 branch to address SiFive internal use cases. #3688 implements empty module removal for IMDCE and #3378 is a minor improvement to propagate constants within IMDCE. 