### PR TITLE
[FSMToSV] Copy constants into `fsm.machine`

### DIFF
--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -68,17 +68,15 @@ static void cloneConstantsIntoRegion(Region &region, OpBuilder &builder) {
   builder.setInsertionPointToStart(&region.front());
 
   // Clone ConstantLike operations into the region.
-  for (Value capture : captures) {
+  for (auto &capture : captures) {
     Operation *op = capture.getDefiningOp();
     if (!op || !op->hasTrait<OpTrait::ConstantLike>())
       continue;
 
     Operation *cloned = builder.clone(*op);
-    for (auto tuple : llvm::zip(op->getResults(), cloned->getResults())) {
-      Value orig = std::get<0>(tuple);
-      Value replacement = std::get<1>(tuple);
+    for (auto [orig, replacement] :
+         llvm::zip(op->getResults(), cloned->getResults()))
       replaceAllUsesInRegionWith(orig, replacement, region);
-    }
   }
 }
 

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/BackedgeBuilder.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <memory>
@@ -55,6 +56,30 @@ static ClkRstIdxs getMachinePortInfo(SmallVectorImpl<hw::PortInfo> &ports,
   specialPorts.resetIdx = reset.argNum;
 
   return specialPorts;
+}
+
+// Clones constants implicitly captured by the region, into the region.
+static void cloneConstantsIntoRegion(Region &region, OpBuilder &builder) {
+  // Values implicitly captured by the region.
+  llvm::SetVector<Value> captures;
+  getUsedValuesDefinedAbove(region, region, captures);
+
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(&region.front());
+
+  // Clone ConstantLike operations into the region.
+  for (Value capture : captures) {
+    Operation *op = capture.getDefiningOp();
+    if (!op || !op->hasTrait<OpTrait::ConstantLike>())
+      continue;
+
+    Operation *cloned = builder.clone(*op);
+    for (auto tuple : llvm::zip(op->getResults(), cloned->getResults())) {
+      Value orig = std::get<0>(tuple);
+      Value replacement = std::get<1>(tuple);
+      replaceAllUsesInRegionWith(orig, replacement, region);
+    }
+  }
 }
 
 namespace {
@@ -375,6 +400,10 @@ LogicalResult MachineOpConverter::dispatch() {
   auto loc = machineOp.getLoc();
   if (machineOp.getNumStates() < 2)
     return machineOp.emitOpError() << "expected at least 2 states.";
+
+  // Clone all referenced constants into the machine body - constants may have
+  // been moved to the machine parent due to the lack of IsolationFromAbove.
+  cloneConstantsIntoRegion(machineOp.getBody(), b);
 
   // 1) Get the port info of the machine and create a new HW module for it.
   SmallVector<hw::PortInfo, 16> ports;

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -150,3 +150,30 @@ module {
     fsm.state @B
   }
 }
+
+// -----
+
+// Test use of constants defined outside the machine. This is just a pass/fail
+// test - the verifier will complain if the constant is not defined within
+// the resulting hw.module.
+
+module {
+  %c0 = hw.constant 0 : i16
+  fsm.machine @M1() -> (i16) attributes {initialState = "A"} {
+    fsm.state @A output {
+      fsm.output %c0 : i16
+    }
+    fsm.state @B output {
+      fsm.output %c0 : i16
+    }
+  }
+
+  fsm.machine @M2() -> (i16) attributes {initialState = "A"} {
+    fsm.state @A output  {
+      fsm.output %c0 : i16
+    }
+    fsm.state @B output {
+      fsm.output %c0 : i16
+    }
+  }
+}


### PR DESCRIPTION
This fixes an error where constant operations would get lifted to the enclosing region (e.g. through canonicalization) due to the "lack" of `IsolatedFromAbove` trait in the `fsm.machine`.
This commit will copy any constants defined within the enclosing scope, fixing the immediate issue.