### PR TITLE
[Seq] `seq.hlmem` ODS and rationale

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -13,9 +13,6 @@ intention of the `seq` dialect is to provide a set of stateful constructs
 which can be used to model sequential logic, independent of the output method
 (e.g. SystemVerilog).
 
-We have yet to flesh this dialect out to represent all common stateful
-components. We start with a register and will build from there.
-
 ## Definitions
 
 For the sake of precision, we use the following definitions:
@@ -217,3 +214,99 @@ information.
 - Initial value: this register is uninitialized. Using an uninitialized value
 results in undefined behavior. We will add an `initialValue` attribute if
 this proves insufficient.
+
+## The High-Level Memory Abstraction
+The  `seq.hlmem` (high-level memory operation) intends to capture the semantics
+of a memory which eventually map to some form on-chip resources - whether being
+FPGA or ASIC-based.
+The abstraction aims to abstract away the physical implementation details of the
+memory, and instead focus on the external interface and access semantics of the
+memory. this, in turn, facilitates analysis and transformation (e.g. memory
+merging, read/write conflicts, merging, etc.) and may serve as a target for
+other high-level abstractions.
+
+The high-level memory abstraction is split into two parts:
+* Memory *allocation* is defined by the `seq.hlmem` operation. This operation defines
+the inner workings of the memory. This includes:
+  - number of read/write ports
+  - read/write latency
+  - Memory size and inner data type
+  The `seq.hlmem` will define references to the read- and write ports of the
+  allocated memory.
+- Memory *access* is defined by separate operations which unwraps a memory port reference
+to its structural components. Port access operations are defined at the same
+level of abstraction as the core RTL dialects and  contain no notion of control
+flow.
+
+Example usage:
+```mlir
+  %read0, %write0 = seq.hlmem @myMemory %clk {
+    NReadPorts = 1 : i32,
+    NWritePorts = 1 : i32,
+    readLatency = 0 : i32,
+    writeLatency = 1 : i32} : !hw.array<4xi32>
+  
+  %c0_i2 = hw.constant 0 : i2
+  %c42_i32 = hw.constant 42 : i32
+  %out = seq.read %read0[%c0_i2] : !seq.read_port<<4xi32>>
+  seq.write %write0[%c0_i2] %c42_i32 : !seq.write_port<<4xi32>>
+```
+
+Lowering the op is intended to be performed by matching on the `seq.hlmem`,
+collecting the port ops which access the defined port references, and based on this
+perform a lowering to an appropriate memory structure. This memory
+could either be behavioral (able to support any combination of memory allocation
+and port accesses) or specialized (e.g. specifically target FPGA resources,
+call a memory compiler, ... which may only be possible for a subset of 
+allocation and access combinations).
+
+### Rationale
+
+The high-level memory abstraction, as presented here, represents a useful
+albeit limited abstraction when considering the complexity of instantiating
+memory resources in both FPGAs and ASICs.
+
+Some restrictions that were considered in designing this op were:
+1. The op allocates a single 1D array, specified by a `!hw.array` type. This is
+also reflected in the accompanying read- and write port ops in that they
+only take a single address index. This restriction has been made to reduce
+the complexity of lowering the op, as well as motivated by the expectation that
+most target architectures will not be able to natively support multidimensional
+memories (i.e. multidimensional memories would be flattened to 1D arrays during
+synthesis).
+2. A port reference can only be unwrapped once. This is to maintain the
+notion that port access ops provide structural access to the memory port. Thus,
+if a given port is expected to be used from multiple sites, it is the job of
+the surrounding IR to arbitrate that port.
+
+
+### Future considerations
+
+#### **Port refinements**
+
+The main design descision of `seq.hlmem` is the choice of abstracting away
+the structural details of a port into separate ops of which we currently
+only provide rudimentary read- and write ops.
+Example future ports could be:
+
+* **Assymetric port widths**
+  Specified as a new `seq.asym_read` port which defines a read data width
+  of some fraction of the native data size.
+  ```mlir
+  %rdata = seq.asym_read %rp[%addr] : !seq.read_port<4xi32> -> i16
+  ```
+  which would then put different typing requirements on the `%addr` signal.
+  Given the halfing of the word size, the expected address type would then
+  be `ceil(log2(4)) << 1 = i3`
+* **Byte-enable write ports**
+  Specified as a new `seq.write_be` port with an additional byte enable
+  signal.
+  ```mlir
+  %wdata = seq.write_be %wp[%addr] %wdata, %be : i32, i4 -> !seq.write_port<4xi32>
+  ```
+* **Debug ports**
+Could be specified as either an additional read port, or (if further
+specialization is needed) attached to the memory symbol.
+  ```mlir
+  %mem = seq.debug @myMemory : !hw.array<4xi32>
+  ```

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -6,132 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This is the top level file for the Seq dialect. It contains the one op and
-// pass. Once we add more than one, we should break it out like the other
-// dialects.
+// This is the top level file for the Seq dialect.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef SEQ_TD
 #define SEQ_TD
 
