### PR TITLE
[CHIRRTL] Add a new MemoryDebugPortOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -207,4 +207,40 @@ def MemoryPortAccessOp : CHIRRTLOp<"memoryport.access"> {
   }];
 }
 
+def MemoryDebugPortOp : CHIRRTLOp<"debugport", [InferTypeOpInterface,
+      HasCustomSSAName]> {
+  let summary = "Declares a memory debug port on a memory";
+
+  let summary = "Defines a debug memory port on CHIRRTL memory";
+  let description = [{
+    This operation defines a new debug memory port on a `combmem`CHISEL.
+    `data` is the data returned from the memory port.
+  }];
+
+  let arguments = (ins CMemoryType:$memory,
+                    StrAttr:$name, AnnotationArrayAttr:$annotations);
+
+  let results = (outs RefType:$data);
+
+  let assemblyFormat = [{
+    $memory custom<MemoryDebugPortOp>(attr-dict) `:`
+       functional-type(operands, results)
+  }];
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$dataType, "::mlir::Value":$memory,
+                   CArg<"StringRef", "{}">:$name,
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+}
 #endif // CHIRRTL_TD

--- a/include/circt/Dialect/FIRRTL/CHIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/CHIRRTLVisitors.h
@@ -28,7 +28,8 @@ public:
   ResultType dispatchCHIRRTLVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<CombMemOp, MemoryPortOp, MemoryPortAccessOp, SeqMemOp>(
+        .template Case<CombMemOp, MemoryPortOp, MemoryDebugPortOp,
+                       MemoryPortAccessOp, SeqMemOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitCHIRRTL(opNode, args...);
             })
@@ -57,6 +58,7 @@ public:
 
   HANDLE(CombMemOp);
   HANDLE(MemoryPortOp);
