### PR TITLE
Bump LLVM to  1bcf21c

### DIFF
--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -63,9 +63,9 @@ static void checkMemrefDependence(SmallVectorImpl<Operation *> &memoryOps,
       // Look for the common parent that src and dst share. If there is none,
       // there is nothing more to do.
       SmallVector<Operation *> srcParents;
-      getEnclosingAffineForAndIfOps(*source, &srcParents);
+      getEnclosingAffineOps(*source, &srcParents);
       SmallVector<Operation *> dstParents;
-      getEnclosingAffineForAndIfOps(*destination, &dstParents);
+      getEnclosingAffineOps(*destination, &dstParents);
 
       Operation *commonParent = nullptr;
       for (auto *srcParent : llvm::reverse(srcParents)) {

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --convert-hw-to-llvm | FileCheck %s
 
-// CHECK-LABEL: llvm.mlir.global internal @_array_global() : !llvm.array<2 x i32> {
+// CHECK-LABEL: llvm.mlir.global internal @_array_global() {addr_space = 0 : i32} : !llvm.array<2 x i32> {
 // CHECK-NEXT: %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.array<2 x i32>
 // CHECK-NEXT: %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0] : !llvm.array<2 x i32>

--- a/test/Conversion/LLHDToLLVM/convert_signals.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_signals.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL:   llvm.func @driveSignal(!llvm.ptr<i8>, !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>, !llvm.ptr<i8>, i64, i64, i64, i64)
 
-// CHECK-LABEL: llvm.mlir.global internal @_array_global_0() : !llvm.array<3 x i5> {
+// CHECK-LABEL: llvm.mlir.global internal @_array_global_0() {addr_space = 0 : i32} : !llvm.array<3 x i5> {
 // CHECK: %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.array<3 x i5>
 // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i5) : i5
 // CHECK: %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0] : !llvm.array<3 x i5>
@@ -13,7 +13,7 @@
 // CHECK: %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_4]][2] : !llvm.array<3 x i5>
 // CHECK: llvm.return %[[VAL_6]] : !llvm.array<3 x i5>
 // CHECK: }
-// CHECK-LABEL: llvm.mlir.global internal @_array_global() : !llvm.array<4 x i1> {
+// CHECK-LABEL: llvm.mlir.global internal @_array_global() {addr_space = 0 : i32} : !llvm.array<4 x i1> {
 // CHECK: %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.array<4 x i1>
 // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
 // CHECK: %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0] : !llvm.array<4 x i1>

--- a/test/Conversion/LLHDToLLVM/signal-init.mlir
+++ b/test/Conversion/LLHDToLLVM/signal-init.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --convert-llhd-to-llvm | FileCheck %s
 
-// CHECK-LABEL: llvm.mlir.global internal @_array_global() : !llvm.array<2 x i1> {
+// CHECK-LABEL: llvm.mlir.global internal @_array_global() {addr_space = 0 : i32} : !llvm.array<2 x i1> {
 // CHECK: [[VAL_0:%.+]] = llvm.mlir.undef : !llvm.array<2 x i1>
 // CHECK: [[VAL_1:%.+]] = llvm.mlir.constant(false) : i1
 // CHECK: [[VAL_2:%.+]] = llvm.insertvalue [[VAL_1]], [[VAL_0]][0] : !llvm.array<2 x i1>

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -56,9 +56,9 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
 // CHECK-NEXT:   %1 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %1, 0
 // CHECK-NEXT:   %2 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assert %clock, %p, %2, ""
+// CHECK-NEXT:   firrtl.assert %clock, %p, %2, "" {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %3 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assume %clock, %p, %3, ""
+// CHECK-NEXT:   firrtl.assume %clock, %p, %3, "" {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %4 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.cover %clock, %p, %4, ""
 // CHECK-NEXT:   %5 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -67,11 +67,11 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
 // CHECK-NEXT:   %7 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %7, 1
 // CHECK-NEXT:   %8 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assert %clock, %p, %8, ""
+// CHECK-NEXT:   firrtl.assert %clock, %p, %8, "" {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %9 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assume %clock, %p, %9, ""
+// CHECK-NEXT:   firrtl.assume %clock, %p, %9, "" {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %10 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.cover %clock, %p, %10, ""
+// CHECK-NEXT:   firrtl.cover %clock, %p, %10, "" {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT: }
 
 

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -900,7 +900,7 @@ HandshakeExecuter::HandshakeExecuter(
 
     for (auto out : enumerate(op.getResults())) {
       LLVM_DEBUG(debugArg("OUT", out.value(), outValues[out.index()], time));
-      assert(outValues[out.index()].hasValue());
+      assert(outValues[out.index()].has_value());
       valueMap[out.value()] = outValues[out.index()];
       timeMap[out.value()] = time + 1;
       scheduleUses(readyList, valueMap, out.value());


### PR DESCRIPTION
1. Rename `getEnclosingAffineForAndIfOps` to `getEnclosingAffineOps`: The utility was extended to also support affine.parallel ops) The commit: https://github.com/llvm/llvm-project/commit/26fedf92c3122ff51fb27f434a8c5b5a47da8f94
2. Update lit tests to make DefaultValueAttr, not optional! https://github.com/llvm/llvm-project/commit/af3ed4a2a760580e9f0e04c7320edafc575d02b8
3. Move `hasValue` to `has_value` 