+include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/Pass/PassBase.td"
 
-def SeqDialect : Dialect {
-  let name = "seq";
-
-  let summary = "Types and operations for seq dialect";
-  let description = [{
-    The `seq` dialect is intended to model digital sequential logic.
-  }];
-
-  let hasConstantMaterializer = 1;
-  let cppNamespace = "::circt::seq";
-}
-
-// Base class for the operation in this dialect.
-class SeqOp<string mnemonic, list<Trait> traits = []> :
-    Op<SeqDialect, mnemonic, traits>;
-
-def CompRegOp : SeqOp<"compreg",
-    [Pure, AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
-     SameVariadicOperandSize,
-     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
-       // AllTypesMatch doesn't work with Optional types yet.
-
-  let summary = "Register a value, storing it for one cycle";
-  let description = "See the Seq dialect rationale for a longer description";
-
-  let arguments = (ins AnyType:$input, I1:$clk, StrAttr:$name,
-    Optional<I1>:$reset, Optional<AnyType>:$resetValue,
-    OptionalAttr<SymbolNameAttr>:$sym_name);
-  let results = (outs AnyType:$data);
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
-
-  let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$clk, "StringRef":$sym_name), [{
-      return build($_builder, $_state, input.getType(),
-                   input, clk, sym_name, Value(), Value(),
-                   StringAttr::get($_builder.getContext(), sym_name));
-    }]>,
-    OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$rst,
-                   "Value":$rstValue, "StringRef":$sym_name), [{
-      return build($_builder, $_state, input.getType(),
-                   input, clk, sym_name, rst, rstValue,
-                   StringAttr::get($_builder.getContext(), sym_name));
-    }]>,
-  ];
-}
-
-def FirRegOp : SeqOp<"firreg",
-    [Pure, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
-     SameVariadicOperandSize, MemoryEffects<[MemWrite, MemRead, MemAlloc]>,
-     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
-      // AllTypesMatch doesn't work with Optional types yet.
-
-  let summary = "Register with preset and sync or async reset";
-  let description = [{
-    `firreg` represents registers originating from FIRRTL after the lowering
-    of the IR to HW.  The register is used as an intermediary in the process
-    of lowering to SystemVerilog to facilitate optimisation at the HW level,
-    compactly representing a register with a single operation instead of
-    composing it from register definitions, always blocks and if statements.
-
-    The `data` output of the register accesses the value it stores.  On the
-    rising edge of the `clk` input, the register takes a new value provided
-    by the `next` signal.  Optionally, the register can also be provided with
-    a synchronous or an asynchronous `reset` signal and `resetValue`, as shown
-    in the example below.
-
-    ```
-    %name = seq.firreg %next clock %clk [ sym @sym ]
-        [ reset (sync|async) %reset, %value ] : type
-    ```
-
-    Implicitly, all registers are pre-set to a randomized value.
-
-    A register implementing a counter starting at 0 from reset can be defined
-    as follows:
-
-    ```
-    %zero = hw.constant 0 : i32
-    %reg = seq.firreg %next clock %clk reset sync %reset, %zero : i32
-    %one = hw.constant 1 : i32
-    %next = comb.add %reg, %one : i32
-    ```
-  }];
-
-  let arguments = (ins AnyType:$next, I1:$clk, StrAttr:$name,
-                       OptionalAttr<SymbolNameAttr>:$inner_sym,
-                       Optional<I1>:$reset, Optional<AnyType>:$resetValue,
-                       UnitAttr:$isAsync);
-  let results = (outs AnyType:$data);
-
-  let skipDefaultBuilders = 1;
-  let hasCanonicalizeMethod = true;
-  let hasFolder = true;
-  let builders = [
-    OpBuilder<(ins "Value":$next, "Value":$clk,
-                   "StringAttr":$name,
-                   CArg<"StringAttr", "{}">:$inner_sym)>,
-    OpBuilder<(ins "Value":$next, "Value":$clk,
-                   "StringAttr":$name,
-                   "Value":$reset, "Value":$resetValue,
-                   CArg<"StringAttr", "{}">:$inner_sym,
-                   CArg<"bool", "false">:$isAsync)>
-  ];
-
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-    /// Check whether the register has a reset value.
-    bool hasReset() { return !!getReset(); }
-  }];
-}
+include "circt/Dialect/Seq/SeqDialect.td"
+include "circt/Dialect/Seq/SeqTypes.td"
+include "circt/Dialect/Seq/SeqOps.td"
 
 #endif // SEQ_TD

