### PR TITLE
[SystemC] Replace func_handle with builtin function type

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -51,7 +51,7 @@ def MethodOp : SystemCOp<"method", []> {
     Represents the SC_METHOD macro as described in IEEE 1666-2011 §5.2.9.
   }];
 
-  let arguments = (ins VoidFunctionType:$funcHandle);
+  let arguments = (ins NullaryVoidFunctionType:$funcHandle);
   let assemblyFormat = "$funcHandle attr-dict";
 }
 
@@ -61,6 +61,6 @@ def ThreadOp : SystemCOp<"thread", []> {
     Represents the SC_THREAD macro as described in IEEE 1666-2011 §5.2.9.
   }];
 
-  let arguments = (ins VoidFunctionType:$funcHandle);
+  let arguments = (ins NullaryVoidFunctionType:$funcHandle);
   let assemblyFormat = "$funcHandle attr-dict";
 }

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -51,7 +51,7 @@ def MethodOp : SystemCOp<"method", []> {
     Represents the SC_METHOD macro as described in IEEE 1666-2011 §5.2.9.
   }];
 
-  let arguments = (ins FuncHandleType:$funcHandle);
+  let arguments = (ins VoidFunctionType:$funcHandle);
   let assemblyFormat = "$funcHandle attr-dict";
 }
 
@@ -61,6 +61,6 @@ def ThreadOp : SystemCOp<"thread", []> {
     Represents the SC_THREAD macro as described in IEEE 1666-2011 §5.2.9.
   }];
 
-  let arguments = (ins FuncHandleType:$funcHandle);
+  let arguments = (ins VoidFunctionType:$funcHandle);
   let assemblyFormat = "$funcHandle attr-dict";
 }

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -137,14 +137,14 @@ def SCFuncOp : SystemCOp<"func", [
   }];
 
   let arguments = (ins StrAttr:$name);
-  let results = (outs FuncHandleType:$handle);
+  let results = (outs VoidFunctionType:$handle);
   let regions = (region SizedRegion<1>:$body);
 
   let builders = [
     OpBuilder<(ins "StringAttr":$name), [{
       $_state.addAttribute(getNameAttrName($_state.name), name);
       Region *region = $_state.addRegion();
-      $_state.addTypes(FuncHandleType::get($_builder.getContext()));
+      $_state.addTypes(FunctionType::get($_builder.getContext(), {}, {}));
       region->push_back(new Block);
     }]>
   ];

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -137,7 +137,7 @@ def SCFuncOp : SystemCOp<"func", [
   }];
 
   let arguments = (ins StrAttr:$name);
