### PR TITLE
[FIRRTL] Add a debug kind of port to MemOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -121,7 +121,7 @@ def MemOp : ReferableDeclOp<"mem"> {
          PortAnnotationsAttr:$portAnnotations,
          OptionalAttr<InnerSymAttr>:$inner_sym,
          OptionalAttr<UI32Attr>:$groupID);
-  let results = (outs Variadic<FIRRTLBaseType>:$results);
+  let results = (outs Variadic<FIRRTLType>:$results);
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? custom<NameKind>($nameKind)
@@ -151,12 +151,12 @@ def MemOp : ReferableDeclOp<"mem"> {
   let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
-    enum class PortKind { Read, Write, ReadWrite };
+    enum class PortKind { Read, Write, ReadWrite, Debug };
 
     using NamedPort = std::pair<StringAttr, MemOp::PortKind>;
 
     /// Return the type of a port given the memory depth, type, and kind
-    static BundleType getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
+    static FIRRTLType getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
                                      PortKind portKind, size_t maskBits = 0);
 
     /// Return the name and kind of ports supported by this memory.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -95,6 +95,38 @@ bool firrtl::isDuplexValue(Value val) {
       .Default([](auto) { return false; });
 }
 
+/// Return the kind of port this is given the port type from a 'mem' decl.
+static MemOp::PortKind getMemPortKindFromType(FIRRTLType type) {
+  if (type.isa<RefType>())
+    return MemOp::PortKind::Debug;
+  // Get the kind of port based on the fields of the Bundle.
+  auto portType = type.dyn_cast<BundleType>();
+  unsigned fields = 0;
+  // Get the kind of port based on the fields of the Bundle.
+  for (auto elem : portType.getElements()) {
+    fields |= llvm::StringSwitch<unsigned>(elem.name.getValue())
+                  .Case("addr", 1)
+                  .Case("en", 2)
+                  .Case("clk", 4)
+                  .Case("data", 8)
+                  .Case("mask", 16)
+                  .Case("rdata", 32)
+                  .Case("wdata", 64)
+                  .Case("wmask", 128)
+                  .Case("wmode", 256)
+                  .Default(512);
+  }
+  // addr, en, clk, data
+  if (fields == 15)
+    return MemOp::PortKind::Read;
+  // addr, en, clk, data, mask
+  if (fields == 31)
+    return MemOp::PortKind::Write;
+  // addr, en, clk, wdata, wmask, rdata, wmode
+  // if (fields == 487)
+  return MemOp::PortKind::ReadWrite;
+}
+
 Flow firrtl::swapFlow(Flow flow) {
   switch (flow) {
   case Flow::Source:
@@ -139,7 +171,12 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
           return accumulatedFlow;
         return swap();
       })
-      .Case<MemOp>([&](auto op) { return swap(); })
+      .Case<MemOp>([&](auto op) {
+        // only debug ports with RefType have source flow.
+        if (val.getType().isa<RefType>())
+          return Flow::Source;
+        return swap();
+      })
       // Anything else acts like a universal source.
       .Default([&](auto) { return accumulatedFlow; });
 }
@@ -1631,11 +1668,6 @@ LogicalResult MemOp::verify() {
             getResult(i).getType().cast<FIRRTLType>())
             .Case<BundleType>([](BundleType a) { return a; })
             .Default([](auto) { return nullptr; });
