### PR TITLE
[HW][Comb] Fix HWIntegerType to account for parameterized hw::IntTypes

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_COMB_COMBOPS_H
 
 #include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -279,7 +279,7 @@ def ReplicateOp : CombOp<"replicate", [NoSideEffect]> {
     /// Returns the number of times the operand is replicated.
     size_t getMultiple() {
       auto opWidth = getInput().getType().cast<IntegerType>().getWidth();
-      return getType().getWidth()/opWidth;
+      return getType().cast<IntegerType>().getWidth()/opWidth;
     }
   }];
 }

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -110,6 +110,21 @@ BaseTy type_dyn_cast(Type type) {
   return type_cast<BaseTy>(type);
 }
 
+/// Utility type that wraps a type that may be one of several possible Types.
+/// This is similar to std::variant but is implemented for mlir::Type, and it
+/// understands how to handle type aliases.
+template <typename... Types>
+class TypeVariant
+    : public ::mlir::Type::TypeBase<TypeVariant<Types...>, mlir::Type,
+                                    mlir::TypeStorage> {
+  using mlir::Type::TypeBase<TypeVariant<Types...>, mlir::Type,
+                             mlir::TypeStorage>::Base::Base;
+
+public:
+  // Support LLVM isa/cast/dyn_cast to one of the possible types.
+  static bool classof(Type other) { return type_isa<Types...>(other); }
+};
+
 template <typename BaseTy>
 class TypeAliasOr
     : public ::mlir::Type::TypeBase<TypeAliasOr<BaseTy>, mlir::Type,

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -23,7 +23,8 @@ include "circt/Dialect/HW/HWDialect.td"
 // known, non-directional type.
 def HWIntegerType : DialectType<HWDialect,
     CPred<"::circt::hw::isHWIntegerType($_self)">,
