### PR TITLE
[HandshakeToFIRRTL] Add support for external function

### DIFF
--- a/integration_test/Dialect/Handshake/mix_std_hs/kernel.mlir
+++ b/integration_test/Dialect/Handshake/mix_std_hs/kernel.mlir
@@ -1,0 +1,25 @@
+func.func @compute(%val: i64) -> i64 {
+  %c1 = arith.constant 1 : i64
+  %shr1 = arith.shrui %val, %c1 : i64
+  %cond0 = arith.trunci %shr1 : i64 to i1
+  cf.cond_br %cond0, ^bb1, ^bb5(%val: i64)
+^bb1:
+  %c2 = arith.constant 2 : i64
+  %shr2 = arith.shrui %val, %c2 : i64
+  %cond1 = arith.trunci %shr2 : i64 to i1
+  cf.cond_br %cond1, ^bb2, ^bb3
+^bb2:
+  %t0 = arith.addi %c1, %val : i64
+  %t1 = arith.addi %c1, %t0 : i64
+  %t2 = arith.addi %c1, %t1 : i64
+  %t3 = arith.addi %c1, %t2 : i64
+  cf.br ^bb4(%t3: i64)
+^bb3:
+  %c10 = arith.constant 10 : i64
+  %t4 = arith.muli %c10, %val : i64
+  cf.br ^bb4(%t4: i64)
+^bb4(%t5: i64):
+  cf.br ^bb5(%t5: i64)
+^bb5(%res: i64):
+  return %res: i64
+}

--- a/integration_test/Dialect/Handshake/mix_std_hs/lit.local.cfg.py
+++ b/integration_test/Dialect/Handshake/mix_std_hs/lit.local.cfg.py
@@ -1,0 +1,2 @@
+config.excludes.add('kernel.mlir')
+config.excludes.add('mix_std_hs.py')