--- a/include/circt/Dialect/Seq/SeqDialect.td
+++ b/include/circt/Dialect/Seq/SeqDialect.td
@@ -1,0 +1,34 @@
+//===- SeqDialect.td - Seq dialect definition --------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains the SeqDialect definition to be included in other files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SEQ_SEQDIALECT
+#define CIRCT_DIALECT_SEQ_SEQDIALECT
+
+def SeqDialect : Dialect {
+  let name = "seq";
+
+  let summary = "Types and operations for seq dialect";
+  let description = [{
+    The `seq` dialect is intended to model digital sequential logic.
+  }];
+
+  let hasConstantMaterializer = 1;
+  let useDefaultTypePrinterParser = 1;
+  let cppNamespace = "::circt::seq";
+
+  let extraClassDeclaration = [{
+    /// Register all Seq types.
+    void registerTypes();
+  }];
+}
+
+#endif // CIRCT_DIALECT_SEQ_SEQDIALECT

--- a/include/circt/Dialect/Seq/SeqOps.h
+++ b/include/circt/Dialect/Seq/SeqOps.h
@@ -13,9 +13,13 @@
 #ifndef CIRCT_DIALECT_SEQ_SEQOPS_H
 #define CIRCT_DIALECT_SEQ_SEQOPS_H
 
