### PR TITLE
Bump LLVM

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -39,6 +39,10 @@ def CalyxDialect : Dialect {
   // Depends on the HWDialect to support external primitives using hw.module.extern
   let dependentDialects = ["circt::hw::HWDialect"];
   let cppNamespace = "::circt::calyx";
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 class SameTypeConstraint<string lhs, string rhs>

--- a/include/circt/Dialect/ESI/ESI.td
+++ b/include/circt/Dialect/ESI/ESI.td
@@ -30,6 +30,10 @@ def ESI_Dialect : Dialect {
     /// Register all ESI types.
     void registerTypes();
   }];
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 class ESI_Op<string mnemonic, list<Trait> traits = []> :

--- a/include/circt/Dialect/FSM/FSM.td
+++ b/include/circt/Dialect/FSM/FSM.td
@@ -24,6 +24,10 @@ def FSMDialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 1;
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 // Base class for the types in this dialect.

--- a/include/circt/Dialect/HWArith/HWArithDialect.td
+++ b/include/circt/Dialect/HWArith/HWArithDialect.td
@@ -22,6 +22,10 @@ def HWArithDialect : Dialect {
     This dialect defines the `HWArith` dialect, modeling bit-width aware
     arithmetic operations.
   }];
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 #endif // HWARITHDIALECT_TD

--- a/include/circt/Dialect/Handshake/Handshake.td
+++ b/include/circt/Dialect/Handshake/Handshake.td
@@ -34,6 +34,10 @@ def Handshake_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 // Base class for Handshake dialect ops.

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -26,6 +26,10 @@ include "mlir/IR/EnumAttr.td"
 def Pipeline_Dialect : Dialect {
   let name = "pipeline";
   let cppNamespace = "::circt::pipeline";
+
+  // TODO: This needs to be flipped to kEmitAccessorPrefix_Prefixed
+  // https://discourse.llvm.org/t/psa-ods-generated-accessors-will-change-to-have-a-get-prefix-update-you-apis/4476
+  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 def PipelineOp : Op<Pipeline_Dialect, "pipeline", [

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3497,9 +3497,8 @@ void FIRRTLLowering::lowerRegConnect(const FieldRef &fieldRef, Value dest,
   // outermost ones, the new value is computed by updating one of its
   // fields. The value of the field itself is determined by updating the
   // previous value according to the subsequent access operation.
-  std::function<Value(Value, Type, unsigned)> inject = [&](Value base,
-                                                           Type type,
-                                                           unsigned fieldID) {
+  std::function<Value(Value, Type, unsigned)> inject =
+      [&](Value base, Type type, unsigned fieldID) -> Value {
     if (auto bundle = type.dyn_cast<BundleType>()) {
       auto index = bundle.getIndexForFieldID(fieldID);
       fieldID -= bundle.getFieldID(index);

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -107,7 +107,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
     // TODO(Calyx): Eventually, we should canonicalize the GroupDoneOp's guard
     // and source.
     auto guard = groupOp.getDoneOp().guard();
-    auto source = groupOp.getDoneOp().src();
+    Value source = groupOp.getDoneOp().src();
     auto doneOpValue = !guard ? source
                               : builder.create<comb::AndOp>(
                                     wires->getLoc(), guard, source, false);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1182,7 +1182,7 @@ static LogicalResult canonicalizeMux(MuxPrimOp op, PatternRewriter &rewriter) {
   if (width < 0)
     return failure();
 
-  auto pad = [&](Value input) {
+  auto pad = [&](Value input) -> Value {
     auto inputWidth =
         input.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel();
     if (inputWidth < 0 || width == inputWidth)
@@ -1868,8 +1868,8 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   }
   auto pt = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(con);
-  replaceOpWithNewOpAndCopyName<ConnectOp>(rewriter, con, con.getDest(),
-                                           constReg ? constOp : mux.getLow());
+  replaceOpWithNewOpAndCopyName<ConnectOp>(
+      rewriter, con, con.getDest(), constReg ? (Value)constOp : mux.getLow());
   rewriter.restoreInsertionPoint(pt);
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include <numeric>
 
 #define DEBUG_TYPE "lower-memory"
 
@@ -76,7 +77,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       maskGran = memWidths[0];
       // Compute the GCD of all data bitwidths.
       for (auto w : memWidths) {
-        maskGran = llvm::GreatestCommonDivisor64(maskGran, w);
+        maskGran = std::gcd(maskGran, (uint64_t)w);
       }
       for (auto w : memWidths) {
         // How many mask bits required for each flattened field.

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -472,7 +472,7 @@ static bool checkBytecodeOutputToConsole(raw_ostream &os) {
 /// requested and politely avoiding dumping to terminal unless forced.
 static void printOp(Operation *op, raw_ostream &os) {
   if (emitBytecode && (force || !checkBytecodeOutputToConsole(os)))
-    writeBytecodeToFile(op, os, getCirctVersion());
+    writeBytecodeToFile(op, os, BytecodeWriterConfig(getCirctVersion()));
   else
     op->print(os);
 }


### PR DESCRIPTION
This doesn't quite get us up to the tip of the LLVM tree, but there were already a lot of changes, mostly split off into other PRs that landed separately, and I wanted to lock in the TypedValue changes by bumping to a commit that includes TypedValue before it regresses.

This branch currently has a nonlinear history because it depends on https://github.com/llvm/circt/pull/3859 as well as a few changes that landed in `main` after my original branch point in https://github.com/llvm/circt/pull/3859. The actual diff is much smaller if you ignore the changes from https://github.com/llvm/circt/pull/3859.

In parallel, I'm working on the next set of issues, at least until I get to September 9th in the LLVM history (this PR brings us to 9/6), after which I'll hand things off to @darthscsi for the next bump. If I end up solving those issues before https://github.com/llvm/circt/pull/3859 merges, then I'll just incorporate them into this PR so that we don't force everyone to recompile LLVM multiple times in a short period of time.