### PR TITLE
integration_test,test: Add dep on hlstool to ensure avail for use.

### DIFF
--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -8,7 +8,9 @@ set(CIRCT_INTEGRATION_TEST_DEPENDS
   circt-translate
   circt-rtl-sim
   esi-cosim-runner
-  firtool)
+  firtool
+  hlstool
+  )
 
 # If Python bindings are available to build then enable the tests.
 if(CIRCT_BINDINGS_PYTHON_ENABLED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CIRCT_TEST_DEPENDS
   esi-tester
   handshake-runner
   firtool
+  hlstool
   )
 
 if (CIRCT_GTEST_AVAILABLE)


### PR DESCRIPTION
Otherwise tests relying on it may not work,
and lit prints a warning about the missing tool.