-    "an integer bitvector of one or more bits", "::mlir::IntegerType">;
+    "an integer bitvector of one or more bits",
+    "::circt::hw::TypeVariant<::mlir::IntegerType, ::circt::hw::IntType>">;
 
 // Type constraint that indicates that an operand/result may only be a valid,
 // known, non-directional type.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1067,7 +1067,8 @@ StringAttr ExportVerilog::inferStructuralNameForTemporary(Value expr) {
           .Case([&result](ExtractOp extract) {
             if (auto operandName =
                     inferStructuralNameForTemporary(extract.getInput())) {
-              unsigned numBits = extract.getType().getWidth();
+              unsigned numBits =
+                  extract.getType().cast<IntegerType>().getWidth();
               if (numBits == 1)
                 result = StringAttr::get(extract.getContext(),
                                          operandName.strref() + "_" +
@@ -2104,7 +2105,7 @@ SubExprInfo ExprEmitter::visitComb(ExtractOp op) {
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   unsigned loBit = op.getLowBit();
-  unsigned hiBit = loBit + op.getType().getWidth() - 1;
+  unsigned hiBit = loBit + op.getType().cast<IntegerType>().getWidth() - 1;
 
   auto x = emitSubExpr(op.getInput(), LowestPrecedence);
   assert((x.precedence == Symbol ||
@@ -2213,7 +2214,7 @@ SubExprInfo ExprEmitter::visitTypeOp(ConstantOp op) {
     isNegated = true;
   }
 
-  os << op.getType().getWidth() << '\'';
+  os << op.getType().cast<IntegerType>().getWidth() << '\'';
 
   // Emit this as a signed constant if the caller would prefer that.
   if (signPreference == RequireSigned)

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -182,7 +182,7 @@ LogicalResult ReplicateOp::verify() {
   // The source must be equal or smaller than the dest type, and an even
   // multiple of it.  Both are already known to be signless integers.
   auto srcWidth = getOperand().getType().cast<IntegerType>().getWidth();
-  auto dstWidth = getType().getWidth();
+  auto dstWidth = getType().cast<IntegerType>().getWidth();
   if (srcWidth == 0)
     return emitOpError("replicate does not take zero bit integer");
 
@@ -241,7 +241,7 @@ static unsigned getTotalWidth(ValueRange inputs) {
 }
 
 LogicalResult ConcatOp::verify() {
-  unsigned tyWidth = getType().getWidth();
+  unsigned tyWidth = getType().cast<IntegerType>().getWidth();
   unsigned operandsTotalWidth = getTotalWidth(getInputs());
   if (tyWidth != operandsTotalWidth)
     return emitOpError("ConcatOp requires operands total width to "
@@ -277,7 +277,7 @@ LogicalResult ConcatOp::inferReturnTypes(MLIRContext *context,
 
 LogicalResult ExtractOp::verify() {
   unsigned srcWidth = getInput().getType().cast<IntegerType>().getWidth();
-  unsigned dstWidth = getType().getWidth();
+  unsigned dstWidth = getType().cast<IntegerType>().getWidth();
   if (getLowBit() >= srcWidth || srcWidth - getLowBit() < dstWidth)
     return emitOpError("from bit too large for input"), failure();
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -234,7 +234,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 
 LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  if (getValue().getBitWidth() != getType().getWidth())
+  if (getValue().getBitWidth() != getType().cast<IntegerType>().getWidth())
     return emitError(
         "hw.constant attribute bitwidth doesn't match return type");
 
@@ -274,7 +274,7 @@ void ConstantOp::getAsmResultNames(
   auto intCst = getValue();
 
   // Sugar i1 constants with 'true' and 'false'.
-  if (intTy.getWidth() == 1)
+  if (intTy.cast<IntegerType>().getWidth() == 1)
     return setNameFn(getResult(), intCst.isZero() ? "false" : "true");
 
   // Otherwise, build a complex name with the value and type.


### PR DESCRIPTION
This fixes a latent bug in the definition of HWIntegerType that was uncovered when I tried to bump LLVM, where the [new `TypedValue`](https://github.com/llvm/llvm-project/commit/688c51a5acc53b456014e53663051476d825e896) performs a runtime type check in an assertion that fails because of this bug.

I'm going to copy and paste the long commit message I wrote for one of my commits, since I think it explains the problem and the fix, but the tl;dr is:

- HWIntegerType's C++ is now defined to be a union of either an `mlir::IntegerType` or a `circt::hw::IntType`.
- Code that previously assumed that you could get an `mlir::IntegerType` from most of the Ops in Comb now require an explicit cast.
- Code that previously assumed that you could get an `mlir::IntegerType` from most of the Ops in Comb is probably broken because it won't work right when you have an `!hw.int` with an unresolved parameter width. This includes all code that assumes that you can call `getWidth()` on the result of a Comb Op.
- We need to merge this in before we can bump LLVM, or we need some other workaround that makes `TypedValue` happy

---

[HW][Comb][ExportVerilog] Fix HWIntegerType's C++ type to allow hw::IntType.

Previously, the dialect type HWIntegerType had a declared C++ type of
mlir::IntegerType. This was fine in the past, when HWIntegerType
was just a lightweight wrapper around the MLIR type. However, this
gradually became incorrect when we created !hw.int for holding
hardware integers with parametric width and as we started using !hw.int
in existing ops that were declared to have HWIntegerType operands and
results.

Although it was technically incorrect, this didn't cause issues because:

1. Parametric !hw.int isn't really fully supported, and most existing
   passes assume we have statically-known widths.
2. Because the C++ type was incorrect, most of the code implicictly
   converted the operand/result types to mlir::IntegerType, which would
   work fine as long as the runtime type was indeed mlir::IntegerType.

2\) is particularly pernicious, since it masked places where we should
have been explicitly casting values to mlir::IntegerType, since the
compiler would assume that it should implicitly convert to
mlir::IntegerType without considering the possibility that we actually
have an hw::IntType.

We need to actually fix this now that upstream MLIR introduced a
TypedValue type, since TypedValue will perform a runtime assertion to
check that the wrapped value is indeed of the correct type.
Specifically, ops that have a dialect type of HWIntegerType would
declare a C++ type of mlir::IntegerType, and if the op _actually_ had a
type of hw::Int, the new TypedValue would fail the runtime type check.

This commit changes HWIntegerType's C++ type to be
TypeOr<mlir::IntegerType, hw::IntType>, which correct accounts for both
possible cases, and it allows for the TypedValue runtime type checks to
succeed.

This change has the side effect of forcing us to explicitly cast most
ops' results to mlir::IntegerType in places where we currently assume
that the type is a non-parametric hardware integer. Ideally, we should
be checking whether an op result is parametric before we run folds that
rely on having a statically-known width, but putting in the explicit
casts preserves the existing behavior while at least making it more
explicit that we need an integer of statically-known width.