### PR TITLE
[hlstool] Add DHLS parallelism selection

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -217,7 +217,8 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createHandshakeAnalysisPass();
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
-createStandardToHandshakePass();
+createStandardToHandshakePass(bool sourceConstants = false,
+                              bool disableTaskPipelining = false);
 
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeCanonicalizePass();

--- a/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
+++ b/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
@@ -12,11 +12,7 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST

--- a/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
+++ b/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
@@ -12,11 +12,7 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST

--- a/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
+++ b/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
@@ -15,11 +15,7 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST

--- a/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
+++ b/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
@@ -12,11 +12,8 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST

--- a/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
+++ b/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
@@ -12,11 +12,7 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST

--- a/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
+++ b/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
@@ -12,11 +12,7 @@
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
-// RUN: circt-opt %s --lower-std-to-handshake=disable-task-pipelining \
-// RUN:   --canonicalize='top-down=true region-simplify=true' --handshake-lock-functions \
-// RUN:   --handshake-materialize-forks-sinks --canonicalize \
-// RUN:   --handshake-insert-buffers=strategy=cycles --lower-handshake-to-firrtl | \
-// RUN: firtool --format=mlir --verilog --lowering-options=disallowLocalVariables > %t.sv && \
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
 // RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1902,6 +1902,10 @@ struct HandshakeRemoveBlockPass
 
 struct StandardToHandshakePass
     : public StandardToHandshakeBase<StandardToHandshakePass> {
+  StandardToHandshakePass(bool sourceConstants, bool disableTaskPipelining) {
+    this->sourceConstants = sourceConstants;
+    this->disableTaskPipelining = disableTaskPipelining;
+  }
   void runOnOperation() override {
     ModuleOp m = getOperation();
 
@@ -1926,8 +1930,10 @@ struct StandardToHandshakePass
 } // namespace
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
-circt::createStandardToHandshakePass() {
-  return std::make_unique<StandardToHandshakePass>();
+circt::createStandardToHandshakePass(bool sourceConstants,
+                                     bool disableTaskPipelining) {
+  return std::make_unique<StandardToHandshakePass>(sourceConstants,
+                                                   disableTaskPipelining);
 }
 
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -117,12 +117,17 @@ enum DynamicParallelismKind {
 
 static cl::opt<DynamicParallelismKind> dynParallelism(
     "dynamic-parallelism", cl::desc("Specify the DHLS task parallelism kind"),
-    cl::values(clEnumValN(DynamicParallelismNone, "none",
-                          "Add no protetion mechanisms"),
-               clEnumValN(DynamicParallelismLocking, "locking",
-                          "Add function locking protection mechanism"),
-               clEnumValN(DynamicParallelismPipelining, "pipelining",
-                          "Add function pipelining mechanism")),
+    cl::values(
+        clEnumValN(DynamicParallelismNone, "none",
+                   "Add no protection mechanisms that could prevent data races "
+                   "when a function has multiple active invocations."),
+        clEnumValN(DynamicParallelismLocking, "locking",
+                   "Add function locking protection mechanism which ensures "
+                   "that only one function invocation is active."),
+        clEnumValN(DynamicParallelismPipelining, "pipelining",
+                   "Add function pipelining mechanism that enables a "
+                   "pipelined execution of multiple function invocations while "
+                   "preserving correctness.")),
     cl::init(DynamicParallelismPipelining));
 
 enum OutputFormatKind { OutputIR, OutputVerilog };


### PR DESCRIPTION
This PR adds a flag to `hlstool` that allows selecting the kind of parallelism to support. Currently, these options are "pipelining", "locking", and "none".