### PR TITLE
[ESI] Use `i0` instead of `none`

### DIFF
--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -23,15 +23,6 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
       "circt::esi::ChannelType", "channelType"
     >,
     InterfaceMethod<
-        "Returns true if this channel carries data.",
-        "bool",
-        "hasData",
-        (ins),
-        /*methodBody=*/"",
-        /*defaultImplementation=*/[{
-          return $_op.channelType().hasData();
-        }]>,
-    InterfaceMethod<
         [{"Returns the inner type of this channel. This will be the type of the
            data value of the channel, if the channel carries data semantics. Else,
            return NoneType."}],
@@ -40,8 +31,6 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
         (ins),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{
-          if(!$_op.hasData())
-            return mlir::NoneType::get($_op.getContext());
           return $_op.channelType().getInner();
         }]>
   ];

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -129,23 +129,3 @@ def NullSourceOp : ESI_Physical_Op<"null", [NoSideEffect]> {
 
   let assemblyFormat = [{ attr-dict `:` qualified(type($out)) }];
 }
-
-def NoneSourceOp : ESI_Physical_Op<"none", [NoSideEffect]> {
-  let summary = [{"
-    An op which produces a 'none'-typed value, used in conjunction.
-    with data-less channels.
-  "}];
-
-  let arguments = (ins);
-  let results = (outs NoneType:$out);
-
-  let assemblyFormat = [{ attr-dict `:` qualified(type($out)) }];
-
-  let builders = [
-    OpBuilder<(ins), [{
-      $_state.addTypes($_builder.getNoneType());
-    }]>
-  ];
-
-
-}

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -36,14 +36,6 @@ def ChannelType : ESI_Port<"Channel"> {
   let parameters = (ins "Type":$inner);
 
   let assemblyFormat = "`<` $inner `>`";
-
-  let extraClassDeclaration = [{
-    /// Returns true if this channel carries a data value.
-    bool hasData() {
-      return !getInner().isa<mlir::NoneType>();
-    }
-  }];
-
 }
 
 //=========

--- a/include/circt/Dialect/ESI/ESIStdServices.td
+++ b/include/circt/Dialect/ESI/ESIStdServices.td
@@ -18,7 +18,7 @@ def RandomAccessMemoryDeclOp: ESI_Op<"mem.ram",
 
     Ports:
       read(address: clog2(depth)) -> data: innerType
-      write({address: clog2(depth), data: innerType}) -> done: none
+      write({address: clog2(depth), data: innerType}) -> done: i0
 
     Users can ensure R/W ordering by waiting for the write "done" message before
     issuing a potentially dependant read. Ordering of R/W messages in flight is

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -195,10 +195,6 @@ StringAttr getArgSym(Operation *op, unsigned i);
 /// argument.
 StringAttr getResultSym(Operation *op, unsigned i);
 
-/// Creates an i0-typed constant.
-Value getI0Constant(OpBuilder &builder, Location loc);
-Value getI0Constant(ImplicitLocOpBuilder &builder);
-
 // A class for providing access to the in- and output ports of a module through
 // use of the HWModuleBuilder.
 class HWModulePortAccessor {

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -18,6 +18,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
@@ -193,6 +194,10 @@ StringAttr getArgSym(Operation *op, unsigned i);
 /// Return the symbol (if any, else null) on the corresponding output port
 /// argument.
 StringAttr getResultSym(Operation *op, unsigned i);
+
+/// Creates an i0-typed constant.
+Value getI0Constant(OpBuilder &builder, Location loc);
+Value getI0Constant(ImplicitLocOpBuilder &builder);
 
 // A class for providing access to the in- and output ports of a module through
 // use of the HWModuleBuilder.

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -133,7 +133,7 @@ instantiateSystemVerilogMemory(ServiceImplementReqOp req,
   auto rst = req.getOperand(1);
   auto write = b.getStringAttr("write");
   auto read = b.getStringAttr("read");
-  auto none = b.create<esi::NoneSourceOp>();
+  auto none = hw::getI0Constant(b);
   auto i1 = b.getI1Type();
   auto c0 = b.create<hw::ConstantOp>(i1, 0);
 

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -133,7 +133,8 @@ instantiateSystemVerilogMemory(ServiceImplementReqOp req,
   auto rst = req.getOperand(1);
   auto write = b.getStringAttr("write");
   auto read = b.getStringAttr("read");
-  auto none = hw::getI0Constant(b);
+  auto none = b.create<hw::ConstantOp>(
+      APInt(/*numBits*/ 0, /*val*/ 0, /*isSigned*/ false));
   auto i1 = b.getI1Type();
   auto c0 = b.create<hw::ConstantOp>(i1, 0);
 

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -43,7 +43,7 @@ void RandomAccessMemoryDeclOp::getPortList(
       {hw::StructType::FieldInfo{StringAttr::get(ctxt, "address"), addressType},
        hw::StructType::FieldInfo{StringAttr::get(ctxt, "data"),
                                  getInnerType()}});
-  ports.push_back(createPort("write", writeType, NoneType::get(ctxt)));
+  ports.push_back(createPort("write", writeType, IntegerType::get(ctxt, 0)));
 
   // Read port
   ports.push_back(createPort("read", addressType, getInnerType()));

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -188,6 +188,14 @@ StringAttr hw::getResultSym(Operation *op, unsigned i) {
   return sym;
 }
 
+Value hw::getI0Constant(OpBuilder &builder, Location loc) {
+  return builder.create<hw::ConstantOp>(
+      loc, APInt(/*numBits*/ 0, /*val*/ 0, /*isSigned*/ false));
+}
+Value hw::getI0Constant(ImplicitLocOpBuilder &builder) {
+  return getI0Constant(builder, builder.getLoc());
+}
+
 HWModulePortAccessor::HWModulePortAccessor(Location loc,
                                            const ModulePortInfo &info,
                                            Region &bodyRegion)

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -188,14 +188,6 @@ StringAttr hw::getResultSym(Operation *op, unsigned i) {
   return sym;
 }
 
-Value hw::getI0Constant(OpBuilder &builder, Location loc) {
-  return builder.create<hw::ConstantOp>(
-      loc, APInt(/*numBits*/ 0, /*val*/ 0, /*isSigned*/ false));
-}
-Value hw::getI0Constant(ImplicitLocOpBuilder &builder) {
-  return getI0Constant(builder, builder.getLoc());
-}
-
 HWModulePortAccessor::HWModulePortAccessor(Location loc,
                                            const ModulePortInfo &info,
                                            Region &bodyRegion)

--- a/test/Conversion/HandshakeToHW/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToHW/test_cmerge.mlir
@@ -3,10 +3,10 @@
 // Test a control merge that is control only.
 
 // CHECK-LABEL:   hw.module @handshake_control_merge_out_ui64_2ins_2outs_ctrl(
-// CHECK-SAME:              %[[VAL_0:.*]]: !esi.channel<none>, %[[VAL_1:.*]]: !esi.channel<none>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (dataOut: !esi.channel<none>, index: !esi.channel<i64>) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : none
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_9:.*]] : none
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : none
+// CHECK-SAME:              %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i0>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (dataOut: !esi.channel<i0>, index: !esi.channel<i64>) {
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : i0
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_9:.*]] : i0
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : i0
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = esi.wrap.vr %[[VAL_16:.*]], %[[VAL_17:.*]] : i64
 // CHECK:           %[[VAL_18:.*]] = hw.constant 0 : i2
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
@@ -27,7 +27,7 @@
 // CHECK:           %[[VAL_37:.*]] = hw.constant true
 // CHECK:           %[[VAL_38:.*]] = comb.xor %[[VAL_22]], %[[VAL_37]] : i1
 // CHECK:           %[[VAL_13]] = comb.and %[[VAL_29]], %[[VAL_38]] : i1
-// CHECK:           %[[VAL_12]] = esi.none : none
+// CHECK:           %[[VAL_12]] = hw.constant 0 : i0
 // CHECK:           %[[VAL_39:.*]] = comb.xor %[[VAL_24]], %[[VAL_37]] : i1
 // CHECK:           %[[VAL_17]] = comb.and %[[VAL_29]], %[[VAL_39]] : i1
 // CHECK:           %[[VAL_16]] = hw.constant 0 : i64
@@ -43,7 +43,7 @@
 // CHECK:           %[[VAL_46:.*]] = comb.mux %[[VAL_41]], %[[VAL_27]], %[[VAL_18]] : i2
 // CHECK:           %[[VAL_6]] = comb.icmp eq %[[VAL_46]], %[[VAL_35]] : i2
 // CHECK:           %[[VAL_9]] = comb.icmp eq %[[VAL_46]], %[[VAL_33]] : i2
-// CHECK:           hw.output %[[VAL_10]], %[[VAL_14]] : !esi.channel<none>, !esi.channel<i64>
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_14]] : !esi.channel<i0>, !esi.channel<i64>
 // CHECK:         }
 
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {

--- a/test/Conversion/HandshakeToHW/test_cond_br.mlir
+++ b/test/Conversion/HandshakeToHW/test_cond_br.mlir
@@ -24,11 +24,11 @@ handshake.func @test_conditional_branch(%arg0: i1, %arg1: index) -> (index, inde
 // -----
 
 // CHECK-LABEL:   hw.module @handshake_cond_br_in_ui1_2ins_2outs_ctrl(
-// CHECK-SAME:              %[[VAL_0:.*]]: !esi.channel<i1>, %[[VAL_1:.*]]: !esi.channel<none>) -> (outTrue: !esi.channel<none>, outFalse: !esi.channel<none>) {
+// CHECK-SAME:              %[[VAL_0:.*]]: !esi.channel<i1>, %[[VAL_1:.*]]: !esi.channel<i0>) -> (outTrue: !esi.channel<i0>, outFalse: !esi.channel<i0>) {
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : i1
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : none
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_5]], %[[VAL_9:.*]] : none
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_5]], %[[VAL_12:.*]] : none
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : i0
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_5]], %[[VAL_9:.*]] : i0
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_5]], %[[VAL_12:.*]] : i0
 // CHECK:           %[[VAL_13:.*]] = comb.and %[[VAL_3]], %[[VAL_6]] : i1
 // CHECK:           %[[VAL_9]] = comb.and %[[VAL_2]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_14:.*]] = hw.constant true
