### PR TITLE
[firtool] Reorganize pass controlling options

### DIFF
--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,5 +1,5 @@
-; RUN: rm -rf %t && mkdir %t && firtool --firrtl-grand-central --split-verilog --annotation-file %s.anno.json --annotation-file %s.extract.anno.json -o %t %s && cd %t && verilator --sv --lint-only Top.sv bindings.sv
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %s.anno.json %s > %t.one-file.sv && verilator --sv --lint-only %t.one-file.sv
+; RUN: rm -rf %t && mkdir %t && firtool --split-verilog --annotation-file %s.anno.json --annotation-file %s.extract.anno.json -o %t %s && cd %t && verilator --sv --lint-only Top.sv bindings.sv
+; RUN: firtool --verilog --annotation-file %s.anno.json %s > %t.one-file.sv && verilator --sv --lint-only %t.one-file.sv
 ; REQUIRES: verilator
 
 circuit Top :

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --annotation-file %S/HWRename.anno.json %s | FileCheck %s --check-prefixes CHECK
+; RUN: firtool --annotation-file %S/HWRename.anno.json %s | FileCheck %s
 
 circuit Top:
   module Companion :

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/HWRename.anno.json %s | FileCheck %s --check-prefixes CHECK
+; RUN: firtool --annotation-file %S/HWRename.anno.json %s | FileCheck %s --check-prefixes CHECK
 
 circuit Top:
   module Companion :

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/PortDelete.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/PortDelete.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -firrtl-grand-central %s | FileCheck %s
+; RUN: firtool %s | FileCheck %s
 
 circuit PortDelete : %[[
   {

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,7 +1,7 @@
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
-; RUN: firtool --firrtl-grand-central --preserve-values=named --verilog --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
-; RUN: firtool --firrtl-grand-central --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
+; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
+; RUN: firtool --preserve-values=named --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
+; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
+; RUN: firtool --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
 
 circuit Top :
   extmodule BlackBox_DUT :

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --firrtl-grand-central --verilog --split-input-file %s | FileCheck %s
+; RUN: firtool --split-input-file %s | FileCheck %s
 
 ; A number of tests use an invalidated wire with a DontTouchAnnotation to block
 ; constant sinking into the XMR.  This is to ensure that the test can check a

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 -imdeadcodeelim=0 %s | FileCheck %s
+; RUN: firtool -dedup -split-input-file -ir-fir -disable-lower-types -disable-imcp -disable-imdce %s | FileCheck %s
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" --mem-to-reg-of-vec=0 --verify-diagnostics --verilog --emit-omir %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" --emit-omir %s | FileCheck %s
 
 circuit Foo : %[[
   {

--- a/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
+++ b/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --annotation-file %S/signal-mappings-subCircuit.json --firrtl-grand-central --verilog | FileCheck %s
+; RUN: firtool %s --annotation-file %S/signal-mappings-subCircuit.json | FileCheck %s
 
 ; Subcircuit:
 

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
@@ -6,8 +6,8 @@
 ; RUN: rm -rf %t && mkdir -p %t/default %t/inline
 
 ; 1) Run on main circuit, with signal mapping annotations
-; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --firrtl-grand-central --split-verilog -o %t/default
-; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --firrtl-grand-central --split-verilog -o %t/inline  --annotation-file %S/inline.json
+; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --split-verilog -o %t/default
+; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --split-verilog -o %t/inline  --annotation-file %S/inline.json
 
 ; Check the generated file
 ; RUN: FileCheck %s --input-file=%t/default/sigdrive.json --check-prefix=JSONDEFAULT
@@ -43,8 +43,8 @@
 
 
 ; 2) Run on sub circuit, with updated annotation file (sigdrive.json) from (1):
-; RUN: firtool %S/subcircuit.fir --annotation-file %t/default/sigdrive.json --firrtl-grand-central | FileCheck %s --check-prefix=MAPPINGDEFAULT
-; RUN: firtool %S/subcircuit.fir --annotation-file %t/inline/sigdrive.json  --firrtl-grand-central | FileCheck %s --check-prefix=MAPPINGINLINE
+; RUN: firtool %S/subcircuit.fir --annotation-file %t/default/sigdrive.json | FileCheck %s --check-prefix=MAPPINGDEFAULT
+; RUN: firtool %S/subcircuit.fir --annotation-file %t/inline/sigdrive.json  | FileCheck %s --check-prefix=MAPPINGINLINE
 
 ; MAPPINGDEFAULT-LABEL: module Sub_signal_mappings(
 ; MAPPINGDEFAULT-NEXT:   input           clock_sink,

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -imdeadcodeelim=false -verilog %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -disable-imdce %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the
 ; no-op wires and nodes are not optimized away, then both ports should always

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir --lower-memory --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" --verilog |  FileCheck %s
+; RUN: firtool %s --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" |  FileCheck %s
 
 circuit test:
   module test:

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s -dedup=false --lower-memory --format=fir --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
+; RUN: firtool %s --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" |  FileCheck %s
 
 
 circuit test:

--- a/test/firtool/print-before.fir
+++ b/test/firtool/print-before.fir
@@ -2,13 +2,12 @@
 ; Check passes from different components and registration categories.
 ; RUN: firtool %s -mlir-print-ir-before=cse 2>&1 | FileCheck %s -Dpass=CSE
 ; RUN: firtool %s -mlir-print-ir-before=strip-debuginfo -strip-debug-info 2>&1 | FileCheck %s -Dpass=StripDebugInfo
-; RUN: firtool %s -mlir-print-ir-before=firrtl-inliner -inline 2>&1 | FileCheck %s -Dpass=Inliner
+; RUN: firtool %s -mlir-print-ir-before=firrtl-inliner 2>&1 | FileCheck %s -Dpass=Inliner
 ; RUN: firtool %s -mlir-print-ir-before=firrtl-lower-annotations 2>&1 | FileCheck %s -Dpass=LowerFIRRTLAnnotations
-; RUN: firtool %s -mlir-print-ir-before=firrtl-grand-central -firrtl-grand-central 2>&1 | FileCheck %s -Dpass=GrandCentral
+; RUN: firtool %s -mlir-print-ir-before=firrtl-grand-central 2>&1 | FileCheck %s -Dpass=GrandCentral
 ; RUN: firtool %s -mlir-print-ir-before=export-verilog 2>&1 | FileCheck %s -Dpass=ExportVerilog
 ; RUN: firtool %s -mlir-print-ir-before=export-split-verilog -split-verilog -o %t 2>&1 | FileCheck %s -Dpass=ExportSplitVerilog
 ; RUN: firtool %s -mlir-print-ir-before=hw-cleanup 2>&1 | FileCheck %s -Dpass=HWCleanup
 ; CHECK: IR Dump Before [[pass]]
 circuit Empty:
   module Empty:
-

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -94,7 +94,7 @@ static cl::opt<bool> disableOptimization("disable-opt",
                                          cl::cat(mainCategory));
 
 static cl::opt<bool> disableInliner("disable-inliner",
-                                    cl::desc("Disable the module inliner"),
+                                    cl::desc("Disable the Inliner pass"),
                                     cl::init(false), cl::Hidden,
                                     cl::cat(mainCategory));
 
@@ -180,10 +180,10 @@ static cl::opt<bool>
                                  "assigning X on read disable"),
                         cl::init(false), cl::cat(mainCategory));
 
-static cl::opt<bool>
-    disableIMCP("disable-imcp",
-                cl::desc("Disable the intermodule constant propagation pass"),
-                cl::init(false), cl::Hidden, cl::cat(mainCategory));
+static cl::opt<bool> disableIMCP("disable-imcp",
+                                 cl::desc("Disable the IMCP pass"),
+                                 cl::init(false), cl::Hidden,
+                                 cl::cat(mainCategory));
 
 static cl::opt<bool>
     disableLowerMemory("disable-lower-memory",
@@ -285,10 +285,10 @@ static cl::opt<bool>
                            cl::desc("Disable the CheckCombCycles pass"),
                            cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
-static cl::opt<bool> disableIMDCE(
-    "disable-imdce",
-    cl::desc("Disable the inter-module dead code elimination pass"),
-    cl::init(false), cl::Hidden, cl::cat(mainCategory));
+static cl::opt<bool> disableIMDCE("disable-imdce",
+                                  cl::desc("Disable the IMDCE pass"),
+                                  cl::init(false), cl::Hidden,
+                                  cl::cat(mainCategory));
 
 static cl::opt<bool>
     disableMergeConnections("disable-merge-connections",

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -90,12 +90,13 @@ static cl::opt<bool>
                       cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool> disableOptimization("disable-opt",
-                                         cl::desc("disable optimizations"),
+                                         cl::desc("Disable optimizations"),
                                          cl::cat(mainCategory));
 
-static cl::opt<bool> inliner("inline",
-                             cl::desc("Run the FIRRTL module inliner"),
-                             cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool> disableInliner("disable-inliner",
+                                    cl::desc("Disable the module inliner"),
+                                    cl::init(false), cl::Hidden,
+                                    cl::cat(mainCategory));
 
 static cl::opt<bool> enableAnnotationWarning(
     "warn-on-unprocessed-annotations",
@@ -119,17 +120,17 @@ static cl::opt<bool> disableAnnotationsUnknown(
 
 static cl::opt<bool>
     emitMetadata("emit-metadata",
-                 cl::desc("emit metadata for metadata annotations"),
+                 cl::desc("Emit metadata for metadata annotations"),
                  cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool> emitOMIR("emit-omir",
-                              cl::desc("emit OMIR annotations to a JSON file"),
+                              cl::desc("Emit OMIR annotations to a JSON file"),
                               cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool> replSeqMem(
     "repl-seq-mem",
     cl::desc(
-        "replace the seq mem for macro replacement and emit relevant metadata"),
+        "Replace the seq mem for macro replacement and emit relevant metadata"),
     cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<circt::firrtl::PreserveAggregate::PreserveMode>
@@ -149,12 +150,12 @@ static cl::opt<circt::firrtl::PreserveAggregate::PreserveMode>
 
 static cl::opt<bool> preservePublicTypes(
     "preserve-public-types",
-    cl::desc("force to lower ports of toplevel and external modules"),
+    cl::desc("Force to lower ports of toplevel and external modules"),
     cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<firrtl::PreserveValues::PreserveMode>
     preserveMode("preserve-values",
-                 cl::desc("specify the values which can be optimized away"),
+                 cl::desc("Specify the values which can be optimized away"),
                  cl::values(clEnumValN(firrtl::PreserveValues::None, "none",
                                        "Preserve no values"),
                             clEnumValN(firrtl::PreserveValues::Named, "named",
@@ -165,143 +166,146 @@ static cl::opt<firrtl::PreserveValues::PreserveMode>
 
 static cl::opt<std::string>
     replSeqMemCircuit("repl-seq-mem-circuit",
-                      cl::desc("circuit root for seq mem metadata"),
+                      cl::desc("Circuit root for seq mem metadata"),
                       cl::init(""), cl::cat(mainCategory));
 
 static cl::opt<std::string>
     replSeqMemFile("repl-seq-mem-file",
-                   cl::desc("file name for seq mem metadata"), cl::init(""),
+                   cl::desc("File name for seq mem metadata"), cl::init(""),
                    cl::cat(mainCategory));
 
 static cl::opt<bool>
     ignoreReadEnableMem("ignore-read-enable-mem",
-                        cl::desc("ignore the read enable signal, instead of "
+                        cl::desc("Ignore the read enable signal, instead of "
                                  "assigning X on read disable"),
                         cl::init(false), cl::cat(mainCategory));
 
-static cl::opt<bool> imconstprop(
-    "imconstprop",
-    cl::desc(
-        "Enable intermodule constant propagation and dead code elimination"),
-    cl::init(true), cl::cat(mainCategory));
-
-static cl::opt<bool> lowerMemory("lower-memory",
-                                 cl::desc("run the lower-memory pass"),
-                                 cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool>
+    disableIMCP("disable-imcp",
+                cl::desc("Disable the intermodule constant propagation pass"),
+                cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
-    lowerTypes("lower-types",
-               cl::desc("run the lower-types pass within lower-to-hw"),
-               cl::init(true), cl::cat(mainCategory));
+    disableLowerMemory("disable-lower-memory",
+                       cl::desc("Disable the LowerMemory pass"),
+                       cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
-static cl::opt<bool> expandWhens("expand-whens",
-                                 cl::desc("disable the expand-whens pass"),
-                                 cl::init(true), cl::cat(mainCategory));
-
-static cl::opt<bool>
-    addSeqMemPorts("add-seqmem-ports",
-                   cl::desc("add user defined ports to sequential memories"),
-                   cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool> disableLowerTypes("disable-lower-types",
+                                       cl::desc("Disable the LowerTypes pass"),
+                                       cl::init(false), cl::Hidden,
+                                       cl::cat(mainCategory));
 
 static cl::opt<bool>
-    dedup("dedup", cl::desc("deduplicate structurally identical modules"),
+    disableExpandWhens("disable-expand-whens",
+                       cl::desc("Disable the ExpandWhens pass"),
+                       cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
+static cl::opt<bool>
+    disableAddSeqMemPorts("disable-add-seqmem-ports",
+                          cl::desc("Disable the AddSeqMemPorts pass"),
+                          cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
+static cl::opt<bool>
+    dedup("dedup", cl::desc("Deduplicate structurally identical modules"),
           cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool>
     ignoreFIRLocations("ignore-fir-locators",
-                       cl::desc("ignore the @info locations in the .fir file"),
+                       cl::desc("Ignore the @info locations in the .fir file"),
                        cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool>
-    lowerCHIRRTL("lower-chirrtl",
-                 cl::desc("lower CHIRRTL memories to FIRRTL memories"),
-                 cl::init(true), cl::cat(mainCategory));
+    disableLowerChirrtl("disable-lower-chirrtl",
+                        cl::desc("Disable the LowerCHIRRTL pass"),
+                        cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
-static cl::opt<bool> wireDFT("wire-dft", cl::desc("wire the DFT ports"),
-                             cl::init(true), cl::cat(mainCategory));
-
-static cl::opt<bool>
-    inferWidths("infer-widths",
-                cl::desc("run the width inference pass on firrtl"),
-                cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool> disableWireDFT("disable-wire-dft",
+                                    cl::desc("Disable the WireDFT pass"),
+                                    cl::init(false), cl::Hidden,
+                                    cl::cat(mainCategory));
 
 static cl::opt<bool>
-    inferResets("infer-resets",
-                cl::desc("run the reset inference pass on firrtl"),
-                cl::init(true), cl::cat(mainCategory));
+    disableInferWidths("disable-infer-widths",
+                       cl::desc("Disable the InferWidths pass"),
+                       cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
+static cl::opt<bool>
+    disableInferResets("disable-infer-resets",
+                       cl::desc("Disable the InferResets pass"),
+                       cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool> exportChiselInterface(
     "export-chisel-interface",
-    cl::desc("generate a Scala Chisel interface to the top level "
+    cl::desc("Generate a Scala Chisel interface to the top level "
              "module of the firrtl circuit"),
     cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<std::string> chiselInterfaceOutDirectory(
     "chisel-interface-out-dir",
-    cl::desc("the output directory for generated Chisel interface files"),
+    cl::desc("The output directory for generated Chisel interface files"),
     cl::init(""), cl::cat(mainCategory));
 
 static cl::opt<bool>
-    injectDUTHierarchy("inject-dut-hierarchy",
-                       cl::desc("add a level of hierarchy to the DUT"),
-                       cl::init(true), cl::cat(mainCategory));
+    disableInjectDutHierarchy("disable-inject-dut-hierarchy",
+                              cl::desc("Disable the InjectDutHierarchy pass"),
+                              cl::init(false), cl::Hidden,
+                              cl::cat(mainCategory));
 
 static cl::opt<bool>
-    extractInstances("extract-instances",
-                     cl::desc("extract black boxes, seq mems, and clock gates"),
-                     cl::init(true), cl::cat(mainCategory));
+    disableExtractInstances("disable-extract-instances",
+                            cl::desc("Disable the ExtractInstances pass"),
+                            cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
-    memToRegOfVec("mem-to-reg-of-vec",
-                  cl::desc("convert combinational memories to registers"),
-                  cl::init(true));
+    disableMemToRegOfVec("disable-mem-to-reg-of-vec",
+                         cl::desc("Disable the MemToRegOfVec pass"),
+                         cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
-    prefixModules("prefix-modules",
-                  cl::desc("prefix modules with NestedPrefixAnnotation"),
-                  cl::init(true), cl::cat(mainCategory));
+    disablePrefixModules("disable-prefix-modules",
+                         cl::desc("Disable the PrefixModules pass"),
+                         cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool> extractTestCode("extract-test-code",
-                                     cl::desc("run the extract test code pass"),
+                                     cl::desc("Run the extract test code pass"),
                                      cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool>
-    grandCentral("firrtl-grand-central",
-                 cl::desc("create interfaces and data/memory taps from SiFive "
-                          "Grand Central annotations"),
-                 cl::init(false), cl::cat(mainCategory));
+    disableGrandCentral("disable-grand-central",
+                        cl::desc("Disable the Grand Central passes"),
+                        cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool> exportModuleHierarchy(
     "export-module-hierarchy",
-    cl::desc("export module and instance hierarchy as JSON"), cl::init(false),
+    cl::desc("Export module and instance hierarchy as JSON"), cl::init(false),
     cl::cat(mainCategory));
 
 static cl::opt<bool>
-    checkCombCycles("firrtl-check-comb-cycles",
-                    cl::desc("check combinational cycles on firrtl"),
-                    cl::init(true), cl::cat(mainCategory));
+    disableCheckCombCycles("disable-check-comb-cycles",
+                           cl::desc("Disable the CheckCombCycles pass"),
+                           cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
+static cl::opt<bool> disableIMDCE(
+    "disable-imdce",
+    cl::desc("Disable the inter-module dead code elimination pass"),
+    cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
-    imdeadcodeelim("imdeadcodeelim",
-                   cl::desc("inter-module dead code elimination."),
-                   cl::init(true), cl::cat(mainCategory));
-
-static cl::opt<bool> mergeConnections(
-    "merge-connections",
-    cl::desc("merge field-level connections into full aggregate connections"),
-    cl::init(true), cl::cat(mainCategory));
+    disableMergeConnections("disable-merge-connections",
+                            cl::desc("Disable the MergeConnections pass"),
+                            cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
     mergeConnectionsAgggresively("merge-connections-aggressive-merging",
-                                 cl::desc("merge connections aggressively"),
+                                 cl::desc("Merge connections aggressively"),
                                  cl::init(false), cl::cat(mainCategory));
 
 /// Enable the pass to merge the read and write ports of a memory, if their
 /// enable conditions are mutually exclusive.
-static cl::opt<bool>
-    inferMemReadWrite("infer-rw",
-                      cl::desc("enable infer read write ports for memory"),
-                      cl::init(true), cl::cat(mainCategory));
+static cl::opt<bool> disableInferRW("disable-infer-rw",
+                                    cl::desc("Disable the InferRW pass"),
+                                    cl::init(false), cl::Hidden,
+                                    cl::cat(mainCategory));
 
 enum OutputFormatKind {
   OutputParseOnly,
@@ -345,7 +349,7 @@ static cl::list<std::string> inputOMIRFilenames(
     cl::CommaSeparated, cl::value_desc("filename"), cl::cat(mainCategory));
 
 static cl::opt<std::string>
-    omirOutFile("output-omir", cl::desc("file name for the output omir"),
+    omirOutFile("output-omir", cl::desc("File name for the output omir"),
                 cl::init(""), cl::cat(mainCategory));
 
 static cl::opt<std::string>
@@ -388,9 +392,9 @@ enum BuildMode { BuildModeDebug, BuildModeRelease };
 static cl::opt<BuildMode> buildMode(
     "O", cl::desc("Controls how much optimization should be performed"),
     cl::values(clEnumValN(BuildModeDebug, "debug",
-                          "compile with only necessary optimizations"),
+                          "Compile with only necessary optimizations"),
                clEnumValN(BuildModeRelease, "release",
-                          "compile with optimizations")),
+                          "Compile with optimizations")),
     cl::init(BuildModeRelease), cl::cat(mainCategory),
     cl::callback([](const BuildMode &buildMode) {
       switch (buildMode) {
@@ -560,23 +564,23 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createCSEPass());
 
-  if (injectDUTHierarchy)
+  if (!disableInjectDutHierarchy)
     pm.nest<firrtl::CircuitOp>().addPass(
         firrtl::createInjectDUTHierarchyPass());
 
-  if (lowerCHIRRTL)
+  if (!disableLowerChirrtl)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createLowerCHIRRTLPass());
 
   // Width inference creates canonicalization opportunities.
-  if (inferWidths)
+  if (!disableInferWidths)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
 
-  if (memToRegOfVec)
+  if (!disableMemToRegOfVec)
     pm.nest<firrtl::CircuitOp>().addPass(
         firrtl::createMemToRegOfVecPass(replSeqMem, ignoreReadEnableMem));
 
-  if (inferResets)
+  if (!disableInferResets)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());
 
   if (exportChiselInterface) {
@@ -591,26 +595,27 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization && dedup)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
-  if (wireDFT)
+  if (!disableWireDFT)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 
   if (replSeqMem)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createFlattenMemoryPass());
+
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.
-  if (lowerTypes) {
+  if (!disableLowerTypes) {
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
         preserveAggregate, preservePublicTypes));
     // Only enable expand whens if lower types is also enabled.
-    if (expandWhens) {
+    if (!disableExpandWhens) {
       auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
       modulePM.addPass(firrtl::createExpandWhensPass());
       modulePM.addPass(firrtl::createSFCCompatPass());
     }
   }
 
-  if (inliner)
+  if (!disableInliner)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInlinerPass());
 
   // Preset the random initialization parameters for each module. The current
@@ -620,7 +625,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createRandomizeRegisterInitPass());
 
-  if (checkCombCycles) {
+  if (!disableCheckCombCycles) {
     // TODO: Currently CheckCombCyles pass doesn't support aggregates so skip
     // the pass for now.
     if (preserveAggregate == firrtl::PreserveAggregate::None)
@@ -638,33 +643,33 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   // Run the infer-rw pass, which merges read and write ports of a memory with
   // mutually exclusive enables.
-  if (inferMemReadWrite)
+  if (!disableInferRW)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createInferReadWritePass());
 
-  if (replSeqMem && lowerMemory)
+  if (replSeqMem && !disableLowerMemory)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerMemoryPass());
 
-  if (prefixModules)
+  if (!disablePrefixModules)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createPrefixModulesPass());
 
-  if (imconstprop && !disableOptimization)
+  if (!disableIMCP && !disableOptimization)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
 
-  if (addSeqMemPorts)
+  if (!disableAddSeqMemPorts)
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 
   if (emitMetadata)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCreateSiFiveMetadataPass(
         replSeqMem, replSeqMemCircuit, replSeqMemFile));
 
-  if (extractInstances)
+  if (!disableExtractInstances)
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
 
   // Run passes to resolve Grand Central features.  This should run before
   // BlackBoxReader because Grand Central needs to inform BlackBoxReader where
   // certain black boxes should be placed.
-  if (grandCentral) {
+  if (!disableGrandCentral) {
     auto &circuitPM = pm.nest<firrtl::CircuitOp>();
     circuitPM.addPass(firrtl::createGrandCentralPass());
     circuitPM.addPass(firrtl::createGrandCentralTapsPass());
@@ -681,13 +686,14 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createDropNamesPass(preserveMode));
+
   // The above passes, IMConstProp in particular, introduce additional
   // canonicalization opportunities that we should pick up here before we
   // proceed to output-specific pipelines.
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
-    if (imdeadcodeelim)
+    if (!disableIMDCE)
       pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMDeadCodeElimPass());
   }
 
@@ -696,7 +702,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         firrtl::createEmitOMIRPass(omirOutFile));
 
   if (!disableOptimization &&
-      preserveAggregate != firrtl::PreserveAggregate::None && mergeConnections)
+      preserveAggregate != firrtl::PreserveAggregate::None &&
+      !disableMergeConnections)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createMergeConnectionsPass(mergeConnectionsAgggresively));
 


### PR DESCRIPTION
We have many flags which control whether or not we run a specific pass,
such as `--lower-types`.  Most of these flags should never be used by
regular firtool users; they are only really useful for circumventing a
crash in a pass and can often lead to other crashes.  This moves most of
the pass options to be of the form `--disable-mypass`, and makes them
 hidden by default.  The descriptions of these options were made
uniform, at the cost of a less detailed description.

The `GrandCentral` pass was enabled by default. Since its behavior is
controlled by annotations, it should always run.

This also did a small sweep to make sure that all our option
descriptions begin with a capital letter.