### PR TITLE
[Handshake] Relax the ctrl in/output requirement

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -200,13 +200,11 @@ def ReturnOp : Handshake_Op<"return", [Terminator]> {
     only operand(exit point of control - only network).
   }];
 
-  let arguments = (ins Variadic<AnyType> : $operands, NoneType : $control);
-
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ValueRange":$operands)>];
+  let arguments = (ins Variadic<AnyType> : $operands);
 
   let hasVerifier = 1;
-  let assemblyFormat = [{ operands attr-dict `:` qualified(type(operands)) }];
+  let assemblyFormat =
+    [{  attr-dict ($operands^ `:` type($operands))? }];
 }
 
 // Here use I32EnumAttr to better suit the BufferOp sequential

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1300,7 +1300,7 @@ static Value getBlockControlValue(Block *block) {
       if (BranchOp.isControl())
         return BranchOp.dataOperand();
     if (auto endOp = dyn_cast<handshake::ReturnOp>(op))
-      return endOp.control();
+      return endOp.getOperands().back();
   }
   return nullptr;
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -911,11 +911,6 @@ void EndOp::build(OpBuilder &builder, OperationState &result, Value operand) {
   result.addOperands(operand);
 }
 
-void handshake::ReturnOp::build(OpBuilder &builder, OperationState &result,
-                                ValueRange operands) {
-  result.addOperands(operands);
-}
-
 void SinkOp::build(OpBuilder &builder, OperationState &result, Value operand) {
   result.addOperands(operand);
   sost::addAttributes(result, 1, operand.getType());

--- a/test/Conversion/HandshakeToFIRRTL/test_func.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_func.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
+
+
+// CHECK-LABEL: firrtl.circuit "no_args"  {
+// CHECK:         firrtl.module @no_args(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+// CHECK:         }
+// CHECK:       }
+
+handshake.func @no_args() {
+  return
+}
+

--- a/test/Dialect/Handshake/add-ids.mlir
+++ b/test/Dialect/Handshake/add-ids.mlir
@@ -6,7 +6,7 @@
 // CHECK:   %2 = arith.addi %0, %1 {handshake_id = 0 : index} : i32
 // CHECK:   %3 = buffer [2] seq %2 {handshake_id = 2 : index} : i32
 // CHECK:   %4 = buffer [2] seq %arg2 {handshake_id = 3 : index} : none
-// CHECK:   return %3, %4 {handshake_id = 0 : index} : i32, none
+// CHECK:   return {handshake_id = 0 : index} %3, %4 : i32, none
 // CHECK: }
 handshake.func @simple_c(%arg0: i32, %arg1: i32, %arg2: none) -> (i32, none) {
   %0 = buffer [2] seq %arg0 : i32

--- a/test/Dialect/Handshake/func.mlir
+++ b/test/Dialect/Handshake/func.mlir
@@ -19,3 +19,13 @@ handshake.func private @private_func(%arg0 : i32, %ctrl: none) -> (i32, none) {
 handshake.func public @public_func(%arg0 : i32, %ctrl: none) -> (i32, none) {
   return %arg0, %ctrl : i32, none
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func public @no_none_type(
+// CHECK-SAME:                   ...) attributes {argNames = [], resNames = []} {
+// CHECK:           return
+// CHECK:         }
+handshake.func public @no_none_type() {
+  return
+}


### PR DESCRIPTION
The ctrl in- and outputs are mandatory for DHLS style usage, but in general, they aren't required for well-formed handshaked circuits.

This PR doesn't touch `StartOp` or `EndOp` as they are only used in `std-to-handshake`.