### PR TITLE
[firtool][HW] Add variadic operation splitting

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -86,6 +86,12 @@ struct LoweringOptions {
   enum { DEFAULT_TERM_LIMIT = 256 };
   unsigned maximumNumberOfTermsPerExpression = DEFAULT_TERM_LIMIT;
 
+  /// This is the maximum number of terms allow in a variadic expression before
+  /// it will spill to a wire.  This is used to break up large product-of-sums
+  /// or sum-of-products for improved simulator performance.
+  enum { DEFAULT_VARIADIC_OPERAND_LIMIT = 32 };
+  unsigned maximumNumberOfVariadicOperands = DEFAULT_VARIADIC_OPERAND_LIMIT;
+
   /// This is the maximum number of terms in an expression used in a concat
   /// before that expression spills a wire.
   enum { DEFAULT_CONCAT_TERM_LIMIT = 10 };

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -90,6 +90,11 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       printDebugInfo = true;
     } else if (option == "useOldEmissionMode") {
       useOldEmissionMode = true;
+    } else if (option.consume_front("maximumNumberOfVariadicOperands=")) {
+      if (option.getAsInteger(10, maximumNumberOfVariadicOperands)) {
+        errorHandler("expected integer for number of variadic operands");
+        maximumNumberOfVariadicOperands = DEFAULT_VARIADIC_OPERAND_LIMIT;
+      }
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -133,6 +138,9 @@ std::string LoweringOptions::toString() const {
   if (maximumNumberOfTermsInConcat != DEFAULT_CONCAT_TERM_LIMIT)
     options += "maximumNumberOfTermsInConcat=" +
                std::to_string(maximumNumberOfTermsInConcat) + ',';
+  if (maximumNumberOfVariadicOperands != DEFAULT_VARIADIC_OPERAND_LIMIT)
+    options += "maximumNumberOfVariadicOperands=" +
+               std::to_string(maximumNumberOfVariadicOperands) + ',';
 
   // Remove a trailing comma if present.
   if (!options.empty()) {
@@ -187,6 +195,7 @@ struct LoweringCLOptions {
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
           "maximumNumberOfTermsPerExpression=<n>, "
           "maximumNumberOfTermsInConcat=<n>, explicitBitcast, "
+          "maximumNumberOfVariadicOperands=<n>, "
           "emitReplicatedOpsToHeader, "
           "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
           "disallowPortDeclSharing, printDebugInfo"),

--- a/test/Conversion/ExportVerilog/variadic-operand-splitting.mlir
+++ b/test/Conversion/ExportVerilog/variadic-operand-splitting.mlir
@@ -1,0 +1,32 @@
+// RUN: circt-opt -lowering-options=maximumNumberOfVariadicOperands=8 -export-verilog %s | FileCheck %s -check-prefixes=CHECK,MAX_8
+// RUN: circt-opt -lowering-options=maximumNumberOfVariadicOperands=4 -export-verilog %s | FileCheck %s -check-prefixes=CHECK,MAX_4
+
+hw.module @Baz(
+  %a0: i1, %a1: i1, %a2: i1, %a3: i1,
+  %a4: i1, %a5: i1, %a6: i1, %a7: i1,
+  %b0: i1, %b1: i1, %b2: i1, %b3: i1,
+  %b4: i1, %b5: i1, %b6: i1, %b7: i1
+) -> (c: i1) {
+  %0 = comb.and %a0, %b0 : i1
+  %1 = comb.and %a1, %b1 : i1
+  %2 = comb.and %a2, %b2 : i1
+  %3 = comb.and %a3, %b3 : i1
+  %4 = comb.and %a4, %b4 : i1
+  %5 = comb.and %a5, %b5 : i1
+  %6 = comb.and %a6, %b6 : i1
+  %7 = comb.and %a7, %b7 : i1
+  %8 = comb.or %0, %1, %2, %3, %4, %5, %6, %7 : i1
+  hw.output %8 : i1
+}
+
+// CHECK-LABEL: module Baz
+
+// MAX_8:       wire [[wire_0:.+]] = a0 & b0 | a1 & b1 | a2 & b2 | a3 & b3;
+// MAX_8:       wire [[wire_1:.+]] = a4 & b4 | a5 & b5 | a6 & b6 | a7 & b7;
+// MAX_8:       assign c = [[wire_0]] | [[wire_1]];
+
+// MAX_4:       wire [[wire_0:.+]] = a0 & b0 | a1 & b1;
+// MAX_4:       wire [[wire_1:.+]] = a2 & b2 | a3 & b3;
+// MAX_4:       wire [[wire_2:.+]] = a4 & b4 | a5 & b5;
+// MAX_4:       wire [[wire_3:.+]] = a6 & b6 | a7 & b7;
+// MAX_4:       assign c = [[wire_0]] | [[wire_1]] | [[wire_2]] | [[wire_3]];


### PR DESCRIPTION
Add a command line option and PrepareForEmission functionality to split
variadic arguments whose operands are composed of many terms.  This is
done to enable large product-of-sum or sum-of-product terms from growing
so large (during inline emission) that they cause poor simulator
performance.  Specifically, this fixes a 10x increase in Verilog
compilation time for Synopsys VCS for an internal design.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>