+  HANDLE(MemoryDebugPortOp);
   HANDLE(MemoryPortAccessOp);
   HANDLE(SeqMemOp);
 #undef HANDLE

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -91,7 +91,7 @@ struct AnnoTargetCache {
     TypeSwitch<Operation *>(op)
         .Case<InstanceOp, MemOp, NodeOp, RegOp, RegResetOp, WireOp,
               chirrtl::CombMemOp, chirrtl::SeqMemOp, chirrtl::MemoryPortOp,
-              PrintFOp>([&](auto op) {
+              chirrtl::MemoryDebugPortOp, PrintFOp>([&](auto op) {
           // To be safe, check attribute and non-empty name before adding.
           if (auto name = op.getNameAttr(); name && !name.getValue().empty())
             targets.insert({name, OpAnnoTarget(op)});

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -229,7 +229,7 @@ static ParseResult parseMemoryDebugPortOp(OpAsmParser &parser,
 /// if it is empty.
 static void printMemoryDebugPortOp(OpAsmPrinter &p, Operation *op,
                                    DictionaryAttr attr) {
-  SmallVector<StringRef,1> elides;
+  SmallVector<StringRef, 1> elides;
   // Annotations elided if empty.
   if (op->getAttrOfType<ArrayAttr>("annotations").empty())
     elides.push_back("annotations");

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -182,6 +182,62 @@ static void printMemoryPortOp(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// MemoryDebugPortOp
+//===----------------------------------------------------------------------===//
+
+void MemoryDebugPortOp::build(OpBuilder &builder, OperationState &result,
+                              Type dataType, Value memory, StringRef name,
+                              ArrayRef<Attribute> annotations) {
+  build(builder, result, dataType, memory, name,
+        builder.getArrayAttr(annotations));
+}
+
+LogicalResult MemoryDebugPortOp::inferReturnTypes(
+    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &results) {
+  auto inType = operands[0].getType();
+  auto memType = inType.dyn_cast<CMemoryType>();
+  if (!memType) {
+    if (loc)
+      mlir::emitError(*loc, "memory port requires memory operand");
+    return failure();
+  }
+  results.push_back(RefType::get(
+      FVectorType::get(memType.getElementType(), memType.getNumElements())));
+  return success();
+}
+
+void MemoryDebugPortOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  StringRef base = getName();
+  if (base.empty())
+    base = "memport";
+  setNameFn(getData(), (base + "_data").str());
+}
+
+static ParseResult parseMemoryDebugPortOp(OpAsmParser &parser,
+                                          NamedAttrList &resultAttrs) {
+  // Add an empty annotation array if none were parsed.
+  auto result = parser.parseOptionalAttrDict(resultAttrs);
+  if (!resultAttrs.get("annotations"))
+    resultAttrs.append("annotations", parser.getBuilder().getArrayAttr({}));
+  return result;
+}
+
+/// Always elide "direction" and elide "annotations" if it exists or
+/// if it is empty.
+static void printMemoryDebugPortOp(OpAsmPrinter &p, Operation *op,
+                                   DictionaryAttr attr) {
+  // "direction" is always elided.
+  SmallVector<StringRef> elides;
+  // Annotations elided if empty.
+  if (op->getAttrOfType<ArrayAttr>("annotations").empty())
+    elides.push_back("annotations");
+  p.printOptionalAttrDict(op->getAttrs(), elides);
+}
+
+//===----------------------------------------------------------------------===//
 // CombMemOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -229,8 +229,7 @@ static ParseResult parseMemoryDebugPortOp(OpAsmParser &parser,
 /// if it is empty.
 static void printMemoryDebugPortOp(OpAsmPrinter &p, Operation *op,
                                    DictionaryAttr attr) {
-  // "direction" is always elided.
-  SmallVector<StringRef> elides;
+  SmallVector<StringRef,1> elides;
   // Annotations elided if empty.
   if (op->getAttrOfType<ArrayAttr>("annotations").empty())
     elides.push_back("annotations");

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -73,6 +73,7 @@ struct Emitter {
   void emitStatement(CombMemOp op);
   void emitStatement(SeqMemOp op);
   void emitStatement(MemoryPortOp op);
+  void emitStatement(MemoryDebugPortOp op);
   void emitStatement(MemoryPortAccessOp op);
 
   template <class T>
@@ -321,7 +322,7 @@ void Emitter::emitStatementsInBlock(Block &block) {
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
               PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, StrictConnectOp,
               InstanceOp, AttachOp, MemOp, InvalidValueOp, SeqMemOp, CombMemOp,
-              MemoryPortOp, MemoryPortAccessOp>(
+              MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp>(
             [&](auto op) { emitStatement(op); })
         .Default([&](auto op) {
           indent() << "// operation " << op->getName() << "\n";
@@ -567,6 +568,11 @@ void Emitter::emitStatement(CombMemOp op) {
 }
 
 void Emitter::emitStatement(MemoryPortOp op) {
+  // Nothing to output for this operation.
+  addValueName(op.getData(), op.getName());
+}
+
+void Emitter::emitStatement(MemoryDebugPortOp op) {
   // Nothing to output for this operation.
   addValueName(op.getData(), op.getName());
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -40,6 +40,7 @@ struct LowerCHIRRTLPass : public LowerCHIRRTLPassBase<LowerCHIRRTLPass>,
   void visitCHIRRTL(CombMemOp op);
   void visitCHIRRTL(SeqMemOp op);
   void visitCHIRRTL(MemoryPortOp op);
+  void visitCHIRRTL(MemoryDebugPortOp op);
   void visitCHIRRTL(MemoryPortAccessOp op);
   void visitExpr(SubaccessOp op);
   void visitExpr(SubfieldOp op);
@@ -483,6 +484,11 @@ void LowerCHIRRTLPass::visitCHIRRTL(SeqMemOp seqmem) {
 }
 
 void LowerCHIRRTLPass::visitCHIRRTL(MemoryPortOp memPort) {
+  // The memory port is mostly handled while processing the memory.
+  opsToDelete.push_back(memPort);
+}
+
+void LowerCHIRRTLPass::visitCHIRRTL(MemoryDebugPortOp memPort) {
   // The memory port is mostly handled while processing the memory.
   opsToDelete.push_back(memPort);
 }


### PR DESCRIPTION
Add a new debug port of `RefType` to chirrtl. The base type of the debug port must be a vector type of the memory's elements with the memory's depth number of elements.