### PR TITLE
[HandshakeToHW] Initial elaboration of module internals

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -274,7 +274,8 @@ def HandshakeToHW : Pass<"lower-handshake-to-hw", "mlir::ModuleOp"> {
     Lower Handshake to ESI/HW/Comb/Seq.
   }];
   let constructor = "circt::createHandshakeToHWPass()";
-  let dependentDialects = ["hw::HWDialect", "esi::ESIDialect"];
+  let dependentDialects = ["hw::HWDialect", "esi::ESIDialect", "comb::CombDialect",
+                           "seq::SeqDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -199,10 +199,13 @@ public:
   // Returns the i'th/named input port of the module.
   Value getInput(unsigned i);
   Value getInput(StringRef name);
+  ValueRange getInputs() { return inputArgs; }
 
   // Assigns the i'th/named output port of the module.
   void setOutput(unsigned i, Value v);
   void setOutput(StringRef name, Value v);
+
+  const ModulePortInfo &getModulePortInfo() const { return info; }
   const llvm::SmallVector<Value> &getOutputOperands() const {
     return outputOperands;
   }
@@ -211,6 +214,7 @@ private:
   llvm::StringMap<unsigned> inputIdx, outputIdx;
   llvm::SmallVector<Value> inputArgs;
   llvm::SmallVector<Value> outputOperands;
+  ModulePortInfo info;
 };
 
 using HWModuleBuilder =

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -12,12 +12,14 @@
 
 #include "circt/Conversion/HandshakeToHW.h"
 #include "../PassDetail.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Dialect/Handshake/Visitor.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/ValueMapper.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
@@ -34,6 +36,59 @@ using namespace circt::handshake;
 using namespace circt::hw;
 
 using NameUniquer = std::function<std::string(Operation *)>;
+
+namespace {
+
+// Shared state used by various functions; captured in a struct to reduce the
+// number of arguments that we have to pass around.
+struct HandshakeLoweringState {
+  ModuleOp parentModule;
+  NameUniquer nameUniquer;
+};
+
+// Wraps a type into an ESI ChannelType type. The inner type is converted to
+// ensure comprehensability by the RTL dialects.
+static Type esiWrapper(Type t) {
+  // Translate index types to something HW understands.
+  if (t.isa<IndexType>())
+    t = IntegerType::get(t.getContext(), 64);
+
+  // Already a channel type.
+  if (t.isa<esi::ChannelType>())
+    return t;
+
+  return esi::ChannelType::get(t.getContext(), t);
+}
+
+// A type converter is needed to perform the in-flight materialization of "raw"
+// (non-ESI channel) types to their ESI channel correspondents. This comes into
+// effect when backedges exist in the input IR.
+class ESITypeConverter : public TypeConverter {
+public:
+  ESITypeConverter() {
+    addConversion([](Type type) -> Type { return esiWrapper(type); });
+
+    addTargetMaterialization(
+        [&](mlir::OpBuilder &builder, mlir::Type resultType,
+            mlir::ValueRange inputs,
+            mlir::Location loc) -> llvm::Optional<mlir::Value> {
+          if (inputs.size() != 1)
+            return llvm::None;
+          return inputs[0];
+        });
+
+    addSourceMaterialization(
+        [&](mlir::OpBuilder &builder, mlir::Type resultType,
+            mlir::ValueRange inputs,
+            mlir::Location loc) -> llvm::Optional<mlir::Value> {
+          if (inputs.size() != 1)
+            return llvm::None;
+          return inputs[0];
+        });
+  }
+};
+
+} // namespace
 
 /// Returns a submodule name resulting from an operation, without discriminating
 /// type information.
@@ -90,16 +145,6 @@ static DiscriminatingTypes getHandshakeDiscriminatingTypes(Operation *op) {
       });
 }
 
-// Wraps a type into an ESI ChannelType type. The inner type is converted to
-// ensure comprehensability by the RTL dialects.
-static Type esiWrapper(Type t) {
-  // Translate index types to something HW understands.
-  if (t.isa<IndexType>())
-    t = IntegerType::get(t.getContext(), 64);
-
-  return esi::ChannelType::get(t.getContext(), t);
-}
-
 /// Get type name. Currently we only support integer or index types.
 /// The emitted type aligns with the getFIRRTLType() method. Thus all integers
 /// other than signed integers will be emitted as unsigned.
@@ -118,6 +163,8 @@ static std::string getTypeName(Location loc, Type type) {
 
   return typeName;
 }