-#include "circt/Dialect/Seq/SeqDialect.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Seq/Seq.h.inc"

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -1,0 +1,159 @@
+//===- Seq.td - Seq dialect definition ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the top level file for the Seq dialect. It contains the one op and
+// pass. Once we add more than one, we should break it out like the other
+// dialects.
+//
+//===----------------------------------------------------------------------===//
+
+include "circt/Dialect/HW/HWTypes.td"
+
+// Base class for the operation in this dialect.
+class SeqOp<string mnemonic, list<Trait> traits = []> :
+    Op<SeqDialect, mnemonic, traits>;
+
+def CompRegOp : SeqOp<"compreg",
+    [Pure, AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
+     SameVariadicOperandSize,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
+       // AllTypesMatch doesn't work with Optional types yet.
+
+  let summary = "Register a value, storing it for one cycle";
+  let description = "See the Seq dialect rationale for a longer description";
+
+  let arguments = (ins AnyType:$input, I1:$clk, StrAttr:$name,
+    Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+    OptionalAttr<SymbolNameAttr>:$sym_name);
+  let results = (outs AnyType:$data);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "Value":$clk, "StringRef":$sym_name), [{
+      return build($_builder, $_state, input.getType(),
+                   input, clk, sym_name, Value(), Value(),
+                   StringAttr::get($_builder.getContext(), sym_name));
+    }]>,
+    OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$rst,
+                   "Value":$rstValue, "StringRef":$sym_name), [{
+      return build($_builder, $_state, input.getType(),
+                   input, clk, sym_name, rst, rstValue,
+                   StringAttr::get($_builder.getContext(), sym_name));
+    }]>,
+  ];
+}
+
+def FirRegOp : SeqOp<"firreg",
+    [Pure, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
+     SameVariadicOperandSize, MemoryEffects<[MemWrite, MemRead, MemAlloc]>,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+      // AllTypesMatch doesn't work with Optional types yet.
+
+  let summary = "Register with preset and sync or async reset";
+  let description = [{
+    `firreg` represents registers originating from FIRRTL after the lowering
+    of the IR to HW.  The register is used as an intermediary in the process
+    of lowering to SystemVerilog to facilitate optimisation at the HW level,
+    compactly representing a register with a single operation instead of
+    composing it from register definitions, always blocks and if statements.
+
+    The `data` output of the register accesses the value it stores.  On the
+    rising edge of the `clk` input, the register takes a new value provided
+    by the `next` signal.  Optionally, the register can also be provided with
+    a synchronous or an asynchronous `reset` signal and `resetValue`, as shown
+    in the example below.
+
+    ```
+    %name = seq.firreg %next clock %clk [ sym @sym ]
+        [ reset (sync|async) %reset, %value ] : type
+    ```
+
+    Implicitly, all registers are pre-set to a randomized value.
+
+    A register implementing a counter starting at 0 from reset can be defined
+    as follows:
+
+    ```
+    %zero = hw.constant 0 : i32
+    %reg = seq.firreg %next clock %clk reset sync %reset, %zero : i32
+    %one = hw.constant 1 : i32
+    %next = comb.add %reg, %one : i32
+    ```
+  }];
+
+  let arguments = (ins AnyType:$next, I1:$clk, StrAttr:$name,
+                       OptionalAttr<SymbolNameAttr>:$inner_sym,
+                       Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+                       UnitAttr:$isAsync);
+  let results = (outs AnyType:$data);
+
+  let skipDefaultBuilders = 1;
+  let hasCanonicalizeMethod = true;
+  let hasFolder = true;
+  let builders = [
+    OpBuilder<(ins "Value":$next, "Value":$clk,
+                   "StringAttr":$name,
+                   CArg<"StringAttr", "{}">:$inner_sym)>,
+    OpBuilder<(ins "Value":$next, "Value":$clk,
+                   "StringAttr":$name,
+                   "Value":$reset, "Value":$resetValue,
+                   CArg<"StringAttr", "{}">:$inner_sym,
+                   CArg<"bool", "false">:$isAsync)>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Check whether the register has a reset value.
+    bool hasReset() { return !!getReset(); }
+  }];
+}
+
+def HLMemOp : SeqOp<"hlmem", [
+     Symbol,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
+
+  let summary = "Instaniate a high-level memory.";
+  let description = "See the Seq dialect rationale for a longer description";
+
+  let arguments = (ins I1:$clk, SymbolNameAttr:$sym_name,
+      TypeAttrOf<ArrayType>:$memoryType,
+      ConfinedAttr<I32Attr, [IntMinValue<0>]>:$NReadPorts,
+      ConfinedAttr<I32Attr, [IntMinValue<0>]>:$NWritePorts,
+      ConfinedAttr<I32Attr, [IntMinValue<0>]>:$readLatency,
+      ConfinedAttr<I32Attr, [IntMinValue<1>]>:$writeLatency);
+  let results = (outs Variadic<AnyType>:$ports);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    // Return the 'idx'th read port of this memory.
+    Value getReadPort(unsigned idx);
+
+    // Return the 'idx'th write port of this memory.
+    Value getWritePort(unsigned idx);
+  }];
+}
+
+def ReadPortOp : SeqOp<"read", 
+  [DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Structural read access to a `!seq.read` port";
+  let arguments = (ins ReadPortType:$port, AnyType:$address);
+  let results = (outs AnyType:$readData);
+  let hasCustomAssemblyFormat = 1;
+}
+
+
+def WritePortOp : SeqOp<"write", []> {
+  let summary = "Structural write access to a `!seq.write` port";
+  let arguments = (ins WritePortType:$port, AnyType:$address, AnyType:$inData);
+  let results = (outs);
+  let hasCustomAssemblyFormat = 1;
+}

--- a/include/circt/Dialect/Seq/SeqTypes.h
+++ b/include/circt/Dialect/Seq/SeqTypes.h
@@ -1,0 +1,26 @@
+//===- SeqTypes.h - Types for the Seq dialect -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Types for the Seq dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SEQ_SEQTYPES_H
+#define CIRCT_DIALECT_SEQ_SEQTYPES_H
+
+#include "circt/Dialect/Seq/SeqDialect.h"
+
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/Seq/SeqTypes.h.inc"
+
+#endif // CIRCT_DIALECT_SEQ_SEQTYPES_H

