### PR TITLE
[PrepareForEmission] Fix "always inline" operation legalization

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -485,7 +485,7 @@ static bool hoistNonSideEffectExpr(Operation *op) {
 /// Check whether an op is a declaration that can be moved.
 static bool isMovableDeclaration(Operation *op) {
   return op->getNumResults() == 1 &&
-         op->getResult(0).getType().isa<InOutType>() &&
+         op->getResult(0).getType().isa<InOutType, sv::InterfaceType>() &&
          op->getNumOperands() == 0;
 }
 

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -202,13 +202,11 @@ static void lowerAlwaysInlineOperation(Operation *op) {
   // Finally, ensures the op is in the same block as its user so it can be
   // inlined.
   Operation *user = *op->getUsers().begin();
-  if (op->getBlock() != user->getBlock()) {
-    op->moveBefore(user);
+  op->moveBefore(user);
 
-    // If any of the operations of the moved op are always inline, recursively
-    // move/clone them too.
-    recursivelyHandleOperands(op);
-  }
+  // If any of the operations of the moved op are always inline, recursively
+  // move/clone them too.
+  recursivelyHandleOperands(op);
   return;
 }
 
@@ -536,6 +534,9 @@ static bool reuseExistingInOut(Operation *op) {
     auto read = builder.create<ReadInOutOp>(assign.getDest());
     use->set(read);
   }
+  if (auto *destOp = assign.getDest().getDefiningOp())
+    if (isExpressionAlwaysInline(destOp))
+      lowerAlwaysInlineOperation(destOp);
   return true;
 }
 
@@ -562,6 +563,10 @@ void ExportVerilog::prepareHWModule(Block &block,
 
   // True if these operations are in a procedural region.
   bool isProceduralRegion = block.getParentOp()->hasTrait<ProceduralRegion>();
+
+  // This tracks "always inline" operation already visited in the iterations to
+  // avoid processing same operations infinitely.
+  DenseSet<Operation *> visitedAlwaysInlineOperations;
 
   // This keeps tracks of an insertion point of logic op.
   std::pair<Block *, Block::iterator> logicOpInsertionPoint =
@@ -671,8 +676,10 @@ void ExportVerilog::prepareHWModule(Block &block,
     }
 
     // Duplicate "always inline" expression for each of their users and move
-    // them to be next to their users.
-    if (isExpressionAlwaysInline(&op)) {
+    // them to be next to their users. Process the op only when the op is never
+    // processed from the top-level loop.
+    if (isExpressionAlwaysInline(&op) &&
+        visitedAlwaysInlineOperations.insert(&op).second) {
       lowerAlwaysInlineOperation(&op);
       continue;
     }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -9,6 +9,22 @@ hw.module @namehint_variadic(%a: i3) -> (b: i3) {
   hw.output %0 : i3
 }
 
+// CHECK-LABEL:  hw.module @outOfOrderInoutOperations
+hw.module @outOfOrderInoutOperations(%a: i4) -> (c: i4) {
+  // CHECK: %wire = sv.wire
+  // CHECK-NEXT: %0 = sv.array_index_inout %wire[%false]
+  // CHECK-NEXT: %1 = sv.array_index_inout %0[%false]
+  // CHECK-NEXT: %2 = sv.array_index_inout %1[%false]
+  // CHECK-NEXT: %3 = sv.read_inout %2
+  %false = hw.constant false
+  %0 = sv.read_inout %3 : !hw.inout<i4>
+  %3 = sv.array_index_inout %2[%false] : !hw.inout<array<1xi4>>, i1
+  %2 = sv.array_index_inout %1[%false] : !hw.inout<array<1xarray<1xi4>>>, i1
+  %1 = sv.array_index_inout %wire[%false] : !hw.inout<array<1xarray<1xarray<1xi4>>>>, i1
+  %wire = sv.wire  : !hw.inout<array<1xarray<1xarray<1xi4>>>>
+  hw.output %0: i4
+}
+
 // -----
 
 module {


### PR DESCRIPTION
This fixes a bug that "always inline" operation is not legalized for the last user. Previously `lowerAlwaysInlineOperation` skipped moving the op for the last user but it caused a bug. If the last user is placed before the op, it causes an error in out-of-order resolution. This fixes the bug by removing the condition `lowerAlwaysInlineOperation` and avoiding processing same operations twice to prevent infinte loops.