### PR TITLE
[HW] Canonicalize array get on uniform arrays

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -39,6 +39,14 @@ def ArrayCreateOp : HWOp<"array_create", [NoSideEffect, SameTypeOperands]> {
     // ValueRange needs to contain at least one element.
     OpBuilder<(ins "ValueRange":$input)>
   ];
+
+  let extraClassDeclaration = [{
+    /// If the all elements of the array are identical, returns that element
+    /// value. Otherwise returns a null value.
+    Value getUniformElement();
+    /// Returns true if all array elements are identical.
+    bool isUniform() { return !!getUniformElement(); }
+  }];
 }
 
 def ArrayConcatOp : HWOp<"array_concat", [NoSideEffect]> {

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1467,3 +1467,11 @@ hw.module @SliceOfCreate(%a0: i1, %a1: i1, %a2: i1, %a3: i1) -> (out: !hw.array<
 
   hw.output %slice : !hw.array<2xi1>
 }
+
+// CHECK-LABEL: hw.module @GetOfUniformArray
+hw.module @GetOfUniformArray(%in: i42, %address: i2) -> (out: i42) {
+  // CHECK: hw.output %in : i42
+  %0 = hw.array_create %in, %in, %in, %in : i42
+  %1 = hw.array_get %0[%address] : !hw.array<4xi42>
+  hw.output %1 : i42
+}


### PR DESCRIPTION
Add a `getUniformElement()` helper function to `ArrayCreateOp` which checks if all elements of the created array are identical and returns that uniform value. Add a folder for `ArrayGetOp` that simply forwards this uniform value if it exists.

Fixes #3841.

The following FIRRTL:
```
circuit Foo :
  module Foo :
    input in0 : UInt<1>
    input in1 : UInt<1>
    input address : UInt<2>

    output out : UInt<1>

    node idStall = or(in0, in1)

    wire sourceStall : UInt<1>[4]
    sourceStall[0] <= idStall
    sourceStall[1] <= idStall
    sourceStall[2] <= idStall
    sourceStall[3] <= idStall
    out <= sourceStall[address]
```

Now expands to:
```systemverilog
module Foo(
  input        in0,
               in1,
  input  [1:0] address,
  output       out);

  wire _GEN;
  /* synopsys infer_mux_override */
  assign _GEN = in0 | in1;
  assign out = _GEN;
endmodule
```