### PR TITLE
[ExportVerilog] Inline read inout op used by bitselect

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -541,13 +541,10 @@ static bool isOkToBitSelectFrom(Value v) {
   if (v.isa<BlockArgument>())
     return true;
 
-  // Uses of a wire or register can be done inline.
-  if (auto read = v.getDefiningOp<ReadInOutOp>()) {
-    if (read.getInput().getDefiningOp<WireOp>() ||
-        read.getInput().getDefiningOp<RegOp>() ||
-        read.getInput().getDefiningOp<LogicOp>())
-      return true;
-  }
+  // Read_inout is valid to inline for bit-select. See `select` syntax on
+  // SV spec A.8.4 (P1174).
+  if (auto read = v.getDefiningOp<ReadInOutOp>())
+    return true;
 
   // Aggregate access can be inlined.
   if (v.getDefiningOp<StructExtractOp>() || v.getDefiningOp<ArrayGetOp>())

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -161,9 +161,8 @@ hw.module @ReadInoutAggregate(%clock: i1) {
     %4 = comb.concat %c0_i16, %3 : i16, i16
     sv.passign %1, %4 : i32
   }
-  // DISALLOW:      wire [31:0] [[READ:.+]] = register[1'h0].a;
-  // DISALLOW-NEXT: always @(
-  // DISALLOW-NEXT:  register[1'h0].a <= {16'h0, [[READ]][15:0]};
+  // DISALLOW: always @(
+  // DISALLOW-NEXT:  register[1'h0].a <= {16'h0, register[1'h0].a[15:0]};
   hw.output
 }
 
@@ -229,9 +228,7 @@ hw.module @AggregateInline(%clock: i1) {
   %1 = sv.struct_field_inout %register["a"] : !hw.inout<struct<a: i32>>
   %2 = sv.read_inout %1 : !hw.inout<i32>
   %3 = comb.extract %2 from 0 : (i32) -> i16
-  // DISALLOW: wire [31:0] [[GEN_2:.+]] = register.a;
-  // DISALLOW-NEXT: assign [[GEN]] = [[GEN_2]]
-  // CHECK: wire [31:0] [[GEN_2:.+]] = register.a;
-  // CHECK-NEXT: assign [[GEN]] = [[GEN_2]]
+  // DISALLOW: assign [[GEN]] = register.a[15:0]
+  // CHECK: assign [[GEN]] = register.a[15:0]
   hw.output
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -946,12 +946,11 @@ hw.module @useRenamedStruct(%a: !hw.inout<struct<repeat: i1, repeat_0: i1>>) -> 
   // CHECK-NEXT:   .r1 (_inst1_r1)
   // CHECK-NEXT: )
 
-  // CHECK: wire struct packed {logic repeat_0; logic repeat_0_1; } [[WIREA:.+]] = a;
   %0 = sv.struct_field_inout %a["repeat"] : !hw.inout<struct<repeat: i1, repeat_0: i1>>
   %1 = sv.read_inout %0 : !hw.inout<i1>
   // assign r1 = a.repeat_0;
   %2 = hw.struct_extract %read["repeat_0"] : !hw.struct<repeat: i1, repeat_0: i1>
-  // assign r2 = [[WIREA]].repeat_0_1;
+  // assign r2 = a.repeat_0_1;
   %true = hw.constant true
   %3 = hw.struct_inject %read["repeat_0"], %true : !hw.struct<repeat: i1, repeat_0: i1>
   // assign r3 = '{repeat_0: a.repeat_0, repeat_0_1: (1'h1)};


### PR DESCRIPTION
This PR fixes the issue https://github.com/llvm/circt/issues/3786 by allowing read_inout to be inlined for bit-select op. 
There is a contradiction between `isExpressionAlwaysInline` and `isOkToBitselectFrom`: `isExpressionAlwaysInline` requires read_inout op to be always inlined, on the other hand  `isOkToBitselectFrom` disallows read op to be inlined for bit-select op. This contradiction causes the bug that temporary wires disappears with the new ExportVerilog emission mode. 

It is syntactically correct to inline read op as defined in the SV spec:
![image](https://user-images.githubusercontent.com/19691120/187187833-067bfaab-4c9a-4cb5-b6c1-217f68db0fca.png)
