### PR TITLE
hlstool,circt-{as,dis}: gather options into category, hide unrelated options

### DIFF
--- a/test/circt-as-dis/commandline-as.mlir
+++ b/test/circt-as-dis/commandline-as.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-as --help | FileCheck %s --implicit-check-not='{{[Oo]}}ptions:'
+
+// CHECK: OVERVIEW: CIRCT .mlir -> .mlirbc assembler
+// CHECK: Color Options
+// CHECK: Generic Options
+// CHECK: circt-as Options

--- a/test/circt-as-dis/commandline-dis.mlir
+++ b/test/circt-as-dis/commandline-dis.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-dis --help | FileCheck %s --implicit-check-not='{{[Oo]}}ptions:'
+
+// CHECK: OVERVIEW: CIRCT .mlirbc -> .mlir disassembler
+// CHECK: Color Options
+// CHECK: General {{[Oo]}}ptions
+// CHECK-NOT: --{{[^m][^l][^i][^r]}}-
+// CHECK: Generic Options
+// CHECK: circt-dis Options

--- a/test/hlstool/commandline.mlir
+++ b/test/hlstool/commandline.mlir
@@ -1,0 +1,8 @@
+// RUN: hlstool --help | FileCheck %s --implicit-check-not='{{[Oo]}}ptions:'
+
+// CHECK: OVERVIEW: CIRCT HLS tool
+// CHECK: General {{[Oo]}}ptions
+// CHECK: --lowering-options=
+// CHECK-NOT: --{{[^m][^l][^i][^r]}}-
+// CHECK: Generic Options
+// CHECK: hlstool Options

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -35,19 +35,21 @@ using namespace llvm;
 using namespace mlir;
 using namespace circt;
 
+static constexpr const char toolName[] = "circt-as";
+static cl::OptionCategory mainCategory("circt-as Options");
+
 static cl::opt<std::string> inputFilename(cl::Positional,
                                           cl::desc("<input .mlir file>"),
-                                          cl::init("-"));
+                                          cl::init("-"), cl::cat(mainCategory));
 
 static cl::opt<std::string> outputFilename("o",
                                            cl::desc("Override output filename"),
-                                           cl::value_desc("filename"));
+                                           cl::value_desc("filename"),
+                                           cl::cat(mainCategory));
 
 static cl::opt<bool> forceOutput("f",
                                  cl::desc("Enable binary output on terminals"),
-                                 cl::init(false));
-
-static constexpr const char toolName[] = "circt-as";
+                                 cl::init(false), cl::cat(mainCategory));
 
 /// Print error and return failure.
 static LogicalResult emitError(const Twine &err) {
@@ -130,6 +132,9 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();
+
+  // Hide default LLVM options, other than for this tool.
+  cl::HideUnrelatedOptions({&mainCategory, &llvm::getColorCategory()});
 
   cl::ParseCommandLineOptions(argc, argv, "CIRCT .mlir -> .mlirbc assembler\n");
 

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -35,15 +35,17 @@ using namespace llvm;
 using namespace mlir;
 using namespace circt;
 
+static constexpr const char toolName[] = "circt-dis";
+static cl::OptionCategory mainCategory("circt-dis Options");
+
 static cl::opt<std::string> inputFilename(cl::Positional,
                                           cl::desc("<input .mlirbc file>"),
-                                          cl::init("-"));
+                                          cl::init("-"), cl::cat(mainCategory));
 
 static cl::opt<std::string> outputFilename("o",
                                            cl::desc("Override output filename"),
-                                           cl::value_desc("filename"));
-
-static constexpr const char toolName[] = "circt-dis";
+                                           cl::value_desc("filename"),
+                                           cl::cat(mainCategory));
 
 /// Print error and return failure.
 static LogicalResult emitError(const Twine &err) {
@@ -109,6 +111,10 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();
+
+  // Hide default LLVM options, other than for this tool.
+  // MLIR options are added below.
+  cl::HideUnrelatedOptions({&mainCategory, &llvm::getColorCategory()});
 
   registerAsmPrinterCLOptions();
 

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -65,40 +65,43 @@ using namespace circt;
 // Tool options
 // --------------------------------------------------------------------------
 
-static cl::opt<std::string>
-    inputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));
+static cl::OptionCategory mainCategory("hlstool Options");
 
