### PR TITLE
[FIRRTL] Touchup version parsing, insist newline before circuit.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3164,10 +3164,8 @@ ParseResult FIRCircuitParser::parseCircuit(
   auto indent = getIndentation();
   uint32_t verMajor(1), verMinor(0), verPatch(0);
   if (consumeIf(FIRToken::kw_FIRRTL)) {
-    if (!indent.has_value() || *indent > 0)
-      return emitError("'FIRRTL' must be first token on its line")
-                 << " and must not be indented",
-             failure();
+    if (!indent.has_value())
+      return emitError("'FIRRTL' must be first token on its line"), failure();
     if (parseToken(FIRToken::kw_version, "expected version after 'FIRRTL'") ||
         parseVersionLit(verMajor, verMinor, verPatch,
                         "expected version literal"))

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3169,7 +3169,8 @@ ParseResult FIRCircuitParser::parseCircuit(
                  << " and must not be indented",
              failure();
     if (parseToken(FIRToken::kw_version, "expected version after 'FIRRTL'") ||
-        parseVersionLit(verMajor, verMinor, verPatch, "expected version literal"))
+        parseVersionLit(verMajor, verMinor, verPatch,
+                        "expected version literal"))
       return failure();
     indent = getIndentation();
   }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -544,7 +544,7 @@ ParseResult FIRParser::parseVersionLit(uint32_t &major, uint32_t &minor,
                                        uint32_t &patch, const Twine &message) {
   auto spelling = getTokenSpelling();
   if (getToken().getKind() != FIRToken::version)
-    return emitError("expected version literal"), failure();
+    return emitError(message), failure();
   // form a.b.c
   auto [a, d] = spelling.split(".");
   auto [b, c] = d.split(".");
@@ -3149,7 +3149,8 @@ FIRCircuitParser::parseModuleBody(DeferredModuleToParse &deferredModule) {
 }
 
 /// file ::= circuit
-/// circuit ::= 'circuit' id ':' info? INDENT module* DEDENT EOF
+/// versionHeader ::= 'FIRRTL' 'version' versionLit NEWLINE
+/// circuit ::= versionHeader? 'circuit' id ':' info? INDENT module* DEDENT EOF
 ///
 /// If non-null, annotationsBuf is a memory buffer containing JSON annotations.
 /// If non-null, omirBufs is a vector of memory buffers containing SiFive Object
@@ -3161,6 +3162,21 @@ ParseResult FIRCircuitParser::parseCircuit(
     mlir::TimingScope &ts) {
 
   auto indent = getIndentation();
+  uint32_t verMajor(1), verMinor(0), verPatch(0);
+  if (consumeIf(FIRToken::kw_FIRRTL)) {
+    if (!indent.has_value() || *indent > 0)
+      return emitError("'FIRRTL' must be first token on its line")
+                 << " and must not be indented",
+             failure();
+    if (parseToken(FIRToken::kw_version, "expected version after 'FIRRTL'") ||
+        parseVersionLit(verMajor, verMinor, verPatch, "expected version literal"))
+      return failure();
+    indent = getIndentation();
+  }
+  (void)verMajor;
+  (void)verMinor;
+  (void)verPatch;
+
   if (!indent.has_value())
     return emitError("'circuit' must be first token on its line"), failure();
   unsigned circuitIndent = indent.value();
@@ -3169,15 +3185,6 @@ ParseResult FIRCircuitParser::parseCircuit(
   StringAttr name;
   SMLoc inlineAnnotationsLoc;
   StringRef inlineAnnotations;
-
-  uint32_t verMajor(1), verMinor(0), verPatch(0);
-  if (consumeIf(FIRToken::kw_FIRRTL))
-    if (parseToken(FIRToken::kw_version, "expected version after 'FIRRTL'") ||
-        parseVersionLit(verMajor, verMinor, verPatch, "expected version"))
-      return failure();
-  (void)verMajor;
-  (void)verMinor;
-  (void)verPatch;
 
   // A file must contain a top level `circuit` definition.
   if (parseToken(FIRToken::kw_circuit,

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -44,6 +44,19 @@ circuit test :
 
 ;// -----
 
+; expected-error @below {{'circuit' must be first token on its line}}
+FIRRTL version 1.1.0 circuit test :
+  module test :
+
+;// -----
+
+; expected-error @below {{'FIRRTL' must be first token on its line and must not be indented}}
+  FIRRTL version 1.1.0
+circuit test :
+    module test :
+
+;// -----
+
 circuit test test : ; expected-error {{expected ':' in circuit definition}}
 
 ;// -----

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -50,13 +50,6 @@ FIRRTL version 1.1.0 circuit test :
 
 ;// -----
 
-; expected-error @below {{'FIRRTL' must be first token on its line and must not be indented}}
-  FIRRTL version 1.1.0
-circuit test :
-    module test :
-
-;// -----
-
 circuit test test : ; expected-error {{expected ':' in circuit definition}}
 
 ;// -----


### PR DESCRIPTION
Also don't allow indentation on the version header/preamble.