### PR TITLE
[FIRRTL][LowerXMR] Handle 0-width XMRs

### DIFF
--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -50,12 +50,21 @@ firrtl.circuit "Top" {
 // Test 0-width xmrs are handled
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>) {
+  firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>, in %bar_b : !firrtl.ref<vector<uint<0>,10>>) {
     %a = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<0>>
     // CHECK:  %0 = firrtl.wire   : !firrtl.uint<0>
+    // CHECK:  %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+    // CHECK:  firrtl.connect %0, %c0_ui0 : !firrtl.uint<0>, !firrtl.uint<0>
     firrtl.strictconnect %a, %0 : !firrtl.uint<0>
     // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<0>
+    %b = firrtl.wire : !firrtl.vector<uint<0>,10>
+    %1 = firrtl.ref.resolve %bar_b : !firrtl.ref<vector<uint<0>,10>>
+    firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>,10>
+		// CHECK:	%c0_ui0_0 = firrtl.constant 0 : !firrtl.uint<0>
+    // CHECK:  %2 = firrtl.bitcast %c0_ui0_0 : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
+    // CHECK:  firrtl.connect %1, %2 : !firrtl.vector<uint<0>, 10>, !firrtl.vector<uint<0>, 10>
+    // CHECK:  firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>, 10>
   }
 }
 

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -47,6 +47,20 @@ firrtl.circuit "Top" {
 
 // -----
 
+// Test 0-width xmrs are handled
+// CHECK-LABEL: firrtl.circuit "Top" {
+firrtl.circuit "Top" {
+  firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>) {
+    %a = firrtl.wire : !firrtl.uint<0>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<0>>
+    // CHECK:  %0 = firrtl.wire   : !firrtl.uint<0>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<0>
+    // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<0>
+  }
+}
+
+// -----
+
 // Test the correct xmr path to port is generated
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -53,14 +53,14 @@ firrtl.circuit "Top" {
   firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>, in %bar_b : !firrtl.ref<vector<uint<0>,10>>) {
     %a = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<0>>
-    // CHECK:  %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+    // CHECK:  %[[c0_ui0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
     firrtl.strictconnect %a, %0 : !firrtl.uint<0>
-    // CHECK:  firrtl.strictconnect %a, %c0_ui0 : !firrtl.uint<0>
+    // CHECK:  firrtl.strictconnect %a, %[[c0_ui0]] : !firrtl.uint<0>
     %b = firrtl.wire : !firrtl.vector<uint<0>,10>
     %1 = firrtl.ref.resolve %bar_b : !firrtl.ref<vector<uint<0>,10>>
     firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>,10>
-		// CHECK:	%c0_ui0_0 = firrtl.constant 0 : !firrtl.uint<0>
-    // CHECK:  %[[v2:.+]] = firrtl.bitcast %c0_ui0_0 : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
+    // CHECK:	%[[c0_ui0_0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
+    // CHECK:  %[[v2:.+]] = firrtl.bitcast %[[c0_ui0_0]] : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
     // CHECK:  firrtl.strictconnect %b, %[[v2]] : !firrtl.vector<uint<0>, 10>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -53,18 +53,15 @@ firrtl.circuit "Top" {
   firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>, in %bar_b : !firrtl.ref<vector<uint<0>,10>>) {
     %a = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<0>>
-    // CHECK:  %0 = firrtl.wire   : !firrtl.uint<0>
     // CHECK:  %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
-    // CHECK:  firrtl.connect %0, %c0_ui0 : !firrtl.uint<0>, !firrtl.uint<0>
     firrtl.strictconnect %a, %0 : !firrtl.uint<0>
-    // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<0>
+    // CHECK:  firrtl.strictconnect %a, %c0_ui0 : !firrtl.uint<0>
     %b = firrtl.wire : !firrtl.vector<uint<0>,10>
     %1 = firrtl.ref.resolve %bar_b : !firrtl.ref<vector<uint<0>,10>>
     firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>,10>
 		// CHECK:	%c0_ui0_0 = firrtl.constant 0 : !firrtl.uint<0>
-    // CHECK:  %2 = firrtl.bitcast %c0_ui0_0 : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
-    // CHECK:  firrtl.connect %1, %2 : !firrtl.vector<uint<0>, 10>, !firrtl.vector<uint<0>, 10>
-    // CHECK:  firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>, 10>
+    // CHECK:  %[[v2:.+]] = firrtl.bitcast %c0_ui0_0 : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
+    // CHECK:  firrtl.strictconnect %b, %[[v2]] : !firrtl.vector<uint<0>, 10>
   }
 }
 


### PR DESCRIPTION
Update `LowerXMR` to generate temporary 0-width wires, for 0-width `RefType`. The 0-width wire will be eliminated by `LowerToHW`.
This updates the last fix, https://github.com/llvm/circt/pull/3944, that just ignored the zero width `RefResolve`, this creates a problem when the result of the `RefResolve` is used by other operations.
Instead of dealing with all the users of the result of `RefResolve`, `LowerXMR` replaces them with a zero-width wire and relies on `LowerToHW` to eliminate them.