--- a/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.mlir
+++ b/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.mlir
@@ -1,0 +1,46 @@
+// REQUIRES: iverilog,cocotb
+
+// This test is executed with all different buffering strategies
+
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: hlstool %S/kernel.mlir --dynamic-firrtl --buffering-strategy=all --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder=%S %T/*.sv 2>&1 | FileCheck %s
+
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=allFIFO --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: hlstool %S/kernel.mlir --dynamic-firrtl --buffering-strategy=allFIFO --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder=%S %T/*.sv 2>&1 | FileCheck %s
+
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=cycles --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: hlstool %S/kernel.mlir --dynamic-firrtl --buffering-strategy=cycles --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder=%S %T/*.sv 2>&1 | FileCheck %s
+
+// RUN: hlstool %s --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: hlstool %S/kernel.mlir --dynamic-firrtl --buffering-strategy=all --dynamic-parallelism=locking --ir | firtool -format=mlir -o %T --split-verilog --lowering-options=disallowLocalVariables && \
+// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder=%S %T/*.sv 2>&1 | FileCheck %s
+
+// CHECK: ** TEST
+// CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
+
+!tupleType = tuple<i64,i64,i64,i64,i64,i64,i64,i64>
+
+module {
+  handshake.func @compute(i64, none) -> (i64, none)
+  handshake.func @top(%arg0: !tupleType, %arg1: none, ...) -> (!tupleType, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
+    %vals:8 = handshake.unpack %arg0 : !tupleType
+    %ctrls:8 = fork [8] %arg1 : none
+
+    %res0, %c0 = handshake.instance @compute(%vals#0, %ctrls#0) : (i64, none) -> (i64, none)
+    %res1, %c1 = handshake.instance @compute(%vals#1, %ctrls#1) : (i64, none) -> (i64, none)
+    %res2, %c2 = handshake.instance @compute(%vals#2, %ctrls#2) : (i64, none) -> (i64, none)
+    %res3, %c3 = handshake.instance @compute(%vals#3, %ctrls#3) : (i64, none) -> (i64, none)
+    %res4, %c4 = handshake.instance @compute(%vals#4, %ctrls#4) : (i64, none) -> (i64, none)
+    %res5, %c5 = handshake.instance @compute(%vals#5, %ctrls#5) : (i64, none) -> (i64, none)
+    %res6, %c6 = handshake.instance @compute(%vals#6, %ctrls#6) : (i64, none) -> (i64, none)
+    %res7, %c7 = handshake.instance @compute(%vals#7, %ctrls#7) : (i64, none) -> (i64, none)
+
+    %res = handshake.pack %res0, %res1, %res2, %res3, %res4, %res5, %res6, %res7 : !tupleType
+    %outCtrl = join %c0, %c1, %c2, %c3, %c4, %c5, %c6, %c7 : none, none, none, none, none, none, none, none
+    return %res, %outCtrl : !tupleType, none
+  }
+}
+

--- a/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.py
+++ b/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.py
@@ -1,0 +1,59 @@
+import cocotb
+from helper import initDut
+import random
+
+
+def kernel(e):
+  if (e >> 1) & 0x1:
+    if (e >> 2) & 0x1:
+      return e + 4
+    return e * 10
+  return e
+
+
+def getOutput(t):
+  return tuple(map(kernel, t))
+
+
+@cocotb.test()
+async def oneInput(dut):
+  [in0, inCtrl], [out0, outCtrl] = await initDut(dut, ["in0", "inCtrl"],
+                                                 ["out0", "outCtrl"])
+
+  inputs = [(8, 8, 4, 8, 5, 3, 1, 0)]
+  outputs = [getOutput(i) for i in inputs]
+  resCheck = cocotb.start_soon(out0.checkOutputs(outputs))
+
+  in0Send = cocotb.start_soon(in0.send(inputs[0]))
+  inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+  await in0Send
+  await inCtrlSend
+
+  await resCheck
+
+
+def randomTuple():
+  return tuple([random.randint(0, 100) for _ in range(8)])
+
+
+@cocotb.test()
+async def multipleInputs(dut):
+  [in0, inCtrl], [out0, outCtrl] = await initDut(dut, ["in0", "inCtrl"],
+                                                 ["out0", "outCtrl"])
+
+  N = 10
+  inputs = [randomTuple() for _ in range(N)]
+
+  outputs = [getOutput(i) for i in inputs]
+  resCheck = cocotb.start_soon(out0.checkOutputs(outputs))
+
+  for i in inputs:
+    print("in: ", i)
+    in0Send = cocotb.start_soon(in0.send(i))
+    inCtrlSend = cocotb.start_soon(inCtrl.send())
+
+    await in0Send
+    await inCtrlSend
+
+  await resCheck

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -644,7 +644,7 @@ createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
        llvm::enumerate(funcOp.getFunctionType().getInputs())) {
     auto portName = funcOp.getArgName(i);
     FIRRTLBaseType bundlePortType;
-    if (argType.isa<MemRefType>()) {
+    if (argType.template isa<MemRefType>()) {
       if (funcOp.isExternal())
         return funcOp.emitError(
             "external functions with memory arguments are not supported");

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -633,27 +633,34 @@ static void extractValues(ArrayRef<ValueVector *> valueVectors, size_t index,
 /// circuit is pure combinational logic. If graph cycle exists, at least one
 /// buffer is required to be inserted for breaking the cycle, which will be
 /// supported in the next patch.
-static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
-                                   ConversionPatternRewriter &rewriter,
-                                   bool setFlattenAttr) {
-  llvm::SmallVector<PortInfo, 8> ports;
+template <typename TModuleOp>
+static FailureOr<TModuleOp>
+createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
+                  ConversionPatternRewriter &rewriter, bool setFlattenAttr) {
+  llvm::SmallVector<PortInfo> ports;
 
   // Add all inputs of funcOp.
-  for (auto &arg : llvm::enumerate(funcOp.getArguments())) {
-    auto portName = funcOp.getArgName(arg.index());
+  for (auto &[i, argType] :
+       llvm::enumerate(funcOp.getFunctionType().getInputs())) {
+    auto portName = funcOp.getArgName(i);
     FIRRTLBaseType bundlePortType;
-    if (arg.value().getType().isa<MemRefType>())
-      bundlePortType =
-          getMemrefBundleType(rewriter, arg.value(), /*flip=*/true);
-    else
-      bundlePortType = getBundleType(arg.value().getType());
+    if (argType.isa<MemRefType>()) {
+      if (funcOp.isExternal())
+        return funcOp.emitError(
+            "external functions with memory arguments are not supported");
+
+      BlockArgument arg = funcOp.getArgument(i);
+      bundlePortType = getMemrefBundleType(rewriter, arg, /*flip=*/true);
+    } else
+      bundlePortType = getBundleType(argType);
 
     if (!bundlePortType)
-      funcOp.emitError("Unsupported data type. Supported data types: integer "
-                       "(signed, unsigned, signless), index, none.");
+      return funcOp.emitError(
+          "Unsupported data type. Supported data types: integer "
+          "(signed, unsigned, signless), index, none.");
 
     ports.push_back({portName, bundlePortType, Direction::In, StringAttr{},
-                     arg.value().getLoc()});
+                     funcOp.getLoc()});
   }
 
   auto funcLoc = funcOp.getLoc();
