### PR TITLE
[FIRRTL][RefType] Lower RefType in LowerTypes 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -131,7 +131,8 @@ static bool isPreservableAggregateType(Type type,
   if (mode == PreserveAggregate::None)
     return false;
 
-  auto firrtlType = type.dyn_cast<FIRRTLBaseType>();
+  auto firrtlType = type.isa<RefType>() ? type.cast<RefType>().getType()
+                                        : type.dyn_cast<FIRRTLBaseType>();
   if (!firrtlType)
     return false;
 
@@ -162,6 +163,8 @@ static bool peelType(Type type, SmallVectorImpl<FlatBundleFieldEntry> &fields,
   if (isPreservableAggregateType(type, mode))
     return false;
 
+  if (auto refType = type.dyn_cast<RefType>())
+    type = refType.getType();
   return TypeSwitch<Type, bool>(type)
       .Case<BundleType>([&](auto bundle) {
         SmallString<16> tmpSuffix;
@@ -380,6 +383,8 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitExpr(MuxPrimOp op);
   bool visitExpr(mlir::UnrealizedConversionCastOp op);
   bool visitExpr(BitCastOp op);
+  bool visitExpr(RefSendOp op);
+  bool visitExpr(RefResolveOp op);
   bool visitStmt(ConnectOp op);
   bool visitStmt(StrictConnectOp op);
   bool visitStmt(WhenOp op);
@@ -452,6 +457,8 @@ Value TypeLoweringVisitor::getSubWhatever(Value val, size_t index) {
     return builder->create<SubfieldOp>(val, index);
   } else if (FVectorType fvector = val.getType().dyn_cast<FVectorType>()) {
     return builder->create<SubindexOp>(val, index);
+  } else if (val.getType().isa<RefType>()) {
+    return builder->create<RefSubOp>(val, index);
   }
   llvm_unreachable("Unknown aggregate type");
   return nullptr;
@@ -612,6 +619,10 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
       Value repl = mapping[sfo.getFieldIndex()];
       sfo.replaceAllUsesWith(repl);
       sfo.erase();
+    } else if (auto refSub = dyn_cast<RefSubOp>(user)) {
+      Value repl = mapping[refSub.getIndex()];
+      refSub.replaceAllUsesWith(repl);
+      refSub.erase();
     } else {
       // This means, we have already processed the user, and it didn't lower its
       // inputs. This is an opaque user, which will continue to have aggregate
@@ -663,10 +674,13 @@ TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
                             unsigned insertPtOffset, FIRRTLType srcType,
                             FlatBundleFieldEntry field, PortInfo &oldArg) {
   Value newValue;
+  FIRRTLType fieldType = srcType.isa<RefType>()
+                             ? FIRRTLType(RefType::get(field.type))
+                             : field.type;
   if (auto mod = dyn_cast<FModuleOp>(module)) {
     Block *body = mod.getBodyBlock();
     // Append the new argument.
-    newValue = body->insertArgument(insertPt, field.type, oldArg.loc);
+    newValue = body->insertArgument(insertPt, fieldType, oldArg.loc);
   }
 
   // Save the name attribute for the new argument.
@@ -686,7 +700,7 @@ TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
   auto direction = (Direction)((unsigned)oldArg.direction ^ field.isOutput);
 
   return std::make_pair(newValue, PortInfo{name,
-                                           field.type,
+                                           fieldType,
                                            direction,
                                            {},
                                            oldArg.loc,
@@ -750,8 +764,18 @@ void TypeLoweringVisitor::lowerSAWritePath(Operation *op,
   }
 }
 
+static bool
+canLowerConnect(FConnectLike op,
+                PreserveAggregate::PreserveMode aggregatePreservationMode) {
+  auto destType = op.getDest().getType();
+  return !(destType.isa<RefType>() &&
+           isPreservableAggregateType(destType, aggregatePreservationMode));
+}
+
 // Expand connects of aggregates
 bool TypeLoweringVisitor::visitStmt(ConnectOp op) {
+  if (!canLowerConnect(op, aggregatePreservationMode))
+    return false;
   if (processSAPath(op))
     return true;
 
@@ -775,6 +799,8 @@ bool TypeLoweringVisitor::visitStmt(ConnectOp op) {
 
 // Expand connects of aggregates
 bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
+  if (!canLowerConnect(op, aggregatePreservationMode))
+    return false;
   if (processSAPath(op))
     return true;
 
@@ -789,7 +815,7 @@ bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
   for (const auto &field : llvm::enumerate(fields)) {
     Value src = getSubWhatever(op.getSrc(), field.index());
     Value dest = getSubWhatever(op.getDest(), field.index());
-    if (field.value().isOutput)
+    if (field.value().isOutput && !op.getDest().getType().isa<RefType>())
       std::swap(src, dest);
     builder->create<StrictConnectOp>(dest, src);
   }
@@ -1154,6 +1180,24 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
   return true;
 }
 
+bool TypeLoweringVisitor::visitExpr(RefSendOp op) {
+  auto clone = [&](const FlatBundleFieldEntry &field,
+                   ArrayAttr attrs) -> Operation * {
+    return builder->create<RefSendOp>(
+        getSubWhatever(op.getBase(), field.index));
+  };
+  return lowerProducer(op, clone);
+}
+
+bool TypeLoweringVisitor::visitExpr(RefResolveOp op) {
+  auto clone = [&](const FlatBundleFieldEntry &field,
+                   ArrayAttr attrs) -> Operation * {
+    Value src = getSubWhatever(op.getRef(), field.index);
+    return builder->create<RefResolveOp>(src);
+  };
+  return lowerProducer(op, clone);
+}
+
 bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
   bool skip = true;
   SmallVector<Type, 8> resultTypes;
@@ -1184,7 +1228,9 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
       for (const auto &field : fieldTypes) {
         newDirs.push_back(direction::get((unsigned)oldDir ^ field.isOutput));
         newNames.push_back(builder->getStringAttr(oldName + field.suffix));
-        resultTypes.push_back(field.type);
+        resultTypes.push_back(srcType.isa<RefType>()
+                                  ? FIRRTLType(RefType::get(field.type))
+                                  : FIRRTLType(field.type));
         auto annos = filterAnnotations(
             context, oldPortAnno[i].dyn_cast_or_null<ArrayAttr>(), srcType,
             field);

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,0 +1,65 @@
+; RUN: firtool --verilog %s | FileCheck %s
+
+circuit Top : %[[
+  {
+    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~Top|DUTModule"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Top|Top>memTap"
+  },
+  {"class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"},
+  {
+    "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
+    "source":"~Top|DUTModule>rf",
+    "wireName":[
+      "~Top|Top>memTap[0]",
+      "~Top|Top>memTap[1]",
+      "~Top|Top>memTap[2]",
+      "~Top|Top>memTap[3]",
+      "~Top|Top>memTap[4]",
+      "~Top|Top>memTap[5]",
+      "~Top|Top>memTap[6]",
+      "~Top|Top>memTap[7]"
+    ]
+  }
+]]
+  module DUTModule :
+    input clock : Clock
+    input reset : Reset
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    cmem rf : UInt<8> [8]
+    infer mport read = rf[io.addr], clock
+    io.dataOut <= read
+    when io.wen :
+      infer mport write = rf[io.addr], clock
+      write <= io.dataIn
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
+
+    inst dut of DUTModule
+    dut.clock <= clock
+    dut.reset <= reset
+    wire memTap : UInt<8>[8]
+    memTap is invalid
+    io.dataOut <= dut.io.dataOut
+    dut.io.wen <= io.wen
+    dut.io.dataIn <= io.dataIn
+    dut.io.addr <= io.addr
+
+; CHECK:      module Top(
+; CHECK-NOT:  module
+; CHECK:  assign memTap_0 = Top.dut.rf_0;
+; CHECK:  assign memTap_1 = Top.dut.rf_1;
+; CHECK:  assign memTap_2 = Top.dut.rf_2;
+; CHECK:  assign memTap_3 = Top.dut.rf_3;
+; CHECK:  assign memTap_4 = Top.dut.rf_4;
+; CHECK:  assign memTap_5 = Top.dut.rf_5;
+; CHECK:  assign memTap_6 = Top.dut.rf_6;
+; CHECK:  assign memTap_7 = Top.dut.rf_7;
+; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1057,36 +1057,53 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT: firrtl.connect %z, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   }
 
-  firrtl.module private @RefTypeBundles(in %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>,
-                        out %sink: !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>) {
-    // CHECK:  %0 = firrtl.cat %source_valid, %source_ready : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK:  %1 = firrtl.cat %0, %source_data : (!firrtl.uint<2>, !firrtl.uint<64>) -> !firrtl.uint<66>
-    // CHECK:  %2 = firrtl.bitcast %1 : (!firrtl.uint<66>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-    // CHECK:  %3 = firrtl.ref.send %2 : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-    %0 = firrtl.ref.send %source: !firrtl.bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>
-    firrtl.strictconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready : uint<1>, data: uint<64>>>
-    // CHECK:  %x_a = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  %x_b = firrtl.wire   : !firrtl.uint<2>
-    %x = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    // CHECK:  %4 = firrtl.cat %x_a, %x_b : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
-    // CHECK:  %5 = firrtl.bitcast %4 : (!firrtl.uint<3>) -> !firrtl.bundle<a: uint<1>, b: uint<2>>
-    // CHECK:  %6 = firrtl.ref.send %5 : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    %1 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
+  firrtl.module private @SendRefTypeBundles1(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, out %sink: !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>) {
+    // CHECK:  firrtl.module private @SendRefTypeBundles1(
+    // CHECK-SAME:  in %source_valid: !firrtl.uint<1>,
+    // CHECK-SAME:  in %source_ready: !firrtl.uint<1>,
+    // CHECK-SAME:  in %source_data: !firrtl.uint<64>,
+    // CHECK-SAME:  out %sink_valid: !firrtl.ref<uint<1>>,
+    // CHECK-SAME:  out %sink_ready: !firrtl.ref<uint<1>>,
+    // CHECK-SAME:  out %sink_data: !firrtl.ref<uint<64>>) {
+    %0 = firrtl.ref.send %source : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    // CHECK:  %0 = firrtl.ref.send %source_valid : !firrtl.uint<1>
+    // CHECK:  %1 = firrtl.ref.send %source_ready : !firrtl.uint<1>
+    // CHECK:  %2 = firrtl.ref.send %source_data : !firrtl.uint<64>
+    firrtl.strictconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
+    // CHECK:  firrtl.strictconnect %sink_valid, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.strictconnect %sink_ready, %1 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.strictconnect %sink_data, %2 : !firrtl.ref<uint<64>>
   }
-
-  firrtl.module private @RefTypeVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {
-    // CHECK:  %0 = firrtl.cat %a_1, %a_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK:  %1 = firrtl.bitcast %0 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
-    // CHECK:  %2 = firrtl.ref.send %1 : !firrtl.vector<uint<1>, 2>
+  firrtl.module private @SendRefTypeVectors1(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {
+    // CHECK-LABEL: firrtl.module private @SendRefTypeVectors1
+    // CHECK-SAME: in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.ref<uint<1>>, out %b_1: !firrtl.ref<uint<1>>)
     %0 = firrtl.ref.send %a : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %b, %0: !firrtl.ref<vector<uint<1>, 2>>
-    // CHECK:  %x_0 = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  %x_1 = firrtl.wire   : !firrtl.uint<1>
-    %x = firrtl.wire : !firrtl.vector<uint<1>, 2>
-    // CHECK:  %3 = firrtl.cat %x_1, %x_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK:  %4 = firrtl.bitcast %3 : (!firrtl.uint<2>) -> !firrtl.vector<uint<1>, 2>
-    // CHECK:  %5 = firrtl.ref.send %4 : !firrtl.vector<uint<1>, 2>
-    %1 = firrtl.ref.send %x : !firrtl.vector<uint<1>, 2>
+    // CHECK:  %0 = firrtl.ref.send %a_0 : !firrtl.uint<1>
+    // CHECK:  %1 = firrtl.ref.send %a_1 : !firrtl.uint<1>
+    firrtl.strictconnect %b, %0 : !firrtl.ref<vector<uint<1>, 2>>
+    // CHECK:  firrtl.strictconnect %b_0, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.strictconnect %b_1, %1 : !firrtl.ref<uint<1>>
+  }
+  firrtl.module private @RefTypeBundles2() {
+    %x = firrtl.wire   : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %0 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    // CHECK:   %0 = firrtl.ref.send %x_a : !firrtl.uint<1>
+    // CHECK:   %1 = firrtl.ref.send %x_b : !firrtl.uint<2>
+    %1 = firrtl.ref.resolve %0 : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+    // CHECK:   %2 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    // CHECK:   %3 = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
+  }
+  firrtl.module private @RefTypeVectors(out %c: !firrtl.vector<uint<1>, 2>) {
+    %x = firrtl.wire   : !firrtl.vector<uint<1>, 2>
+    %0 = firrtl.ref.send %x : !firrtl.vector<uint<1>, 2>
+    // CHECK:  %0 = firrtl.ref.send %x_0 : !firrtl.uint<1>
+    // CHECK:  %1 = firrtl.ref.send %x_1 : !firrtl.uint<1>
+    %1 = firrtl.ref.resolve %0 : !firrtl.ref<vector<uint<1>, 2>>
+    // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    // CHECK:  %3 = firrtl.ref.resolve %1 : !firrtl.ref<uint<1>>
+    firrtl.strictconnect %c, %1 : !firrtl.vector<uint<1>, 2>
+    // CHECK:  firrtl.strictconnect %c_0, %2 : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>
   }
 
 } // CIRCUIT


### PR DESCRIPTION
This PR lowers the `RefType` of aggregate values, to the `RefType` of the individual elements.
A new `RefSubOp` is added to handle the lowering and access individual elements of the `RefType`.
A `ref.send` and `ref.resolve` of aggregate type is lowered to the `ref.send`/`ref.resolve` of the individual aggregate elements. 
The `RefSubOp` is in general used temporarily in `LowerTypes` and then replaced by the corresponding definitions.
Only a debug port from a `MemOp` can introduce `RefSendOp` in the IR. Because the debug port output from the `MemOp` will not be lowered, but all its users will be lowered.