### PR TITLE
[FIRRTL][WireDFT] Handle wiring in enable from outside DUT.

### DIFF
--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -45,3 +45,44 @@ firrtl.circuit "TwoEnables" {
     %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
   }
 }
+
+
+// -----
+
+// Test enable signal that isn't reachable from DUT.
+// expected-error @below {{unable to connect enable signal and DUT, may not be reachable from top-level module}}
+firrtl.circuit "EnableNotReachable" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  firrtl.module @TestEn() {
+    // expected-note @below {{enable signal here}}
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+  }
+  // expected-note @below {{DUT here}}
+  // expected-note @below {{top-level module here}}
+  firrtl.module @EnableNotReachable() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+}
+
+// -----
+
+// Test clock gate instantiated both in and outside DUT
+firrtl.circuit "InAndOutOfDUT" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  // expected-error @below {{clock gates within DUT must not be instantiated outside the DUT}}
+  firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    firrtl.instance a @A()
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+  }
+
+  firrtl.module @A() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+
+  firrtl.module @InAndOutOfDUT() {
+    firrtl.instance a @A()
+    firrtl.instance d @DUT()
+  }
+}

--- a/test/Dialect/FIRRTL/wire-dft.mlir
+++ b/test/Dialect/FIRRTL/wire-dft.mlir
@@ -113,3 +113,69 @@ firrtl.circuit "TestHarness" {
     // CHECK-NOT: firrtl.connect
   }
 }
+
+// Test enable signal as input to top module, and outside of DUT (issue #3784).
+// CHECK-LABEL: firrtl.circuit "EnableOutsideDUT"
+firrtl.circuit "EnableOutsideDUT" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // Regardless of enable signal origin, leave clocks outside DUT alone.
+  firrtl.module @OutsideDUT() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK-NOT: firrtl.connect
+  }
+
+  firrtl.module @EnableOutsideDUT(in %port_en: !firrtl.uint<1>) attributes {
+    portAnnotations = [[{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]]
+  } {
+    // CHECK: firrtl.instance o @OutsideDUT
+    firrtl.instance o @OutsideDUT()
+
+    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    // CHECK: firrtl.connect %a_test_en, %port_en
+  }
+}
+
+// Test enable signal outside DUT but not top.
+// CHECK-LABEL: firrtl.circuit "EnableOutsideDUT2"
+firrtl.circuit "EnableOutsideDUT2" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // Regardless of enable signal origin, leave clocks outside DUT alone.
+  // CHECK: @OutsideDUT()
+  firrtl.module @OutsideDUT() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK-NOT: firrtl.connect
+  }
+
+  // CHECK-LABEL: @enableSignal
+  firrtl.module @enableSignal() {
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @EnableOutsideDUT2
+  firrtl.module @EnableOutsideDUT2() {
+    // CHECK: %[[en:.+]] = firrtl.instance en @enableSignal
+    firrtl.instance en @enableSignal()
+    // CHECK: firrtl.instance o @OutsideDUT
+    firrtl.instance o @OutsideDUT()
+
+    // CHECK: %[[a_en:.+]] = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    // CHECK: firrtl.connect %[[a_en]], %[[en]]
+  }
+}
+


### PR DESCRIPTION
Still only wire to clock gates within the DUT, however, if the enable signal
originates outside the DUT handle this and wire it in.

This is not expected to be common/usual, but handle it if requested.

Also detect few other error cases:

* clockgates instantiated in and out the DUT
* enable signal can't reach DUT
  (unlikely to happen in practice, but not much more to check)

Fixes #3784.