@@ -36,7 +36,7 @@ handshake.func @test_conditional_branch(%arg0: i1, %arg1: index) -> (index, inde
 // CHECK:           %[[VAL_12]] = comb.and %[[VAL_15]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_16:.*]] = comb.mux %[[VAL_2]], %[[VAL_8]], %[[VAL_11]] : i1
 // CHECK:           %[[VAL_4]] = comb.and %[[VAL_16]], %[[VAL_13]] : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_10]] : !esi.channel<none>, !esi.channel<none>
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_10]] : !esi.channel<i0>, !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @test_nonetyped_conditional_branch(%arg0: i1, %arg1: none) -> (none, none) {

--- a/test/Conversion/HandshakeToHW/test_constant.mlir
+++ b/test/Conversion/HandshakeToHW/test_constant.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_constant_c42_out_ui64(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<none>) -> (out0: !esi.channel<i64>) {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : none
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<i0>) -> (out0: !esi.channel<i64>) {
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : i0
 // CHECK:           %[[VAL_4:.*]], %[[VAL_3]] = esi.wrap.vr %[[VAL_5:.*]], %[[VAL_2]] : i64
 // CHECK:           %[[VAL_5]] = hw.constant 42 : i64
 // CHECK:           hw.output %[[VAL_4]] : !esi.channel<i64>
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @handshake_constant_c42_out_ui32(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<none>) -> (out0: !esi.channel<i32>) {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : none
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<i0>) -> (out0: !esi.channel<i32>) {
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : i0
 // CHECK:           %[[VAL_4:.*]], %[[VAL_3]] = esi.wrap.vr %[[VAL_5:.*]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5]] = hw.constant 42 : i32
 // CHECK:           hw.output %[[VAL_4]] : !esi.channel<i32>

--- a/test/Conversion/HandshakeToHW/test_extmemory.mlir
+++ b/test/Conversion/HandshakeToHW/test_extmemory.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_load_in_ui64_ui32_out_ui32_ui64(
-// CHECK-SAME:          %[[VAL_0:.*]]: !esi.channel<i64>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: !esi.channel<none>) -> (dataOut: !esi.channel<i32>, addrOut0: !esi.channel<i64>) {
+// CHECK-SAME:          %[[VAL_0:.*]]: !esi.channel<i64>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: !esi.channel<i0>) -> (dataOut: !esi.channel<i32>, addrOut0: !esi.channel<i64>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i64
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_8:.*]] : i32
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : none
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : i0
 // CHECK:           %[[VAL_11:.*]], %[[VAL_8]] = esi.wrap.vr %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_14:.*]] : i64
 // CHECK:           %[[VAL_14]] = comb.and %[[VAL_4]], %[[VAL_10]] : i1
@@ -13,10 +13,10 @@
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @handshake_store_in_ui64_ui32_out_ui32_ui64(
-// CHECK-SAME:         %[[VAL_0:.*]]: !esi.channel<i64>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: !esi.channel<none>) -> (dataToMem: !esi.channel<i32>, addrOut0: !esi.channel<i64>) {
+// CHECK-SAME:         %[[VAL_0:.*]]: !esi.channel<i64>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: !esi.channel<i0>) -> (dataToMem: !esi.channel<i32>, addrOut0: !esi.channel<i64>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i64
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_5]] : i32
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : none
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : i0
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_6]], %[[VAL_12:.*]] : i32
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_12]] : i64
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_11]], %[[VAL_14]] : i1

