### PR TITLE
Revert "[FIRRTL] Verify FModuleLike's have unique port names."

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -51,13 +51,9 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
     return module.emitOpError("requires valid port names");
   if (portNames.size() != numPorts)
     return module.emitOpError("requires ") << numPorts << " port names";
-  SmallDenseSet<Attribute> names;
-  for (auto name : portNames.getValue()) {
-    if (!name.isa<StringAttr>())
-      return module.emitOpError("port names should all be string attributes");
-    if (!names.insert(name).second)
-      return module.emitOpError("port names should be unique");
-  }
+  if (llvm::any_of(portNames.getValue(),
+                   [](Attribute attr) { return !attr.isa<StringAttr>(); }))
+    return module.emitOpError("port names should all be string attributes");
 
   // Verify the port annotations.
   auto portAnnotations = module.getPortAnnotationsAttr();

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -192,6 +192,11 @@ firrtl.circuit "Simple" {
     // CHECK: [[OUTAC:%.+]] = hw.constant 0 : i4
     // CHECK-NEXT: hw.output [[OUTAC]] : i4
   }
+  firrtl.extmodule private @SameNamePorts(in inA: !firrtl.uint<4>,
+                                in inA: !firrtl.uint<1>,
+                                in inA: !firrtl.analog<1>,
+                                out outa: !firrtl.uint<4>,
+                                out outa: !firrtl.uint<1>)
   // CHECK-LABEL: hw.module private @ZeroWidthInstance
   firrtl.module private @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
                                    in %iB: !firrtl.uint<0>,
@@ -202,6 +207,9 @@ firrtl.circuit "Simple" {
     // CHECK: %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(inA: %iA: i4) -> (outa: i4)
     %myinst:5 = firrtl.instance myinst @ZeroWidthPorts(
       in inA: !firrtl.uint<4>, in inB: !firrtl.uint<0>, in inC: !firrtl.analog<0>, out outa: !firrtl.uint<4>, out outb: !firrtl.uint<0>)
+    // CHECK: = hw.instance "myinst" @SameNamePorts(inA: {{.+}}, inA: {{.+}}, inA: {{.+}}) -> (outa: i4, outa: i1)
+    %myinst_sameName:5 = firrtl.instance myinst @SameNamePorts(
+      in inA: !firrtl.uint<4>, in inA: !firrtl.uint<1>, in inA: !firrtl.analog<1>, out outa: !firrtl.uint<4>, out outa: !firrtl.uint<1>)
 
     // Output of the instance is fed into the input!
     firrtl.connect %myinst#0, %iA : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -81,13 +81,6 @@ firrtl.module @foo(in %a : !firrtl.uint<1>) attributes {portNames=[1 : i1]} {}
 // -----
 
 firrtl.circuit "foo" {
-// expected-error @below {{port names should be unique}}
-firrtl.module @foo(in %a : !firrtl.uint<1>, in %b: !firrtl.uint<1>) attributes {portNames=["a", "a"]} {}
-}
-
-// -----
-
-firrtl.circuit "foo" {
 // expected-error @+1 {{op requires 1 port annotations}}
 firrtl.module @foo(in %a : !firrtl.uint<1>) attributes {portAnnotations=[[], []]} {}
 }

--- a/test/Dialect/FIRRTL/lower-types-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-errors.mlir
@@ -1,7 +1,0 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-types)' %s -split-input-file -verify-diagnostics
-
-firrtl.circuit "Uniquification" {
-  // expected-error@below {{port names should be unique}}
-  firrtl.module @Uniquification(in %a: !firrtl.bundle<b: uint<1>>, in %a_b: !firrtl.uint<1>) {
-  }
-}

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -87,6 +87,13 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %out2, %3 : !firrtl.sint<64>, !firrtl.sint<64>
   }
 
+  // CHECK-LABEL: firrtl.module private @Uniquification
+  // CHECK-SAME: in %[[FLATTENED_ARG:a_b]]: [[FLATTENED_TYPE:!firrtl.uint<1>]],
+  // CHECK-NOT: %[[FLATTENED_ARG]]
+  // CHECK-SAME: in %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: {portNames = ["a_b", "a_b"]}
+  firrtl.module private @Uniquification(in %a: !firrtl.bundle<b: uint<1>>, in %a_b: !firrtl.uint<1>) {
+  }
 
   // CHECK-LABEL: firrtl.module private @Top
   firrtl.module private @Top(in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,


### PR DESCRIPTION
Reverts llvm/circt#3891, until have better fix for #3968 .

Conflicts in this way are not quite invalid FIRRTL per spec ($ vs _) and it seems to be expected to "work" in some designs.  FWIW SFC has tests for handling this sort of lowering conflict specifically.  Neither compiler does what the spec says re:"$" however which would avoid the conflict here.

These duplicate names will be resolved/legalized before verilog emission.

They should not be trusted until that point (similarly wires and regs and other namable things), and the way the conflicts are resolved should not be relied upon (at best implementation-defined behavior).

This sort of conflict is likely a problem if occurs on public/top module or extmodule-- that is, where used in contexts where the lowered names need to be reliably referenced from the outside.

Anyway until have better story for all this let's not error out.

