### PR TITLE
[ExportVerilog] Improve XMR emission when used as bound inputs

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -49,7 +49,7 @@ bool ExportVerilog::isSimpleReadOrPort(Value v) {
   auto readSrc = read.getInput().getDefiningOp();
   if (!readSrc)
     return false;
-  return isa<WireOp, RegOp>(readSrc);
+  return isa<WireOp, RegOp, LogicOp, XMROp>(readSrc);
 }
 
 // Check if the value is deemed worth spilling into a wire.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -712,11 +712,13 @@ hw.module @instance_result_reuse_wires() -> (b: i3) {
 }
 
 hw.module.extern @ExternDestMod(%a: i1, %b: i2) -> (c: i3, d: i4)
-hw.module @InternalDestMod(%a: i1, %b: i3) {}
+hw.module @InternalDestMod(%a: i1, %b: i3, %c: i1) {}
 // CHECK-LABEL module ABC
 hw.module @ABC(%a: i1, %b: i2) -> (c: i4) {
   %0,%1 = hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> (c: i3, d: i4) {doNotPrint=1}
-  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %0: i3) -> () {doNotPrint=1}
+  %2 = sv.xmr "whatever", "a" : !hw.inout<i1>
+  %3 = sv.read_inout %2: !hw.inout<i1>
+  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %0: i3, c: %3: i1) -> () {doNotPrint=1}
   hw.output %1 : i4
 }
 
@@ -733,6 +735,7 @@ hw.module @ABC(%a: i1, %b: i2) -> (c: i4) {
 // CHECK-NEXT:      InternalDestMod yo (
 // CHECK-NEXT:        .a (a),
 // CHECK-NEXT:        .b (_whatever_c)
+// CHECK-NEXT:        .c (whatever.a)
 // CHECK-NEXT:      );
 // CHECK-NEXT:   */
 // CHECK-NEXT: endmodule


### PR DESCRIPTION
For https://github.com/llvm/circt/issues/3853, this commit improves emission of XMR to inline XMR references into bound instance ports. 

For the example in #3853, the difference of w/ and w/o the PR:
```verilog
<   wire struct packed {logic x; logic y; } _TopXMRAsserts_inst0_a;
<   wire                                    _TopXMRAsserts_inst0_b;
38,39d35
<   assign _TopXMRAsserts_inst0_a = middle.bottom.O;
<   assign _TopXMRAsserts_inst0_b = middle.bottom.I.x;
44,45c40,41
<       .a (_TopXMRAsserts_inst0_a),
<       .b (_TopXMRAsserts_inst0_b)
---
>       .a (middle.bottom.O),
>       .b (middle.bottom.I.x)
57,58c53,54
<   .a (_TopXMRAsserts_inst0_a),
<   .b (_TopXMRAsserts_inst0_b)
---
>   .a (middle.bottom.O),
>   .b (middle.bottom.I.x)
```

CC: @rsetaluri 