--- a/test/Conversion/HandshakeToHW/test_fork.mlir
+++ b/test/Conversion/HandshakeToHW/test_fork.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_fork_1ins_2outs_ctrl(
-// CHECK-SAME:            %[[VAL_0:.*]]: !esi.channel<none>, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<none>) {
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : none
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_8:.*]] : none
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_11:.*]] : none
+// CHECK-SAME:            %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i0>, out1: !esi.channel<i0>) {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i0
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_8:.*]] : i0
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.wrap.vr %[[VAL_3]], %[[VAL_11:.*]] : i0
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_5]], %[[VAL_13]] : i1
@@ -22,7 +22,7 @@
 // CHECK:           %[[VAL_25:.*]] = comb.and %[[VAL_10]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_22]] = comb.and %[[VAL_25]], %[[VAL_23]] : i1
 // CHECK:           %[[VAL_5]] = comb.and %[[VAL_16]], %[[VAL_22]] : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_9]] : !esi.channel<none>, !esi.channel<none>
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_9]] : !esi.channel<i0>, !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {

--- a/test/Conversion/HandshakeToHW/test_join.mlir
+++ b/test/Conversion/HandshakeToHW/test_join.mlir
@@ -1,15 +1,15 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_join_2ins_1outs_ctrl(
-// CHECK-SAME:                                              %[[VAL_0:.*]]: !esi.channel<none>,
-// CHECK-SAME:                                              %[[VAL_1:.*]]: !esi.channel<none>) -> (out0: !esi.channel<none>) {
-// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : none
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : none
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_9:.*]], %[[VAL_10:.*]] : none
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !esi.channel<i0>,
+// CHECK-SAME:                                              %[[VAL_1:.*]]: !esi.channel<i0>) -> (out0: !esi.channel<i0>) {
+// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : i0
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : i0
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_9:.*]], %[[VAL_10:.*]] : i0
 // CHECK:           %[[VAL_10]] = comb.and %[[VAL_3]], %[[VAL_6]] : i1
 // CHECK:           %[[VAL_4]] = comb.and %[[VAL_8]], %[[VAL_10]] : i1
-// CHECK:           %[[VAL_9]] = esi.none : none
-// CHECK:           hw.output %[[VAL_7]] : !esi.channel<none>
+// CHECK:           %[[VAL_9]] = hw.constant 0 : i0
+// CHECK:           hw.output %[[VAL_7]] : !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, none) {
@@ -22,15 +22,15 @@ handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, 
 // CHECK-LABEL:   hw.module @handshake_join_in_ui32_ui1_3ins_1outs_ctrl(
 // CHECK-SAME:                                                          %[[VAL_0:.*]]: !esi.channel<i32>,
 // CHECK-SAME:                                                          %[[VAL_1:.*]]: !esi.channel<i1>,
-// CHECK-SAME:                                                          %[[VAL_2:.*]]: !esi.channel<none>) -> (out0: !esi.channel<none>) {
+// CHECK-SAME:                                                          %[[VAL_2:.*]]: !esi.channel<i0>) -> (out0: !esi.channel<i0>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i32
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_5]] : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : none
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : none
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : i0
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : i0
 // CHECK:           %[[VAL_13]] = comb.and %[[VAL_4]], %[[VAL_7]], %[[VAL_9]] : i1
 // CHECK:           %[[VAL_5]] = comb.and %[[VAL_11]], %[[VAL_13]] : i1
-// CHECK:           %[[VAL_12]] = esi.none : none
-// CHECK:           hw.output %[[VAL_10]] : !esi.channel<none>
+// CHECK:           %[[VAL_12]] = hw.constant 0 : i0
+// CHECK:           hw.output %[[VAL_10]] : !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @test_join_multi_types(%arg0: i32, %arg1: i1, %arg2: none, ...) -> (none) {

