### PR TITLE
[ExportSystemC] Add systemc type emission

### DIFF
--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -4,25 +4,25 @@
 
 emitc.include <"systemc.h">
 
-systemc.module @submodule (%in0: !systemc.in<i32>, %in1: !systemc.in<i32>, %out0: !systemc.out<i32>) {}
+systemc.module @submodule (%in0: !systemc.in<!systemc.uint<32>>, %in1: !systemc.in<!systemc.uint<32>>, %out0: !systemc.out<!systemc.uint<32>>) {}
 
-systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>, %port4: !systemc.out<i1>) {
-  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
-  %sig = systemc.signal : !systemc.signal<i64>
-  %channel = systemc.signal : !systemc.signal<i32>
+systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<!systemc.uint<64>>, %port2: !systemc.out<i64>, %port3: !systemc.out<!systemc.bv<1024>>, %port4: !systemc.out<i1>) {
+  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<32>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<32>>)>
+  %sig = systemc.signal : !systemc.signal<!systemc.uint<64>>
+  %channel = systemc.signal : !systemc.signal<!systemc.uint<32>>
   %testvar = systemc.cpp.variable : i32
   %c42_i32 = hw.constant 42 : i32
   %testvarwithinit = systemc.cpp.variable %c42_i32 : i32
   systemc.ctor {
-    systemc.instance.bind_port %submoduleInstance["in0"] to %channel : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>, !systemc.signal<i32>
+    systemc.instance.bind_port %submoduleInstance["in0"] to %channel : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<32>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<32>>)>, !systemc.signal<!systemc.uint<32>>
     systemc.method %add
     systemc.thread %add
   }
   %add = systemc.func {
-    %0 = systemc.signal.read %port1 : !systemc.inout<i64>
-    systemc.signal.write %sig, %0 : !systemc.signal<i64>
-    %1 = hw.constant 42 : i512
-    systemc.signal.write %port2, %1 : !systemc.out<i512>
+    %0 = systemc.signal.read %port1 : !systemc.inout<!systemc.uint<64>>
+    systemc.signal.write %sig, %0 : !systemc.signal<!systemc.uint<64>>
+    %1 = hw.constant 42 : i64
+    systemc.signal.write %port2, %1 : !systemc.out<i64>
     %2 = hw.constant 1 : i1
     systemc.signal.write %port4, %2 : !systemc.out<i1>
     %3 = hw.constant 0 : i1
@@ -31,3 +31,33 @@ systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %p
     systemc.cpp.assign %testvarwithinit = %testvar : i32
   }
 }
+
+systemc.module @nativeCTypes (%port0: !systemc.in<i1>,
+                              %port1: !systemc.in<i8>,
+                              %port2: !systemc.in<i16>,
+                              %port3: !systemc.in<i32>,
+                              %port4: !systemc.in<i64>,
+                              %port5: !systemc.in<si1>,
+                              %port6: !systemc.in<si8>,
+                              %port7: !systemc.in<si16>,
+                              %port8: !systemc.in<si32>,
+                              %port9: !systemc.in<si64>,
+                              %port10: !systemc.in<ui1>,
+                              %port11: !systemc.in<ui8>,
+                              %port12: !systemc.in<ui16>,
+                              %port13: !systemc.in<ui32>,
+                              %port14: !systemc.in<ui64>) {}
+
+systemc.module @systemCTypes (%p0: !systemc.in<!systemc.int_base>,
+                              %p1: !systemc.in<!systemc.int<32>>,
+                              %p2: !systemc.in<!systemc.uint_base>,
+                              %p3: !systemc.in<!systemc.uint<32>>,
+                              %p4: !systemc.in<!systemc.signed>,
+                              %p5: !systemc.in<!systemc.bigint<256>>,
+                              %p6: !systemc.in<!systemc.unsigned>,
+                              %p7: !systemc.in<!systemc.biguint<256>>,
+                              %p8: !systemc.in<!systemc.bv_base>,
+                              %p9: !systemc.in<!systemc.bv<1024>>,
+                              %p10: !systemc.in<!systemc.lv_base>,
+                              %p11: !systemc.in<!systemc.lv<1024>>,
+                              %p12: !systemc.in<!systemc.logic>) {}

