### PR TITLE
[FIRRTL][LowerXMR] Handle debug ports on Memory

### DIFF
--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -385,34 +385,34 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 8>
     firrtl.strictconnect %memTap_0, %1 : !firrtl.uint<8>
-    %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
-    %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
-    %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
-    %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
-    %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
-    %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
-    %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[0]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
+    %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[1]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
+    %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %2 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[2]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_2, %2 : !firrtl.uint<8>
+    %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %3 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[3]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_3, %3 : !firrtl.uint<8>
+    %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %4 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[4]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_4, %4 : !firrtl.uint<8>
+    %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %5 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[5]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_5, %5 : !firrtl.uint<8>
+    %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %6 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[6]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_6, %6 : !firrtl.uint<8>
+    %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
     // CHECK{LITERAL}:  %7 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[7]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     // CHECK:  firrtl.strictconnect %memTap_7, %7 : !firrtl.uint<8>
   }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -337,3 +337,83 @@ firrtl.circuit "Top" {
     // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
   }
 }
+
+// -----
+
+firrtl.circuit "Top"  {
+    // CHECK-LABEL: firrtl.module private @DUTModule
+    // CHECK-SAME: (in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
+  firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap: !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %0 = firrtl.subfield %rf_read(0) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<3>
+    %1 = firrtl.subfield %rf_read(1) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %rf_read(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+    %3 = firrtl.subfield %rf_read(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
+    %4 = firrtl.subfield %rf_write(0) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<3>
+    %5 = firrtl.subfield %rf_write(1) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %rf_write(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+    %7 = firrtl.subfield %rf_write(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
+    %8 = firrtl.subfield %rf_write(4) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+    firrtl.strictconnect %0, %io_addr : !firrtl.uint<3>
+    firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
+    firrtl.strictconnect %2, %clock : !firrtl.clock
+    firrtl.strictconnect %io_dataOut, %3 : !firrtl.uint<8>
+    firrtl.strictconnect %4, %io_addr : !firrtl.uint<3>
+    firrtl.strictconnect %5, %io_wen : !firrtl.uint<1>
+    firrtl.strictconnect %6, %clock : !firrtl.clock
+    firrtl.strictconnect %8, %c1_ui1 : !firrtl.uint<1>
+    firrtl.strictconnect %7, %io_dataIn : !firrtl.uint<8>
+    firrtl.connect %_gen_memTap, %rf_memTap : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.ref<vector<uint<8>, 8>>
+  }
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
+    %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.ref<vector<uint<8>, 8>>)
+    %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
+    %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_2 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_3 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_4 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_5 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_6 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    %memTap_7 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
+    firrtl.strictconnect %io_dataOut, %dut_io_dataOut : !firrtl.uint<8>
+    firrtl.strictconnect %dut_io_wen, %io_wen : !firrtl.uint<1>
+    firrtl.strictconnect %dut_io_dataIn, %io_dataIn : !firrtl.uint<8>
+    firrtl.strictconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
+    %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_0, %1 : !firrtl.uint<8>
+    %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
+    %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
+    %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
+    %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
+    %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
+    %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
+    %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
+    firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[0]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[1]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %2 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[2]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_2, %2 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %3 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[3]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_3, %3 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %4 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[4]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_4, %4 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %5 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[5]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_5, %5 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %6 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[6]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_6, %6 : !firrtl.uint<8>
+    // CHECK{LITERAL}:  %7 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[7]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:  firrtl.strictconnect %memTap_7, %7 : !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
This commit lowers the debug ports of `firrtl.mem` to cross-module-reference of the memory register. The memory is yet to be lowered to the register, so the pass uses a string to encode the internal path to the memory. This same mechanism can be used to encode internal paths into external modules.
The lowering also ensures a `RefType` of vectors is lowered to appropriate indexed xmr accesses.