### PR TITLE
[HandshakeToHW] Cache RTLBuilder constants

### DIFF
--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -451,7 +451,14 @@ struct RTLBuilder {
       : b(builder), loc(loc), clk(clk), rst(rst) {}
 
   Value constant(unsigned width, int64_t value, Location *extLoc = nullptr) {
-    return b.create<hw::ConstantOp>(getLoc(extLoc), APInt(width, value));
+    APInt apv = APInt(width, value);
+    auto it = constants.find(apv);
+    if (it != constants.end())
+      return it->second;
+
+    auto cval = b.create<hw::ConstantOp>(getLoc(extLoc), apv);
+    constants[apv] = cval;
+    return cval;
   }
   std::pair<Value, Value> wrap(Value data, Value valid,
                                Location *extLoc = nullptr) {
@@ -493,7 +500,8 @@ struct RTLBuilder {
 
   // Bitwise 'not'.
   Value bNot(Value value, Location *extLoc = nullptr) {
-    return comb::createOrFoldNot(getLoc(extLoc), value, b);
+    auto allOnes = constant(value.getType().getIntOrFloatBitWidth(), -1);
+    return b.createOrFold<comb::XorOp>(loc, value, allOnes, false);
   }
 
   Value shl(Value value, Value shift, Location *extLoc = nullptr) {
@@ -560,6 +568,7 @@ struct RTLBuilder {
   OpBuilder &b;
   Location loc;
   Value clk, rst;
+  DenseMap<APInt, Value> constants;
 };
 
 static void

--- a/test/Conversion/HandshakeToHW/test_sync.mlir
+++ b/test/Conversion/HandshakeToHW/test_sync.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_sync_in_ui32_out_ui32(
-// CHECK-SAME:      %[[VAL_0:.*]]: !esi.channel<none>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<i32>) {
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<none>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<i32>) {
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : none
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.wrap.vr %[[VAL_4]], %[[VAL_11:.*]] : none
@@ -13,21 +13,18 @@
 // CHECK:           %[[VAL_19:.*]] = comb.xor %[[VAL_16]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_20:.*]] = comb.and %[[VAL_21:.*]], %[[VAL_19]] : i1
 // CHECK:           %[[VAL_22:.*]] = seq.compreg %[[VAL_20]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
-// CHECK:           %[[VAL_23:.*]] = hw.constant true
-// CHECK:           %[[VAL_24:.*]] = comb.xor %[[VAL_22]], %[[VAL_23]] : i1
-// CHECK:           %[[VAL_11]] = comb.and %[[VAL_24]], %[[VAL_15]] : i1
-// CHECK:           %[[VAL_25:.*]] = comb.and %[[VAL_10]], %[[VAL_15]] : i1
-// CHECK:           %[[VAL_21]] = comb.and %[[VAL_25]], %[[VAL_22]] : i1
-// CHECK:           %[[VAL_26:.*]] = hw.constant true
-// CHECK:           %[[VAL_27:.*]] = comb.xor %[[VAL_16]], %[[VAL_26]] : i1
-// CHECK:           %[[VAL_28:.*]] = comb.and %[[VAL_29:.*]], %[[VAL_27]] : i1
-// CHECK:           %[[VAL_30:.*]] = seq.compreg %[[VAL_28]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
-// CHECK:           %[[VAL_31:.*]] = hw.constant true
-// CHECK:           %[[VAL_32:.*]] = comb.xor %[[VAL_30]], %[[VAL_31]] : i1
-// CHECK:           %[[VAL_14]] = comb.and %[[VAL_32]], %[[VAL_15]] : i1
-// CHECK:           %[[VAL_33:.*]] = comb.and %[[VAL_13]], %[[VAL_15]] : i1
-// CHECK:           %[[VAL_29]] = comb.and %[[VAL_33]], %[[VAL_30]] : i1
-// CHECK:           %[[VAL_16]] = comb.and %[[VAL_21]], %[[VAL_29]] : i1
+// CHECK:           %[[VAL_23:.*]] = comb.xor %[[VAL_22]], %[[VAL_18]] : i1
+// CHECK:           %[[VAL_11]] = comb.and %[[VAL_23]], %[[VAL_15]] : i1
+// CHECK:           %[[VAL_24:.*]] = comb.and %[[VAL_10]], %[[VAL_15]] : i1
+// CHECK:           %[[VAL_21]] = comb.and %[[VAL_24]], %[[VAL_22]] : i1
+// CHECK:           %[[VAL_25:.*]] = comb.xor %[[VAL_16]], %[[VAL_18]] : i1
+// CHECK:           %[[VAL_26:.*]] = comb.and %[[VAL_27:.*]], %[[VAL_25]] : i1
+// CHECK:           %[[VAL_28:.*]] = seq.compreg %[[VAL_26]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_29:.*]] = comb.xor %[[VAL_28]], %[[VAL_18]] : i1
+// CHECK:           %[[VAL_14]] = comb.and %[[VAL_29]], %[[VAL_15]] : i1
+// CHECK:           %[[VAL_30:.*]] = comb.and %[[VAL_13]], %[[VAL_15]] : i1
+// CHECK:           %[[VAL_27]] = comb.and %[[VAL_30]], %[[VAL_28]] : i1
+// CHECK:           %[[VAL_16]] = comb.and %[[VAL_21]], %[[VAL_27]] : i1
 // CHECK:           hw.output %[[VAL_9]], %[[VAL_12]] : !esi.channel<none>, !esi.channel<i32>
 // CHECK:         }
 


### PR DESCRIPTION
Main side effect of this is to reduce the size of the generated IR without having to run the canonicalizer. This, in turn, is easier to write a test against and reason about.