### PR TITLE
FIREmitter: explicitly handle new Debug port type with diagnostic.

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -537,6 +537,9 @@ void Emitter::emitStatement(MemOp op) {
     case MemOp::PortKind::ReadWrite:
       add(readwriter, port.first);
       break;
+    case MemOp::PortKind::Debug:
+      emitOpError(op, "has unsupported 'debug' port");
+      return;
     }
   }
   if (!reader.empty())


### PR DESCRIPTION
Quiet compiler warning about missed case.