### PR TITLE
[FIRRTL] Draft PR of changes to Grand Central taps

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -110,10 +110,14 @@ constexpr const char *dataTapsBlackboxClass =
     "sifive.enterprise.grandcentral.DataTapsAnnotation.blackbox"; // not in SFC
 constexpr const char *memTapClass =
     "sifive.enterprise.grandcentral.MemTapAnnotation";
+// TODO Delete this
 constexpr const char *memTapBlackboxClass =
     "sifive.enterprise.grandcentral.MemTapAnnotation.blackbox"; // not in SFC
+// TODO Delete this
 constexpr const char *memTapPortClass =
     "sifive.enterprise.grandcentral.MemTapAnnotation.port"; // not in SFC
+constexpr const char *memTapWireClass =
+    "sifive.enterprise.grandcentral.MemTapAnnotation.wire"; // not in SFC
 constexpr const char *memTapSourceClass =
     "sifive.enterprise.grandcentral.MemTapAnnotation.source"; // not in SFC
 constexpr const char *deletedKeyClass =

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -105,6 +105,7 @@ constexpr const char *augmentedBundleTypeClass =
     "sifive.enterprise.grandcentral.AugmentedBundleType"; // not an annotation
 constexpr const char *dataTapsClass =
     "sifive.enterprise.grandcentral.DataTapsAnnotation";
+// TODO Delete this
 constexpr const char *dataTapsBlackboxClass =
     "sifive.enterprise.grandcentral.DataTapsAnnotation.blackbox"; // not in SFC
 constexpr const char *memTapClass =
@@ -121,6 +122,9 @@ constexpr const char *literalKeyClass =
     "sifive.enterprise.grandcentral.LiteralDataTapKey";
 constexpr const char *referenceKeyClass =
     "sifive.enterprise.grandcentral.ReferenceDataTapKey";
+constexpr const char *referenceKeyWireClass =
+    "sifive.enterprise.grandcentral.ReferenceDataTapKey.wire"; // not in SFC
+// TODO Delete this
 constexpr const char *referenceKeyPortClass =
     "sifive.enterprise.grandcentral.ReferenceDataTapKey.port"; // not in SFC
 constexpr const char *referenceKeySourceClass =

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -320,8 +320,7 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
     // Grand Central Mem Tap Annotations
     {memTapClass, {noResolve, applyGCTMemTaps}},
     {memTapSourceClass, {stdResolve, applyWithoutTarget<true>}},
-    {memTapPortClass, {stdResolve, applyWithoutTarget<true>}},
-    {memTapBlackboxClass, {stdResolve, applyWithoutTarget<true>}},
+    {memTapWireClass, {stdResolve, applyWithoutTarget<true>}},
     // Grand Central Signal Mapping Annotations
     {signalDriverAnnoClass, {noResolve, applyGCTSignalMappings}},
     {signalDriverTargetAnnoClass, {stdResolve, applyWithoutTarget<true>}},

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -310,7 +310,9 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
     {dataTapsClass, {noResolve, applyGCTDataTaps}},
     {dataTapsBlackboxClass, {stdResolve, applyWithoutTarget<true>}},
     {referenceKeySourceClass, {stdResolve, applyWithoutTarget<true>}},
-    {referenceKeyPortClass, {stdResolve, applyWithoutTarget<true>}},
+    {referenceKeyWireClass,
+     {stdResolve,
+      applyWithoutTarget<false, WireOp>}}, // this may need to be true
     {internalKeySourceClass, {stdResolve, applyWithoutTarget<true>}},
     {internalKeyPortClass, {stdResolve, applyWithoutTarget<true>}},
     {deletedKeyClass, {stdResolve, applyWithoutTarget<true>}},

--- a/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
@@ -1,0 +1,26 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit ConstantSinking : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~ConstantSinking|ConstantSinking>w",
+        "wireName": "~ConstantSinking|ConstantSinking>t"
+      }
+    ]
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~ConstantSinking|ConstantSinking>t"
+  }
+]]
+  module ConstantSinking:
+    output out : UInt<1>
+    wire t : UInt<1>
+    out <= t
+    t is invalid
+    node w = UInt<1>(1)
+
+; CHECK: assign t = 1'h1;

