### PR TITLE
[SystemC] Add DestructorOp and some helper functions

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -96,6 +96,14 @@ def SCModuleOp : SystemCOp<"module", [
     PortDirectionRange getInOutPorts() {
       return getPortsOfDirection(hw::PortDirection::INOUT);
     }
+
+    // Return the Ctor operation in this module's body or create one if none
+    // exists yet.
+    systemc::CtorOp getOrCreateCtor();
+
+    // Return the Destructor operation in this module's body or create one if
+    // none exists yet.
+    systemc::DestructorOp getOrCreateDestructor();
   }];
 }
 
@@ -109,7 +117,7 @@ def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator,
   }];
 
   let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = "$body attr-dict";
+  let assemblyFormat = "attr-dict-with-keyword $body";
 
   let builders = [
     OpBuilder<(ins), [{
@@ -118,6 +126,11 @@ def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator,
     }]>
   ];
 
+  let extraClassDeclaration = [{
+    /// Return the block corresponding to the region.
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
+
   let hasVerifier = true;
   let skipDefaultBuilders = 1;
 }
@@ -125,6 +138,7 @@ def CtorOp : SystemCOp<"ctor", [SingleBlock, NoTerminator,
 def SCFuncOp : SystemCOp<"func", [
   HasCustomSSAName,
   SystemCNameDeclOpInterface,
+  SingleBlock,
   NoTerminator,
   HasParent<"SCModuleOp">
 ]> {
@@ -149,7 +163,48 @@ def SCFuncOp : SystemCOp<"func", [
     }]>
   ];
 
-  let assemblyFormat = "custom<ImplicitSSAName>($name) $body attr-dict";
+  let extraClassDeclaration = [{
+    /// Return the block corresponding to the region.
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
+
+  let assemblyFormat = "custom<ImplicitSSAName>($name) attr-dict-with-keyword $body";
+
+  let hasVerifier = true;
+  let skipDefaultBuilders = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// 
+//===----------------------------------------------------------------------===//
+
+def DestructorOp : SystemCOp<"cpp.destructor", [
+    SingleBlock,
+    NoTerminator,
+    HasParent<"SCModuleOp">
+]> {
+  let summary = "A C++ destructor definition.";
+  let description = [{
+    This operation models a C++ destructor of a class or struct. It is not an
+    operation modelling some abstract SystemC construct, but still required to
+    support more complex functionality such as having a pointer to an external
+    object inside a SystemC module, e.g., for interoperability purposes.
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "attr-dict-with-keyword $body";
+
+  let builders = [
+    OpBuilder<(ins), [{
+      Region *region = $_state.addRegion();
+      region->push_back(new Block);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the block corresponding to the region.
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
 
   let hasVerifier = true;
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -175,7 +175,7 @@ def SCFuncOp : SystemCOp<"func", [
 }
 
 //===----------------------------------------------------------------------===//
-// 
+// Operations that model C++-level features.
 //===----------------------------------------------------------------------===//
 
 def DestructorOp : SystemCOp<"cpp.destructor", [

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -293,7 +293,13 @@ LogicalResult SCModuleOp::verifyRegions() {
 
 CtorOp SCModuleOp::getOrCreateCtor() {
   CtorOp ctor;
-  getBody().walk([&](CtorOp op) { ctor = op; });
+  getBody().walk([&](Operation *op) {
+    if ((ctor = dyn_cast<CtorOp>(op)))
+      return WalkResult::interrupt();
+
+    return WalkResult::skip();
+  });
+
   if (ctor)
     return ctor;
 
@@ -302,7 +308,13 @@ CtorOp SCModuleOp::getOrCreateCtor() {
 
 DestructorOp SCModuleOp::getOrCreateDestructor() {
   DestructorOp destructor;
-  getBody().walk([&](DestructorOp op) { destructor = op; });
+  getBody().walk([&](Operation *op) {
+    if ((destructor = dyn_cast<DestructorOp>(op)))
+      return WalkResult::interrupt();
+
+    return WalkResult::skip();
+  });
+
   if (destructor)
     return destructor;
 

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -291,6 +291,24 @@ LogicalResult SCModuleOp::verifyRegions() {
   return success();
 }
 
+CtorOp SCModuleOp::getOrCreateCtor() {
+  CtorOp ctor;
+  getBody().walk([&](CtorOp op) { ctor = op; });
+  if (ctor)
+    return ctor;
+
+  return OpBuilder(getBody()).create<CtorOp>(getLoc());
+}
+
+DestructorOp SCModuleOp::getOrCreateDestructor() {
+  DestructorOp destructor;
+  getBody().walk([&](DestructorOp op) { destructor = op; });
+  if (destructor)
+    return destructor;
+
+  return OpBuilder::atBlockEnd(getBodyBlock()).create<DestructorOp>(getLoc());
+}
+
 //===----------------------------------------------------------------------===//
 // SignalOp
 //===----------------------------------------------------------------------===//
@@ -319,6 +337,17 @@ void SCFuncOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 LogicalResult SCFuncOp::verify() {
+  if (getBody().getNumArguments() != 0)
+    return emitOpError("must not have any arguments");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DestructorOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult DestructorOp::verify() {
   if (getBody().getNumArguments() != 0)
     return emitOpError("must not have any arguments");
 

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -107,6 +107,15 @@ systemc.module @ctorNoBlockArguments () {
 
 // -----
 
+systemc.module @destructorNoBlockArguments () {
+  // expected-error @+1 {{op must not have any arguments}} 
+  "systemc.cpp.destructor"() ({
+    ^bb0(%arg0: i32):
+    }) : () -> ()
+}
+
+// -----
+
 systemc.module @funcNoBlockArguments () {
   // expected-error @+1 {{op must not have any arguments}} 
   %0 = "systemc.func"() ({

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -22,6 +22,9 @@ systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32
     systemc.signal.write %sum, %res : !systemc.out<i32>
   // CHECK-NEXT: }
   }
+  // CHECK-NEXT: systemc.cpp.destructor {
+  systemc.cpp.destructor { }
+  // CHECK-NEXT: }
 // CHECK-NEXT: }
 }
 
@@ -63,3 +66,16 @@ systemc.module @argAttrs (%port0: !systemc.in<i32> {hw.attrname = "sometext"}, %
 
 // CHECK-LABEL: systemc.module @resultAttrs (%port0: !systemc.in<i32>, %out0: !systemc.out<i32> {hw.attrname = "sometext"})
 systemc.module @resultAttrs (%port0: !systemc.in<i32>, %out0: !systemc.out<i32> {hw.attrname = "sometext"}) {}
+
+// CHECK-LABEL: systemc.module @attributes
+systemc.module @attributes () {
+  // CHECK-NEXT: systemc.ctor attributes {systemc.someattr = 0 : i64} {
+  systemc.ctor attributes {systemc.someattr = 0 : i64} {}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: %func = systemc.func attributes {systemc.someattr = 0 : i64} {
+  %func = systemc.func attributes {systemc.someattr = 0 : i64} {}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: systemc.cpp.destructor attributes {systemc.someattr = 0 : i64} {
+  systemc.cpp.destructor attributes {systemc.someattr = 0 : i64} {}
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
Add an operation to model a C++ destructor that is required to deallocate objects such as a verilated model stored as a pointer that is allocated in the SC_CTOR body.
Also adds a helper function to get the body block more easily and one to the SC_MODULE to get the destructor inside or lazily create one if it does not exist yet. The same helpers are added for the Ctor operation.

Additionally, switch to `attr-dict-with-keyword` to have the attributes before the region for `ctor`, `func`, and `cpp.destructor`.