### PR TITLE
[ESI][NFC][Services] In service implement reqs, avoid args

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -189,16 +189,10 @@ class _ServiceGeneratorChannels:
     portReqsBlock = req.portReqs.blocks[0]
 
     # Find the input channel requests and store named versions of the values.
-    input_req_ops = [
-        x for x in portReqsBlock
-        if isinstance(x, raw_esi.RequestToServerConnectionOp)
-    ]
-    start_inputs_chan_num = len(mod.input_port_lookup)
-    assert len(input_req_ops) == len(req.inputs) - len(mod.input_port_lookup)
     self._input_reqs = [
-        NamedChannelValue(input_value, req.clientNamePath)
-        for input_value, req in zip(
-            list(req.inputs)[start_inputs_chan_num:], input_req_ops)
+        NamedChannelValue(x.toServer, x.clientNamePath)
+        for x in portReqsBlock
+        if isinstance(x, raw_esi.RequestToServerConnectionOp)
     ]
 
     # Find the output channel requests and store the settable proxies.

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -17,10 +17,9 @@ with Context() as ctx:
 
 
 # CHECK-LABEL: === testGen called with op:
-# CHECK:       %0:2 = esi.service.impl_req @HostComms impl as "test"(%clk, %m1.loopback_fromhw) : (i1, !esi.channel<i8>) -> (i8, !esi.channel<i8>) {
-# CHECK:       ^bb0(%arg0: !esi.channel<i8>):
+# CHECK:       %0:2 = esi.service.impl_req @HostComms impl as "test"(%clk) : (i1) -> (i8, !esi.channel<i8>) {
 # CHECK:         %2 = esi.service.req.to_client <@HostComms::@Recv>(["m1", "loopback_tohw"]) : !esi.channel<i8>
-# CHECK:         esi.service.req.to_server %arg0 -> <@HostComms::@Send>(["m1", "loopback_fromhw"]) : !esi.channel<i8>
+# CHECK:         esi.service.req.to_server %m1.loopback_fromhw -> <@HostComms::@Send>(["m1", "loopback_fromhw"]) : !esi.channel<i8>
 def testGen(reqOp: esi.ServiceImplementReqOp) -> bool:
   print("=== testGen called with op:")
   reqOp.print()

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -42,7 +42,6 @@ LogicalResult ServiceGeneratorDispatcher::generate(ServiceImplementReqOp req) {
 static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp req) {
   auto *ctxt = req.getContext();
   OpBuilder b(req);
-  Block *portReqs = &req.getPortReqs().getBlocks().front();
   Value clk = req.getOperand(0);
   Value rst = req.getOperand(1);
 
@@ -62,12 +61,6 @@ static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp req) {
     llvm::interleave(strArr.getAsValueRange<StringAttr>(), os, ".");
     return StringAttr::get(ctxt, os.str());
   };
-
-  // Since outgoing data gets passed in through block args, we need to translate
-  // internal Values (with the block) to the external Values driving them.
-  // BlockAndValueMapping argMap;
-  // for (unsigned i = 0, e = portReqs->getArguments().size(); i < e; ++i)
-  //   argMap.map(portReqs->getArgument(i), req->getOperand(i + 2));
 
   llvm::DenseMap<RequestToClientConnectionOp, unsigned> toClientResultNum;
   for (auto toClient : req.getOps<RequestToClientConnectionOp>())