-    if (!portBundleType) {
-      emitOpError() << "has an invalid type on port " << portName
-                    << " (expected '!firrtl.bundle<...>')";
-      return failure();
-    }
 
     // Require that all port names are unique.
     if (!portNamesSet.insert(portName).second) {
@@ -1646,37 +1678,34 @@ LogicalResult MemOp::verify() {
     // Determine the kind of the memory.  If the kind cannot be
     // determined, then it's indicative of the wrong number of fields
     // in the type (but we don't know any more just yet).
-    MemOp::PortKind portKind;
-    {
-      auto elt = getPortNamed(portName);
-      if (!elt) {
-        emitOpError() << "could not get port with name " << portName;
-        return failure();
-      }
-      auto firrtlType = elt.getType().cast<FIRRTLType>();
-      auto portType = firrtlType.dyn_cast<BundleType>();
-      switch (portType.getNumElements()) {
-      case 4:
-        portKind = MemOp::PortKind::Read;
-        break;
-      case 5:
-        portKind = MemOp::PortKind::Write;
-        break;
-      case 7:
-        portKind = MemOp::PortKind::ReadWrite;
-        break;
-      default:
-        emitOpError()
-            << "has an invalid number of fields on port " << portName
-            << " (expected 4 for read, 5 for write, or 7 for read/write)";
-        return failure();
-      }
+
+    auto elt = getPortNamed(portName);
+    if (!elt) {
+      emitOpError() << "could not get port with name " << portName;
+      return failure();
     }
+    auto firrtlType = elt.getType().cast<FIRRTLType>();
+    MemOp::PortKind portKind = getMemPortKindFromType(firrtlType);
+
+    if ((!portBundleType && portKind != MemOp::PortKind::Debug) ||
+        (portKind == MemOp::PortKind::Debug &&
+         !getResult(i).getType().isa<RefType>()))
+      return emitOpError() << "has an invalid type on port " << portName
+                           << " (expected Read/Write/ReadWrite/Debug)";
+    if (firrtlType.isa<RefType>() && e == 1)
+      return emitOpError()
+             << "cannot have only one port of debug type. Debug port can only "
+                "exist alongside other read/write/read-write port";
 
     // Safely search for the "data" field, erroring if it can't be
     // found.
     FIRRTLBaseType dataType;
-    {
+    if (portKind == MemOp::PortKind::Debug) {
+      auto resType = getResult(i).getType().dyn_cast<RefType>();
+      if (!(resType && resType.getType().isa<FVectorType>()))
+        return emitOpError() << "debug ports must be a RefType of FVectorType";
+      dataType = resType.getType().cast<FVectorType>().getElementType();
+    } else {
       auto dataTypeOption = portBundleType.getElement("data");
       if (!dataTypeOption && portKind == MemOp::PortKind::ReadWrite)
         dataTypeOption = portBundleType.getElement("wdata");
@@ -1729,6 +1758,9 @@ LogicalResult MemOp::verify() {
       case MemOp::PortKind::ReadWrite:
         portKindName = "readwrite";
         break;
+      case MemOp::PortKind::Debug:
+        portKindName = "dbg";
+        break;
       }
       emitOpError() << "has an invalid type for port " << portName
                     << " of determined kind \"" << portKindName
@@ -1764,10 +1796,12 @@ LogicalResult MemOp::verify() {
   return success();
 }
 
-BundleType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
+FIRRTLType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
                                  PortKind portKind, size_t maskBits) {
 
   auto *context = dataType.getContext();
+  if (portKind == PortKind::Debug)
+    return RefType::get(FVectorType::get(dataType, depth));
   FIRRTLBaseType maskType;
   // maskBits not specified (==0), then get the mask type from the dataType.
   if (maskBits == 0)
@@ -1804,39 +1838,12 @@ BundleType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
     portFields.push_back({getId("wdata"), false, dataType});
     portFields.push_back({getId("wmask"), false, maskType});
     break;
+  default:
+    llvm::report_fatal_error("memory port kind not handled");
+    break;
   }
 
   return BundleType::get(portFields, context).cast<BundleType>();
-}
-
-/// Return the kind of port this is given the port type from a 'mem' decl.
-static MemOp::PortKind getMemPortKindFromType(FIRRTLType type) {
-  auto portType = type.dyn_cast<BundleType>();
-  unsigned fields = 0;
-  // Get the kind of port based on the fields of the Bundle.
-  for (auto elem : portType.getElements()) {
-    fields |= llvm::StringSwitch<unsigned>(elem.name.getValue())
-                  .Case("addr", 1)
-                  .Case("en", 2)
-                  .Case("clk", 4)
-                  .Case("data", 8)
-                  .Case("mask", 16)
-                  .Case("rdata", 32)
-                  .Case("wdata", 64)
-                  .Case("wmask", 128)
-                  .Case("wmode", 256)
-                  .Default(512);
-  }
-  // addr, en, clk, data
-  if (fields == 15)
-    return MemOp::PortKind::Read;
-  // addr, en, clk, data, mask
-  if (fields == 31)
-    return MemOp::PortKind::Write;
-  // This check is required once we add a Debug port kind.
-  // addr, en, clk, wdata, wmask, rdata, wmode
-  // if (fields == 487)
-  return MemOp::PortKind::ReadWrite;
 }
 
 /// Return the name and kind of ports supported by this memory.
@@ -1867,6 +1874,8 @@ MemOp::PortKind MemOp::getPortKind(size_t resultNo) {
 size_t MemOp::getMaskBits() {
 
   for (auto res : getResults()) {
+    if (res.getType().isa<RefType>())
+      continue;
     auto firstPortType = res.getType().cast<FIRRTLBaseType>();
     if (getMemPortKindFromType(firstPortType) == PortKind::Read)
       continue;
@@ -1888,6 +1897,8 @@ size_t MemOp::getMaskBits() {
 FIRRTLBaseType MemOp::getDataType() {
   assert(getNumResults() != 0 && "Mems with no read/write ports are illegal");
 
+  if (auto refType = getResult(0).getType().dyn_cast<RefType>())
+    return refType.getType().cast<FVectorType>().getElementType();
   auto firstPortType = getResult(0).getType().cast<FIRRTLBaseType>();
 
   StringRef dataFieldName = "data";

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -530,7 +530,7 @@ firrtl.circuit "MemoryZeroDepth" {
 
 firrtl.circuit "MemoryBadPortType" {
   firrtl.module @MemoryBadPortType() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port "r" (expected '!firrtl.bundle<...>'}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port "r"}}
     %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.uint<1>
   }
 }
@@ -548,7 +548,7 @@ firrtl.circuit "MemoryPortNamesCollide" {
 
 firrtl.circuit "MemoryUnexpectedNumberOfFields" {
   firrtl.module @MemoryUnexpectedNumberOfFields() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid number of fields on port "r" (expected 4 for read, 5 for write, or 7 for read/write)}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port "r"}}
     %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<a: uint<1>>
   }
 }
@@ -557,7 +557,7 @@ firrtl.circuit "MemoryUnexpectedNumberOfFields" {
 
 firrtl.circuit "MemoryMissingDataField" {
   firrtl.module @MemoryMissingDataField() {
-    // expected-error @+1 {{'firrtl.mem' op has no data field on port "r" (expected to see "data" for a read or write port or "rdata" for a read/write port)}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port}}
     %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>>
   }
 }
@@ -566,7 +566,7 @@ firrtl.circuit "MemoryMissingDataField" {
 
 firrtl.circuit "MemoryMissingDataField2" {
   firrtl.module @MemoryMissingDataField2() {
-    // expected-error @+1 {{'firrtl.mem' op has no data field on port "rw" (expected to see "data" for a read or write port or "rdata" for a read/write port)}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port}}
     %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory2", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, writedata: uint<8>, wmask: uint<1>>
   }
 }
@@ -593,7 +593,7 @@ firrtl.circuit "MemoryDataContainsAnalog" {
 
 firrtl.circuit "MemoryPortInvalidReadKind" {
   firrtl.module @MemoryPortInvalidReadKind() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "r" of determined kind "read" (expected '!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>', but got '!firrtl.bundle<BAD: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>')}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port}}
     %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<BAD: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
   }
 }
@@ -602,7 +602,7 @@ firrtl.circuit "MemoryPortInvalidReadKind" {
 
 firrtl.circuit "MemoryPortInvalidWriteKind" {
   firrtl.module @MemoryPortInvalidWriteKind() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "w" of determined kind "write" (expected '!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>', but got '!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, BAD: uint<1>>')}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port}}
     %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, BAD: uint<1>>
   }
 }
@@ -611,7 +611,7 @@ firrtl.circuit "MemoryPortInvalidWriteKind" {
 
 firrtl.circuit "MemoryPortInvalidReadWriteKind" {
   firrtl.module @MemoryPortInvalidReadWriteKind() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "rw" of determined kind "readwrite" (expected '!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>', but got '!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, BAD: uint<1>>')}}
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type on port}}
     %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, BAD: uint<1>>
   }
 }


### PR DESCRIPTION
Add a Debug kind of memory port. The Debug port must be of `RefType`. The `RefType` must be a vector of the memory data type, with memory depth number of elements.