### PR TITLE
{HW,FIRRTL}::ParamDeclAttr: Implement "raw" parse, touchup print.

### DIFF
--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -75,7 +75,7 @@ with Context() as ctx, Location.unknown():
   print(typeAlias.name)
 
   pdecl = hw.ParamDeclAttr.get("param1", i32, IntegerAttr.get(i32, 13))
-  # CHECK: #hw.param.decl<"param1": i32 = 13 : i32>
+  # CHECK: #hw.param.decl<"param1": i32 = 13>
   print(pdecl)
 
   pdecl = hw.ParamDeclAttr.get_nodefault("param2", i32)

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -73,15 +73,35 @@ void FIRRTLDialect::registerAttributes() {
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//
 
-Attribute ParamDeclAttr::parse(AsmParser &p, Type type) {
-  llvm::errs() << "Should never parse raw\n";
-  abort();
+Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
+  std::string name;
+  Type type;
+  Attribute value;
+  // < "FOO" : i32 > : i32
+  // < "FOO" : i32 = 0 > : i32
+  // < "FOO" : none >
+  if (p.parseLess() || p.parseString(&name) || p.parseColonType(type))
+    return Attribute();
+
+  if (succeeded(p.parseOptionalEqual())) {
+    if (p.parseAttribute(value, type))
+      return Attribute();
+  }
+
+  if (p.parseGreater())
+    return Attribute();
+
+  if (value)
+    return ParamDeclAttr::get(name, value);
+  return ParamDeclAttr::get(name, type);
 }
 
 void ParamDeclAttr::print(AsmPrinter &p) const {
   p << "<" << getName() << ": " << getType();
-  if (getValue())
-    p << " = " << getValue();
+  if (getValue()) {
+    p << " = ";
+    p.printAttributeWithoutType(getValue());
+  }
   p << ">";
 }
 

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -237,15 +237,35 @@ InnerRefAttr::replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//
 
-Attribute ParamDeclAttr::parse(AsmParser &p, Type type) {
-  llvm::errs() << "Should never parse raw\n";
-  abort();
+Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
+  std::string name;
+  Type type;
+  Attribute value;
+  // < "FOO" : i32 > : i32
+  // < "FOO" : i32 = 0 > : i32
+  // < "FOO" : none >
+  if (p.parseLess() || p.parseString(&name) || p.parseColonType(type))
+    return Attribute();
+
+  if (succeeded(p.parseOptionalEqual())) {
+    if (p.parseAttribute(value, type))
+      return Attribute();
+  }
+
+  if (p.parseGreater())
+    return Attribute();
+
+  if (value)
+    return ParamDeclAttr::get(name, value);
+  return ParamDeclAttr::get(name, type);
 }
 
 void ParamDeclAttr::print(AsmPrinter &p) const {
   p << "<" << getName() << ": " << getType();
-  if (getValue())
-    p << " = " << getValue();
+  if (getValue()) {
+    p << " = ";
+    p.printAttributeWithoutType(getValue());
+  }
   p << ">";
 }
 

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -285,8 +285,17 @@ hw.module @Use<xx: i41>() {
 // -----
 
 // expected-error @+1 {{parameter #hw.param.decl<"xx": i41> : i41 has the same name as a previous parameter}}
-hw.module @Use<xx: i41, xx: i41>() {
-}
+hw.module @Use<xx: i41, xx: i41>() {}
+
+// -----
+
+// expected-error @+1 {{parameter #hw.param.decl<"xx": i41 = 1> : i41 has the same name as a previous parameter}}
+hw.module @Use<xx: i41, xx: i41 = 1>() {}
+
+// -----
+
+// expected-error @+1 {{parameter #hw.param.decl<"xx": none> has the same name as a previous parameter}}
+hw.module @Use<xx: none, xx: none>() {}
 
 // -----
 


### PR DESCRIPTION
Support round-trip'ing of these, format like:

< "NAME" : T > : T
< "NAME" : T = attr > : T

When printing, don't include attr type as well.
(Previously: #hw.param.decl<"DEFAULT": ui32 = 0 : ui32> : ui32)

These parse methods aren't expected to ever be encountered directly,
but are triggered when using bitcode support.

In the future we can implement hooks to define our own custom
encoding/decoding which will be faster/smaller but for now
the fallback encoding uses the raw assembly.