+
+namespace {
 
 /// A class to be used with getPortInfoForOp. Provides an opaque interface for
 /// generating the port names of an operation; handshake operations generate
@@ -245,6 +292,8 @@ static std::string getSubModuleName(Operation *oldOp) {
   return subModuleName;
 }
 
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // HW Sub-module Related Functions
 //===----------------------------------------------------------------------===//
@@ -272,32 +321,36 @@ static Operation *checkSubModuleOp(mlir::ModuleOp parentModule,
   return moduleOp;
 }
 
-static llvm::SmallVector<PortInfo>
-getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op,
-                 TypeRange inputs, TypeRange outputs) {
-  llvm::SmallVector<PortInfo> ports;
+static ModulePortInfo getPortInfoForOp(ConversionPatternRewriter &rewriter,
+                                       Operation *op, TypeRange inputs,
+                                       TypeRange outputs) {
+  ModulePortInfo ports({}, {});
   HandshakePortNameGenerator portNames(op);
 
   // Add all inputs of funcOp.
   unsigned inIdx = 0;
   for (auto &arg : llvm::enumerate(inputs)) {
-    ports.push_back({portNames.inputName(arg.index()), PortDirection::INPUT,
-                     esiWrapper(arg.value()), arg.index(), StringAttr{}});
+    ports.inputs.push_back({portNames.inputName(arg.index()),
+                            PortDirection::INPUT, esiWrapper(arg.value()),
+                            arg.index(), StringAttr{}});
     inIdx++;
   }
 
   // Add all outputs of funcOp.
   for (auto &res : llvm::enumerate(outputs)) {
-    ports.push_back({portNames.outputName(res.index()), PortDirection::OUTPUT,
-                     esiWrapper(res.value()), res.index(), StringAttr{}});
+    ports.outputs.push_back({portNames.outputName(res.index()),
+                             PortDirection::OUTPUT, esiWrapper(res.value()),
+                             res.index(), StringAttr{}});
   }
 
   // Add clock and reset signals.
   if (op->hasTrait<mlir::OpTrait::HasClock>()) {
-    ports.push_back({rewriter.getStringAttr("clock"), PortDirection::INPUT,
-                     rewriter.getI1Type(), inIdx++, StringAttr{}});
-    ports.push_back({rewriter.getStringAttr("reset"), PortDirection::INPUT,
-                     rewriter.getI1Type(), inIdx, StringAttr{}});
+    ports.inputs.push_back({rewriter.getStringAttr("clock"),
+                            PortDirection::INPUT, rewriter.getI1Type(), inIdx++,
+                            StringAttr{}});
+    ports.inputs.push_back({rewriter.getStringAttr("reset"),
+                            PortDirection::INPUT, rewriter.getI1Type(), inIdx,
+                            StringAttr{}});
   }
 
   return ports;
@@ -305,47 +358,337 @@ getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op,
 
 /// Returns a vector of PortInfo's which defines the FIRRTL interface of the
 /// to-be-converted op.
-static llvm::SmallVector<PortInfo>
-getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op) {
+static ModulePortInfo getPortInfoForOp(ConversionPatternRewriter &rewriter,
+                                       Operation *op) {
   return getPortInfoForOp(rewriter, op, op->getOperandTypes(),
                           op->getResultTypes());
 }
 
-/// All standard expressions and handshake elastic components will be converted
-/// to a HW sub-module and be instantiated in the top-module.
-static HWModuleExternOp createSubModuleOp(ModuleOp parentModule,
-                                          Operation *oldOp,
-                                          ConversionPatternRewriter &rewriter) {
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPointToStart(parentModule.getBody());
-  auto ports = getPortInfoForOp(rewriter, oldOp);
-  // todo: HWModuleOp; for this initial commit we'll leave this as an extern op.
-  return rewriter.create<HWModuleExternOp>(
-      parentModule.getLoc(), rewriter.getStringAttr(getSubModuleName(oldOp)),
-      ports);
+namespace {
+
+// Input handshakes contain a resolved valid and (optional )data signal, and
+// a to-be-assigned ready signal.
+struct InputHandshake {
+  Value valid;
+  std::shared_ptr<Backedge> ready;
+  Value data;
+};
+
+// Output handshakes contain a resolved ready, and to-be-assigned valid and
+// (optional) data signals.
+struct OutputHandshake {
+  std::shared_ptr<Backedge> valid;
+  Value ready;
+  std::shared_ptr<Backedge> data;
+};
+
+struct UnwrappedIO {
+  llvm::SmallVector<InputHandshake> inputs;
+  llvm::SmallVector<OutputHandshake> outputs;
+
+  template <typename T, typename TInner>
+  llvm::SmallVector<T> IOAccessor(llvm::SmallVector<TInner> &container,
+                                  llvm::function_ref<T(TInner &)> extractor) {
+    llvm::SmallVector<T> result;
+    llvm::transform(container, std::back_inserter(result), extractor);
+    return result;
+  }
+
+  llvm::SmallVector<Value> getInputValids() {
+    return IOAccessor<Value, InputHandshake>(inputs,
+                                             [](auto &hs) { return hs.valid; });
+  }
+  llvm::SmallVector<std::shared_ptr<Backedge>> getInputReadys() {
+    return IOAccessor<std::shared_ptr<Backedge>, InputHandshake>(
+        inputs, [](auto &hs) { return hs.ready; });
+  }
+  llvm::SmallVector<Value> getInputDatas() {
+    return IOAccessor<Value, InputHandshake>(inputs,
+                                             [](auto &hs) { return hs.data; });
+  }
+  llvm::SmallVector<std::shared_ptr<Backedge>> getOutputValids() {
+    return IOAccessor<std::shared_ptr<Backedge>, OutputHandshake>(
+        outputs, [](auto &hs) { return hs.valid; });
+  }
+  llvm::SmallVector<Value> getOutputReadys() {
+    return IOAccessor<Value, OutputHandshake>(
+        outputs, [](auto &hs) { return hs.ready; });
+  }
+  llvm::SmallVector<std::shared_ptr<Backedge>> getOutputDatas() {
+    return IOAccessor<std::shared_ptr<Backedge>, OutputHandshake>(
+        outputs, [](auto &hs) { return hs.data; });
+  }
+};
+
+// A class containing a bunch of syntactic sugar to reduce builder function
+// verbosity.
+// @todo: should be moved to support.
+struct RTLBuilder {
+  RTLBuilder(OpBuilder &b, Location loc) : b(b), loc(loc) {}
+  Value constant(unsigned width, int64_t value, Location *extLoc = nullptr) {
+    return b.create<hw::ConstantOp>(getLoc(extLoc), APInt(width, value));
+  }
+  std::pair<Value, Value> wrap(Value data, Value valid,
+                               Location *extLoc = nullptr) {
+    auto wrapOp = b.create<esi::WrapValidReadyOp>(getLoc(extLoc), data, valid);
+    return {wrapOp.getResult(0), wrapOp.getResult(1)};
+  }
+  std::pair<Value, Value> unwrap(Value channel, Value ready,
+                                 Location *extLoc = nullptr) {
+    auto unwrapOp =
+        b.create<esi::UnwrapValidReadyOp>(getLoc(extLoc), channel, ready);
+    return {unwrapOp.getResult(0), unwrapOp.getResult(1)};
+  }
+
+  // Various syntactic sugar functions.
+  Value reg(StringRef name, Value in, Value rstValue, Value clk, Value rst,
+            Location *extLoc = nullptr) {
+    return b.create<seq::CompRegOp>(getLoc(extLoc), in.getType(), in, clk, name,
+                                    rst, rstValue, mlir::StringAttr());
+  }
+
+  Value And(ValueRange values, Location *extLoc = nullptr) {
+    return b.create<comb::AndOp>(getLoc(extLoc), values).getResult();
+  }
+
+  Value Not(Value value, Location *extLoc = nullptr) {
+    return comb::createOrFoldNot(getLoc(extLoc), value, b);
+  }
+
+  Location getLoc(Location *extLoc) { return extLoc ? *extLoc : loc; }
+  OpBuilder &b;
+  Location loc;
+};
+
+static void
+addSequentialIOOperandsIfNeeded(Operation *op,
+                                llvm::SmallVectorImpl<Value> &operands) {
+  if (op->hasTrait<mlir::OpTrait::HasClock>()) {
+    // Parent should at this point be a hw.module and have clock and reset
+    // ports.
+    auto parent = cast<hw::HWModuleOp>(op->getParentOp());
+    operands.push_back(parent.getArgument(parent.getNumArguments() - 2));
+    operands.push_back(parent.getArgument(parent.getNumArguments() - 1));
+  }
 }
+
+template <typename T>
+class HandshakeConversionPattern : public OpConversionPattern<T> {
+public:
+  HandshakeConversionPattern(ESITypeConverter &typeConverter,
+                             MLIRContext *context, OpBuilder &submoduleBuilder,
+                             HandshakeLoweringState &ls)
+      : OpConversionPattern<T>::OpConversionPattern(typeConverter, context),
+        submoduleBuilder(submoduleBuilder), ls(ls) {}
+
+  using OpAdaptor = typename T::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(T op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // Check if a submodule has already been created for the op. If so,
+    // instantiate the submodule. Else, run the pattern-defined module builder.
+    hw::HWModuleLike implModule = checkSubModuleOp(ls.parentModule, op);
+    if (!implModule) {
+      auto portInfo = ModulePortInfo(getPortInfoForOp(rewriter, op));
+
+      implModule = submoduleBuilder.create<hw::HWModuleOp>(
+          op.getLoc(), submoduleBuilder.getStringAttr(getSubModuleName(op)),
+          portInfo, [&](OpBuilder &b, hw::HWModulePortAccessor &ports) {
+            BackedgeBuilder bb(b, op.getLoc());
+            RTLBuilder s(b, op.getLoc());
+            this->buildModule(op, bb, s, ports);
+          });
+    }
+
+    // Instantiate the submodule.
+    llvm::SmallVector<Value> operands = adaptor.getOperands();
+    addSequentialIOOperandsIfNeeded(op, operands);
+    rewriter.replaceOpWithNewOp<hw::InstanceOp>(
+        op, implModule, rewriter.getStringAttr(ls.nameUniquer(op)), operands);
+    return success();
+  }
+
+  virtual void buildModule(T op, BackedgeBuilder &bb, RTLBuilder &builder,
+                           hw::HWModulePortAccessor &ports) const = 0;
+
+  // Syntactic sugar functions.
+  // Unwraps an ESI-interfaced module into its constituent handshake signals.
+  // Backedges are created for the to-be-resolved signals, and output ports
+  // are assigned to their wrapped counterparts.
+  UnwrappedIO unwrapIO(RTLBuilder &s, BackedgeBuilder &bb,
+                       hw::HWModulePortAccessor &ports) const {
+    UnwrappedIO unwrapped;
+    for (auto port : ports.getInputs()) {
+      if (!isa<esi::ChannelType>(port.getType()))
+        continue;
+      InputHandshake hs;
+      auto ready = std::make_shared<Backedge>(bb.get(s.b.getI1Type()));
+      auto [data, valid] = s.unwrap(port, *ready);
+      hs.data = data;
+      hs.valid = valid;
+      hs.ready = ready;
+      unwrapped.inputs.push_back(hs);
+    }
+    for (auto &outputInfo : ports.getModulePortInfo().outputs) {
+      if (!isa<esi::ChannelType>(outputInfo.type))
+        continue;
+      OutputHandshake hs;
+      auto data = std::make_shared<Backedge>(
+          bb.get(cast<esi::ChannelType>(outputInfo.type).getInner()));
+      auto valid = std::make_shared<Backedge>(bb.get(s.b.getI1Type()));
+      auto [dataCh, ready] = s.wrap(*data, *valid);
+      hs.data = data;
+      hs.valid = valid;
+      hs.ready = ready;
+      ports.setOutput(outputInfo.name, dataCh);
+      unwrapped.outputs.push_back(hs);
+    }
+    return unwrapped;
+  }
+
+  void setAllReadyWithCond(RTLBuilder &s, ArrayRef<InputHandshake> inputs,
+                           OutputHandshake &output, Value cond) const {
+    auto validAndReady = s.And({output.ready, cond});
+    for (auto &input : inputs)
+      input.ready->setValue(validAndReady);
+  }
+
+  void buildJoinLogic(RTLBuilder &s, ArrayRef<InputHandshake> inputs,
+                      OutputHandshake &output) const {
+    llvm::SmallVector<Value> valids;
+    for (auto &input : inputs)
+      valids.push_back(input.valid);
+    Value allValid = s.And(valids);
+    setAllReadyWithCond(s, inputs, output, allValid);
+  }
+
+  void buildMuxLogic(RTLBuilder &s, ArrayRef<InputHandshake> inputs,
+                     InputHandshake &cond, OutputHandshake &output) const {}
+
+  void buildForkLogic(RTLBuilder &s, BackedgeBuilder &bb, InputHandshake &input,
+                      ArrayRef<OutputHandshake> outputs,
+                      hw::HWModulePortAccessor &ports) const {
+    auto c0_i1 = s.constant(1, 0);
+    llvm::SmallVector<Value> doneWires;
+    for (auto [i, output] : llvm::enumerate(outputs)) {
+      auto done = bb.get(s.b.getI1Type());
+      auto emitted = s.And({done, s.Not(*input.ready)});
+      auto emitted_reg =
+          s.reg("emitted_" + std::to_string(i), emitted, c0_i1,
+                ports.getInput("clock"), ports.getInput("reset"));
+      auto outValid = s.And({s.Not(emitted_reg), input.valid});
+      output.data->setValue(input.data);
+      output.valid->setValue(outValid);
+      auto validReady = s.And({output.ready, input.valid});
+      done.setValue(s.And({validReady, emitted_reg}));
+      doneWires.push_back(done);
+    }
+    input.ready->setValue(s.And(doneWires));
+  }
+
+private:
+  OpBuilder &submoduleBuilder;
+  HandshakeLoweringState &ls;
+};
+
+class ForkConversionPattern : public HandshakeConversionPattern<ForkOp> {
+public:
+  using HandshakeConversionPattern<ForkOp>::HandshakeConversionPattern;
+  void buildModule(ForkOp op, BackedgeBuilder &bb, RTLBuilder &s,
+                   hw::HWModulePortAccessor &ports) const override {
+    auto unwrapped = unwrapIO(s, bb, ports);
+    buildForkLogic(s, bb, unwrapped.inputs[0], unwrapped.outputs, ports);
+  }
+};
+
+class JoinConversionPattern : public HandshakeConversionPattern<JoinOp> {
+public:
+  using HandshakeConversionPattern<JoinOp>::HandshakeConversionPattern;
+  void buildModule(JoinOp op, BackedgeBuilder &bb, RTLBuilder &s,
+                   hw::HWModulePortAccessor &ports) const override {
+    auto unwrappedIO = unwrapIO(s, bb, ports);
+    buildJoinLogic(s, unwrappedIO.inputs, unwrappedIO.outputs[0]);
+  };
+};
+
+class ReturnConversionPattern
+    : public OpConversionPattern<handshake::ReturnOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Locate existing output op, Append operands to output op, and move to the
+    // end of the block.
+    auto parent = cast<hw::HWModuleOp>(op->getParentOp());
+    auto outputOp = *parent.getBodyBlock()->getOps<hw::OutputOp>().begin();
+    outputOp->setOperands(adaptor.getOperands());
+    outputOp->moveAfter(&parent.getBodyBlock()->back());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+template <typename T>
+class ExtModuleConversionPattern : public OpConversionPattern<T> {
+public:
+  ExtModuleConversionPattern(ESITypeConverter &typeConverter,
+                             MLIRContext *context, OpBuilder &submoduleBuilder,
+                             HandshakeLoweringState &ls)
+      : OpConversionPattern<T>::OpConversionPattern(typeConverter, context),
+        submoduleBuilder(submoduleBuilder), ls(ls) {}
+  using OpAdaptor = typename T::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(T op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    hw::HWModuleLike implModule = checkSubModuleOp(ls.parentModule, op);
+    if (!implModule) {
+      auto portInfo = ModulePortInfo(getPortInfoForOp(rewriter, op));
+      implModule = submoduleBuilder.create<hw::HWModuleExternOp>(
+          op.getLoc(), submoduleBuilder.getStringAttr(getSubModuleName(op)),
+          portInfo);
+    }
+
+    llvm::SmallVector<Value> operands = adaptor.getOperands();
+    addSequentialIOOperandsIfNeeded(op, operands);
+    rewriter.replaceOpWithNewOp<hw::InstanceOp>(
+        op, implModule, rewriter.getStringAttr(ls.nameUniquer(op)), operands);
+    return success();
+  }
+
+private:
+  OpBuilder &submoduleBuilder;
+  HandshakeLoweringState &ls;
+};
+
+class FuncOpConversionPattern : public OpConversionPattern<handshake::FuncOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(handshake::FuncOp op, OpAdaptor operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    ModulePortInfo ports = getPortInfoForOp(rewriter, op, op.getArgumentTypes(),
+                                            op.getResultTypes());
+    auto hwModule = rewriter.create<hw::HWModuleOp>(
+        op.getLoc(), rewriter.getStringAttr(op.getName()), ports);
+    auto args = hwModule.getArguments().drop_back(2);
+    rewriter.mergeBlockBefore(&op.getBody().front(),
+                              hwModule.getBodyBlock()->getTerminator(), args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // HW Top-module Related Functions
 //===----------------------------------------------------------------------===//
-
-static hw::HWModuleOp createTopModuleOp(handshake::FuncOp funcOp,
-                                        ConversionPatternRewriter &rewriter) {
-  llvm::SmallVector<PortInfo, 8> ports = getPortInfoForOp(
-      rewriter, funcOp, funcOp.getArgumentTypes(), funcOp.getResultTypes());
-
-  // Create a HW module.
-  auto hwModuleOp = rewriter.create<hw::HWModuleOp>(
-      funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()), ports);
-
-  // Remove the default created hw_output operation.
-  auto outputOps = hwModuleOp.getOps<hw::OutputOp>();
-  assert(std::distance(outputOps.begin(), outputOps.end()) == 1 &&
-         "Expected exactly 1 default created hw_output operation");
-  rewriter.eraseOp(*outputOps.begin());
-
-  return hwModuleOp;
-}
 
 static bool isMemrefType(Type t) { return t.isa<mlir::MemRefType>(); }
 static LogicalResult verifyHandshakeFuncOp(handshake::FuncOp &funcOp) {
@@ -358,139 +701,58 @@ static LogicalResult verifyHandshakeFuncOp(handshake::FuncOp &funcOp) {
   return success();
 }
 
-namespace {
+static LogicalResult convertFuncOp(ESITypeConverter &typeConverter,
+                                   ConversionTarget &target,
+                                   handshake::FuncOp op,
+                                   OpBuilder &moduleBuilder) {
 
-// Shared state used by various functions; captured in a struct to reduce the
-// number of arguments that we have to pass around.
-struct HandshakeLoweringState {
-  ValueMapper &mapper;
-  ModuleOp parentModule;
-  hw::HWModuleOp hwModuleOp;
-  NameUniquer nameUniquer;
-  Value clock;
-  Value reset;
-};
-
-static Operation *createOpInHWModule(ConversionPatternRewriter &rewriter,
-                                     HandshakeLoweringState &ls,
-                                     Operation *op) {
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPointToEnd(ls.hwModuleOp.getBodyBlock());
-
-  // Create a mapper between the operands of 'op' and the replacement operands
-  // in the target hwModule. For any missing operands, we create a new backedge.
-  llvm::SmallVector<Value> hwOperands =
-      ls.mapper.get(op->getOperands(), esiWrapper);
-
-  // Add clock and reset if needed.
-  if (op->hasTrait<mlir::OpTrait::HasClock>())
-    hwOperands.append({ls.clock, ls.reset});
-
-  // Check if a sub-module for the operation already exists.
-  Operation *subModuleSymOp = checkSubModuleOp(ls.parentModule, op);
-  if (!subModuleSymOp) {
-    subModuleSymOp = createSubModuleOp(ls.parentModule, op, rewriter);
-    // TODO: fill the subModuleSymOp with the meat of the handshake
-    // operations.
-  }
-
-  // Instantiate the new created sub-module.
-  rewriter.setInsertionPointToEnd(ls.hwModuleOp.getBodyBlock());
-  auto submoduleInstanceOp = rewriter.create<hw::InstanceOp>(
-      op->getLoc(), subModuleSymOp, rewriter.getStringAttr(ls.nameUniquer(op)),
-      hwOperands);
-
-  // Resolve any previously created backedges that referred to the results of
-  // 'op'.
-  ls.mapper.set(op->getResults(), submoduleInstanceOp.getResults());
-
-  return submoduleInstanceOp;
-}
-
-static void convertReturnOp(handshake::ReturnOp op, HandshakeLoweringState &ls,
-                            ConversionPatternRewriter &rewriter) {
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPointToEnd(ls.hwModuleOp.getBodyBlock());
-  rewriter.create<hw::OutputOp>(op.getLoc(), ls.mapper.get(op.getOperands()));
-}
-
-struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
-  using OpConversionPattern<handshake::FuncOp>::OpConversionPattern;
-  HandshakeFuncOpLowering(MLIRContext *context)
-      : OpConversionPattern<handshake::FuncOp>(context) {}
-
-  LogicalResult
-  matchAndRewrite(handshake::FuncOp funcOp, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyHandshakeFuncOp(funcOp)))
-      return failure();
-
-    ModuleOp parentModule = funcOp->getParentOfType<ModuleOp>();
-    rewriter.setInsertionPointToStart(funcOp->getBlock());
-    HWModuleOp topModuleOp = createTopModuleOp(funcOp, rewriter);
-    Value clockPort =
-        topModuleOp.getArgument(topModuleOp.getNumArguments() - 2);
-    Value resetPort =
-        topModuleOp.getArgument(topModuleOp.getNumArguments() - 1);
-
-    // Create a uniquer function for creating instance names.
-    NameUniquer instanceUniquer = [&](Operation *op) {
-      std::string instName = getCallName(op);
-      if (auto idAttr = op->getAttrOfType<IntegerAttr>("handshake_id");
-          idAttr) {
-        // We use a special naming convention for operations which have a
-        // 'handshake_id' attribute.
-        instName += "_id" + std::to_string(idAttr.getValue().getZExtValue());
-      } else {
-        // Fallback to just prefixing with an integer.
-        instName += std::to_string(instanceNameCntr[instName]++);
-      }
-      return instName;
-    };
-
-    // Initialize the Handshake lowering state.
-    BackedgeBuilder bb(rewriter, funcOp.getLoc());
-    ValueMapper valuemapper(&bb);
-    auto ls = HandshakeLoweringState{valuemapper,     parentModule, topModuleOp,
-                                     instanceUniquer, clockPort,    resetPort};
-
-    // Extend value mapper with input arguments. Drop the 2 last inputs from
-    // the HW module (clock and reset).
-    valuemapper.set(funcOp.getArguments(),
-                    topModuleOp.getArguments().drop_back(2));
-
-    // Traverse and convert each operation in funcOp.
-    for (Operation &op : funcOp.front()) {
-      if (isa<hw::OutputOp>(op)) {
-        // Skip the default created HWModule terminator, for now.
-        continue;
-      }
-      if (auto returnOp = dyn_cast<handshake::ReturnOp>(op)) {
-        convertReturnOp(returnOp, ls, rewriter);
-      } else {
-        // Regular operation.
-        createOpInHWModule(rewriter, ls, &op);
-      }
+  std::map<std::string, unsigned> instanceNameCntr;
+  NameUniquer instanceUniquer = [&](Operation *op) {
+    std::string instName = getCallName(op);
+    if (auto idAttr = op->getAttrOfType<IntegerAttr>("handshake_id"); idAttr) {
+      // We use a special naming convention for operations which have a
+      // 'handshake_id' attribute.
+      instName += "_id" + std::to_string(idAttr.getValue().getZExtValue());
+    } else {
+      // Fallback to just prefixing with an integer.
+      instName += std::to_string(instanceNameCntr[instName]++);
     }
-    rewriter.eraseOp(funcOp);
-    return success();
-  }
+    return instName;
+  };
 
-private:
-  /// Maintain a map from module names to the # of times the module has been
-  /// instantiated inside this module. This is used to generate unique names for
-  /// each instance.
-  mutable std::map<std::string, unsigned> instanceNameCntr;
-};
+  auto ls = HandshakeLoweringState{op->getParentOfType<mlir::ModuleOp>(),
+                                   instanceUniquer};
+  RewritePatternSet patterns(op.getContext());
+  patterns.insert<FuncOpConversionPattern, ReturnConversionPattern>(
+      op.getContext());
+  patterns.insert<JoinConversionPattern, ForkConversionPattern>(
+      typeConverter, op.getContext(), moduleBuilder, ls);
 
+  // All other patterns are (for this commit only!) unit rate actors. This
+  // allows CI to pass, and we'll implement the meat of these later.
+  patterns.insert<ExtModuleConversionPattern<comb::AddOp>,
+                  ExtModuleConversionPattern<comb::ICmpOp>,
+                  ExtModuleConversionPattern<handshake::ConstantOp>,
+                  ExtModuleConversionPattern<handshake::BufferOp>,
+                  ExtModuleConversionPattern<handshake::MuxOp>,
+                  ExtModuleConversionPattern<handshake::SinkOp>,
+                  ExtModuleConversionPattern<handshake::ConditionalBranchOp>>(
+      typeConverter, op.getContext(), moduleBuilder, ls);
+
+  if (failed(applyPartialConversion(op, target, std::move(patterns))))
+    return op->emitOpError() << "error during conversion";
+  return success();
+}
+
+namespace {
 class HandshakeToHWPass : public HandshakeToHWBase<HandshakeToHWPass> {
 public:
   void runOnOperation() override {
-    auto op = getOperation();
+    mlir::ModuleOp mod = getOperation();
 
     // Lowering to HW requires that every value is used exactly once. Check
     // whether this precondition is met, and if not, exit.
-    if (llvm::any_of(op.getOps<handshake::FuncOp>(), [](auto f) {
+    if (llvm::any_of(mod.getOps<handshake::FuncOp>(), [](auto f) {
           return failed(verifyAllValuesHasOneUse(f));
         })) {
       signalPassFailure();
@@ -501,11 +763,12 @@ public:
     std::string topLevel;
     handshake::InstanceGraph uses;
     SmallVector<std::string> sortedFuncs;
-    if (resolveInstanceGraph(op, uses, topLevel, sortedFuncs).failed()) {
+    if (resolveInstanceGraph(mod, uses, topLevel, sortedFuncs).failed()) {
       signalPassFailure();
       return;
     }
 
+    ESITypeConverter typeConverter;
     ConversionTarget target(getContext());
     target.addLegalDialect<HWDialect>();
     target.addIllegalDialect<handshake::HandshakeDialect>();
@@ -514,14 +777,15 @@ public:
     // graph. This ensures that any referenced submodules (through
     // handshake.instance) has already been lowered, and their HW module
     // equivalents are available.
+    OpBuilder submoduleBuilder(mod.getContext());
+    submoduleBuilder.setInsertionPointToStart(mod.getBody());
     for (auto &funcName : llvm::reverse(sortedFuncs)) {
-      RewritePatternSet patterns(op.getContext());
-      patterns.insert<HandshakeFuncOpLowering>(op.getContext());
-      auto *funcOp = op.lookupSymbol(funcName);
-      assert(funcOp && "Symbol not found in module!");
-      if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+      auto funcOp = mod.lookupSymbol<handshake::FuncOp>(funcName);
+      assert(funcOp && "handshake.func not found in module!");
+      if (failed(verifyHandshakeFuncOp(funcOp)) ||
+          failed(
+              convertFuncOp(typeConverter, target, funcOp, submoduleBuilder))) {
         signalPassFailure();
-        funcOp->emitOpError() << "error during conversion";
         return;
       }
     }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -180,7 +180,8 @@ StringAttr hw::getResultSym(Operation *op, unsigned i) {
 
 HWModulePortAccessor::HWModulePortAccessor(Location loc,
                                            const ModulePortInfo &info,
-                                           Region &bodyRegion) {
+                                           Region &bodyRegion)
+    : info(info) {
   inputArgs.resize(info.inputs.size());
   for (auto [i, barg] : llvm::enumerate(bodyRegion.getArguments())) {
     inputIdx[info.inputs[i].name.str()] = i;

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -25,6 +25,10 @@ void Backedge::setValue(mlir::Value newValue) {
   assert(!set && "backedge already set to a value!");
   value.replaceAllUsesWith(newValue);
   set = true;
+
+  // If the backedge is referenced again, it should now point to the updated
+  // value.
+  value = newValue;
 }
 
 BackedgeBuilder::~BackedgeBuilder() { (void)clearOrEmitError(); }

--- a/test/Conversion/HandshakeToHW/test_simple_loop.mlir
+++ b/test/Conversion/HandshakeToHW/test_simple_loop.mlir
@@ -1,49 +1,32 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module.extern @arith_addi_in_ui64_ui64_out_ui64(
-// CHECK-SAME:                                                       %[[VAL_0:.*]]: !esi.channel<i64>,
-// CHECK-SAME:                                                       %[[VAL_1:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_cond_br_in_ui1_2ins_2outs_ctrl(%[[VAL_2:.*]]: !esi.channel<i1>, %[[VAL_3:.*]]: !esi.channel<none>) -> (outTrue: !esi.channel<none>, outFalse: !esi.channel<none>)
-// CHECK:         hw.module.extern @handshake_sink_in_ui64(%[[VAL_0]]: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(%[[VAL_2]]: !esi.channel<i1>, %[[VAL_3]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1_ui1(%[[VAL_0]]: !esi.channel<i1>, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>, out4: !esi.channel<i1>)
-// CHECK:         hw.module.extern @arith_cmpi_in_ui64_ui64_out_ui1_slt(%[[VAL_0]]: !esi.channel<i64>, %[[VAL_1]]: !esi.channel<i64>) -> (out0: !esi.channel<i1>)
-// CHECK:         hw.module.extern @handshake_fork_in_ui64_out_ui64_ui64(%[[VAL_0]]: !esi.channel<i64>, %[[VAL_4]]: i1, %[[VAL_5]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_mux_in_ui1_ui64_ui64_out_ui64(%[[VAL_6:.*]]: !esi.channel<i1>, %[[VAL_0]]: !esi.channel<i64>, %[[VAL_1]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_mux_in_ui1_3ins_1outs_ctrl(%[[VAL_6]]: !esi.channel<i1>, %[[VAL_0]]: !esi.channel<none>, %[[VAL_1]]: !esi.channel<none>) -> (out0: !esi.channel<none>)
-// CHECK:         hw.module.extern @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1(%[[VAL_0]]: !esi.channel<i1>, %[[VAL_4]]: i1, %[[VAL_5]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>)
-// CHECK:         hw.module.extern @handshake_buffer_in_ui1_out_ui1_1slots_seq(%[[VAL_0]]: !esi.channel<i1>, %[[VAL_4]]: i1, %[[VAL_5]]: i1) -> (out0: !esi.channel<i1>)
-// CHECK:         hw.module.extern @handshake_constant_c42_out_ui64(%[[VAL_7:.*]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_constant_c1_out_ui64(%[[VAL_7]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:         hw.module.extern @handshake_fork_1ins_4outs_ctrl(%[[VAL_0]]: !esi.channel<none>, %[[VAL_4]]: i1, %[[VAL_5]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<none>, out2: !esi.channel<none>, out3: !esi.channel<none>)
-
 // CHECK-LABEL:   hw.module @main(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !esi.channel<none>,
-// CHECK-SAME:                    %[[VAL_4:.*]]: i1,
-// CHECK-SAME:                    %[[VAL_5:.*]]: i1) -> (out0: !esi.channel<i64>, outCtrl: !esi.channel<none>) {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]], %[[VAL_3:.*]], %[[VAL_42:.*]] = hw.instance "handshake_fork0" @handshake_fork_1ins_4outs_ctrl(in0: %[[VAL_0]]: !esi.channel<none>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<none>, out2: !esi.channel<none>, out3: !esi.channel<none>)
-// CHECK:           %[[VAL_52:.*]] = hw.instance "handshake_constant0" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_3]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_6:.*]] = hw.instance "handshake_constant1" @handshake_constant_c42_out_ui64(ctrl: %[[VAL_2]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_7:.*]] = hw.instance "handshake_constant2" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_1]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_8:.*]] = hw.instance "handshake_buffer0" @handshake_buffer_in_ui1_out_ui1_1slots_seq(in0: %[[VAL_9:.*]]: !esi.channel<i1>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i1>)
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = hw.instance "handshake_fork1" @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1(in0: %[[VAL_8]]: !esi.channel<i1>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>)
-// CHECK:           %[[VAL_14:.*]] = hw.instance "handshake_mux0" @handshake_mux_in_ui1_3ins_1outs_ctrl(select: %[[VAL_13]]: !esi.channel<i1>, in0: %[[VAL_42]]: !esi.channel<none>, in1: %[[VAL_15:.*]]: !esi.channel<none>) -> (out0: !esi.channel<none>)
-// CHECK:           %[[VAL_16:.*]] = hw.instance "handshake_mux1" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_12]]: !esi.channel<i1>, in0: %[[VAL_6]]: !esi.channel<i64>, in1: %[[VAL_17:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = hw.instance "handshake_fork2" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_16]]: !esi.channel<i64>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
-// CHECK:           %[[VAL_20:.*]] = hw.instance "handshake_mux2" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_11]]: !esi.channel<i1>, in0: %[[VAL_7]]: !esi.channel<i64>, in1: %[[VAL_21:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_22:.*]] = hw.instance "handshake_mux3" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_10]]: !esi.channel<i1>, in0: %[[VAL_52]]: !esi.channel<i64>, in1: %[[VAL_23:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = hw.instance "handshake_fork3" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_22]]: !esi.channel<i64>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
-// CHECK:           %[[VAL_26:.*]] = hw.instance "arith_cmpi0" @arith_cmpi_in_ui64_ui64_out_ui1_slt(in0: %[[VAL_24]]: !esi.channel<i64>, in1: %[[VAL_18]]: !esi.channel<i64>) -> (out0: !esi.channel<i1>)
-// CHECK:           %[[VAL_9]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]] = hw.instance "handshake_fork4" @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1_ui1(in0: %[[VAL_26]]: !esi.channel<i1>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>, out4: !esi.channel<i1>)
-// CHECK:           %[[VAL_17]], %[[VAL_31:.*]] = hw.instance "handshake_cond_br0" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_30]]: !esi.channel<i1>, data: %[[VAL_19]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
-// CHECK:           hw.instance "handshake_sink0" @handshake_sink_in_ui64(in0: %[[VAL_31]]: !esi.channel<i64>) -> ()
-// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]] = hw.instance "handshake_cond_br1" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_29]]: !esi.channel<i1>, data: %[[VAL_20]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
-// CHECK:           hw.instance "handshake_sink1" @handshake_sink_in_ui64(in0: %[[VAL_33]]: !esi.channel<i64>) -> ()
-// CHECK:           %[[VAL_15]], %[[VAL_34:.*]] = hw.instance "handshake_cond_br2" @handshake_cond_br_in_ui1_2ins_2outs_ctrl(cond: %[[VAL_28]]: !esi.channel<i1>, data: %[[VAL_14]]: !esi.channel<none>) -> (outTrue: !esi.channel<none>, outFalse: !esi.channel<none>)
-// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = hw.instance "handshake_cond_br3" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_27]]: !esi.channel<i1>, data: %[[VAL_25]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
-// CHECK:           %[[VAL_21]], %[[VAL_37:.*]] = hw.instance "handshake_fork5" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_32]]: !esi.channel<i64>, clock: %[[VAL_4]]: i1, reset: %[[VAL_5]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
-// CHECK:           %[[VAL_23]] = hw.instance "arith_addi0" @arith_addi_in_ui64_ui64_out_ui64(in0: %[[VAL_35]]: !esi.channel<i64>, in1: %[[VAL_37]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:           hw.output %[[VAL_36]], %[[VAL_34]] : !esi.channel<i64>, !esi.channel<none>
+// CHECK-SAME:                    %[[VAL_1:.*]]: i1,
+// CHECK-SAME:                    %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i64>, outCtrl: !esi.channel<none>) {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "handshake_fork0" @handshake_fork_1ins_4outs_ctrl(in0: %[[VAL_0]]: !esi.channel<none>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<none>, out2: !esi.channel<none>, out3: !esi.channel<none>)
+// CHECK:           %[[VAL_7:.*]] = hw.instance "handshake_constant0" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_5]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_8:.*]] = hw.instance "handshake_constant1" @handshake_constant_c42_out_ui64(ctrl: %[[VAL_4]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_9:.*]] = hw.instance "handshake_constant2" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_3]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_10:.*]] = hw.instance "handshake_buffer0" @handshake_buffer_in_ui1_out_ui1_1slots_seq(in0: %[[VAL_11:.*]]: !esi.channel<i1>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i1>)
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = hw.instance "handshake_fork1" @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1(in0: %[[VAL_10]]: !esi.channel<i1>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>)
+// CHECK:           %[[VAL_16:.*]] = hw.instance "handshake_mux0" @handshake_mux_in_ui1_3ins_1outs_ctrl(select: %[[VAL_15]]: !esi.channel<i1>, in0: %[[VAL_6]]: !esi.channel<none>, in1: %[[VAL_17:.*]]: !esi.channel<none>) -> (out0: !esi.channel<none>)
+// CHECK:           %[[VAL_18:.*]] = hw.instance "handshake_mux1" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_14]]: !esi.channel<i1>, in0: %[[VAL_8]]: !esi.channel<i64>, in1: %[[VAL_19:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = hw.instance "handshake_fork2" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_18]]: !esi.channel<i64>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
+// CHECK:           %[[VAL_22:.*]] = hw.instance "handshake_mux2" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_13]]: !esi.channel<i1>, in0: %[[VAL_9]]: !esi.channel<i64>, in1: %[[VAL_23:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_24:.*]] = hw.instance "handshake_mux3" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_12]]: !esi.channel<i1>, in0: %[[VAL_7]]: !esi.channel<i64>, in1: %[[VAL_25:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = hw.instance "handshake_fork3" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_24]]: !esi.channel<i64>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
+// CHECK:           %[[VAL_28:.*]] = hw.instance "comb_icmp0" @comb_icmp_in_ui64_ui64_out_ui1(in0: %[[VAL_26]]: !esi.channel<i64>, in1: %[[VAL_20]]: !esi.channel<i64>) -> (out0: !esi.channel<i1>)
+// CHECK:           %[[VAL_11]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]] = hw.instance "handshake_fork4" @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1_ui1(in0: %[[VAL_28]]: !esi.channel<i1>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>, out4: !esi.channel<i1>)
+// CHECK:           %[[VAL_19]], %[[VAL_33:.*]] = hw.instance "handshake_cond_br0" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_32]]: !esi.channel<i1>, data: %[[VAL_21]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
+// CHECK:           hw.instance "handshake_sink0" @handshake_sink_in_ui64(in0: %[[VAL_33]]: !esi.channel<i64>) -> ()
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = hw.instance "handshake_cond_br1" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_31]]: !esi.channel<i1>, data: %[[VAL_22]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
+// CHECK:           hw.instance "handshake_sink1" @handshake_sink_in_ui64(in0: %[[VAL_35]]: !esi.channel<i64>) -> ()
+// CHECK:           %[[VAL_17]], %[[VAL_36:.*]] = hw.instance "handshake_cond_br2" @handshake_cond_br_in_ui1_2ins_2outs_ctrl(cond: %[[VAL_30]]: !esi.channel<i1>, data: %[[VAL_16]]: !esi.channel<none>) -> (outTrue: !esi.channel<none>, outFalse: !esi.channel<none>)
+// CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]] = hw.instance "handshake_cond_br3" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_29]]: !esi.channel<i1>, data: %[[VAL_27]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
+// CHECK:           %[[VAL_23]], %[[VAL_39:.*]] = hw.instance "handshake_fork5" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_34]]: !esi.channel<i64>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
+// CHECK:           %[[VAL_25]] = hw.instance "comb_add0" @comb_add_in_ui64_ui64_out_ui64(in0: %[[VAL_37]]: !esi.channel<i64>, in1: %[[VAL_39]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
+// CHECK:           hw.output %[[VAL_38]], %[[VAL_36]] : !esi.channel<i64>, !esi.channel<none>
 // CHECK:         }
 
 handshake.func @main(%arg0: none, ...) -> (i64, none) attributes {argNames = ["inCtrl"], resNames = ["out0", "outCtrl"]} {
@@ -59,7 +42,7 @@ handshake.func @main(%arg0: none, ...) -> (i64, none) attributes {argNames = ["i
   %9 = mux %5#1 [%3, %14#0] : i1, i64
   %10 = mux %5#0 [%1, %15] : i1, i64
   %11:2 = fork [2] %10 : i64
-  %12 = arith.cmpi slt, %11#0, %8#0 : i64
+  %12 = comb.icmp slt %11#0, %8#0 : i64
   %13:5 = fork [5] %12 : i1
   %trueResult, %falseResult = cond_br %13#4, %8#1 : i64
   sink %falseResult : i64
@@ -68,6 +51,6 @@ handshake.func @main(%arg0: none, ...) -> (i64, none) attributes {argNames = ["i
   %trueResult_2, %falseResult_3 = cond_br %13#2, %6 : none
   %trueResult_4, %falseResult_5 = cond_br %13#1, %11#1 : i64
   %14:2 = fork [2] %trueResult_0 : i64
-  %15 = arith.addi %trueResult_4, %14#1 : i64
+  %15 = comb.add %trueResult_4, %14#1 : i64
   return %falseResult_5, %falseResult_3 : i64, none
 }


### PR DESCRIPTION
This commit provides the infrastructure used to generate handshake module internals. This initial commit contains implementations of fork and join components, which follow directly from their `HandshakeToFIRRTL` implementation. Any other op in the `test_simple_loop.mlir` test is implemented as an external module. Once this commit is merged, implementations for these will be pushed in followup commits.