### PR TITLE
[SystemC] Add BindPortOp

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -123,14 +123,10 @@ def BindPortOp : SystemCOp<"instance.bind_port", [HasParent<"CtorOp">]> {
   }];
 
   let arguments = (ins ModuleType:$instance,
-                       StrAttr:$portName,
+                       IndexAttr:$portId,
                        ChannelType:$channel);
 
-  let assemblyFormat = [{
-    $instance `[` $portName `]` `to` $channel attr-dict `:`
-    type($instance) `,` type($channel)
-  }];
-
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
 

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -108,6 +108,32 @@ def InstanceDeclOp : SystemCOp<"instance.decl", [
   }];
 }
 
+def BindPortOp : SystemCOp<"instance.bind_port", [HasParent<"CtorOp">]> {
+  let summary = "Binds a port of a module instance to a channel.";
+  let description = [{
+    The ports of a submodule have to be bound to channels in a module further
+    up in the instance hierarchy (as opposed to `sc_export` where the channel
+    has to reside in the same module or a submodule). Therefore, a port can be
+    bound to either a signal declared by the `systemc.signal` operation or to
+    a port with matching direction (and thus bound to a channel further up in
+    the hierarchy).
+    More information on ports can be found in IEEE 1666-2011 §5.12.,
+    in particular IEEE 1666-2011 §5.12.7. is about port binding.
+    More information on predefined channels can be found in IEEE 1666-2011 §6.
+  }];
+
+  let arguments = (ins ModuleType:$instance,
+                       StrAttr:$portName,
+                       ChannelType:$channel);
+
+  let assemblyFormat = [{
+    $instance `[` $portName `]` `to` $channel attr-dict `:`
+    type($instance) `,` type($channel)
+  }];
+
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Operations that model C++-level features.
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/SystemC/SystemCTypes.td
+++ b/include/circt/Dialect/SystemC/SystemCTypes.td
@@ -65,4 +65,6 @@ def ModuleType : SystemCType<
     CPred<"::circt::hw::type_isa<circt::systemc::ModuleType>($_self)">,
     "a ModuleType", "::circt::hw::TypeAliasOr<circt::systemc::ModuleType>">;
 
+def ChannelType : AnyTypeOf<[InputType, InOutType, OutputType, SignalType]>;
+
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCTYPES

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -454,18 +454,78 @@ LogicalResult DestructorOp::verify() {
 // BindPortOp
 //===----------------------------------------------------------------------===//
 
+ParseResult BindPortOp::parse(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::UnresolvedOperand instance, channel;
+  std::string portName;
+  if (parser.parseOperand(instance) || parser.parseLSquare() ||
+      parser.parseString(&portName))
+    return failure();
+
+  auto portNameLoc = parser.getCurrentLocation();
+
+  if (parser.parseRSquare() || parser.parseKeyword("to") ||
+      parser.parseOperand(channel))
+    return failure();
+
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  auto typeListLoc = parser.getCurrentLocation();
+  SmallVector<Type> types;
+  if (parser.parseColonTypeList(types))
+    return failure();
+
+  if (types.size() != 2)
+    return parser.emitError(typeListLoc,
+                            "expected a list of exactly 2 types, but got ")
+           << types.size();
+
+  if (parser.resolveOperand(instance, types[0], result.operands))
+    return failure();
+  if (parser.resolveOperand(channel, types[1], result.operands))
+    return failure();
+
+  if (auto moduleType = types[0].dyn_cast<ModuleType>()) {
+    auto ports = moduleType.getPorts();
+    uint64_t index = 0;
+    for (auto port : ports) {
+      if (port.name == portName)
+        break;
+      index++;
+    }
+    if (index >= ports.size())
+      return parser.emitError(portNameLoc, "port name \"")
+             << portName << "\" not found in module";
+
+    result.addAttribute("portId", parser.getBuilder().getIndexAttr(index));
+
+    return success();
+  }
+
+  return failure();
+}
+
+void BindPortOp::print(OpAsmPrinter &p) {
+  p << " " << getInstance() << "["
+    << getInstance()
+           .getType()
+           .cast<ModuleType>()
+           .getPorts()[getPortId().getZExtValue()]
+           .name
+    << "] to " << getChannel();
+  p.printOptionalAttrDict((*this)->getAttrs(), {"portId"});
+  p << " : " << getInstance().getType() << ", " << getChannel().getType();
+}
+
 LogicalResult BindPortOp::verify() {
   auto ports = getInstance().getType().cast<ModuleType>().getPorts();
-  auto *searchIter =
-      std::find_if(ports.begin(), ports.end(), [&](ModuleType::PortInfo port) {
-        return port.name == getPortNameAttr();
-      });
-  if (searchIter == ports.end())
-    return emitOpError("port name ")
-           << getPortNameAttr() << " not found in module";
+  if (getPortId().getZExtValue() >= ports.size())
+    return emitOpError("port #")
+           << getPortId().getZExtValue() << " does not exist, there are only "
+           << ports.size() << " ports";
 
   // Verify that the base types match.
-  Type portType = searchIter->type;
+  Type portType = ports[getPortId().getZExtValue()].type;
   Type channelType = getChannel().getType();
   if (getSignalBaseType(portType) != getSignalBaseType(channelType))
     return emitOpError() << portType << " port cannot be bound to "

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -207,6 +207,16 @@ systemc.module @instanceDeclMustBeDirectChildOfModule () {
 
 // -----
 
+systemc.module @submodule (%in0: !systemc.in<i32>) {}
+
+systemc.module @bindPortMustBeDirectChildOfCtor (%input0: !systemc.in<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>)>
+  // expected-error @+1 {{expects parent op 'systemc.ctor'}}
+  systemc.instance.bind_port %instance["in0"] to %input0 : !systemc.module<submodule(in0: !systemc.in<i32>)>, !systemc.in<i32>
+}
+
+// -----
+
 // expected-note @+1 {{module declared here}}
 systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32>, %sum: !systemc.out<i32>) {}
 
@@ -260,4 +270,53 @@ systemc.module @adder (%summand_a: !systemc.in<i32>, %summand_b: !systemc.in<i32
 systemc.module @instanceDeclPortNumMismatch () {
   // expected-error @+1 {{module names must match; expected 'adder' but got 'wrongname'}}
   %moduleInstance = systemc.instance.decl @adder : !systemc.module<wrongname(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>)>
+}
+
+// -----
+
+systemc.module @submodule (%in0: !systemc.in<i32>) {}
+
+systemc.module @invalidPortName (%input0: !systemc.in<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{port name "out" not found in module}}
+    systemc.instance.bind_port %instance["out"] to %input0 : !systemc.module<submodule(in0: !systemc.in<i32>)>, !systemc.in<i32>
+  }
+}
+
+// -----
+
+systemc.module @submodule (%in0: !systemc.in<i32>) {}
+
+systemc.module @directionOfPortAndChannelMismatch (%output0: !systemc.out<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{'!systemc.in<i32>' port cannot be bound to '!systemc.out<i32>' channel due to port direction mismatch}}
+    systemc.instance.bind_port %instance["in0"] to %output0 : !systemc.module<submodule(in0: !systemc.in<i32>)>, !systemc.out<i32>
+  }
+}
+
+// -----
+
+systemc.module @submodule (%out0: !systemc.out<i32>) {}
+
+systemc.module @directionOfPortAndChannelMismatch (%input0: !systemc.in<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(out0: !systemc.out<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{'!systemc.out<i32>' port cannot be bound to '!systemc.in<i32>' channel due to port direction mismatch}}
+    systemc.instance.bind_port %instance["out0"] to %input0 : !systemc.module<submodule(out0: !systemc.out<i32>)>, !systemc.in<i32>
+  }
+}
+
+// -----
+
+systemc.module @submodule (%out0: !systemc.out<i32>) {}
+
+systemc.module @baseTypeMismatch () {
+  %signal = systemc.signal : !systemc.signal<i8>
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(out0: !systemc.out<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{'!systemc.out<i32>' port cannot be bound to '!systemc.signal<i8>' channel due to base type mismatch}}
+    systemc.instance.bind_port %instance["out0"] to %signal : !systemc.module<submodule(out0: !systemc.out<i32>)>, !systemc.signal<i8>
+  }
 }

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -320,3 +320,27 @@ systemc.module @baseTypeMismatch () {
     systemc.instance.bind_port %instance["out0"] to %signal : !systemc.module<submodule(out0: !systemc.out<i32>)>, !systemc.signal<i8>
   }
 }
