### PR TITLE
[Github actions] Include release tag version in automated release build

### DIFF
--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -116,7 +116,7 @@ jobs:
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
             -DLLVM_PARALLEL_LINK_JOBS=1 \
             -DCIRCT_RELEASE_TAG_ENABLED=ON \
-            -DCIRCT_RELEASE_TAG={{ github.ref_name }} \
+            -DCIRCT_RELEASE_TAG=${{ github.ref_name }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
           ninja
           ninja check-circt

--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -115,6 +115,8 @@ jobs:
             -DLLVM_ENABLE_TERMINFO=OFF \
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
             -DLLVM_PARALLEL_LINK_JOBS=1 \
+            -DCIRCT_RELEASE_TAG_ENABLED=ON \
+            -DCIRCT_RELEASE_TAG={{ github.ref_name }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
           ninja
           ninja check-circt


### PR DESCRIPTION
Release binaries produced by the uploadBinaries action now build with a specified version computed using the tag of the release that caused the job to run.