### PR TITLE
[SystemC] Add VariableOp and AssignOp

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -150,3 +150,36 @@ def DeleteOp : SystemCOp<"cpp.delete", []> {
   let arguments = (ins EmitC_PointerType:$pointer);
   let assemblyFormat = "$pointer attr-dict `:` qualified(type($pointer))";
 }
+
+def AssignOp : SystemCOp<"cpp.assign", [SameTypeOperands]> {
+  let summary = "A C++ assignment.";
+  let description = [{
+    Assigns one SSA value to another. Note that there is no notion of lvalues
+    and rvalues. This means that one can assign to a value that is the result
+    of, e.g., an addition, which is not allowed in C++. It is the responsibility
+    of the user and the implementor of a lowering pass that creates this
+    operation to make sure that the operands are valid according to C++
+    semantics. Rationale for that: implementing these constraints would add
+    quite some complexity, but still does not guarantee that the assignment
+    is valid because we also make use of non-verifyable verbatim types, etc.
+  }];
+
+  let arguments = (ins AnyType:$dest, AnyType:$source);
+  let assemblyFormat = "$dest `=` $source attr-dict `:` type($dest)";
+}
+
+def VariableOp : SystemCOp<"cpp.variable", [HasCustomSSAName,
+                                            SystemCNameDeclOpInterface]> {
+  let summary = "Declare a C++ variable with optional initialization value.";
+  let description = [{
+    Declares a variable according to C++ semantics. If an initialization value
+    is present, the variable will be assigned that value at the declaration,
+    e.g, `int varname = 0;`.
+  }];
+
+  let arguments = (ins StrAttr:$name, Optional<AnyType>:$init);
+  let results = (outs AnyType:$variable);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -10,6 +10,9 @@ systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %p
   %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
   %sig = systemc.signal : !systemc.signal<i64>
   %channel = systemc.signal : !systemc.signal<i32>
+  %testvar = systemc.cpp.variable : i32
+  %c42_i32 = hw.constant 42 : i32
+  %testvarwithinit = systemc.cpp.variable %c42_i32 : i32
   systemc.ctor {
     systemc.instance.bind_port %submoduleInstance["in0"] to %channel : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>, !systemc.signal<i32>
     systemc.method %add
@@ -24,5 +27,7 @@ systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %p
     systemc.signal.write %port4, %2 : !systemc.out<i1>
     %3 = hw.constant 0 : i1
     systemc.signal.write %port4, %3 : !systemc.out<i1>
+    systemc.cpp.assign %testvar = %c42_i32 : i32
+    systemc.cpp.assign %testvarwithinit = %testvar : i32
   }
 }

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -550,6 +550,58 @@ StringRef BindPortOp::getPortName() {
 }
 
 //===----------------------------------------------------------------------===//
+// VariableOp
+//===----------------------------------------------------------------------===//
+
+void VariableOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getVariable(), getName());
+}
+
+ParseResult VariableOp::parse(OpAsmParser &parser, OperationState &result) {
+  StringAttr nameAttr;
+  if (parseImplicitSSAName(parser, nameAttr))
+    return failure();
+  result.addAttribute("name", nameAttr);
+
+  OpAsmParser::UnresolvedOperand init;
+  auto initResult = parser.parseOptionalOperand(init);
+
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  Type variableType;
+  if (parser.parseColonType(variableType))
+    return failure();
+
+  if (initResult.has_value()) {
+    if (parser.resolveOperand(init, variableType, result.operands))
+      return failure();
+  }
+  result.addTypes({variableType});
+
+  return success();
+}
+
+void VariableOp::print(::mlir::OpAsmPrinter &p) {
+  p << " ";
+
+  if (getInit())
+    p << getInit() << " ";
+
+  p.printOptionalAttrDict(getOperation()->getAttrs(), {"name"});
+  p << ": " << getVariable().getType();
+}
+
+LogicalResult VariableOp::verify() {
+  if (getInit() && getInit().getType() != getVariable().getType())
+    return emitOpError(
+               "'init' and 'variable' must have the same type, but got ")
+           << getInit().getType() << " and " << getVariable().getType();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -18,6 +18,17 @@ using namespace circt;
 using namespace circt::systemc;
 using namespace circt::ExportSystemC;
 
+static void parenthesizeOnLowerPrecedence(InlineEmitter &emitter,
+                                          Precedence prec, EmissionPrinter &p) {
+  if (emitter.getPrecedence() >= prec)
+    p << "(";
+
+  emitter.emit();
+
+  if (emitter.getPrecedence() >= prec)
+    p << ")";
+}
+
 //===----------------------------------------------------------------------===//
 // Operation emission patterns.
 //===----------------------------------------------------------------------===//
@@ -222,6 +233,49 @@ struct BindPortEmitter : OpEmissionPattern<BindPortOp> {
   }
 };
 
