### PR TITLE
[FIRRTL] Add ports to a sequence of InstanceOps via an LCA

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -284,11 +284,18 @@ A tryGetAs(DictionaryAttr &dict, const Attribute &root, StringRef key,
 InstanceOp addPortsToModule(
     FModuleOp mod, InstanceOp instOnPath, FIRRTLType portType, Direction dir,
     StringRef newName, InstancePathCache &instancePathcache,
-    MLIRContext *context,
     llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace,
-    AnnoPathValue *instancePathToUpdate = nullptr,
     CircuitTargetCache *targetCaches = nullptr);
 
+/// Add a port to each instance on the path `instancePath` and forward the
+/// `fromVal` through them. It returns the port added to the last module on the
+/// given path. The module referenced by the first instance on the path must
+/// contain `fromVal`.
+Value borePortsOnPath(
+    SmallVector<InstanceOp> &instancePath, FModuleOp lcaModule, Value fromVal,
+    StringRef newNameHint, InstancePathCache &instancePathcache,
+    llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace,
+    CircuitTargetCache *targetCachesInstancePathCache);
 } // namespace firrtl
 } // namespace circt
 


### PR DESCRIPTION
Add a helper `borePortsOnPath` to add ports along a sequence of `InstanceOps`. It connects all the ports to each other and forwards a given value from the source module. 
`instancePath` specifies a path from a source module through the `lcaModule` till a target module. Source module is the
 module referenced by the first instance on the path  and target module is the referenced target module of the last instance in the instancePath.

If the `lcaModule` is the source module, then we only need to drill input ports starting from the `lcaModule` till the end of `instancePath`. For all other cases, we start to drill output ports from the source module  till the  `lcaModule`, and then input ports from `lcaModule` till the end of  `instancePath`.

This utility is required in https://github.com/llvm/circt/pull/3804