### PR TITLE
[firtool] Enable LowerXMR by default

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -700,13 +700,14 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createMergeConnectionsPass(mergeConnectionsAgggresively));
 
-  // Lower the ref.resolve and ref.send ops and remove the RefType ports.
-  // LowerToHW cannot handle RefType so, this pass must be run to remove all
-  // RefType ports and ops.
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
-
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
+
+    // Lower the ref.resolve and ref.send ops and remove the RefType ports.
+    // LowerToHW cannot handle RefType so, this pass must be run to remove all
+    // RefType ports and ops.
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
+
     pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue(),
                                          emitChiselAssertsAsSVA.getValue()));
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -700,6 +700,11 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createMergeConnectionsPass(mergeConnectionsAgggresively));
 
+  // Lower the ref.resolve and ref.send ops and remove the RefType ports.
+  // LowerToHW cannot handle RefType so, this pass must be run to remove all
+  // RefType ports and ops.
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
+
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
     pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue(),


### PR DESCRIPTION
This commit adds the `LowerXMR` pass to the firtool pipeline and enables it by default. This is required since the `LowerToHW` pass cannot handle `RefType`, so all ops and ports of `RefType` must be removed.