### PR TITLE
[FIRRTL][MemTap] Lower Memtap annotations to RefType connections

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -726,6 +726,108 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
   return success();
 }
 
+LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
+                                       DictionaryAttr anno,
+                                       std::string &sourceTargetStr,
+                                       ApplyState &state) {
+  auto loc = state.circuit.getLoc();
+  Value memDbgPort;
+  Optional<AnnoPathValue> srcTarget = resolvePath(
+      sourceTargetStr, state.circuit, state.symTbl, state.targetCaches);
+  if (!srcTarget)
+    return mlir::emitError(loc, "cannot resolve source target path '")
+           << sourceTargetStr << "'";
+  auto tapsAttr = tryGetAs<ArrayAttr>(anno, anno, "wireName", loc, memTapClass);
+  if (!tapsAttr || tapsAttr.empty())
+    return mlir::emitError(loc, "wireName must have at least one entry");
+  if (auto combMem = dyn_cast<chirrtl::CombMemOp>(srcTarget->ref.getOp())) {
+    if (!combMem.getType().getElementType().isGround())
+      return combMem.emitOpError("cannot generate MemTap to a memory with aggregate data type");
+    ImplicitLocOpBuilder builder(combMem->getLoc(), combMem);
+    builder.setInsertionPointAfter(combMem);
+    // Construct the type for the debug port.
+    auto debugType =
+        RefType::get(FVectorType::get(combMem.getType().getElementType(),
+                                      combMem.getType().getNumElements()));
+
+    auto debugPort = builder.create<chirrtl::MemoryDebugPortOp>(
+        debugType, combMem,
+        state.getNamespace(srcTarget->ref.getModule()).newName("memTap"));
+
+    memDbgPort = debugPort.getResult();
+    if (srcTarget->instances.empty()) {
+      auto path = state.instancePathCache.getAbsolutePaths(
+          combMem->getParentOfType<FModuleOp>());
+      if (path.size() > 1)
+        return combMem.emitOpError(
+            "cannot be resolved as source for MemTap, multiple paths from top "
+            "exist and unique instance cannot be resolved");
+      srcTarget->instances.append(path.back().begin(), path.back().end());
+    }
+    if (tapsAttr.size() != combMem.getType().getNumElements())
+      return mlir::emitError(
+          loc,
+          "wireName cannot specify more taps than the depth of the memory");
+  } else
+    return srcTarget->ref.getOp()->emitOpError(
+        "unsupported operation, only CombMem can be used as the source of "
+        "MemTap");
+
+  auto tap = tapsAttr[0].dyn_cast_or_null<StringAttr>();
+  if (!tap) {
+    return mlir::emitError(
+               loc, "Annotation '" + Twine(memTapClass) +
+                        "' with path '.taps[0" +
+                        "]' contained an unexpected type (expected a string).")
+               .attachNote()
+           << "The full Annotation is reprodcued here: " << anno << "\n";
+  }
+  auto wireTargetStr = canonicalizeTarget(tap.getValue());
+  if (!tokenizePath(wireTargetStr))
+    return failure();
+  Optional<AnnoPathValue> wireTarget = resolvePath(
+      wireTargetStr, state.circuit, state.symTbl, state.targetCaches);
+  SmallVector<InstanceOp> pathFromSrcToWire;
+  FModuleOp lcaModule;
+  // Find the lca and get the path from source to wire through that lca.
+  if (findLCAandSetPath(*srcTarget, *wireTarget, pathFromSrcToWire, lcaModule,
+                        state)
+          .failed())
+    return mlir::emitError(loc,
+                           "Failed to find a uinque path from source to wire.");
+  LLVM_DEBUG(llvm::dbgs() << "\n lca :" << lcaModule.getNameAttr();
+             for (auto i
+                  : pathFromSrcToWire) llvm::dbgs()
+             << "\n"
+             << i->getParentOfType<FModuleOp>().getNameAttr() << ">"
+             << i.getNameAttr(););
+  auto srcModule = dyn_cast<FModuleOp>(srcTarget->ref.getModule());
+  ImplicitLocOpBuilder refSendBuilder(srcModule.getLoc(), srcModule);
+  auto sendVal = memDbgPort;
+  // Now drill ports to connect the `sendVal` to the `wireTarget`.
+  auto remoteXMR = borePortsOnPath(
+      pathFromSrcToWire, lcaModule, sendVal, "memTap", state.instancePathCache,
+      [&](FModuleLike mod) -> ModuleNamespace & {
+        return state.getNamespace(mod);
+      },
+      &state.targetCaches);
+  auto wireModule = cast<FModuleOp>(wireTarget->ref.getModule());
+  ImplicitLocOpBuilder refResolveBuilder(wireModule.getLoc(), wireModule);
+  if (remoteXMR.isa<BlockArgument>())
+    refResolveBuilder.setInsertionPointToStart(wireModule.getBodyBlock());
+  else
+    refResolveBuilder.setInsertionPointAfter(remoteXMR.getDefiningOp());
+  auto refResolve = refResolveBuilder.create<RefResolveOp>(remoteXMR);
+  refResolveBuilder.setInsertionPointToEnd(wireTarget->ref.getOp()->getBlock());
+  if (wireTarget->ref.getOp()->getResult(0).getType() != refResolve.getType())
+    return wireTarget->ref.getOp()->emitError(
+        "cannot generate the MemTap, wiretap Type does not match the memory "
+        "type");
+  refResolveBuilder.create<StrictConnectOp>(
+      wireTarget->ref.getOp()->getResult(0), refResolve.getResult());
+  return success();
+}
+
 LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
                                              DictionaryAttr anno,
                                              ApplyState &state) {
@@ -745,11 +847,11 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
   attrs.append("class", StringAttr::get(context, memTapSourceClass));
   attrs.append("id", id);
   attrs.append("target", StringAttr::get(context, sourceTarget));
-  state.addToWorklistFn(DictionaryAttr::get(context, attrs));
 
+  if (!anno.contains("taps"))
+    return applyGCTMemTapsWithWires(target, anno, sourceTarget, state);
   auto tapsAttr = tryGetAs<ArrayAttr>(anno, anno, "taps", loc, memTapClass);
-  if (!tapsAttr)
-    return failure();
+  state.addToWorklistFn(DictionaryAttr::get(context, attrs));
   StringSet<> memTapBlackboxes;
   for (size_t i = 0, e = tapsAttr.size(); i != e; ++i) {
     auto tap = tapsAttr[i].dyn_cast_or_null<StringAttr>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -742,7 +742,8 @@ LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
     return mlir::emitError(loc, "wireName must have at least one entry");
   if (auto combMem = dyn_cast<chirrtl::CombMemOp>(srcTarget->ref.getOp())) {
     if (!combMem.getType().getElementType().isGround())
-      return combMem.emitOpError("cannot generate MemTap to a memory with aggregate data type");
+      return combMem.emitOpError(
+          "cannot generate MemTap to a memory with aggregate data type");
     ImplicitLocOpBuilder builder(combMem->getLoc(), combMem);
     builder.setInsertionPointAfter(combMem);
     // Construct the type for the debug port.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -359,7 +359,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         SmallVector<Type, 4> resultTypes;
         SmallVector<Attribute, 4> portAnnotations;
         SmallVector<Value, 4> oldResults;
-        for (auto res : llvm::enumerate(mem.getResults())) {
+        for (const auto &res : llvm::enumerate(mem.getResults())) {
           if (mem.getResult(res.index())
                   .getType()
                   .cast<FIRRTLType>()

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -64,7 +64,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // NodeOp to add the InnerSym.
             if (!xmrDef.isa<BlockArgument>()) {
               Operation *xmrDefOp = xmrDef.getDefiningOp();
-              if (!isa<InnerSymbolOpInterface>(xmrDefOp)) {
+              if (!isa<InnerSymbolOpInterface>(xmrDefOp) ||
+                  xmrDefOp->getResults().size() > 1) {
                 // Add a node, for non-innerSym ops. Otherwise the sym will be
                 // dropped after LowerToHW.
                 ImplicitLocOpBuilder b(xmrDefOp->getLoc(), xmrDefOp);
@@ -83,6 +84,19 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // local.
             addReachingSendsEntry(send.getResult(), getInnerRefTo(xmrDef));
             markForRemoval(send);
+            return success();
+          })
+          .Case<MemOp>([&](MemOp mem) {
+            for (const auto &res : llvm::enumerate(mem.getResults()))
+              if (mem.getResult(res.index())
+                      .getType()
+                      .cast<FIRRTLType>()
+                      .isa<RefType>()) {
+                auto inRef = getInnerRefTo(mem);
+                addReachingSendsEntry(res.value(), inRef);
+                stringXMR[inRef] = ".Memory";
+                refPortsToRemoveMap[mem].resize(1);
+              }
             return success();
           })
           .Case<InstanceOp>([&](auto inst) { return handleInstanceOp(inst); })
@@ -181,15 +195,33 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                               .first.cast<InnerRefAttr>()
                               .getModuleRef());
     SmallString<128> xmrString;
+    Attribute lastInnerRef;
     unsigned index = 0;
     for (; remoteOpPath; ++index) {
       auto entr = refSendPathList[remoteOpPath.value()];
       refSendPath.push_back(entr.first);
+      lastInnerRef = entr.first;
       remoteOpPath = entr.second;
       ("{{" + Twine(index) + "}}").toVector(xmrString);
       xmrString += '.';
     }
     ("{{" + Twine(index) + "}}").toVector(xmrString);
+    if (lastInnerRef && stringXMR.find(lastInnerRef) != stringXMR.end())
+      xmrString += stringXMR[lastInnerRef];
+    if (auto vec = resolve.getResult().getType().dyn_cast<FVectorType>()) {
+      for (Operation *user : resolve.getResult().getUsers()) {
+        if (auto sub = dyn_cast<SubindexOp>(user)) {
+          auto index = sub.getIndex();
+          ImplicitLocOpBuilder builder(sub.getLoc(), sub);
+          auto xmrVerbatim = builder.create<VerbatimExprOp>(
+              vec.getElementType(), xmrString + "[" + Twine(index) + "]",
+              ValueRange{}, refSendPath);
+          sub.getResult().replaceAllUsesWith(xmrVerbatim);
+          opsToRemove.push_back(sub);
+        }
+      }
+      return success();
+    }
 
     // The source of the dataflow for this RefResolveOp is established. So
     // replace the RefResolveOp with the coresponding VerbatimExpr to
@@ -321,6 +353,33 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         ImplicitLocOpBuilder b(inst.getLoc(), inst);
         inst.erasePorts(b, iter.getSecond());
         inst.erase();
+      } else if (auto mem = dyn_cast<MemOp>(iter.getFirst())) {
+        ImplicitLocOpBuilder builder(mem.getLoc(), mem);
+        SmallVector<Attribute, 4> resultNames;
+        SmallVector<Type, 4> resultTypes;
+        SmallVector<Attribute, 4> portAnnotations;
+        SmallVector<Value, 4> oldResults;
+        for (auto res : llvm::enumerate(mem.getResults())) {
+          if (mem.getResult(res.index())
+                  .getType()
+                  .cast<FIRRTLType>()
+                  .isa<RefType>())
+            continue;
+          resultNames.push_back(mem.getPortName(res.index()));
+          resultTypes.push_back(res.value().getType());
+          portAnnotations.push_back(mem.getPortAnnotation(res.index()));
+          oldResults.push_back(res.value());
+        }
+        auto newMem = builder.create<MemOp>(
+            resultTypes, mem.getReadLatency(), mem.getWriteLatency(),
+            mem.getDepth(), RUWAttr::Undefined,
+            builder.getArrayAttr(resultNames), mem.getNameAttr(),
+            mem.getNameKind(), mem.getAnnotations(),
+            builder.getArrayAttr(portAnnotations), mem.getInnerSymAttr(),
+            mem.getGroupIDAttr());
+        for (const auto &res : llvm::enumerate(oldResults))
+          res.value().replaceAllUsesWith(newMem.getResult(res.index()));
+        mem.erase();
       }
     opsToRemove.clear();
     refPortsToRemoveMap.clear();
@@ -363,6 +422,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   /// RefResolve, RefSend, and Connects involving them that will be removed.
   SmallVector<Operation *> opsToRemove;
+
+  /// Record the internal path to an external module or a memory.
+  DenseMap<innerRefToVal, SmallString<128>> stringXMR;
 };
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLowerXMRPass() {

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -90,13 +90,11 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             return success();
           })
           .Case<MemOp>([&](MemOp mem) {
-
             // MemOp can produce debug ports of RefType. Each debug port
             // represents the RefType for the corresponding register of the
             // memory. Since the memory is not yet generated the register name
             // is assumed to be "Memory". Note that MemOp creates RefType
             // without a RefSend.
-
             for (const auto &res : llvm::enumerate(mem.getResults()))
               if (mem.getResult(res.index())
                       .getType()
@@ -104,7 +102,6 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                       .isa<RefType>()) {
                 auto inRef = getInnerRefTo(mem);
                 addReachingSendsEntry(res.value(), inRef);
-
                 xmrPathSuffix[inRef] = ".Memory";
                 // Just node that all the debug ports of memory must be removed.
                 // So this does not record the port index.
@@ -219,7 +216,6 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       xmrString += '.';
     }
     ("{{" + Twine(index) + "}}").toVector(xmrString);
-    if (lastInnerRef && stringXMR.find(lastInnerRef) != stringXMR.end())
     auto iter = xmrPathSuffix.find(lastInnerRef);
     // If this xmr has a suffix string (internal path into a module, that is not
     // yet generated).

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,0 +1,64 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~Top|DUTModule"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Top|Top>memTap"
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
+    "source":"~Top|DUTModule>rf",
+    "wireName":[
+      "~Top|Top>memTap[0]",
+      "~Top|Top>memTap[1]",
+      "~Top|Top>memTap[2]",
+      "~Top|Top>memTap[3]",
+      "~Top|Top>memTap[4]",
+      "~Top|Top>memTap[5]",
+      "~Top|Top>memTap[6]",
+      "~Top|Top>memTap[7]"
+    ]
+  }
+]]
+  module DUTModule :
+    input clock : Clock
+    input reset : Reset
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    cmem rf : UInt<8> [8]
+    infer mport read = rf[io.addr], clock
+    io.dataOut <= read
+    when io.wen :
+      infer mport write = rf[io.addr], clock
+      write <= io.dataIn
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    inst dut of DUTModule
+    dut.clock <= clock
+    dut.reset <= reset
+    wire memTap : UInt<8>[8]
+    memTap is invalid
+    io.dataOut <= dut.io.dataOut
+    dut.io.wen <= io.wen
+    dut.io.dataIn <= io.dataIn
+    dut.io.addr <= io.addr
+
+; CHECK:      module Top(
+; CHECK-NOT:  module
+; CHECK:  assign memTap_0 = Top.dut.rf_ext.Memory[0];
+; CHECK:  assign memTap_1 = Top.dut.rf_ext.Memory[1];
+; CHECK:  assign memTap_2 = Top.dut.rf_ext.Memory[2];
+; CHECK:  assign memTap_3 = Top.dut.rf_ext.Memory[3];
+; CHECK:  assign memTap_4 = Top.dut.rf_ext.Memory[4];
+; CHECK:  assign memTap_5 = Top.dut.rf_ext.Memory[5];
+; CHECK:  assign memTap_6 = Top.dut.rf_ext.Memory[6];
+; CHECK:  assign memTap_7 = Top.dut.rf_ext.Memory[7];
+; CHECK:      endmodule


### PR DESCRIPTION
This PR generates debug ports on the memory with the `MemTap` annotation. The debug port is a `RefType` handle of the memory register. The cross-module-reference for the memory is then encoded in the IR using `RefType` connections from the memory debug port to the target wire.
This implementation assumes that the target wire and the memory have the same datatype. 