+/// Emit a systemc.cpp.assign operation.
+struct AssignEmitter : OpEmissionPattern<AssignOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  void emitStatement(AssignOp op, EmissionPrinter &p) override {
+    auto sourceEmitter = p.getInlinable(op.getSource());
+    auto destEmitter = p.getInlinable(op.getDest());
+
+    parenthesizeOnLowerPrecedence(destEmitter, Precedence::ASSIGN, p);
+    p << " = ";
+    parenthesizeOnLowerPrecedence(sourceEmitter, Precedence::ASSIGN, p);
+    p << ";\n";
+  }
+};
+
+/// Emit a systemc.cpp.variable operation.
+struct VariableEmitter : OpEmissionPattern<VariableOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  MatchResult matchInlinable(Value value) override {
+    if (value.getDefiningOp<VariableOp>())
+      return Precedence::VAR;
+    return {};
+  }
+
+  void emitInlined(Value value, EmissionPrinter &p) override {
+    p << value.getDefiningOp<VariableOp>().getName();
+  }
+
+  void emitStatement(VariableOp op, EmissionPrinter &p) override {
+    p.emitType(op.getVariable().getType());
+    p << " " << op.getName();
+
+    if (op.getInit()) {
+      p << " = ";
+      auto initEmitter = p.getInlinable(op.getInit());
+      parenthesizeOnLowerPrecedence(initEmitter, Precedence::ASSIGN, p);
+    }
+
+    p << ";\n";
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Type emission patterns.
 //===----------------------------------------------------------------------===//
@@ -253,11 +307,10 @@ struct ModuleTypeEmitter : public TypeEmissionPattern<ModuleType> {
 
 void circt::ExportSystemC::populateSystemCOpEmitters(
     OpEmissionPatternSet &patterns, MLIRContext *context) {
-  patterns
-      .add<BuiltinModuleEmitter, SCModuleEmitter, SignalWriteEmitter,
-           SignalReadEmitter, CtorEmitter, SCFuncEmitter, MethodEmitter,
-           ThreadEmitter, SignalEmitter, InstanceDeclEmitter, BindPortEmitter>(
-          context);
+  patterns.add<BuiltinModuleEmitter, SCModuleEmitter, SignalWriteEmitter,
+               SignalReadEmitter, CtorEmitter, SCFuncEmitter, MethodEmitter,
+               ThreadEmitter, SignalEmitter, InstanceDeclEmitter,
+               BindPortEmitter, AssignEmitter, VariableEmitter>(context);
 }
 
 void circt::ExportSystemC::populateSystemCTypeEmitters(

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -20,12 +20,13 @@ using namespace circt::ExportSystemC;
 
 static void parenthesizeOnLowerPrecedence(InlineEmitter &emitter,
                                           Precedence prec, EmissionPrinter &p) {
-  if (emitter.getPrecedence() >= prec)
+  bool needParens = emitter.getPrecedence() >= prec;
+  if (needParens)
     p << "(";
 
   emitter.emit();
 
-  if (emitter.getPrecedence() >= prec)
+  if (needParens)
     p << ")";
 }
 

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -344,3 +344,36 @@ systemc.module @baseTypeMismatch (%out0: !systemc.out<i32>) {
     "systemc.instance.bind_port"(%instance, %out0) {portId = 1 : index} : (!systemc.module<submodule(out0: !systemc.out<i32>)>, !systemc.out<i32>) -> ()
   }
 }
+
+// -----
+
+systemc.module @assignOperandTypeMismatch () {
+  %var = systemc.cpp.variable : i32
+  systemc.ctor {
+    %0 = hw.constant 0 : i8
+    // expected-error @+1 {{requires all operands to have the same type}}
+    "systemc.cpp.assign"(%var, %0) : (i32, i8) -> ()
+  }
+}
+
+// -----
+
+systemc.module @variableOperandTypeMismatch () {
+  systemc.ctor {
+    %0 = hw.constant 0 : i8
+    // expected-error @+1 {{'init' and 'variable' must have the same type, but got 'i8' and 'i32'}}
+    %1 = "systemc.cpp.variable"(%0) {name = "var"} : (i8) -> i32
+  }
+}
+
+// -----
+
+// expected-note @+1 {{in module '@variableNameCollision'}}
+systemc.module @variableNameCollision () {
+  systemc.ctor {
+    // expected-note @+1 {{'var' first defined here}}
+    %0 = "systemc.cpp.variable"() {name = "var"} : () -> i32
+    // expected-error @+1 {{redefines name 'var'}}
+    %1 = "systemc.cpp.variable"() {name = "var"} : () -> i32
+  }
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -99,3 +99,20 @@ systemc.module @attributes () {
   systemc.cpp.destructor attributes {systemc.someattr = 0 : i64} {}
   // CHECK-NEXT: }
 }
+
+// CHECK-LABEL: systemc.module @variableAndAssign
+systemc.module @variableAndAssign () {
+  // CHECK-NEXT: %varname = systemc.cpp.variable : i32
+  %varname = systemc.cpp.variable : i32
+  // CHECK-NEXT: systemc.ctor {
+  systemc.ctor {
+    // CHECK-NEXT: %c42_i32 = hw.constant 42 : i32
+    %c42_i32 = hw.constant 42 : i32
+    // CHECK-NEXT: systemc.cpp.assign %varname = %c42_i32 : i32
+    systemc.cpp.assign %varname = %c42_i32 : i32
+    // CHECK-NEXT: %varwithinit = systemc.cpp.variable %varname : i32
+    %varwithinit = systemc.cpp.variable %varname : i32
+    // CHECK-NEXT: systemc.cpp.assign %varwithinit = %varname : i32
+    systemc.cpp.assign %varwithinit = %varname : i32
+  }
+}

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -33,6 +33,11 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %po
   %channel = systemc.signal : !systemc.signal<i32>
   // CHECK-NEXT: submodule submoduleInstance;
   %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
+  // CHECK-NEXT: sc_uint<32> testvar;
+  %testvar = systemc.cpp.variable : i32
+  // CHECK-NEXT: sc_uint<32> testvarwithinit = 42;
+  %c42_i32 = hw.constant 42 : i32
+  %testvarwithinit = systemc.cpp.variable %c42_i32 : i32
   // CHECK-EMPTY: 
   // CHECK-NEXT: SC_CTOR(basic) {
   systemc.ctor {
@@ -59,6 +64,10 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %po
     // CHECK-NEXT: port4.write(false);
     %3 = hw.constant 0 : i1
     systemc.signal.write %port4, %3 : !systemc.out<i1>
+    // CHECK-NEXT: testvar = 42;
+    systemc.cpp.assign %testvar = %c42_i32 : i32
+    // CHECK-NEXT: testvarwithinit = testvar;
+    systemc.cpp.assign %testvarwithinit = %testvar : i32
   // CHECK-NEXT: }
   }
 // CHECK-NEXT: };


### PR DESCRIPTION
Add an operation to model C++ level variable declarations and one to assign to them. This also includes the emission patterns for ExportSystemC. Note that the variable op implements custom parser, printer, and verifier because the single optional operand makes it difficult to use the predefined constraints to check for type equality and infer the type from the result type.