### PR TITLE
[PrepareForEmission] Reorder inout ops before legalizing OoO uses

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -736,6 +736,18 @@ void ExportVerilog::prepareHWModule(Block &block,
     SmallPtrSet<Operation *, 32> seenOperations;
 
     for (auto &op : llvm::make_early_inc_range(block)) {
+      // Move the inout operation after its operand position before actually
+      // resolving out-of-order uses. This reordering makes it simple to resolve
+      // the dependency from inout operations to their operands as well.
+      if (isa<ReadInOutOp, StructFieldInOutOp, ArrayIndexInOutOp,
+              IndexedPartSelectInOutOp>(&op)) {
+        if (auto *defOp = op.getOperand(0).getDefiningOp()) {
+          if (op.getBlock() != defOp->getBlock() || op.isBeforeInBlock(defOp)) {
+            op.moveAfter(defOp);
+            continue;
+          }
+        }
+      }
       // Check the users of any expressions to see if they are
       // lexically below the operation itself.  If so, it is being used out
       // of order.


### PR DESCRIPTION
This commit fixes an assertion failure in PrepareForEmission that wrongly tries creating temporary wires for inout operations. In the first place, inout operations are *always inline operations* therefore we might not have to legailze OoO uses of inout operations. But it would be more reasonable to keep the invariance that "after PrepareForEmission, operations in the toplevel module are sorted in the def-use order".

Fix https://github.com/llvm/circt/issues/3831