### PR TITLE
[HW] Expose `appendOutputs` in the HWMutableModuleLike interface.

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -115,6 +115,16 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
     /*defaultImplementation=*/[{
       $_op.modifyPorts({}, {}, eraseInputs, eraseOutputs);
     }]>,
+
+    /// Appends output ports to the module with the specified names and rewrites
+    /// the output op to return the associated values.
+    InterfaceMethod<"Append output values to this module",
+    "void", "appendOutputs", (ins
+      "ArrayRef<std::pair<StringAttr, Value>>":$outputs),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return;
+    }]>
   ];
 }
 

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -120,11 +120,7 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
     /// the output op to return the associated values.
     InterfaceMethod<"Append output values to this module",
     "void", "appendOutputs", (ins
-      "ArrayRef<std::pair<StringAttr, Value>>":$outputs),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return;
-    }]>
+      "ArrayRef<std::pair<StringAttr, Value>>":$outputs)>
   ];
 }
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -97,10 +97,6 @@ def HWModuleOp : HWModuleOpBase<"module",
     void insertOutputs(unsigned index,
                        ArrayRef<std::pair<StringAttr, Value>> outputs);
 
-    /// Appends output ports to the module with the specified names and
-    /// rewrites the output op to return the associated values.
-    void appendOutputs(ArrayRef<std::pair<StringAttr, Value>> outputs);
-
     // TODO(mlir): FunctionLike shouldn't produce a getBody() helper, it is
     // squatting on the name.
     Block *getBodyBlock() { return &getBody().front(); }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -628,6 +628,9 @@ void HWModuleExternOp::modifyPorts(
                         eraseOutputs);
 }
 
+void HWModuleExternOp::appendOutputs(
+    ArrayRef<std::pair<StringAttr, Value>> outputs) {}
+
 void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
                                 FlatSymbolRefAttr genKind, StringAttr name,
                                 const ModulePortInfo &ports,
@@ -655,6 +658,9 @@ void HWModuleGeneratedOp::modifyPorts(
   hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
                         eraseOutputs);
 }
+
+void HWModuleGeneratedOp::appendOutputs(
+    ArrayRef<std::pair<StringAttr, Value>> outputs) {}
 
 /// Return an encapsulated set of information about input and output ports of
 /// the specified module or instance.  The input ports always come before the

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -589,6 +589,11 @@ void MSFTModuleOp::modifyPorts(
                         eraseOutputs);
 }
 
+void MSFTModuleOp::appendOutputs(
+    ArrayRef<std::pair<StringAttr, Value>> outputs) {
+  addPorts({}, outputs);
+}
+
 void MSFTModuleOp::build(OpBuilder &builder, OperationState &result,
                          StringAttr name, hw::ModulePortInfo ports,
                          ArrayRef<NamedAttribute> params) {


### PR DESCRIPTION
This is a useful piece of generic functionality to be able to add
output values to modules implementing the interface. It is
complementary to the modifyPorts methods that update the module
boundary with new Types. After adding new outputs, it will usually be
necessary to specify which Values should appear on those outputs, and
this additional method makes it possible to do generically. The
default implementation is a no-op, so HWModuleExtern and
HWModuleGenerated will not need to do anything. The implementation on
HWModule overrides this default with the existing behavior.

Closes https://github.com/llvm/circt/issues/3791