### PR TITLE
[ExportSystemC] Support operations from func dialect

### DIFF
--- a/include/circt/Dialect/SystemC/SystemC.td
+++ b/include/circt/Dialect/SystemC/SystemC.td
@@ -22,6 +22,7 @@ include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 
 include "circt/Dialect/SystemC/SystemCOpInterfaces.td"

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -193,3 +193,126 @@ def VariableOp : SystemCOp<"cpp.variable", [HasCustomSSAName,
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
+
+def CallIndirectOp : SystemCOp<"cpp.call_indirect", [
+      CallOpInterface,
+      TypesMatchWith<"callee input types match argument types",
+                     "callee", "callee_operands",
+                     "$_self.cast<FunctionType>().getInputs()">,
+      TypesMatchWith<"callee result types match result types",
+                     "callee", "results",
+                     "$_self.cast<FunctionType>().getResults()">
+    ]> {
+  let summary = "indirect call operation";
+  let description = [{
+    The `systemc.cpp.call_indirect` operation represents an indirect call to a
+    value of function type. The operands and result types of the call must match
+    the specified function type.
+
+    Example:
+
+    ```mlir
+    %func = systemc.cpp.member_access %object dot "func" : () -> i32
+    %result = systemc.cpp.call_indirect %func() : () -> i32
+    ```
+  }];
+
+  let arguments = (ins FunctionType:$callee,
+                       Variadic<AnyType>:$callee_operands);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let builders = [
+    OpBuilder<(ins "Value":$callee, CArg<"ValueRange", "{}">:$operands), [{
+      $_state.operands.push_back(callee);
+      $_state.addOperands(operands);
+      $_state.addTypes(callee.getType().cast<FunctionType>().getResults());
+    }]>];
+
+  let extraClassDeclaration = [{
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return ++operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() { return getCallee(); }
+  }];
+
+  let assemblyFormat = [{
+    $callee `(` $callee_operands `)` attr-dict `:` type($callee)
+  }];
+
+  let hasVerifier = 1;
+}
+
+def CallOp : SystemCOp<"cpp.call", [
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "call operation";
+  let description = [{
+    The `systemc.cpp.call` operation represents a direct call to a function that
+    is within the same symbol scope as the call. The operands and result types
+    of the call must match the specified function type. The callee is encoded as
+    a symbol reference attribute named "callee".
+
+    Example:
+
+    ```mlir
+    %2 = systemc.cpp.call @my_add(%0, %1) : (i32, i32) -> i32
+    ```
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$callee,
+                       Variadic<AnyType>:$callee_operands);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let builders = [
+    OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
+      $_state.addOperands(operands);
+      $_state.addAttribute("callee", SymbolRefAttr::get(callee));
+      $_state.addTypes(callee.getFunctionType().getResults());
+    }]>,
+    OpBuilder<(ins "SymbolRefAttr":$callee, "Type":$result,
+      CArg<"ValueRange", "{}">:$operands), [{
+      $_state.addOperands(operands);
+      $_state.addAttribute("callee", callee);
+      $_state.addTypes(result);
+    }]>,
+    OpBuilder<(ins "StringAttr":$callee, "Type":$result,
+      CArg<"ValueRange", "{}">:$operands), [{
+      build($_builder, $_state, SymbolRefAttr::get(callee), result, operands);
+    }]>,
+    OpBuilder<(ins "StringRef":$callee, "Type":$result,
+      CArg<"ValueRange", "{}">:$operands), [{
+      build($_builder, $_state, StringAttr::get($_builder.getContext(), callee),
+            result, operands);
+    }]>];
+
+  let extraClassDeclaration = [{
+    FunctionType getCalleeType();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+  }];
+
+  let assemblyFormat = [{
+    $callee `(` $callee_operands `)` attr-dict `:`
+    functional-type($callee_operands, $results)
+  }];
+
+  let hasVerifier = 1;
+}

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -303,3 +303,167 @@ def DestructorOp : SystemCOp<"cpp.destructor", [
   let hasVerifier = true;
   let skipDefaultBuilders = 1;
 }