-  let results = (outs VoidFunctionType:$handle);
+  let results = (outs NullaryVoidFunctionType:$handle);
   let regions = (region SizedRegion<1>:$body);
 
   let builders = [

--- a/include/circt/Dialect/SystemC/SystemCTypes.td
+++ b/include/circt/Dialect/SystemC/SystemCTypes.td
@@ -18,12 +18,17 @@ include "circt/Dialect/SystemC/SystemCDialect.td"
 class SystemCType<Pred condition, string description, string cppClassName>
   : DialectType<SystemCDialect, condition, description, cppClassName>;
 
-// A handle to refer to circt::systemc::FuncHandleType in ODS.
-def FuncHandleType : SystemCType<
-    CPred<"::circt::hw::type_isa<circt::systemc::FuncHandleType>($_self)">,
-    "FuncHandleType",
-    "::circt::hw::TypeAliasOr<circt::systemc::FuncHandleType>">,
-  BuildableType<"::circt::systemc::FuncHandleType::get($_builder.getContext())">;
+// A handle to refer to a mlir::FunctionType with zero inputs and results,
+// i.e., a void function.
+def VoidFunctionType : SystemCType<
+    CPred<
+      "::circt::hw::type_isa<mlir::FunctionType>($_self) && " #
+      "::circt::hw::type_cast<mlir::FunctionType>($_self)" #
+        ".getNumResults() == 0 && " #
+      "::circt::hw::type_cast<mlir::FunctionType>($_self).getNumInputs() == 0">,
+    "FunctionType with no inputs and results",
+    "::circt::hw::TypeAliasOr<mlir::FunctionType>">,
+  BuildableType<"mlir::FunctionType::get($_builder.getContext(), {}, {})">;
 
 // A handle to refer to circt::systemc::InputType in ODS.
 def InputType : SystemCType<

--- a/include/circt/Dialect/SystemC/SystemCTypes.td
+++ b/include/circt/Dialect/SystemC/SystemCTypes.td
@@ -18,14 +18,20 @@ include "circt/Dialect/SystemC/SystemCDialect.td"
 class SystemCType<Pred condition, string description, string cppClassName>
   : DialectType<SystemCDialect, condition, description, cppClassName>;
 
+// A constraint for a mlir::FunctionType with zero inputs.
+def NullaryFunctionConstraint : CPred<
+  "::circt::hw::type_isa<mlir::FunctionType>($_self) && " #
+  "::circt::hw::type_cast<mlir::FunctionType>($_self).getNumInputs() == 0">;
+
+// A constraint for a mlir::FunctionType with zero results.
+def VoidFunctionConstraint : CPred<
+  "::circt::hw::type_isa<mlir::FunctionType>($_self) && " #
+  "::circt::hw::type_cast<mlir::FunctionType>($_self).getNumResults() == 0">;
+
 // A handle to refer to a mlir::FunctionType with zero inputs and results,
-// i.e., a void function.
-def VoidFunctionType : SystemCType<
-    CPred<
-      "::circt::hw::type_isa<mlir::FunctionType>($_self) && " #
-      "::circt::hw::type_cast<mlir::FunctionType>($_self)" #
-        ".getNumResults() == 0 && " #
-      "::circt::hw::type_cast<mlir::FunctionType>($_self).getNumInputs() == 0">,
+// i.e., a nullary void function.
+def NullaryVoidFunctionType : SystemCType<
+    And<[NullaryFunctionConstraint, VoidFunctionConstraint]>,
     "FunctionType with no inputs and results",
     "::circt::hw::TypeAliasOr<mlir::FunctionType>">,
   BuildableType<"mlir::FunctionType::get($_builder.getContext(), {}, {})">;

--- a/include/circt/Dialect/SystemC/SystemCTypesImpl.td
+++ b/include/circt/Dialect/SystemC/SystemCTypesImpl.td
@@ -14,16 +14,6 @@ include "mlir/IR/EnumAttr.td"
 
 class SystemCTypeDef<string name> : TypeDef<SystemCDialect, name> { }
 
-// A handle to a systemc::SCFuncOp. Declares the systemc::FuncHandleType in C++.
-def FuncHandleTypeImpl : SystemCTypeDef<"FuncHandle"> {
-  let summary = "A function handle type";
-  let description = [{
-    Represents a handle to a SystemC module's member function that
-    can be used in places like SC_METHOD, SC_THREAD, etc.
-  }];
-  let mnemonic = "func_handle";
-}
-
 class SignalTypesImplBase<string name> : SystemCTypeDef<name> {
   let parameters = (ins "::mlir::Type":$baseType);
   let assemblyFormat = "`<` $baseType `>`";

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -111,7 +111,16 @@ systemc.module @funcNoBlockArguments () {
   // expected-error @+1 {{op must not have any arguments}} 
   %0 = "systemc.func"() ({
     ^bb0(%arg0: i32):
-    }) {name="funcname"}: () -> (!systemc.func_handle)
+    }) {name="funcname"}: () -> (() -> ())
+}
+
+// -----
+
+systemc.module @funcNoBlockArguments () {
+  // expected-error @+1 {{result #0 must be FunctionType with no inputs and results, but got '(i32) -> ()'}}
+  %0 = "systemc.func"() ({
+    ^bb0():
+    }) {name="funcname"}: () -> ((i32) -> ())
 }
 
 // -----
@@ -123,7 +132,7 @@ systemc.module @signalFuncNameConflict () {
   // expected-error @+1 {{redefines name 'name'}}
   %1 = "systemc.func"() ({
     ^bb0:
-    }) {name="name"}: () -> (!systemc.func_handle)
+    }) {name="name"}: () -> (() -> ())
 }
 
 // -----


### PR DESCRIPTION
Instead of defining a custom type for void functions, we can reuse the builtin function type and define a ODS constraint to limit the function type to have zero inputs and results.