### PR TITLE
[hlstool][lit] Change outdated flags in integration tests

### DIFF
--- a/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
+++ b/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s \

--- a/integration_test/Dialect/Handshake/buffer_initial_values/buffer_initial_values.mlir
+++ b/integration_test/Dialect/Handshake/buffer_initial_values/buffer_initial_values.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_initial_values --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s \

--- a/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
+++ b/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/dot/dot.mlir
+++ b/integration_test/Dialect/Handshake/dot/dot.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=dot --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/matmul/matmul.mlir
+++ b/integration_test/Dialect/Handshake/matmul/matmul.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=matmul --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/max/max.mlir
+++ b/integration_test/Dialect/Handshake/max/max.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=max --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
+++ b/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
+++ b/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
@@ -2,11 +2,8 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: circt-opt %s --insert-merge-blocks --lower-std-to-handshake \
-// RUN:   --canonicalize='top-down=true region-simplify=true' \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: circt-opt %s --insert-merge-blocks | \
+// RUN: hlstool --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --insert-merge-blocks --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
+++ b/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/sync_op/sync_op.mlir
+++ b/integration_test/Dialect/Handshake/sync_op/sync_op.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=sync_op --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s \

--- a/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
+++ b/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
+++ b/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s --lower-std-to-handshake \

--- a/integration_test/Dialect/Handshake/tuple_input/tuple_input.mlir
+++ b/integration_test/Dialect/Handshake/tuple_input/tuple_input.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_input --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s \

--- a/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
+++ b/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
@@ -2,7 +2,7 @@
 
 // This test is executed with all different buffering strategies
 
-// RUN: hlstool %s --dynamic --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --ir-input-level 1 --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // RUN: circt-opt %s \


### PR DESCRIPTION
Changing the flag from `--dynamic` to `--dynamic-firrtl` was overlooked. 