### PR TITLE
[CI] Disable gcc/debug on nightly tests

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -25,6 +25,9 @@ jobs:
             cxx: clang++
           - cc: gcc
             cxx: g++
+        exclude:
+          - build-type: Debug
+            compiler: {cc: gcc, cxx: g++}
 
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone


### PR DESCRIPTION
GCC debug binaries are just too large and have been causing disk space issues intermittently. Just disable them for now as it is a longer effort to cut down on the amount of stuff we build. Fixes #3328 .