### PR TITLE
[Support] CPPCDE - C++-based CIRCT design entry

### DIFF
--- a/include/circt/Support/BackedgeBuilder.h
+++ b/include/circt/Support/BackedgeBuilder.h
@@ -89,6 +89,7 @@ public:
   explicit operator bool() const { return !!value; }
   operator mlir::Value() const { return value; }
   void setValue(mlir::Value);
+  bool isSet() { return set; }
 
 private:
   mlir::Value value;

--- a/include/circt/Support/CPPCDE.h
+++ b/include/circt/Support/CPPCDE.h
@@ -1,0 +1,398 @@
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Support/BackedgeBuilder.h"
+
+#include "assert.h"
+#include <iostream>
+#include <variant>
+
+using namespace mlir;
+using namespace circt;
+
+/*
+CPPCDE: C++ CIRCT Design Entry
+
+Syntactic sugar for creating CIRCT modules and operations. This library is
+intended to be used in places where a large amount of CIRCT IR needs to be
+generated (think generators) within a pass, wherein a syntactically sugar'ed
+approach will lead itself to a significant decrease in the LOC required.
+
+... not a HDL...!
+*/
+
+namespace circt {
+namespace cppcde {
+
+// Port annotations.
+enum class PortKind { Clock, Reset, Default };
+
+// A context defining the operations that define a given semantic.
+// This can be used to overload the inferred operations in a CPPCDE
+// generator.
+struct CDEOperatorSelector {
+  // Logical operators.
+  using And = comb::AndOp;
+  using Or = comb::OrOp;
+  using XOr = comb::XorOp;
+  using Shl = comb::ShlOp;
+  using ShrS = comb::ShrSOp;
+  using ShrU = comb::ShrUOp;
+  using Concat = comb::ConcatOp;
+
+  // Arithmetic operators.
+  using Mul = comb::MulOp;
+  using Add = comb::AddOp;
+  using Sub = comb::SubOp;
+  using DivU = comb::DivUOp;
+  using DivS = comb::DivSOp;
+  using ModU = comb::ModUOp;
+  using ModS = comb::ModSOp;
+};
+
+// A context containing the shared state of a generator.
+struct CDEContext {
+  CDEContext(Location loc, OpBuilder &b, BackedgeBuilder &bb)
+      : loc(loc), b(b), bb(bb) {}
+  Location loc;
+  OpBuilder &b;
+  BackedgeBuilder &bb;
+  Value clk;
+  Value rst;
+};
+
+// Base class for CPPCDE values. Users can specialize this class for
+// dialect-specific operations.
+template <typename TOps, typename CDEValue>
+class CDEValueImpl {
+
+  template <typename TBinOp>
+  CDEValue execBinOp(CDEValue other) {
+    return CDEValue(this->ctx,
+                    this->ctx->b.template create<TBinOp>(
+                        this->get().getLoc(), this->get(), other.get()));
+  }
+
+public:
+  using OpTypes = TOps;
+  CDEValueImpl() {
+    // Null value.
+  }
+  explicit CDEValueImpl(const CDEValue &other) : ctx(other.ctx) {
+    this->valueOrBackedge = other.valueOrBackedge;
+  }
+  CDEValueImpl(CDEContext *ctx, Value v) : ctx(ctx), valueOrBackedge(v) {}
+  CDEValueImpl(CDEContext *ctx, CDEValue v) : ctx(ctx), valueOrBackedge(v) {}
+  CDEValueImpl(CDEContext *ctx, Backedge *b) : ctx(ctx), valueOrBackedge(b) {}
+
+  virtual ~CDEValueImpl() {}
+
+  bool isNull() { return ctx == nullptr; }
+
+  // Returns a registered version of this value. If no clock is provided,
+  // it is assumed that the context contains a clock value.
+  CDEValue reg(StringRef name, CDEValue clk = CDEValue()) {
+    Value clock;
+    if (clk.isNull()) {
+      assert(ctx->clk && "A clock must be in the CDE context to creae a "
+                         "register.");
+      clock = ctx->clk;
+    } else {
+      clock = clk.get();
+    }
+    return CDEValue(ctx,
+                    ctx->b.create<seq::CompRegOp>(get().getLoc(), get(), clock,
+                                                  ctx->b.getStringAttr(name)));
+  }
+
+  // An explicit function for backedge assignment instead of overloading the
+  // '=' operator.
+  // By this, we avoid aliasing with the implicit copy constructor + don't mix
+  // C++ and the underlying op generation semantics.
+  void assign(CDEValue rhs) {
+    auto *backedge = std::get_if<Backedge *>(&valueOrBackedge);
+    assert(backedge && "Cannot assign to a value.");
+    assert(!(*backedge)->isSet() && "backedge already assigned.");
+    (*backedge)->setValue(rhs.get());
+  }
+
+  // As an alternative to static_cast when implicit conversion won't apply.
+  Value get() const {
+    auto *value = std::get_if<Value>(&valueOrBackedge);
+    if (value)
+      return *value;
+
+    return **std::get_if<Backedge *>(&valueOrBackedge);
+  }
+
+  // Various binary operators.
+  // @todo: These only really make sense for bitvector operations... The dilemma
+  // is to choose between having the user forced to cast values to a CDEValue
+  // specialization (e.g. CDEBitVectorValue) which then contains the operators -
+  // of which use is guaranteed to be correct - or to make the API less
+  // verbose by allowing all operators on all CDE values, and let type checking
+  // be done at CIRCT verification time.
+  // For this initial version, just use the latter.
+
+  virtual CDEValue operator+(CDEValue other) {
+    return execBinOp<typename TOps::Add>(other);
+  }
+  virtual CDEValue operator-(CDEValue other) {
+    return execBinOp<typename TOps::Sub>(other);
+  }
+  virtual CDEValue operator*(CDEValue other) {
+    return execBinOp<typename TOps::Mul>(other);
+  }
+  virtual CDEValue operator<<(CDEValue other) {
+    return execBinOp<typename TOps::Shl>(other);
+  }
+  virtual CDEValue operator&(CDEValue other) {
+    return execBinOp<typename TOps::And>(other);
+  }
+  virtual CDEValue operator|(CDEValue other) {
+    return execBinOp<typename TOps::Or>(other);
+  }
+  virtual CDEValue operator^(CDEValue other) {
+    return execBinOp<typename TOps::XOr>(other);
+  }
+  virtual CDEValue operator~() {
+    return CDEValue(
+        this->ctx,
+        comb::createOrFoldNot(this->get().getLoc(), this->get(), this->ctx->b));
+  }
+  virtual CDEValue shrs(CDEValue other) {
+    return execBinOp<typename TOps::ShrS>(other);
+  }
+  virtual CDEValue shru(CDEValue other) {
+    return execBinOp<typename TOps::ShrU>(other);
+  }
+  virtual CDEValue divu(CDEValue other) {
+    return execBinOp<typename TOps::DivU>(other);
+  }
+  virtual CDEValue divs(CDEValue other) {
+    return execBinOp<typename TOps::DivS>(other);
+  }
+  virtual CDEValue modu(CDEValue other) {
+    return execBinOp<typename TOps::ModU>(other);
+  }
+  virtual CDEValue mods(CDEValue other) {
+    return execBinOp<typename TOps::ModS>(other);
+  }
+  virtual CDEValue concat(CDEValue other) {
+    return execBinOp<typename TOps::Concat>(other);
+  }
+
+protected:
+  CDEContext *ctx = nullptr;
+  std::variant<Value, Backedge *> valueOrBackedge;
+};
+
+class ESICDEValue : public CDEValueImpl<CDEOperatorSelector, ESICDEValue> {
+public:
+  using CDEValueImpl::CDEValueImpl;
+
+  std::pair<ESICDEValue, ESICDEValue> wrap(ESICDEValue valid) {
+    auto wrapOp = ctx->b.create<esi::WrapValidReadyOp>(
+        get().getLoc(), this->get(), valid.get());
+    return std::make_pair(ESICDEValue(ctx, wrapOp.getResult(0)),
+                          ESICDEValue(ctx, wrapOp.getResult(1)));
+  }
+
+  std::pair<ESICDEValue, ESICDEValue> unwrap(ESICDEValue ready) {
+    auto unwrapOp = this->ctx->b.template create<esi::UnwrapValidReadyOp>(
+        this->get().getLoc(), this->get(), ready.get());
+    return std::make_pair(ESICDEValue(this->ctx, unwrapOp.getResult(0)),
+                          ESICDEValue(this->ctx, unwrapOp.getResult(1)));
+  }
+};
+
+struct DefaultCDEValue
+    : public CDEValueImpl<CDEOperatorSelector, DefaultCDEValue> {
+  using CDEValueImpl::CDEValueImpl;
+};
+
+// A class for providing backedge-based access to the in- and output ports of
+// a module.
+template <typename CDEValue>
+class CDEPorts {
+
+public:
+  CDEPorts(CDEContext &ctx, hw::HWModuleOp module) : ctx(ctx) {
+    auto modPorts = module.getPorts();
+
+    for (auto [barg, info] : llvm::zip(module.getArguments(), modPorts.inputs))
+      ports.try_emplace(info.name.str(), CDEValue(&ctx, barg));
+
+    auto outputOp = cast<hw::OutputOp>(module.getBodyBlock()->getTerminator());
+    assert(outputOp.getNumOperands() == 0);
+
+    OpBuilder::InsertionGuard g(ctx.b);
+    ctx.b.setInsertionPoint(outputOp);
+    llvm::SmallVector<Value> outputOpArgs;
+    for (auto &info : modPorts.outputs) {
+      outputBackedges.push_back(ctx.bb.get(info.type));
+      ports.try_emplace(info.name.str(),
+                        CDEValue(&ctx, &outputBackedges.back()));
+      outputOpArgs.push_back(outputBackedges.back());
+    }
+
+    ctx.b.create<hw::OutputOp>(outputOp.getLoc(), outputOpArgs);
+    outputOp.erase();
+  }
+
+  CDEValue operator[](llvm::StringRef name) {
+    auto it = ports.find(name.str());
+    assert(it != ports.end() && "Port not found.");
+    return it->second;
+  }
+
+private:
+  std::map<std::string, CDEValue> ports;
+  CDEContext &ctx;
+  std::vector<Backedge> outputBackedges;
+};
+
+// A CDE Generator is a utility class for supporting syntactically sugar'ed
+// building of CIRCT RTL dialect operations.
+template <typename CDEValue>
+class Generator {
+public:
+  using CDEPorts = CDEPorts<CDEValue>;
+  Generator(Location loc, OpBuilder &b)
+      : loc(loc), bb(b, loc), ctx(loc, b, bb) {}
+  virtual ~Generator() = default;
+
+protected:
+  /// Unwraps a range of CDEValues to their underlying mlir::Value's.
+  static llvm::SmallVector<Value> unwrap(llvm::ArrayRef<CDEValue> values) {
+    SmallVector<Value> unwrapped;
+    llvm::transform(values, std::back_inserter(unwrapped),
+                    [](auto &v) { return v.get(); });
+    return unwrapped;
+  }
+
+  // Executes an N-ary operation on a range of CDEValues and returns the
+  // result as a CDEValue.
+  template <typename TOp>
+  CDEValue execNAryOp(llvm::ArrayRef<CDEValue> operands) {
+    return CDEValue(
+        &ctx, ctx.b.create<TOp>(operands[0].get().getLoc(), unwrap(operands)));
+  }
+
+  // Various N-ary operations.
+  CDEValue And(llvm::ArrayRef<CDEValue> operands) {
+    return execNAryOp<CDEValue::OpTypes::And>(operands);
+  }
+
+  CDEValue Or(llvm::ArrayRef<CDEValue> operands) {
+    return execNAryOp<CDEValue::OpTypes::Or>(operands);
+  }
+
+  CDEValue Xor(llvm::ArrayRef<CDEValue> operands) {
+    return execNAryOp<CDEValue::OpTypes::XOr>(operands);
+  }
+
+  CDEValue cint(size_t width, int64_t value) {
+    return CDEValue(&ctx,
+                    ctx.b.create<hw::ConstantOp>(ctx.loc, APInt(width, value)));
+  }
+
+  CDEValue wire(Type t) {
+    backedges.push_back(ctx.bb.get(t));
+    return CDEValue(&ctx, &backedges.back());
+  }
+
+  // Implementation-defined generator function - this is where user logic
+  // should be implemented.
+  virtual void generate(CDEPorts &ports) = 0;
+
+  Location loc;
+  BackedgeBuilder bb;
+  CDEContext ctx;
+  llvm::SmallVector<Backedge> backedges;
+};
+
+/// A CDE Generator which generates hw::HWModuleOp modules.
+template <typename CDEValue>
+class HWModuleGenerator : public Generator<CDEValue> {
+
+public:
+  HWModuleGenerator(Location loc, OpBuilder &b)
+      : Generator<CDEValue>(loc, b), portInfo({}) {}
+
+  // Returns the name of this module.
+  virtual std::string getName() = 0;
+
+  // Run module generation.
+  FailureOr<hw::HWModuleOp> operator()() {
+    OpBuilder::InsertionGuard g(this->ctx.b);
+
+    // Reset I/O.
+    portInfo = hw::ModulePortInfo({});
+    createIO();
+
+    // Create the module.
+    auto module = this->ctx.b.template create<hw::HWModuleOp>(
+        this->loc, this->ctx.b.getStringAttr(getName()), portInfo);
+
+    // Generate module port accessors.
+    auto ports = CDEPorts<CDEValue>(this->ctx, module);
+    this->ctx.b.setInsertionPointToStart(module.getBodyBlock());
+
+    if (clockIdx.has_value())
+      this->ctx.clk = module.getArgument(clockIdx.value());
+    if (resetIdx.has_value())
+      this->ctx.rst = module.getArgument(resetIdx.value());
+
+    // Go generate!
+    this->generate(ports);
+    return module;
+  }
+
+protected:
+  // Adds an input port to this module.
+  void input(llvm::StringRef name, Type type,
+             PortKind kind = PortKind::Default) {
+    size_t idx = portInfo.inputs.size();
+    portInfo.inputs.push_back(hw::PortInfo{
+        this->ctx.b.getStringAttr(name), hw::PortDirection::INPUT, type, idx});
+    if (kind == PortKind::Clock) {
+      assert(!clockIdx.has_value() && "multiple clocks not allowed");
+      clockIdx = idx;
+    } else if (kind == PortKind::Reset) {
+      assert(!resetIdx.has_value() && "multiple resets not allowed");
+      resetIdx = idx;
+    }
+  }
+
+  // Shorthand for creating a clock input port.
+  void clock(llvm::StringRef name = "clk") {
+    input(name, this->ctx.b.getIntegerType(1), PortKind::Clock);
+  }
+
+  // Shorthand for creating a reset input port.
+  void reset(llvm::StringRef name = "rst") {
+    input(name, this->ctx.b.getIntegerType(1), PortKind::Reset);
+  }
+
+  // Adds an output port to this module.
+  void output(llvm::StringRef name, Type type) {
+    portInfo.outputs.push_back(hw::PortInfo{this->ctx.b.getStringAttr(name),
+                                            hw::PortDirection::OUTPUT, type,
+                                            portInfo.outputs.size()});
+  }
+
+  // Hook for creating the input and output ports of this module.
+  virtual void createIO() = 0;
+
+  hw::ModulePortInfo portInfo;
+
+private:
+  // Indices of the clock and reset ports in the generated module.
+  std::optional<size_t> clockIdx, resetIdx;
+};
+
+} // namespace cppcde
+} // namespace circt

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -25,6 +25,10 @@ void Backedge::setValue(mlir::Value newValue) {
   assert(!set && "backedge already set to a value!");
   value.replaceAllUsesWith(newValue);
   set = true;
+
+  // In case this backedge is still referenced, ensure that references point
+  // to the new value.
+  value = newValue;
 }
 
 BackedgeBuilder::~BackedgeBuilder() { (void)clearOrEmitError(); }

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -5,6 +5,19 @@
 set(VERSION_CPP "${CMAKE_CURRENT_BINARY_DIR}/Version.cpp")
 set_source_files_properties("${VERSION_CPP}" PROPERTIES GENERATED TRUE)
 
