### PR TITLE
[FIRRTL][CheckCombCycles] Ignore register self initialization connects

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -361,16 +361,14 @@ public:
           if (isa_and_nonnull<MemOp>(subfield.getInput().getDefiningOp()))
             return static_cast<variant_iterator>(
                 SubfieldNodeIterator(subfield, node, end));
-          // This is required to explicitly ignore self initialization connects
-          // for registers.
+          // This is required to explicitly ignore self loops of register.
           if (isa_and_nonnull<RegOp, RegResetOp>(
                   getFieldRefFromValue(subfield).getDefiningOp()))
             return static_cast<variant_iterator>(NodeIterator(node, true));
           return static_cast<variant_iterator>(NodeIterator(node, end));
         })
         .Case<SubindexOp>([&](SubindexOp sub) {
-          // This is required to explicitly ignore self initialization connects
-          // for registers.
+          // This is required to explicitly ignore self loops of register.
           if (isa_and_nonnull<RegOp, RegResetOp>(
                   getFieldRefFromValue(sub).getDefiningOp()))
             return NodeIterator(node, true);

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -176,3 +176,23 @@ firrtl.circuit "strictConnectAndConnect" {
     firrtl.strictconnect %b, %a : !firrtl.uint<11>
   }
 }
+
+// -----
+
+firrtl.circuit "vectorRegInit"   {
+  firrtl.module @vectorRegInit(in %clk: !firrtl.clock) {
+    %reg = firrtl.reg %clk : !firrtl.vector<uint<8>, 2>
+    %0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<8>, 2>
+    firrtl.connect %0, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+firrtl.circuit "bundleRegInit"   {
+  firrtl.module @bundleRegInit(in %clk: !firrtl.clock) {
+    %reg = firrtl.reg %clk : !firrtl.bundle<a: uint<1>>
+    %0 = firrtl.subfield %reg(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
CheckCombCycles should handle register self initialization connects properly. It should not error out on self initialization of individual fields of an aggregate kind of register.