### PR TITLE
[ESI][Bugfix] Combine inout channels in service description

### DIFF
--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -114,6 +114,15 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [NoTerminator]> {
   let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$portReqs);
 
+  let extraClassDeclaration = [{
+    /// Find pairs of toServer and toClient requests with the same client path.
+    /// In cases where there doesn't exist a pair, one of the two entries will
+    /// be null. Should never contain a pair with both entries null.
+    void gatherPairedReqs(
+      llvm::SmallVectorImpl<std::pair<RequestToServerConnectionOp,
+                                      RequestToClientConnectionOp>>&);
+  }];
+
   let assemblyFormat = [{
     $service_symbol `impl` `as` $impl_type (`opts` $impl_opts^)?
      `(` $inputs `)` attr-dict `:` functional-type($inputs, results)

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -15,9 +15,9 @@ esi.service.decl @HostComms {
 // CHECK:         hw.instance "m1" @Loopback(clk: %clk: i1) -> ()
 
 // CONN-LABEL: hw.module @Top(%clk: i1, %rst: i1) {
-// CONN:         [[R2:%.+]] = esi.cosim %clk, %rst, %m1.loopback_fromhw, "m1.loopback_fromhw" : !esi.channel<i8> -> !esi.channel<i1>
-// CONN:         [[R0:%.+]] = esi.null : !esi.channel<i1>
-// CONN:         [[R1:%.+]] = esi.cosim %clk, %rst, [[R0]], "m1.loopback_tohw" : !esi.channel<i1> -> !esi.channel<i8>
+// CONN-DAG:     [[R2:%.+]] = esi.cosim %clk, %rst, %m1.loopback_fromhw, "m1.loopback_fromhw" : !esi.channel<i8> -> !esi.channel<i1>
+// CONN-DAG:     [[R0:%.+]] = esi.null : !esi.channel<i1>
+// CONN-DAG:     [[R1:%.+]] = esi.cosim %clk, %rst, [[R0]], "m1.loopback_tohw" : !esi.channel<i1> -> !esi.channel<i8>
 // CONN:         %m1.loopback_fromhw = hw.instance "m1" @Loopback(clk: %clk: i1, loopback_tohw: [[R1]]: !esi.channel<i8>) -> (loopback_fromhw: !esi.channel<i8>)
 hw.module @Top (%clk: i1, %rst: i1) {
   esi.service.instance @HostComms impl as  "cosim" (%clk, %rst) : (i1, i1) -> ()

--- a/test/Dialect/ESI/services_collateral.mlir
+++ b/test/Dialect/ESI/services_collateral.mlir
@@ -112,16 +112,6 @@ msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
 // CHECK-NEXT:                   },
 // CHECK-NEXT:                   "mnemonic": "channel"
 // CHECK-NEXT:                 }
-// CHECK-NEXT:               }
-// CHECK-NEXT:             },
-// CHECK-NEXT:             {
-// CHECK-NEXT:               "client_name": [
-// CHECK-NEXT:                 "m1",
-// CHECK-NEXT:                 "loopback_inout"
-// CHECK-NEXT:               ],
-// CHECK-NEXT:               "port": {
-// CHECK-NEXT:                 "inner": "ReqResp",
-// CHECK-NEXT:                 "outer_sym": "HostComms"
 // CHECK-NEXT:               },
 // CHECK-NEXT:               "to_server_type": {
 // CHECK-NEXT:                 "capnp_name": "I8",


### PR DESCRIPTION
Previously, inout channels were listed as separate input and output ports. This change combines them. To implement this change we refactor some code to base cosim implementation and json service descriptions on (partial) pairs.