### PR TITLE
[Pipeline] Add pipeline stage register materialization pass

### DIFF
--- a/include/circt/Dialect/Pipeline/CMakeLists.txt
+++ b/include/circt/Dialect/Pipeline/CMakeLists.txt
@@ -2,3 +2,8 @@ add_circt_dialect(Pipeline pipeline)
 add_circt_dialect_doc(Pipeline pipeline)
 
 set(LLVM_TARGET_DEFINITIONS Pipeline.td)
+
+set(LLVM_TARGET_DEFINITIONS PipelinePasses.td)
+mlir_tablegen(PipelinePasses.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTPipelineTransformsIncGen)
+add_circt_doc(PipelinePasses PipelinePasses -gen-pass-doc)

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -177,6 +177,8 @@ def PipelineStageRegisterOp : Op<Pipeline_Dialect, "stage.register", [
   let arguments = (ins Variadic<AnyType>:$regIns, I1:$when);
   let results = (outs Variadic<AnyType>:$regOuts, I1:$valid);
 
+  let builders = [OpBuilder<(ins "mlir::Value":$when, "mlir::ValueRange":$regIns)>];
+
   let assemblyFormat = [{
     `when` $when (`regs` $regIns^)? attr-dict (`:` type($regIns)^)?
   }];

--- a/include/circt/Dialect/Pipeline/PipelinePasses.h
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.h
@@ -1,0 +1,31 @@
+//===- PipelinePasses.h - Pipeline pass entry points ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_H
+#define CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_H
+
+#include "circt/Support/LLVM.h"
+#include <memory>
+
+namespace circt {
+namespace pipeline {
+
+std::unique_ptr<mlir::Pass> createExplicitRegsPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/Pipeline/PipelinePasses.h.inc"
+
+} // namespace pipeline
+} // namespace circt
+
+#endif // CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_H

--- a/include/circt/Dialect/Pipeline/PipelinePasses.td
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.td
@@ -1,0 +1,29 @@
+//===-- PipelinePasses.td - Pipeline pass definition file --*- tablegen -*-===//
+//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for passes that work on the Pipeline dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_TD
+#define CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def ExplicitRegs : Pass<"pipeline-explicit-regs", "pipeline::PipelineOp"> {
+  let summary = "Makes stage registers explicit.";
+  let description = [{
+    Makes all stage-crossing def-use chains into explicit registers.
+  }];
+  let dependentDialects = ["hw::HWDialect"];
+  let constructor = "circt::pipeline::createExplicitRegsPass()";
+}
+
+
+#endif // CIRCT_DIALECT_PIPELINE_PIPELINEPASSES_TD

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -24,6 +24,7 @@
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
 #include "circt/Dialect/MSFT/MSFTPasses.h"
+#include "circt/Dialect/Pipeline/PipelinePasses.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Transforms/Passes.h"
@@ -48,6 +49,7 @@ inline void registerAllPasses() {
   sv::registerPasses();
   handshake::registerPasses();
   hw::registerPasses();
+  pipeline::registerPasses();
 }
 
 } // namespace circt

--- a/lib/Dialect/Pipeline/CMakeLists.txt
+++ b/lib/Dialect/Pipeline/CMakeLists.txt
@@ -20,3 +20,5 @@ add_circt_dialect_library(CIRCTPipelineOps
   DEPENDS
   MLIRPipelineIncGen
 )
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -297,6 +297,17 @@ void PipelineWhileOp::build(OpBuilder &builder, OperationState &state,
 }
 
 //===----------------------------------------------------------------------===//
+// PipelineStageRegisterOp
+//===----------------------------------------------------------------------===//
+
+void PipelineStageRegisterOp::build(OpBuilder &builder, OperationState &state,
+                                    Value when, ValueRange regIns) {
+  PipelineStageRegisterOp::build(builder, state, regIns.getTypes(), regIns,
+                                 when);
+  state.addTypes({when.getType()});
+}
+
+//===----------------------------------------------------------------------===//
 // PipelineWhileStageOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Pipeline/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Pipeline/Transforms/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_circt_dialect_library(CIRCTPipelineTransforms
