### PR TITLE
[FIRRTL] Improved code generation for register initialization

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -95,7 +95,30 @@ def MacroRefExprOp : SVOp<"macro.ref", [NoSideEffect, HasCustomSSAName]> {
   let arguments = (ins MacroIdentAttr:$ident);
   let results = (outs HWValueOrInOutType:$result);
 
-  let assemblyFormat = "`<` $ident `>` attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "`<` $ident `>` attr-dict `:` type($result)";
+
+  let builders = [
+    OpBuilder<(ins "Type":$resultType, "StringRef":$ident),
+               "build(odsBuilder, odsState, resultType, "
+                 "::circt::sv::MacroIdentAttr::get("
+                   "$_builder.getContext(), ident));">
+  ];
+}
+
+def MacroRefExprSEOp : SVOp<"macro.ref.se", [HasCustomSSAName]> {
+  let summary = "Expression to refer to a SystemVerilog macro";
+  let description = [{
+    This operation produces a value by referencing a named macro.
+
+    Presently, it is assumed that the referenced macro is not constant and has
+    side effects.  This expression is not subject to CSE.  It can not be
+    duplicated, but can be emitted inline by the Verilog emitter.
+    }];
+
+  let arguments = (ins MacroIdentAttr:$ident);
+  let results = (outs HWValueOrInOutType:$result);
+
+  let assemblyFormat = "`<` $ident `>` attr-dict `:` type($result)";
 
   let builders = [
     OpBuilder<(ins "Type":$resultType, "StringRef":$ident),

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -30,7 +30,7 @@ public:
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
-            ConstantXOp, ConstantZOp, MacroRefExprOp,
+            ConstantXOp, ConstantZOp, MacroRefExprOp, MacroRefExprSEOp,
             // Declarations.
             RegOp, WireOp, LogicOp, LocalParamOp, XMROp,
             // Control flow.
@@ -98,6 +98,7 @@ public:
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
   HANDLE(MacroRefExprOp, Unhandled);
+  HANDLE(MacroRefExprSEOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1530,7 +1530,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   if (expr.getOpcode() == PEO::StrConcat)
     os << '{';
   bool allOperandsSigned = emitOperand(expr.getOperands()[0]);
-  for (auto op : ArrayRef(expr.getOperands()).drop_front()) {
+  for (auto op : expr.getOperands().drop_front()) {
     // Handle the special case of (a + b + -42) as (a + b - 42).
     // TODO: Also handle (a + b + x*-1).
     if (expr.getOpcode() == PEO::Add) {
@@ -2571,7 +2571,7 @@ void NameCollector::collectNames(Block &block) {
     // Recursively process any regions under the op iff this is a procedural
     // #ifdef region: we need to emit automatic logic values at the top of the
     // enclosing region.
-    if (isa<IfDefProceduralOp>(op)) {
+    if (isa<IfDefProceduralOp, OrderedOutputOp>(op)) {
       for (auto &region : op.getRegions()) {
         if (!region.empty())
           collectNames(region.front());

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1672,6 +1672,7 @@ private:
     return visitVerbatimExprOp(op, op.getSymbols());
   }
   SubExprInfo visitSV(MacroRefExprOp op);
+  SubExprInfo visitSV(MacroRefExprSEOp op);
   SubExprInfo visitSV(ConstantXOp op);
   SubExprInfo visitSV(ConstantZOp op);
 
@@ -2167,6 +2168,14 @@ SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
 }
 
 SubExprInfo ExprEmitter::visitSV(MacroRefExprOp op) {
+  if (hasSVAttributes(op))
+    emitError(op, "SV attributes emission is unimplemented for the op");
+
+  os << "`" << op.getIdent().getName();
+  return {LowestPrecedence, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(MacroRefExprSEOp op) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 

--- a/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
@@ -45,11 +45,8 @@ std::unique_ptr<mlir::Pass> circt::firrtl::createRandomizeRegisterInitPass() {
 static void createRandomizationAttributes(FModuleOp mod) {
   OpBuilder builder(mod);
 
-  // Set a maximum width for any single register, based on Verilog 1364-2005.
-  constexpr uint64_t maxRegisterWidth = 65536;
-
   // Walk all registers.
-  uint64_t currentRegister = 0;
+  uint64_t currentWidth = 0;
   SmallDenseMap<uint64_t, uint64_t> widths;
   auto ui64Type = builder.getIntegerType(64, false);
   mod.walk([&](Operation *op) {
@@ -62,41 +59,11 @@ static void createRandomizationAttributes(FModuleOp mod) {
     Optional<int64_t> regWidth = getBitWidth(regType);
     assert(regWidth.has_value() && "register must have a valid FIRRTL width");
 
-    auto currentWidth = widths[currentRegister];
-
-    // If the current register width is non-zero, and the current width plus the
-    // size of the next register exceeds the limit, spill over to a new
-    // register. Note that if a single register exceeds the limit, this will
-    // still happily emit a single random initialization register that also
-    // exceeds the limit.
-    if (currentWidth > 0 &&
-        currentWidth + regWidth.value() > maxRegisterWidth) {
-      ++currentRegister;
-      currentWidth = widths[currentRegister];
-    }
-
     auto start = builder.getIntegerAttr(ui64Type, currentWidth);
-    auto end =
-        builder.getIntegerAttr(ui64Type, currentWidth + regWidth.value() - 1);
-    op->setAttr("firrtl.random_init_register",
-                builder.getStringAttr(Twine(currentRegister)));
     op->setAttr("firrtl.random_init_start", start);
-    op->setAttr("firrtl.random_init_end", end);
 
-    widths[currentRegister] += regWidth.value();
+    currentWidth += regWidth.value();
   });
-
-  // Remember the width of the random vector in the module's attributes so
-  // LowerSeqToSV can grab it to create the appropriate random register.
-  if (!widths.empty()) {
-    SmallVector<NamedAttribute> widthDictionary;
-    for (auto [registerIndex, registerWidth] : widths)
-      widthDictionary.emplace_back(
-          builder.getStringAttr(Twine(registerIndex)),
-          builder.getIntegerAttr(ui64Type, registerWidth));
-    mod->setAttr("firrtl.random_init_width",
-                 builder.getDictionaryAttr(widthDictionary));
-  }
 }
 
 void RandomizeRegisterInitPass::runOnOperation() {

--- a/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
@@ -47,7 +47,6 @@ static void createRandomizationAttributes(FModuleOp mod) {
 
   // Walk all registers.
   uint64_t currentWidth = 0;
-  SmallDenseMap<uint64_t, uint64_t> widths;
   auto ui64Type = builder.getIntegerType(64, false);
   mod.walk([&](Operation *op) {
     if (!isa<RegOp, RegResetOp>(op))

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -31,8 +31,8 @@ using mlir::TypedAttr;
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
   return isa<VerbatimExprOp, VerbatimExprSEOp, GetModportOp,
-             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp>(
-      op);
+             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp,
+             MacroRefExprSEOp>(op);
 }
 
 LogicalResult sv::verifyInProceduralRegion(Operation *op) {
@@ -173,6 +173,11 @@ void VerbatimExprSEOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 
 void MacroRefExprOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), getIdent().getName());
+}
+
+void MacroRefExprSEOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), getIdent().getName());
 }
@@ -1609,7 +1614,7 @@ ParseResult parseXMRPath(::mlir::OpAsmParser &parser, ArrayAttr &pathAttr,
   });
   if (succeeded(ret)) {
     pathAttr = parser.getBuilder().getArrayAttr(
-        ArrayRef(strings.begin(), strings.end() - 1));
+        ArrayRef<Attribute>(strings).drop_back());
     terminalAttr = (*strings.rbegin()).cast<StringAttr>();
   }
   return ret;

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -248,7 +248,7 @@ FirRegLower::RegLowerInfo FirRegLower::lower(FirRegOp reg) {
 
   ImplicitLocOpBuilder builder(reg.getLoc(), reg);
   RegLowerInfo svReg{nullptr, nullptr, nullptr, -1, 0};
-  svReg.reg = builder.create<sv::RegOp>(loc, reg.getResult().getType(),
+  svReg.reg = builder.create<sv::RegOp>(loc, reg.getType(),
                                         reg.getNameAttr());
   svReg.width = hw::getBitWidth(reg.getResult().getType());
   if (auto attr = reg->getAttrOfType<IntegerAttr>("firrtl.random_init_start"))

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/Namespace.h"
@@ -84,8 +85,6 @@ public:
 };
 } // namespace
 
-constexpr uint64_t randomWidth = 32;
-
 namespace {
 /// Lower FirRegOp to `sv.reg` and `sv.always`.
 class FirRegLower {
@@ -97,16 +96,19 @@ public:
   using SymbolAndRange = std::pair<Attribute, std::pair<uint64_t, uint64_t>>;
 
 private:
+  struct RegLowerInfo {
+    sv::RegOp reg;
+    Value asyncResetSignal;
+    Value asyncResetValue;
+    int64_t randStart;
+    size_t width;
+  };
+
   using AsyncResetSignal = std::pair<Value, Value>;
 
-  std::pair<sv::RegOp, llvm::Optional<AsyncResetSignal>> lower(FirRegOp reg);
+  RegLowerInfo lower(FirRegOp reg);
 
-  bool isInitialisePreset(sv::RegOp);
-
-  void initialisePreset(OpBuilder &regBuilder, OpBuilder &initBuilder,
-                        sv::RegOp reg);
-
-  void initialise(OpBuilder &regBuilder, OpBuilder &initBuilder, sv::RegOp reg);
+  void initialize(OpBuilder &builder, RegLowerInfo reg, ArrayRef<Value> rands);
 
   void addToAlwaysBlock(sv::EventControl clockEdge, Value clock,
                         std::function<void(OpBuilder &)> body,
@@ -136,15 +138,29 @@ void FirRegLower::lower() {
     return;
 
   // Lower the regs to SV regs.
-  SmallVector<std::pair<sv::RegOp, llvm::Optional<AsyncResetSignal>>> toInit;
+  SmallVector<RegLowerInfo> toInit;
   for (auto reg : llvm::make_early_inc_range(regs))
     toInit.push_back(lower(reg));
+
+  // Compute total width of random space.  Place non-chisel registers at the end
+  // of the space.  The Random space is unique to the initial block, due to
+  // verilog thread rules, so we can drop trailing random calls if they are
+  // unused.
+  uint64_t maxBit = 0;
+  for (auto reg : toInit)
+    if (reg.randStart >= 0)
+      maxBit = std::max(maxBit, (uint64_t)reg.randStart + reg.width);
+  for (auto &reg : toInit)
+    if (reg.randStart == -1) {
+      reg.randStart = maxBit;
+      maxBit += reg.width;
+    }
 
   // Create an initial block at the end of the module where random
   // initialisation will be inserted.  Create two builders into the two
   // `ifdef` ops where the registers will be placed.
   //
-  // `ifdef SYNTHESIS
+  // `ifndef SYNTHESIS
   //   `ifdef RANDOMIZE_REG_INIT
   //      ... regBuilder ...
   //   `endif
@@ -152,98 +168,106 @@ void FirRegLower::lower() {
   //     `INIT_RANDOM_PROLOG_
   //     ... initBuilder ..
   // `endif
-  if (!toInit.empty()) {
-    auto loc = module.getLoc();
-    MLIRContext *context = module.getContext();
-    auto randInitRef = sv::MacroIdentAttr::get(context, "RANDOMIZE_REG_INIT");
+  if (toInit.empty())
+    return;
 
-    auto builder =
-        ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
-    builder.create<sv::IfDefOp>(
-        "SYNTHESIS", [] {},
-        [&] {
-          builder.create<sv::OrderedOutputOp>([&] {
-            auto ifInitOp = builder.create<sv::IfDefOp>(randInitRef);
-            auto regBuilder =
-                ImplicitLocOpBuilder::atBlockEnd(loc, ifInitOp.getThenBlock());
+  auto loc = module.getLoc();
+  MLIRContext *context = module.getContext();
+  auto randInitRef = sv::MacroIdentAttr::get(context, "RANDOMIZE_REG_INIT");
 
-            builder.create<sv::IfDefOp>("FIRRTL_BEFORE_INITIAL", [&] {
-              builder.create<sv::VerbatimOp>("`FIRRTL_BEFORE_INITIAL");
+  auto builder =
+      ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
+  builder.create<sv::IfDefOp>(
+      "SYNTHESIS", [] {},
+      [&] {
+        builder.create<sv::OrderedOutputOp>([&] {
+          builder.create<sv::IfDefOp>("FIRRTL_BEFORE_INITIAL", [&] {
+            builder.create<sv::VerbatimOp>("`FIRRTL_BEFORE_INITIAL");
+          });
+
+          builder.create<sv::InitialOp>([&] {
+            builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
+              builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
             });
+            llvm::MapVector<Value, SmallVector<RegLowerInfo>> resets;
+            builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
+              // Create randomization vector
+              SmallVector<Value> randValues;
+              for (uint64_t x = 0; x < (maxBit + 31) / 32; ++x) {
+                auto lhs =
+                    builder.create<sv::LogicOp>(loc, builder.getIntegerType(32),
+                                                "_RANDOM_" + llvm::utostr(x));
+                auto rhs = builder.create<sv::VerbatimExprSEOp>(
+                    loc, builder.getIntegerType(32), "`RANDOM");
+                builder.create<sv::BPAssignOp>(loc, lhs, rhs);
+                randValues.push_back(lhs.getResult());
+              }
 
-            builder.create<sv::InitialOp>([&] {
-              builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
-                builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
-              });
-              llvm::MapVector<Value, SmallVector<std::pair<sv::RegOp, Value>>>
-                  resets;
-              builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
-                // Create initialisers for all registers.
-                for (auto &[svReg, asyncReset] : toInit) {
-                  if (isInitialisePreset(svReg))
-                    initialisePreset(regBuilder, builder, svReg);
-                  else
-                    initialise(regBuilder, builder, svReg);
+              // Create initialisers for all registers.
+              for (auto &svReg : toInit) {
+                initialize(builder, svReg, randValues);
 
-                  if (asyncReset) {
-                    auto &[resetSignal, resetValue] = *asyncReset;
-                    resets[resetSignal].emplace_back(svReg, resetValue);
-                  }
-                }
-              });
-
-              if (!resets.empty()) {
-                builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
-                  // If the register is async reset, we need to insert extra
-                  // initialization in post-randomization so that we can set the
-                  // reset value to register if the reset signal is enabled.
-                  for (auto &reset : resets) {
-                    // Create a block guarded by the RANDOMIZE macro and the
-                    // reset: `ifdef RANDOMIZE
-                    //   if (reset) begin
-                    //     ..
-                    //   end
-                    // `endif
-                    builder.create<sv::IfOp>(reset.first, [&] {
-                      for (auto &[reg, value] : reset.second)
-                        builder.create<sv::BPAssignOp>(reg.getLoc(), reg,
-                                                       value);
-                    });
-                  }
-                });
+                if (svReg.asyncResetSignal)
+                  resets[svReg.asyncResetSignal].emplace_back(svReg);
               }
             });
 
-            builder.create<sv::IfDefOp>("FIRRTL_AFTER_INITIAL", [&] {
-              builder.create<sv::VerbatimOp>("`FIRRTL_AFTER_INITIAL");
-            });
+            if (!resets.empty()) {
+              builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
+                // If the register is async reset, we need to insert extra
+                // initialization in post-randomization so that we can set the
+                // reset value to register if the reset signal is enabled.
+                for (auto &reset : resets) {
+                  // Create a block guarded by the RANDOMIZE macro and the
+                  // reset: `ifdef RANDOMIZE
+                  //   if (reset) begin
+                  //     ..
+                  //   end
+                  // `endif
+                  builder.create<sv::IfOp>(reset.first, [&] {
+                    for (auto &reg : reset.second)
+                      builder.create<sv::BPAssignOp>(reg.reg.getLoc(), reg.reg,
+                                                     reg.asyncResetValue);
+                  });
+                }
+              });
+            }
+          });
+
+          builder.create<sv::IfDefOp>("FIRRTL_AFTER_INITIAL", [&] {
+            builder.create<sv::VerbatimOp>("`FIRRTL_AFTER_INITIAL");
           });
         });
-  }
+      });
 
   module->removeAttr("firrtl.random_init_width");
 }
 
-std::pair<sv::RegOp, llvm::Optional<FirRegLower::AsyncResetSignal>>
-FirRegLower::lower(FirRegOp reg) {
+FirRegLower::RegLowerInfo FirRegLower::lower(FirRegOp reg) {
   Location loc = reg.getLoc();
 
   ImplicitLocOpBuilder builder(reg.getLoc(), reg);
-  auto svReg = builder.create<sv::RegOp>(loc, reg.getResult().getType(),
-                                         reg.getNameAttr());
-  svReg->setDialectAttrs(reg->getDialectAttrs());
+  RegLowerInfo svReg{nullptr, nullptr, nullptr, -1, 0};
+  svReg.reg = builder.create<sv::RegOp>(loc, reg.getResult().getType(),
+                                        reg.getNameAttr());
+  svReg.width = hw::getBitWidth(reg.getResult().getType());
+  if (auto attr = reg->getAttrOfType<IntegerAttr>("firrtl.random_init_start"))
+    svReg.randStart = attr.getUInt();
+
+  // Don't move these over
+  reg->removeAttr("firrtl.random_init_start");
+
+  // Move Attributes
+  svReg.reg->setDialectAttrs(reg->getDialectAttrs());
 
   if (auto innerSymAttr = reg.getInnerSymAttr())
-    svReg.setInnerSymAttr(innerSymAttr);
-  else
-    svReg.setInnerSymAttr(
-        builder.getStringAttr(ns.newName(Twine("__") + reg.getName() + "__")));
+    svReg.reg.setInnerSymAttr(innerSymAttr);
 
-  auto regVal = builder.create<sv::ReadInOutOp>(loc, svReg);
+  auto regVal = builder.create<sv::ReadInOutOp>(loc, svReg.reg);
 
   auto setInput = [&](OpBuilder &builder) {
     if (reg.getNext() != reg)
-      builder.create<sv::PAssignOp>(loc, svReg, reg.getNext());
+      builder.create<sv::PAssignOp>(loc, svReg.reg, reg.getNext());
   };
 
   llvm::Optional<AsyncResetSignal> asyncReset;
@@ -252,11 +276,11 @@ FirRegLower::lower(FirRegOp reg) {
         sv::EventControl::AtPosEdge, reg.getClk(), setInput,
         reg.getIsAsync() ? ResetType::AsyncReset : ResetType::SyncReset,
         sv::EventControl::AtPosEdge, reg.getReset(), [&](OpBuilder &builder) {
-          builder.create<sv::PAssignOp>(loc, svReg, reg.getResetValue());
+          builder.create<sv::PAssignOp>(loc, svReg.reg, reg.getResetValue());
         });
-
     if (reg.getIsAsync()) {
-      asyncReset = std::make_pair(reg.getReset(), reg.getResetValue());
+      svReg.asyncResetSignal = reg.getReset();
+      svReg.asyncResetValue = reg.getResetValue();
     }
   } else {
     addToAlwaysBlock(sv::EventControl::AtPosEdge, reg.getClk(), setInput);
@@ -265,218 +289,33 @@ FirRegLower::lower(FirRegOp reg) {
   reg.replaceAllUsesWith(regVal.getResult());
   reg.erase();
 
-  return {svReg, asyncReset};
+  return svReg;
 }
 
-static void emitRandomInit(
-    hw::HWModuleOp module, sv::RegOp reg, OpBuilder &builder,
-    uint64_t randomRegWidth,
-    llvm::function_ref<void(IntegerType,
-                            SmallVector<FirRegLower::SymbolAndRange> &)>
-        getRandomValues) {
-  auto regDefSym =
-      hw::InnerRefAttr::get(module.getNameAttr(), reg.getInnerSymAttr());
+void FirRegLower::initialize(OpBuilder &builder, RegLowerInfo reg,
+                             ArrayRef<Value> rands) {
+  auto loc = reg.reg.getLoc();
+  SmallVector<Value> nibbles;
+  if (reg.width == 0)
+    return;
 
-  // Get a random value with the specified width, combining or truncating
-  // 32-bit units as necessary.
-  auto emitRandomInit = [&](Value dest, Type type, const Twine &accessor) {
-    auto intType = type.cast<IntegerType>();
-    if (intType.getWidth() == 0)
-      return;
-
-    SmallVector<FirRegLower::SymbolAndRange> values;
-    getRandomValues(intType, values);
-
-    SmallString<32> rhs(("{{0}}" + accessor + " = ").str());
-    unsigned i = 1;
-    SmallVector<Attribute, 4> symbols({regDefSym});
-    if (values.size() > 1)
-      rhs.append("{");
-    for (auto [value, range] : llvm::reverse(values)) {
-      symbols.push_back(value);
-      auto [high, low] = range;
-      if (i > 1)
-        rhs.append(", ");
-      rhs.append(("{{" + Twine(i++) + "}}").str());
-
-      // This uses all bits of the random value. Emit without part select.
-      if (high == randomWidth - 1 && low == 0 && randomRegWidth == randomWidth)
-        continue;
-
-      // Emit a single bit part select, e.g., emit "[0]" and not "[0:0]".
-      if (high == low) {
-        rhs.append(("[" + Twine(high) + "]").str());
-        continue;
-      }
-
-      // Emit a part select, e.g., "[4:2]"
-      rhs.append(
-          ("[" + Twine(range.first) + ":" + Twine(range.second) + "]").str());
-    }
-    if (values.size() > 1)
-      rhs.append("}");
-    rhs.append(";");
-
-    builder.create<sv::VerbatimOp>(reg.getLoc(), rhs, ValueRange{},
-                                   builder.getArrayAttr(symbols));
-  };
-
-  // Randomly initialize everything in the register. If the register
-  // is an aggregate type, then assign random values to all its
-  // constituent ground types.
-  auto type = reg.getType().dyn_cast<hw::InOutType>().getElementType();
-  std::function<void(Type, const Twine &)> recurse = [&](Type type,
-                                                         const Twine &member) {
-    TypeSwitch<Type>(type)
-        .Case<hw::UnpackedArrayType, hw::ArrayType>([&](auto a) {
-          for (size_t i = 0, e = a.getSize(); i != e; ++i)
-            recurse(a.getElementType(), member + "[" + Twine(i) + "]");
-        })
-        .Case<hw::StructType>([&](hw::StructType s) {
-          for (auto elem : s.getElements())
-            recurse(elem.type, member + "." + elem.name.getValue());
-        })
-        .Default([&](auto type) { emitRandomInit(reg, type, member); });
-  };
-  recurse(type, "");
-}
-
-bool FirRegLower::isInitialisePreset(sv::RegOp reg) {
-  return module->hasAttr("firrtl.random_init_width") &&
-         reg->hasAttr("firrtl.random_init_register") &&
-         reg->hasAttr("firrtl.random_init_start") &&
-         reg->hasAttr("firrtl.random_init_end");
-}
-
-void FirRegLower::initialisePreset(OpBuilder &regBuilder,
-                                   OpBuilder &initBuilder, sv::RegOp reg) {
-  // Extract the required random initialisation width and compute the number of
-  // `RANDOM calls required to fill it up, as well as the final register width.
-  auto randomInitWidthDict =
-      module->getAttrOfType<DictionaryAttr>("firrtl.random_init_width");
-  assert(randomInitWidthDict &&
-         "firrtl.random_init_width required for preset initialisation");
-
-  auto randomRegister =
-      reg->getAttrOfType<StringAttr>("firrtl.random_init_register");
-  assert(randomRegister &&
-         "firrtl.random_init_register required for preset initialisation");
-
-  // Only create the random register(s) once.
-  if (presetRandomValues.empty()) {
-    for (NamedAttribute registerAndWidth : randomInitWidthDict.getValue()) {
-      auto randomInitWidth =
-          registerAndWidth.getValue().cast<IntegerAttr>().getUInt();
-      assert(randomInitWidth > 0 &&
-             "random initialization width should be non-zero");
-      uint64_t numRandomSources =
-          llvm::divideCeil(randomInitWidth, randomWidth);
-      uint64_t randomRegWidth = randomWidth * numRandomSources;
-
-      // Declare the random register.
-      auto randReg = regBuilder.create<sv::RegOp>(
-          reg.getLoc(), regBuilder.getIntegerType(randomRegWidth),
-          /*name=*/regBuilder.getStringAttr("_RANDOM"),
-          /*inner_sym=*/
-          regBuilder.getStringAttr(ns.newName(Twine("_RANDOM"))));
-
-      presetRandomValues[registerAndWidth.getName()] = randReg;
-
-      SmallString<32> randomRegAssign("{{0}} = {");
-
-      // Fill the random register by concatenating calls to `RANDOM in a
-      // verbatim string.
-      for (uint64_t i = 0; i < numRandomSources; ++i) {
-        randomRegAssign.append("`RANDOM");
-        if (i < numRandomSources - 1)
-          randomRegAssign.append(",");
-        // Add a line break when line length gets close to 1000 characters.
-        if (i > 0 && i % 125 == 0)
-          randomRegAssign.append("\n");
-      }
-
-      randomRegAssign.append("};");
-
-      // Assign the concatenated calls to the declared register.
-      initBuilder.create<sv::VerbatimOp>(
-          reg.getLoc(), initBuilder.getStringAttr(randomRegAssign),
-          ValueRange{},
-          initBuilder.getArrayAttr({hw::InnerRefAttr::get(
-              module.getNameAttr(), randReg.getInnerSymAttr())}));
-    }
+  uint64_t width = reg.width;
+  uint64_t offset = reg.randStart;
+  while (width) {
+    auto index = offset / 32;
+    auto start = offset % 32;
+    auto nwidth = std::min(32 - start, width);
+    auto elemVal = builder.create<sv::ReadInOutOp>(loc, rands[index]);
+    auto elem =
+        builder.createOrFold<comb::ExtractOp>(loc, elemVal, start, nwidth);
+    nibbles.push_back(elem);
+    offset += nwidth;
+    width -= nwidth;
   }
-
-  auto getRandomValues = [&](IntegerType type,
-                             SmallVector<SymbolAndRange> &values) {
-    assert(type.getWidth() != 0 && "zero bit width's not supported");
-
-    auto randomStart =
-        reg->getAttrOfType<IntegerAttr>("firrtl.random_init_start").getUInt();
-    auto randomEnd =
-        reg->getAttrOfType<IntegerAttr>("firrtl.random_init_end").getUInt();
-    reg->removeAttr("firrtl.random_init_start");
-    reg->removeAttr("firrtl.random_init_end");
-
-    auto randReg = presetRandomValues[randomRegister];
-
-    auto symbol =
-        hw::InnerRefAttr::get(module.getNameAttr(), randReg.getInnerSymAttr());
-
-    values.push_back({symbol, {randomEnd, randomStart}});
-  };
-
-  auto randomRegWidth = presetRandomValues[randomRegister]
-                            .getElementType()
-                            .getIntOrFloatBitWidth();
-  emitRandomInit(module, reg, initBuilder, randomRegWidth, getRandomValues);
-}
-
-void FirRegLower::initialise(OpBuilder &regBuilder, OpBuilder &initBuilder,
-                             sv::RegOp reg) {
-  // Construct and return a new reference to `RANDOM.  It is always a 32-bit
-  // unsigned expression.  Calls to $random have side effects, so we use
-  // VerbatimExprSEOp.
-  auto getRandom32Val = [&](const char *suffix = "") -> Value {
-    sv::RegOp randReg = regBuilder.create<sv::RegOp>(
-        reg.getLoc(), regBuilder.getIntegerType(randomWidth),
-        /*name=*/regBuilder.getStringAttr("_RANDOM"),
-        /*inner_sym=*/
-        regBuilder.getStringAttr(ns.newName("_RANDOM")));
-
-    initBuilder.create<sv::VerbatimOp>(
-        reg.getLoc(), initBuilder.getStringAttr("{{0}} = {`RANDOM};"),
-        ValueRange{},
-        initBuilder.getArrayAttr({hw::InnerRefAttr::get(
-            module.getNameAttr(), randReg.getInnerSymAttr())}));
-
-    return randReg.getResult();
-  };
-
-  auto getRandomValues = [&](IntegerType type,
-                             SmallVector<SymbolAndRange> &values) {
-    auto width = type.getWidth();
-    assert(width != 0 && "zero bit width's not supported");
-    while (width > 0) {
-      // If there are no bits left, then generate a new random value.
-      if (!randomValueAndRemain.second)
-        randomValueAndRemain = {getRandom32Val("foo"), randomWidth};
-
-      auto reg = cast<sv::RegOp>(randomValueAndRemain.first.getDefiningOp());
-
-      auto symbol =
-          hw::InnerRefAttr::get(module.getNameAttr(), reg.getInnerSymAttr());
-      unsigned low = randomWidth - randomValueAndRemain.second;
-      unsigned high = randomWidth - 1;
-      if (width <= randomValueAndRemain.second)
-        high = width - 1 + low;
-      unsigned consumed = high - low + 1;
-      values.push_back({symbol, {high, low}});
-      randomValueAndRemain.second -= consumed;
-      width -= consumed;
-    }
-  };
-
-  emitRandomInit(module, reg, initBuilder, randomWidth, getRandomValues);
+  auto concat = builder.createOrFold<comb::ConcatOp>(loc, nibbles);
+  auto bitcast = builder.createOrFold<hw::BitcastOp>(
+      loc, reg.reg.getElementType(), concat);
+  builder.create<sv::BPAssignOp>(loc, reg.reg, bitcast);
 }
 
 void FirRegLower::addToAlwaysBlock(sv::EventControl clockEdge, Value clock,

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -197,8 +197,8 @@ void FirRegLower::lower() {
                 auto lhs =
                     builder.create<sv::LogicOp>(loc, builder.getIntegerType(32),
                                                 "_RANDOM_" + llvm::utostr(x));
-                auto rhs = builder.create<sv::VerbatimExprSEOp>(
-                    loc, builder.getIntegerType(32), "`RANDOM");
+                auto rhs = builder.create<sv::MacroRefExprSEOp>(
+                    loc, builder.getIntegerType(32), "RANDOM");
                 builder.create<sv::BPAssignOp>(loc, lhs, rhs);
                 randValues.push_back(lhs.getResult());
               }
@@ -248,8 +248,7 @@ FirRegLower::RegLowerInfo FirRegLower::lower(FirRegOp reg) {
 
   ImplicitLocOpBuilder builder(reg.getLoc(), reg);
   RegLowerInfo svReg{nullptr, nullptr, nullptr, -1, 0};
-  svReg.reg = builder.create<sv::RegOp>(loc, reg.getType(),
-                                        reg.getNameAttr());
+  svReg.reg = builder.create<sv::RegOp>(loc, reg.getType(), reg.getNameAttr());
   svReg.width = hw::getBitWidth(reg.getResult().getType());
   if (auto attr = reg->getAttrOfType<IntegerAttr>("firrtl.random_init_start"))
     svReg.randStart = attr.getUInt();

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -42,7 +42,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
     sv.ifdef.procedural "SYNTHESIS" {
     } else {
   // CHECK-NEXT:     if ((`PRINTF_COND_) & 1'bx & 1'bz & 1'bz & cond & forceWire)
-      %tmp = sv.macro.ref<"PRINTF_COND_"> : i1
+      %tmp = sv.macro.ref< "PRINTF_COND_"> : i1
       %verb_tmp = sv.verbatim.expr "{{0}}" : () -> i1 {symbols = [#hw.innerNameRef<@M1::@wire1>] }
       %tmp1 = sv.constantX : i1
       %tmp2 = sv.constantZ : i1

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -465,7 +465,7 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
   %0 = comb.concat %false, %a : i1, i4
   %1 = comb.shl %0, %c1_i5 : i5
   sv.always posedge %clock  {
-    %2 = sv.macro.ref<"PRINTF_COND_"> : i1
+    %2 = sv.macro.ref< "PRINTF_COND_" > : i1
     %3 = comb.and %2, %reset : i1
     sv.if %3  {
       sv.fwrite %fd, "Hi %x %x\0A"(%1, %b) : i5, i4

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -20,7 +20,7 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   sv.always posedge  %arg0 {
     sv.ifdef.procedural "SYNTHESIS" {
     } else {
-      %tmp = sv.macro.ref<"PRINTF_COND_">: i1
+      %tmp = sv.macro.ref< "PRINTF_COND_" > : i1
       %tmpx = sv.constantX : i1
       %tmpz = sv.constantZ : i1
       %tmp2 = comb.and %tmp, %tmpx, %tmpz, %arg1 : i1

--- a/test/Dialect/SV/cse.mlir
+++ b/test/Dialect/SV/cse.mlir
@@ -5,8 +5,20 @@
 // CHECK: [[AND:%.+]] = comb.and [[VAR]], [[VAR]] : i1
 // CHECK: hw.output [[AND]] : i1
 hw.module @cse_macro_ref() -> (out: i1) {
-  %PRINTF_COND__0 = sv.macro.ref< "PRINTF_COND_"> : i1
-  %PRINTF_COND__1 = sv.macro.ref< "PRINTF_COND_"> : i1
+  %PRINTF_COND__0 = sv.macro.ref< "PRINTF_COND_" > : i1
+  %PRINTF_COND__1 = sv.macro.ref< "PRINTF_COND_" > : i1
+  %0 = comb.and %PRINTF_COND__0, %PRINTF_COND__1 : i1
+  hw.output %0 : i1
+}
+
+// CHECK-LABEL: @nocse_macro_ref()
+// CHECK: [[VAR1:%.+]] = sv.macro.ref.se< "PRINTF_COND_"> : i1
+// CHECK: [[VAR2:%.+]] = sv.macro.ref.se< "PRINTF_COND_"> : i1
+// CHECK: [[AND:%.+]] = comb.and [[VAR1]], [[VAR2]] : i1
+// CHECK: hw.output [[AND]] : i1
+hw.module @nocse_macro_ref() -> (out: i1) {
+  %PRINTF_COND__0 = sv.macro.ref.se< "PRINTF_COND_" > : i1
+  %PRINTF_COND__1 = sv.macro.ref.se< "PRINTF_COND_" > : i1
   %0 = comb.and %PRINTF_COND__0, %PRINTF_COND__1 : i1
   hw.output %0 : i1
 }

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -71,28 +71,28 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
   // CHECK-NEXT:          %_RANDOM_0 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_0, %RANDOM : i32
   // CHECK-NEXT:          %_RANDOM_1 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_0 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
   // CHECK-NEXT:          %_RANDOM_2 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_1 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_2, %RANDOM_1 : i32
   // CHECK-NEXT:          %_RANDOM_3 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_2 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_2 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_3, %RANDOM_2 : i32
   // CHECK-NEXT:          %_RANDOM_4 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_3 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_3 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_4, %RANDOM_3 : i32
   // CHECK-NEXT:          %_RANDOM_5 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_4 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_4 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_5, %RANDOM_4 : i32
   // CHECK-NEXT:          %_RANDOM_6 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_5 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_5 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_6, %RANDOM_5 : i32
   // CHECK-NEXT:          %_RANDOM_7 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:          %RANDOM_6 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          %RANDOM_6 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:          sv.bpassign %_RANDOM_7, %RANDOM_6 : i32
   // CHECK-NEXT:          %8 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
   // CHECK-NEXT:          sv.bpassign %rA, %8 : i32
@@ -156,7 +156,7 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT:       }
   // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:        %_RANDOM_0 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:        %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:        %RANDOM = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:        sv.bpassign %_RANDOM_0, %RANDOM : i32
   // CHECK-NEXT:        %3 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
   // CHECK-NEXT:        %4 = comb.extract %3 from 0 : (i32) -> i2
@@ -237,13 +237,13 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:         %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         %RANDOM = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:         sv.bpassign %_RANDOM_0, %RANDOM : i32
   // CHECK-NEXT:         %_RANDOM_1 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:         %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         %RANDOM_0 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:         sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
   // CHECK-NEXT:         %_RANDOM_2 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:         %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         %RANDOM_1 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:         sv.bpassign %_RANDOM_2, %RANDOM_1 : i32
   // CHECK-NEXT:         %8 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
   // CHECK-NEXT:         sv.bpassign %reg, %8 : i32
@@ -288,10 +288,10 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:         %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         %RANDOM = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:         sv.bpassign %_RANDOM_0, %RANDOM : i32
   // CHECK-NEXT:         %_RANDOM_1 = sv.logic  : !hw.inout<i32>
-  // CHECK-NEXT:         %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         %RANDOM_0 = sv.macro.ref.se< "RANDOM"> : i32
   // CHECK-NEXT:         sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
   // CHECK-NEXT:         %3 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
   // CHECK-NEXT:         %4 = sv.read_inout %_RANDOM_1 : !hw.inout<i32>

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -31,7 +31,7 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK: %rAnamed = sv.reg sym @regA : !hw.inout<i32>
   %r = seq.firreg %in clock %clk sym @regA { "name" = "rAnamed" }: i32
 
-  // CHECK: %rNoSym = sv.reg sym @__rNoSym__ : !hw.inout<i32>
+  // CHECK: %rNoSym = sv.reg : !hw.inout<i32>
   %rNoSym = seq.firreg %in clock %clk : i32
 
   // CHECK:      sv.always posedge %clk {
@@ -62,16 +62,6 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK:      sv.ifdef  "SYNTHESIS" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %_RANDOM = sv.reg sym @_RANDOM  : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_0 = sv.reg sym @_RANDOM_0  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_1 = sv.reg sym @_RANDOM_1  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_2 = sv.reg sym @_RANDOM_2  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_3 = sv.reg sym @_RANDOM_3  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_4 = sv.reg sym @_RANDOM_4  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_5 = sv.reg sym @_RANDOM_5  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:       %_RANDOM_6 = sv.reg sym @_RANDOM_6  {name = "_RANDOM"} : !hw.inout<i32>
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -80,22 +70,46 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regA>, #hw.innerNameRef<@lowering::@_RANDOM>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_0>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regB>, #hw.innerNameRef<@lowering::@_RANDOM_0>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_1>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regC>, #hw.innerNameRef<@lowering::@_RANDOM_1>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_2>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regD>, #hw.innerNameRef<@lowering::@_RANDOM_2>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_3>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regE>, #hw.innerNameRef<@lowering::@_RANDOM_3>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_4>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regF>, #hw.innerNameRef<@lowering::@_RANDOM_4>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_5>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regA>, #hw.innerNameRef<@lowering::@_RANDOM_5>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_6>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@__rNoSym__>, #hw.innerNameRef<@lowering::@_RANDOM_6>]}
+  // CHECK-NEXT:          %_RANDOM_0 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_0, %RANDOM : i32
+  // CHECK-NEXT:          %_RANDOM_1 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
+  // CHECK-NEXT:          %_RANDOM_2 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_2, %RANDOM_1 : i32
+  // CHECK-NEXT:          %_RANDOM_3 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_2 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_3, %RANDOM_2 : i32
+  // CHECK-NEXT:          %_RANDOM_4 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_3 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_4, %RANDOM_3 : i32
+  // CHECK-NEXT:          %_RANDOM_5 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_4 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_5, %RANDOM_4 : i32
+  // CHECK-NEXT:          %_RANDOM_6 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_5 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_6, %RANDOM_5 : i32
+  // CHECK-NEXT:          %_RANDOM_7 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:          %RANDOM_6 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:          sv.bpassign %_RANDOM_7, %RANDOM_6 : i32
+  // CHECK-NEXT:          %8 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rA, %8 : i32
+  // CHECK-NEXT:          %9 = sv.read_inout %_RANDOM_1 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rB, %9 : i32
+  // CHECK-NEXT:          %10 = sv.read_inout %_RANDOM_2 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rC, %10 : i32
+  // CHECK-NEXT:          %11 = sv.read_inout %_RANDOM_3 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rD, %11 : i32
+  // CHECK-NEXT:          %12 = sv.read_inout %_RANDOM_4 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rE, %12 : i32
+  // CHECK-NEXT:          %13 = sv.read_inout %_RANDOM_5 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rF, %13 : i32
+  // CHECK-NEXT:          %14 = sv.read_inout %_RANDOM_6 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rAnamed, %14 : i32
+  // CHECK-NEXT:          %15 = sv.read_inout %_RANDOM_7 : !hw.inout<i32>
+  // CHECK-NEXT:          sv.bpassign %rNoSym, %15 : i32
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE" {
   // CHECK-NEXT:         sv.if %rst {
@@ -133,9 +147,6 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -144,8 +155,12 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:        sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:        sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@UninitReg1::@count>, #hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:        %_RANDOM_0 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:        %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:        sv.bpassign %_RANDOM_0, %RANDOM : i32
+  // CHECK-NEXT:        %3 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
+  // CHECK-NEXT:        %4 = comb.extract %3 from 0 : (i32) -> i2
+  // CHECK-NEXT:        sv.bpassign %count, %4 : i2
   // CHECK-NEXT:      }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
@@ -213,11 +228,6 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -226,12 +236,21 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg2_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg3_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
+  // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:         %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         sv.bpassign %_RANDOM_0, %RANDOM : i32
+  // CHECK-NEXT:         %_RANDOM_1 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:         %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
+  // CHECK-NEXT:         %_RANDOM_2 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:         %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         sv.bpassign %_RANDOM_2, %RANDOM_1 : i32
+  // CHECK-NEXT:         %8 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
+  // CHECK-NEXT:         sv.bpassign %reg, %8 : i32
+  // CHECK-NEXT:         %9 = sv.read_inout %_RANDOM_1 : !hw.inout<i32>
+  // CHECK-NEXT:         sv.bpassign %reg2, %9 : i32
+  // CHECK-NEXT:         %10 = sv.read_inout %_RANDOM_2 : !hw.inout<i32>
+  // CHECK-NEXT:         sv.bpassign %reg3, %10 : i32
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE"  {
   // CHECK-NEXT:         sv.if %reset {
@@ -260,10 +279,6 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
   // CHECK:      sv.ifdef "SYNTHESIS"  {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:       %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]] {{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -272,9 +287,17 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{][{]1[}][}]}}[9:0], {{[{][{]2[}][}][}]}};" {symbols = [#hw.innerNameRef<@UninitReg42::@count>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:         %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         sv.bpassign %_RANDOM_0, %RANDOM : i32
+  // CHECK-NEXT:         %_RANDOM_1 = sv.logic  : !hw.inout<i32>
+  // CHECK-NEXT:         %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+  // CHECK-NEXT:         sv.bpassign %_RANDOM_1, %RANDOM_0 : i32
+  // CHECK-NEXT:         %3 = sv.read_inout %_RANDOM_0 : !hw.inout<i32>
+  // CHECK-NEXT:         %4 = sv.read_inout %_RANDOM_1 : !hw.inout<i32>
+  // CHECK-NEXT:         %5 = comb.extract %4 from 0 : (i32) -> i10
+  // CHECK-NEXT:         %6 = comb.concat %3, %5 : i32, i10
+  // CHECK-NEXT:         sv.bpassign %count, %6 : i42
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
@@ -307,13 +330,6 @@ hw.module private @regInitRandomReuse(%clock: i1, %a: i1) -> (o1: i2, o2: i4, o3
   // CHECK:      sv.ifdef "SYNTHESIS" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]]
-  // CHECK-NEXT:       %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]]
-  // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]]
-  // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]]
-  // CHECK-NEXT:       %[[RANDOM_4:.+]] = sv.reg sym @[[RANDOM_4_SYM:[_A-Za-z0-9]+]]{{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -322,16 +338,15 @@ hw.module private @regInitRandomReuse(%clock: i1, %a: i1) -> (o1: i2, o2: i4, o3
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r1_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[5:2];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r2_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[5:0], {{[{][{]2[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r3_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[9:0], {{[{][{]2[}][}]}}, {{[{][{]3[}][}]}}, {{[{][{]4[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r4_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
-  // CHECK-NEXT:       }
+  // CHECK:              %9 = comb.extract %8 from 0 : (i32) -> i2
+  // CHECK:              %11 = comb.extract %10 from 2 : (i32) -> i4
+  // CHECK:              %13 = comb.extract %12 from 6 : (i32) -> i26
+  // CHECK:              %15 = comb.extract %14 from 0 : (i32) -> i6
+  // CHECK:              %16 = comb.concat %13, %15 : i26, i6
+  // CHECK:              %18 = comb.extract %17 from 6 : (i32) -> i26
+  // CHECK:              %22 = comb.extract %21 from 0 : (i32) -> i10
+  // CHECK:              %23 = comb.concat %18, %19, %20, %22 : i26, i32, i32, i10
+  // CHECK:           }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
@@ -354,9 +369,6 @@ hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.arra
   // CHECK:      sv.ifdef "SYNTHESIS" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -365,10 +377,9 @@ hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.arra
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[1] = {{[{][{]1[}][}]}}[1];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:       }
+  // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i2
+  // CHECK:              %3 = hw.bitcast %2 : (i2) -> !hw.array<2xi1>
+  // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
@@ -390,9 +401,6 @@ hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b:
   // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %_RANDOM = sv.reg sym @_RANDOM  : !hw.inout<i32>
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -401,9 +409,9 @@ hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b:
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@init2DVector::@_RANDOM>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[0][0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init2DVector::@__r__>, #hw.innerNameRef<@init2DVector::@_RANDOM>]}
-  // CHECK-NEXT:       }
+  // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i1
+  // CHECK:              %3 = hw.bitcast %2 : (i1) -> !hw.array<1xarray<1xi1>>
+  // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
@@ -423,9 +431,6 @@ hw.module private @initStruct(%clock: i1) {
   // CHECK:      sv.ifdef "SYNTHESIS" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
-  // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
   // CHECK-NEXT:     }
@@ -434,9 +439,9 @@ hw.module private @initStruct(%clock: i1) {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}.a = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@initStruct::@[[r_sym]]>, #hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
-  // CHECK-NEXT:       }
+  // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i1
+  // CHECK:              %3 = hw.bitcast %2 : (i1) -> !hw.struct<a: i1>
+  // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -1,6 +1,7 @@
 ; RUN: firtool -preserve-values=all -verilog %s | FileCheck %s --check-prefix=ALL
 ; RUN: firtool -preserve-values=named -verilog %s | FileCheck %s --check-prefix=NAMED
 ; RUN: firtool -preserve-values=none -verilog %s | FileCheck %s --check-prefix=NONE
+; RUN: firtool -preserve-values=all -verilog %s --lowering-options=disallowLocalVariables| FileCheck %s --check-prefix=ALL
 
 circuit Foo:
   module Foo:

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -12,34 +12,55 @@ circuit Foo:
     output q0: UInt<60000>
     output q1: UInt<120000>
 
-    ; ALL:   reg [127:0] _RANDOM;
-    ; ALL:   _RANDOM = {`RANDOM,`RANDOM,`RANDOM,`RANDOM};
 
-    ; NAMED: reg [127:0] _RANDOM;
-    ; NAMED: _RANDOM = {`RANDOM,`RANDOM,`RANDOM,`RANDOM};
-
-    ; NONE:  reg [127:0] _RANDOM;
-    ; NONE:  _RANDOM = {`RANDOM,`RANDOM,`RANDOM,`RANDOM};
-
-    ; ALL:       _r = _RANDOM[32:0];
+    ; ALL:       _r <= d;
     ; NAMED-NOT: _r = {{.*}};
     ; NONE-NOT:  _r = {{.*}};
     reg _r: UInt<33>, clock
     _r <= d
 
-    ; ALL:       r = _RANDOM[65:33];
-    ; NAMED:     r = _RANDOM[65:33];
-    ; NONE-NOT:  r = {{.*}};
     reg r: UInt<33>, clock
     r <= d
 
-    ; ALL:       s = _RANDOM[98:66];
-    ; NAMED:     s = _RANDOM[98:66];
-    ; NONE:      s = _RANDOM[98:66];
     reg s: UInt<33>, clock
     s <= d
 
     q <= s
+
+    ; ALL:   automatic logic [31:0] _RANDOM_0;
+    ; ALL:   automatic logic [31:0] _RANDOM_1;
+    ; ALL:   automatic logic [31:0] _RANDOM_2;
+    ; ALL:   automatic logic [31:0] _RANDOM_3;
+    ; ALL:   _RANDOM_0 = `RANDOM;
+    ; ALL:   _RANDOM_1 = `RANDOM;
+    ; ALL:   _RANDOM_2 = `RANDOM;
+    ; ALL:   _RANDOM_3 = `RANDOM;
+
+    ; NAMED:   automatic logic [31:0] _RANDOM_0;
+    ; NAMED:   automatic logic [31:0] _RANDOM_1;
+    ; NAMED:   automatic logic [31:0] _RANDOM_2;
+    ; NAMED:   automatic logic [31:0] _RANDOM_3;
+    ; NAMED:   _RANDOM_0 = `RANDOM;
+    ; NAMED:   _RANDOM_1 = `RANDOM;
+    ; NAMED:   _RANDOM_2 = `RANDOM;
+    ; NAMED:   _RANDOM_3 = `RANDOM;
+
+    ; NONE:   automatic logic [31:0] _RANDOM_0;
+    ; NONE:   automatic logic [31:0] _RANDOM_1;
+    ; NONE:   automatic logic [31:0] _RANDOM_2;
+    ; NONE:   automatic logic [31:0] _RANDOM_3;
+    ; NONE:   _RANDOM_0 = `RANDOM;
+    ; NONE:   _RANDOM_1 = `RANDOM;
+    ; NONE:   _RANDOM_2 = `RANDOM;
+    ; NONE:   _RANDOM_3 = `RANDOM;
+
+    ; ALL:       r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
+    ; NAMED:     r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
+    ; NONE-NOT:  r = {{.*}};
+
+    ; ALL:       s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
+    ; NAMED:     s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
+    ; NONE:      s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
 
     inst i0 of TwoLargeRegisters
     i0.clock <= clock
@@ -51,13 +72,14 @@ circuit Foo:
     i1.d <= d1
     q1 <= i1.q
 
+  ; ALL: module TwoLargeRegisters
   module TwoLargeRegisters:
     input clock: Clock
     input d: UInt<60000>
     output q: UInt<60000>
-
-    ; ALL: reg [59999:0] _RANDOM;
-    ; ALL: reg [59999:0] _RANDOM_0;
+    ; ALL: automatic logic [31:0]   _RANDOM_0;
+    ; ALL: automatic logic [31:0]   _RANDOM_3749;
+    ; ALL-NOT: automatic logic [31:0]   _RANDOM_3750;
 
     reg r0: UInt<60000>, clock
     reg r1: UInt<60000>, clock
@@ -66,12 +88,15 @@ circuit Foo:
     r1 <= r0
     q <= r1
 
+  ; ALL: module OneReallyLargeRegister
   module OneReallyLargeRegister:
     input clock: Clock
     input d: UInt<120000>
     output q: UInt<120000>
 
-    ; ALL: reg [119999:0] _RANDOM;
+    ; ALL: automatic logic [31:0]   _RANDOM_0;
+    ; ALL: automatic logic [31:0]   _RANDOM_3749;
+    ; ALL-NOT: automatic logic [31:0]   _RANDOM_3750;
 
     reg r: UInt<120000>, clock
 

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -54,6 +54,11 @@ circuit Foo:
     ; NONE:   _RANDOM_2 = `RANDOM;
     ; NONE:   _RANDOM_3 = `RANDOM;
 
+    ; ALL:       _r = {_RANDOM_0, _RANDOM_1[0]}; 
+    ; NAMED-NOT: _r = 
+    ; NONE-NOT:  _r = 
+    
+
     ; ALL:       r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
     ; NAMED:     r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
     ; NONE-NOT:  r = {{.*}};

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -1,7 +1,7 @@
 ; RUN: firtool -preserve-values=all -verilog %s | FileCheck %s --check-prefix=ALL
 ; RUN: firtool -preserve-values=named -verilog %s | FileCheck %s --check-prefix=NAMED
 ; RUN: firtool -preserve-values=none -verilog %s | FileCheck %s --check-prefix=NONE
-; RUN: firtool -preserve-values=all -verilog %s --lowering-options=disallowLocalVariables| FileCheck %s --check-prefix=ALL
+; RUN: firtool -preserve-values=all -verilog %s --lowering-options=disallowLocalVariables| FileCheck %s --check-prefix=LOCAL
 
 circuit Foo:
   module Foo:
@@ -17,6 +17,7 @@ circuit Foo:
     ; ALL:       _r <= d;
     ; NAMED-NOT: _r = {{.*}};
     ; NONE-NOT:  _r = {{.*}};
+    ; LOCAL:     _r <= d;
     reg _r: UInt<33>, clock
     _r <= d
 


### PR DESCRIPTION
Lower-seq-firrtl-to-sv  now doesn't generate temporary registers to hold the random values, rather, it generates local temporaries.  This greatly reduces the number of registers in modules.