### PR TITLE
[FIRRTL][GrandCentral] Update attribute wireName to sink

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -303,11 +303,11 @@ LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
                  .attachNote()
              << "The full Annotation is reprodcued here: " << anno << "\n";
 
-    auto wireNameAttr =
-        tryGetAs<StringAttr>(bDict, anno, "wireName", loc, dataTapsClass, path);
+    auto sinkNameAttr =
+        tryGetAs<StringAttr>(bDict, anno, "sink", loc, dataTapsClass, path);
     std::string wirePathStr;
-    if (wireNameAttr)
-      wirePathStr = canonicalizeTarget(wireNameAttr.getValue());
+    if (sinkNameAttr)
+      wirePathStr = canonicalizeTarget(sinkNameAttr.getValue());
     if (!wirePathStr.empty())
       if (!tokenizePath(wirePathStr))
         wirePathStr.clear();
@@ -322,7 +322,7 @@ LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
     if (!wireTarget->ref.getImpl().isOp())
       return mlir::emitError(loc, "Annotation '" + Twine(dataTapsClass) +
                                       "' with path '" + path + ".class" +
-                                      +"' cannot specify a port for wireName.");
+                                      +"' cannot specify a port for sink.");
     // Extract the name of the wire, used for datatap.
     auto tapName = StringAttr::get(
         context, wirePathStr.substr(wirePathStr.find_last_of('>') + 1));
@@ -675,9 +675,13 @@ LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
   if (!srcTarget)
     return mlir::emitError(loc, "cannot resolve source target path '")
            << sourceTargetStr << "'";
-  auto tapsAttr = tryGetAs<ArrayAttr>(anno, anno, "wireName", loc, memTapClass);
-  if (!tapsAttr || tapsAttr.empty())
-    return mlir::emitError(loc, "wireName must have at least one entry");
+  auto tapsAttr = tryGetAs<StringAttr>(anno, anno, "sink", loc, memTapClass);
+  if (!tapsAttr) {
+    return mlir::emitError(loc, "Annotation '" + Twine(memTapClass) +
+                                    "contained an unknown sink attribute.")
+               .attachNote()
+           << "The full Annotation is reprodcued here: " << anno << "\n";
+  }
   if (auto combMem = dyn_cast<chirrtl::CombMemOp>(srcTarget->ref.getOp())) {
     if (!combMem.getType().getElementType().isGround())
       return combMem.emitOpError(
@@ -703,25 +707,12 @@ LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
             "exist and unique instance cannot be resolved");
       srcTarget->instances.append(path.back().begin(), path.back().end());
     }
-    if (tapsAttr.size() != combMem.getType().getNumElements())
-      return mlir::emitError(
-          loc,
-          "wireName cannot specify more taps than the depth of the memory");
   } else
     return srcTarget->ref.getOp()->emitOpError(
         "unsupported operation, only CombMem can be used as the source of "
         "MemTap");
 
-  auto tap = tapsAttr[0].dyn_cast_or_null<StringAttr>();
-  if (!tap) {
-    return mlir::emitError(
-               loc, "Annotation '" + Twine(memTapClass) +
-                        "' with path '.taps[0" +
-                        "]' contained an unexpected type (expected a string).")
-               .attachNote()
-           << "The full Annotation is reprodcued here: " << anno << "\n";
-  }
-  auto wireTargetStr = canonicalizeTarget(tap.getValue());
+  auto wireTargetStr = canonicalizeTarget(tapsAttr.getValue());
   if (!tokenizePath(wireTargetStr))
     return failure();
   Optional<AnnoPathValue> wireTarget = resolvePath(

--- a/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/constant-data-taps.fir
@@ -7,7 +7,7 @@ circuit ConstantSinking : %[[
       {
         "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source": "~ConstantSinking|ConstantSinking>w",
-        "wireName": "~ConstantSinking|ConstantSinking>t"
+        "sink": "~ConstantSinking|ConstantSinking>t"
       }
     ]
   },

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
@@ -7,32 +7,32 @@ circuit Top : %[[
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
-        "wireName":"~Top|Submodule>tap_0"
+        "sink":"~Top|Submodule>tap_0"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>wire_DUT",
-        "wireName":"~Top|Submodule>tap_1"
+        "sink":"~Top|Submodule>tap_1"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
-        "wireName":"~Top|Submodule>tap_2"
+        "sink":"~Top|Submodule>tap_2"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
-        "wireName":"~Top|Submodule>tap_3"
+        "sink":"~Top|Submodule>tap_3"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>port_DUT",
-        "wireName":"~Top|Submodule>tap_4"
+        "sink":"~Top|Submodule>tap_4"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>port_Top",
-        "wireName":"~Top|Submodule>tap_5"
+        "sink":"~Top|Submodule>tap_5"
       }
     ]
   },
