### PR TITLE
[FIRRTL] Remove large registers from register-randomization.fir

### DIFF
--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -47,11 +47,9 @@ circuit Foo:
     ; NONE:   automatic logic [31:0] _RANDOM_0;
     ; NONE:   automatic logic [31:0] _RANDOM_1;
     ; NONE:   automatic logic [31:0] _RANDOM_2;
-    ; NONE-NOT:   automatic logic [31:0] _RANDOM_3;
     ; NONE:   _RANDOM_0 = `RANDOM;
     ; NONE:   _RANDOM_1 = `RANDOM;
     ; NONE:   _RANDOM_2 = `RANDOM;
-    ; NONE-NOT: _RANDOM_3 = `RANDOM;
 
     ; ALL:       _r = {_RANDOM_0, _RANDOM_1[0]}; 
     ; NAMED-NOT: _r = 

--- a/test/firtool/register-randomization.fir
+++ b/test/firtool/register-randomization.fir
@@ -10,9 +10,6 @@ circuit Foo:
     input d0: UInt<60000>
     input d1: UInt<120000>
     output q: UInt<33>
-    output q0: UInt<60000>
-    output q1: UInt<120000>
-
 
     ; ALL:       _r <= d;
     ; NAMED-NOT: _r = {{.*}};
@@ -50,11 +47,11 @@ circuit Foo:
     ; NONE:   automatic logic [31:0] _RANDOM_0;
     ; NONE:   automatic logic [31:0] _RANDOM_1;
     ; NONE:   automatic logic [31:0] _RANDOM_2;
-    ; NONE:   automatic logic [31:0] _RANDOM_3;
+    ; NONE-NOT:   automatic logic [31:0] _RANDOM_3;
     ; NONE:   _RANDOM_0 = `RANDOM;
     ; NONE:   _RANDOM_1 = `RANDOM;
     ; NONE:   _RANDOM_2 = `RANDOM;
-    ; NONE:   _RANDOM_3 = `RANDOM;
+    ; NONE-NOT: _RANDOM_3 = `RANDOM;
 
     ; ALL:       _r = {_RANDOM_0, _RANDOM_1[0]}; 
     ; NAMED-NOT: _r = 
@@ -63,49 +60,8 @@ circuit Foo:
 
     ; ALL:       r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
     ; NAMED:     r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
-    ; NONE-NOT:  r = {{.*}};
+    ; NONE:      r = {_RANDOM_1[31:1], _RANDOM_2[1:0]};
 
     ; ALL:       s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
     ; NAMED:     s = {_RANDOM_2[31:2], _RANDOM_3[2:0]};
     ; NONE-NOT:  s = {{.*}};
-
-    inst i0 of TwoLargeRegisters
-    i0.clock <= clock
-    i0.d <= d0
-    q0 <= i0.q
-
-    inst i1 of OneReallyLargeRegister
-    i1.clock <= clock
-    i1.d <= d1
-    q1 <= i1.q
-
-  ; ALL: module TwoLargeRegisters
-  module TwoLargeRegisters:
-    input clock: Clock
-    input d: UInt<60000>
-    output q: UInt<60000>
-    ; ALL: automatic logic [31:0]   _RANDOM_0;
-    ; ALL: automatic logic [31:0]   _RANDOM_3749;
-    ; ALL-NOT: automatic logic [31:0]   _RANDOM_3750;
-
-    reg r0: UInt<60000>, clock
-    reg r1: UInt<60000>, clock
-
-    r0 <= d
-    r1 <= r0
-    q <= r1
-
-  ; ALL: module OneReallyLargeRegister
-  module OneReallyLargeRegister:
-    input clock: Clock
-    input d: UInt<120000>
-    output q: UInt<120000>
-
-    ; ALL: automatic logic [31:0]   _RANDOM_0;
-    ; ALL: automatic logic [31:0]   _RANDOM_3749;
-    ; ALL-NOT: automatic logic [31:0]   _RANDOM_3750;
-
-    reg r: UInt<120000>, clock
-
-    r <= d
-    q <= r


### PR DESCRIPTION
This removes large register tests from register-randomization.fir. The tests originally checked that large registers which violates VCS limitations were properly split into small registers (#3748). However improved version of register randomization (#3802) doesn't create a large size of register in the first place, so it's not required to have the tests now. 
This test has caused a regression for `check-circt` since >15000 lines of verilog are emitted in each test. 