### PR TITLE
[ExportVerliog] Add a `sv.hint.emit_as_mux` attribute

### DIFF
--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -9,6 +9,19 @@ hw.module @namehint_variadic(%a: i3) -> (b: i3) {
   hw.output %0 : i3
 }
 
+// CHECK-LABEL: hw.module @MuxEmissionHints
+hw.module @MuxEmissionHints(%in: !hw.array<4xi42>, %index: i2) -> (outA: i42, outB: i42) {
+  %0 = hw.array_get %in[%index] : !hw.array<4xi42>
+  // CHECK-NEXT: [[GET0:%.+]] = hw.array_get %in[%index] :
+  %1 = hw.array_get %in[%index] {sv.hint.emit_as_mux} : !hw.array<4xi42>
+  // CHECK-NEXT: [[GET1:%.+]] = hw.array_get %in[%index] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>} :
+  // CHECK-NEXT: [[WIRE:%.+]] = sv.wire
+  // CHECK-NEXT: [[READ:%.+]] = sv.read_inout [[WIRE]]
+  // CHECK-NEXT: sv.assign [[WIRE]], [[GET1]] {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
+  hw.output %0, %1 : i42, i42
+  // CHECK-NEXT: hw.output [[GET0]], [[READ]]
+}
+
 // -----
 
 module {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -289,13 +289,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %61 = firrtl.multibit_mux %17, %55, %55, %55 : !firrtl.uint<1>, !firrtl.sint<1>
     // CHECK:      %[[ZEXT_INDEX:.+]] = comb.concat %false, {{.*}} : i1, i1
     // CHECK-NEXT: %[[ARRAY:.+]] = hw.array_create %false, %false, %false
-    // CHECK-NEXT: %[[WIRE:.+]] = sv.wire
-    // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[ARRAY]][%[[ZEXT_INDEX]]]
-    // CHECK-NEXT: sv.assign %[[WIRE]], %[[ARRAY_GET]]
-    // CHECK-NEXT: %[[READ_WIRE:.+]] = sv.read_inout %[[WIRE]] : !hw.inout<i1>
+    // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[ARRAY]][%[[ZEXT_INDEX]]] {sv.hint.emit_as_mux}
     // CHECK-NEXT: %[[ARRAY_ZEROTH:.+]] = hw.array_get %[[ARRAY]][%c0_i2]
     // CHECK-NEXT: %[[IS_OOB:.+]] = comb.icmp bin uge %[[ZEXT_INDEX]], %c-1_i2
-    // CHECK-NEXT: %[[GUARDED:.+]] = comb.mux bin %[[IS_OOB]], %[[ARRAY_ZEROTH]], %[[READ_WIRE]]
+    // CHECK-NEXT: %[[GUARDED:.+]] = comb.mux bin %[[IS_OOB]], %[[ARRAY_ZEROTH]], %[[ARRAY_GET]]
     // CHECK: hw.output %false, %[[GUARDED]] : i1, i1
     firrtl.connect %out2, %61 : !firrtl.sint<1>, !firrtl.sint<1>
   }
@@ -1255,14 +1252,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %0 = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %sink, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:      %0 = hw.array_create %source_2, %source_1, %source_0 : i1
-    // CHECK-NEXT: %1 = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: %2 = hw.array_get %0[%index] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>}
-    // CHECK-NEXT: sv.assign %1, %2 {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
-    // CHECK-NEXT: %3 = sv.read_inout %1 : !hw.inout<i1>
-    // CHECK-NEXT: %4 = hw.array_get %0[%c0_i2]
-    // CHECK-NEXT: %5 = comb.icmp bin uge %index, %c-1_i2
-    // CHECK-NEXT: %6 = comb.mux bin %5, %4, %3
-    // CHECK-NEXT: hw.output %6 : i1
+    // CHECK-NEXT: %1 = hw.array_get %0[%index] {sv.hint.emit_as_mux}
+    // CHECK-NEXT: %2 = hw.array_get %0[%c0_i2]
+    // CHECK-NEXT: %3 = comb.icmp bin uge %index, %c-1_i2
+    // CHECK-NEXT: %4 = comb.mux bin %3, %2, %1
+    // CHECK-NEXT: hw.output %4 : i1
   }
 
   firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -68,13 +68,8 @@ circuit Qux: %[[{
 ;CHECK:    %[[addr:.+]] = sv.reg
 ;CHECK:    %[[v4:.+]] = sv.read_inout %[[addr]]
 ;CHECK:    %[[v5:.+]] = hw.array_create
-;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%[[v4]]]
-;CHECK:    sv.assign %[[multbit_mux_wire]], %[[array_get]]
-;CHECK:    %[[v6:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
-;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%rwAddr]
-;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
+;CHECK:    %[[v6:.+]] = hw.array_get %[[v5]][%[[v4]]] {sv.hint.emit_as_mux}
+;CHECK:    %[[v7:.+]] = hw.array_get %[[v5]][%rwAddr] {sv.hint.emit_as_mux}
 ;CHECK:    sv.always posedge %clock {
 ;CHECK-NEXT:      sv.passign %[[memory_0]]
 ;CHECK-NEXT:      sv.passign %[[memory_1]]


### PR DESCRIPTION
In some cases we would like to emit `array_get` operations in SV with additional vendor pragmas, like `cadence map_to_mux` and `synopsys infer_mux_override`. This comes up in the FIRRTL dialect when lowering the `MultibitMuxOp`.

The current solution requires `LowerToHW` to not only generate the `array_get` operation, but also introduce an `sv.wire` and `sv.assign` with the corresponding SV attributes configured. What bothers me about this is that it _skips_ the HW dialect level and makes the FIRRTL dialect talk about SV things, which precludes us from reasoning about the design at an HW level without any knowledge of SV. Furthermore, it seems useful for other dialects to be able to say "decorate this array_get such that it gets inferred as a mux by downstream tools", instead of resorting to mixing HW with SV themselves.

This PR changes FIRRTL's LowerToHW to just lower `MultibitMuxOp` to the `array_get` op, but with an additional `sv.hint.emit_as_mux` unit attribute. This attribute is then picked up by `ExportVerilog`'s emission preparation, which inserts the appropriate SV IR nodes to get the temporary wire with the desired pragma decorations.

As a result, dialects above HW don't need to talk about the SV AST through the SV dialect just to achieve an optimization hint in the SV output, and the SV dialect becomes responsible for cooking up the necessary pragmas and decorations to honor the hint.