### PR TITLE
[FIRRTL] Allow RefType of aggregate type

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1083,8 +1083,8 @@ auto RefType::getType() -> FIRRTLBaseType { return getImpl()->value; }
 
 auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
                      FIRRTLBaseType base) -> LogicalResult {
-  if (!base.isGround())
-    return emitErrorFn() << "reference base type must be ground";
+  if (!base.isPassive())
+    return emitErrorFn() << "reference base type must be passive";
   return success();
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -940,8 +940,8 @@ firrtl.circuit "MyView" {
 // Ref types must be ground
 
 firrtl.circuit "RefBundle" {
-  // expected-error @+1 {{reference base type must be ground}}
-  firrtl.module @RefBundle(in %in1 : !firrtl.ref<bundle<valid: uint<1>>>) {
+  // expected-error @+1 {{reference base type must be passive}}
+  firrtl.module @RefBundle(in %in1 : !firrtl.ref<bundle<valid flip : uint<1>>>) {
   }
 }
 


### PR DESCRIPTION
Remove the restriction of only `Ground` type from RefTypes. This is required for enabling GrandCentral to use `RefType` and also enable aggregate preservation. 