### PR TITLE
[FIRRTL] Add helper utility to get the leaf sub element of an aggregate

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -84,6 +84,16 @@ std::string getFieldName(const FieldRef &fieldRef, bool &rootKnown);
 Value getValueByFieldID(ImplicitLocOpBuilder builder, Value value,
                         unsigned fieldID);
 
+/// Get the ground type leaf-sub-element from the aggregate type val. This
+/// constructs the appropriate SubindexOp/SubfieldOp ops recursively to get the
+/// ground type at the given `fieldID`. Unlike the `getValueByFieldID`, which
+/// returns the immediate field value at a given fieldID, which maybe an
+/// aggregate type and generates at most a single subField/subIndex op, this
+/// always generates as many subField/subIndex ops necessary to get the leaf
+/// value of ground type recursively.
+Value getLeafSubElement(Value val, unsigned fieldID,
+                        ImplicitLocOpBuilder &builder);
+
 //===----------------------------------------------------------------------===//
 // Inner symbol and InnerRef helpers.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Add a helper `getLeafSubElement` to `FIRRTLUtils` to get the ground type leaf-sub-element from the aggregate type val. This constructs the appropriate `SubindexOp`/`SubfieldOp` ops recursively to get the ground type at the given `fieldID`. 
Unlike the `getValueByFieldID`, which returns the immediate field value at a given fieldID, that could be an aggregate type and generates at most a single subField/subIndex op, `getLeafSubElement` always generates as many subField/subIndex ops necessary to get the leaf value of ground type recursively.
