### PR TITLE
[FIRRTL] InferWidths of memory debug port

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1509,7 +1509,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         for (unsigned i = 0, e = op.getResults().size(); i < e; ++i) {
           auto result = op.getResult(i);
           if (result.getType().cast<FIRRTLType>().isa<RefType>()) {
-            // Debug ports are firrtl.ref<vector<data-type>, depth>
+            // Debug ports are firrtl.ref<vector<data-type, depth>>
             // Use FieldRef of 1, to indicate the first vector element must be
             // of the dataType.
             unifyTypes(firstData, FieldRef(result, 1), dataType);

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1469,7 +1469,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       .Case<MemOp>([&](MemOp op) {
         // Create constraint variables for all ports.
         unsigned nonDebugPort = 0;
-        for (auto result : llvm::enumerate(op.getResults())) {
+        for (const auto &result : llvm::enumerate(op.getResults())) {
           declareVars(result.value(), op.getLoc());
           if (!result.value().getType().cast<FIRRTLType>().isa<RefType>())
             nonDebugPort = result.index();

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -715,17 +715,20 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @MemScalar
   // CHECK-SAME: out %out: !firrtl.uint<7>
-  firrtl.module @MemScalar(out %out: !firrtl.uint) {
+  // CHECK-SAME: out %dbg: !firrtl.ref<vector<uint<7>, 8>>
+  firrtl.module @MemScalar(out %out: !firrtl.uint, out %dbg: !firrtl.ref<vector<uint, 8>>) {
     // CHECK: firrtl.mem
+    // CHECK-SAME: !firrtl.ref<vector<uint<7>, 8>>
     // CHECK-SAME: data flip: uint<7>
     // CHECK-SAME: data: uint<7>
     // CHECK-SAME: data: uint<7>
-    %m_p0, %m_p1, %m_p2 = firrtl.mem Undefined {
+    %m_dbg, %m_p0, %m_p1, %m_p2 = firrtl.mem Undefined {
       depth = 8 : i64,
       name = "m",
-      portNames = ["p0", "p1", "p2"],
+      portNames = ["dbg", "p0", "p1", "p2"],
       readLatency = 0 : i32,
       writeLatency = 1 : i32} :
+      !firrtl.ref<vector<uint, 8>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint, mask: uint<1>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint, wmode: uint<1>, wdata: uint, wmask: uint<1>>
@@ -737,6 +740,8 @@ firrtl.circuit "Foo" {
     firrtl.connect %m_p1_data, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
     firrtl.connect %m_p2_wdata, %c0_ui7 : !firrtl.uint, !firrtl.uint<7>
     firrtl.connect %out, %m_p0_data : !firrtl.uint, !firrtl.uint
+    firrtl.connect %dbg, %m_dbg : !firrtl.ref<vector<uint, 8>>, !firrtl.ref<vector<uint, 8>>
+    // CHECK:  firrtl.connect %dbg, %m_dbg : !firrtl.ref<vector<uint<7>, 8>>, !firrtl.ref<vector<uint<7>, 8>>
   }
 
   // CHECK-LABEL: @MemBundle


### PR DESCRIPTION
Handle the memory debug ports in `InferWidths` pass.
The debug port must be a `firrtl.ref` of a `firrtl.vector` of the data type.