### PR TITLE
[FIRRTL][RefType] Add a new RefSub Op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -736,3 +736,22 @@ def RefSendOp: FIRRTLExprOp<"ref.send", [RefResultTypeConstraint<"base", "result
 
   let assemblyFormat = "$base attr-dict `:` qualified(type($base))";
 }
+
+def RefSubOp : FIRRTLExprOp<"ref.sub"> {
+  let summary = "Extract an element of an aggregate RefType value";
+  let description = [{
+    The refsub expression statically refers, by index, to a sub-element
+    of an expression with a RefType. The index must be a non-negative
+    integer and cannot be equal to or exceed the underlying vector size
+    or number of elements in bundle.
+    ```
+      %result = firrtl.ref.sub %input[index] : t1
+    ```
+    }];
+
+  let arguments = (ins RefType:$input, I32Attr:$index);
+  let results = (outs RefType:$result);
+
+  let assemblyFormat =
+     "$input `[` $index `]` attr-dict `:` qualified(type($input))";
+}

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -113,3 +113,23 @@ firrtl.circuit "DUT" {
     sv.interface.signal @bool : i1
   }
 }
+
+// -----
+
+// RefType of aggregates and RefSub. 
+firrtl.circuit "RefTypeVector" {
+  firrtl.module @RefTypeVector() {
+    %zero = firrtl.constant 0 : !firrtl.uint<4>
+    %z = firrtl.bitcast %zero : (!firrtl.uint<4>) -> !firrtl.vector<uint<1>,4>
+    %1 = firrtl.ref.send %z : !firrtl.vector<uint<1>,4>
+    %10 = firrtl.ref.sub %1[0] : !firrtl.ref<vector<uint<1>,4>>
+    %11 = firrtl.ref.sub %1[1] : !firrtl.ref<vector<uint<1>,4>>
+    %a = firrtl.ref.resolve %10 : !firrtl.ref<uint<1>>
+    %b = firrtl.ref.resolve %11 : !firrtl.ref<uint<1>>
+    %z2 = firrtl.constant 0 : !firrtl.uint<3>
+    %bundle = firrtl.bitcast %z2 : (!firrtl.uint<3>) -> !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %b1 = firrtl.ref.send %bundle : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %12 = firrtl.ref.sub %b1[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+    %rb = firrtl.ref.resolve %12 : !firrtl.ref<uint<2>>
+  }
+}


### PR DESCRIPTION
Add a new op to extract individual elements from a `RefType` of `Bundle` or `Vector` base type.
This op will be generated by `LowerTypes`, when the output debug port of `RefType` of a `MemOp` is not lowered but all its subsequent users and the `ref.resolve` ops are all lowered to the individual elements.
The `RefSubOp` can be used to index into both `Bundles` and `Vector` with an index. The index must be valid with respect to the base type.

```
    %0 = firrtl.ref.sub %b1[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
```