### PR TITLE
Revert "[HW] Address new HWModule builder review comments (#3844)"

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -25,6 +25,8 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/StringExtras.h"
 
+#include <map>
+
 namespace circt {
 namespace hw {
 
@@ -197,20 +199,24 @@ public:
                        Region &bodyRegion);
 
   // Returns the i'th/named input port of the module.
-  Value getInput(unsigned i);
-  Value getInput(StringRef name);
-
+  Value getInput(unsigned i) { return inputArgs.find(i)->second; }
+  Value getInput(StringRef name) {
+    return getInput(inputIdx.find(name.str())->second);
+  }
   // Assigns the i'th/named output port of the module.
   void setOutput(unsigned i, Value v);
-  void setOutput(StringRef name, Value v);
-  const llvm::SmallVector<Value> &getOutputOperands() const {
+  void setOutput(StringRef name, Value v) {
+    setOutput(outputIdx.find(name.str())->second, v);
+  }
+
+  const DenseMap<unsigned, Value> &getOutputOperands() const {
     return outputOperands;
   }
 
 private:
-  llvm::StringMap<unsigned> inputIdx, outputIdx;
-  llvm::SmallVector<Value> inputArgs;
-  llvm::SmallVector<Value> outputOperands;
+  std::map<std::string, unsigned> inputIdx, outputIdx;
+  DenseMap<unsigned, Value> inputArgs;
+  DenseMap<unsigned, Value> outputOperands;
 };
 
 using HWModuleBuilder =

--- a/include/circt/Support/BackedgeBuilder.h
+++ b/include/circt/Support/BackedgeBuilder.h
@@ -89,6 +89,7 @@ public:
   explicit operator bool() const { return !!value; }
   operator mlir::Value() const { return value; }
   void setValue(mlir::Value);
+  bool isSet() { return set; }
 
 private:
   mlir::Value value;


### PR DESCRIPTION
This reverts commit c4e272064d76e75dab7de7d32c5857e01418b5d8. (https://github.com/llvm/circt/pull/3844)

This commit is causing nondeterministic crashes in the test/Conversion/CalyxToHW/basic.mlir test.

This test crashes with about 75% probability on my machine, which is an x86 MacBook running the latest macOS, 12 (Monterey), and with the Apple-provided clang (`Apple clang version 13.1.6 (clang-1316.0.21.2.5)`). When it crashes, I get a stack trace like the following:


```
FAIL: CIRCT :: Conversion/CalyxToHW/basic.mlir (10 of 427)
******************** TEST 'CIRCT :: Conversion/CalyxToHW/basic.mlir' FAILED ********************
Script:
--
: 'RUN: at line 1';   /Users/richardx/git/circt/build/bin/circt-opt /Users/richardx/git/circt/test/Conversion/CalyxToHW/basic.mlir -lower-calyx-to-hw | /Users/richardx/git/circt/build/bin/FileCheck /Users/richardx/git/circt/test/Conversion/CalyxToHW/basic.mlir
--
Exit Code: 2

Command Output (stderr):
--
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /Users/richardx/git/circt/build/bin/circt-opt /Users/richardx/git/circt/test/Conversion/CalyxToHW/basic.mlir -lower-calyx-to-hw
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  circt-opt                0x000000010f33f3ad llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  circt-opt                0x000000010f33f8eb PrintStackTraceSignalHandler(void*) + 27
2  circt-opt                0x000000010f33d796 llvm::sys::RunSignalHandlers() + 134
3  circt-opt                0x000000010f3413bf SignalHandler(int) + 223
4  libsystem_platform.dylib 0x00007ff805331dfd _sigtramp + 29
5  libc++abi.dylib          0x00007ff8052dbaf1
6  circt-opt                0x000000010f274847 llvm::StringMapImpl::FindKey(llvm::StringRef) const + 87
7  circt-opt                0x0000000111809059 llvm::StringMap<mlir::ConversionTarget::LegalizationAction, llvm::MallocAllocator>::find(llvm::StringRef) const + 57
8  circt-opt                0x0000000111807855 mlir::ConversionTarget::getOpInfo(mlir::OperationName) const + 261
9  circt-opt                0x0000000111807b7d mlir::ConversionTarget::isLegal(mlir::Operation*) const + 77
10 circt-opt                0x0000000111825179 (anonymous namespace)::OperationLegalizer::legalize(mlir::Operation*, mlir::ConversionPatternRewriter&) + 425
11 circt-opt                0x000000011182b3de (anonymous namespace)::OperationLegalizer::legalizePatternCreatedOperations(mlir::ConversionPatternRewriter&, mlir::detail::ConversionPatternRewriterImpl&, (anonymous namespace)::RewriterState&, (anonymous namespace)::RewriterState&) + 110
12 circt-opt                0x000000011182ac82 (anonymous namespace)::OperationLegalizer::legalizePatternResult(mlir::Operation*, mlir::Pattern const&, mlir::ConversionPatternRewriter&, (anonymous namespace)::RewriterState&) + 498
13 circt-opt                0x000000011182aa07 (anonymous namespace)::OperationLegalizer::legalizeWithPattern(mlir::Operation*, mlir::ConversionPatternRewriter&)::$_16::operator()(mlir::Pattern const&) const + 55
14 circt-opt                0x000000011182a9bd mlir::LogicalResult llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>::callback_fn<(anonymous namespace)::OperationLegalizer::legalizeWithPattern(mlir::Operation*, mlir::ConversionPatternRewriter&)::$_16>(long, mlir::Pattern const&) + 45
15 circt-opt                0x00000001118ca2c9 llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>::operator()(mlir::Pattern const&) const + 57
16 circt-opt                0x00000001118c9c7f mlir::PatternApplicator::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&, llvm::function_ref<bool (mlir::Pattern const&)>, llvm::function_ref<void (mlir::Pattern const&)>, llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>) + 2079
17 circt-opt                0x0000000111825d60 (anonymous namespace)::OperationLegalizer::legalizeWithPattern(mlir::Operation*, mlir::ConversionPatternRewriter&) + 368
18 circt-opt                0x00000001118253fb (anonymous namespace)::OperationLegalizer::legalize(mlir::Operation*, mlir::ConversionPatternRewriter&) + 1067
19 circt-opt                0x00000001118248af (anonymous namespace)::OperationConverter::convert(mlir::ConversionPatternRewriter&, mlir::Operation*) + 79
20 circt-opt                0x00000001118097d2 (anonymous namespace)::OperationConverter::convertOperations(llvm::ArrayRef<mlir::Operation*>, llvm::function_ref<void (mlir::Diagnostic&)>) + 722
21 circt-opt                0x0000000111809473 mlir::applyPartialConversion(llvm::ArrayRef<mlir::Operation*>, mlir::ConversionTarget&, mlir::FrozenRewritePatternSet const&, llvm::DenseSet<mlir::Operation*, llvm::DenseMapInfo<mlir::Operation*, void>>*) + 179
22 circt-opt                0x0000000111809a72 mlir::applyPartialConversion(mlir::Operation*, mlir::ConversionTarget&, mlir::FrozenRewritePatternSet const&, llvm::DenseSet<mlir::Operation*, llvm::DenseMapInfo<mlir::Operation*, void>>*) + 66
23 circt-opt                0x000000010f4ba856 (anonymous namespace)::CalyxToHWPass::runOnModule(mlir::ModuleOp) + 470
24 circt-opt                0x000000010f4b27f2 (anonymous namespace)::CalyxToHWPass::runOnOperation() + 50
25 circt-opt                0x0000000111a9c41c mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 620
26 circt-opt                0x0000000111a9cb26 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 390
27 circt-opt                0x0000000111a9ee7c mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) + 108
28 circt-opt                0x0000000111a9ec55 mlir::PassManager::run(mlir::Operation*) + 885
29 circt-opt                0x0000000110d6db42 performActions(llvm::raw_ostream&, bool, bool, llvm::SourceMgr&, mlir::MLIRContext*, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, bool) + 514
30 circt-opt                0x0000000110d6d70b processBuffer(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, bool, bool, bool, bool, bool, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, llvm::ThreadPool*) + 491
31 circt-opt                0x0000000110d6d4df mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, bool, bool, bool, bool, bool, bool)::$_0::operator()(std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) const + 207
32 circt-opt                0x0000000110d6d3ed mlir::LogicalResult llvm::function_ref<mlir::LogicalResult (std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>::callback_fn<mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, bool, bool, bool, bool, bool, bool)::$_0>(long, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) + 77
33 circt-opt                0x0000000110dd32b9 llvm::function_ref<mlir::LogicalResult (std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>::operator()(std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) const + 89
34 circt-opt                0x0000000110dd2be1 mlir::splitAndProcessBuffer(std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, bool, bool) + 193
35 circt-opt                0x0000000110d6af2d mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, bool, bool, bool, bool, bool, bool) + 333
36 circt-opt                0x0000000110d6b10f mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, mlir::PassPipelineCLParser const&, mlir::DialectRegistry&, bool, bool, bool, bool, bool, bool) + 271
37 circt-opt                0x0000000110d6bbec mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&, bool) + 2684
38 circt-opt                0x000000010f0b6c71 main + 209
39 dyld                     0x000000012a8c652e start + 462
FileCheck error: '<stdin>' is empty.
FileCheck command line:  /Users/richardx/git/circt/build/bin/FileCheck /Users/richardx/git/circt/test/Conversion/CalyxToHW/basic.mlir
```

When I revert this commit, the test no longer fails, at least out of 5 attempts to run the whole `check-circt` test suite.

I was speaking with @mikeurbach offline, and he noticed a few things in the original PR that are unsafe, which I can leave inline comments about. We attempted to fix those issues, but the test still crashes (nondeterministically) for me, and since it's getting late on a Friday night, I think reverting the changes would be expedient so that we can more carefully review the changeset for safety later.