### PR TITLE
[FIRRTL] HierPathOp: create with private vis, propagate vis in passes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -123,6 +123,7 @@ static FlatSymbolRefAttr buildNLA(const AnnoPathValue &target,
   // Create the NLA
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
   state.symTbl.insert(nla);
+  nla.setVisibility(SymbolTable::Visibility::Private);
   auto sym = FlatSymbolRefAttr::get(nla);
   state.instPathToNLAMap.insert({instAttr, sym});
   return sym;

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -200,8 +200,10 @@ public:
       else
         namepath.push_back(FlatSymbolRefAttr::get(modPart));
 
-      return b.create<HierPathOp>(b.getUnknownLoc(), sym,
-                                  b.getArrayAttr(namepath));
+      auto hp = b.create<HierPathOp>(b.getUnknownLoc(), sym,
+                                     b.getArrayAttr(namepath));
+      hp.setVisibility(nla.getVisibility());
+      return hp;
     };
 
     HierPathOp last;


### PR DESCRIPTION
Follow-up to #3863 to address symbol visibility on HierPathOp's, from when they're created to how they're propagated/modified in passes.

Dedup propagates visibility when modifying existing NLA, will create as private if promoting local to non-local.

Inliner copies visibility when doing its `writeBack`s.

EmitOMIR does create HierPathOp's but they're temporary and are deleted before pass completion so leaving that alone.