### PR TITLE
[LowerTypes] Lower size 1 vector even when 1d vector preservation.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -107,7 +107,9 @@ static bool isOneDimVectorType(FIRRTLType type) {
   return TypeSwitch<FIRRTLType, bool>(type)
       .Case<BundleType>([&](auto bundle) { return false; })
       .Case<FVectorType>([&](FVectorType vector) {
-        return vector.getElementType().isGround();
+        // When the size is 1, lower the vector into a scalar.
+        return vector.getElementType().isGround() &&
+               vector.getNumElements() > 1;
       })
       .Default([](auto groundType) { return true; });
 }

--- a/test/Dialect/FIRRTL/lower-types-aggregate.mlir
+++ b/test/Dialect/FIRRTL/lower-types-aggregate.mlir
@@ -17,4 +17,7 @@ firrtl.circuit "TopLevel" {
   // 1D_VEC: @Foo(in %a_a_0: !firrtl.vector<uint<1>, 2>, in %a_a_1: !firrtl.vector<uint<1>, 2>)
   firrtl.module private @Foo(in %a: !firrtl.bundle<a: vector<vector<uint<1>, 2>, 2>>) {
   }
+  // 1D_VEC: %a_0: !firrtl.uint<1>
+  firrtl.module private @Bar(in %a: !firrtl.vector<uint<1>, 1>) {
+  }
 }


### PR DESCRIPTION
Chisel produces bunch of single element vectors. In terms of verilog quality, we can produce more simpler verilog when we lower singleton vector into scalar. 