### PR TITLE
[StandardToHandshake] Expose post dataflow converison

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -207,6 +207,10 @@ LogicalResult lowerRegion(HandshakeLowering &hl, bool sourceConstants,
 /// be graph regions currently.
 void removeBasicBlocks(Region &r);
 
+/// Lowers the mlir operations into handshake that are not part of the dataflow
+/// conversion.
+LogicalResult postDataflowConvert(Operation *op);
+
 } // namespace handshake
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>


### PR DESCRIPTION
This PR ensures that the last part of the `std-to-handshake` pass is exposed as well.