### PR TITLE
[FIRRTL] Lower GrandCentralTaps to RefOps

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
@@ -1,0 +1,26 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit ConstantSinking : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~ConstantSinking|ConstantSinking>w",
+        "wireName": "~ConstantSinking|ConstantSinking>t"
+      }
+    ]
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~ConstantSinking|ConstantSinking>t"
+  }
+]]
+  module ConstantSinking:
+    output out : UInt<1>
+    wire t : UInt<1>
+    out <= t
+    t is invalid
+    node w = UInt<1>(1)
+
+; CHECK: wire t = 1'h1;

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
@@ -1,0 +1,258 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|Submodule>tap_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|Submodule>tap_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|Submodule>tap_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|Submodule>tap_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|Submodule>tap_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|Submodule>tap_5"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|DUT>tap_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|DUT>tap_1"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|DUT>tap_2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|DUT>tap_3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|DUT>tap_4"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|DUT>tap_5"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
+        "wireName":"~Top|Top>tap[0]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>wire_DUT",
+        "wireName":"~Top|Top>tap[1]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>wire_Top",
+        "wireName":"~Top|Top>tap[2]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
+        "wireName":"~Top|Top>tap[3]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top/dut:DUT>port_DUT",
+        "wireName":"~Top|Top>tap[4]"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source":"~Top|Top>port_Top",
+        "wireName":"~Top|Top>tap[5]"
+      }
+    ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>inv"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_0"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_1"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_3"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_4"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Submodule>tap_5"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_0"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_1"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_3"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_4"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|DUT>tap_5"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap"
+  }
+]]
+  module Submodule :
+    output port_Submodule: UInt<1>
+    port_Submodule is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_Submodule: UInt<1>
+    wire_Submodule <= inv
+
+    wire tap_0 : UInt<1>
+    wire tap_1 : UInt<1>
+    wire tap_2 : UInt<1>
+    wire tap_3 : UInt<1>
+    wire tap_4 : UInt<1>
+    wire tap_5 : UInt<1>
+    tap_0 is invalid
+    tap_1 is invalid
+    tap_2 is invalid
+    tap_3 is invalid
+    tap_4 is invalid
+    tap_5 is invalid
+
+  module DUT :
+    output port_DUT: UInt<1>
+    port_DUT is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_DUT: UInt<1>
+    wire_DUT <= inv
+
+    inst submodule of Submodule
+
+    wire tap_0 : UInt<1>
+    wire tap_1 : UInt<1>
+    wire tap_2 : UInt<1>
+    wire tap_3 : UInt<1>
+    wire tap_4 : UInt<1>
+    wire tap_5 : UInt<1>
+    tap_0 is invalid
+    tap_1 is invalid
+    tap_2 is invalid
+    tap_3 is invalid
+    tap_4 is invalid
+    tap_5 is invalid
+
+  module Top :
+    output port_Top : UInt<1>
+    port_Top is invalid
+
+    wire inv: UInt<1>
+    inv is invalid
+
+    wire wire_Top: UInt<1>
+    wire_Top <= inv
+
+    inst dut of DUT
+    wire tap : UInt<1>[6]
+    tap is invalid
+
+    ; CHECK:      module Submodule
+    ; CHECK:      wire tap_3 = 1'h0
+    ; CHECK-NEXT: wire tap_4 = 1'h0
+    ; CHECK:      assign tap_0 = Submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
+
+    ; CHECK: module DUT
+    ; CHECK:      wire tap_3 = 1'h0
+    ; CHECK-NEXT: wire tap_4 = 1'h0
+    ; CHECK:      assign tap_0 = DUT.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
+
+    ; CHECK: module Top
+    ; CHECK:      wire tap_3 = 1'h0
+    ; CHECK-NEXT: wire tap_4 = 1'h0
+    ; CHECK:      assign tap_0 = Top.dut.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = Top.dut.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -1,0 +1,124 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~Top|Top/foo:Foo/b:Bar>inv",
+        "wireName": "~Top|Top>tap"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|BlackBox",
+        "internalPath":"random.something",
+        "wireName": "~Top|Top>tap2"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|InternalPathChild",
+        "internalPath":"io_out",
+        "wireName": "~Top|Top/unsigned:ChildWrapper/signed:Child>tap"
+      }
+    ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Child>tap"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Bar>inv"
+  }
+]]
+  module InternalPathChild :
+    output io : { flip in : UInt<8>, out : UInt<8>}
+
+    node sum = tail(add(io.in, UInt<1>(1)), 1)
+
+    io.out <= sum
+
+  extmodule BlackBox :
+    input in : UInt<1>
+    output out : UInt<1>
+    defname = BlackBox
+
+  module Child :
+    output io : { flip in : UInt<1>, out : UInt<1>}
+
+    inst localparam of BlackBox
+    localparam.out is invalid
+    localparam.in is invalid
+    localparam.in <= io.in
+    io.out <= localparam.out
+    wire tap : UInt<1>
+    tap is invalid
+
+  module ChildWrapper :
+    output io : { flip in : UInt<1>, out : UInt<1>}
+
+    inst signed of Child
+    signed.io.in <= io.in
+    io.out <= signed.io.out
+
+  module Bar :
+    input in : UInt<1>
+    output out : UInt<1>
+    wire inv : UInt<1>
+    inv <= not(in)
+    out <= inv
+
+  module Foo :
+    input in : UInt<1>
+    output out : UInt<1>
+
+    inst b of Bar
+    b.in <= in
+    out <= b.out
+
+  module Top:
+    input in : UInt<1>
+    output out : UInt<1>
+    output io : { flip in : UInt<1>, out : UInt<1>}
+    output io2 : { flip in : UInt<8>, out : UInt<8>}
+
+    inst foo of Foo
+    foo.in <= in
+    out <= foo.out
+
+    wire tap : UInt<1>
+    tap is invalid
+
+    wire tap2 : UInt<1>
+    tap2 is invalid
+
+    inst unsigned of ChildWrapper
+    node _child_io_in_T = and(io.in, in)
+    unsigned.io.in <= _child_io_in_T
+    node _io_out_T = and(unsigned.io.out, out)
+    io.out <= _io_out_T
+
+    inst int of InternalPathChild
+    io2 <= int.io
+
+; CHECK-LABEL: module Child(
+; CHECK:   wire [[tap2_internalPath:.+]] = localparam_0.random.something;
+; CHECK:   wire tap = Top.[[tap_internalPath:.+]];
+; CHECK:   BlackBox localparam_0 (
+
+; CHECK: module Top(
+; CHECK-NOT: module
+; CHECK:   wire [[tap_internalPath]] = int_1.io_out;
+; CHECK:   tap = Top.foo.b.inv;
+; CHECK:   assign tap2 = Top.unsigned_0.signed_0.[[tap2_internalPath]];
+; CHECK:   InternalPathChild int_1 (
+; CHECK: endmodule


### PR DESCRIPTION
This  PR lowers the new `GrandCentralTaps` directly to the `RefOps` in the
 `LowerAnnotations` pass. This encodes the cross-module-reference explicitly
 in the IR using `RefTypes`.
The new `DataTaps` format specifies the source of the XMR and the wire that
reads the XMR.

Given the annotation, the `LowerAnnotations` pass overview,
1. Get the lowest-common-ancestor(lca) between the `source` and the `wireName`:
	a. LCA is searched from the unique path from top to source and wireName.	
2. Insert a `ref.send` to get the `RefType` corresponding to the `source` value.
3. Drill ports of `RefType` from the `source` through the lca, till the `wireName`. 
4. Insert a `ref.resolve` to assign the `RefType` value to the `wireName`.

```mlir
{class = "sifive.enterprise.grandcentral.DataTapsAnnotation",
  keys = 
[
  {
   class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
   source = "~Top|Top/foo:Foo/b:Bar>inv",
   wireName = "~Top|Top>tap"
  }
]
```