### PR TITLE
[FIRRTL] Invalidate registers in the parser

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2754,9 +2754,12 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
     result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
                                         id, NameKindEnum::InterestingName,
                                         annotations, sym);
-  else
+  else {
     result = builder.create<RegOp>(
         type, clock, id, NameKindEnum::InterestingName, annotations, sym);
+    // Emit an implicit invalid connection to align with SFC's behavior.
+    emitInvalidate(result);
+  }
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -332,6 +332,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %_t_2622 = firrtl.reg interesting_name %clock : !firrtl.uint<4>
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
+    ; CHECK:  firrtl.strictconnect %_t_2622, %invalid_ui4 : !firrtl.uint<4>
 
     ; CHECK: %xyz_in = firrtl.instance xyz interesting_name @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit


### PR DESCRIPTION
This commit adds an emission of implicit invalidation of registers in the parser. 