### PR TITLE
[FIRRTL] Keep InstancePathCache updated

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
@@ -75,6 +75,12 @@ struct InstancePathCache {
       : instanceGraph(instanceGraph) {}
   ArrayRef<InstancePath> getAbsolutePaths(Operation *op);
 
+  /// Clear the cache.
+  void invalidate() { absolutePathsCache.clear(); }
+
+  /// Replace an InstanceOp. This is required to keep the cache updated.
+  void replaceInstance(InstanceOp oldOp, InstanceOp newOp);
+
 private:
   /// An allocator for individual instance paths and entire path lists.
   llvm::BumpPtrAllocator allocator;

--- a/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
@@ -76,7 +76,10 @@ struct InstancePathCache {
   ArrayRef<InstancePath> getAbsolutePaths(Operation *op);
 
   /// Clear the cache.
-  void invalidate() { absolutePathsCache.clear(); }
+  void invalidate() {
+    allocator.Reset();
+    absolutePathsCache.clear();
+  }
 
   /// Replace an InstanceOp. This is required to keep the cache updated.
   void replaceInstance(InstanceOp oldOp, InstanceOp newOp);

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
@@ -80,9 +80,8 @@ void InstancePathCache::replaceInstance(InstanceOp oldOp, InstanceOp newOp) {
   // then replace it with the new InstanceOp, and create a new copy of the paths
   // and update the cache.
   auto instanceExists = [&](const ArrayRef<InstancePath> &paths) -> bool {
-    return llvm::any_of(paths, [&](InstancePath p) {
-      return llvm::is_contained(p, oldOp);
-    });
+    return llvm::any_of(
+        paths, [&](InstancePath p) { return llvm::is_contained(p, oldOp); });
   };
 
   for (auto &iter : absolutePathsCache) {

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
@@ -71,3 +71,40 @@ InstancePath InstancePathCache::appendInstance(InstancePath path,
   newPath[path.size()] = inst;
   return InstancePath(newPath, n);
 }
+
+void InstancePathCache::replaceInstance(InstanceOp oldOp, InstanceOp newOp) {
+
+  instanceGraph.replaceInstance(oldOp, newOp);
+
+  // Iterate over all the paths, and search for the old InstanceOp. If found,
+  // then replace it with the new InstanceOp, and create a new copy of the paths
+  // and update the cache.
+  auto instanceExists = [&](const ArrayRef<InstancePath> &paths) -> bool {
+    return llvm::any_of(paths, [&](InstancePath p) {
+      return llvm::any_of(p, [&](InstanceOp inst) { return inst == oldOp; });
+    });
+  };
+
+  for (auto &iter : absolutePathsCache) {
+    if (!instanceExists(iter.getSecond()))
+      continue;
+    SmallVector<InstancePath, 8> updatedPaths;
+    for (auto path : iter.getSecond()) {
+      const auto *iter = llvm::find(path, oldOp);
+      if (iter == path.end()) {
+        // path does not contain the oldOp, just copy it as is.
+        updatedPaths.push_back(path);
+        continue;
+      }
+      auto *newPath = allocator.Allocate<InstanceOp>(path.size());
+      std::copy(path.begin(), path.end(), newPath);
+      newPath[iter - path.begin()] = newOp;
+      updatedPaths.push_back(InstancePath(newPath, path.size()));
+    }
+    // Move the list of paths into the bump allocator for later quick
+    // retrieval.
+    auto *paths = allocator.Allocate<InstancePath>(updatedPaths.size());
+    std::copy(updatedPaths.begin(), updatedPaths.end(), paths);
+    iter.getSecond() = ArrayRef<InstancePath>(paths, updatedPaths.size());
+  }
+}

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
@@ -81,7 +81,7 @@ void InstancePathCache::replaceInstance(InstanceOp oldOp, InstanceOp newOp) {
   // and update the cache.
   auto instanceExists = [&](const ArrayRef<InstancePath> &paths) -> bool {
     return llvm::any_of(paths, [&](InstancePath p) {
-      return llvm::any_of(p, [&](InstanceOp inst) { return inst == oldOp; });
+      return llvm::is_contained(p, oldOp);
     });
   };
 
@@ -97,14 +97,14 @@ void InstancePathCache::replaceInstance(InstanceOp oldOp, InstanceOp newOp) {
         continue;
       }
       auto *newPath = allocator.Allocate<InstanceOp>(path.size());
-      std::copy(path.begin(), path.end(), newPath);
+      llvm::copy(path, newPath);
       newPath[iter - path.begin()] = newOp;
       updatedPaths.push_back(InstancePath(newPath, path.size()));
     }
     // Move the list of paths into the bump allocator for later quick
     // retrieval.
     auto *paths = allocator.Allocate<InstancePath>(updatedPaths.size());
-    std::copy(updatedPaths.begin(), updatedPaths.end(), paths);
+    llvm::copy(updatedPaths, paths);
     iter.getSecond() = ArrayRef<InstancePath>(paths, updatedPaths.size());
   }
 }


### PR DESCRIPTION
Add helper to replace an old `InstanceOp` with a new `InstanceOp` to keep the InstancePathCache updated.