### PR TITLE
[FIRRTL] Lower Memory debug port to Ref of Register

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -55,6 +55,12 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       // How many mask bits each field type requires.
       SmallVector<unsigned> maskWidths;
 
+      // Cannot flatten a memory if it has debug ports, because debug port
+      // implies a memtap and we cannot transform the datatype for a memory that
+      // is tapped.
+      for (auto res : memOp.getResults())
+        if (res.getType().cast<FIRRTLType>().isa<RefType>())
+          return;
       // If subannotations present on aggregate fields, we cannot flatten the
       // memory. It must be split into one memory per aggregate field.
       // Do not overwrite the pass flag!

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -796,6 +796,10 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
   // Wires for old ports
   for (unsigned int index = 0, end = op.getNumResults(); index < end; ++index) {
     auto result = op.getResult(index);
+    if (op.getPortKind(index) == MemOp::PortKind::Debug) {
+      op.emitOpError("cannot lower memory with debug port");
+      return false;
+    }
     auto wire = builder->create<WireOp>(
         result.getType(),
         (op.getName() + "_" + op.getPortName(index).getValue()).str());

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,17 +1,20 @@
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-mem-to-reg-of-vec)' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
-  firrtl.module public @Mem() attributes {annotations = [
+  firrtl.module public @Mem(out %d : !firrtl.ref<vector<uint<8>, 8>>, out %d2 : !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [
     {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
   ]} {
-    %mem_read, %mem_write = firrtl.mem Undefined {
+    %dbg, %mem_read, %mem_write, %debug = firrtl.mem Undefined {
       depth = 8 : i64,
       name = "mem",
-      portNames = ["read", "write"],
+      portNames = ["dbg", "read", "write", "debug"],
       readLatency = 0 : i32,
       writeLatency = 1 : i32
-    } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
-        !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    } : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
+        !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>,
+        !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.strictconnect %d, %debug : !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.strictconnect %d2, %dbg : !firrtl.ref<vector<uint<8>, 8>>
   }
     // CHECK-LABEL: firrtl.circuit "Mem" {
     // CHECK:         firrtl.module public @Mem(
@@ -39,6 +42,10 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:               firrtl.strictconnect %[[v10]], %[[v8]] : !firrtl.uint<8>
     // CHECK:             }
     // CHECK:           }
+    // CHECK:           %11 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
+    // CHECK:           %12 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
+    // CHECK:           firrtl.strictconnect %d, %12 : !firrtl.ref<vector<uint<8>, 8>>
+    // CHECK:           firrtl.strictconnect %d2, %11 : !firrtl.ref<vector<uint<8>, 8>>
 
 
 }


### PR DESCRIPTION
This commit updates the memory lowering passes to handle the memory debug port.
The `MemToRegOfVec` pass lowers the debug ports to a RefType of the register. The pass connects the debug ports to a `RefSend` of the register. This ensures that any `MemTap` of the memory can be lowered to a cross-module-reference of the memory register.
The `FlattenMemory` cannot flatten a memory with any Debug port.
The `LowerTypes` cannot handle debug port in memories with aggregate data type.