+  ExplicitRegs.cpp
+
+  DEPENDS
+  CIRCTPipelineTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTComb
+  CIRCTHW
+  CIRCTPipelineOps
+  CIRCTSupport
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -92,7 +92,7 @@ void ExplicitRegsPass::runOnOperation() {
   SmallVector<PipelineStageOp> stageList;
   PipelineStageOp currStage = nullptr;
   // Iterate over the pipeline body in-order (!).
-  for (auto &op : *pipeline.getBody()) {
+  for (auto &op : *pipeline.getBodyBlock()) {
     if (auto stageOp = dyn_cast<PipelineStageOp>(&op)) {
       stagePredecessor[stageOp] = currStage;
       currStage = stageOp;
@@ -131,15 +131,15 @@ void ExplicitRegsPass::runOnOperation() {
       regIns.push_back(value);
     }
 
-    auto newStageOp = b.create<PipelineStageRegisterOp>(stageOp.getLoc(),
-                                                        stageOp.when(), regIns);
-    stageOp.valid().replaceAllUsesWith(newStageOp.valid());
+    auto newStageOp = b.create<PipelineStageRegisterOp>(
+        stageOp.getLoc(), stageOp.getWhen(), regIns);
+    stageOp.getValid().replaceAllUsesWith(newStageOp.getValid());
 
     // Replace backedges with the outputs of the new stage.
     for (auto &it : llvm::enumerate(regMap)) {
       auto index = it.index();
       auto &[value, backedge] = it.value();
-      backedge.setValue(newStageOp.regOuts()[index]);
+      backedge.setValue(newStageOp.getRegOuts()[index]);
     }
     stageOp.erase();
   }

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -1,0 +1,163 @@
+//===- ExplicitRegs.cpp - Explicit regs pass --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the explicit regs pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Support/BackedgeBuilder.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace pipeline;
+
+namespace {
+
+class ExplicitRegsPass : public ExplicitRegsBase<ExplicitRegsPass> {
+public:
+  void runOnOperation() override;
+
+private:
+  // Recursively routes value v backwards through the pipeline, adding new
+  // registers to 'stage' if the value was not already registered in the stage.
+  // Returns the registerred version of 'v' through 'stage'.
+  Value routeThroughStage(OpOperand &v, PipelineStageOp stage);
+
+  // A mapping storing whether a given stage register constains a registerred
+  // version of a given value. The registered version will be a backedge during
+  // pipeline body analysis. Once the entire body has been analyzed, the
+  // pipeline.stage operations will be replaced with pipeline.stage.register
+  // operations containing the requested regs, and the backedge will be
+  // replaced. MapVector ensures deterministic iteration order, which in turn
+  // ensures determinism during stage op IR emission.
+  DenseMap<PipelineStageOp, llvm::MapVector<Value, Backedge>> stageRegMap;
+
+  // A linked list of stages in the pipeline. Allows for easily looking up the
+  // predecessor stage of a given stage.
+  DenseMap<PipelineStageOp, PipelineStageOp> stagePredecessor;
+
+  std::shared_ptr<BackedgeBuilder> bb;
+};
+
+} // end anonymous namespace
+
+// NOLINTNEXTLINE(misc-no-recursion)
+Value ExplicitRegsPass::routeThroughStage(OpOperand &v, PipelineStageOp stage) {
+  if (!stage) {
+    // Recursive base case - nothing to route (v is a block operand).
+    return v.get();
+  }
+
+  auto regIt = stageRegMap[stage].find(v.get());
+  if (regIt != stageRegMap[stage].end()) {
+    // 'v' is already registered in 'stage'.
+    return regIt->second;
+  }
+
+  auto *definingOp = v.get().getDefiningOp();
+  auto blockPos = [&](Operation *op) {
+    return std::distance(op->getBlock()->begin(), op->getIterator());
+  };
+
+  // If no defining op (a block operand), define the defining position as a
+  // negative value (indicating "earliest possible position").
+  int pDef = definingOp ? blockPos(definingOp) : -1;
+  int pStage = blockPos(stage);
+
+  Value retVal = v.get();
+  if (pDef < pStage) {
+    // Value is defined before the provided stage - route it through the stage.
+    auto regBackedge = bb->get(v.get().getType());
+    stageRegMap[stage].insert({v.get(), regBackedge});
+    retVal = regBackedge;
+  } else {
+    // Value is defined after the provided stage - early exit here.
+    return retVal;
+  }
+
+  // Recurse - recursion will only create a new backedge if necessary.
+  auto predStageIt = stagePredecessor.find(stage);
+  assert(predStageIt != stagePredecessor.end() &&
+         "stage should have been registered before calling this function");
+  PipelineStageOp predecessorStage = predStageIt->second;
+  if (predecessorStage)
+    routeThroughStage(v, predecessorStage);
+
+  return retVal;
+}
+
+void ExplicitRegsPass::runOnOperation() {
+  auto pipeline = getOperation();
+  OpBuilder b(getOperation().getContext());
+  bb = std::make_shared<BackedgeBuilder>(b, getOperation().getLoc());
+
+  // A list of stages in the pipeline in the order which they appear.
+  SmallVector<PipelineStageOp> stageList;
+  PipelineStageOp currStage = nullptr;
+  // Iterate over the pipeline body in-order (!).
+  for (auto &op : *pipeline.getBody()) {
+    if (auto stageOp = dyn_cast<PipelineStageOp>(&op)) {
+      stagePredecessor[stageOp] = currStage;
+      currStage = stageOp;
+      continue;
+    }
+
+    // Check the operands of this operation to see if any of them cross a
+    // stage boundary.
+    for (OpOperand &operand : op.getOpOperands()) {
+      Value reroutedValue = routeThroughStage(operand, currStage);
+      if (reroutedValue != operand.get())
+        op.setOperand(operand.getOperandNumber(), reroutedValue);
+    }
+  }
+
+  // All values have been recorded through the stages. Now, replace the
+  // stages with new stage operations containing the required registers.
+  for (auto &[stageOp, regMap] : stageRegMap) {
+    b.setInsertionPoint(stageOp);
+    auto predStageOp = stagePredecessor[stageOp];
+
+    // Gather register inputs to this stage, either from a predecessor stage
+    // or from the original op.
+    llvm::SmallVector<Value> regIns;
+    for (auto &[value, backedge] : regMap) {
+      if (predStageOp) {
+        // Grab the value if registerred through the predecessor op, else,
+        // use the raw value.
+        auto predRegIt = stageRegMap[predStageOp].find(value);
+        if (predRegIt != stageRegMap[predStageOp].end()) {
+          regIns.push_back(predRegIt->second);
+          continue;
+        }
+      }
+      // Not in predecessor stage - must be the original value.
+      regIns.push_back(value);
+    }
+
+    auto newStageOp = b.create<PipelineStageRegisterOp>(stageOp.getLoc(),
+                                                        stageOp.when(), regIns);
+    stageOp.valid().replaceAllUsesWith(newStageOp.valid());
+
+    // Replace backedges with the outputs of the new stage.
+    for (auto &it : llvm::enumerate(regMap)) {
+      auto index = it.index();
+      auto &[value, backedge] = it.value();
+      backedge.setValue(newStageOp.regOuts()[index]);
+    }
+    stageOp.erase();
+  }
+
+  // Clear internal state. See https://github.com/llvm/circt/issues/3235
+  stageRegMap.clear();
+  stagePredecessor.clear();
+}
+
+std::unique_ptr<mlir::Pass> circt::pipeline::createExplicitRegsPass() {
+  return std::make_unique<ExplicitRegsPass>();
+}

--- a/lib/Dialect/Pipeline/Transforms/PassDetails.h
+++ b/lib/Dialect/Pipeline/Transforms/PassDetails.h
@@ -1,0 +1,35 @@
+//===- PassDetails.h - Pipeline pass class details --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the stuff shared between the different Pipeline passes.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the
+// header guard on some systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_PIPELINE_TRANSFORMS_PASSDETAILS_H
+#define DIALECT_PIPELINE_TRANSFORMS_PASSDETAILS_H
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Pipeline/Pipeline.h"
+#include "circt/Dialect/Pipeline/PipelinePasses.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace pipeline {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/Pipeline/PipelinePasses.h.inc"
+
+} // namespace pipeline
+} // namespace circt
+
+#endif // DIALECT_PIPELINE_TRANSFORMS_PASSDETAILS_H

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -24,6 +24,7 @@ void Backedge::setValue(mlir::Value newValue) {
   assert(value.getType() == newValue.getType());
   assert(!set && "backedge already set to a value!");
   value.replaceAllUsesWith(newValue);
+  value = newValue; // In case the backedge is still referred to after setting.
   set = true;
 
   // If the backedge is referenced again, it should now point to the updated

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt %s -pass-pipeline='hw.module(pipeline.pipeline(pipeline-explicit-regs))' | FileCheck %s
+
+// CHECK:      %[[PIPELINE_RES:.*]] = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> i32 {
+// CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i1):
+// CHECK-NEXT:     %[[ARG0_REG:.*]], %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG1]] regs %[[ARG0]] : i32
+// CHECK-NEXT:     pipeline.return %[[ARG0_REG]] valid %[[S0_VALID]] : i32
+// CHECK-NEXT: }
+
+hw.module @test1(%arg0 : i32,  %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> (i32) {
+    ^bb0(%a0 : i32, %g : i1):
+      %s0_valid = pipeline.stage when %g
+      pipeline.return %a0 valid %s0_valid : i32
+  }
+  hw.output %out : i32
+}
+
+// CHECK:      %0 = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> i32 {
+// CHECK-NEXT:   ^bb0(%[[ARG0]]: i32, %[[ARG1:.*]]: i1):
+// CHECK-NEXT:     %[[S0_REG:.*]], %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG1]] regs %[[ARG0]] : i32
+// CHECK-NEXT:     %[[ADD0_OUT:.*]] = comb.add %[[S0_REG]], %[[S0_REG]] : i32
+// CHECK-NEXT:     pipeline.return %[[ADD0_OUT]] valid %[[S0_VALID]] : i32
+// CHECK-NEXT: }
+
+hw.module @test2(%arg0 : i32,  %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> (i32) {
+    ^bb0(%a0 : i32, %g : i1):
+      %s0_valid = pipeline.stage when %g
+      %add = comb.add %a0, %a0 : i32
+      pipeline.return %add valid %s0_valid : i32
+  }
+  hw.output %out : i32
+}
+
+// CHECK:      %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
+// CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i1):
+// CHECK-NEXT:     %[[ADD0_OUT:.*]] = comb.add %[[ARG0]], %[[ARG1]] : i32
+// CHECK-NEXT:     %[[S0_REGS:.*]]:2, %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG2]] regs %[[ADD0_OUT]], %[[ARG0]] : i32, i32
+// CHECK-NEXT:     %[[ADD1_OUT:.*]] = comb.add %[[S0_REGS]]#0, %[[S0_REGS]]#1 : i32
+// CHECK-NEXT:     %[[S1_REGS:.*]]:2, %[[S1_VALID:.*]] = pipeline.stage.register when %[[S0_VALID]] regs %[[ADD1_OUT]], %[[S0_REGS]]#0 : i32, i32
+// CHECK-NEXT:     %[[ADD2_OUT:.*]] = comb.add %[[S1_REGS]]#0, %[[S1_REGS]]#1 : i32
+// CHECK-NEXT:     pipeline.return %[[ADD2_OUT]] valid %[[S1_VALID]] : i32
+// CHECK-NEXT: }
+
+hw.module @test3(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32) {
+    ^bb0(%a0 : i32, %a1: i32, %g : i1):
+      %add0 = comb.add %a0, %a1 : i32
+
+      %s0_valid = pipeline.stage when %g
+      %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
+
+      %s1_valid = pipeline.stage when %s0_valid
+      %add2 = comb.add %add1, %add0 : i32 // %add0 crosses multiple stages.
+
+      pipeline.return %add2 valid %s1_valid : i32
+  }
+  hw.output %out : i32
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(circt-opt
   CIRCTStandardToHandshake
   CIRCTPipelineOps
   CIRCTPipelineToHW
+  CIRCTPipelineTransforms
   CIRCTPipelineToCalyx
   CIRCTSV
   CIRCTSVTransforms


### PR DESCRIPTION
This commit adds an intermediate transformation to the Pipeline dialect which is responsible for converting `pipeline.stage` to `pipeline.stage.register` operations. The purpose of this transformation is to 'fix' where registers needs to be placed in the pipeline, after all stages have been defined and placed.

In short, the transformation will scan through the pipeline (in order, top to bottom) and insert `pipeline.stage.register` operations in place of `pipeline.stage` operations. Any operand used in any operation will be analyzed to determine if it originates in between the last seen stage and the operation itself. If not, this means that the operand crossed a pipeline stage, and as such, the value will be routed through the predecessor stage (`routeThroughStage`).