### PR TITLE
[FIRRTL] Reuse HierPathOp's when creating in LA, fix GC(T) cleanup, add SymbolDCE to pipeline

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -206,6 +206,7 @@ struct ApplyState {
   CircuitTargetCache targetCaches;
   AddToWorklistFn addToWorklistFn;
   InstancePathCache &instancePathCache;
+  DenseMap<Attribute, FlatSymbolRefAttr> instPathToNLAMap;
 
   ModuleNamespace &getNamespace(FModuleLike module) {
     auto &ptr = namespaces[module];

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -207,6 +207,7 @@ struct ApplyState {
   AddToWorklistFn addToWorklistFn;
   InstancePathCache &instancePathCache;
   DenseMap<Attribute, FlatSymbolRefAttr> instPathToNLAMap;
+  size_t numReusedHierPaths = 0;
 
   ModuleNamespace &getNamespace(FModuleLike module) {
     auto &ptr = namespaces[module];

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -39,6 +39,8 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
        "Total number of annotations processed">,
     Statistic<"numUnhandled", "num-unhandled-annos",
       "Number of unhandled annotations">,
+    Statistic<"numReusedHierPathOps", "num-reused-hierpath",
+      "Number of reused HierPathOp's">,
   ];
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -112,11 +112,21 @@ static FlatSymbolRefAttr buildNLA(const AnnoPathValue &target,
 
   insts.push_back(
       FlatSymbolRefAttr::get(target.ref.getModule().moduleNameAttr()));
+
   auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
+
+  // Re-use NLA for this path if already created.
+  auto it = state.instPathToNLAMap.find(instAttr);
+  if (it != state.instPathToNLAMap.end())
+    return it->second;
+
+  // Create the NLA
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
   state.symTbl.insert(nla);
   nla.setVisibility(SymbolTable::Visibility::Private);
-  return FlatSymbolRefAttr::get(nla);
+  auto sym = FlatSymbolRefAttr::get(nla);
+  state.instPathToNLAMap.insert({instAttr, sym});
+  return sym;
 }
 
 /// Scatter breadcrumb annotations corresponding to non-local annotations

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -117,8 +117,10 @@ static FlatSymbolRefAttr buildNLA(const AnnoPathValue &target,
 
   // Re-use NLA for this path if already created.
   auto it = state.instPathToNLAMap.find(instAttr);
-  if (it != state.instPathToNLAMap.end())
+  if (it != state.instPathToNLAMap.end()) {
+    ++state.numReusedHierPaths;
     return it->second;
+  }
 
   // Create the NLA
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
@@ -514,6 +516,7 @@ void LowerAnnotationsPass::runOnOperation() {
   numRawAnnotations += annotations.size();
   numAddedAnnos += numAdded;
   numAnnos += numAdded + annotations.size();
+  numReusedHierPathOps += state.numReusedHierPaths;
 
   if (numFailures)
     signalPassFailure();

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -458,10 +458,8 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.hierpath private @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
-  ; CHECK: firrtl.hierpath private @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
+  ; CHECK: firrtl.hierpath private @[[nla_a:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
     ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
@@ -477,12 +475,12 @@ circuit Top : %[[
   module A_ :
     inst b_ of B_
   ; CHECK: firrtl.module private @B
-  ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "circt.test", data = "B_"}
-  ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "circt.test", data = "B"}
+  ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_"}
+  ; CHECK-SAME: {circt.nonlocal = @[[nla_a]], class = "circt.test", data = "B"}
   module B :
     ; CHECK: firrtl.node
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "circt.test", data = "B_.bar"}
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "circt.test", data = "B.foo"}
+    ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_.bar"}
+    ; CHECK-SAME: {circt.nonlocal = @[[nla_a]], class = "circt.test", data = "B.foo"}
     node foo = UInt<1>(0)
   ; CHECK-NOT: firrtl.module private @B_
   module B_ :
@@ -519,26 +517,14 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_/c_:C_/d_:D_>bar"
   }
 ]]
-  ; CHECK:        firrtl.hierpath private @[[nla_4:[_a-zA-Z0-9]+]]
+  ; CHECK:        firrtl.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_3:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[a_Sym]],
-  ; CHECK-SAME:      @A::@[[bSym]],
-  ; CHECK-SAME:      @B::@[[cSym]],
-  ; CHECK-SAME:      @C::@[[dSym]],
-  ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_a:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @A::@[[bSym]],
-  ; CHECK-SAME:      @B::@[[cSym]],
-  ; CHECK-SAME:      @C::@[[dSym]],
-  ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[aSym]],
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -70,9 +70,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 //
 // CHECK-LABEL: firrtl.circuit "Foo"
 // CHECK-NOT:     rawAnnotations
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_c:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_b:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_a:[^ ]+]] [@Foo::@[[bar_sym]],       @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
 firrtl.circuit "Foo" attributes {rawAnnotations = [
   {
     class = "circt.test",
@@ -92,9 +90,9 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 ]} {
   // CHECK-NEXT: firrtl.module @Bar()
   // CHECK-SAME:   annotations =
-  // CHECK-SAME:     {circt.nonlocal = @[[nla_a]], class = "circt.test", data = "a"}
-  // CHECK-SAME:     {circt.nonlocal = @[[nla_b]], class = "circt.test", data = "b"}
-  // CHECK-SAME:     {circt.nonlocal = @[[nla_c]], class = "circt.test", data = "c"}
+  // CHECK-SAME:     {circt.nonlocal = @[[nla]], class = "circt.test", data = "a"}
+  // CHECK-SAME:     {circt.nonlocal = @[[nla]], class = "circt.test", data = "b"}
+  // CHECK-SAME:     {circt.nonlocal = @[[nla]], class = "circt.test", data = "c"}
   firrtl.module @Bar() {}
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
@@ -113,11 +111,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 //
 // CHECK-LABEL: firrtl.circuit "Foo"
 // CHECK-NOT:     rawAnnotations
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_4:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_3:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_2:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_1:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
-// CHECK-NEXT:    firrtl.hierpath private @[[nla_0:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
+// CHECK-NEXT:    firrtl.hierpath private @[[nla:[^ ]+]] [@Foo::@[[bar_sym:[^ ]+]], @Bar]
 firrtl.circuit "Foo" attributes {rawAnnotations = [
   {
     class = "circt.test",
@@ -147,12 +141,12 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 ]} {
   // CHECK-NEXT: firrtl.module @Bar
   // CHECK-SAME:   in %a
-  // CHECK-SAME:     {circt.nonlocal = @[[nla_0]], class = "circt.test", data = 0 : i64}
+  // CHECK-SAME:     {circt.nonlocal = @[[nla]], class = "circt.test", data = 0 : i64}
   // CHECK-SAME:   out %b
-  // CHECK-SAME:     {circt.fieldID = 1 : i32, circt.nonlocal = @[[nla_1]], class = "circt.test", data = 1 : i64}
-  // CHECK-SAME:     {circt.fieldID = 2 : i32, circt.nonlocal = @[[nla_2]], class = "circt.test", data = 2 : i64}
+  // CHECK-SAME:     {circt.fieldID = 1 : i32, circt.nonlocal = @[[nla]], class = "circt.test", data = 1 : i64}
+  // CHECK-SAME:     {circt.fieldID = 2 : i32, circt.nonlocal = @[[nla]], class = "circt.test", data = 2 : i64}
   // CHECK-SAME:   out %c
-  // CHECK-SAME:     {circt.nonlocal = @[[nla_4]], class = "circt.test", data = 4 : i64}
+  // CHECK-SAME:     {circt.nonlocal = @[[nla]], class = "circt.test", data = 4 : i64}
   firrtl.module @Bar(
     in %a: !firrtl.uint<1>,
     out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>,
@@ -160,7 +154,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   ) {
     // CHECK-NEXT: %d = firrtl.wire
     // CHECK-NOT:    sym
-    // CHECK-SAME:   {circt.fieldID = 2 : i32, circt.nonlocal = @[[nla_3]], class = "circt.test", data = 3 : i64}
+    // CHECK-SAME:   {circt.fieldID = 2 : i32, circt.nonlocal = @[[nla]], class = "circt.test", data = 3 : i64}
     %d = firrtl.wire : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
   }
   // CHECK: firrtl.module @Foo
@@ -543,10 +537,9 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   }
 }
 // CHECK-LABEL: firrtl.circuit "Foo"
-// CHECK:         firrtl.hierpath private @[[nla_b:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
-// CHECK:         firrtl.hierpath private @[[nla_a:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
+// CHECK:         firrtl.hierpath private @[[nla:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
 // CHECK:         firrtl.module @Baz
-// CHECK-SAME:      annotations = [{circt.nonlocal = @[[nla_a]], class = "circt.test", data = "a"}, {circt.nonlocal = @[[nla_b]], class = "circt.test", data = "b"}]
+// CHECK-SAME:      annotations = [{circt.nonlocal = @[[nla]], class = "circt.test", data = "a"}, {circt.nonlocal = @[[nla]], class = "circt.test", data = "b"}]
 // CHECK:         firrtl.module @Bar()
 // CHECK:           firrtl.instance baz sym @baz @Baz()
 // CHECK:           firrtl.module @Foo()
@@ -626,12 +619,10 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
-// CHECK: firrtl.hierpath private @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath private @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.hierpath private @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.module @BarNL
-// CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
-// CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla_1, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
+// CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]}
+// CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
 // CHECK: firrtl.instance bar sym @bar @BarNL()
 // CHECK: firrtl.instance baz sym @baz @BazNL()
 // CHECK: firrtl.module @FooL

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --firrtl-grand-central-taps --split-input-file | FileCheck %s
+// RUN: circt-opt %s --firrtl-grand-central-taps --symbol-dce --split-input-file | FileCheck %s
 
 firrtl.circuit "TestHarness" attributes {
   annotations = [{
@@ -407,22 +407,12 @@ firrtl.circuit "NLAGarbageCollection" {
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
     ]
   } {
-    %submodule_port = firrtl.instance submodule sym @submodule  {
-      annotations = [
-        {circt.nonlocal = @nla_1, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_2, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]
-    } @Submodule(in port : !firrtl.uint<1>)
+    %submodule_port = firrtl.instance submodule sym @submodule @Submodule(in port : !firrtl.uint<1>)
     %MemTap_0 = firrtl.instance mem_tap_MemTap  @MemTap(out mem_0: !firrtl.uint<1>)
     %DataTap_0, %DataTap_1 = firrtl.instance DataTap_1  @DataTap_1(out _1: !firrtl.uint<1>, out _0: !firrtl.uint<1>)
   }
   firrtl.module @NLAGarbageCollection() {
-    firrtl.instance dut sym @dut {
-      annotations = [
-        {circt.nonlocal = @nla_1, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_2, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]
-    } @DUT()
+    firrtl.instance dut sym @dut @DUT()
   }
 }
 
@@ -486,10 +476,7 @@ firrtl.circuit "NLAUsedInWiring"  {
   }
 
   firrtl.module @NLAUsedInWiring() {
-    %foo_g = firrtl.instance foo sym @foo {annotations = [
-      {circt.nonlocal = @nla_1, class = "circt.nonlocal"},
-      {circt.nonlocal = @nla_2, class = "circt.nonlocal"}
-    ]} @Foo(out g: !firrtl.uint<1>)
+    %foo_g = firrtl.instance foo sym @foo @Foo(out g: !firrtl.uint<1>)
     %bar_g = firrtl.instance bar @Foo(out g: !firrtl.uint<1>)
     %k = firrtl.wire sym @k {annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source",
@@ -524,9 +511,9 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %out, %3 : !firrtl.uint<1>
   }
   firrtl.module private @DUT(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
-    %submodule_1_clock, %submodule_1_out = firrtl.instance submodule_1 sym @submodule_1  {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @Submodule(in clock: !firrtl.clock, out out: !firrtl.uint<1>)
+    %submodule_1_clock, %submodule_1_out = firrtl.instance submodule_1 sym @submodule_1 @Submodule(in clock: !firrtl.clock, out out: !firrtl.uint<1>)
     firrtl.strictconnect %submodule_1_clock, %clock : !firrtl.clock
-    %submodule_2_clock, %submodule_2_out = firrtl.instance submodule_2 sym @submodule_2  {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @Submodule(in clock: !firrtl.clock, out out: !firrtl.uint<1>)
+    %submodule_2_clock, %submodule_2_out = firrtl.instance submodule_2 sym @submodule_2 @Submodule(in clock: !firrtl.clock, out out: !firrtl.uint<1>)
     firrtl.strictconnect %submodule_2_clock, %clock : !firrtl.clock
     %0 = firrtl.or %submodule_1_out, %submodule_2_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %out, %0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central)' -split-input-file %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
 
 firrtl.circuit "InterfaceGroundType" attributes {
   annotations = [

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
   mlir::registerSCCPPass();
   mlir::registerInlinerPass();
   mlir::registerCanonicalizerPass();
+  mlir::registerSymbolDCEPass();
 
   // Register test passes
   circt::test::registerAnalysisTestPasses();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -679,6 +679,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         firrtl::createGrandCentralSignalMappingsPass(outputFilename));
   }
 
+  // Run SymbolDCE after GC for hierpathop's and just for general cleanup.
+  pm.addNestedPass<firrtl::CircuitOp>(mlir::createSymbolDCEPass());
+
   // Read black box source files into the IR.
   StringRef blackBoxRoot = blackBoxRootPath.empty()
                                ? llvm::sys::path::parent_path(inputFilename)
@@ -983,6 +986,7 @@ int main(int argc, char **argv) {
     registerCSEPass();
     registerCanonicalizerPass();
     registerStripDebugInfoPass();
+    registerSymbolDCEPass();
 
     // Dialect passes:
     firrtl::registerPasses();


### PR DESCRIPTION
## Summary
We create and manage many thousands of HierPathOp's unnecessarily.
Fix this by addressing the primary location they're added to the IR: LowerAnnotations, by using a simple cache to avoid emitting duplicate ops.
This reduces the count from thousands to tens on even small-ish designs.

Modify GC and GCT passes to stop deleting HierPathOp's as they don't know if they're still used.  Indeed, in our tests we were deleting these ops despite them still being alive (breadcrumbs).

Add SymbolDCE to the pipeline to do this cleanup instead, thanks to various recent changes using private visibility in many places, particularly the HierPathOp's themselves (#3871).

## More

Previously this was done in #3863, which was reverted due to breakage with passes deleting HP's under assumption their use case was only users of the op.  This revives that change, also adding a new statistic to track HP reuse.

The problematic passes were GC and GCT, which have been modified to no longer delete these ops.
While it would be nice for these passes to delete them right away in the (likely?) case where they don't have other users, doing this safely requires scanning entire design for symbol references.
Instead, leave this to the pass that already knows how to do this: SymbolDCE.
This pass is added to the firtool pipeline (not 100% where to best drop it in, other than downstream of GC/GCT to cleanup unused HierPathOp's now that they don't do this cleanup themselves).

SymbolDCE computes the set of live symbols (see https://github.com/llvm/llvm-project/blob/1a50213ce7e8aa2a82ab3824cabc7f2a44805681/mlir/lib/Transforms/SymbolDCE.cpp#L83) walking from public/non-dead top-level ops, notably using the `SymbolOpInterface` method `canDiscardOnUseEmpty()` which we can use in the future to keep symbols alive if their liveness is not evident otherwise.
SymbolDCE will delete any symbols that appear dead in this manner-- for example possibly deleting Module's with private visibility that are unused (which we do that in other places (Inliner, IMDCE, ...)).

Drop breadcrumbs from test, as they would keep the HP's alive (rightfully so)-- actually we were generating invalid IR in those tests (fixed in d479173078ddb8e09be951f99f7c9ab26557d140), as nothing cleaned up the breadcrumbs so they were left with invalid symbol references to erased HierPathOp's.