+
+// -----
+
+systemc.module @submodule (%out0: !systemc.out<i32>) {}
+
+systemc.module @baseTypeMismatch (%out0: !systemc.out<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(out0: !systemc.out<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{expected a list of exactly 2 types, but got 1}}
+    systemc.instance.bind_port %instance["out0"] to %out0 : !systemc.module<submodule(out0: !systemc.out<i32>)>
+  }
+}
+
+// -----
+
+systemc.module @submodule (%out0: !systemc.out<i32>) {}
+
+systemc.module @baseTypeMismatch (%out0: !systemc.out<i32>) {
+  %instance = systemc.instance.decl @submodule : !systemc.module<submodule(out0: !systemc.out<i32>)>
+  systemc.ctor {
+    // expected-error @+1 {{port #1 does not exist, there are only 1 ports}}
+    "systemc.instance.bind_port"(%instance, %out0) {portId = 1 : index} : (!systemc.module<submodule(out0: !systemc.out<i32>)>, !systemc.out<i32>) -> ()
+  }
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -75,11 +75,16 @@ systemc.module @argAttrs (%port0: !systemc.in<i32> {hw.attrname = "sometext"}, %
 systemc.module @resultAttrs (%port0: !systemc.in<i32>, %out0: !systemc.out<i32> {hw.attrname = "sometext"}) {}
 
 // CHECK-LABEL: systemc.module @instanceDecl
-systemc.module @instanceDecl () {
+systemc.module @instanceDecl (%input0: !systemc.in<i32>) {
   // CHECK-NEXT: %moduleInstance0 = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>
   %moduleInstance0 = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>
   // CHECK-NEXT: %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
   %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
+  // CHECK-NEXT: systemc.ctor
+  systemc.ctor {
+    // CHECK-NEXT: systemc.instance.bind_port %moduleInstance0["summand_a"] to %input0 : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>, !systemc.in<i32>
+    systemc.instance.bind_port %moduleInstance0["summand_a"] to %input0 : !systemc.module<adder(summand_a: !systemc.in<i32>, summand_b: !systemc.in<i32>, sum: !systemc.out<i32>)>, !systemc.in<i32>
+  }
 }
 
 // CHECK-LABEL: systemc.module @attributes


### PR DESCRIPTION
Add an operation to bind the ports of a submodule to a channel or port in the instantiating module. Currently, the in, inout, and out port types and signals are the only supported channels.