+set(LLVM_OPTIONAL_SOURCES
+  BackedgeBuilder.cpp
+  FieldRef.cpp
+  LoweringOptions.cpp
+  Path.cpp
+  APInt.cpp
+  ValueMapper.cpp
+  SymCache.cpp
+  TestPasses.cpp
+  "${VERSION_CPP}"
+  )
+
+
 add_circt_library(CIRCTSupport
   BackedgeBuilder.cpp
   FieldRef.cpp
@@ -20,6 +33,18 @@ add_circt_library(CIRCTSupport
   LINK_LIBS PUBLIC
   MLIRIR
   )
+
+
+add_circt_library(CIRCTSupportTestPasses
+  TestPasses.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTHW
+  CIRCTESI
+  CIRCTSeq
+  MLIRPass
+)
+
 
 #-------------------------------------------------------------------------------
 # Generate Version.cpp

--- a/lib/Support/TestPasses.cpp
+++ b/lib/Support/TestPasses.cpp
@@ -1,0 +1,112 @@
+//===- TestPasses.cpp - Test passes for the support infrastructure -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements test passes for the support infrastructure.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Support/CPPCDE.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace cppcde;
+
+//===----------------------------------------------------------------------===//
+// CPPCDE passes.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestCPPCDEPass
+    : public PassWrapper<TestCPPCDEPass, OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestCPPCDEPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-cppcde"; }
+  StringRef getDescription() const override {
+    return "Runs various built-in cppcde tests.";
+  }
+
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<hw::HWDialect, comb::CombDialect, seq::SeqDialect,
+                    esi::ESIDialect>();
+  }
+};
+} // namespace
+
+class MyAdder : public HWModuleGenerator<DefaultCDEValue> {
+public:
+  using HWModuleGenerator::HWModuleGenerator;
+  std::string getName() override { return "MyAdder"; }
+  void createIO() override {
+    input("in0", ctx.b.getIntegerType(32));
+    input("in1", ctx.b.getIntegerType(32));
+    clock();
+    output("out0", ctx.b.getIntegerType(32));
+  }
+
+  void generate(CDEPorts &ports) override {
+    ports["out0"].assign((ports["in0"] + ports["in1"]).reg("add_reg"));
+  }
+};
+
+// Example of specializing the generator with a custom value type that extends
+// the default value type with a few extra operators.
+class MyESIAdder : public HWModuleGenerator<ESICDEValue> {
+public:
+  using HWModuleGenerator::HWModuleGenerator;
+  std::string getName() override { return "MyESIAdder"; }
+  void createIO() override {
+    Type channelType =
+        esi::ChannelType::get(ctx.b.getContext(), ctx.b.getIntegerType(32));
+    input("in0", channelType);
+    input("in1", channelType);
+    clock();
+    output("out0", channelType);
+  }
+
+  void generate(CDEPorts &ports) override {
+    auto c1_i1 = cint(1, 1);
+    auto valid = wire(ctx.b.getI1Type());
+    auto [inner1, valid1] = ports["in0"].unwrap(valid);
+    auto [inner2, valid2] = ports["in1"].unwrap(valid);
+    auto res = inner1 + inner2;
+    auto [outCh, outReady] = res.wrap(valid1 & valid2);
+    valid.assign(outReady);
+    ports["out0"].assign(outCh);
+  }
+};
+
+void TestCPPCDEPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  Location loc = getOperation().getLoc();
+  OpBuilder b(context);
+  b.setInsertionPointToStart(getOperation().getBody());
+
+  if (failed((MyAdder(loc, b))()) || failed((MyESIAdder(loc, b))())) {
+    signalPassFailure();
+    return;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace circt {
+namespace test {
+void registerSupportTestPasses() {
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestCPPCDEPass>();
+  });
+}
+
+} // namespace test
+} // namespace circt

