### PR TITLE
[VerbosePassInstrumentation] Moved verbose pass logging to a helper class

### DIFF
--- a/include/circt/Support/Passes.h
+++ b/include/circt/Support/Passes.h
@@ -1,0 +1,39 @@
+//===- Passes.h - Helpers for pipeline instrumentation ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PASSES_H
+#define CIRCT_SUPPORT_PASSES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassInstrumentation.h"
+#include "llvm/Support/Chrono.h"
+
+namespace circt {
+
+// This class prints logs before and after of pass executions. This
+// insrumentation assumes that passes are not parallelized for firrtl::CircuitOp
+// and mlir::ModuleOp.
+class VerbosePassInstrumentation final : public mlir::PassInstrumentation {
+  // This stores start time points of passes.
+  using TimePoint = llvm::sys::TimePoint<>;
+  llvm::SmallVector<TimePoint> timePoints;
+  std::string toolName;
+  int level = 0;
+
+public:
+  VerbosePassInstrumentation(StringRef toolName) : toolName(toolName.str()) {}
+
+  void runBeforePass(mlir::Pass *pass, Operation *op) override;
+
+  void runAfterPass(mlir::Pass *pass, Operation *op) override;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_PASSES_H

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_library(CIRCTSupport
   BackedgeBuilder.cpp
   FieldRef.cpp
   LoweringOptions.cpp
+  Passes.cpp
   Path.cpp
   APInt.cpp
   ValueMapper.cpp

--- a/lib/Support/Passes.cpp
+++ b/lib/Support/Passes.cpp
@@ -1,0 +1,44 @@
+//===- Passes.cpp - Helpers for pipeline instrumentation --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/Passes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/Support/Format.h"
+
+using namespace mlir;
+using namespace circt;
+
+void VerbosePassInstrumentation::runBeforePass(Pass *pass, Operation *op) {
+  // This assumes that it is safe to log messages to stderr if the operation
+  // is circuit or module op.
+  if (isa<firrtl::CircuitOp, mlir::ModuleOp>(op)) {
+    timePoints.push_back(TimePoint::clock::now());
+    auto &os = llvm::errs();
+    os << "[" << toolName << "] ";
+    os.indent(2 * level++);
+    os << "Running \"";
+    pass->printAsTextualPipeline(llvm::errs());
+    os << "\"\n";
+  }
+}
+
+void VerbosePassInstrumentation::runAfterPass(Pass *pass, Operation *op) {
+  using namespace std::chrono;
+  // This assumes that it is safe to log messages to stderr if the operation
+  // is circuit or module op.
+  if (isa<firrtl::CircuitOp, mlir::ModuleOp>(op)) {
+    auto &os = llvm::errs();
+    auto elapsed =
+        duration<double>(TimePoint::clock::now() - timePoints.pop_back_val()) /
+        seconds(1);
+    os << "[" << toolName << "] ";
+    os.indent(2 * --level);
+    os << "-- Done in " << llvm::format("%.3f", elapsed) << " sec\n";
+  }
+}

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTHWTransforms
   CIRCTSeq
   CIRCTSeqTransforms
+  CIRCTSupport
   CIRCTSVTransforms
   CIRCTTransforms
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
 #include "mlir/Bytecode/BytecodeReader.h"
@@ -415,46 +416,6 @@ static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   return mlir::createCanonicalizerPass(config);
 }
 
-// This class prints logs before and after of pass executions. This
-// insrumentation assumes that passes are not parallelized for firrtl::CircuitOp
-// and mlir::ModuleOp.
-class FirtoolPassInstrumentation : public mlir::PassInstrumentation {
-  // This stores start time points of passes.
-  using TimePoint = llvm::sys::TimePoint<>;
-  llvm::SmallVector<TimePoint> timePoints;
-  int level = 0;
-
-public:
-  void runBeforePass(Pass *pass, Operation *op) override {
-    // This assumes that it is safe to log messages to stderr if the operation
-    // is circuit or module op.
-    if (isa<firrtl::CircuitOp, mlir::ModuleOp>(op)) {
-      timePoints.push_back(TimePoint::clock::now());
-      auto &os = llvm::errs();
-      os << "[firtool] ";
-      os.indent(2 * level++);
-      os << "Running \"";
-      pass->printAsTextualPipeline(llvm::errs());
-      os << "\"\n";
-    }
-  }
-
-  void runAfterPass(Pass *pass, Operation *op) override {
-    using namespace std::chrono;
-    // This assumes that it is safe to log messages to stderr if the operation
-    // is circuit or module op.
-    if (isa<firrtl::CircuitOp, mlir::ModuleOp>(op)) {
-      auto &os = llvm::errs();
-      auto elapsed = duration<double>(TimePoint::clock::now() -
-                                      timePoints.pop_back_val()) /
-                     seconds(1);
-      os << "[firtool] ";
-      os.indent(2 * --level);
-      os << "-- Done in " << llvm::format("%.3f", elapsed) << " sec\n";
-    }
-  }
-};
-
 /// Check output stream before writing bytecode to it.
 /// Warn and return true if output is known to be displayed.
 static bool checkBytecodeOutputToConsole(raw_ostream &os) {
@@ -550,7 +511,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   pm.enableVerifier(verifyPasses);
   pm.enableTiming(ts);
   if (verbosePassExecutions)
-    pm.addInstrumentation(std::make_unique<FirtoolPassInstrumentation>());
+    pm.addInstrumentation(
+        std::make_unique<VerbosePassInstrumentation>("firtool"));
   applyPassManagerCLOptions(pm);
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
@@ -757,7 +719,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     applyPassManagerCLOptions(exportPm);
     if (verbosePassExecutions)
       exportPm.addInstrumentation(
-          std::make_unique<FirtoolPassInstrumentation>());
+          std::make_unique<VerbosePassInstrumentation>("firtool"));
     // Legalize unsupported operations within the modules.
     exportPm.nest<hw::HWModuleOp>().addPass(sv::createHWLegalizeModulesPass());
 


### PR DESCRIPTION
Renamed `FirtoolPassInstrumentation` to `VerbosePassInstrumentation` and added a generic argument to name any tool.