### PR TITLE
[HWToSystemC] Add support for lowering hw.instance operations

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -88,6 +88,16 @@ def InstanceDeclOp : SystemCOp<"instance.decl", [
     `:` type($instanceHandle)
   }];
 
+  let builders = [
+    OpBuilder<(ins "StringAttr":$instanceName,
+                   "FlatSymbolRefAttr":$moduleRef,
+                   "ArrayRef<ModuleType::PortInfo>":$ports), [{
+      build($_builder, $_state,
+            ModuleType::get($_builder.getContext(), moduleRef.getAttr(), ports),
+            instanceName, moduleRef);
+    }]>
+  ];
+
   let extraClassDeclaration = [{
     /// Get the systemc::ModuleType that represents the instantiated module.
     systemc::ModuleType getInstanceType() {

--- a/lib/Conversion/HWToSystemC/HWToSystemC.cpp
+++ b/lib/Conversion/HWToSystemC/HWToSystemC.cpp
@@ -185,8 +185,8 @@ public:
          ++i) {
       Value input = adaptor.getInputs()[i];
       APInt portId = APInt(32, i);
-      std::string signalName =
-          (instanceName.getValue() + "_" + portInfo[i].name.getValue()).str();
+      StringAttr signalName = rewriter.getStringAttr(
+          instanceName.getValue() + "_" + portInfo[i].name.getValue());
 
       if (auto readOp = input.getDefiningOp<SignalReadOp>()) {
         // Use the read channel directly without adding an
@@ -209,9 +209,9 @@ public:
       size_t numInputs = adaptor.getInputs().size();
       Value output = instanceOp->getResult(i);
       APInt portId = APInt(32, i + numInputs);
-      std::string signalName = (instanceName.getValue() + "_" +
-                                portInfo[i + numInputs].name.getValue())
-                                   .str();
+      StringAttr signalName =
+          rewriter.getStringAttr(instanceName.getValue() + "_" +
+                                 portInfo[i + numInputs].name.getValue());
 
       if (output.hasOneUse()) {
         if (auto writeOp = dyn_cast<SignalWriteOp>(*output.user_begin())) {

--- a/lib/Conversion/HWToSystemC/HWToSystemC.cpp
+++ b/lib/Conversion/HWToSystemC/HWToSystemC.cpp
@@ -52,6 +52,7 @@ struct ConvertHWModule : public OpConversionPattern<HWModuleOp> {
     // Create the SystemC module.
     auto scModule = rewriter.create<SCModuleOp>(
         module.getLoc(), module.getNameAttr(), module.getAllPorts());
+    auto *outputOp = module.getBodyBlock()->getTerminator();
     scModule.setVisibility(module.getVisibility());
 
     SmallVector<Attribute> portAttrs;
@@ -100,32 +101,144 @@ struct ConvertHWModule : public OpConversionPattern<HWModuleOp> {
     // Erase the HW module.
     rewriter.eraseOp(module);
 
+    SmallVector<Value> outPorts;
+    for (auto val : scModule.getArguments()) {
+      if (val.getType().isa<OutputType>())
+        outPorts.push_back(val);
+    }
+
+    rewriter.setInsertionPoint(outputOp);
+    for (auto args : llvm::zip(outPorts, outputOp->getOperands()))
+      rewriter.create<SignalWriteOp>(outputOp->getLoc(), std::get<0>(args),
+                                     std::get<1>(args));
+
+    // Erase the HW OutputOp.
+    outputOp->dropAllReferences();
+    rewriter.eraseOp(outputOp);
+
     return success();
   }
 };
 
-/// Convert output operations to alias operations connecting the result SSA
-/// values to the output block arguments.
-struct ConvertOutput : public OpConversionPattern<OutputOp> {
+/// Convert hw.instance operations to systemc.instance.decl and a
+/// systemc.instance.bind_port operation for each port in the constructor. Also
+/// insert the necessary intermediate signals and write or read their state in
+/// the update function accordingly.
+class ConvertInstance : public OpConversionPattern<InstanceOp> {
   using OpConversionPattern::OpConversionPattern;
 
+private:
+  template <typename PortTy>
   LogicalResult
-  matchAndRewrite(OutputOp outputOp, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+  collectPortInfo(ValueRange ports, ArrayAttr portNames,
+                  SmallVector<ModuleType::PortInfo> &portInfo) const {
+    for (auto inPort : llvm::zip(ports, portNames)) {
+      Type ty = std::get<0>(inPort).getType();
+      ModuleType::PortInfo info;
 
-    if (auto scModule = outputOp->getParentOfType<SCModuleOp>()) {
-      for (auto args :
-           llvm::zip(scModule.getOutputPorts(), outputOp.getOperands())) {
-        rewriter.create<SignalWriteOp>(outputOp->getLoc(), std::get<0>(args),
-                                       std::get<1>(args));
-      }
+      if (ty.isa<hw::InOutType>())
+        return failure();
 
-      // Erase the HW OutputOp.
-      rewriter.eraseOp(outputOp);
-      return success();
+      info.type = PortTy::get(ty);
+      info.name = std::get<1>(inPort).cast<StringAttr>();
+      portInfo.push_back(info);
     }
 
-    return failure();
+    return success();
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(InstanceOp instanceOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Make sure the parent is already converted such that we already have a
+    // constructor and update function to insert operations into.
+    auto scModule = instanceOp->getParentOfType<SCModuleOp>();
+    if (!scModule)
+      return rewriter.notifyMatchFailure(instanceOp,
+                                         "parent was not an SCModuleOp");
+
+    // Get the builders for the different places to insert operations.
+    auto ctor = scModule.getOrCreateCtor();
+    OpBuilder stateBuilder(ctor);
+    OpBuilder initBuilder = OpBuilder::atBlockEnd(ctor.getBodyBlock());
+
+    // Collect the port types and names of the instantiated module and convert
+    // them to appropriate systemc types.
+    SmallVector<ModuleType::PortInfo> portInfo;
+    if (failed(collectPortInfo<InputType>(adaptor.getInputs(),
+                                          adaptor.getArgNames(), portInfo)) ||
+        failed(collectPortInfo<OutputType>(instanceOp->getResults(),
+                                           adaptor.getResultNames(), portInfo)))
+      return instanceOp->emitOpError("inout ports not supported");
+
+    Location loc = instanceOp->getLoc();
+    auto instanceName = instanceOp.getInstanceNameAttr();
+    auto instModuleName = instanceOp.getModuleNameAttr();
+
+    // Declare the instance.
+    auto instDecl = stateBuilder.create<InstanceDeclOp>(
+        loc, instanceName, instModuleName, portInfo);
+
+    // Bind the input ports.
+    for (size_t i = 0, numInputs = adaptor.getInputs().size(); i < numInputs;
+         ++i) {
+      Value input = adaptor.getInputs()[i];
+      APInt portId = APInt(32, i);
+      std::string signalName =
+          (instanceName.getValue() + "_" + portInfo[i].name.getValue()).str();
+
+      if (auto readOp = input.getDefiningOp<SignalReadOp>()) {
+        // Use the read channel directly without adding an
+        // intermediate signal.
+        initBuilder.create<BindPortOp>(loc, instDecl, portId,
+                                       readOp.getInput());
+        continue;
+      }
+
+      // Otherwise, create an intermediate signal to bind the instance port to.
+      Type sigType = SignalType::get(getSignalBaseType(portInfo[i].type));
+      Value channel = stateBuilder.create<SignalOp>(loc, sigType, signalName);
+      initBuilder.create<BindPortOp>(loc, instDecl, portId, channel);
+      rewriter.create<SignalWriteOp>(loc, channel, input);
+    }
+
+    // Bind the output ports.
+    for (size_t i = 0, numOutputs = instanceOp->getNumResults(); i < numOutputs;
+         ++i) {
+      size_t numInputs = adaptor.getInputs().size();
+      Value output = instanceOp->getResult(i);
+      APInt portId = APInt(32, i + numInputs);
+      std::string signalName = (instanceName.getValue() + "_" +
+                                portInfo[i + numInputs].name.getValue())
+                                   .str();
+
+      if (output.hasOneUse()) {
+        if (auto writeOp = dyn_cast<SignalWriteOp>(*output.user_begin())) {
+          // Use the channel written to directly. When there are multiple
+          // channels this value is written to or it is used somewhere else, we
+          // cannot shortcut it and have to insert an intermediate value because
+          // we cannot insert multiple bind statements for one submodule port.
+          // It is also necessary to bind it to an intermediate signal when it
+          // has no uses as every port has to be bound to a channel.
+          initBuilder.create<BindPortOp>(loc, instDecl, portId,
+                                         writeOp.getDest());
+          writeOp->erase();
+          continue;
+        }
+      }
+
+      // Otherwise, create an intermediate signal.
+      Type sigType =
+          SignalType::get(getSignalBaseType(portInfo[i + numInputs].type));
+      Value channel = stateBuilder.create<SignalOp>(loc, sigType, signalName);
+      initBuilder.create<BindPortOp>(loc, instDecl, portId, channel);
+      auto instOut = rewriter.create<SignalReadOp>(loc, channel);
+      output.replaceAllUsesWith(instOut);
+    }
+
+    rewriter.eraseOp(instanceOp);
+    return success();
   }
 };
 
@@ -145,7 +258,7 @@ static void populateLegality(ConversionTarget &target) {
 }
 
 static void populateOpConversion(RewritePatternSet &patterns) {
-  patterns.add<ConvertHWModule, ConvertOutput>(patterns.getContext());
+  patterns.add<ConvertHWModule, ConvertInstance>(patterns.getContext());
 }
 
 //===----------------------------------------------------------------------===//
@@ -174,7 +287,6 @@ void HWToSystemCPass::runOnOperation() {
   builder.create<emitc::IncludeOp>(module->getLoc(), "systemc.h", true);
 
   ConversionTarget target(context);
-  TypeConverter typeConverter;
   RewritePatternSet patterns(&context);
   populateLegality(target);
   populateOpConversion(patterns);

--- a/test/Conversion/HWToSystemC/structure.mlir
+++ b/test/Conversion/HWToSystemC/structure.mlir
@@ -51,3 +51,57 @@ hw.module @resultAttrs (%port0: i32) -> (out0: i32 {hw.attrname = "sometext"}) {
   %0 = hw.constant 0 : i32
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: systemc.module @submodule
+hw.module @submodule (%in0: i16, %in1: i32) -> (out0: i16, out1: i32, out2: i64) {
+  %0 = hw.constant 0 : i64
+  hw.output %in0, %in1, %0 : i16, i32, i64
+}
+
+// CHECK-LABEL:  systemc.module @instanceLowering (%port0: !systemc.in<i32>, %out0: !systemc.out<i16>, %out1: !systemc.out<i32>, %out2: !systemc.out<i64>) {
+hw.module @instanceLowering (%port0: i32) -> (out0: i16, out1: i32, out2: i64) {
+// CHECK-NEXT:    %inst1 = systemc.instance.decl  @submodule : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>
+// CHECK-NEXT:    %inst1_in0 = systemc.signal  : !systemc.signal<i16>
+// CHECK-NEXT:    %inst1_out0 = systemc.signal  : !systemc.signal<i16>
+// CHECK-NEXT:    %inst1_out1 = systemc.signal  : !systemc.signal<i32>
+// CHECK-NEXT:    %inst2 = systemc.instance.decl  @submodule : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>
+// CHECK-NEXT:    %inst2_out2 = systemc.signal  : !systemc.signal<i64>
+// CHECK-NEXT:    systemc.ctor {
+// CHECK-NEXT:      systemc.method [[UPDATEFUNC:%.+]]
+// CHECK-NEXT:      systemc.instance.bind_port %inst1["in0"] to %inst1_in0 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i16>
+// CHECK-NEXT:      systemc.instance.bind_port %inst1["in1"] to %port0 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.in<i32>
+// CHECK-NEXT:      systemc.instance.bind_port %inst1["out0"] to %inst1_out0 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i16>
+// CHECK-NEXT:      systemc.instance.bind_port %inst1["out1"] to %inst1_out1 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i32>
+// CHECK-NEXT:      systemc.instance.bind_port %inst1["out2"] to %out2 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.out<i64>
+// CHECK-NEXT:      systemc.instance.bind_port %inst2["in0"] to %inst1_out0 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i16>
+// CHECK-NEXT:      systemc.instance.bind_port %inst2["in1"] to %inst1_out1 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i32>
+// CHECK-NEXT:      systemc.instance.bind_port %inst2["out0"] to %out0 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.out<i16>
+// CHECK-NEXT:      systemc.instance.bind_port %inst2["out1"] to %out1 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.out<i32>
+// CHECK-NEXT:      systemc.instance.bind_port %inst2["out2"] to %inst2_out2 : !systemc.module<submodule(in0: !systemc.in<i16>, in1: !systemc.in<i32>, out0: !systemc.out<i16>, out1: !systemc.out<i32>, out2: !systemc.out<i64>)>, !systemc.signal<i64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    [[UPDATEFUNC]] = systemc.func  {
+// CHECK-NEXT:      systemc.signal.read %port0 : !systemc.in<i32>
+// CHECK-NEXT:      %c0_i16 = hw.constant 0 : i16
+// CHECK-NEXT:      systemc.signal.write %inst1_in0, %c0_i16 : !systemc.signal<i16>
+// CHECK-NEXT:      systemc.signal.read %inst1_out0 : !systemc.signal<i16>
+// CHECK-NEXT:      systemc.signal.read %inst1_out1 : !systemc.signal<i32>
+// CHECK-NEXT:      systemc.signal.read %inst2_out2 : !systemc.signal<i64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+  %0 = hw.constant 0 : i16
+  %inst1.out0, %inst1.out1, %inst1.out2 = hw.instance "inst1" @submodule (in0: %0: i16, in1: %port0: i32) -> (out0: i16, out1: i32, out2: i64)
+  %inst2.out0, %inst2.out1, %inst2.out2 = hw.instance "inst2" @submodule (in0: %inst1.out0: i16, in1: %inst1.out1: i32) -> (out0: i16, out1: i32, out2: i64)
+  hw.output %inst2.out0, %inst2.out1, %inst1.out2 : i16, i32, i64
+}
+
+// CHECK-LABEL:  systemc.module @instanceLowering2
+hw.module @instanceLowering2 () -> () {
+// CHECK-NEXT: %inst1 = systemc.instance.decl @emptyModule : !systemc.module<emptyModule()>
+// CHECK-NEXT: systemc.ctor {
+// CHECK-NEXT:   systemc.method %
+// CHECK-NEXT: }
+// CHECK-NEXT: systemc.func {
+// CHECK-NEXT: }
+  hw.instance "inst1" @emptyModule () -> ()
+// CHECK-NEXT: }
+}


### PR DESCRIPTION
* Merged the `hw.output` operation lowering with the module lowering because it allows for easier code in the instance lowering pattern and there is likely no benefit in a separate lowering pattern as there is exactly one output operation per hw module and it only ever occurs in combination with such a module.
* Added a convenience builder for the `systemc.instance.decl` operation.
* Replaced the usage of `scModule.getOutputPorts()` with a for-loop over all arguments that materializes a list of the output ports because of #3810. I couldn't immediately find a fix for that and didn't want to block this PR on it.
* Default behavior is to insert a signal for each port of each instance and bind the port to it. Then write to that signal or read from it in the update function depending on the port direction. However, when the value used/returned by the `hw.instance` operation is read/written from/to a port or signal it should be fine to bind to that directly without adding the overhead of an additional intermediate signal.
* It would be nice to add an error-test for a inout port on an instance, but it is hard to get such a value without using ops from the SV dialect and not add it as a port to the toplevel module (as it would already fail in the module lowering pattern).