@@ -340,22 +333,11 @@ LogicalResult ESIConnectServicesPass::replaceInst(ServiceInstanceOp instOp,
   for (auto toClient : portReqs->getOps<RequestToClientConnectionOp>())
     resultTypes.push_back(toClient.getToClient().getType());
 
-  // Compute the operands for the new op -- the instance op's operands + the
-  // to_server types. Reassign the reqs' operand to the new blocks arguments.
-  SmallVector<Value, 8> operands(instOp.getOperands().begin(),
-                                 instOp.getOperands().end());
-  // for (auto toServer : portReqs->getOps<RequestToServerConnectionOp>()) {
-  //   Value sending = toServer.getToServer();
-  //   operands.push_back(sending);
-  //   toServer.getToServerMutable().assign(
-  //       portReqs->addArgument(sending.getType(), toServer.getLoc()));
-  // }
-
   // Create the generation request op.
   OpBuilder b(instOp);
   auto implOp = b.create<ServiceImplementReqOp>(
       instOp.getLoc(), resultTypes, instOp.getServiceSymbolAttr(),
-      instOp.getImplTypeAttr(), instOp.getImplOptsAttr(), operands);
+      instOp.getImplTypeAttr(), instOp.getImplOptsAttr(), instOp.getOperands());
   implOp->setDialectAttrs(instOp->getDialectAttrs());
   implOp.getPortReqs().push_back(portReqs);
 

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -65,9 +65,9 @@ static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp req) {
 
   // Since outgoing data gets passed in through block args, we need to translate
   // internal Values (with the block) to the external Values driving them.
-  BlockAndValueMapping argMap;
-  for (unsigned i = 0, e = portReqs->getArguments().size(); i < e; ++i)
-    argMap.map(portReqs->getArgument(i), req->getOperand(i + 2));
+  // BlockAndValueMapping argMap;
+  // for (unsigned i = 0, e = portReqs->getArguments().size(); i < e; ++i)
+  //   argMap.map(portReqs->getArgument(i), req->getOperand(i + 2));
 
   llvm::DenseMap<RequestToClientConnectionOp, unsigned> toClientResultNum;
   for (auto toClient : req.getOps<RequestToClientConnectionOp>())
@@ -89,7 +89,7 @@ static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp req) {
 
     Value toServerValue;
     if (toServer)
-      toServerValue = argMap.lookup(toServer.getToServer());
+      toServerValue = toServer.getToServer();
     else
       toServerValue =
           b.create<NullSourceOp>(loc, ChannelType::get(ctxt, b.getI1Type()));
@@ -344,12 +344,12 @@ LogicalResult ESIConnectServicesPass::replaceInst(ServiceInstanceOp instOp,
   // to_server types. Reassign the reqs' operand to the new blocks arguments.
   SmallVector<Value, 8> operands(instOp.getOperands().begin(),
                                  instOp.getOperands().end());
-  for (auto toServer : portReqs->getOps<RequestToServerConnectionOp>()) {
-    Value sending = toServer.getToServer();
-    operands.push_back(sending);
-    toServer.getToServerMutable().assign(
-        portReqs->addArgument(sending.getType(), toServer.getLoc()));
-  }
+  // for (auto toServer : portReqs->getOps<RequestToServerConnectionOp>()) {
+  //   Value sending = toServer.getToServer();
+  //   operands.push_back(sending);
+  //   toServer.getToServerMutable().assign(
+  //       portReqs->addArgument(sending.getType(), toServer.getLoc()));
+  // }
 
   // Create the generation request op.
   OpBuilder b(instOp);

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -36,13 +36,12 @@ hw.module @Loopback (%clk: i1) -> () {
 }
 
 // CONN-LABEL: hw.module @Top2(%clk: i1) -> (chksum: i8) {
-// CONN:         [[r0:%.+]]:3 = esi.service.impl_req @HostComms impl as "topComms2"(%clk, %r1.m1.loopback_fromhw, %r1.p1.producedMsgChan, %r1.p2.producedMsgChan) : (i1, !esi.channel<i8>, !esi.channel<i8>, !esi.channel<i8>) -> (i8, !esi.channel<i8>, !esi.channel<i8>) {
-// CONN:         ^bb0(%arg0: !esi.channel<i8>, %arg1: !esi.channel<i8>, %arg2: !esi.channel<i8>):
+// CONN:         [[r0:%.+]]:3 = esi.service.impl_req @HostComms impl as "topComms2"(%clk) : (i1) -> (i8, !esi.channel<i8>, !esi.channel<i8>) {
 // CONN:           %1 = esi.service.req.to_client <@HostComms::@Recv>(["r1", "m1", "loopback_tohw"]) : !esi.channel<i8>
 // CONN:           %2 = esi.service.req.to_client <@HostComms::@Recv>(["r1", "c1", "consumingFromChan"]) : !esi.channel<i8>
-// CONN:           esi.service.req.to_server %arg0 -> <@HostComms::@Send>(["r1", "m1", "loopback_fromhw"]) : !esi.channel<i8>
-// CONN:           esi.service.req.to_server %arg1 -> <@HostComms::@Send>(["r1", "p1", "producedMsgChan"]) : !esi.channel<i8>
-// CONN:           esi.service.req.to_server %arg2 -> <@HostComms::@Send>(["r1", "p2", "producedMsgChan"]) : !esi.channel<i8>
+// CONN:           esi.service.req.to_server %r1.m1.loopback_fromhw -> <@HostComms::@Send>(["r1", "m1", "loopback_fromhw"]) : !esi.channel<i8>
+// CONN:           esi.service.req.to_server %r1.p1.producedMsgChan -> <@HostComms::@Send>(["r1", "p1", "producedMsgChan"]) : !esi.channel<i8>
+// CONN:           esi.service.req.to_server %r1.p2.producedMsgChan -> <@HostComms::@Send>(["r1", "p2", "producedMsgChan"]) : !esi.channel<i8>
 // CONN:         }
 // CONN:         %r1.m1.loopback_fromhw, %r1.p1.producedMsgChan, %r1.p2.producedMsgChan = hw.instance "r1" @Rec(clk: %clk: i1, m1.loopback_tohw: [[r0]]#1: !esi.channel<i8>, c1.consumingFromChan: [[r0]]#2: !esi.channel<i8>) -> (m1.loopback_fromhw: !esi.channel<i8>, p1.producedMsgChan: !esi.channel<i8>, p2.producedMsgChan: !esi.channel<i8>)
 // CONN:         hw.output [[r0]]#0 : i8
@@ -89,10 +88,9 @@ hw.module @Producer(%clk: i1) -> () {
 }
 
 // CONN-LABEL: msft.module @MsTop {} (%clk: i1) -> (chksum: i8)
-// CONN:         [[r1:%.+]]:2 = esi.service.impl_req @HostComms impl as "topComms"(%clk, %m1.loopback_fromhw) : (i1, !esi.channel<i8>) -> (i8, !esi.channel<i8>) {
-// CONN:         ^bb0(%arg0: !esi.channel<i8>):
+// CONN:         [[r1:%.+]]:2 = esi.service.impl_req @HostComms impl as "topComms"(%clk) : (i1) -> (i8, !esi.channel<i8>) {
 // CONN:           [[r2:%.+]] = esi.service.req.to_client <@HostComms::@Recv>(["m1", "loopback_tohw"]) : !esi.channel<i8>
-// CONN:           esi.service.req.to_server %arg0 -> <@HostComms::@Send>(["m1", "loopback_fromhw"]) : !esi.channel<i8>
+// CONN:           esi.service.req.to_server %m1.loopback_fromhw -> <@HostComms::@Send>(["m1", "loopback_fromhw"]) : !esi.channel<i8>
 // CONN:         }
 // CONN:         %m1.loopback_fromhw = msft.instance @m1 @MsLoopback(%clk, [[r1]]#1) : (i1, !esi.channel<i8>) -> !esi.channel<i8>
 // CONN:         msft.output [[r1]]#0 : i8
@@ -113,10 +111,9 @@ msft.module @MsLoopback {} (%clk: i1) -> () {
 
 
 // CONN-LABEL: msft.module @InOutTop {} (%clk: i1) -> (chksum: i8) {
-// CONN:          %0:2 = esi.service.impl_req @HostComms impl as "topComms"(%clk, %m1.loopback_inout) : (i1, !esi.channel<i8>) -> (i8, !esi.channel<i16>) {
-// CONN:          ^bb0(%arg0: !esi.channel<i8>):
+// CONN:          %0:2 = esi.service.impl_req @HostComms impl as "topComms"(%clk) : (i1) -> (i8, !esi.channel<i16>) {
 // CONN:            %1 = esi.service.req.to_client <@HostComms::@ReqResp>(["m1", "loopback_inout"]) : !esi.channel<i16>
-// CONN:            esi.service.req.to_server %arg0 -> <@HostComms::@ReqResp>(["m1", "loopback_inout"]) : !esi.channel<i8>
+// CONN:            esi.service.req.to_server %m1.loopback_inout -> <@HostComms::@ReqResp>(["m1", "loopback_inout"]) : !esi.channel<i8>
 // CONN:          }
 // CONN:          %m1.loopback_inout = msft.instance @m1 @InOutLoopback(%clk, %0#1)  : (i1, !esi.channel<i16>) -> !esi.channel<i8>
 // CONN:          msft.output %0#0 : i8


### PR DESCRIPTION
Previously toServer inputs were being passed into the port req block via block args, which needlessly complicates things. Change that.