--- a/include/circt/Dialect/Seq/SeqTypes.td
+++ b/include/circt/Dialect/Seq/SeqTypes.td
@@ -1,0 +1,39 @@
+//===- SeqTypes.td - Seq data type definitions -------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Data types for the Seq dialect.
+//
+//===----------------------------------------------------------------------===//
+
+class SeqType<string name> : TypeDef<SeqDialect, name> { }
+
+class MemoryPortType<string name, string _mnemonic> : TypeDef<SeqDialect, name # "Port"> {
+  let parameters = (ins "hw::ArrayType":$memoryType);
+  let assemblyFormat = [{
+      `<` $memoryType `>`
+  }];
+  let mnemonic = _mnemonic;
+}
+
+def ReadPortType : MemoryPortType<"Read", "read_port"> {
+  let summary = "Read port type";
+  let description = [{
+      This type represents a reference to a read port of a memory. The type
+      serves as a link between the owner of the port (the instantiated memory)
+      and the user of the port (some `seq` read port operation).
+  }];
+}
+
+def WritePortType : MemoryPortType<"Write", "write_port"> {
+  let summary = "Write port type";
+  let description = [{
+      This type represents a reference to a write port of a memory. The type
+      serves as a link between the owner of the port (the instantiated memory)
+      and the user of the port (some `seq` write port operation).
+  }];
+}

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -12,6 +12,7 @@
 add_circt_dialect_library(CIRCTSeq
   SeqDialect.cpp
   SeqOps.cpp
+  SeqTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Seq

--- a/lib/Dialect/Seq/SeqDialect.cpp
+++ b/lib/Dialect/Seq/SeqDialect.cpp
@@ -25,6 +25,8 @@ using namespace seq;
 //===----------------------------------------------------------------------===//
 
 void SeqDialect::initialize() {
+  registerTypes();
+
   // Register operations.
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/Seq/SeqTypes.cpp
+++ b/lib/Dialect/Seq/SeqTypes.cpp
@@ -1,0 +1,37 @@
+//===- SeqTypes.cpp - Seq types code defs ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation logic for Seq data types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Seq/SeqTypes.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/StorageUniquerSupport.h"
+#include "mlir/IR/Types.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace seq;
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/Seq/SeqTypes.cpp.inc"
+
+void SeqDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/Seq/SeqTypes.cpp.inc"
+      >();
+}

--- a/test/Dialect/Seq/hlmem-errors.mlir
+++ b/test/Dialect/Seq/hlmem-errors.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt %s -verify-diagnostics --split-input-file
+
+hw.module @MultipleUse(%input: i1, %clk: i1) {
+  // expected-error@+1 {{'seq.hlmem' op output port #0 has multiple uses.}}
+  %read0, %write0 = seq.hlmem @myMemory %clk {
+    NReadPorts = 1 : i32,
+    NWritePorts = 1 : i32,
+    readLatency = 0 : i32,
+    writeLatency = 1 : i32} : !hw.array<4xi32>
+  
+  %c0_i2 = hw.constant 0 : i2
+  %c42_i32 = hw.constant 42 : i32
+
+  %out0 = seq.read %read0[%c0_i2] : !seq.read_port<<4xi32>>
+  %out1 = seq.read %read0[%c0_i2] : !seq.read_port<<4xi32>>
+}

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt %s | circt-opt %s | FileCheck %s
+
+hw.module @mod(%clk : i1) -> () {
+// CHECK: %read0, %write0 = seq.hlmem @myMemory %clk {NReadPorts = 1 : i32, NWritePorts = 1 : i32, readLatency = 0 : i32, writeLatency = 1 : i32} : !hw.array<4xi32>
+  %read0, %write0 = seq.hlmem @myMemory %clk {
+    NReadPorts = 1 : i32,
+    NWritePorts = 1 : i32,
+    readLatency = 0 : i32,
+    writeLatency = 1 : i32} : !hw.array<4xi32>
+  
+  %c0_i2 = hw.constant 0 : i2
+  %c42_i32 = hw.constant 42 : i32
+
+// CHECK: %data = seq.read %read0[%c0_i2] : !seq.read_port<<4xi32>>
+  %out = seq.read %read0[%c0_i2] : !seq.read_port<<4xi32>>
+
+// CHECK: seq.write %write0[%c0_i2] %c42_i32 : !seq.write_port<<4xi32>>
+  seq.write %write0[%c0_i2] %c42_i32 : !seq.write_port<<4xi32>>
+  hw.output
+}


### PR DESCRIPTION
This commit introduces `seq.hlmem` and ops for providing structural access to the defined memory ports.
Please see the updated `RationaleSeq.md` for further info.

Edit: still trying to triage the `pure virtual method called` error that is (non-deterministically) being thrown, and not reproducible locally.