--- a/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
@@ -79,7 +79,7 @@ struct IntegerTypeEmitter : TypeEmissionPattern<IntegerType> {
       p << (type.isSigned() ? "" : "u") << "int" << bitWidth << "_t";
       break;
     default:
-      assert(false && "This bit-width not supported!");
+      assert(false && "All cases allowed by match function must be covered.");
     }
   }
 };

--- a/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/HWEmissionPatterns.cpp
@@ -56,29 +56,31 @@ struct ConstantEmitter : OpEmissionPattern<ConstantOp> {
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Emit integer types. There are several datatypes to represent integers in
-/// SystemC. In contrast to HW and Comb, SystemC chooses the signedness
-/// semantics of operations not by the operation itself, but by the type of the
-/// operands. We generally map the signless integers of HW to unsigned integers
-/// in SystemC and cast to/from signed integers whenever needed. SystemC also
-/// uses different types depending on the bit-width of the integer. For 1-bit
-/// integers it simply uses 'bool', for integers with up to 64 bits it uses
-/// 'sc_uint<>' which maps to native C types for performance reasons. For bigger
-/// integers 'sc_biguint<>' is used. However, often a limit of 512 bits is
-/// configured for this datatype to improve performance. In that case, we have
-/// to fall back to 'sc_bv' bit-vectors which have the disadvantage that many
-/// operations such as arithmetics are not supported.
+/// Emit the builtin integer type to native C integer types.
 struct IntegerTypeEmitter : TypeEmissionPattern<IntegerType> {
+  bool match(Type type) override {
+    if (!type.isa<IntegerType>())
+      return false;
+
+    unsigned bw = type.getIntOrFloatBitWidth();
+    return bw == 1 || bw == 8 || bw == 16 || bw == 32 || bw == 64;
+  }
+
   void emitType(IntegerType type, EmissionPrinter &p) override {
     unsigned bitWidth = type.getIntOrFloatBitWidth();
-    if (bitWidth == 1)
+    switch (bitWidth) {
+    case 1:
       p << "bool";
-    else if (bitWidth <= 64)
-      p << "sc_uint<" << bitWidth << ">";
-    else if (bitWidth <= 512)
-      p << "sc_biguint<" << bitWidth << ">";
-    else
-      p << "sc_bv<" << bitWidth << ">";
+      break;
+    case 8:
+    case 16:
+    case 32:
+    case 64:
+      p << (type.isSigned() ? "" : "u") << "int" << bitWidth << "_t";
+      break;
+    default:
+      assert(false && "This bit-width not supported!");
+    }
   }
 };
 } // namespace

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -300,6 +300,24 @@ struct ModuleTypeEmitter : public TypeEmissionPattern<ModuleType> {
     p << type.getModuleName().getValue();
   }
 };