--- a/lib/Support/TestPasses.cpp
+++ b/lib/Support/TestPasses.cpp
@@ -46,10 +46,10 @@ public:
   using HWModuleGenerator::HWModuleGenerator;
   std::string getName() override { return "MyAdder"; }
   void createIO() override {
-    input("in0", ctx.b.getIntegerType(32));
-    input("in1", ctx.b.getIntegerType(32));
+    input("in0", type<IntegerType>(32));
+    input("in1", type<IntegerType>(32));
     clock();
-    output("out0", ctx.b.getIntegerType(32));
+    output("out0", type<IntegerType>(32));
   }
 
   void generate(CDEPorts &ports) override {
@@ -64,8 +64,7 @@ public:
   using HWModuleGenerator::HWModuleGenerator;
   std::string getName() override { return "MyESIAdder"; }
   void createIO() override {
-    Type channelType =
-        esi::ChannelType::get(ctx.b.getContext(), ctx.b.getIntegerType(32));
+    Type channelType = type<esi::ChannelType>(type<IntegerType>(32));
     input("in0", channelType);
     input("in1", channelType);
     clock();
@@ -73,7 +72,6 @@ public:
   }
 
   void generate(CDEPorts &ports) override {
-    auto c1_i1 = cint(1, 1);
     auto valid = wire(ctx.b.getI1Type());
     auto [inner1, valid1] = ports["in0"].unwrap(valid);
     auto [inner2, valid2] = ports["in1"].unwrap(valid);

--- a/test/Support/test_cppcde.mlir
+++ b/test/Support/test_cppcde.mlir
@@ -7,7 +7,6 @@
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @MyESIAdder(%in0: !esi.channel<i32>, %in1: !esi.channel<i32>, %clk: i1) -> (out0: !esi.channel<i32>) {
-// CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %in0, %ready : i32
 // CHECK-NEXT:    %rawOutput_0, %valid_1 = esi.unwrap.vr %in1, %ready : i32
 // CHECK-NEXT:    %0 = comb.add %rawOutput, %rawOutput_0 : i32

--- a/test/Support/test_cppcde.mlir
+++ b/test/Support/test_cppcde.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt -split-input-file -test-cppcde -verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @MyAdder(%in0: i32, %in1: i32, %clk: i1) -> (out0: i32) {
+// CHECK-NEXT:    %0 = comb.add %in0, %in1 : i32
+// CHECK-NEXT:    %add_reg = seq.compreg sym @add_reg %0, %clk : i32
+// CHECK-NEXT:    hw.output %add_reg : i32
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: hw.module @MyESIAdder(%in0: !esi.channel<i32>, %in1: !esi.channel<i32>, %clk: i1) -> (out0: !esi.channel<i32>) {
+// CHECK-NEXT:    %true = hw.constant true
+// CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %in0, %ready : i32
+// CHECK-NEXT:    %rawOutput_0, %valid_1 = esi.unwrap.vr %in1, %ready : i32
+// CHECK-NEXT:    %0 = comb.add %rawOutput, %rawOutput_0 : i32
+// CHECK-NEXT:    %1 = comb.and %valid, %valid_1 : i1
+// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %0, %1 : i32
+// CHECK-NEXT:    hw.output %chanOutput : !esi.channel<i32>
+// CHECK-NEXT:  }
+
+module {}

--- a/test/Support/test_cppcde.mlir
+++ b/test/Support/test_cppcde.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -split-input-file -test-cppcde -verify-diagnostics %s | FileCheck %s
 
-// CHECK-LABEL: hw.module @MyAdder(%in0: i32, %in1: i32, %clk: i1) -> (out0: i32) {
+// CHECK-LABEL: hw.module @MyAdder_32(%in0: i32, %in1: i32, %clk: i1) -> (out0: i32) {
 // CHECK-NEXT:    %0 = comb.add %in0, %in1 : i32
 // CHECK-NEXT:    %add_reg = seq.compreg sym @add_reg %0, %clk : i32
 // CHECK-NEXT:    hw.output %add_reg : i32
@@ -9,9 +9,9 @@
 // CHECK-LABEL: hw.module @MyESIAdder(%in0: !esi.channel<i32>, %in1: !esi.channel<i32>, %clk: i1) -> (out0: !esi.channel<i32>) {
 // CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %in0, %ready : i32
 // CHECK-NEXT:    %rawOutput_0, %valid_1 = esi.unwrap.vr %in1, %ready : i32
-// CHECK-NEXT:    %0 = comb.add %rawOutput, %rawOutput_0 : i32
-// CHECK-NEXT:    %1 = comb.and %valid, %valid_1 : i1
-// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %0, %1 : i32
+// CHECK-NEXT:    %myAdder.out0 = hw.instance "myAdder" @MyAdder_32(in0: %rawOutput: i32, in1: %rawOutput_0: i32, clk: %clk: i1) -> (out0: i32)
+// CHECK-NEXT:    %0 = comb.and %valid, %valid_1 : i1
+// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %myAdder.out0, %0 : i32
 // CHECK-NEXT:    hw.output %chanOutput : !esi.channel<i32>
 // CHECK-NEXT:  }
 

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(circt-opt
   CIRCTHWArith
   CIRCTSystemC
   CIRCTTransforms
+  CIRCTSupportTestPasses
 
   MLIRIR
   MLIRLLVMDialect

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -30,6 +30,7 @@ namespace circt {
 namespace test {
 void registerAnalysisTestPasses();
 void registerSchedulingTestPasses();
+void registerSupportTestPasses();
 } // namespace test
 } // namespace circt
 
@@ -57,6 +58,7 @@ int main(int argc, char **argv) {
   // Register test passes
   circt::test::registerAnalysisTestPasses();
   circt::test::registerSchedulingTestPasses();
+  circt::test::registerSupportTestPasses();
 
   // Other command line options.
   circt::registerLoweringCLOptions();


### PR DESCRIPTION
CPPCDE intends to reduce the verboseness of emitting large amounts of CIRCT IR by providing an in-CIRCT generator "infrastructure".

One example is the IR generated in the `HandshakeToFIRRTL` pass - locally, I'm able to reduce operator implementation sizes to 33% their `HandshakeToFIRRTL` LOC using this. As an added incentive, this kind of in-CIRCT generator infrastructure has been a long-standing prerequisite for me to start working on getting `HandshakeToHW` finished...!

Is this a fully-fledged DSL? ...no - the intentions are the same as with PyCDE. That is, to provide a layer of syntactic sugar on top of the builder infrastructure to facilitate writing IR generators. A further restriction is that this is intended (at least to begin with) 
 to be strictly a library that other passes can leverage.

The implementation shares similarities to PyCDE, and takes a dynamic approach whereever possible. A more static, typesafe, approach would have been to e.g. create ports as member variables. The intention here is to allow a more flexible generator infrastructure - generators of generators - which we've seen useful in PyCDE. Also, this implementation is simpler and more like 'syntactic sugar' instead of a full-blown DSL.

Error handling is currently done by asserts - not ideal. Exception raising would be preferred (caught in the `go` method, which would return a `LogicalResult`) but currently not possible, due to the project being built with exceptions disabled.

As a future addition, i'd like to also provide an in-line way of using this (e.g. for using CPPCDE inside a pattern rewriter, if one doesn't need to generate an entire `hw::HWModuleOp` but just IR within some other region).

This initial commit doesn't do everything (obvious omissions are e.g. HW arrays, extract operations, ...) - all of this can be added later. The main point, for now, is to figure out whether this is something the community would be open to have in CIRCT.

LMKWYT!