### PR TITLE
[LowerToHW] Use SV attributes to annotate multibit mux pragmas

### DIFF
--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -77,5 +77,15 @@ def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
   let parameters = (ins "mlir::ArrayAttr":$attributes,
                       DefaultValuedParameter<"mlir::BoolAttr",
                       "mlir::BoolAttr::get($_ctxt, false)">:$emitAsComments);
+  let builders = [
+    AttrBuilder<(ins "llvm::ArrayRef<llvm::StringRef>":$strings, "bool": $emitAsComments), [{
+      SmallVector<Attribute> attrs;
+      for (auto str : strings)
+        attrs.push_back(sv::SVAttributeAttr::get(
+            $_ctxt, ::mlir::StringAttr::get($_ctxt, str), ::mlir::StringAttr()));
+      return $_get($_ctxt, ::mlir::ArrayAttr::get($_ctxt, attrs),
+                   ::mlir::BoolAttr::get($_ctxt, emitAsComments));
+    }]>,
+  ];
   let hasCustomAssemblyFormat = true;
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -291,8 +291,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %[[ARRAY:.+]] = hw.array_create %false, %false, %false
     // CHECK-NEXT: %[[WIRE:.+]] = sv.wire
     // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[ARRAY]][%[[ZEXT_INDEX]]]
-    // CHECK-NEXT{LITERAL}: sv.verbatim "assign {{0}} = {{1}} /* cadence map_to_mux */; /* synopsys infer_mux_override */"
-    // CHECK-SAME: (%[[WIRE]], %[[ARRAY_GET]])
+    // CHECK-NEXT: sv.assign %[[WIRE]], %[[ARRAY_GET]]
     // CHECK-NEXT: %[[READ_WIRE:.+]] = sv.read_inout %[[WIRE]] : !hw.inout<i1>
     // CHECK-NEXT: %[[ARRAY_ZEROTH:.+]] = hw.array_get %[[ARRAY]][%c0_i2]
     // CHECK-NEXT: %[[IS_OOB:.+]] = comb.icmp bin uge %[[ZEXT_INDEX]], %c-1_i2
@@ -1257,9 +1256,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %sink, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:      %0 = hw.array_create %source_2, %source_1, %source_0 : i1
     // CHECK-NEXT: %1 = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: %2 = hw.array_get %0[%index] : !hw.array<3xi1>
-    // CHECK-NEXT{LITERAL}: sv.verbatim "assign {{0}} = {{1}} /* cadence map_to_mux */; /* synopsys infer_mux_override */"
-    // CHECK-SAME: (%1, %2)
+    // CHECK-NEXT: %2 = hw.array_get %0[%index] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>}
+    // CHECK-NEXT: sv.assign %1, %2 {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
     // CHECK-NEXT: %3 = sv.read_inout %1 : !hw.inout<i1>
     // CHECK-NEXT: %4 = hw.array_get %0[%c0_i2]
     // CHECK-NEXT: %5 = comb.icmp bin uge %index, %c-1_i2

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -276,7 +276,8 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; VERILOG:  wire [2:0] [[T2:.*]] =
 ; VERILOG-SAME{LITERAL}: {{a_2}, {a_1}, {a_0}};
 ; VERILOG-NEXT:  wire [[T1:.*]];
-; VERILOG-NEXT:  assign [[T1]] = [[T2]][sel] /* cadence map_to_mux */; /* synopsys infer_mux_override */
+; VERILOG-NEXT:  /* synopsys infer_mux_override */
+; VERILOG-NEXT:  assign [[T1]] = [[T2]][sel] /* cadence map_to_mux */;
 ; VERILOG-NEXT:  assign b = &sel ? a_0 : [[T1]];
 
   module UnusedPortsMod :

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -69,14 +69,11 @@ circuit Qux: %[[{
 ;CHECK:    %[[v4:.+]] = sv.read_inout %[[addr]]
 ;CHECK:    %[[v5:.+]] = hw.array_create
 ;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%[[v4]]] : !hw.array<4xi8>
-;CHECK{LITERAL}:    sv.verbatim "assign {{0}} = {{1}} /* cadence map_to_mux */; /* synopsys infer_mux_override */"
-;CHECK-SAME:        (%[[multbit_mux_wire]], %[[array_get]])
+;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%[[v4]]]
+;CHECK:    sv.assign %[[multbit_mux_wire]], %[[array_get]]
 ;CHECK:    %[[v6:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
 ;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
 ;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%rwAddr]
-;CHECK{LITERAL}:    sv.verbatim "assign {{0}} = {{1}} /* cadence map_to_mux */; /* synopsys infer_mux_override */"
-;CHECK-SAME:        (%[[multbit_mux_wire]], %[[array_get]])
 ;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
 ;CHECK:    sv.always posedge %clock {
 ;CHECK-NEXT:      sv.passign %[[memory_0]]


### PR DESCRIPTION
This PR is a follow up of https://github.com/llvm/circt/pull/3404 to replace verbatim uses with SV attributes.
Fix https://github.com/llvm/circt/issues/3828 by eliminating verbatim from multbitmux lowerings.