### PR TITLE
[FIRRTL] Use BitVector over ArrayRef/SmallVector for eraseArguments.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -101,7 +101,7 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
     /// Builds a new `InstanceOp` with the ports listed in `portIndices` erased,
     /// and updates any users of the remaining ports to point at the new
     /// instance.
-    InstanceOp erasePorts(OpBuilder &builder, ArrayRef<unsigned> portIndices);
+    InstanceOp erasePorts(OpBuilder &builder, const llvm::BitVector &portIndices);
 
     /// Clone the instance op and add ports.  This is usually used in
     /// conjuction with adding ports to the referenced module. This will emit

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -100,7 +100,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
 
     /// Erases the ports listed in `portIndices`.  `portIndices` is expected to
     /// be in order and unique.
-    void erasePorts(ArrayRef<unsigned> portIndices);
+    void erasePorts(const llvm::BitVector &portIndices);
 
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -98,8 +98,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
     /// Inserts the given ports.
     void insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports);
 
-    /// Erases the ports listed in `portIndices`.  `portIndices` is expected to
-    /// be in order and unique.
+    /// Erases the ports that have their corresponding bit set in `portIndices`.
     void erasePorts(const llvm::BitVector &portIndices);
 
     void getAsmBlockArgumentNames(mlir::Region &region,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -42,9 +42,8 @@ using namespace chirrtl;
 // Utilities
 //===----------------------------------------------------------------------===//
 
-/// Remove elements at the specified indices from the input array, returning the
-/// elements not mentioned.  The indices array is expected to be sorted and
-/// unique.
+/// Remove elements from the input array corresponding to set bits in
+/// `indicesToDrop`, returning the elements not mentioned.
 template <typename T>
 static SmallVector<T>
 removeElementsAtIndices(ArrayRef<T> input,
@@ -575,8 +574,7 @@ void FMemModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
   (*this).setPortSymbols(newSyms);
 }
 
-/// Erases the ports listed in `portIndices`.  `portIndices` is expected to
-/// be in order and unique.
+/// Erases the ports that have their corresponding bit set in `portIndices`.
 void FModuleOp::erasePorts(const llvm::BitVector &portIndices) {
   if (portIndices.none())
     return;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1221,6 +1221,9 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
 /// updates any users of the remaining ports to point at the new instance.
 InstanceOp InstanceOp::erasePorts(OpBuilder &builder,
                                   const llvm::BitVector &portIndices) {
+  assert(portIndices.size() <= getNumResults() &&
+         "portIndices is not at least as large as getNumResults()");
+
   if (portIndices.none())
     return *this;
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1219,7 +1219,7 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
 /// updates any users of the remaining ports to point at the new instance.
 InstanceOp InstanceOp::erasePorts(OpBuilder &builder,
                                   const llvm::BitVector &portIndices) {
-  assert(portIndices.size() <= getNumResults() &&
+  assert(portIndices.size() >= getNumResults() &&
          "portIndices is not at least as large as getNumResults()");
 
   if (portIndices.none())

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Support/Debug.h"
 
@@ -53,12 +54,12 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
     FModuleOp module, InstanceGraphNode *instanceGraphNode) {
   LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
                           << "\n");
-  // This tracks port indexes that can be erased.
-  SmallVector<unsigned> removalPortIndexes;
   // This tracks constant values of output ports. None indicates an invalid
   // value.
   SmallVector<llvm::Optional<APSInt>> outputPortConstants;
   auto ports = module.getPorts();
+  // This tracks port indexes that can be erased.
+  llvm::BitVector removalPortIndexes(ports.size());
 
   for (const auto &e : llvm::enumerate(ports)) {
     unsigned index = e.index();
@@ -126,16 +127,16 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
       }
     }
 
-    removalPortIndexes.push_back(index);
+    removalPortIndexes.set(index);
   }
 
   // If there is nothing to remove, abort.
-  if (removalPortIndexes.empty())
+  if (removalPortIndexes.none())
     return;
 
   // Delete ports from the module.
   module.erasePorts(removalPortIndexes);
-  LLVM_DEBUG(llvm::for_each(removalPortIndexes, [&](unsigned index) {
+  LLVM_DEBUG(llvm::for_each(removalPortIndexes.set_bits(), [&](unsigned index) {
                llvm::dbgs() << "Delete port: " << ports[index].name << "\n";
              }););
 
@@ -144,7 +145,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
     auto instance = ::cast<InstanceOp>(*use->getInstance());
     ImplicitLocOpBuilder builder(instance.getLoc(), instance);
     unsigned outputPortIndex = 0;
-    for (auto index : removalPortIndexes) {
+    for (auto index : removalPortIndexes.set_bits()) {
       auto result = instance.getResult(index);
       assert(!ports[index].isInOut() && "don't expect inout ports");
 
@@ -195,7 +196,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
     instance.erase();
   }
 
-  numRemovedPorts += removalPortIndexes.size();
+  numRemovedPorts += removalPortIndexes.count();
 }
 
 std::unique_ptr<mlir::Pass>


### PR DESCRIPTION
Upstream MLIR removed an overload of `eraseArguments()` in [27e8ee208cb2142514ee2e3ab342dafaf6374f9e](https://github.com/llvm/llvm-project/commit/27e8ee208cb2142514ee2e3ab342dafaf6374f9e) (https://reviews.llvm.org/D132896), stating that the overload isn't useful because we should probably be using BitVector in most cases.

This mostly affected code in the FIRRTL dialect that used SmallVector for holding the list of port indices to delete, which indeed can be replaced with a BitVector.

One thing to be careful about is that while `push_back()` is still defined on BitVector, it has different behavior than `SmallVector<unsigned>::push_back()`, in that the former only allows you to push back a boolean 0 or 1 to the end of the bit vector, while the latter pushes back an integer index. `BitVector::set()` matches the previous behavior.


There are a few places where I wasn't 100% sure if my changes are correct/safe/efficient, so I'd appreciate it if someone could carefully review the code changes.