### PR TITLE
 [FIRRTL][LowerTypes] Lower aggregate type operand

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -613,9 +613,34 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
       sfo.replaceAllUsesWith(repl);
       sfo.erase();
     } else {
-      val.dump();
-      val.getDefiningOp()->getParentOfType<FModuleOp>()->dump();
-      llvm_unreachable("Unknown aggregate user");
+      // This means, we have already processed the user, and it didnot lower its
+      // inputs. This is an opaque user, which will continue to have aggregate
+      // type as input, even after LowerTypes. So, construct the vector/bundle
+      // back from the lowered elements to ensure a valid input into the opaque
+      // op. This only supports Bundle or vector of ground type elements.
+      // Recursive aggregate types are not yet supported.
+
+      // This builder ensures that the aggregate construction happens at the
+      // user location, and the LowerTypes algorithm will not touch them any
+      // more, because LowerTypes was reverse iterating on the block and the
+      // user has already been processed.
+      ImplicitLocOpBuilder b(user->getLoc(), user);
+      // Get the operand number in the op.
+      auto it = llvm::find(user->getOperands(), val);
+      // Cat all the field elements.
+      Value accumulate;
+      for (auto v : mapping) {
+        if (!v.getType().cast<FIRRTLBaseType>().isGround()) {
+          user->emitError("cannot handle an opaque user of aggregate types "
+                          "with non-ground type elements");
+          return;
+        }
+        accumulate =
+            (accumulate ? b.createOrFold<CatPrimOp>(v, accumulate) : v);
+      }
+      // Cast it back to the original aggregate type.
+      auto input = b.createOrFold<BitCastOp>(val.getType(), accumulate);
+      user->setOperand(it.getIndex(), input);
     }
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1059,17 +1059,19 @@ firrtl.module private @is1436_FOO() {
 
   firrtl.module private @RefTypeBundles(in %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>,
                         out %sink: !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>) {
-    // CHECK:  %0 = firrtl.cat %source_ready, %source_valid : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK:  %1 = firrtl.cat %source_data, %0 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
+    // CHECK:  %0 = firrtl.cat %source_valid, %source_ready : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK:  %1 = firrtl.cat %0, %source_data : (!firrtl.uint<2>, !firrtl.uint<64>) -> !firrtl.uint<66>
     // CHECK:  %2 = firrtl.bitcast %1 : (!firrtl.uint<66>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     // CHECK:  %3 = firrtl.ref.send %2 : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     %0 = firrtl.ref.send %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>
     firrtl.strictconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>
     // CHECK:  %x_a = firrtl.wire   : !firrtl.uint<1>
-    %x = firrtl.wire : !firrtl.bundle<a: uint<1>>
-    // CHECK:  %4 = firrtl.bitcast %x_a : (!firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>>
-    // CHECK:  %5 = firrtl.ref.send %4 : !firrtl.bundle<a: uint<1>>
-    %1 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>>
+    // CHECK:  %x_b = firrtl.wire   : !firrtl.uint<2>
+    %x = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    // CHECK:  %4 = firrtl.cat %x_a, %x_b : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+    // CHECK:  %5 = firrtl.bitcast %4 : (!firrtl.uint<3>) -> !firrtl.bundle<a: uint<1>, b: uint<2>>
+    // CHECK:  %6 = firrtl.ref.send %5 : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %1 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
   }
 
   firrtl.module private @RefTypeVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1057,6 +1057,36 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT: firrtl.connect %z, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   }
 
+  firrtl.module private @RefTypeBundles(in %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>,
+                        out %sink: !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>) {
+    // CHECK:  %0 = firrtl.cat %source_ready, %source_valid : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK:  %1 = firrtl.cat %source_data, %0 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
+    // CHECK:  %2 = firrtl.bitcast %1 : (!firrtl.uint<66>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    // CHECK:  %3 = firrtl.ref.send %2 : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    %0 = firrtl.ref.send %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>
+    firrtl.strictconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>
+    // CHECK:  %x_a = firrtl.wire   : !firrtl.uint<1>
+    %x = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    // CHECK:  %4 = firrtl.bitcast %x_a : (!firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>>
+    // CHECK:  %5 = firrtl.ref.send %4 : !firrtl.bundle<a: uint<1>>
+    %1 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>>
+  }
+
+  firrtl.module private @RefTypeVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {
+    // CHECK:  %0 = firrtl.cat %a_1, %a_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK:  %1 = firrtl.bitcast %0 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
+    // CHECK:  %2 = firrtl.ref.send %1 : !firrtl.vector<uint<1>, 2>
+    %0 = firrtl.ref.send %a : !firrtl.vector<uint<1>, 2>
+    firrtl.strictconnect %b, %0: !firrtl.ref<vector<uint<1>, 2>>
+    // CHECK:  %x_0 = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  %x_1 = firrtl.wire   : !firrtl.uint<1>
+    %x = firrtl.wire : !firrtl.vector<uint<1>, 2>
+    // CHECK:  %3 = firrtl.cat %x_1, %x_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK:  %4 = firrtl.bitcast %3 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
+    // CHECK:  %5 = firrtl.ref.send %4 : !firrtl.vector<uint<1>, 2>
+    %1 = firrtl.ref.send %x : !firrtl.vector<uint<1>, 2>
+  }
+
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last


### PR DESCRIPTION
This  PR handles operations with aggregate type operands, that cannot be lowered. Some operations can be `opaque` to the `LowerTypes` algorithm. The `opaque` ops will not be lowered, and can continue to have aggregate type operands after the lowering.
The `ref.send` is such an example of an `opaque` op.
The problem is that, even though the `opaque` op is not being lowered, its inputs can be lowered. So, it is required to re-construct the aggregate type input from the lowered elements in order to maintain a valid IR.
This PR, uses `BitCastOp` of `CatPrimOp` of the individual elements to create the original aggregate type input.
This transformation will also be used for registers that are selectively lowered.