### PR TITLE
[CI] Try to trim cached LLVM builds

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -199,7 +199,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            llvm/build
+            llvm/build/bin/llvm-lit
             llvm/install
           key: ${{ runner.os }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }} 
 

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -75,8 +75,8 @@ jobs:
           cd build_release
           cmake ../ -GNinja `
             -DLLVM_ENABLE_ASSERTIONS=ON `
-            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir/" `
-            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm/" `
+            -DMLIR_DIR="$(pwd)/../llvm/install/lib/cmake/mlir/" `
+            -DLLVM_DIR="$(pwd)/../llvm/install/lib/cmake/llvm/" `
             -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/Release/bin/llvm-lit.py" `
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            llvm/build
+            llvm/build/Release/bin/llvm-lit.py
             llvm/install
           key: ${{ runner.os }}-llvm-relobj-${{ steps.get-llvm-hash.outputs.hash }}
 


### PR DESCRIPTION
In two places, we create very large cache objects containing both the `build` and `install` directories for LLVM.

We generally don't seem to need the `build` directory, other than for grabbing `lit`.

Try trimming the cached paths to `install` and just the `lit` entry point (actually implementation is in LLVM's source).
If lit breaks, maybe we can just grab it from the PyPi package: https://pypi.org/project/lit/ .

Hopefully this helps improve CI performance by evicting cache entries less often.

cc #3761 .