### PR TITLE
[FIRRTL][LowerTypes] Canonicalize the CatPrimOp

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -612,39 +612,44 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
       Value repl = mapping[sfo.getFieldIndex()];
       sfo.replaceAllUsesWith(repl);
       sfo.erase();
-    } else {
-      // This means, we have already processed the user, and it didn't lower its
-      // inputs. This is an opaque user, which will continue to have aggregate
-      // type as input, even after LowerTypes. So, construct the vector/bundle
-      // back from the lowered elements to ensure a valid input into the opaque
-      // op. This only supports Bundle or vector of ground type elements.
-      // Recursive aggregate types are not yet supported.
-
-      // This builder ensures that the aggregate construction happens at the
-      // user location, and the LowerTypes algorithm will not touch them any
-      // more, because LowerTypes was reverse iterating on the block and the
-      // user has already been processed.
-      ImplicitLocOpBuilder b(user->getLoc(), user);
-      // Cat all the field elements.
-      Value accumulate;
-      for (auto v : mapping) {
-        if (!v.getType().cast<FIRRTLBaseType>().isGround()) {
-          user->emitError("cannot handle an opaque user of aggregate types "
-                          "with non-ground type elements");
-          return;
-        }
-        if (val.getType().cast<FIRRTLType>().isa<FVectorType>())
-          accumulate =
-              (accumulate ? b.createOrFold<CatPrimOp>(v, accumulate) : v);
-        else
-          // Bundle subfields are filled from MSB to LSB.
-          accumulate =
-              (accumulate ? b.createOrFold<CatPrimOp>(accumulate, v) : v);
-      }
-      // Cast it back to the original aggregate type.
-      auto input = b.createOrFold<BitCastOp>(val.getType(), accumulate);
-      user->replaceUsesOfWith(val, input);
     }
+  }
+  // After all the subindex/subfield users are lowered, handle the rest. Any
+  // leftover user means, we have already processed the user, and it didn't
+  // lower its inputs. This implies its an opaque user, which will continue to
+  // have aggregate type as input, even after LowerTypes. So, construct the
+  // vector/bundle back from the lowered elements to ensure a valid input into
+  // the opaque op. This only supports Bundle or vector of ground type elements.
+  // Recursive aggregate types are not yet supported.
+  for (auto user : llvm::make_early_inc_range(val.getUsers())) {
+
+    // This builder ensures that the aggregate construction happens at the
+    // user location, and the LowerTypes algorithm will not touch them any
+    // more, because LowerTypes was reverse iterating on the block and the
+    // user has already been processed.
+    ImplicitLocOpBuilder b(user->getLoc(), user);
+    // Cat all the field elements.
+    Value accumulate;
+    for (auto v : mapping) {
+      if (!v.getType().cast<FIRRTLBaseType>().isGround()) {
+        user->emitError("cannot handle an opaque user of aggregate types "
+                        "with non-ground type elements");
+        return;
+      }
+      auto driver = getDriverFromConnect(v);
+      if (driver)
+        v = driver;
+      if (val.getType().cast<FIRRTLType>().isa<FVectorType>())
+        accumulate =
+            (accumulate ? b.createOrFold<CatPrimOp>(v, accumulate) : v);
+      else
+        // Bundle subfields are filled from MSB to LSB.
+        accumulate =
+            (accumulate ? b.createOrFold<CatPrimOp>(accumulate, v) : v);
+    }
+    // Cast it back to the original aggregate type.
+    auto input = b.createOrFold<BitCastOp>(val.getType(), accumulate);
+    user->replaceUsesOfWith(val, input);
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1083,9 +1083,14 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  %x_0 = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %x_1 = firrtl.wire   : !firrtl.uint<1>
     %x = firrtl.wire : !firrtl.vector<uint<1>, 2>
-    // CHECK:  %3 = firrtl.cat %x_1, %x_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK:  %4 = firrtl.bitcast %3 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
-    // CHECK:  %5 = firrtl.ref.send %4 : !firrtl.vector<uint<1>, 2>
+    %x0 = firrtl.subindex %x[0] :!firrtl.vector<uint<1>, 2>
+    %x1 = firrtl.subindex %x[1] :!firrtl.vector<uint<1>, 2>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.strictconnect %x0, %c0_ui1 : !firrtl.uint<1>
+    firrtl.strictconnect %x1, %c0_ui1 : !firrtl.uint<1>
+    // CHECK:  %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+    // CHECK:  %3 = firrtl.bitcast %c0_ui2 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
+    // CHECK:  %4 = firrtl.ref.send %3 : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.ref.send %x : !firrtl.vector<uint<1>, 2>
   }
 


### PR DESCRIPTION
This is a followup to https://github.com/llvm/circt/pull/3982
Instead of creating the `CatPrimOp` while iterating over the users of an aggregate value, this commit delays it after all the `Subfield` and `Subindex` ops have been replaced. This ensures that any constant assignment to the individual fields can be folded by the `CatPrimOp`. This has a big impact when each field of a vector is assigned a constant.