### PR TITLE
[FIRRTL] Print/parse visibility for HierPathOp explicitly

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -111,7 +111,7 @@ firrtl.circuit "Foo" attributes {annotations = [
         {class = "firrtl.transforms.BlackBox", circt.nonlocal = @nla_1}
     ]} {}
     // Non-local annotations should not produce errors either.
-    firrtl.hierpath  @nla_1 [@Bar::@s1, @Foo]
+    firrtl.hierpath private  @nla_1 [@Bar::@s1, @Foo]
     firrtl.module @Bar() {
       firrtl.instance foo sym @s1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
     }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1226,8 +1226,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module private @ForceNameSubmodule
-  firrtl.hierpath @nla_1 [@ForceNameTop::@sym_foo, @ForceNameSubmodule]
-  firrtl.hierpath @nla_2 [@ForceNameTop::@sym_bar, @ForceNameSubmodule]
+  firrtl.hierpath private @nla_1 [@ForceNameTop::@sym_foo, @ForceNameSubmodule]
+  firrtl.hierpath private @nla_2 [@ForceNameTop::@sym_bar, @ForceNameSubmodule]
   firrtl.module private @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},

--- a/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
@@ -61,7 +61,7 @@ circuit Top : %[[
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.hierpath @[[nlaSym]] [@Top::@[[a1Sym]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath private @[[nlaSym]] [@Top::@[[a1Sym]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "firrtl.transforms.DontTouchAnnotation"}]}
@@ -101,8 +101,8 @@ circuit Top : %[[
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.hierpath @[[nlaSym1]] [@Top::@[[a1Sym1]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
-  ; CHECK: firrtl.hierpath @[[nlaSym2]] [@Top::@[[a1Sym2]], @A::@[[bSym]]]
+  ; CHECK: firrtl.hierpath private @[[nlaSym1]] [@Top::@[[a1Sym1]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath private @[[nlaSym2]] [@Top::@[[a1Sym2]], @A::@[[bSym]]]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]]

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath private @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
@@ -356,8 +356,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
-  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath private @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath private @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
@@ -458,10 +458,10 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
     ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
@@ -519,25 +519,25 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_/c_:C_/d_:D_>bar"
   }
 ]]
-  ; CHECK:        firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_4:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]]
+  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_3:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym]],
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
   ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
   ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym]],
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
@@ -656,54 +656,54 @@ circuit Top : %[[
     "target":"~Top|Top/a2:A/b:B/c:C"
   }
 ]]
