### PR TITLE
Fix Calyx PrimitiveOp attributes

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1417,7 +1417,8 @@ SmallVector<Direction> PrimitiveOp::portDirections() {
 }
 
 /// Returns a new DictionaryAttr containing only the calyx dialect attrs
-/// in the input DictionaryAttr. Also strips the calyx. prefix from these attrs.
+/// in the input DictionaryAttr. Also strips the 'calyx.' prefix from these
+/// attrs.
 static DictionaryAttr cleanCalyxPortAttrs(OpBuilder builder,
                                           DictionaryAttr dict) {
   if (!dict) {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1419,7 +1419,7 @@ SmallVector<Direction> PrimitiveOp::portDirections() {
 SmallVector<DictionaryAttr> PrimitiveOp::portAttributes() {
   SmallVector<DictionaryAttr> portAttributes;
   OpBuilder builder(getContext());
-  auto cleanAttrs = [&](DictionaryAttr dict){
+  auto cleanAttrs = [&](DictionaryAttr dict) {
     if (dict) {
       llvm::SmallVector<NamedAttribute> attrs;
       for (NamedAttribute attr : dict) {
@@ -1437,11 +1437,13 @@ SmallVector<DictionaryAttr> PrimitiveOp::portAttributes() {
     return dict;
   };
   for (size_t i = 0; i < getReferencedPrimitive().getNumArguments(); ++i) {
-    DictionaryAttr dict = cleanAttrs(getReferencedPrimitive().getArgAttrDict(i));
+    DictionaryAttr dict =
+        cleanAttrs(getReferencedPrimitive().getArgAttrDict(i));
     portAttributes.push_back(dict);
   }
   for (size_t i = 0; i < getReferencedPrimitive().getNumResults(); ++i) {
-    DictionaryAttr dict = cleanAttrs(getReferencedPrimitive().getResultAttrDict(i));
+    DictionaryAttr dict =
+        cleanAttrs(getReferencedPrimitive().getResultAttrDict(i));
     portAttributes.push_back(dict);
   }
   return portAttributes;

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1436,7 +1436,7 @@ static DictionaryAttr cleanCalyxPortAttrs(OpBuilder builder,
   return builder.getDictionaryAttr(attrs);
 }
 
-// Grabs calyx port attributes from the HWModuleExternOp arg/result attributes
+// Grabs calyx port attributes from the HWModuleExternOp arg/result attributes.
 SmallVector<DictionaryAttr> PrimitiveOp::portAttributes() {
   SmallVector<DictionaryAttr> portAttributes;
   OpBuilder builder(getContext());


### PR DESCRIPTION
This fixes an issue where the PrimitiveOp would have no port attributes in the Calyx CellInterface. It now grabs all the calyx attributes attached to the HWModuleExternOp that is referenced by the PrimitiveOp. This has no effect on emission but allows Calyx MLIR passes to work properly with PrimitiveOps.