### PR TITLE
[PrepareForEmission] Add an option to anchor wiers for input ports

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -127,9 +127,9 @@ struct LoweringOptions {
   /// deprecated once the old emission mode is no longer necessary.
   bool useOldEmissionMode = false;
 
-  /// If true, every expression passed to instance ports is derived by a wire.
-  /// Some LINT tool dislikes expressions being inlined into input ports so this
-  /// option surpasses that warning.
+  /// If true, every expression passed to an instance port is driven by a wire.
+  /// Some lint tools dislike expressions being inlined into input ports so this
+  /// option avoids such warnings.
   bool disallowExpressionInliningInPorts = false;
 };
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -126,6 +126,11 @@ struct LoweringOptions {
   /// If true, ExportVerilog uses an old emission. This flag should be
   /// deprecated once the old emission mode is no longer necessary.
   bool useOldEmissionMode = false;
+
+  /// If true, every expression passed to instance ports is derived by a wire.
+  /// Some LINT tool dislikes expressions being inlined into input ports so this
+  /// option surpasses that warning.
+  bool disallowExpressionInliningInPorts = false;
 };
 
 /// Register commandline options for the verilog emitter.

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -90,6 +90,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       printDebugInfo = true;
     } else if (option == "useOldEmissionMode") {
       useOldEmissionMode = true;
+    } else if (option == "disallowExpressionInliningInPorts") {
+      disallowExpressionInliningInPorts = true;
     } else if (option.consume_front("maximumNumberOfVariadicOperands=")) {
       if (option.getAsInteger(10, maximumNumberOfVariadicOperands)) {
         errorHandler("expected integer for number of variadic operands");
@@ -129,6 +131,8 @@ std::string LoweringOptions::toString() const {
     options += "printDebugInfo,";
   if (useOldEmissionMode)
     options += "useOldEmissionMode,";
+  if (disallowExpressionInliningInPorts)
+    options += "disallowExpressionInliningInPorts,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -202,7 +202,8 @@ struct LoweringCLOptions {
           "maximumNumberOfVariadicOperands=<n>, "
           "emitReplicatedOpsToHeader, "
           "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
-          "disallowPortDeclSharing, printDebugInfo"),
+          "disallowPortDeclSharing, printDebugInfo, useOldEmissionMode, "
+          "disallowExpressionInliningInPorts"),
       llvm::cl::value_desc("option")};
 };
 } // namespace

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -93,3 +93,19 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     hw.output %0, %0 : i4, i4
   }
 }
+
+// -----
+
+module attributes {circt.loweringOptions = "disallowExpressionInliningInPorts"} {
+ hw.module.extern @MyExtModule(%in: i8)
+ // CHECK-LABEL: @MoveInstances
+ hw.module @MoveInstances(%a_in: i8) -> (){
+  // CHECK-NEXT: %_xyz3_in = sv.wire
+  // CHECK-NEXT: %0 = comb.add %a_in, %a_in
+  // CHECK-NEXT: %1 = sv.read_inout %_xyz3_in
+  // CHECK-NEXT: sv.assign %_xyz3_in, %0
+  // CHECK-NEXT: hw.instance "xyz3" @MyExtModule(in: %1: i8) -> ()
+  %0 = comb.add %a_in, %a_in : i8
+  hw.instance "xyz3" @MyExtModule(in: %0: i8) -> ()
+ }
+}


### PR DESCRIPTION
Some LINT tool dislikes expression being inlined into instance ports. This PR adds an option to force wires for
input ports. 

Example:
```mlir
 hw.module.extern @MyExtModule(%in: i8)
 hw.module @MoveInstances(%a_in: i8) -> (){
  %0 = comb.add %a_in, %a_in : i8
  hw.instance "xyz3" @MyExtModule(in: %0: i8) -> ()
 }
```
w/o PR:
```verilog
  MyExtModule xyz3 (    // foo.mlir:12:3
    .in (a_in + a_in)   // foo.mlir:11:8
  );
```
w/ PR and option:
```verilog
  wire [7:0] _xyz3_in;  // foo.mlir:12:3
  assign _xyz3_in = a_in + a_in;        // foo.mlir:11:8, :12:3
  MyExtModule xyz3 (    // foo.mlir:12:3
    .in (_xyz3_in)      // foo.mlir:12:3
  );
```

CC: @rsetaluri