### PR TITLE
[Handshake][HandshakeToFIRRTL] NoneType buffer initialization

### DIFF
--- a/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
+++ b/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
@@ -1,0 +1,37 @@
+// REQUIRES: iverilog,cocotb
+
+// This test is executed with all different buffering strategies
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+
+// CHECK: ** TEST
+// CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
+
+module {
+  handshake.func @top(%arg0: none, ...) -> (none) attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]}{
+    %3 = buffer [1] seq %f#1 {initValues = [0]}: none
+    %ctrlOut = join %3, %arg0 : none
+    %f:2 = fork [2] %ctrlOut : none
+    return %f#0 : none
+  }
+}
+

--- a/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.py
+++ b/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.py
@@ -1,0 +1,13 @@
+import cocotb
+from helper import initDut
+
+
+@cocotb.test()
+async def oneInput(dut):
+  [inCtrl], [outCtrl] = await initDut(dut, ["inCtrl"], ["outCtrl"])
+
+  outCtrlCheck = cocotb.start_soon(outCtrl.awaitNOutputs(1))
+  inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+  await inCtrlSend
+  await outCtrlCheck

--- a/integration_test/Dialect/Handshake/lit.local.cfg.py
+++ b/integration_test/Dialect/Handshake/lit.local.cfg.py
@@ -1,3 +1,4 @@
+config.excludes.add('buffer_init_none.py')
 config.excludes.add('driver.sv')
 config.excludes.add('driver_with_input.sv')
 config.excludes.add('tp_memory.py')

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2370,17 +2370,18 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
     // Create registers for data signal.
     Value dataReg = nullptr;
     Value initValue = zeroDataConst;
-    if (isInitialized) {
-      assert(dataType.isa<IntType>() &&
-             "initial values are only supported for integer buffers");
-      initValue = createConstantOp(
-          dataType, APInt(dataType.getBitWidthOrSentinel(), initValues[i]),
-          insertLoc, rewriter);
-    }
-    if (!isControl)
+    if (!isControl) {
+      if (isInitialized) {
+        assert(dataType.isa<IntType>() &&
+               "initial values are only supported for integer buffers");
+        initValue = createConstantOp(
+            dataType, APInt(dataType.getBitWidthOrSentinel(), initValues[i]),
+            insertLoc, rewriter);
+      }
       dataReg =
           rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
                                       initValue, "dataReg" + std::to_string(i));
+    }
 
     // Create wires for valid, ready and data signal coming from the control
     // buffer stage.

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -161,3 +161,14 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
   %0 = buffer [2] seq %arg0 {initValues=[42, 24]} : index
   return %0, %arg1 : index, none
 }
+
+// -----
+
+
+// CHECK-LABEL: firrtl.module @handshake_buffer_1slots_seq_init_0_1ins_1outs_ctrl(
+// CHECK: %[[C1:.*]] = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK: %validReg0 = firrtl.regreset  %clock, %reset, %[[C1]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+handshake.func @test_buffer_init_none_type(%arg0: none, ...) -> (none) {
+  %0 = buffer [1] seq %arg0 {initValues = [0]}: none
+  return %0 : none
+}


### PR DESCRIPTION
Add support to initialize NoneType buffers with tokens. The provided array indicates that the buffer is initialized, but its values are ignored.

I do not like the ignoring of the `initValue` array, but adding a unit attr or something will just increase the different cases we have to support. If you have a good suggestion, please let me know. 