### PR TITLE
[FIRRTL][LowerAnnotation] Mark the DataTap sink as NoDedup

### DIFF
--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1359,6 +1359,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
     // CHECK:  %b__gen_tap = firrtl.instance b interesting_name  @Bar(out _gen_tap: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.connect %_gen_tap, %b__gen_tap : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
+  // CHECK: firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]}
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>


### PR DESCRIPTION
This commit adds a `firrtl.transforms.NoDedupAnnotation` annotation to the datatap sink module, to ensure they are not deduped.
Datatap sink modules will have input `RefType` ports, and `LowerXMR` should be able to statically resolve each `RefType` to a single `ref.send`, otherwise the pass will fail to generate the XMR strings. If the sink modules are deduped, then the input ref port cannot be resolved statically to a single `ref.send`. Hence it is required to block their dedup.
