### PR TITLE
[Support] Add RTLBuilder - syntactic sugar for building core dialect ops

### DIFF
--- a/include/circt/Support/RTLBuilder.h
+++ b/include/circt/Support/RTLBuilder.h
@@ -1,0 +1,73 @@
+//===- RTLBuilder.h - CIRCT core RTL builder sugar --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A convenience builder for building CIRCT RTL operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_RTLBUILDER_H
+#define CIRCT_SUPPORT_RTLBUILDER_H
+
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+class OpBuilder;
+class PatternRewriter;
+class Operation;
+class ImplicitLocOpBuilder;
+} // namespace mlir
+
+namespace circt {
+
+// A class containing a bunch of syntactic sugar to reduce builder function
+// verbosity when building core RTL dialect operations.
+class RTLBuilder {
+public:
+  RTLBuilder(mlir::OpBuilder &builder, mlir::Location loc,
+             mlir::Value clk = mlir::Value(), mlir::Value rst = mlir::Value());
+  RTLBuilder(mlir::ImplicitLocOpBuilder &builder,
+             mlir::Value clk = mlir::Value(), mlir::Value rst = mlir::Value());
+
+  // Return a constant value of the specified width and value.
+  mlir::Value constant(unsigned width, int64_t value,
+                       mlir::Location *extLoc = nullptr);
+
+  // Create a register on the 'in' value and return the registered value.
+  // If the RTLBuilder was created with a clock and reset, clock and reset
+  // signals may be omitted from this function.
+  mlir::Value reg(mlir::StringRef name, mlir::Value in, mlir::Value rstValue,
+                  mlir::Value clk = mlir::Value(),
+                  mlir::Value rst = mlir::Value(),
+                  mlir::Location *extLoc = nullptr);
+
+  // Bitwise AND.
+  mlir::Value bAnd(mlir::ValueRange values, mlir::Location *extLoc = nullptr);
+  // Bitwise NOT.
+  mlir::Value bNot(mlir::Value value, mlir::Location *extLoc = nullptr);
+  // Bitwise OR.
+  mlir::Value bOr(mlir::ValueRange values, mlir::Location *extLoc = nullptr);
+  // Bitwise XOR.
+  mlir::Value bXor(mlir::ValueRange values, mlir::Location *extLoc = nullptr);
+
+  mlir::OpBuilder &b;
+
+protected:
+  mlir::Location getLoc(mlir::Location *extLoc = nullptr) {
+    return extLoc ? *extLoc : loc;
+  }
+
+  mlir::Location loc;
+  mlir::Value clk, rst;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_RTLBUILDER_H

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -19,6 +19,9 @@ add_circt_library(CIRCTSupport
   ADDITIONAL_HEADER_DIRS
 
   LINK_LIBS PUBLIC
+  CIRCTHW
+  CIRCTComb
+  CIRCTSeq
   MLIRIR
   )
 

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -7,6 +7,7 @@ set_source_files_properties("${VERSION_CPP}" PROPERTIES GENERATED TRUE)
 
 add_circt_library(CIRCTSupport
   BackedgeBuilder.cpp
+  RTLBuilder.cpp
   FieldRef.cpp
   LoweringOptions.cpp
   Path.cpp

--- a/lib/Support/RTLBuilder.cpp
+++ b/lib/Support/RTLBuilder.cpp
@@ -1,0 +1,59 @@
+//===- RTLBuilder.cpp - CIRCT core RTL builder sugar ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/RTLBuilder.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+using namespace mlir;
+using namespace circt;
+
+RTLBuilder::RTLBuilder(mlir::OpBuilder &builder, mlir::Location loc, Value clk,
+                       Value rst)
+    : b(builder), loc(loc), clk(clk), rst(rst) {}
+
+RTLBuilder::RTLBuilder(mlir::ImplicitLocOpBuilder &builder, Value clk,
+                       Value rst)
+    : b(builder), loc(builder.getLoc()), clk(clk), rst(rst) {}
+
+Value RTLBuilder::constant(unsigned width, int64_t value, Location *extLoc) {
+  return b.create<hw::ConstantOp>(getLoc(extLoc), APInt(width, value));
+}
+
+Value RTLBuilder::reg(StringRef name, Value in, Value rstValue, Value clk,
+                      Value rst, Location *extLoc) {
+  Value resolvedClk = clk ? clk : this->clk;
+  Value resolvedRst = rst ? rst : this->rst;
+  assert(resolvedClk && "No global clock provided to this RTLBuilder - a clock "
+                        "signal must be provided to the reg(...) function.");
+  assert(resolvedRst && "No global reset provided to this RTLBuilder - a reset "
+                        "signal must be provided to the reg(...) function.");
+
+  return b.create<seq::CompRegOp>(getLoc(extLoc), in.getType(), in, resolvedClk,
+                                  name, resolvedRst, rstValue,
+                                  mlir::StringAttr());
+}
+
+Value RTLBuilder::bAnd(ValueRange values, Location *extLoc) {
+  return b.create<comb::AndOp>(getLoc(extLoc), values).getResult();
+}
+
+Value RTLBuilder::bNot(Value value, Location *extLoc) {
+  return comb::createOrFoldNot(getLoc(extLoc), value, b);
+}
+
+Value RTLBuilder::bOr(ValueRange values, Location *extLoc) {
+  return b.create<comb::OrOp>(getLoc(extLoc), values).getResult();
+}
+
+Value RTLBuilder::bXor(ValueRange values, Location *extLoc) {
+  return b.create<comb::XorOp>(getLoc(extLoc), values).getResult();
+}


### PR DESCRIPTION
Moving this from `HandshakeToHW` to support. A class containing a bunch of syntactic sugar to reduce builder function verbosity when building core RTL dialect operations. Can/should be extended to provide additional builder functionality, e.g. the ESI wrap/unwrap operations in `HandshakeToHW`.