### PR TITLE
[FIRRTL][LowerXMR] Donot emit 0-width XMR

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -140,8 +140,11 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // same reaching RefSend. This condition is true for upward scoped
             // XMRs. That is, RefResolveOp can be visited before the
             // corresponding RefSendOp is recorded.
-            dataFlowClasses.unionSets(resolve.getRef(), resolve.getResult());
-            resolveOps.push_back(resolve);
+            // Donot emit 0 width XMRs
+            if (resolve.getType().getBitWidthOrSentinel()) {
+              dataFlowClasses.unionSets(resolve.getRef(), resolve.getResult());
+              resolveOps.push_back(resolve);
+            }
             markForRemoval(resolve);
             return success();
           })

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -3,10 +3,13 @@
 // Test for same module lowering
 // CHECK-LABEL: firrtl.circuit "xmr"
 firrtl.circuit "xmr" {
-  firrtl.module @xmr(out %o: !firrtl.uint<2>) {
+  // CHECK-LABEL: firrtl.module @xmr(out %o: !firrtl.uint<2>)
+  firrtl.module @xmr(out %o: !firrtl.uint<2>, in %2: !firrtl.ref<uint<0>>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
     %x = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
+    %x2 = firrtl.ref.resolve %2 : !firrtl.ref<uint<0>>
+    // CHECK-NOT: %x2 = firrtl.ref.resolve %2 : !firrtl.ref<uint<0>>
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:  %w = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
     // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<2> {symbols = [@xmr, #hw.innerNameRef<@xmr::@xmr_sym>]}


### PR DESCRIPTION
Ignore any `RefType` of zero width, and donot emit any XMR. 