### PR TITLE
[FIRTOOL] Run canonicalization prior to seq lowering.

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -62,7 +62,7 @@ def CompRegOp : SeqOp<"compreg",
 
 def FirRegOp : SeqOp<"firreg",
     [NoSideEffect, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
-     SameVariadicOperandSize,
+     SameVariadicOperandSize, MemoryEffects<[MemWrite, MemRead, MemAlloc]>,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
       // AllTypesMatch doesn't work with Optional types yet.
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2573,7 +2573,9 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
 
   // Add symbol if DontTouch annotation present.
   auto symName = getInnerSymName(op);
-  if (AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) && !symName)
+  if ((AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) ||
+       op.getNameKind() == NameKindEnum::InterestingName) &&
+      !symName)
     symName = op.getNameAttr();
 
   // Create a reg op, wiring itself to its input.
@@ -2613,7 +2615,9 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
     return failure();
 
   auto symName = getInnerSymName(op);
-  if (AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) && !symName)
+  if ((AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) ||
+       op.getNameKind() == NameKindEnum::InterestingName) &&
+      !symName)
     symName = op.getNameAttr();
 
   // Create a reg op, wiring itself to its input.

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -27,7 +27,7 @@ circuit Foo:
     reg s: UInt<33>, clock
     s <= d
 
-    q <= s
+    q <= r
 
     ; ALL:   automatic logic [31:0] _RANDOM_0;
     ; ALL:   automatic logic [31:0] _RANDOM_1;
@@ -67,7 +67,7 @@ circuit Foo:
 
     ; ALL:       s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
     ; NAMED:     s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
-    ; NONE:      s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
+    ; NONE-NOT:  s = {{.*}};
 
     inst i0 of TwoLargeRegisters
     i0.clock <= clock

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -728,7 +728,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       // If enabled, run the optimizer.
       if (!disableOptimization) {
         auto &modulePM = pm.nest<hw::HWModuleOp>();
+        modulePM.addPass(createCSEPass());
         modulePM.addPass(createSimpleCanonicalizerPass());
+        modulePM.addPass(createCSEPass());
       }
 
       pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass());

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -725,6 +725,12 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createSimpleCanonicalizerPass());
       }
     } else {
+      // If enabled, run the optimizer.
+      if (!disableOptimization) {
+        auto &modulePM = pm.nest<hw::HWModuleOp>();
+        modulePM.addPass(createSimpleCanonicalizerPass());
+      }
+
       pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass());
       pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem));
 


### PR DESCRIPTION
Register lowering is very sensitive to mux structure, so clean this up prior.