@@ -42,32 +42,32 @@ circuit Top : %[[
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
-        "wireName":"~Top|DUT>tap_0"
+        "sink":"~Top|DUT>tap_0"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>wire_DUT",
-        "wireName":"~Top|DUT>tap_1"
+        "sink":"~Top|DUT>tap_1"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
-        "wireName":"~Top|DUT>tap_2"
+        "sink":"~Top|DUT>tap_2"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
-        "wireName":"~Top|DUT>tap_3"
+        "sink":"~Top|DUT>tap_3"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>port_DUT",
-        "wireName":"~Top|DUT>tap_4"
+        "sink":"~Top|DUT>tap_4"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>port_Top",
-        "wireName":"~Top|DUT>tap_5"
+        "sink":"~Top|DUT>tap_5"
       }
     ]
   },
@@ -77,32 +77,32 @@ circuit Top : %[[
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
-        "wireName":"~Top|Top>tap[0]"
+        "sink":"~Top|Top>tap[0]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>wire_DUT",
-        "wireName":"~Top|Top>tap[1]"
+        "sink":"~Top|Top>tap[1]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
-        "wireName":"~Top|Top>tap[2]"
+        "sink":"~Top|Top>tap[2]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
-        "wireName":"~Top|Top>tap[3]"
+        "sink":"~Top|Top>tap[3]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>port_DUT",
-        "wireName":"~Top|Top>tap[4]"
+        "sink":"~Top|Top>tap[4]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>port_Top",
-        "wireName":"~Top|Top>tap[5]"
+        "sink":"~Top|Top>tap[5]"
       }
     ]
   },

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -7,19 +7,19 @@ circuit Top : %[[
       {
         "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source": "~Top|Top/foo:Foo/b:Bar>inv",
-        "wireName": "~Top|Top>tap"
+        "sink": "~Top|Top>tap"
       },
       {
         "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
         "module":"~Top|BlackBox",
         "internalPath":"random.something",
-        "wireName": "~Top|Top>tap2"
+        "sink": "~Top|Top>tap2"
       },
       {
         "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
         "module":"~Top|InternalPathChild",
         "internalPath":"io_out",
-        "wireName": "~Top|Top/unsigned:ChildWrapper/signed:Child>tap"
+        "sink": "~Top|Top/unsigned:ChildWrapper/signed:Child>tap"
       }
     ]
   },

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -13,16 +13,7 @@ circuit Top : %[[
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
     "source":"~Top|DUTModule>rf",
-    "wireName":[
-      "~Top|Top>memTap[0]",
-      "~Top|Top>memTap[1]",
-      "~Top|Top>memTap[2]",
-      "~Top|Top>memTap[3]",
-      "~Top|Top>memTap[4]",
-      "~Top|Top>memTap[5]",
-      "~Top|Top>memTap[6]",
-      "~Top|Top>memTap[7]"
-    ]
+    "sink": "~Top|Top>memTap"
   }
 ]]
   module DUTModule :

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -12,16 +12,7 @@ circuit Top : %[[
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
     "source":"~Top|DUTModule>rf",
-    "wireName":[
-      "~Top|Top>memTap[0]",
-      "~Top|Top>memTap[1]",
-      "~Top|Top>memTap[2]",
-      "~Top|Top>memTap[3]",
-      "~Top|Top>memTap[4]",
-      "~Top|Top>memTap[5]",
-      "~Top|Top>memTap[6]",
-      "~Top|Top>memTap[7]"
-    ]
+    "sink":"~Top|Top>memTap"
   }
 ]]
   module DUTModule :

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1342,7 +1342,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   keys = [
     {
        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-       source = "~Top|Top/foo:Foo/b:Bar>inv", wireName = "~Top|Top>tap"
+       source = "~Top|Top/foo:Foo/b:Bar>inv", sink = "~Top|Top>tap"
     }
   ]}]} {
   // CHECK-LABEL: firrtl.circuit "Top"  {
@@ -1380,7 +1380,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
         class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
         internalPath = "random.something",
         module = "~Top|Bar",
-        wireName = "~Top|Top>tap"
+        sink = "~Top|Top>tap"
       }
     ]}]} {
   firrtl.module private @Bar() {


### PR DESCRIPTION
Update the GrandCentral attribute `wireName` to `sink`.