+
+def FuncOp : SystemCOp<"cpp.func", [
+  AutomaticAllocationScope,
+  CallableOpInterface,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+  OpAsmOpInterface,
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
+  Symbol
+]> {
+  let summary = "An operation with a name containing a single `SSACFG` region";
+  let description = [{
+    Operations within the function cannot implicitly capture values defined
+    outside of the function, i.e. Functions are `IsolatedFromAbove`. All
+    external references must use function arguments or attributes that establish
+    a symbolic connection (e.g. symbols referenced by name via a string
+    attribute like SymbolRefAttr). An external function declaration (used when
+    referring to a function declared in some other module) has no body. While
+    the MLIR textual form provides a nice inline syntax for function arguments,
+    they are internally represented as “block arguments” to the first block in
+    the region.
+
+    Argument names are stored in a 'argNames' attribute, but used directly as
+    the SSA value's names. They are verified to be unique and can be used to
+    print them, e.g., as C function argument names.
+
+    Only dialect attribute names may be specified in the attribute dictionaries
+    for function arguments, results, or the function itself.
+
+    Example:
+
+    ```mlir
+    // External function definitions.
+    systemc.cpp.func @abort()
+    systemc.cpp.func externC @scribble(i32, i64) -> i64
+
+    // A function that returns its argument twice:
+    systemc.cpp.func @count(%argumentName: i64) -> (i64, i64) {
+      return %argumentName, %argumentName: i64, i64
+    }
+
+    // A function with an attribute
+    systemc.cpp.func @exampleFnAttr() attributes {dialectName.attrName = false}
+    ```
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<FunctionType>:$function_type,
+                       StrArrayAttr:$argNames,
+                       UnitAttr:$externC,
+                       OptionalAttr<StrAttr>:$sym_visibility);
+  let regions = (region AnyRegion:$body);
+
+  let builders = [OpBuilder<(ins
+    "StringRef":$name, "ArrayAttr":$argNames, "FunctionType":$type,
+    CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
+    CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)>
+  ];
+
+  let extraClassDeclaration = [{
+    static FuncOp create(Location location, StringRef name,
+                         ArrayAttr argNames, FunctionType type,
+                         ArrayRef<NamedAttribute> attrs = {});
+    static FuncOp create(Location location, StringRef name,
+                         ArrayAttr argNames, FunctionType type,
+                         Operation::dialect_attr_range attrs);
+    static FuncOp create(Location location, StringRef name,
+                         ArrayAttr argNames, FunctionType type,
+                         ArrayRef<NamedAttribute> attrs,
+                         ArrayRef<DictionaryAttr> argAttrs);
+
+    /// Create a deep copy of this function and all of its blocks, remapping any
+    /// operands that use values outside of the function using the map that is
+    /// provided (leaving them alone if no entry is present). If the mapper
+    /// contains entries for function arguments, these arguments are not
+    /// included in the new function. Replaces references to cloned sub-values
+    /// with the corresponding value that is copied, and adds those mappings to
+    /// the mapper.
+    FuncOp clone(BlockAndValueMapping &mapper);
+    FuncOp clone();
+
+    /// Clone the internal blocks and attributes from this function into dest.
+    /// Any cloned blocks are appended to the back of dest. This function
+    /// asserts that the attributes of the current function and dest are
+    /// compatible.
+    void cloneInto(FuncOp dest, BlockAndValueMapping &mapper);
+
+    //===------------------------------------------------------------------===//
+    // CallableOpInterface
+    //===------------------------------------------------------------------===//
+
+    /// Returns the region on the current operation that is callable. This may
+    /// return null in the case of an external callable object, e.g. an external
+    /// function.
+    ::mlir::Region *getCallableRegion() {
+      return isExternal() ? nullptr : &getBody();
+    }
+
+    /// Returns the results types that the callable region produces when
+    /// executed.
+    ArrayRef<Type> getCallableResults() {
+      return getFunctionType().getResults();
+    }
+
+    //===------------------------------------------------------------------===//
+    // FunctionOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    //===------------------------------------------------------------------===//
+    // OpAsmOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Allow the dialect prefix to be omitted.
+    static StringRef getDefaultDialect() { return "systemc"; }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    bool isDeclaration() { return isExternal(); }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+}
+
+def ReturnOp : SystemCOp<"cpp.return", [
+  Pure,
+  HasParent<"systemc::FuncOp">,
+  ReturnLike, Terminator
+]> {
+  let summary = "Function return operation";
+  let description = [{
+    The `systemc.cpp.return` operation represents a return operation within a
+    function. The operand number and types must match the signature of the
+    function that contains the operation.
+
+    Example:
+
+    ```mlir
+    systemc.cpp.func @foo() : i32 {
+      ...
+      systemc.cpp.return %0 : i32
+    }
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$returnValues);
+
+  let builders = [OpBuilder<(ins), [{
+    build($_builder, $_state, llvm::None);
+  }]>];
+
+  let assemblyFormat = "attr-dict ($returnValues^ `:` type($returnValues))?";
+  let hasVerifier = 1;
+}

--- a/integration_test/Target/ExportSystemC/func.mlir
+++ b/integration_test/Target/ExportSystemC/func.mlir
@@ -1,0 +1,27 @@
+// REQUIRES: clang-tidy
+// RUN: circt-translate %s --export-systemc > %t.cpp
+// RUN: clang-tidy --extra-arg=-frtti %t.cpp
+
+emitc.include <"stdint.h">
+emitc.include <"functional">
+emitc.include <"vector">
+
+systemc.cpp.func private @funcDeclaration (%a: i32, %b: i32) -> i32
+
+systemc.cpp.func externC private @declarationWithoutArgNames(i32, i8)
+
+systemc.cpp.func @voidFunc () {
+  systemc.cpp.return
+}
+
+systemc.cpp.func @testFunc (%a: i64, %b: i32) -> i32 {
+  %0 = systemc.cpp.call @funcDeclaration(%b, %b) : (i32, i32) -> i32
+  systemc.cpp.call @voidFunc() : () -> ()
+  %v1 = systemc.cpp.variable : !emitc.opaque<"std::vector<int>">
+  %pb = systemc.cpp.member_access %v1 dot "push_back" : (!emitc.opaque<"std::vector<int>">) -> ((!emitc.opaque<"int">) -> ())
+  %c0 = "emitc.constant" () {value=#emitc.opaque<"0"> : !emitc.opaque<"int">} : () -> !emitc.opaque<"int">
+  systemc.cpp.call_indirect %pb (%c0) : (!emitc.opaque<"int">) -> ()
+  %2 = systemc.cpp.call @funcDeclaration(%b, %b) : (i32, i32) -> i32
+  %v = systemc.cpp.variable %2 : i32
+  systemc.cpp.return %0 : i32
+}

--- a/lib/Target/ExportSystemC/EmissionPrinter.cpp
+++ b/lib/Target/ExportSystemC/EmissionPrinter.cpp
@@ -89,7 +89,7 @@ InlineEmitter EmissionPrinter::getInlinable(Value value) {
       << value << "'\n";
   err.attachNote(requestLoc) << "requested to be inlined here";
   return InlineEmitter(
-      [&]() { os << "<<INVALID VALUE TO INLINE (" << value << ")>>"; },
+      [=]() { os << "<<INVALID VALUE TO INLINE (" << value << ")>>"; },
       Precedence::LIT, *this);
 }
 

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -327,6 +327,176 @@ struct VariableEmitter : OpEmissionPattern<VariableOp> {
   }
 };
 
+/// Emit a systemc.cpp.func function. Users of the function arguments request an
+/// expression to be inlined and we simply return the name of the argument. This
+/// name has to be passed to this emission pattern via an array of strings
+/// attribute called 'argNames' because the emitter cannot do any name uniquing
+/// as it just emits the IR statement by statement. However, relying on an
+/// attribute for the argument names also has the advantage that the names
+/// can be preserved 1-1 during a lowering pipeline and upstream passes have
+/// more control on how the arguments should be named (e.g. when they create a
+/// function and have some context to assign better names).
+struct FuncEmitter : OpEmissionPattern<FuncOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+  MatchResult matchInlinable(Value value) override {
+    // Note that the verifier of systemc::FuncOp guarantees that whenever the
+    // function has a body, argNames is present and of the correct length
+    if (value.isa<BlockArgument>() &&
+        value.getParentRegion()->getParentOfType<FuncOp>())
+      return Precedence::VAR;
+
+    return {};
+  }
+
+  void emitInlined(Value value, EmissionPrinter &p) override {
+    auto func = value.getParentRegion()->getParentOfType<FuncOp>();
+    for (auto [arg, name] :
+         llvm::zip(func.getArguments(), func.getArgNames())) {
+      if (arg == value) {
+        p << name.cast<StringAttr>().getValue();
+        return;
+      }
+    }
+  }
+
+  void emitStatement(FuncOp func, EmissionPrinter &p) override {
+    // Emit a newline at the start to ensure an empty line before the function
+    // for better readability.
+    p << "\n";
+
+    if (func.getExternC())
+      p << "extern \"C\" ";
+
+    // Emit return type.
+    if (func.getFunctionType().getNumResults() == 0)
+      p << "void";
+    else
+      p.emitType(func.getFunctionType().getResult(0));
+
+    p << " " << func.getSymName() << "(";
+
+    // Emit the argument list. When the function is a declaration, it is not
+    // required to have argument names, in that case just print the types.
+    if (func.isDeclaration() && func.getArgNames().empty())
+      llvm::interleaveComma(func.getFunctionType().getInputs(), p,
+                            [&](Type ty) { p.emitType(ty); });
+    else
+      llvm::interleaveComma(
+          llvm::zip(func.getFunctionType().getInputs(), func.getArgNames()), p,
+          [&](std::tuple<Type, Attribute> arg) {
+            p.emitType(std::get<0>(arg));
+            p << " " << std::get<1>(arg).cast<StringAttr>().getValue();
+          });
+
+    p << ")";
+
+    // Emit body when present.
+    if (func.isDeclaration()) {
+      p << ";\n";
+    } else {
+      p << " ";
+      p.emitRegion(func.getRegion());
+    }
+  }
+};
+
+/// Emit a systemc.cpp.call operation. If it has no result, it is treated as a
+/// statement, otherwise as an expression that will always be inlined. That
+/// means, an emission preparation pass has to insert a VariableOp to bind the
+/// call result to such that reordering of the call cannot lead to incorrectness
+/// due to interference of side-effects.
+class CallEmitter : public OpEmissionPattern<CallOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  MatchResult matchInlinable(Value value) override {
+    if (value.getDefiningOp<CallOp>())
+      return Precedence::FUNCTION_CALL;
+    return {};
+  }
+
+  void emitInlined(Value value, EmissionPrinter &p) override {
+    printCall(value.getDefiningOp<CallOp>(), p);
+  }
+
+  void emitStatement(CallOp op, EmissionPrinter &p) override {
+    // If the call returns values, then it is treated as an expression rather
+    // than a statement.
+    if (op.getNumResults() > 0)
+      return;
+
+    printCall(op, p);
+    p << ";\n";
+  }
+
+private:
+  void printCall(CallOp op, EmissionPrinter &p) {
+    p << op.getCallee() << "(";
+    llvm::interleaveComma(op.getOperands(), p, [&](auto arg) {
+      p.getInlinable(arg).emitWithParensOnLowerPrecedence(Precedence::COMMA);
+    });
+    p << ")";
+  }
+};
+
+/// Emit a systemc.cpp.call_indirect operation. If it has no result, it is
+/// treated as a statement, otherwise as an expression that will always be
+/// inlined. That means, an emission preparation pass has to insert a VariableOp
+/// to bind the call result to such that reordering of the call cannot lead to
+/// incorrectness due to interference of side-effects.
+class CallIndirectEmitter : public OpEmissionPattern<CallIndirectOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  MatchResult matchInlinable(Value value) override {
+    if (value.getDefiningOp<CallIndirectOp>())
+      return Precedence::FUNCTION_CALL;
+
+    return {};
+  }
+
+  void emitInlined(Value value, EmissionPrinter &p) override {
+    printCall(value.getDefiningOp<CallIndirectOp>(), p);
+  }
+
+  void emitStatement(CallIndirectOp op, EmissionPrinter &p) override {
+    // If the call returns values, then it is treated as an expression rather
+    // than a statement.
+    if (op.getNumResults() > 0)
+      return;
+
+    printCall(op, p);
+    p << ";\n";
+  }
+
+private:
+  void printCall(CallIndirectOp op, EmissionPrinter &p) {
+    p.getInlinable(op.getCallee())
+        .emitWithParensOnLowerPrecedence(Precedence::FUNCTION_CALL);
+    p << "(";
+    llvm::interleaveComma(op.getCalleeOperands(), p, [&](auto arg) {
+      p.getInlinable(arg).emitWithParensOnLowerPrecedence(Precedence::COMMA);
+    });
+    p << ")";
+  }
+};
+
+/// Emit a systemc.cpp.return operation.
+struct ReturnEmitter : OpEmissionPattern<ReturnOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  bool matchStatement(Operation *op) override {
+    return isa<ReturnOp>(op) && cast<ReturnOp>(op)->getNumOperands() <= 1;
+  }
+
+  void emitStatement(ReturnOp op, EmissionPrinter &p) override {
+    p << "return";
+    if (!op.getReturnValues().empty()) {
+      p << " ";
+      p.getInlinable(op.getReturnValues()[0]).emit();
+    }
+    p << ";\n";
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Type emission patterns.
 //===----------------------------------------------------------------------===//
@@ -384,7 +554,10 @@ void circt::ExportSystemC::populateSystemCOpEmitters(
                InstanceDeclEmitter, BindPortEmitter,
                // CPP-level operation emitters
                AssignEmitter, VariableEmitter, NewEmitter, DestructorEmitter,
-               DeleteEmitter, MemberAccessEmitter>(context);
+               DeleteEmitter, MemberAccessEmitter,
+               // Function related emitters
+               FuncEmitter, ReturnEmitter, CallEmitter, CallIndirectEmitter>(
+      context);
 }
 
 void circt::ExportSystemC::populateSystemCTypeEmitters(

--- a/test/Dialect/SystemC/func-invalid.mlir
+++ b/test/Dialect/SystemC/func-invalid.mlir
@@ -1,0 +1,201 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// expected-error @+1 {{incorrect number of function results (always has to be 0 or 1)}}
+systemc.cpp.func private @return_i32_f32() -> (i32, f32)
+
+// -----
+
+systemc.cpp.func private @return_i32() -> i32
+
+systemc.cpp.func @call() {
+  // expected-error @+3 {{op result type mismatch at index 0}}
+  // expected-note @+2 {{op result types: 'f32'}}
+  // expected-note @+1 {{function result types: 'i32'}}
+  %0 = systemc.cpp.call @return_i32() : () -> f32
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func @resulterror() -> i32 {
+^bb42:
+  systemc.cpp.return    // expected-error {{op has 0 operands, but enclosing function (@resulterror) returns 1}}
+}
+
+// -----
+
+systemc.cpp.func @return_type_mismatch(%arg0: f32) -> i32 {
+  systemc.cpp.return %arg0 : f32  // expected-error {{type of return operand 0 ('f32') doesn't match function result type ('i32') in function @return_type_mismatch}}
+}
+
+// -----
+
+systemc.module @return_inside_module() {
+  // expected-error@+1 {{'systemc.cpp.return' op expects parent op 'systemc.cpp.func'}}
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-error@+1 {{expected non-function type}}
+systemc.cpp.func @func_variadic(...)
+
+// -----
+
+systemc.cpp.func @redundant_signature(%a : i32) -> () {
+^bb0(%b : i32):  // expected-error {{invalid block name in region with named arguments}}
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func @mixed_named_arguments(%a : i32,
+                               f32) -> () {
+    // expected-error @-1 {{expected SSA identifier}}
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func @mixed_named_arguments(f32,
+                               %a : i32) -> () { // expected-error {{expected type instead of SSA identifier}}
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-error @+1 {{@ identifier expected to start with letter or '_'}}
+systemc.cpp.func @$invalid_function_name()
+
+// -----
+
+// expected-error @+1 {{arguments may only have dialect attributes}}
+systemc.cpp.func @invalid_func_arg_attr(i1 {non_dialect_attr = 10})
+
+// -----
+
+// expected-error @+1 {{results may only have dialect attributes}}
+systemc.cpp.func @invalid_func_result_attr() -> (i1 {non_dialect_attr = 10})
+
+// -----
+
+systemc.cpp.func @foo() {} // expected-error {{expected non-empty function body}}
+
+// -----
+
+func.func @bar () {
+  return
+}
+
+systemc.cpp.func @foo() {
+  // expected-error @+1 {{'bar' does not reference a valid function}}
+  systemc.cpp.call @bar() : () -> ()
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func private @bar (i32)
+
+systemc.cpp.func @foo() {
+  // expected-error @+1 {{incorrect number of operands for callee}}
+  systemc.cpp.call @bar() : () -> ()
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func private @bar (i32)
+
+systemc.cpp.func @foo(%arg0: i8) {
+  // expected-error @+1 {{operand type mismatch: expected operand type 'i32', but provided 'i8' for operand number 0}}
+  systemc.cpp.call @bar(%arg0) : (i8) -> ()
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func private @bar ()
+
+systemc.cpp.func @foo() {
+  // expected-error @+1 {{incorrect number of results for callee}}
+  %0 = systemc.cpp.call @bar() : () -> i32
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func private @bar () -> i32
+
+systemc.cpp.func @foo() {
+  // expected-error @+1 {{incorrect number of function results (always has to be 0 or 1)}}
+  %0, %1 = systemc.cpp.call @bar() : () -> (i32, i32)
+  systemc.cpp.return
+}
+
+// -----
+
+systemc.cpp.func @foo(%arg0: () -> (i32, i32)) {
+  // expected-error @+1 {{incorrect number of function results (always has to be 0 or 1)}}
+  %0, %1 = systemc.cpp.call_indirect %arg0() : () -> (i32, i32)
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-error @+1 {{'function_type' is an inferred attribute and should not be specified in the explicit attribute dictionary}}
+systemc.cpp.func @foo() attributes {function_type=()->()} {
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-error @+1 {{incorrect number of argument names}}
+"systemc.cpp.func"() ({
+  ^bb0(%arg0: i32):
+    "systemc.cpp.return"() : () -> ()
+}) {sym_name="foo", function_type=(i32)->(), argNames=[]} : () -> () 
+
+// -----
+
+// expected-error @+1 {{arg name must not be empty}}
+"systemc.cpp.func"() ({
+  ^bb0(%arg0: i32):
+    "systemc.cpp.return"() : () -> ()
+}) {sym_name="foo", function_type=(i32)->(), argNames=[""]} : () -> () 
+
+// -----
+
+// expected-note @+1 {{in function '@foo'}}
+systemc.cpp.func @foo() {
+  // expected-note @+1 {{'var0' first defined here}}
+  %0 = "systemc.cpp.variable"() {name = "var0"} : () -> i32
+  // expected-error @+1 {{redefines name 'var0'}}
+  %1 = "systemc.cpp.variable"() {name = "var0"} : () -> i32
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-note @+1 {{in function '@foo'}}
+"systemc.cpp.func"() ({
+  // expected-error @+2 {{redefines name 'a'}}
+  // expected-note @+1 {{'a' first defined here}}
+  ^bb0(%arg0: i32, %arg1: i32):
+    "systemc.cpp.return"() : () -> ()
+}) {sym_name="foo", function_type=(i32, i32)->(), argNames=["a", "a"]} : () -> () 
+
+// -----
+
+// expected-error @+1 {{entry block must have 2 arguments to match function signature}}
+systemc.cpp.func @foo (i32, i32) {
+  systemc.cpp.return
+}
+
+// -----
+
+// expected-error @+1 {{incorrect number of argument names}}
+systemc.cpp.func @foo (i32, i32) {
+  ^bb0(%a: i32, %b: i32):
+  systemc.cpp.return
+}

--- a/test/Dialect/SystemC/func.mlir
+++ b/test/Dialect/SystemC/func.mlir
@@ -1,0 +1,27 @@
+// RUN: circt-opt %s | FileCheck %s
+
+// CHECK-LABEL: systemc.cpp.func externC @basic(%name0: i32, %name1: i1) {
+systemc.cpp.func externC @basic(%name0: i32, %name1: i1) {
+  // CHECK-NEXT: systemc.cpp.return
+  systemc.cpp.return
+}
+
+// CHECK-LABEL: systemc.cpp.func private @foo(i32)
+systemc.cpp.func private @foo(i32)
+
+// CHECK-LABEL: systemc.cpp.func private @foo2(i32, i32) -> i32
+systemc.cpp.func private @foo2(i32, i32) -> i32
+
+// CHECK-LABEL: systemc.cpp.func externC private @foobar(%abc: i32, %func1: (i32) -> (), %func2: (i32, i32) -> i32) -> i32 {
+systemc.cpp.func externC private @foobar(%abc: i32, %func1: (i32) -> (), %func2 : (i32, i32) -> i32) -> i32 {
+  // CHECK-NEXT: systemc.cpp.call @foo(%abc) : (i32) -> ()
+  systemc.cpp.call @foo(%abc) : (i32) -> ()
+  // CHECK-NEXT: {{%.+}} = systemc.cpp.call @foo2(%abc, %abc) : (i32, i32) -> i32
+  %0 = systemc.cpp.call @foo2(%abc, %abc) : (i32, i32) -> i32
+  // CHECK-NEXT: systemc.cpp.call_indirect %func1(%abc) : (i32) -> ()
+  systemc.cpp.call_indirect %func1(%abc) : (i32) -> ()
+  // CHECK-NEXT: {{%.+}} = systemc.cpp.call_indirect %func2(%abc, %abc) : (i32, i32) -> i32
+  %1 = systemc.cpp.call_indirect %func2(%abc, %abc) : (i32, i32) -> i32
+  // CHECK-NEXT: systemc.cpp.return %abc : i32
+  systemc.cpp.return %abc : i32
+}

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -30,7 +30,7 @@
 
 // expected-note @+1 {{in module '@verifierTest'}}
 "systemc.module"() ({
-  // expected-error @+2 {{redefines port name 'port2'}}
+  // expected-error @+2 {{redefines name 'port2'}}
   // expected-note @+1 {{'port2' first defined here}}
   ^bb0(%arg0: !systemc.out<i4>, %arg1: !systemc.in<i32>, %arg2: !systemc.out<i4>, %arg3: !systemc.inout<i8>):
   }) {function_type = (!systemc.out<i4>, !systemc.in<i32>, !systemc.out<i4>, !systemc.inout<i8>) -> (), portNames = ["port0", "port1", "port2", "port2"], sym_name = "verifierTest"} : () -> ()

--- a/test/Target/ExportSystemC/func.mlir
+++ b/test/Target/ExportSystemC/func.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-translate %s --export-systemc | FileCheck %s
+
+// CHECK-LABEL: // stdout.h
+// CHECK-NEXT: #ifndef STDOUT_H
+// CHECK-NEXT: #define STDOUT_H
+
+// CHECK: uint32_t funcDeclaration(uint32_t funcArg0, uint32_t funcArg1);
+systemc.cpp.func private @funcDeclaration (%funcArg0: i32, %funcArg1: i32) -> i32
+// CHECK-EMPTY:
+// CHECK-NEXT: void voidFunc() {
+systemc.cpp.func @voidFunc () {
+  // CHECK-NEXT: return;
+  systemc.cpp.return
+// CHECK-NEXT: }
+}
+// CHECK-EMPTY: 
+// CHECK-NEXT: uint32_t testFunc(uint64_t a, uint32_t b) {
+systemc.cpp.func @testFunc (%a: i64, %b: i32) -> i32 {
+  %0 = systemc.cpp.call @funcDeclaration(%b, %b) : (i32, i32) -> i32
+  // CHECK-NEXT: voidFunc();
+  systemc.cpp.call @voidFunc() : () -> ()
+  // CHECK-NEXT: SomeClass v0;
+  // CHECK-NEXT: (v0.someFunc)();
+  %v0 = systemc.cpp.variable : !emitc.opaque<"SomeClass">
+  %1 = systemc.cpp.member_access %v0 dot "someFunc" : (!emitc.opaque<"SomeClass">) -> (() -> ())
+  systemc.cpp.call_indirect %1 () : () -> ()
+  // CHECK-NEXT: uint32_t v1 = funcDeclaration(b, b);
+  %2 = systemc.cpp.call @funcDeclaration(%b, %b) : (i32, i32) -> i32
+  %v1 = systemc.cpp.variable %2 : i32
+  // CHECK-NEXT: return funcDeclaration(b, b);
+  systemc.cpp.return %0 : i32
+// CHECK-NEXT: }
+}
+// CHECK-EMPTY: 
+// CHECK-NEXT: extern "C" void declarationWithoutArgNames(uint32_t, uint8_t);
+systemc.cpp.func externC private @declarationWithoutArgNames(i32, i8)
+
+// CHECK: #endif // STDOUT_H


### PR DESCRIPTION
Emit functions from the func dialect as regular C functions. This is useful for interop when we, e.g., want to wrap some C++ code in a C function such that a caller which does not support C++ can still call that code.

`call_indirect` is also especially useful for calling member functions accessed by `systemc.cpp.member_access`.