-static cl::opt<std::string>
-    outputFilename("o",
-                   cl::desc("Output filename, or directory for split output"),
-                   cl::value_desc("filename"), cl::init("-"));
+static cl::opt<std::string> inputFilename(cl::Positional,
+                                          cl::desc("<input file>"),
+                                          cl::init("-"), cl::cat(mainCategory));
+
+static cl::opt<std::string> outputFilename(
+    "o", cl::desc("Output filename, or directory for split output"),
+    cl::value_desc("filename"), cl::init("-"), cl::cat(mainCategory));
 
 static cl::opt<bool>
     splitInputFile("split-input-file",
                    cl::desc("Split the input file into pieces and process each "
                             "chunk independently"),
-                   cl::init(false), cl::Hidden);
+                   cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
     verifyDiagnostics("verify-diagnostics",
                       cl::desc("Check that emitted diagnostics match "
                                "expected-* lines on the corresponding line"),
-                      cl::init(false), cl::Hidden);
+                      cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::opt<bool>
     verbosePassExecutions("verbose-pass-executions",
                           cl::desc("Log executions of toplevel module passes"),
-                          cl::init(false));
+                          cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool>
     verifyPasses("verify-each",
                  cl::desc("Run the verifier after each transformation pass"),
-                 cl::init(true));
+                 cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool>
     allowUnregisteredDialects("allow-unregistered-dialects",
                               cl::desc("Allow unknown dialects in the input"),
-                              cl::init(false), cl::Hidden);
+                              cl::init(false), cl::Hidden,
+                              cl::cat(mainCategory));
 
 enum HLSFlow { HLSFlowDynamicFIRRTL, HLSFlowDynamicHW };
 
@@ -107,7 +110,8 @@ static cl::opt<HLSFlow>
             cl::values(clEnumValN(HLSFlowDynamicFIRRTL, "dynamic-firrtl",
                                   "Dynamically scheduled (FIRRTL path)"),
                        clEnumValN(HLSFlowDynamicHW, "dynamic-hw",
-                                  "Dynamically scheduled (HW path)")));
+                                  "Dynamically scheduled (HW path)")),
+            cl::cat(mainCategory));
 
 enum DynamicParallelismKind {
   DynamicParallelismNone,
@@ -128,7 +132,7 @@ static cl::opt<DynamicParallelismKind> dynParallelism(
                    "Add function pipelining mechanism that enables a "
                    "pipelined execution of multiple function invocations while "
                    "preserving correctness.")),
-    cl::init(DynamicParallelismPipelining));
+    cl::init(DynamicParallelismPipelining), cl::cat(mainCategory));
 
 enum OutputFormatKind { OutputIR, OutputVerilog };
 
@@ -136,29 +140,29 @@ static cl::opt<int>
     irInputLevel("ir-input-level",
                  cl::desc("Level at which to input IR at. It is flow-defined "
                           "which value corersponds to which IR level."),
-                 cl::init(-1));
+                 cl::init(-1), cl::cat(mainCategory));
 
 static cl::opt<int>
     irOutputLevel("ir-output-level",
                   cl::desc("Level at which to output IR at. It is flow-defined "
                            "which value corersponds to which IR level."),
-                  cl::init(-1));
+                  cl::init(-1), cl::cat(mainCategory));
 
 static cl::opt<OutputFormatKind> outputFormat(
     cl::desc("Specify output format:"),
     cl::values(clEnumValN(OutputIR, "ir", "Emit post-HLS IR"),
                clEnumValN(OutputVerilog, "verilog", "Emit Verilog")),
-    cl::init(OutputVerilog));
+    cl::init(OutputVerilog), cl::cat(mainCategory));
 
 static cl::opt<std::string>
     bufferingStrategy("buffering-strategy",
                       cl::desc("Strategy to apply. Possible values are: "
                                "cycles, allFIFO, all (default)"),
-                      cl::init("all"));
+                      cl::init("all"), cl::cat(mainCategory));
 
 static cl::opt<unsigned> bufferSize("buffer-size",
                                     cl::desc("Number of slots in each buffer"),
-                                    cl::init(2));
+                                    cl::init(2), cl::cat(mainCategory));
 
 // --------------------------------------------------------------------------
 // (Configurable) pass pipelines
@@ -477,6 +481,10 @@ static LogicalResult executeHlstool(MLIRContext &context) {
 /// MLIRContext and modules inside of it (reducing compile time).
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Hide default LLVM options, other than for this tool.
+  // MLIR options are added below.
+  cl::HideUnrelatedOptions(mainCategory);
 
   // Register any pass manager command line options.
   registerMLIRContextCLOptions();


### PR DESCRIPTION
Similar to changes made for other tools in #2979.
Primarily motivated to avoid huge option lists in certain build configurations (see linked PR).

Add "commandline" tests for these as well, as for other utilities.

Verifies they at least run and that loosely speaking the output and options are what we expect.

Some tools want to hide the MLIR options as well and more explicitly manage categories + options, as in c468158ee3ec6278df911b7970103b29cd3fb2ab , but for now starting with what is done for `firtool`.