--- a/test/Conversion/HandshakeToHW/test_simple_loop.mlir
+++ b/test/Conversion/HandshakeToHW/test_simple_loop.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @main(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !esi.channel<none>,
+// CHECK-SAME:                    %[[VAL_0:.*]]: !esi.channel<i0>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i1,
-// CHECK-SAME:                    %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i64>, outCtrl: !esi.channel<none>) {
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "handshake_fork0" @handshake_fork_1ins_4outs_ctrl(in0: %[[VAL_0]]: !esi.channel<none>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<none>, out2: !esi.channel<none>, out3: !esi.channel<none>)
-// CHECK:           %[[VAL_7:.*]] = hw.instance "handshake_constant0" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_5]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_8:.*]] = hw.instance "handshake_constant1" @handshake_constant_c42_out_ui64(ctrl: %[[VAL_4]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
-// CHECK:           %[[VAL_9:.*]] = hw.instance "handshake_constant2" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_3]]: !esi.channel<none>) -> (out0: !esi.channel<i64>)
+// CHECK-SAME:                    %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i64>, outCtrl: !esi.channel<i0>) {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "handshake_fork0" @handshake_fork_1ins_4outs_ctrl(in0: %[[VAL_0]]: !esi.channel<i0>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i0>, out1: !esi.channel<i0>, out2: !esi.channel<i0>, out3: !esi.channel<i0>)
+// CHECK:           %[[VAL_7:.*]] = hw.instance "handshake_constant0" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_5]]: !esi.channel<i0>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_8:.*]] = hw.instance "handshake_constant1" @handshake_constant_c42_out_ui64(ctrl: %[[VAL_4]]: !esi.channel<i0>) -> (out0: !esi.channel<i64>)
+// CHECK:           %[[VAL_9:.*]] = hw.instance "handshake_constant2" @handshake_constant_c1_out_ui64(ctrl: %[[VAL_3]]: !esi.channel<i0>) -> (out0: !esi.channel<i64>)
 // CHECK:           %[[VAL_10:.*]] = hw.instance "handshake_buffer0" @handshake_buffer_in_ui1_out_ui1_1slots_seq(in0: %[[VAL_11:.*]]: !esi.channel<i1>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i1>)
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = hw.instance "handshake_fork1" @handshake_fork_in_ui1_out_ui1_ui1_ui1_ui1(in0: %[[VAL_10]]: !esi.channel<i1>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i1>, out1: !esi.channel<i1>, out2: !esi.channel<i1>, out3: !esi.channel<i1>)
-// CHECK:           %[[VAL_16:.*]] = hw.instance "handshake_mux0" @handshake_mux_in_ui1_3ins_1outs_ctrl(select: %[[VAL_15]]: !esi.channel<i1>, in0: %[[VAL_6]]: !esi.channel<none>, in1: %[[VAL_17:.*]]: !esi.channel<none>) -> (out0: !esi.channel<none>)
+// CHECK:           %[[VAL_16:.*]] = hw.instance "handshake_mux0" @handshake_mux_in_ui1_3ins_1outs_ctrl(select: %[[VAL_15]]: !esi.channel<i1>, in0: %[[VAL_6]]: !esi.channel<i0>, in1: %[[VAL_17:.*]]: !esi.channel<i0>) -> (out0: !esi.channel<i0>)
 // CHECK:           %[[VAL_18:.*]] = hw.instance "handshake_mux1" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_14]]: !esi.channel<i1>, in0: %[[VAL_8]]: !esi.channel<i64>, in1: %[[VAL_19:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
 // CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = hw.instance "handshake_fork2" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_18]]: !esi.channel<i64>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
 // CHECK:           %[[VAL_22:.*]] = hw.instance "handshake_mux2" @handshake_mux_in_ui1_ui64_ui64_out_ui64(select: %[[VAL_13]]: !esi.channel<i1>, in0: %[[VAL_9]]: !esi.channel<i64>, in1: %[[VAL_23:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
@@ -22,11 +22,11 @@
 // CHECK:           hw.instance "handshake_sink0" @handshake_sink_in_ui64(in0: %[[VAL_33]]: !esi.channel<i64>) -> ()
 // CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = hw.instance "handshake_cond_br1" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_31]]: !esi.channel<i1>, data: %[[VAL_22]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
 // CHECK:           hw.instance "handshake_sink1" @handshake_sink_in_ui64(in0: %[[VAL_35]]: !esi.channel<i64>) -> ()
-// CHECK:           %[[VAL_17]], %[[VAL_36:.*]] = hw.instance "handshake_cond_br2" @handshake_cond_br_in_ui1_2ins_2outs_ctrl(cond: %[[VAL_30]]: !esi.channel<i1>, data: %[[VAL_16]]: !esi.channel<none>) -> (outTrue: !esi.channel<none>, outFalse: !esi.channel<none>)
+// CHECK:           %[[VAL_17]], %[[VAL_36:.*]] = hw.instance "handshake_cond_br2" @handshake_cond_br_in_ui1_2ins_2outs_ctrl(cond: %[[VAL_30]]: !esi.channel<i1>, data: %[[VAL_16]]: !esi.channel<i0>) -> (outTrue: !esi.channel<i0>, outFalse: !esi.channel<i0>)
 // CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]] = hw.instance "handshake_cond_br3" @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(cond: %[[VAL_29]]: !esi.channel<i1>, data: %[[VAL_27]]: !esi.channel<i64>) -> (outTrue: !esi.channel<i64>, outFalse: !esi.channel<i64>)
 // CHECK:           %[[VAL_23]], %[[VAL_39:.*]] = hw.instance "handshake_fork5" @handshake_fork_in_ui64_out_ui64_ui64(in0: %[[VAL_34]]: !esi.channel<i64>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i64>, out1: !esi.channel<i64>)
 // CHECK:           %[[VAL_25]] = hw.instance "arith_addi0" @arith_addi_in_ui64_ui64_out_ui64(in0: %[[VAL_37]]: !esi.channel<i64>, in1: %[[VAL_39]]: !esi.channel<i64>) -> (out0: !esi.channel<i64>)
-// CHECK:           hw.output %[[VAL_38]], %[[VAL_36]] : !esi.channel<i64>, !esi.channel<none>
+// CHECK:           hw.output %[[VAL_38]], %[[VAL_36]] : !esi.channel<i64>, !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @main(%arg0: none, ...) -> (i64, none) attributes {argNames = ["inCtrl"], resNames = ["out0", "outCtrl"]} {

--- a/test/Conversion/HandshakeToHW/test_source.mlir
+++ b/test/Conversion/HandshakeToHW/test_source.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt -lower-handshake-to-hw %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @handshake_source_0ins_1outs_ctrl() -> (out0: !esi.channel<none>) {
-// CHECK:           %[[VAL_0:.*]], %[[VAL_1:.*]] = esi.wrap.vr %[[VAL_2:.*]], %[[VAL_3:.*]] : none
+// CHECK-LABEL:   hw.module @handshake_source_0ins_1outs_ctrl() -> (out0: !esi.channel<i0>) {
+// CHECK:           %[[VAL_0:.*]], %[[VAL_1:.*]] = esi.wrap.vr %[[VAL_2:.*]], %[[VAL_3:.*]] : i0
 // CHECK:           %[[VAL_3]] = hw.constant true
-// CHECK:           %[[VAL_2]] = esi.none : none
-// CHECK:           hw.output %[[VAL_0]] : !esi.channel<none>
+// CHECK:           %[[VAL_2]] = hw.constant 0 : i0
+// CHECK:           hw.output %[[VAL_0]] : !esi.channel<i0>
 // CHECK:         }
 
 handshake.func @test_source() -> (none) {

--- a/test/Conversion/HandshakeToHW/test_sync.mlir
+++ b/test/Conversion/HandshakeToHW/test_sync.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @handshake_sync_in_ui32_out_ui32(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<none>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: !esi.channel<none>, out1: !esi.channel<i32>) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : none
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: !esi.channel<i0>, out1: !esi.channel<i32>) {
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : i0
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.wrap.vr %[[VAL_4]], %[[VAL_11:.*]] : none
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = esi.wrap.vr %[[VAL_4]], %[[VAL_11:.*]] : i0
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = esi.wrap.vr %[[VAL_7]], %[[VAL_14:.*]] : i32
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_5]], %[[VAL_8]] : i1
 // CHECK:           %[[VAL_6]] = comb.and %[[VAL_16:.*]], %[[VAL_15]] : i1
@@ -25,7 +25,7 @@
 // CHECK:           %[[VAL_30:.*]] = comb.and %[[VAL_13]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_27]] = comb.and %[[VAL_30]], %[[VAL_28]] : i1
 // CHECK:           %[[VAL_16]] = comb.and %[[VAL_21]], %[[VAL_27]] : i1
-// CHECK:           hw.output %[[VAL_9]], %[[VAL_12]] : !esi.channel<none>, !esi.channel<i32>
+// CHECK:           hw.output %[[VAL_9]], %[[VAL_12]] : !esi.channel<i0>, !esi.channel<i32>
 // CHECK:         }
 
 handshake.func @main(%arg0: none, %arg1: i32) -> (none, i32) {

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -83,20 +83,18 @@ hw.module @testIfaceWrap() {
   // CHECK-NEXT:     esi.unwrap.iface %3 into %6 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 }
 
-// CHECK-LABEL: hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rst: i1) -> (x: !esi.channel<none>) {
-// CHECK-NEXT:    %0 = esi.buffer %clk, %rst, %a  : none
-// CHECK-NEXT:    %1 = esi.stage %clk, %rst, %0  : none
-// CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %1, %ready : none
-// CHECK-NEXT:    %2 = esi.none : none
-// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %2, %valid : none
-// CHECK-NEXT:    hw.output %chanOutput : !esi.channel<none>
+// CHECK-LABEL: hw.module @i0Typed(%a: !esi.channel<i0>, %clk: i1, %rst: i1) -> (x: !esi.channel<i0>) {
+// CHECK-NEXT:    %0 = esi.buffer %clk, %rst, %a  : i0
+// CHECK-NEXT:    %1 = esi.stage %clk, %rst, %0  : i0
+// CHECK-NEXT:    %rawOutput, %valid = esi.unwrap.vr %1, %ready : i0
+// CHECK-NEXT:    %chanOutput, %ready = esi.wrap.vr %rawOutput, %valid : i0
+// CHECK-NEXT:    hw.output %chanOutput : !esi.channel<i0>
 // CHECK-NEXT:  }
 
-hw.module @NoneTyped(%a: !esi.channel<none>, %clk : i1, %rst : i1) -> (x: !esi.channel<none>) {
-  %bufferedA = esi.buffer %clk, %rst, %a : none
-  %stagedA = esi.stage %clk, %rst, %bufferedA : none
-  %none1, %valid = esi.unwrap.vr %stagedA, %rcvrRdy : none
-  %none2 = esi.none : none
-  %ch, %rcvrRdy = esi.wrap.vr %none2, %valid : none
-  hw.output %ch : !esi.channel<none>
+hw.module @i0Typed(%a: !esi.channel<i0>, %clk : i1, %rst : i1) -> (x: !esi.channel<i0>) {
+  %bufferedA = esi.buffer %clk, %rst, %a : i0
+  %stagedA = esi.stage %clk, %rst, %bufferedA : i0
+  %rawOutput, %valid = esi.unwrap.vr %stagedA, %rcvrRdy : i0
+  %ch, %rcvrRdy = esi.wrap.vr %rawOutput, %valid : i0
+  hw.output %ch : !esi.channel<i0>
 }

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -5,7 +5,7 @@
 hw.module.extern @Sender(%clk: i1) -> (x: !esi.channel<i4>, y: i8)
 hw.module.extern @ArrSender() -> (x: !esi.channel<!hw.array<4xi64>>)
 hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
-hw.module.extern @NoneSenderReceiver(%in: !esi.channel<none>) -> (out: !esi.channel<none>)
+hw.module.extern @i0SenderReceiver(%in: !esi.channel<i0>) -> (out: !esi.channel<i0>)
 
 // CHECK-LABEL: hw.module.extern @Sender(%clk: i1) -> (x: !esi.channel<i4>, y: i8)
 // CHECK-LABEL: hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
@@ -22,15 +22,16 @@ hw.module.extern @NoneSenderReceiver(%in: !esi.channel<none>) -> (out: !esi.chan
 // IFACE-NEXT:    sv.interface.signal @data : !hw.array<4xi64>
 // IFACE-NEXT:    sv.interface.modport @sink  (input @ready, output @valid, output @data)
 // IFACE-NEXT:    sv.interface.modport @source  (input @valid, input @data, output @ready)
-// IFACE-LABEL: sv.interface @IValidReady_none {
+// IFACE-LABEL: sv.interface @IValidReady_i0 {
 // IFACE-NEXT:    sv.interface.signal @valid : i1
 // IFACE-NEXT:    sv.interface.signal @ready : i1
-// IFACE-NEXT:    sv.interface.modport @sink (input @ready, output @valid)
-// IFACE-NEXT:    sv.interface.modport @source (input @valid, output @ready)
+// IFACE-NEXT:    sv.interface.signal @data : i0
+// IFACE-NEXT:    sv.interface.modport @sink (input @ready, output @valid, output @data)
+// IFACE-NEXT:    sv.interface.modport @source (input @valid, input @data, output @ready)
 // IFACE-LABEL: hw.module.extern @Sender(%clk: i1, %x: !sv.modport<@IValidReady_i4::@sink>) -> (y: i8)
 // IFACE-LABEL: hw.module.extern @ArrSender(%x: !sv.modport<@IValidReady_ArrayOf4xi64::@sink>)
 // IFACE-LABEL: hw.module.extern @Reciever(%a: !sv.modport<@IValidReady_i4::@source>, %clk: i1)
-// IFACE-LABEL: hw.module.extern @NoneSenderReceiver(%in: !sv.modport<@IValidReady_none::@source>, %out: !sv.modport<@IValidReady_none::@sink>)
+// IFACE-LABEL: hw.module.extern @i0SenderReceiver(%in: !sv.modport<@IValidReady_i0::@source>, %out: !sv.modport<@IValidReady_i0::@sink>)
 
 hw.module @test(%clk:i1, %rst:i1) {
 
@@ -113,33 +114,32 @@ hw.module @test_constant(%arg0: !esi.channel<i1>, %clock: i1, %reset: i1) -> (ou
   hw.output %handshake_fork0.out1 : !esi.channel<i1>
 }
 
-// HW-LABEL: hw.module @NoneTyped(%a_valid: i1, %clk: i1, %rst: i1, %x_ready: i1) -> (x_valid: i1, a_ready: i1) {
-// HW:         %pipelineStage.a_ready, %pipelineStage.x_valid = hw.instance "pipelineStage" @ESI_PipelineStage1<WIDTH: ui32 = [[DEFAULT_WIDTH:.*]]>(clk: %clk: i1, rst: %rst: i1, a_valid: %a_valid: i1, x_ready: %x_ready: i1) -> (a_ready: i1, x_valid: i1)
-// HW:         hw.output %pipelineStage.x_valid, %pipelineStage.a_ready : i1, i1
+// HW-LABEL: hw.module @i0Typed(%a: i0, %a_valid: i1, %clk: i1, %rst: i1, %x_ready: i1) -> (x: i0, x_valid: i1, a_ready: i1) {
+// HW:         %pipelineStage.a_ready, %pipelineStage.x, %pipelineStage.x_valid = hw.instance "pipelineStage" @ESI_PipelineStage1<WIDTH: ui32 = 0>(clk: %clk: i1, rst: %rst: i1, a: %a: i0, a_valid: %a_valid: i1, x_ready: %x_ready: i1) -> (a_ready: i1, x: i0, x_valid: i1)
+// HW:         hw.output %pipelineStage.x, %pipelineStage.x_valid, %pipelineStage.a_ready : i0, i1, i1
 // HW:       }
-hw.module @NoneTyped(%a: !esi.channel<none>, %clk: i1, %rst: i1) -> (x: !esi.channel<none>) {
-  %0 = esi.buffer %clk, %rst, %a  : none
-  %noneValue, %valid = esi.unwrap.vr %0, %ready : none
-  %noneV2 = esi.none : none
-  %chanOutput, %ready = esi.wrap.vr %noneV2, %valid : none
-  hw.output %chanOutput : !esi.channel<none>
+hw.module @i0Typed(%a: !esi.channel<i0>, %clk: i1, %rst: i1) -> (x: !esi.channel<i0>) {
+  %0 = esi.buffer %clk, %rst, %a  : i0
+  %i0Value, %valid = esi.unwrap.vr %0, %ready : i0
+  %chanOutput, %ready = esi.wrap.vr %i0Value, %valid : i0
+  hw.output %chanOutput : !esi.channel<i0>
 }
 
-// IFACE: hw.module @HandshakeToESIWrapper(%clock: i1, %reset: i1, %in_ctrl_valid: i1, %in0_ld_data0: i32, %in0_ld_data0_valid: i1, %in1_ld_data0: i32, %in1_ld_data0_valid: i1, %out_ctrl_ready: i1, %in0_ld_addr0_ready: i1, %in1_ld_addr0_ready: i1, %out0_ready: i1) -> (out_ctrl_valid: i1, in0_ld_addr0: i64, in0_ld_addr0_valid: i1, in1_ld_addr0: i64, in1_ld_addr0_valid: i1, out0: i32, out0_valid: i1, in_ctrl_ready: i1, in0_ld_data0_ready: i1, in1_ld_data0_ready: i1)
-hw.module @HandshakeToESIWrapper(%clock: i1, %reset: i1, %in_ctrl: !esi.channel<none>, %in0_ld_data0: !esi.channel<i32>, %in1_ld_data0: !esi.channel<i32>) -> (out_ctrl: !esi.channel<none>, in0_ld_addr0: !esi.channel<i64>, in1_ld_addr0: !esi.channel<i64>, out0: !esi.channel<i32>) {
-  %none = esi.none : none
+// IFACE: hw.module @HandshakeToESIWrapper(%clock: i1, %reset: i1, %in_ctrl: i0, %in_ctrl_valid: i1, %in0_ld_data0: i32, %in0_ld_data0_valid: i1, %in1_ld_data0: i32, %in1_ld_data0_valid: i1, %out_ctrl_ready: i1, %in0_ld_addr0_ready: i1, %in1_ld_addr0_ready: i1, %out0_ready: i1) -> (out_ctrl: i0, out_ctrl_valid: i1, in0_ld_addr0: i64, in0_ld_addr0_valid: i1, in1_ld_addr0: i64, in1_ld_addr0_valid: i1, out0: i32, out0_valid: i1, in_ctrl_ready: i1, in0_ld_data0_ready: i1, in1_ld_data0_ready: i1)
+hw.module @HandshakeToESIWrapper(%clock: i1, %reset: i1, %in_ctrl: !esi.channel<i0>, %in0_ld_data0: !esi.channel<i32>, %in1_ld_data0: !esi.channel<i32>) -> (out_ctrl: !esi.channel<i0>, in0_ld_addr0: !esi.channel<i64>, in1_ld_addr0: !esi.channel<i64>, out0: !esi.channel<i32>) {
+  %i0 = hw.constant 0 : i0
   %c1 = hw.constant 1 : i1
   %c32 = hw.constant 1 : i32
   %c64 = hw.constant 1 : i64
-  %chanOutput, %ready = esi.wrap.vr %none, %c1 : none
+  %chanOutput, %ready = esi.wrap.vr %i0, %c1 : i0
   %chanOutput_2, %ready_3 = esi.wrap.vr %c64, %c1 : i64
   %chanOutput_6, %ready_7 = esi.wrap.vr %c64, %c1 : i64
   %chanOutput_8, %ready_9 = esi.wrap.vr %c32, %c1 : i32
-  hw.output %chanOutput, %chanOutput_2, %chanOutput_6, %chanOutput_8 : !esi.channel<none>, !esi.channel<i64>, !esi.channel<i64>, !esi.channel<i32>
+  hw.output %chanOutput, %chanOutput_2, %chanOutput_6, %chanOutput_8 : !esi.channel<i0>, !esi.channel<i64>, !esi.channel<i64>, !esi.channel<i32>
 }
 
-// IFACE: hw.module @ServiceWrapper(%clock: i1, %reset: i1, %ctrl_valid: i1, %port0: i32, %port0_valid: i1, %port1: i32, %port1_valid: i1, %ctrl_ready: i1, %port0_ready: i1, %port1_ready: i1) -> (ctrl_valid: i1, port0: i64, port0_valid: i1, port1: i64, port1_valid: i1, ctrl_ready: i1, port0_ready: i1, port1_ready: i1)
-hw.module @ServiceWrapper(%clock: i1, %reset: i1, %ctrl: !esi.channel<none>, %port0: !esi.channel<i32>, %port1: !esi.channel<i32>) -> (ctrl: !esi.channel<none>, port0: !esi.channel<i64>, port1: !esi.channel<i64>) {
-  %HandshakeToESIWrapper.out_ctrl, %HandshakeToESIWrapper.in0_ld_addr0, %HandshakeToESIWrapper.in1_ld_addr0, %HandshakeToESIWrapper.out0 = hw.instance "HandshakeToESIWrapper" @HandshakeToESIWrapper(clock: %clock: i1, reset: %reset: i1, in_ctrl: %ctrl: !esi.channel<none>, in0_ld_data0: %port0: !esi.channel<i32>, in1_ld_data0: %port1: !esi.channel<i32>) -> (out_ctrl: !esi.channel<none>, in0_ld_addr0: !esi.channel<i64>, in1_ld_addr0: !esi.channel<i64>, out0: !esi.channel<i32>)
-  hw.output %HandshakeToESIWrapper.out_ctrl, %HandshakeToESIWrapper.in0_ld_addr0, %HandshakeToESIWrapper.in1_ld_addr0 : !esi.channel<none>, !esi.channel<i64>, !esi.channel<i64>
+// IFACE: hw.module @ServiceWrapper(%clock: i1, %reset: i1, %ctrl: i0, %ctrl_valid: i1, %port0: i32, %port0_valid: i1, %port1: i32, %port1_valid: i1, %ctrl_ready: i1, %port0_ready: i1, %port1_ready: i1) -> (ctrl: i0, ctrl_valid: i1, port0: i64, port0_valid: i1, port1: i64, port1_valid: i1, ctrl_ready: i1, port0_ready: i1, port1_ready: i1)
+hw.module @ServiceWrapper(%clock: i1, %reset: i1, %ctrl: !esi.channel<i0>, %port0: !esi.channel<i32>, %port1: !esi.channel<i32>) -> (ctrl: !esi.channel<i0>, port0: !esi.channel<i64>, port1: !esi.channel<i64>) {
+  %HandshakeToESIWrapper.out_ctrl, %HandshakeToESIWrapper.in0_ld_addr0, %HandshakeToESIWrapper.in1_ld_addr0, %HandshakeToESIWrapper.out0 = hw.instance "HandshakeToESIWrapper" @HandshakeToESIWrapper(clock: %clock: i1, reset: %reset: i1, in_ctrl: %ctrl: !esi.channel<i0>, in0_ld_data0: %port0: !esi.channel<i32>, in1_ld_data0: %port1: !esi.channel<i32>) -> (out_ctrl: !esi.channel<i0>, in0_ld_addr0: !esi.channel<i64>, in1_ld_addr0: !esi.channel<i64>, out0: !esi.channel<i32>)
+  hw.output %HandshakeToESIWrapper.out_ctrl, %HandshakeToESIWrapper.in0_ld_addr0, %HandshakeToESIWrapper.in1_ld_addr0 : !esi.channel<i0>, !esi.channel<i64>, !esi.channel<i64>
 }

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -146,39 +146,39 @@ msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
 }
 
 // CHECK-LABEL: esi.mem.ram @MemA i64 x 20
-// CHECK-LABEL: hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!hw.struct<address: i5, data: i64>>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<none>) {
+// CHECK-LABEL: hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!hw.struct<address: i5, data: i64>>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<i0>) {
 // CHECK:         esi.service.instance @MemA impl as "sv_mem"(%clk, %rst) : (i1, i1) -> ()
-// CHECK:         [[DONE:%.+]] = esi.service.req.inout %write -> <@MemA::@write>([]) : !esi.channel<!hw.struct<address: i5, data: i64>> -> !esi.channel<none>
+// CHECK:         [[DONE:%.+]] = esi.service.req.inout %write -> <@MemA::@write>([]) : !esi.channel<!hw.struct<address: i5, data: i64>> -> !esi.channel<i0>
 // CHECK:         [[READ_DATA:%.+]] = esi.service.req.inout %readAddress -> <@MemA::@read>([]) : !esi.channel<i5> -> !esi.channel<i64>
-// CHECK:         hw.output [[READ_DATA]], [[DONE]] : !esi.channel<i64>, !esi.channel<none>
+// CHECK:         hw.output [[READ_DATA]], [[DONE]] : !esi.channel<i64>, !esi.channel<i0>
 
 // CONN-LABEL: esi.mem.ram @MemA i64 x 20
-// CONN-LABEL: hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!hw.struct<address: i5, data: i64>>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<none>) {
+// CONN-LABEL: hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!hw.struct<address: i5, data: i64>>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<i0>) {
 // CONN:         %MemA = sv.reg  : !hw.inout<uarray<20xi64>>
-// CONN:         %chanOutput, %ready = esi.wrap.vr %0, %write_done : none
+// CONN:         %chanOutput, %ready = esi.wrap.vr %c0_i0, %write_done : i0
 // CONN:         %rawOutput, %valid = esi.unwrap.vr %write, %ready : !hw.struct<address: i5, data: i64>
-// CONN:         %1 = hw.struct_extract %rawOutput["address"] : !hw.struct<address: i5, data: i64>
-// CONN:         %2 = hw.struct_extract %rawOutput["data"] : !hw.struct<address: i5, data: i64>
-// CONN:         %3 = comb.and %valid, %ready {sv.namehint = "write_go"} : i1
-// CONN:         %write_done = seq.compreg sym @write_done %3, %clk, %rst, %false  : i1
-// CONN:         %chanOutput_0, %ready_1 = esi.wrap.vr %5, %valid_3 : i64
+// CONN:         %0 = hw.struct_extract %rawOutput["address"] : !hw.struct<address: i5, data: i64>
+// CONN:         %1 = hw.struct_extract %rawOutput["data"] : !hw.struct<address: i5, data: i64>
+// CONN:         %2 = comb.and %valid, %ready {sv.namehint = "write_go"} : i1
+// CONN:         %write_done = seq.compreg sym @write_done %2, %clk, %rst, %false  : i1
+// CONN:         %chanOutput_0, %ready_1 = esi.wrap.vr %4, %valid_3 : i64
 // CONN:         %rawOutput_2, %valid_3 = esi.unwrap.vr %readAddress, %ready_1 : i5
-// CONN:         %4 = sv.array_index_inout %MemA[%rawOutput_2] : !hw.inout<uarray<20xi64>>, i5
-// CONN:         %5 = sv.read_inout %4 : !hw.inout<i64>
+// CONN:         %3 = sv.array_index_inout %MemA[%rawOutput_2] : !hw.inout<uarray<20xi64>>, i5
+// CONN:         %4 = sv.read_inout %3 : !hw.inout<i64>
 // CONN:         sv.alwaysff(posedge %clk) {
-// CONN:           sv.if %3 {
-// CONN:             %6 = sv.array_index_inout %MemA[%1] : !hw.inout<uarray<20xi64>>, i5
-// CONN:             sv.passign %6, %2 : i64
+// CONN:           sv.if %2 {
+// CONN:             %5 = sv.array_index_inout %MemA[%0] : !hw.inout<uarray<20xi64>>, i5
+// CONN:             sv.passign %5, %1 : i64
 // CONN:           }
 // CONN:         }(syncreset : posedge %rst) {
 // CONN:         }
-// CONN:         hw.output %chanOutput_0, %chanOutput : !esi.channel<i64>, !esi.channel<none>
+// CONN:         hw.output %chanOutput_0, %chanOutput : !esi.channel<i64>, !esi.channel<i0>
 
 esi.mem.ram @MemA i64 x 20
 !write = !hw.struct<address: i5, data: i64>
-hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!write>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<none>) {
+hw.module @MemoryAccess1(%clk: i1, %rst: i1, %write: !esi.channel<!write>, %readAddress: !esi.channel<i5>) -> (readData: !esi.channel<i64>, writeDone: !esi.channel<i0>) {
   esi.service.instance @MemA impl as "sv_mem" (%clk, %rst) : (i1, i1) -> ()
-  %done = esi.service.req.inout %write -> <@MemA::@write> ([]) : !esi.channel<!write> -> !esi.channel<none>
+  %done = esi.service.req.inout %write -> <@MemA::@write> ([]) : !esi.channel<!write> -> !esi.channel<i0>
   %readData = esi.service.req.inout %readAddress -> <@MemA::@read> ([]) : !esi.channel<i5> -> !esi.channel<i64>
-  hw.output %readData, %done : !esi.channel<i64>, !esi.channel<none>
+  hw.output %readData, %done : !esi.channel<i64>, !esi.channel<i0>
 }


### PR DESCRIPTION
Lots of special-case logic removed - `i0` is working as intended, feels good...!