### PR TITLE
[SystemC] Add NewOp and DeleteOp

### DIFF
--- a/include/circt/Dialect/SystemC/SystemC.td
+++ b/include/circt/Dialect/SystemC/SystemC.td
@@ -26,6 +26,9 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "circt/Dialect/SystemC/SystemCOpInterfaces.td"
 include "circt/Dialect/SystemC/SystemCDialect.td"
 
+// Import EmitC types
+include "mlir/Dialect/EmitC/IR/EmitCTypes.td"
+
 // Base class for the operations in this dialect.
 class SystemCOp<string mnemonic, list<Trait> traits = []> :
   Op<SystemCDialect, mnemonic, traits>;

--- a/include/circt/Dialect/SystemC/SystemCExpressions.td
+++ b/include/circt/Dialect/SystemC/SystemCExpressions.td
@@ -38,3 +38,24 @@ def SignalReadOp : SystemCOp<"signal.read", [NoSideEffect,
     }
   }];
 }
+
+//===----------------------------------------------------------------------===//
+// Operations that model C++-level features.
+//===----------------------------------------------------------------------===//
+
+def NewOp : SystemCOp<"cpp.new", [NoSideEffect]> {
+  let summary = "A C++ 'new' expression.";
+  let description = [{
+    Creates and initializes C++ objects using dynamic storage.
+    Note that the types of the constructor arguments are not verified in any way
+    w.r.t. the result's type because it is allowed to use an opaque type for the
+    pointee.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$args);
+  let results = (outs EmitC_PointerType:$result);
+
+  let assemblyFormat = [{
+    `(` $args `)` attr-dict `:` functional-type($args, $result)
+  }];
+}

--- a/include/circt/Dialect/SystemC/SystemCOps.h
+++ b/include/circt/Dialect/SystemC/SystemCOps.h
@@ -19,6 +19,7 @@
 #include "circt/Dialect/SystemC/SystemCOpInterfaces.h"
 #include "circt/Dialect/SystemC/SystemCTypes.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/Interfaces/CallInterfaces.h"

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -64,3 +64,18 @@ def ThreadOp : SystemCOp<"thread", []> {
   let arguments = (ins NullaryVoidFunctionType:$funcHandle);
   let assemblyFormat = "$funcHandle attr-dict";
 }
+
+//===----------------------------------------------------------------------===//
+// Operations that model C++-level features.
+//===----------------------------------------------------------------------===//
+
+def DeleteOp : SystemCOp<"cpp.delete", []> {
+  let summary = "A C++ delete expression.";
+  let description = [{
+    Destroys objects previously allocated by the new expression and releases
+    the allocated memory.
+  }];
+
+  let arguments = (ins EmitC_PointerType:$pointer);
+  let assemblyFormat = "$pointer attr-dict `:` qualified(type($pointer))";
+}

--- a/lib/Dialect/SystemC/CMakeLists.txt
+++ b/lib/Dialect/SystemC/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTSystemC
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface
+  MLIREmitCDialect
   CIRCTHW
 )
 

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -23,8 +23,15 @@ systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32
   // CHECK-NEXT: }
   }
   // CHECK-NEXT: systemc.cpp.destructor {
-  systemc.cpp.destructor { }
+  systemc.cpp.destructor {
+    // CHECK-NEXT: [[PTR:%.+]] = systemc.cpp.new(%summand_a, %summand_b) : (!systemc.in<i32>, !systemc.in<i32>) -> !emitc.ptr<!emitc.opaque<"someclass">>
+    %0 = systemc.cpp.new(%summand_a, %summand_b) : (!systemc.in<i32>, !systemc.in<i32>) -> !emitc.ptr<!emitc.opaque<"someclass">>
+    // CHECK-NEXT: systemc.cpp.delete [[PTR]] : !emitc.ptr<!emitc.opaque<"someclass">>
+    systemc.cpp.delete %0 : !emitc.ptr<!emitc.opaque<"someclass">>
+    // CHECK-NEXT: systemc.cpp.new() : () -> !emitc.ptr<!emitc.opaque<"someclass">>
+    %1 = systemc.cpp.new() : () -> !emitc.ptr<!emitc.opaque<"someclass">>
   // CHECK-NEXT: }
+  }
 // CHECK-NEXT: }
 }
 

--- a/test/circt-opt/commandline.mlir
+++ b/test/circt-opt/commandline.mlir
@@ -11,6 +11,7 @@
 // DIALECT-NEXT: cf
 // DIALECT-NEXT: chirrtl
 // DIALECT-NEXT: comb
+// DIALECT-NEXT: emitc
 // DIALECT-NEXT: esi
 // DIALECT-NEXT: firrtl
 // DIALECT-NEXT: fsm

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -66,4 +66,5 @@ target_link_libraries(circt-opt
   MLIRSupport
   MLIRTransforms
   MLIRSCFDialect
+  MLIREmitCDialect
 )

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -44,6 +45,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::arith::ArithmeticDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
+  registry.insert<mlir::emitc::EmitCDialect>();
 
   circt::registerAllDialects(registry);
   circt::registerAllPasses();


### PR DESCRIPTION
Also adds a dependency on the EmitC dialect to reuse the pointer and opaque types.