+
+/// Emit SystemC integer and bit-vector types with known-at-compile-time
+/// bit-width according to the specification listed in their class description.
+template <typename Ty>
+struct IntegerTypeEmitter : public TypeEmissionPattern<Ty> {
+  void emitType(Ty type, EmissionPrinter &p) override {
+    p << "sc_" << Ty::getMnemonic() << "<" << type.getWidth() << ">";
+  }
+};
+
+/// Emit SystemC integer and bit-vector types without known bit-width according
+/// to the specification listed in their class description.
+template <typename Ty>
+struct DynIntegerTypeEmitter : public TypeEmissionPattern<Ty> {
+  void emitType(Ty type, EmissionPrinter &p) override {
+    p << "sc_" << Ty::getMnemonic();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -326,6 +344,19 @@ void circt::ExportSystemC::populateSystemCTypeEmitters(
                SignalTypeEmitter<InOutType, inout>,
                SignalTypeEmitter<OutputType, out>,
                SignalTypeEmitter<SignalType, signal>,
+               IntegerTypeEmitter<IntType>,
+               IntegerTypeEmitter<UIntType>,
+               IntegerTypeEmitter<BigIntType>,
+               IntegerTypeEmitter<BigUIntType>,
+               IntegerTypeEmitter<BitVectorType>,
+               IntegerTypeEmitter<LogicVectorType>,
+               DynIntegerTypeEmitter<IntBaseType>,
+               DynIntegerTypeEmitter<UIntBaseType>,
+               DynIntegerTypeEmitter<SignedType>,
+               DynIntegerTypeEmitter<UnsignedType>,
+               DynIntegerTypeEmitter<BitVectorBaseType>,
+               DynIntegerTypeEmitter<LogicVectorBaseType>,
+               DynIntegerTypeEmitter<LogicType>,
                ModuleTypeEmitter>();
   // clang-format on
 }

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -12,7 +12,7 @@ emitc.include "nosystemheader"
 
 // CHECK-EMPTY:
 // CHECK-LABEL: SC_MODULE(submodule) {
-systemc.module @submodule (%in0: !systemc.in<i32>, %in1: !systemc.in<i32>, %out0: !systemc.out<i32>) {
+systemc.module @submodule (%in0: !systemc.in<!systemc.uint<32>>, %in1: !systemc.in<!systemc.uint<32>>, %out0: !systemc.out<!systemc.uint<32>>) {
 // CHECK-NEXT: sc_in<sc_uint<32>> in0;
 // CHECK-NEXT: sc_in<sc_uint<32>> in1;
 // CHECK-NEXT: sc_out<sc_uint<32>> out0;
@@ -21,28 +21,28 @@ systemc.module @submodule (%in0: !systemc.in<i32>, %in1: !systemc.in<i32>, %out0
 
 // CHECK-EMPTY:
 // CHECK-LABEL: SC_MODULE(basic) {
-systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %port2: !systemc.out<i512>, %port3: !systemc.out<i1024>, %port4: !systemc.out<i1>) {
+systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<!systemc.uint<64>>, %port2: !systemc.out<i64>, %port3: !systemc.out<!systemc.bv<1024>>, %port4: !systemc.out<i1>) {
   // CHECK-NEXT: sc_in<bool> port0;
   // CHECK-NEXT: sc_inout<sc_uint<64>> port1;
-  // CHECK-NEXT: sc_out<sc_biguint<512>> port2;
+  // CHECK-NEXT: sc_out<uint64_t> port2;
   // CHECK-NEXT: sc_out<sc_bv<1024>> port3;
   // CHECK-NEXT: sc_out<bool> port4;
   // CHECK-NEXT: sc_signal<sc_uint<64>> sig;
-  %sig = systemc.signal : !systemc.signal<i64>
+  %sig = systemc.signal : !systemc.signal<!systemc.uint<64>>
   // CHECK-NEXT: sc_signal<sc_uint<32>> channel;
-  %channel = systemc.signal : !systemc.signal<i32>
+  %channel = systemc.signal : !systemc.signal<!systemc.uint<32>>
   // CHECK-NEXT: submodule submoduleInstance;
-  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>
-  // CHECK-NEXT: sc_uint<32> testvar;
+  %submoduleInstance = systemc.instance.decl @submodule : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<32>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<32>>)>
+  // CHECK-NEXT: uint32_t testvar;
   %testvar = systemc.cpp.variable : i32
-  // CHECK-NEXT: sc_uint<32> testvarwithinit = 42;
+  // CHECK-NEXT: uint32_t testvarwithinit = 42;
   %c42_i32 = hw.constant 42 : i32
   %testvarwithinit = systemc.cpp.variable %c42_i32 : i32
   // CHECK-EMPTY: 
   // CHECK-NEXT: SC_CTOR(basic) {
   systemc.ctor {
     // CHECK-NEXT: submoduleInstance.in0(channel);
-    systemc.instance.bind_port %submoduleInstance["in0"] to %channel : !systemc.module<submodule(in0: !systemc.in<i32>, in1: !systemc.in<i32>, out0: !systemc.out<i32>)>, !systemc.signal<i32>
+    systemc.instance.bind_port %submoduleInstance["in0"] to %channel : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<32>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<32>>)>, !systemc.signal<!systemc.uint<32>>
     // CHECK-NEXT: SC_METHOD(add);
     systemc.method %add
     // CHECK-NEXT: SC_THREAD(add);
@@ -53,11 +53,11 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %po
   // CHECK-NEXT: void add() {
   %add = systemc.func {
     // CHECK-NEXT: sig.write(port1.read());
-    %0 = systemc.signal.read %port1 : !systemc.inout<i64>
-    systemc.signal.write %sig, %0 : !systemc.signal<i64>
+    %0 = systemc.signal.read %port1 : !systemc.inout<!systemc.uint<64>>
+    systemc.signal.write %sig, %0 : !systemc.signal<!systemc.uint<64>>
     // CHECK-NEXT: port2.write(42);
-    %1 = hw.constant 42 : i512
-    systemc.signal.write %port2, %1 : !systemc.out<i512>
+    %1 = hw.constant 42 : i64
+    systemc.signal.write %port2, %1 : !systemc.out<i64>
     // CHECK-NEXT: port4.write(true);
     %2 = hw.constant 1 : i1
     systemc.signal.write %port4, %2 : !systemc.out<i1>
@@ -72,5 +72,65 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<i64>, %po
   }
 // CHECK-NEXT: };
 }
+
+// CHECK-LABEL: SC_MODULE(nativeCTypes)
+// CHECK-NEXT: sc_in<bool> port0;
+// CHECK-NEXT: sc_in<uint8_t> port1;
+// CHECK-NEXT: sc_in<uint16_t> port2;
+// CHECK-NEXT: sc_in<uint32_t> port3;
+// CHECK-NEXT: sc_in<uint64_t> port4;
+// CHECK-NEXT: sc_in<bool> port5;
+// CHECK-NEXT: sc_in<int8_t> port6;
+// CHECK-NEXT: sc_in<int16_t> port7;
+// CHECK-NEXT: sc_in<int32_t> port8;
+// CHECK-NEXT: sc_in<int64_t> port9;
+// CHECK-NEXT: sc_in<bool> port10;
+// CHECK-NEXT: sc_in<uint8_t> port11;
+// CHECK-NEXT: sc_in<uint16_t> port12;
+// CHECK-NEXT: sc_in<uint32_t> port13;
+// CHECK-NEXT: sc_in<uint64_t> port14;
+systemc.module @nativeCTypes (%port0: !systemc.in<i1>,
+                              %port1: !systemc.in<i8>,
+                              %port2: !systemc.in<i16>,
+                              %port3: !systemc.in<i32>,
+                              %port4: !systemc.in<i64>,
+                              %port5: !systemc.in<si1>,
+                              %port6: !systemc.in<si8>,
+                              %port7: !systemc.in<si16>,
+                              %port8: !systemc.in<si32>,
+                              %port9: !systemc.in<si64>,
+                              %port10: !systemc.in<ui1>,
+                              %port11: !systemc.in<ui8>,
+                              %port12: !systemc.in<ui16>,
+                              %port13: !systemc.in<ui32>,
+                              %port14: !systemc.in<ui64>) {}
+
+// CHECK-LABEL: SC_MODULE(systemCTypes)
+// CHECK-NEXT: sc_in<sc_int_base> p0;
+// CHECK-NEXT: sc_in<sc_int<32>> p1;
+// CHECK-NEXT: sc_in<sc_uint_base> p2;
+// CHECK-NEXT: sc_in<sc_uint<32>> p3;
+// CHECK-NEXT: sc_in<sc_signed> p4;
+// CHECK-NEXT: sc_in<sc_bigint<256>> p5;
+// CHECK-NEXT: sc_in<sc_unsigned> p6;
+// CHECK-NEXT: sc_in<sc_biguint<256>> p7;
+// CHECK-NEXT: sc_in<sc_bv_base> p8;
+// CHECK-NEXT: sc_in<sc_bv<1024>> p9;
+// CHECK-NEXT: sc_in<sc_lv_base> p10
+// CHECK-NEXT: sc_in<sc_lv<1024>> p11
+// CHECK-NEXT: sc_in<sc_logic> p12;
+systemc.module @systemCTypes (%p0: !systemc.in<!systemc.int_base>,
+                              %p1: !systemc.in<!systemc.int<32>>,
+                              %p2: !systemc.in<!systemc.uint_base>,
+                              %p3: !systemc.in<!systemc.uint<32>>,
+                              %p4: !systemc.in<!systemc.signed>,
+                              %p5: !systemc.in<!systemc.bigint<256>>,
+                              %p6: !systemc.in<!systemc.unsigned>,
+                              %p7: !systemc.in<!systemc.biguint<256>>,
+                              %p8: !systemc.in<!systemc.bv_base>,
+                              %p9: !systemc.in<!systemc.bv<1024>>,
+                              %p10: !systemc.in<!systemc.lv_base>,
+                              %p11: !systemc.in<!systemc.lv<1024>>,
+                              %p12: !systemc.in<!systemc.logic>) {}
 
 // CHECK: #endif // STDOUT_H


### PR DESCRIPTION
Change the emission of the bulitin integer types to map to native C integers and map the dedicated systemc types to the corresponding C++ classes.