### PR TITLE
[PrepareForEmission] Hoist LogicOp when disallowLocalVariable is enabled

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -576,8 +576,8 @@ void ExportVerilog::prepareHWModule(Block &block,
       if (options.disallowLocalVariables) {
         // When `disallowLocalVariables` is enabled, "automatic logic" is
         // prohibited so hoist the op to a non-procedural region.
-        auto moveOp = findParentInNonProceduralRegion(&op);
-        op.moveBefore(moveOp);
+        auto *parentOp = findParentInNonProceduralRegion(&op);
+        op.moveBefore(parentOp);
       } else {
         // Otherwise, move the logic op to the beggining of the block.
         auto [block, it] = findLogicOpInsertionPoint(&op);

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -385,8 +385,8 @@ static Operation *findParentInNonProceduralRegion(Operation *op) {
 /// This function is invoked on side effecting Verilog expressions when we're in
 /// 'disallowLocalVariables' mode for old Verilog clients.  This ensures that
 /// any side effecting expressions are only used by a single BPAssign to a
-/// sv.reg operation.  This ensures that the verilog emitter doesn't have to
-/// worry about spilling them.
+/// sv.reg or sv.logic operation.  This ensures that the verilog emitter doesn't
+/// have to worry about spilling them.
 ///
 /// This returns true if the op was rewritten, false otherwise.
 static bool rewriteSideEffectingExpr(Operation *op) {
@@ -395,7 +395,7 @@ static bool rewriteSideEffectingExpr(Operation *op) {
   // Check to see if this is already rewritten.
   if (op->hasOneUse()) {
     if (auto assign = dyn_cast<BPAssignOp>(*op->user_begin()))
-      if (assign.getDest().getDefiningOp<RegOp>())
+      if (isa_and_nonnull<RegOp, LogicOp>(assign.getDest().getDefiningOp()))
         return false;
   }
 
@@ -570,9 +570,17 @@ void ExportVerilog::prepareHWModule(Block &block,
       lowerBoundInstance(instance);
     }
 
-    if (isProceduralRegion) {
-      if (auto logic = dyn_cast<LogicOp>(op)) {
-        auto [block, it] = findLogicOpInsertionPoint(logic);
+    // If logic op is located in a procedural region, we have to move the logic
+    // op declaration to a valid program point.
+    if (isProceduralRegion && isa<LogicOp>(op)) {
+      if (options.disallowLocalVariables) {
+        // When `disallowLocalVariables` is enabled, "automatic logic" is
+        // prohibited so hoist the op to a non-procedural region.
+        auto moveOp = findParentInNonProceduralRegion(&op);
+        op.moveBefore(moveOp);
+      } else {
+        // Otherwise, move the logic op to the beggining of the block.
+        auto [block, it] = findLogicOpInsertionPoint(&op);
         op.moveBefore(block, it);
       }
     }

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -11,12 +11,15 @@ hw.module @side_effect_expr(%clock: i1) -> (a: i1, a2: i1) {
   // CHECK: `ifdef FOO_MACRO
   // DISALLOW: `ifdef FOO_MACRO
   sv.ifdef "FOO_MACRO" {
-    // DISALLOW: {{^    }}reg [[SE_REG:[_A-Za-z0-9]+]];
+    // DISALLOW: logic logicOp;
+    // DISALLOW: {{^    }}reg   [[SE_REG:[_A-Za-z0-9]+]];
 
     // CHECK:    always @(posedge clock)
     // DISALLOW: always @(posedge clock)
     sv.always posedge %clock  {
       %0 = sv.verbatim.expr "INLINE_OK" : () -> i1
+      // CHECK: automatic logic logicOp;
+      %logicOp = sv.logic : !hw.inout<i1>
 
       // This shouldn't be pushed into a reg.
       // CHECK: if (INLINE_OK)


### PR DESCRIPTION
This PR fixes an issue that logic op is not hoisted to non-procedural region with disallowLocalVariables.
This also improves `rewriteSideEffectingExpr` to handle logic op as well as reg op to reduce the number of 
temporary registers. 