### PR TITLE
[FIRRTL] Fold aggregate multibit mux into subaccess op

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -110,7 +110,7 @@ std::unique_ptr<mlir::Pass> createCheckCombCyclesPass();
 std::unique_ptr<mlir::Pass> createSFCCompatPass();
 
 std::unique_ptr<mlir::Pass>
-createMergeConnectionsPass(bool enableAggressiveMerging = false);
+createSimplifyAggregatesPass(bool enableAggressiveMerging = false);
 
 std::unique_ptr<mlir::Pass> createInjectDUTHierarchyPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -476,9 +476,9 @@ def SFCCompat : Pass<"firrtl-sfc-compat", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createSFCCompatPass()";
 }
 
-def MergeConnections : Pass<"merge-connections", "firrtl::FModuleOp"> {
+def SimplifyAggregates : Pass<"merge-connections", "firrtl::FModuleOp"> {
   let summary = "Merge field-level connections into full bundle connections";
-  let constructor = "circt::firrtl::createMergeConnectionsPass()";
+  let constructor = "circt::firrtl::createSimplifyAggregatesPass()";
   let options = [
     Option<"enableAggressiveMerging", "aggressive-merging", "bool", "false",
       "Merge connections even when source values won't be simplified.">

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -23,7 +23,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerMemory.cpp
   LowerTypes.cpp
   LowerXMR.cpp
-  MergeConnections.cpp
+  SimplifyAggregates.cpp
   MemToRegOfVec.cpp
   ModuleInliner.cpp
   PrefixModules.cpp

--- a/test/Dialect/FIRRTL/simplify-aggregates.mlir
+++ b/test/Dialect/FIRRTL/simplify-aggregates.mlir
@@ -107,4 +107,15 @@ firrtl.circuit "Test"   {
     firrtl.strictconnect %2, %invalid_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %1, %invalid_ui1 : !firrtl.uint<1>
   }
+
+  // COMMON-LABEL:  firrtl.module @MultibitMux
+  // COMMON-NEXT:      %0 = firrtl.subaccess %a[%sel] : !firrtl.vector<uint<1>, 3>, !firrtl.uint<2>
+  // COMMON-NEXT:      firrtl.strictconnect %b, %0 : !firrtl.uint<1>
+  firrtl.module @MultibitMux(in %a: !firrtl.vector<uint<1>, 3>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<1>) {
+    %0 = firrtl.subindex %a[2] : !firrtl.vector<uint<1>, 3>
+    %1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 3>
+    %2 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 3>
+    %3 = firrtl.multibit_mux %sel, %0, %1, %2 : !firrtl.uint<2>, !firrtl.uint<1>
+    firrtl.strictconnect %b, %3 : !firrtl.uint<1>
+  }
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -291,9 +291,10 @@ static cl::opt<bool> disableIMDCE("disable-imdce",
                                   cl::cat(mainCategory));
 
 static cl::opt<bool>
-    disableMergeConnections("disable-merge-connections",
-                            cl::desc("Disable the MergeConnections pass"),
-                            cl::init(false), cl::Hidden, cl::cat(mainCategory));
+    disableSimplifyAggregates("disable-simplify-aggregates",
+                              cl::desc("Disable the SimplifyAggregates pass"),
+                              cl::init(false), cl::Hidden,
+                              cl::cat(mainCategory));
 
 static cl::opt<bool>
     mergeConnectionsAgggresively("merge-connections-aggressive-merging",
@@ -703,9 +704,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (!disableOptimization &&
       preserveAggregate != firrtl::PreserveAggregate::None &&
-      !disableMergeConnections)
+      !disableSimplifyAggregates)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        firrtl::createMergeConnectionsPass(mergeConnectionsAgggresively));
+        firrtl::createSimplifyAggregatesPass(mergeConnectionsAgggresively));
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {


### PR DESCRIPTION
This commit first renames MergeConnections pass to SimplifyAggregate
pass since the pass will performs simplifications not only merge
connectinos but also ones related to aggregates. Currently aggregate
multibitmux, e.g. `multibit_mux i, a[n-1], a[n-2], .., a[0]`, creates
a temporary array `{a[n-1], a[n-2], ..., a[0]}`. This is obviosuly
unnecessary so we have to fold such multibit mux into subaccess op.