@@ -664,8 +671,9 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
     auto bundlePortType = getBundleType(portType.value());
 
     if (!bundlePortType)
-      funcOp.emitError("Unsupported data type. Supported data types: integer "
-                       "(signed, unsigned, signless), index, none.");
+      return funcOp.emitError(
+          "Unsupported data type. Supported data types: integer "
+          "(signed, unsigned, signless), index, none.");
 
     ports.push_back(
         {portName, bundlePortType, Direction::Out, StringAttr{}, funcLoc});
@@ -691,19 +699,24 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
                        StringAttr{}, funcLoc});
     }
   }
-
   // Create a FIRRTL module and inline the funcOp into the FIRRTL module.
-  auto topModuleOp = rewriter.create<FModuleOp>(
+  auto topModuleOp = rewriter.create<TModuleOp>(
       funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()), ports);
 
-  if (setFlattenAttr) {
+  if (setFlattenAttr)
     topModuleOp->setAttr(
         "annotations",
         rewriter.getArrayAttr(rewriter.getDictionaryAttr(
             llvm::SmallVector<NamedAttribute>{rewriter.getNamedAttr(
                 "class", rewriter.getStringAttr(
                              "firrtl.transforms.FlattenAnnotation"))})));
-  }
+
+  return topModuleOp;
+}
+
+/// Inlines the region of the handshake function into the FIRRTL module.
+static void inlineFuncRegion(handshake::FuncOp funcOp, FModuleOp topModuleOp,
+                             ConversionPatternRewriter &rewriter) {
 
   rewriter.inlineRegionBefore(funcOp.getBody(), topModuleOp.getBody(),
                               topModuleOp.getBody().end());
@@ -728,7 +741,6 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
   entryBlock->getOperations().splice(entryBlock->end(),
                                      secondBlock->getOperations());
   rewriter.eraseBlock(secondBlock);
-  return topModuleOp;
 }
 
 //===----------------------------------------------------------------------===//
@@ -3057,8 +3069,20 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
   matchAndRewrite(handshake::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.setInsertionPointToStart(circuitOp.getBodyBlock());
-    auto topModuleOp =
-        createTopModuleOp(funcOp, /*numClocks=*/1, rewriter, setFlattenAttr);
+    if (funcOp.isExternal()) {
+      if (failed(createTopModuleOp<FExtModuleOp>(funcOp, /*numClocks=*/1,
+                                                 rewriter, setFlattenAttr)))
+        return failure();
+      rewriter.eraseOp(funcOp);
+      return success();
+    }
+
+    auto maybeTopModuleOp = createTopModuleOp<FModuleOp>(
+        funcOp, /*numClocks=*/1, rewriter, setFlattenAttr);
+    if (failed(maybeTopModuleOp))
+      return failure();
+    auto topModuleOp = maybeTopModuleOp.value();
+    inlineFuncRegion(funcOp, topModuleOp, rewriter);
 
     NameUniquer instanceUniquer = [&](Operation *op) {
       std::string instName = getInstanceName(op);

--- a/test/Conversion/HandshakeToFIRRTL/test_func.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_func.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
+// RUN: circt-opt -lower-handshake-to-firrtl --split-input-file %s | FileCheck %s
 
 
 // CHECK-LABEL: firrtl.circuit "no_args"  {
@@ -10,3 +10,9 @@ handshake.func @no_args() {
   return
 }
 
+// -----
+
+// CHECK-LABEL:  firrtl.circuit "external"  {
+// CHECK:          firrtl.extmodule @external(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in ctrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
+// CHECK:         }
+handshake.func @external(%arg0: i32, %ctrl: none, ...) -> none

--- a/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
+// RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK:           firrtl.module @foo(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_4:.*]]: !firrtl.clock, in %[[VAL_5:.*]]: !firrtl.uint<1>) {
 // CHECK:             %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = firrtl.instance bar0  @bar(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in ctrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
@@ -26,4 +26,13 @@ module {
     %b:2 = handshake.instance @bar(%a, %ctrl) : (i32, none) -> (i32, none)
     return %b#0, %b#1 : i32, none
   }
+}
+
+// -----
+
+handshake.func @external(%arg0: i32, %ctrl: none, ...) -> none
+
+handshake.func @call_external(%a: i32, %ctrl : none) -> none {
+  %b = handshake.instance @external(%a, %ctrl) : (i32, none) -> none
+  return %b : none
 }


### PR DESCRIPTION
This PR adds support for external handshake functions to the `HandshakeToFIRRTL` lowering. 

As the port for external memories depends on its usages, we cannot lower external functions that consume memory references.