### PR TITLE
[FIRRTLFolds] Forward non-constant values through wires

### DIFF
--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2432,4 +2432,17 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>) {
   // CHECK-NOT: firrtl.cover
   firrtl.cover %clock, %c0, %p, "cover0"
 }
+
+// CHECK-LABEL: firrtl.module @ForwardWireSource
+firrtl.module @ForwardWireSource(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, in %address: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %sourceStall_0 = firrtl.wire   : !firrtl.uint<1>
+  %sourceStall_1 = firrtl.wire   : !firrtl.uint<1>
+  firrtl.strictconnect %sourceStall_0, %0 : !firrtl.uint<1>
+  firrtl.strictconnect %sourceStall_1, %0 : !firrtl.uint<1>
+  // CHECK: %sourceStall_0 = firrtl.or %in0, %in1
+  // CHECK-NEXT: firrtl.strictconnect %out, %sourceStall_0 : !firrtl.uint<1>
+  %1 = firrtl.multibit_mux %address, %sourceStall_1, %sourceStall_0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.strictconnect %out, %1 : !firrtl.uint<1>
+}
 }


### PR DESCRIPTION
This PR modifies `canonicalizeSingleSetConnect` to forward non-constant values through wires. Currently `canonicalizeSingleSetConnect` forwards only constants even for wires that results in some missed optimization opportunity such as https://github.com/llvm/circt/issues/3841. This PR allows non-constant values to be propagated through wires as well.  
The canonicalization implemented by this PR is very similar to https://github.com/llvm/circt/pull/3284, which caused some runtime regression possibly related to `isBeforeInBlock`. Therefore in this PR I limited the number of calls of `isBeforeInBlock`.  

With this PR, 
```
circuit Foo :
  module Foo :
    input in0 : UInt<1>
    input in1 : UInt<1>
    input address : UInt<2>
    
    output out : UInt<1>

    node idStall = or(in0, in1) 

    wire sourceStall : UInt<1>[4]
    sourceStall[0] <= idStall
    sourceStall[1] <= idStall
    sourceStall[2] <= idStall
    sourceStall[3] <= idStall
    out <= sourceStall[address]
```
becomes
```
module Foo(
  input        in0,
               in1,
  input  [1:0] address,
  output       out);

  assign out = in0 | in1;
endmodule
```