--- a/test/Dialect/FIRRTL/SFCTests/lots-of-xmr-data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/lots-of-xmr-data-taps.fir
@@ -1,0 +1,260 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|Submodule>tap_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|Submodule>tap_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|Submodule>tap_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|Submodule>tap_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|Submodule>tap_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|Submodule>tap_5"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|DUT>tap_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|DUT>tap_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|DUT>tap_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|DUT>tap_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|DUT>tap_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|DUT>tap_5"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap_Top",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|Top>tap[0]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|Top>tap[1]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|Top>tap[2]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|Top>tap[3]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|Top>tap[4]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|Top>tap[5]"
+      }
+    ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_0"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_1"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_3"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_4"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_5"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_0"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_1"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_3"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_4"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_5"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap"
+  }
+]]
+  module Submodule :
+    output port_Submodule: UInt<1>
+    port_Submodule is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_Submodule: UInt<1>
+    wire_Submodule <= inv
+
+    wire tap_0 : UInt<1>
+    wire tap_1 : UInt<1>
+    wire tap_2 : UInt<1>
+    wire tap_3 : UInt<1>
+    wire tap_4 : UInt<1>
+    wire tap_5 : UInt<1>
+    tap_0 is invalid
+    tap_1 is invalid
+    tap_2 is invalid
+    tap_3 is invalid
+    tap_4 is invalid
+    tap_5 is invalid
+
+  module DUT :
+    output port_DUT: UInt<1>
+    port_DUT is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_DUT: UInt<1>
+    wire_DUT <= inv
+
+    inst submodule of Submodule
+
+    wire tap_0 : UInt<1>
+    wire tap_1 : UInt<1>
+    wire tap_2 : UInt<1>
+    wire tap_3 : UInt<1>
+    wire tap_4 : UInt<1>
+    wire tap_5 : UInt<1>
+    tap_0 is invalid
+    tap_1 is invalid
+    tap_2 is invalid
+    tap_3 is invalid
+    tap_4 is invalid
+    tap_5 is invalid
+
+  module Top :
+    output port_Top : UInt<1>
+    port_Top is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_Top: UInt<1>
+    wire_Top <= inv
+
+    inst dut of DUT
+    wire tap : UInt<1>[6]
+    tap is invalid
+
+    ; CHECK:      module Submodule
+    ; CHECK:      assign tap_0 = Submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_3 = Submodule.port_Submodule
+    ; CHECK-NEXT: assign tap_4 = DUT.port_DUT
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
+
+    ; CHECK: module DUT
+    ; CHECK:      assign tap_0 = DUT.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_3 = DUT.submodule.port_Submodule
+    ; CHECK-NEXT: assign tap_4 = DUT.port_DUT
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
+
+    ; CHECK: module Top
+    ; CHECK:      assign tap_0 = Top.dut.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = Top.dut.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_3 = Top.dut.submodule.port_Submodule
+    ; CHECK-NEXT: assign tap_4 = Top.dut.port_DUT
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
+

--- a/test/Dialect/FIRRTL/SFCTests/memtaps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/memtaps.fir
@@ -1,0 +1,60 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Top|Top>memTap"
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
+    "source":"~Top|DUTModule>rf",
+    "wireName":[
+      "~Top|Top>memTap[0]",
+      "~Top|Top>memTap[1]",
+      "~Top|Top>memTap[2]",
+      "~Top|Top>memTap[3]",
+      "~Top|Top>memTap[4]",
+      "~Top|Top>memTap[5]",
+      "~Top|Top>memTap[6]",
+      "~Top|Top>memTap[7]"
+    ]
+  }
+]]
+  module DUTModule :
+    input clock : Clock
+    input reset : Reset
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    cmem rf : UInt<8> [8]
+    infer mport read = rf[io.addr], clock
+    io.dataOut <= read
+    when io.wen :
+      infer mport write = rf[io.addr], clock
+      write <= io.dataIn
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    inst dut of DUTModule
+    dut.clock <= clock
+    dut.reset <= reset
+    wire memTap : UInt<8>[8]
+    memTap is invalid
+    io.dataOut <= dut.io.dataOut
+    dut.io.wen <= io.wen
+    dut.io.dataIn <= io.dataIn
+    dut.io.addr <= io.addr
+
+; CHECK:      module Top(
+; CHECK-NOT:  module
+; CHECK:        assign memTap_0 = dut.rf[0];
+; CHECK-NEXT:   assign memTap_1 = dut.rf[1];
+; CHECK-NEXT:   assign memTap_2 = dut.rf[2];
+; CHECK-NEXT:   assign memTap_3 = dut.rf[3];
+; CHECK-NEXT:   assign memTap_4 = dut.rf[4];
+; CHECK-NEXT:   assign memTap_5 = dut.rf[5];
+; CHECK-NEXT:   assign memTap_6 = dut.rf[6];
+; CHECK-NEXT:   assign memTap_7 = dut.rf[7];
+; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/SFCTests/xmr-data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/xmr-data-taps.fir
@@ -1,0 +1,53 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~Top|Top/foo:Foo/b:Bar>inv",
+        "wireName": "~Top|Top>tap"
+      }
+    ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Bar>inv"
+  }
+]]
+  module Bar :
+    input in : UInt<1>
+    output out : UInt<1>
+    wire inv : UInt<1>
+    inv <= not(in)
+    out <= inv
+
+  module Foo :
+    input in : UInt<1>
+    output out : UInt<1>
+
+    inst b of Bar
+    b.in <= in
+    out <= b.out
+
+  module Top:
+    input in : UInt<1>
+    output out : UInt<1>
+
+    inst foo of Foo
+    foo.in <= in
+    out <= foo.out
+
+    wire tap : UInt<1>
+    tap is invalid
+
+; CHECK: module Top(
+; CHECK-NOT: module
+; CHECK:   assign tap = Top.foo.b.inv;
+; CHECK: endmodule
+


### PR DESCRIPTION
This is my work-in-progress for changing the Grand Central taps and memtaps annotations to no longer rely on using FIRRTL extmodules but instead just annotate the source of the XMR and the sink (called `wireName` at the moment but it would probably be better to just call this `sink`).

This work is incomplete, I'm PRing it to make it easier to collaborate with @prithayan since we may just ditch the old implementation of Grand Central taps in favor of the new FIRRTL XMR support that @prithayan has been working on.