-  ; CHECK:        firrtl.hierpath @[[nla_12:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_12:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[AbSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[BcSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_11:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_11:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa1Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[AbSym]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_10:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_10:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
   ; CHECK-SAME:      @A::@[[Ab_Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_9:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_9:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
   ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_8:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_8:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topb_Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_7:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_7:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[TopbSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        firrtl.hierpath @[[nla_6:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_6:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
   ; CHECK-SAME:      @A::@[[AbSym]],
   ; CHECK-SAME:      @B]
-  ; CHECK:        firrtl.hierpath @[[nla_5:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_5:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
   ; CHECK-SAME:      @A::@[[AbSym]],
   ; CHECK-SAME:      @B]
-  ; CHECK:        firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_4:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
   ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B]
-  ; CHECK:        firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_3:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
   ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B]
-  ; CHECK:        firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topb_Sym]],
   ; CHECK-SAME:      @B]
-  ; CHECK:        firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[TopbSym]],
   ; CHECK-SAME:      @B]
   ; CHECK-NEXT:   firrtl.module @Top
@@ -777,9 +777,9 @@ circuit top : %[[
     "target":"~top|b>q.a"
   }
 ]]
-  ; CHECK:      firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK:      firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
-  ; CHECK:      firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK:      firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @top
   module top:

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -70,9 +70,9 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 //
 // CHECK-LABEL: firrtl.circuit "Foo"
 // CHECK-NOT:     rawAnnotations
-// CHECK-NEXT:    firrtl.hierpath @[[nla_c:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_b:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_a:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_c:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_b:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_a:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
 firrtl.circuit "Foo" attributes {rawAnnotations = [
   {
     class = "circt.test",
@@ -113,11 +113,11 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 //
 // CHECK-LABEL: firrtl.circuit "Foo"
 // CHECK-NOT:     rawAnnotations
-// CHECK-NEXT:    firrtl.hierpath @[[nla_4:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_3:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_2:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_1:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath @[[nla_0:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_4:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_3:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_2:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_1:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla_0:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
 firrtl.circuit "Foo" attributes {rawAnnotations = [
   {
     class = "circt.test",
@@ -521,7 +521,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL:  firrtl.circuit "Foo"
-// CHECK:          firrtl.hierpath @[[nla:[^ ]+]] [@Foo::@Foo, @Example]
+// CHECK:          firrtl.hierpath private @[[nla:[^ ]+]] [@Foo::@Foo, @Example]
 // CHECK:          firrtl.module @Example() attributes {
 // CHECK-SAME:       annotations = [{circt.nonlocal = @[[nla]], class = "circt.test"}]
 // CHECK:          firrtl.module @Foo()
@@ -543,8 +543,8 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   }
 }
 // CHECK-LABEL: firrtl.circuit "Foo"
-// CHECK:         firrtl.hierpath @[[nla_b:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
-// CHECK:         firrtl.hierpath @[[nla_a:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
+// CHECK:         firrtl.hierpath private @[[nla_b:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
+// CHECK:         firrtl.hierpath private @[[nla_a:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
 // CHECK:         firrtl.module @Baz
 // CHECK-SAME:      annotations = [{circt.nonlocal = @[[nla_a]], class = "circt.test", data = "a"}, {circt.nonlocal = @[[nla_b]], class = "circt.test", data = "b"}]
 // CHECK:         firrtl.module @Bar()
@@ -575,7 +575,7 @@ firrtl.circuit "memportAnno"  attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL: firrtl.circuit "memportAnno"  {
-// CHECK:        firrtl.hierpath @nla [@memportAnno::@foo, @Foo]
+// CHECK:        firrtl.hierpath private @nla [@memportAnno::@foo, @Foo]
 // CHECK:        %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portAnnotations
 // CHECK-SAME:   [{circt.nonlocal = @nla, class = "circt.test"}]
 
@@ -602,7 +602,7 @@ firrtl.circuit "instportAnno" attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL: firrtl.circuit "instportAnno"
-// CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz, @Baz]
+// CHECK:        firrtl.hierpath private @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz, @Baz]
 // CHECK:        firrtl.module @Baz
 // CHECK-SAME:     {circt.nonlocal = @[[HIER]], class = "circt.test"}
 
@@ -626,9 +626,9 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
-// CHECK: firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath private @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath private @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath private @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla_1, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
@@ -663,7 +663,7 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child]
+// CHECK: firrtl.hierpath private @nla [@MemPortsNL::@child, @Child]
 // CHECK: firrtl.module @Child()
 // CHECK:   %bar_r = firrtl.mem
 // CHECK-NOT: sym
@@ -711,7 +711,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest"}
   ]} {
-  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest]
+  // CHECK: firrtl.hierpath private @nla [@Test::@exttest, @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest() attributes {annotations = [{circt.nonlocal = @nla, class = "circt.test"}]}
   firrtl.extmodule @ExtTest()
 
@@ -727,7 +727,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest]
+  // CHECK: firrtl.hierpath private @nla [@Test::@exttest, @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
@@ -753,7 +753,7 @@ firrtl.circuit "Foo"  attributes {
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo>_T_8"},
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo>_T_9.a"},
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo/bar:Bar>_T.a"}]} {
-  // CHECK:      firrtl.hierpath @nla [@Foo::@bar, @Bar]
+  // CHECK:      firrtl.hierpath private @nla [@Foo::@bar, @Bar]
   // CHECK-NEXT: firrtl.module @Foo
   firrtl.module @Foo(in %reset: !firrtl.uint<1>, in %clock: !firrtl.clock) {
     // CHECK-NEXT: %_T_0 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
@@ -996,7 +996,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod]
+// CHECK:      firrtl.hierpath private [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -91,16 +91,16 @@ firrtl.circuit "WhenOps" {
 
 // CHECK-LABEL: firrtl.circuit "Annotations"
 firrtl.circuit "Annotations" {
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations0, @Annotations0]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations1, @Annotations0]
-  // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
-  firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
-  // CHECK: firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
-  firrtl.hierpath @annos_nla2 [@Annotations::@annotations0, @Annotations0]
-  // CHECK: firrtl.hierpath @annos_nla3 [@Annotations::@annotations0, @Annotations0]
-  firrtl.hierpath @annos_nla3 [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath private [[NLA0:@nla.*]] [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath private [[NLA1:@nla.*]] [@Annotations::@annotations1, @Annotations0]
+  // CHECK: firrtl.hierpath private @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  firrtl.hierpath private @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  // CHECK: firrtl.hierpath private @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
+  firrtl.hierpath private @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
+  // CHECK: firrtl.hierpath private @annos_nla2 [@Annotations::@annotations0, @Annotations0]
+  firrtl.hierpath private @annos_nla2 [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath private @annos_nla3 [@Annotations::@annotations0, @Annotations0]
+  firrtl.hierpath private @annos_nla3 [@Annotations::@annotations0, @Annotations0]
 
   // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
   firrtl.module @Annotations0() {
@@ -148,8 +148,8 @@ firrtl.circuit "Annotations" {
 // Check that module and memory port annotations are merged correctly.
 // CHECK-LABEL: firrtl.circuit "PortAnnotations"
 firrtl.circuit "PortAnnotations" {
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
+  // CHECK: firrtl.hierpath private [[NLA0:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
+  // CHECK: firrtl.hierpath private [[NLA1:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
   // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> [
   // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "port1"},
   // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"}]) {
@@ -178,13 +178,13 @@ firrtl.circuit "PortAnnotations" {
 // CHECK-LABEL: firrtl.circuit "Breadcrumb"
 firrtl.circuit "Breadcrumb" {
   // CHECK:  @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
-  firrtl.hierpath @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
+  firrtl.hierpath private @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
   // CHECK:  @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@in]
-  firrtl.hierpath @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@in]
+  firrtl.hierpath private @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@in]
   // CHECK:  @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
-  firrtl.hierpath @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
+  firrtl.hierpath private @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
   // CHECK:  @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@w]
-  firrtl.hierpath @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@w]
+  firrtl.hierpath private @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@w]
   firrtl.module @Crumb(in %in: !firrtl.uint<1> sym @in [
       {circt.nonlocal = @breadcrumb_nla0, class = "port0"},
       {circt.nonlocal = @breadcrumb_nla1, class = "port1"}]) {
@@ -213,18 +213,18 @@ firrtl.circuit "Breadcrumb" {
 // and the annotation should be cloned for each parent of the root module.
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
-  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@in]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: firrtl.hierpath private [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: firrtl.hierpath private [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: firrtl.hierpath private [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: firrtl.hierpath private [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@in]
   // CHECK-NOT: @context_nla0
   // CHECK-NOT: @context_nla1
   // CHECK-NOT: @context_nla2
   // CHECK-NOT: @context_nla3
-  firrtl.hierpath @context_nla0 [@Context0::@c0, @ContextLeaf::@in]
-  firrtl.hierpath @context_nla1 [@Context0::@c0, @ContextLeaf::@w]
-  firrtl.hierpath @context_nla2 [@Context1::@c1, @ContextLeaf::@in]
-  firrtl.hierpath @context_nla3 [@Context1::@c1, @ContextLeaf::@w]
+  firrtl.hierpath private @context_nla0 [@Context0::@c0, @ContextLeaf::@in]
+  firrtl.hierpath private @context_nla1 [@Context0::@c0, @ContextLeaf::@w]
+  firrtl.hierpath private @context_nla2 [@Context1::@c1, @ContextLeaf::@in]
+  firrtl.hierpath private @context_nla3 [@Context1::@c1, @ContextLeaf::@w]
 
   // CHECK: firrtl.module @ContextLeaf(in %in: !firrtl.uint<1> sym @in [
   // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"},
@@ -261,8 +261,8 @@ firrtl.circuit "Context" {
 // External modules should dedup and fixup any NLAs.
 // CHECK: firrtl.circuit "ExtModuleTest"
 firrtl.circuit "ExtModuleTest" {
-  // CHECK: firrtl.hierpath @ext_nla [@ExtModuleTest::@e1, @ExtMod0]
-  firrtl.hierpath @ext_nla [@ExtModuleTest::@e1, @ExtMod1]
+  // CHECK: firrtl.hierpath private @ext_nla [@ExtModuleTest::@e1, @ExtMod0]
+  firrtl.hierpath private @ext_nla [@ExtModuleTest::@e1, @ExtMod1]
   // CHECK: firrtl.extmodule @ExtMod0() attributes {annotations = [{circt.nonlocal = @ext_nla}], defname = "a"}
   firrtl.extmodule @ExtMod0() attributes {defname = "a"}
   // CHECK-NOT: firrtl.extmodule @ExtMod1()
@@ -279,8 +279,8 @@ firrtl.circuit "ExtModuleTest" {
 // https://github.com/llvm/circt/issues/2713
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "Foo"  {
-  // CHECK: firrtl.hierpath @nla_1 [@Foo::@b, @A::@a]
-  firrtl.hierpath @nla_1 [@Foo::@b, @B::@b]
+  // CHECK: firrtl.hierpath private @nla_1 [@Foo::@b, @A::@a]
+  firrtl.hierpath private @nla_1 [@Foo::@b, @B::@b]
   // CHECK: firrtl.extmodule @A(out a: !firrtl.clock sym @a [{circt.nonlocal = @nla_1}])
   firrtl.extmodule @A(out a: !firrtl.clock)
   firrtl.extmodule @B(out b: !firrtl.clock sym @b [{circt.nonlocal = @nla_1}])
@@ -311,8 +311,8 @@ firrtl.circuit "Foo"  {
 // As we dedup modules, the chain on NLAs should continuously grow.
 // CHECK-LABEL: firrtl.circuit "Chain"
 firrtl.circuit "Chain" {
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Chain::@chainB1, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Chain::@chainB0, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
+  // CHECK: firrtl.hierpath private [[NLA0:@nla.*]] [@Chain::@chainB1, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
+  // CHECK: firrtl.hierpath private [[NLA1:@nla.*]] [@Chain::@chainB0, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
   // CHECK: firrtl.module @ChainB0()
   firrtl.module @ChainB0() {
     firrtl.instance chainA0 @ChainA0()

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -206,7 +206,7 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
 }]} {
   // Both OMReferenceTarget1 and OMReferenceTarget2 share the same NLA.  This
   // NLA should not be deleted.
-  firrtl.hierpath @nla_0 [@NonLocalTrackers::@b, @B::@a, @A]
+  firrtl.hierpath private @nla_0 [@NonLocalTrackers::@b, @B::@a, @A]
   // CHECK: firrtl.module @A
   firrtl.module @A() attributes {annotations = [{circt.nonlocal = @nla_0, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {
     // CHECK-NEXT: %a = firrtl.wire sym @[[a_sym:[^ ]+]]
@@ -368,8 +368,8 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.hierpath @nla_old [@SRAMPathsWithNLA::@s1, @Submodule::@mem]
-  firrtl.hierpath @nla_new [@SRAMPathsWithNLA::@s1, @Submodule]
+  firrtl.hierpath private @nla_old [@SRAMPathsWithNLA::@s1, @Submodule::@mem]
+  firrtl.hierpath private @nla_new [@SRAMPathsWithNLA::@s1, @Submodule]
   firrtl.module @Submodule() {
     %mem_port = firrtl.mem sym @mem Undefined {
       annotations = [
@@ -447,7 +447,7 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.hierpath @nla [@SRAMPaths::@sub, @Submodule]
+  firrtl.hierpath private @nla [@SRAMPaths::@sub, @Submodule]
   firrtl.extmodule private @MySRAM()
   firrtl.module private @Submodule() {
     firrtl.instance mem1 {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} @MySRAM()
@@ -775,9 +775,9 @@ firrtl.circuit "FixPath"  attributes {annotations = [
       id = "OMID:0",
       info = loc(unknown)}
     ]}]} {
-  firrtl.hierpath @nla_3 [@FixPath::@c, @C::@cd, @D]
-  firrtl.hierpath @nla_2 [@FixPath::@c, @C::@in]
-  firrtl.hierpath @nla_1 [@FixPath::@c, @C]
+  firrtl.hierpath private @nla_3 [@FixPath::@c, @C::@cd, @D]
+  firrtl.hierpath private @nla_2 [@FixPath::@c, @C::@in]
+  firrtl.hierpath private @nla_1 [@FixPath::@c, @C]
   firrtl.module @C(
     in %in: !firrtl.uint<1> sym @in [
       {circt.nonlocal = @nla_2, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -670,7 +670,7 @@ firrtl.circuit "BitCast4" {
 firrtl.circuit "NLAWithNestedReference" {
 firrtl.module @NLAWithNestedReference() { }
 // expected-error @below {{only one nested reference is allowed}}
-firrtl.hierpath @nla [@A::@B::@C]
+firrtl.hierpath private @nla [@A::@B::@C]
 }
 
 // -----
@@ -678,8 +678,8 @@ firrtl.hierpath @nla [@A::@B::@C]
 
 firrtl.circuit "LowerToBind" {
  // expected-error @+1 {{the instance path cannot be empty/single element}}
-firrtl.hierpath @NLA1 []
-firrtl.hierpath @NLA2 [@LowerToBind::@s1]
+firrtl.hierpath private @NLA1 []
+firrtl.hierpath private @NLA2 [@LowerToBind::@s1]
 firrtl.module @InstanceLowerToBind() {}
 firrtl.module @LowerToBind() {
   firrtl.instance foo sym @s1 {lowerToBind} @InstanceLowerToBind()
@@ -691,8 +691,8 @@ firrtl.module @LowerToBind() {
 firrtl.circuit "NLATop" {
 
  // expected-error @+1 {{the instance path can only contain inner sym reference, only the leaf can refer to a module symbol}}
-  firrtl.hierpath @nla [@NLATop::@test, @Aardvark, @Zebra]
-  firrtl.hierpath @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
+  firrtl.hierpath private @nla [@NLATop::@test, @Aardvark, @Zebra]
+  firrtl.hierpath private @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @NLATop() {
     firrtl.instance test  sym @test @Aardvark()
     firrtl.instance test2 @Zebra()
@@ -711,8 +711,8 @@ firrtl.circuit "NLATop" {
 
 firrtl.circuit "NLATop1" {
   // expected-error @+1 {{instance path is incorrect. Expected module: "Aardvark" instead found: "Zebra"}}
-  firrtl.hierpath @nla [@NLATop1::@test, @Zebra::@test,@Aardvark::@test]
-  firrtl.hierpath @nla_1 [@NLATop1::@test,@Aardvark::@test_1, @Zebra]
+  firrtl.hierpath private @nla [@NLATop1::@test, @Zebra::@test,@Aardvark::@test]
+  firrtl.hierpath private @nla_1 [@NLATop1::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @NLATop1() {
     firrtl.instance test  sym @test @Aardvark()
     firrtl.instance test2 @Zebra()
@@ -737,8 +737,8 @@ firrtl.circuit "NLATop1" {
 // This should not error out. Note that there is no symbol on the %bundle. This handles a special case, when the nonlocal is applied to a subfield.
 firrtl.circuit "fallBackName" {
 
-  firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@bundle]
-  firrtl.hierpath @nla_1 [@fallBackName::@test,@Aardvark::@test_1, @Zebra]
+  firrtl.hierpath private @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@bundle]
+  firrtl.hierpath private @nla_1 [@fallBackName::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @fallBackName() {
     firrtl.instance test  sym @test @Aardvark()
     firrtl.instance test2 @Zebra()
@@ -758,7 +758,7 @@ firrtl.circuit "fallBackName" {
 
 firrtl.circuit "Foo"   {
   // expected-error @+1 {{operation with symbol: #hw.innerNameRef<@Bar::@b> was not found}}
-  firrtl.hierpath @nla_1 [@Foo::@bar, @Bar::@b]
+  firrtl.hierpath private @nla_1 [@Foo::@bar, @Bar::@b]
   firrtl.module @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [{circt.fieldID = 2 : i32, circt.nonlocal = @nla_1, three}], out %c: !firrtl.uint<1>) {
   }
   firrtl.module @Foo() {
@@ -770,9 +770,9 @@ firrtl.circuit "Foo"   {
 
 firrtl.circuit "Top"   {
  // Legal nla would be:
-//firrtl.hierpath @nla [@Top::@mid, @Mid::@leaf, @Leaf::@w]
+//firrtl.hierpath private @nla [@Top::@mid, @Mid::@leaf, @Leaf::@w]
   // expected-error @+1 {{instance path is incorrect. Expected module: "Middle" instead found: "Leaf"}}
-  firrtl.hierpath @nla [@Top::@mid, @Leaf::@w]
+  firrtl.hierpath private @nla [@Top::@mid, @Leaf::@w]
   firrtl.module @Leaf() {
     %w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla, class = "fake1"}]} : !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -66,18 +66,18 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
 // CHECK: firrtl.circuit "ExtractBlackBoxesSimple2"
 firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "firrtl.transforms.BlackBoxTargetDirAnno", targetDir = "BlackBoxes"}]} {
   // Old style NLAs
-  firrtl.hierpath @nla_old1 [@DUTModule::@mod, @BBWrapper::@bb]
-  firrtl.hierpath @nla_old2 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper::@bb]
+  firrtl.hierpath private @nla_old1 [@DUTModule::@mod, @BBWrapper::@bb]
+  firrtl.hierpath private @nla_old2 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper::@bb]
   // New style NLAs on extracted instance
-  firrtl.hierpath @nla_on1 [@DUTModule::@mod, @BBWrapper]
-  firrtl.hierpath @nla_on2 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper]
+  firrtl.hierpath private @nla_on1 [@DUTModule::@mod, @BBWrapper]
+  firrtl.hierpath private @nla_on2 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper]
   // New style NLAs through extracted instance
-  firrtl.hierpath @nla_thru1 [@BBWrapper::@bb, @MyBlackBox]
-  firrtl.hierpath @nla_thru2 [@DUTModule::@mod, @BBWrapper::@bb, @MyBlackBox]
-  firrtl.hierpath @nla_thru3 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper::@bb, @MyBlackBox]
-  // CHECK: firrtl.hierpath [[THRU1:@nla_thru1]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
-  // CHECK: firrtl.hierpath [[THRU2:@nla_thru2]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
-  // CHECK: firrtl.hierpath [[THRU3:@nla_thru3]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
+  firrtl.hierpath private @nla_thru1 [@BBWrapper::@bb, @MyBlackBox]
+  firrtl.hierpath private @nla_thru2 [@DUTModule::@mod, @BBWrapper::@bb, @MyBlackBox]
+  firrtl.hierpath private @nla_thru3 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper::@bb, @MyBlackBox]
+  // CHECK: firrtl.hierpath private [[THRU1:@nla_thru1]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
+  // CHECK: firrtl.hierpath private [[THRU2:@nla_thru2]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
+  // CHECK: firrtl.hierpath private [[THRU3:@nla_thru3]] [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
 
   // Annotation on the extmodule itself
   // CHECK-LABEL: firrtl.extmodule private @MyBlackBox
@@ -165,43 +165,43 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
 
 // CHECK: firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"
 firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
-  // CHECK-LABEL: firrtl.hierpath @nla_new_0 [
+  // CHECK-LABEL: firrtl.hierpath private @nla_new_0 [
   // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
   // CHECK-SAME:    @TestHarness::@dut
   // CHECK-SAME:    @DUTModule::@BlackBoxes
   // CHECK-SAME:    @BlackBoxes
   // CHECK-SAME:  ]
-  // CHECK-LABEL: firrtl.hierpath @nla_new_1 [
+  // CHECK-LABEL: firrtl.hierpath private @nla_new_1 [
   // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
   // CHECK-SAME:    @TestHarness::@dut
   // CHECK-SAME:    @DUTModule::@BlackBoxes
   // CHECK-SAME:    @BlackBoxes
   // CHECK-SAME:  ]
-  firrtl.hierpath @nla_new [
+  firrtl.hierpath private @nla_new [
     @ExtractBlackBoxesIntoDUTSubmodule::@tb,
     @TestHarness::@dut,
     @DUTModule::@mod,
     @BBWrapper
   ]
-  // CHECK-LABEL: firrtl.hierpath @nla_old1 [
+  // CHECK-LABEL: firrtl.hierpath private @nla_old1 [
   // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
   // CHECK-SAME:    @TestHarness::@dut
   // CHECK-SAME:    @DUTModule::@BlackBoxes
   // CHECK-SAME:    @BlackBoxes::@bb1
   // CHECK-SAME:  ]
-  firrtl.hierpath @nla_old1 [
+  firrtl.hierpath private @nla_old1 [
     @ExtractBlackBoxesIntoDUTSubmodule::@tb,
     @TestHarness::@dut,
     @DUTModule::@mod,
     @BBWrapper::@bb1
   ]
-  // CHECK-LABEL: firrtl.hierpath @nla_old2 [
+  // CHECK-LABEL: firrtl.hierpath private @nla_old2 [
   // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
   // CHECK-SAME:    @TestHarness::@dut
   // CHECK-SAME:    @DUTModule::@BlackBoxes
   // CHECK-SAME:    @BlackBoxes::@bb2
   // CHECK-SAME:  ]
-  firrtl.hierpath @nla_old2 [
+  firrtl.hierpath private @nla_old2 [
     @ExtractBlackBoxesIntoDUTSubmodule::@tb,
     @TestHarness::@dut,
     @DUTModule::@mod,
@@ -455,14 +455,14 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
 
 // CHECK: firrtl.circuit "InstSymConflict"
 firrtl.circuit "InstSymConflict" {
-  // CHECK-NOT: firrtl.hierpath @nla_1
-  // CHECK-NOT: firrtl.hierpath @nla_2
-  firrtl.hierpath @nla_1 [
+  // CHECK-NOT: firrtl.hierpath private @nla_1
+  // CHECK-NOT: firrtl.hierpath private @nla_2
+  firrtl.hierpath private @nla_1 [
     @InstSymConflict::@dut,
     @DUTModule::@mod1,
     @BBWrapper::@bb
   ]
-  firrtl.hierpath @nla_2 [
+  firrtl.hierpath private @nla_2 [
     @InstSymConflict::@dut,
     @DUTModule::@mod2,
     @BBWrapper::@bb

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -279,11 +279,11 @@ firrtl.circuit "MainWithNLA" attributes {
     }
   ]} {
   // Starting from DUT
-  firrtl.hierpath @nla_dut_rel [@DUT::@l, @Leaf::@w]
+  firrtl.hierpath private @nla_dut_rel [@DUT::@l, @Leaf::@w]
   // Not through DUT, describes multiple paths
-  firrtl.hierpath @nla_segment [@Mid::@l, @Leaf::@in]
+  firrtl.hierpath private @nla_segment [@Mid::@l, @Leaf::@in]
   // Top to leaf, through the DUT
-  firrtl.hierpath @nla_top_thru_dut_to_w [@MainWithNLA::@dut, @DUT::@m, @Mid::@l, @Leaf::@w]
+  firrtl.hierpath private @nla_top_thru_dut_to_w [@MainWithNLA::@dut, @DUT::@m, @Mid::@l, @Leaf::@w]
   firrtl.module private @Leaf(
     in %in: !firrtl.uint<1> sym @in [{
       circt.nonlocal = @nla_segment,
@@ -473,11 +473,11 @@ firrtl.circuit "MainWithnewNLA" attributes {
     }
   ]} {
   // Starting from DUT
-  firrtl.hierpath @nla_dut_rel [@DUT::@l, @Leaf]
+  firrtl.hierpath private @nla_dut_rel [@DUT::@l, @Leaf]
   // Not through DUT, describes multiple paths
-  firrtl.hierpath @nla_segment [@Mid::@l, @Leaf]
+  firrtl.hierpath private @nla_segment [@Mid::@l, @Leaf]
   // Top to leaf, through the DUT
-  firrtl.hierpath @nla_top_thru_dut_to_w [@MainWithnewNLA::@dut, @DUT::@m, @Mid::@l, @Leaf]
+  firrtl.hierpath private @nla_top_thru_dut_to_w [@MainWithnewNLA::@dut, @DUT::@m, @Mid::@l, @Leaf]
   firrtl.module private @Leaf(
     in %in: !firrtl.uint<1> [{
       circt.nonlocal = @nla_segment,

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -349,9 +349,9 @@ firrtl.circuit "NLAGarbageCollection" {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
   // CHECK-NOT: @nla_3
-  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
-  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
-  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
+  firrtl.hierpath private @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
+  firrtl.hierpath private @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
+  firrtl.hierpath private @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
   firrtl.module private @Submodule(
     in %port: !firrtl.uint<1> sym @port [
       {circt.nonlocal = @nla_2,
@@ -435,8 +435,8 @@ firrtl.circuit "NLAGarbageCollection" {
 firrtl.circuit "NLAUsedInWiring"  {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
-  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
-  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
+  firrtl.hierpath private @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
+  firrtl.hierpath private @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
 
   // CHECK-LABEL: firrtl.module private @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
@@ -506,8 +506,8 @@ firrtl.circuit "NLAUsedInWiring"  {
 // See https://github.com/llvm/circt/issues/2767.
 
 firrtl.circuit "Top" {
-  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
-  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule::@bar_0]
+  firrtl.hierpath private @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
+  firrtl.hierpath private @nla [@DUT::@submodule_2, @Submodule::@bar_0]
   firrtl.module private @Submodule(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -952,10 +952,10 @@ firrtl.circuit "DedupedPath" attributes {
      name = "View"}]} {
   // TODO: Remove @nla_0 and @nla once NLAs are fully migrated to use hierpaths
   // that end at the module.
-  firrtl.hierpath @nla_0 [@DUT::@tile1, @Tile::@w]
-  firrtl.hierpath @nla [@DUT::@tile2, @Tile::@w]
-  firrtl.hierpath @nla_new_0 [@DUT::@tile1, @Tile]
-  firrtl.hierpath @nla_new_1 [@DUT::@tile2, @Tile]
+  firrtl.hierpath private @nla_0 [@DUT::@tile1, @Tile::@w]
+  firrtl.hierpath private @nla [@DUT::@tile2, @Tile::@w]
+  firrtl.hierpath private @nla_new_0 [@DUT::@tile1, @Tile]
+  firrtl.hierpath private @nla_new_1 [@DUT::@tile2, @Tile]
   firrtl.module private @Tile() {
     %w = firrtl.wire sym @w {
       annotations = [

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -28,26 +28,26 @@ firrtl.circuit "NLARenaming" attributes {
   } {
   // An NLA that is rooted at the DUT moves to the wrapper.
   //
-  // CHECK:      firrtl.hierpath @nla_DUTRoot [@Foo::@sub, @Sub::@a]
-  firrtl.hierpath @nla_DUTRoot [@DUT::@sub, @Sub::@a]
+  // CHECK:      firrtl.hierpath private @nla_DUTRoot [@Foo::@sub, @Sub::@a]
+  firrtl.hierpath private @nla_DUTRoot [@DUT::@sub, @Sub::@a]
 
   // NLAs that end at the DUT or a DUT port are unmodified.
   //
-  // CHECK-NEXT: firrtl.hierpath @[[nla_DUTLeafModule_clone:.+]] [@NLARenaming::@dut, @DUT]
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafModule [@NLARenaming::@dut, @DUT::@Foo, @Foo]
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
-  firrtl.hierpath @nla_DUTLeafModule [@NLARenaming::@dut, @DUT]
-  firrtl.hierpath @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
+  // CHECK-NEXT: firrtl.hierpath private @[[nla_DUTLeafModule_clone:.+]] [@NLARenaming::@dut, @DUT]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafModule [@NLARenaming::@dut, @DUT::@Foo, @Foo]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
+  firrtl.hierpath private @nla_DUTLeafModule [@NLARenaming::@dut, @DUT]
+  firrtl.hierpath private @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
 
   // NLAs that end inside the DUT get an extra level of hierarchy.
   //
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@w]
-  firrtl.hierpath @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@w]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@w]
+  firrtl.hierpath private @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@w]
 
   // An NLA that passes through the DUT gets an extra level of hierarchy.
   //
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@sub, @Sub]
-  firrtl.hierpath @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@sub, @Sub]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@sub, @Sub]
+  firrtl.hierpath private @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@sub, @Sub]
   firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
     %a = firrtl.wire sym @a : !firrtl.uint<1>
   }
@@ -82,31 +82,31 @@ firrtl.circuit "NLARenamingNewNLAs" attributes {
   } {
   // An NLA that is rooted at the DUT moves to the wrapper.
   //
-  // CHECK:      firrtl.hierpath @nla_DUTRoot [@Foo::@sub, @Sub]
-  // CHECK:      firrtl.hierpath @nla_DUTRootRef [@Foo::@sub, @Sub::@a]
-  firrtl.hierpath @nla_DUTRoot [@DUT::@sub, @Sub]
-  firrtl.hierpath @nla_DUTRootRef [@DUT::@sub, @Sub::@a]
+  // CHECK:      firrtl.hierpath private @nla_DUTRoot [@Foo::@sub, @Sub]
+  // CHECK:      firrtl.hierpath private @nla_DUTRootRef [@Foo::@sub, @Sub::@a]
+  firrtl.hierpath private @nla_DUTRoot [@DUT::@sub, @Sub]
+  firrtl.hierpath private @nla_DUTRootRef [@DUT::@sub, @Sub::@a]
 
   // NLAs that end at the DUT or a DUT port are unmodified.  These should not be
   // cloned unless they have users.
   //
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafModule[[_:.+]] [@NLARenamingNewNLAs::@dut, @DUT]
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafModule [@NLARenamingNewNLAs::@dut, @DUT::@Foo, @Foo]
-  // CHECK-NEXT: firrtl.hierpath @[[nla_DUTLeafPort_clone:.+]] [@NLARenamingNewNLAs::@dut, @DUT]
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafPort [@NLARenamingNewNLAs::@dut, @DUT::@Foo, @Foo]
-  firrtl.hierpath @nla_DUTLeafModule [@NLARenamingNewNLAs::@dut, @DUT]
-  firrtl.hierpath @nla_DUTLeafPort [@NLARenamingNewNLAs::@dut, @DUT]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafModule[[_:.+]] [@NLARenamingNewNLAs::@dut, @DUT]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafModule [@NLARenamingNewNLAs::@dut, @DUT::@Foo, @Foo]
+  // CHECK-NEXT: firrtl.hierpath private @[[nla_DUTLeafPort_clone:.+]] [@NLARenamingNewNLAs::@dut, @DUT]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafPort [@NLARenamingNewNLAs::@dut, @DUT::@Foo, @Foo]
+  firrtl.hierpath private @nla_DUTLeafModule [@NLARenamingNewNLAs::@dut, @DUT]
+  firrtl.hierpath private @nla_DUTLeafPort [@NLARenamingNewNLAs::@dut, @DUT]
 
   // NLAs that end at the DUT are moved to a cloned path.  NLAs that end inside
   // the DUT keep the old path symbol which gets the added hierarchy.
   //
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTLeafWire [@NLARenamingNewNLAs::@dut, @DUT::@[[inst_sym:.+]], @Foo]
-  firrtl.hierpath @nla_DUTLeafWire [@NLARenamingNewNLAs::@dut, @DUT]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTLeafWire [@NLARenamingNewNLAs::@dut, @DUT::@[[inst_sym:.+]], @Foo]
+  firrtl.hierpath private @nla_DUTLeafWire [@NLARenamingNewNLAs::@dut, @DUT]
 
   // An NLA that passes through the DUT gets an extra level of hierarchy.
   //
-  // CHECK-NEXT: firrtl.hierpath @nla_DUTPassthrough [@NLARenamingNewNLAs::@dut, @DUT::@[[inst_sym]], @Foo::@sub, @Sub]
-  firrtl.hierpath @nla_DUTPassthrough [@NLARenamingNewNLAs::@dut, @DUT::@sub, @Sub]
+  // CHECK-NEXT: firrtl.hierpath private @nla_DUTPassthrough [@NLARenamingNewNLAs::@dut, @DUT::@[[inst_sym]], @Foo::@sub, @Sub]
+  firrtl.hierpath private @nla_DUTPassthrough [@NLARenamingNewNLAs::@dut, @DUT::@sub, @Sub]
   firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
     %a = firrtl.wire sym @a : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -300,17 +300,17 @@ sv.verbatim "hello"
 //
 // CHECK-LABEL: firrtl.circuit "NLAInlining"
 firrtl.circuit "NLAInlining" {
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@NLAInlining::@bar, @Bar]
-  // CHECK-NEXT: firrtl.hierpath @nla2 [@NLAInlining::@bar, @Bar::@a]
-  // CHECK-NEXT: firrtl.hierpath @nla3 [@NLAInlining::@bar, @Bar::@port]
-  // CHECK-NOT:  firrtl.hierpath @nla4
-  // CHECK-NOT:  firrtl.hierpath @nla5
-  firrtl.hierpath @nla1 [@NLAInlining::@foo, @Foo::@bar, @Bar]
-  firrtl.hierpath @nla2 [@NLAInlining::@foo, @Foo::@bar, @Bar::@a]
-  firrtl.hierpath @nla3 [@NLAInlining::@foo, @Foo::@bar, @Bar::@port]
-  firrtl.hierpath @nla4 [@NLAInlining::@foo, @Foo]
-  firrtl.hierpath @nla5 [@NLAInlining::@foo, @Foo::@b]
-  firrtl.hierpath @nla6 [@NLAInlining::@foo, @Foo::@port]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@NLAInlining::@bar, @Bar]
+  // CHECK-NEXT: firrtl.hierpath private @nla2 [@NLAInlining::@bar, @Bar::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla3 [@NLAInlining::@bar, @Bar::@port]
+  // CHECK-NOT:  firrtl.hierpath private @nla4
+  // CHECK-NOT:  firrtl.hierpath private @nla5
+  firrtl.hierpath private @nla1 [@NLAInlining::@foo, @Foo::@bar, @Bar]
+  firrtl.hierpath private @nla2 [@NLAInlining::@foo, @Foo::@bar, @Bar::@a]
+  firrtl.hierpath private @nla3 [@NLAInlining::@foo, @Foo::@bar, @Bar::@port]
+  firrtl.hierpath private @nla4 [@NLAInlining::@foo, @Foo]
+  firrtl.hierpath private @nla5 [@NLAInlining::@foo, @Foo::@b]
+  firrtl.hierpath private @nla6 [@NLAInlining::@foo, @Foo::@port]
   // CHECK-NEXT: firrtl.module private @Bar
   // CHECK-SAME: %port: {{.+}} sym @port [{circt.nonlocal = @nla3, class = "nla3"}]
   // CHECK-SAME: [{circt.nonlocal = @nla1, class = "nla1"}]
@@ -339,12 +339,12 @@ firrtl.circuit "NLAInlining" {
 //
 // CHECK-LABEL: firrtl.circuit "NLAInliningNotMainRoot"
 firrtl.circuit "NLAInliningNotMainRoot" {
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@NLAInliningNotMainRoot::@baz, @Baz::@a]
-  // CHECK-NEXT: firrtl.hierpath @nla1_0 [@Foo::@baz, @Baz::@a]
-  // CHECK-NEXT: firrtl.hierpath @nla2 [@NLAInliningNotMainRoot::@baz, @Baz::@port]
-  // CHECK-NEXT: firrtl.hierpath @nla2_0 [@Foo::@baz, @Baz::@port]
-  firrtl.hierpath @nla1 [@Bar::@baz, @Baz::@a]
-  firrtl.hierpath @nla2 [@Bar::@baz, @Baz::@port]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@NLAInliningNotMainRoot::@baz, @Baz::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla1_0 [@Foo::@baz, @Baz::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla2 [@NLAInliningNotMainRoot::@baz, @Baz::@port]
+  // CHECK-NEXT: firrtl.hierpath private @nla2_0 [@Foo::@baz, @Baz::@port]
+  firrtl.hierpath private @nla1 [@Bar::@baz, @Baz::@a]
+  firrtl.hierpath private @nla2 [@Bar::@baz, @Baz::@port]
   // CHECK: firrtl.module private @Baz
   // CHECK-SAME: %port: {{.+}} [{circt.nonlocal = @nla2, class = "nla2"}, {circt.nonlocal = @nla2_0, class = "nla2"}]
   firrtl.module private @Baz(
@@ -381,14 +381,14 @@ firrtl.circuit "NLAInliningNotMainRoot" {
 //
 // CHECK-LABEL: firrtl.circuit "NLAFlattening"
 firrtl.circuit "NLAFlattening" {
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@NLAFlattening::@foo, @Foo::@a]
-  // CHECK-NEXT: firrtl.hierpath @nla2 [@NLAFlattening::@foo, @Foo::@port]
-  // CHECK-NOT:  firrtl.hierpath @nla3
-  // CHECK-NOT:  firrtl.hierpath @nla4
-  firrtl.hierpath @nla1 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@a]
-  firrtl.hierpath @nla2 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@port]
-  firrtl.hierpath @nla3 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz]
-  firrtl.hierpath @nla4 [@Foo::@bar, @Bar::@b]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@NLAFlattening::@foo, @Foo::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla2 [@NLAFlattening::@foo, @Foo::@port]
+  // CHECK-NOT:  firrtl.hierpath private @nla3
+  // CHECK-NOT:  firrtl.hierpath private @nla4
+  firrtl.hierpath private @nla1 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@a]
+  firrtl.hierpath private @nla2 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@port]
+  firrtl.hierpath private @nla3 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz]
+  firrtl.hierpath private @nla4 [@Foo::@bar, @Bar::@b]
   firrtl.module @Baz(
     in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla2, class = "nla2"}]
   ) attributes {annotations = [{circt.nonlocal = @nla3, class = "nla3"}]} {
@@ -422,14 +422,14 @@ firrtl.circuit "NLAFlattening" {
 //
 // CHECK-LABEL: firrtl.circuit "NLAFlatteningChildRoot"
 firrtl.circuit "NLAFlatteningChildRoot" {
-  // CHECK-NOT:  firrtl.hierpath @nla1
-  // CHECK-NOT:  firrtl.hierpath @nla2
-  // CHECK-NEXT: firrtl.hierpath @nla3 [@Baz::@quz, @Quz::@b]
-  // CHECK-NEXT: firrtl.hierpath @nla4 [@Baz::@quz, @Quz::@Quz_port]
-  firrtl.hierpath @nla1 [@Bar::@qux, @Qux::@a]
-  firrtl.hierpath @nla2 [@Bar::@qux, @Qux::@Qux_port]
-  firrtl.hierpath @nla3 [@Baz::@quz, @Quz::@b]
-  firrtl.hierpath @nla4 [@Baz::@quz, @Quz::@Quz_port]
+  // CHECK-NOT:  firrtl.hierpath private @nla1
+  // CHECK-NOT:  firrtl.hierpath private @nla2
+  // CHECK-NEXT: firrtl.hierpath private @nla3 [@Baz::@quz, @Quz::@b]
+  // CHECK-NEXT: firrtl.hierpath private @nla4 [@Baz::@quz, @Quz::@Quz_port]
+  firrtl.hierpath private @nla1 [@Bar::@qux, @Qux::@a]
+  firrtl.hierpath private @nla2 [@Bar::@qux, @Qux::@Qux_port]
+  firrtl.hierpath private @nla3 [@Baz::@quz, @Quz::@b]
+  firrtl.hierpath private @nla4 [@Baz::@quz, @Quz::@Quz_port]
   // CHECK: firrtl.module private @Quz
   // CHECK-SAME: in %port: {{.+}} [{circt.nonlocal = @nla4, class = "nla4"}]
   firrtl.module private @Quz(
@@ -473,8 +473,8 @@ firrtl.circuit "NLAFlatteningChildRoot" {
 //
 // CHECK-LABEL: CollidingSymbols
 firrtl.circuit "CollidingSymbols" {
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@CollidingSymbols::@[[FoobarSym:[_a-zA-Z0-9]+]], @Bar]
-  firrtl.hierpath @nla1 [@CollidingSymbols::@foo, @Foo::@bar, @Bar]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@CollidingSymbols::@[[FoobarSym:[_a-zA-Z0-9]+]], @Bar]
+  firrtl.hierpath private @nla1 [@CollidingSymbols::@foo, @Foo::@bar, @Bar]
   firrtl.module @Bar() attributes {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]} {}
   firrtl.module @Foo() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %b = firrtl.wire sym @b : !firrtl.uint<1>
@@ -498,8 +498,8 @@ firrtl.circuit "CollidingSymbols" {
 //
 // CHECK-LABEL: CollidingSymbolsPort
 firrtl.circuit "CollidingSymbolsPort" {
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@CollidingSymbolsPort::@foo, @Foo::@[[BarbSym:[_a-zA-Z0-9]+]]]
-  firrtl.hierpath @nla1 [@CollidingSymbolsPort::@foo, @Foo::@bar, @Bar::@b]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@CollidingSymbolsPort::@foo, @Foo::@[[BarbSym:[_a-zA-Z0-9]+]]]
+  firrtl.hierpath private @nla1 [@CollidingSymbolsPort::@foo, @Foo::@bar, @Bar::@b]
   // CHECK-NOT: firrtl.module private @Bar
   firrtl.module private @Bar(
     in %b: !firrtl.uint<1> sym @b [{circt.nonlocal = @nla1, class = "nla1"}]
@@ -528,9 +528,9 @@ firrtl.circuit "CollidingSymbolsPort" {
 firrtl.circuit "CollidingSymbolsReTop" {
   // CHECK-NOT:  #hw.innerNameRef<@CollidingSymbolsReTop::@baz>
   // CHECK-NOT:  #hw.innerNameRef<@Foo::@baz>
-  // CHECK-NEXT: firrtl.hierpath @nla1 [@CollidingSymbolsReTop::@[[TopbazSym:[_a-zA-Z0-9]+]], @Baz::@a]
-  // CHECK-NEXT: firrtl.hierpath @nla1_0 [@Foo::@[[FoobazSym:[_a-zA-Z0-9]+]], @Baz::@a]
-  firrtl.hierpath @nla1 [@Bar::@baz, @Baz::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla1 [@CollidingSymbolsReTop::@[[TopbazSym:[_a-zA-Z0-9]+]], @Baz::@a]
+  // CHECK-NEXT: firrtl.hierpath private @nla1_0 [@Foo::@[[FoobazSym:[_a-zA-Z0-9]+]], @Baz::@a]
+  firrtl.hierpath private @nla1 [@Bar::@baz, @Baz::@a]
   // CHECK: firrtl.module @Baz
   firrtl.module @Baz() {
     // CHECK-NEXT: firrtl.wire {{.+}} [{circt.nonlocal = @nla1, class = "hello"}, {circt.nonlocal = @nla1_0, class = "hello"}]
@@ -561,11 +561,11 @@ firrtl.circuit "CollidingSymbolsReTop" {
 // instance inlined should be renamed, and it should *not* update the NLA.
 // CHECK-LABEL: firrtl.circuit "CollidingSymbolsNLAFixup"
 firrtl.circuit "CollidingSymbolsNLAFixup" {
-  // CHECK: firrtl.hierpath @nla0 [@Foo::@bar, @Bar::@io]
-  firrtl.hierpath @nla0 [@Foo::@bar, @Bar::@baz0, @Baz::@io]
+  // CHECK: firrtl.hierpath private @nla0 [@Foo::@bar, @Bar::@io]
+  firrtl.hierpath private @nla0 [@Foo::@bar, @Bar::@baz0, @Baz::@io]
 
-  // CHECK: firrtl.hierpath @nla1 [@Foo::@bar, @Bar::@w]
-  firrtl.hierpath @nla1 [@Foo::@bar, @Bar::@baz0, @Baz::@w]
+  // CHECK: firrtl.hierpath private @nla1 [@Foo::@bar, @Bar::@w]
+  firrtl.hierpath private @nla1 [@Foo::@bar, @Bar::@baz0, @Baz::@w]
 
   firrtl.module @Baz(out %io: !firrtl.uint<1> sym @io [{circt.nonlocal = @nla0, class = "test"}])
        attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
@@ -612,8 +612,8 @@ firrtl.circuit "RenameAnything" {
 // corresponds to the original NLA path.
 // CHECK-LABEL: firrtl.circuit "AnnotationSplit0"
 firrtl.circuit "AnnotationSplit0" {
-firrtl.hierpath @nla_5560 [@Bar0::@leaf, @Leaf::@w]
-firrtl.hierpath @nla_5561 [@Bar1::@leaf, @Leaf::@w]
+firrtl.hierpath private @nla_5560 [@Bar0::@leaf, @Leaf::@w]
+firrtl.hierpath private @nla_5561 [@Bar1::@leaf, @Leaf::@w]
 firrtl.module @Leaf() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %w = firrtl.wire sym @w {annotations = [
     {circt.nonlocal = @nla_5560, class = "test0"},
@@ -640,8 +640,8 @@ firrtl.module @AnnotationSplit0() {
 // above in that the annotation does not become a regular local annotation.
 // CHECK-LABEL: firrtl.circuit "AnnotationSplit1"
 firrtl.circuit "AnnotationSplit1" {
-firrtl.hierpath @nla_5560 [@AnnotationSplit1::@bar0, @Bar0::@leaf, @Leaf::@w]
-firrtl.hierpath @nla_5561 [@AnnotationSplit1::@bar1, @Bar1::@leaf, @Leaf::@w]
+firrtl.hierpath private @nla_5560 [@AnnotationSplit1::@bar0, @Bar0::@leaf, @Leaf::@w]
+firrtl.hierpath private @nla_5561 [@AnnotationSplit1::@bar1, @Bar1::@leaf, @Leaf::@w]
 firrtl.module @Leaf() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %w = firrtl.wire sym @w {annotations = [
     {circt.nonlocal = @nla_5560, class = "test0"},
@@ -667,10 +667,10 @@ firrtl.module @AnnotationSplit1() {
 // https://github.com/llvm/circt/issues/3307
 firrtl.circuit "Inline"  {
   // CHECK: firrtl.circuit "Inline"
-  firrtl.hierpath @nla_2 [@Inline::@bar, @Bar::@i]
-  firrtl.hierpath @nla_1 [@Inline::@foo, @Foo::@bar, @Bar::@i]
-  // CHECK:   firrtl.hierpath @nla_2 [@Inline::@bar, @Bar::@i]
-  // CHECK:   firrtl.hierpath @nla_1 [@Inline::@[[bar_0:.+]], @Bar::@i]
+  firrtl.hierpath private @nla_2 [@Inline::@bar, @Bar::@i]
+  firrtl.hierpath private @nla_1 [@Inline::@foo, @Foo::@bar, @Bar::@i]
+  // CHECK:   firrtl.hierpath private @nla_2 [@Inline::@bar, @Bar::@i]
+  // CHECK:   firrtl.hierpath private @nla_1 [@Inline::@[[bar_0:.+]], @Bar::@i]
   firrtl.module @Inline(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
     %foo_i, %foo_o = firrtl.instance foo sym @foo  @Foo(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     // CHECK:  = firrtl.instance foo_bar sym @[[bar_0]]  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
@@ -692,8 +692,8 @@ firrtl.circuit "Inline"  {
 
 firrtl.circuit "Inline2"  {
   // CHECK-LABEL firrtl.circuit "Inline2"
-  firrtl.hierpath @nla_1 [@Inline2::@foo, @Foo::@bar, @Bar::@i]
-  // CHECK:  firrtl.hierpath @nla_1 [@Inline2::@[[bar_0:.+]], @Bar::@i]
+  firrtl.hierpath private @nla_1 [@Inline2::@foo, @Foo::@bar, @Bar::@i]
+  // CHECK:  firrtl.hierpath private @nla_1 [@Inline2::@[[bar_0:.+]], @Bar::@i]
   firrtl.module @Inline2(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
     %foo_i, %foo_o = firrtl.instance foo sym @foo  @Foo(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     %bar = firrtl.wire sym @bar  : !firrtl.uint<1>
@@ -714,10 +714,10 @@ firrtl.circuit "Inline2"  {
 
 // CHECK-LABEL: firrtl.circuit "Issue3334"
 firrtl.circuit "Issue3334" {
-  // CHECK: firrtl.hierpath @path_component_old
-  // CHECK: firrtl.hierpath @path_component_new
-  firrtl.hierpath @path_component_old [@Issue3334::@foo, @Foo::@bar1, @Bar::@b]
-  firrtl.hierpath @path_component_new [@Issue3334::@foo, @Foo::@bar1, @Bar]
+  // CHECK: firrtl.hierpath private @path_component_old
+  // CHECK: firrtl.hierpath private @path_component_new
+  firrtl.hierpath private @path_component_old [@Issue3334::@foo, @Foo::@bar1, @Bar::@b]
+  firrtl.hierpath private @path_component_new [@Issue3334::@foo, @Foo::@bar1, @Bar]
   firrtl.module private @Bar() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %b = firrtl.wire sym @b {annotations = [
       {circt.nonlocal = @path_component_old, "path_component_old"},
@@ -735,10 +735,10 @@ firrtl.circuit "Issue3334" {
 
 // CHECK-LABEL: firrtl.circuit "Issue3334_flatten"
 firrtl.circuit "Issue3334_flatten" {
-  // CHECK: firrtl.hierpath @path_component_old
-  // CHECK: firrtl.hierpath @path_component_new
-  firrtl.hierpath @path_component_old [@Issue3334_flatten::@foo, @Foo::@bar1, @Bar::@b]
-  firrtl.hierpath @path_component_new [@Issue3334_flatten::@foo, @Foo::@bar1, @Bar]
+  // CHECK: firrtl.hierpath private @path_component_old
+  // CHECK: firrtl.hierpath private @path_component_new
+  firrtl.hierpath private @path_component_old [@Issue3334_flatten::@foo, @Foo::@bar1, @Bar::@b]
+  firrtl.hierpath private @path_component_new [@Issue3334_flatten::@foo, @Foo::@bar1, @Bar]
   firrtl.module private @Bar() {
     %b = firrtl.wire sym @b {annotations = [
       {circt.nonlocal = @path_component_old, "path_component_old"},
@@ -755,10 +755,10 @@ firrtl.circuit "Issue3334_flatten" {
 }
 
 firrtl.circuit "instNameRename"  {
-  firrtl.hierpath @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1]
-  // CHECK:  firrtl.hierpath @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1]
-  firrtl.hierpath @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1]
-  // CHECK:  firrtl.hierpath @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1]
+  firrtl.hierpath private @nla_5560 [@instNameRename::@bar0, @Bar0::@w, @Bar2::@w, @Bar1]
+  // CHECK:  firrtl.hierpath private @nla_5560 [@instNameRename::@[[w_1:.+]], @Bar2::@w, @Bar1]
+  firrtl.hierpath private @nla_5560_1 [@instNameRename::@bar1, @Bar0::@w, @Bar2::@w, @Bar1]
+  // CHECK:  firrtl.hierpath private @nla_5560_1 [@instNameRename::@[[w_2:.+]], @Bar2::@w, @Bar1]
   firrtl.module @Bar1() {
     %w = firrtl.wire   {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}, {circt.nonlocal = @nla_5560_1, class = "test1"}]} : !firrtl.uint<8>
   }
@@ -783,10 +783,10 @@ firrtl.circuit "instNameRename"  {
 // but only two of them should have valid HierPathOps.
 firrtl.circuit "CollidingSymbolsMultiInline" {
 
-  firrtl.hierpath @nla1 [@Foo1::@bar1, @Foo2::@bar, @Foo::@bar, @Bar::@w, @Baz::@w]
-  // CHECK: firrtl.hierpath @nla1 [@Foo1::@w_0, @Baz::@w]
-  firrtl.hierpath @nla2 [@Foo1::@bar2, @Foo2::@bar1, @Foo::@bar, @Bar::@w, @Baz::@w]
-  // CHECK:  firrtl.hierpath @nla2 [@Foo1::@w_7, @Baz::@w]
+  firrtl.hierpath private @nla1 [@Foo1::@bar1, @Foo2::@bar, @Foo::@bar, @Bar::@w, @Baz::@w]
+  // CHECK: firrtl.hierpath private @nla1 [@Foo1::@w_0, @Baz::@w]
+  firrtl.hierpath private @nla2 [@Foo1::@bar2, @Foo2::@bar1, @Foo::@bar, @Bar::@w, @Baz::@w]
+  // CHECK:  firrtl.hierpath private @nla2 [@Foo1::@w_7, @Baz::@w]
 
   firrtl.module @Baz(out %io: !firrtl.uint<1> )
         {

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -240,10 +240,10 @@ firrtl.module @Annotations() attributes {annotations = [{class = "sifive.enterpr
 // CHECK-LABEL: firrtl.circuit "NonLocalAnnotation"
 firrtl.circuit "NonLocalAnnotation" {
 
-// CHECK:  firrtl.hierpath @[[nla_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem0, @mem0]
-firrtl.hierpath @nla0 [@NonLocalAnnotation::@dut, @DUT::@mem0]
-// CHECK:  firrtl.hierpath @[[nla_1:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem1, @mem1]
-firrtl.hierpath @nla1 [@NonLocalAnnotation::@dut, @DUT]
+// CHECK:  firrtl.hierpath private @[[nla_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem0, @mem0]
+firrtl.hierpath private @nla0 [@NonLocalAnnotation::@dut, @DUT::@mem0]
+// CHECK:  firrtl.hierpath private @[[nla_1:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem1, @mem1]
+firrtl.hierpath private @nla1 [@NonLocalAnnotation::@dut, @DUT]
 
 // CHECK: firrtl.module @NonLocalAnnotation()
 firrtl.module @NonLocalAnnotation()  {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1067,7 +1067,7 @@ firrtl.circuit "DontTouch" {
 
 // Check that we don't create symbols for non-local annotations.
 firrtl.circuit "Foo"  {
-  firrtl.hierpath @nla [@Foo::@bar, @Bar]
+  firrtl.hierpath private @nla [@Foo::@bar, @Bar]
   // CHECK:       firrtl.module private @Bar(in %a_b:
   // CHECK-SAME:    !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.module private @Bar(in %a: !firrtl.bundle<b: uint<1>>

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -243,10 +243,10 @@ firrtl.circuit "NLA" attributes {annotations = [
   {class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}
 ]} {
   // The hierachical paths are unchanged.
-  // CHECK:      firrtl.hierpath @path_old [@NLA::@foo, @Foo::@old]
-  // CHECK-NEXT: firrtl.hierpath @path_new [@NLA::@foo, @Foo]
-  firrtl.hierpath @path_old [@NLA::@foo, @Foo::@old]
-  firrtl.hierpath @path_new [@NLA::@foo, @Foo]
+  // CHECK:      firrtl.hierpath private @path_old [@NLA::@foo, @Foo::@old]
+  // CHECK-NEXT: firrtl.hierpath private @path_new [@NLA::@foo, @Foo]
+  firrtl.hierpath private @path_old [@NLA::@foo, @Foo::@old]
+  firrtl.hierpath private @path_new [@NLA::@foo, @Foo]
   firrtl.module private @Foo() {
     // CHECK:      %old = firrtl.reg sym @old
     // CHECK-SAME:   {circt.nonlocal = @path, class = "oldNLA"}

--- a/test/Dialect/FIRRTL/omir.mlir
+++ b/test/Dialect/FIRRTL/omir.mlir
@@ -267,8 +267,8 @@ firrtl.circuit "Foo"  attributes {rawAnnotations = [
 // CHECK-SAME:    e = {{{[^{}]+}} value = {id = [[eID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = {{"OM[a-zA-Z]+"}}
 // CHECK-SAME:    f = {{{[^{}]+}} value = {id = [[fID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = {{"OM[a-zA-Z]+"}}
 // CHECK-SAME:    g = {{{[^{}]+}} value = {id = [[gID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = {{"OM[a-zA-Z]+"}}
-// CHECK:       firrtl.hierpath @[[Foo_cC_C:nla[_0-9]*]]
-// CHECK-NEXT:  firrtl.hierpath @[[Foo_eE_E:nla[_0-9]*]]
+// CHECK:       firrtl.hierpath private @[[Foo_cC_C:nla[_0-9]*]]
+// CHECK-NEXT:  firrtl.hierpath private @[[Foo_eE_E:nla[_0-9]*]]
 // CHECK:       firrtl.module private @C
 // CHECK-SAME:    {circt.nonlocal = @[[Foo_cC_C]], class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[cID]] : i64}
 // CHECK:       firrtl.module private @D

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -205,10 +205,10 @@ firrtl.circuit "GCTInterfacePrefix"
 // CHECK: firrtl.circuit "T_NLATop"
 firrtl.circuit "NLATop" {
 
-  firrtl.hierpath @nla [@NLATop::@test, @Aardvark::@test, @Zebra]
-  firrtl.hierpath @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
-  // CHECK: firrtl.hierpath @nla [@T_NLATop::@test, @T_Aardvark::@test, @T_A_Z_Zebra]
-  // CHECK: firrtl.hierpath @nla_1 [@T_NLATop::@test, @T_Aardvark::@test_1, @T_A_Z_Zebra]
+  firrtl.hierpath private @nla [@NLATop::@test, @Aardvark::@test, @Zebra]
+  firrtl.hierpath private @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
+  // CHECK: firrtl.hierpath private @nla [@T_NLATop::@test, @T_Aardvark::@test, @T_A_Z_Zebra]
+  // CHECK: firrtl.hierpath private @nla_1 [@T_NLATop::@test, @T_Aardvark::@test_1, @T_A_Z_Zebra]
   // CHECK: firrtl.module @T_NLATop
   firrtl.module @NLATop()
     attributes {annotations = [{
@@ -306,14 +306,14 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
 // Test the the NonLocalAnchor is properly updated.
 // CHECK-LABEL: firrtl.circuit "FixNLA" {
   firrtl.circuit "FixNLA"   {
-    firrtl.hierpath @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
-    // CHECK:   firrtl.hierpath @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
-    firrtl.hierpath @nla_2 [@FixNLA::@foo, @Foo::@bar, @Bar::@baz, @Baz::@s1]
-    // CHECK:   firrtl.hierpath @nla_2 [@FixNLA::@foo, @X_Foo::@bar, @X_Bar::@baz, @X_Baz::@s1]
-    firrtl.hierpath @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
-    // CHECK:   firrtl.hierpath @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
-    firrtl.hierpath @nla_4 [@Foo::@bar, @Bar::@baz, @Baz]
-    // CHECK:       firrtl.hierpath @nla_4 [@X_Foo::@bar, @X_Bar::@baz, @X_Baz]
+    firrtl.hierpath private @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    // CHECK:   firrtl.hierpath private @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    firrtl.hierpath private @nla_2 [@FixNLA::@foo, @Foo::@bar, @Bar::@baz, @Baz::@s1]
+    // CHECK:   firrtl.hierpath private @nla_2 [@FixNLA::@foo, @X_Foo::@bar, @X_Bar::@baz, @X_Baz::@s1]
+    firrtl.hierpath private @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    // CHECK:   firrtl.hierpath private @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    firrtl.hierpath private @nla_4 [@Foo::@bar, @Bar::@baz, @Baz]
+    // CHECK:       firrtl.hierpath private @nla_4 [@X_Foo::@bar, @X_Bar::@baz, @X_Baz]
     // CHECK-LABEL: firrtl.module @FixNLA()
     firrtl.module @FixNLA() {
       firrtl.instance foo sym @foo  @Foo()
@@ -349,10 +349,10 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
 
 // Test that NonLocalAnchors are properly updated with memmodules.
 firrtl.circuit "Test"   {
-  // CHECK: firrtl.hierpath @nla_1 [@Test::@foo1, @A_Foo1::@bar, @A_Bar]
-  firrtl.hierpath @nla_1 [@Test::@foo1, @Foo1::@bar, @Bar]
-  // CHECK: firrtl.hierpath @nla_2 [@Test::@foo2, @B_Foo2::@bar, @B_Bar]
-  firrtl.hierpath @nla_2 [@Test::@foo2, @Foo2::@bar, @Bar]
+  // CHECK: firrtl.hierpath private @nla_1 [@Test::@foo1, @A_Foo1::@bar, @A_Bar]
+  firrtl.hierpath private @nla_1 [@Test::@foo1, @Foo1::@bar, @Bar]
+  // CHECK: firrtl.hierpath private @nla_2 [@Test::@foo2, @B_Foo2::@bar, @B_Bar]
+  firrtl.hierpath private @nla_2 [@Test::@foo2, @Foo2::@bar, @Bar]
 
   firrtl.module @Test() {
     firrtl.instance foo1 sym @foo1 @Foo1()

--- a/test/Dialect/FIRRTL/print-nla-table.mlir
+++ b/test/Dialect/FIRRTL/print-nla-table.mlir
@@ -6,9 +6,9 @@
 // CHECK: FooL:
 
 firrtl.circuit "FooNL"  {
-  firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL]
-  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
+  firrtl.hierpath private @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+  firrtl.hierpath private @nla_0 [@FooNL::@baz, @BazNL]
+  firrtl.hierpath private @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 
   firrtl.module @BarNL() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.test", nl = "nl"}]} {
     %w2 = firrtl.wire sym @w2  {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -154,8 +154,8 @@ firrtl.module @TestInvalidAttr() {
 }
 
 // Basic test for NLA operations.
-// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child]
-firrtl.hierpath @nla [@Parent::@child, @Child]
+// CHECK: firrtl.hierpath private @nla [@Parent::@child, @Child]
+firrtl.hierpath private @nla [@Parent::@child, @Child]
 firrtl.module @Child() {
   %w = firrtl.wire sym @w : !firrtl.uint<1>
 }


### PR DESCRIPTION
Tidy up visibility printing for hierpath's.

Before:
```
firrtl.hierpath @nla_361 [@Top::@inst, ...] {sym_visibility = "private"}
```

After:
```
firrtl.hierpath private @nla_361 [@Top::@inst, ...]
```

Update tests (first those required, rest for consistency).

Follow-up to #3871 .