### PR TITLE
[ESI] Fix use-after-free.

### DIFF
--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1425,7 +1425,7 @@ static llvm::json::Value toJSON(Attribute attr) {
 #ifdef CAPNP
           capnp::TypeSchema schema(inner);
           typeMD["capnp_type_id"] = schema.capnpTypeID();
-          typeMD["capnp_name"] = schema.name();
+          typeMD["capnp_name"] = schema.name().str();
 #endif
         } else {
           typeMD["hw_bitwidth"] = hw::getBitWidth(t);


### PR DESCRIPTION
The StringRef is backed by the schema object, which goes out of scope
immediately.  Give the json a std::string so it has its own copy.

Caught by asan (and valgrind).
(on lit test "Dialect/ESI/services_collateral.mlir")