### PR TITLE
[FIRRTLFolds] Improve name propagations

### DIFF
--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2437,9 +2437,9 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>) {
 firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
   %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %_useless_name_1 = firrtl.node  %0  : !firrtl.uint<1>
-  %usefull_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
+  %useful_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
   %_useless_name_2 = firrtl.node  %usefull_name  : !firrtl.uint<1>
-  // CHECK-NEXT: %usefull_name = firrtl.or %in0, %in1
+  // CHECK-NEXT: %useful_name = firrtl.or %in0, %in1
   // CHECK-NEXT: firrtl.strictconnect %out, %usefull_name
   firrtl.strictconnect %out, %_useless_name_2 : !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2432,4 +2432,16 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>) {
   // CHECK-NOT: firrtl.cover
   firrtl.cover %clock, %c0, %p, "cover0"
 }
+
+// CHECK-LABEL: firrtl.module @NameProp
+firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %_useless_name_1 = firrtl.node  %0  : !firrtl.uint<1>
+  %usefull_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
+  %_useless_name_2 = firrtl.node  %usefull_name  : !firrtl.uint<1>
+  // CHECK-NEXT: %usefull_name = firrtl.or %in0, %in1
+  // CHECK-NEXT: firrtl.strictconnect %out, %usefull_name
+  firrtl.strictconnect %out, %_useless_name_2 : !firrtl.uint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2440,7 +2440,7 @@ firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out 
   %useful_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
   %_useless_name_2 = firrtl.node  %usefull_name  : !firrtl.uint<1>
   // CHECK-NEXT: %useful_name = firrtl.or %in0, %in1
-  // CHECK-NEXT: firrtl.strictconnect %out, %usefull_name
+  // CHECK-NEXT: firrtl.strictconnect %out, %useful_name
   firrtl.strictconnect %out, %_useless_name_2 : !firrtl.uint<1>
 }
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2438,7 +2438,7 @@ firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out 
   %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %_useless_name_1 = firrtl.node  %0  : !firrtl.uint<1>
   %useful_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
-  %_useless_name_2 = firrtl.node  %usefull_name  : !firrtl.uint<1>
+  %_useless_name_2 = firrtl.node  %useful_name  : !firrtl.uint<1>
   // CHECK-NEXT: %useful_name = firrtl.or %in0, %in1
   // CHECK-NEXT: firrtl.strictconnect %out, %useful_name
   firrtl.strictconnect %out, %_useless_name_2 : !firrtl.uint<1>


### PR DESCRIPTION
This PR improves name propagations at FIRRTL canonicalizations. Previsouly useful names (i.e. names without prefix "\_") might not be propagated because of the existence of useless names (i.e. names with prefix "\_"). This PR overwrites useless names if we can find useful names.