### PR TITLE
[FIRRTL] Support GC internalPath on Modules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -935,8 +935,12 @@ void GrandCentralTapsPass::gatherAnnotations(Operation *op) {
     };
     AnnotationSet::removePortAnnotations(op, gather);
 
-    // Handle internal data taps on extmodule ops.
-    if (isa<FExtModuleOp>(op)) {
+    // Handle internal data taps.
+    // Note that these work for both extmodules AND regular modules.
+    // Note also that we do NOT currently check that the String target of an
+    // internalKeySourceClass actually corresponds to anything in regular
+    // modules.
+    if (isa<FModuleOp, FExtModuleOp>(op)) {
       auto gather = [&](Annotation anno) {
         if (anno.isClass(internalKeySourceClass)) {
           gatherTap(anno, op);

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -459,3 +459,59 @@ circuit ConstantSinking : %[[
   module ConstantSinking:
     inst dataTap of DataTap
     node w = UInt<1>(1)
+
+; // -----
+
+circuit Top : %[[
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Top|Child>sum"
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|Child",
+        "internalPath":"sum",
+        "portName":"~Top|DataTap>_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|Child",
+        "internalPath":"not.a.real.path",
+        "portName":"~Top|DataTap>_1"
+      }
+    ]
+  }
+]]
+  module Child :
+    output io : { flip in : UInt<8>, out : UInt<8>}
+
+    node sum = tail(add(io.in, UInt<1>(1)), 1)
+
+    io.out <= sum
+
+  extmodule DataTap :
+    output _0 : UInt<8>
+    output _1 : UInt<8>
+    defname = DataTap
+
+  module Top :
+    output io : { flip in : UInt<8>, out : UInt<8>}
+    output taps : UInt<8>[2]
+
+    inst child of Child
+    io <= child.io
+
+    inst dt of DataTap
+    taps[0] <= dt._0
+    taps[1] <= dt._1
+
+; CHECK: module DataTap_impl_0(
+; CHECK:   output [7:0] _0,
+; CHECK:                _1);
+; CHECK:   assign _0 = Top.child.sum;
+; CHECK:   assign _1 = Top.child.not.a.real.path;
+; CHECK: endmodule


### PR DESCRIPTION
In GrandCentral DataTapsAnnotations, there are DataTapModuleSignalKeys which tap signals based on a string `internalPath`. These are typically used on extmodules with the promise that the `internalPath` exists somewhere in the implementation of the extmodule. Generators that cannot distinguish between they are constructing Grand Central annotations on modules or extmodules in their emitted FIRRTL use these unsafe `internalPath`s on actual modules.

This is a patch fix for something we can better implement once GrandCentral is migrated to using RefOps.

Reiterating that this is not great, we could definitely check that the `internalPath` does actually correspond to an op or port. This is a patch solution supporting a use case that will ultimately be replaced by exposing RefOps in the FIRRTL spec and getting rid of the Grand Central annotations.

Note that I do intentionally include an `internalPath` that doesn't correspond to anything in the actual module. The intent of the API is that such things don't error in firtool, but rather error in Verilog.