### PR TITLE
[HW] Add pass for flattening structs in module in/out ports

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -24,6 +24,7 @@ namespace hw {
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
+std::unique_ptr<mlir::Pass> createFlattenIOPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -35,8 +35,8 @@ def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
   let constructor =  "circt::hw::createFlattenIOPass()";
   
   let options = [
-    Option<"verboseEdges", "verbose-edges", "bool", "false",
-      "Print information on SSA edges (types, operand #, ...)">,
+    Option<"recursive", "recursive", "bool", "false",
+      "Recursively flatten nested structs.">,
   ];
 }
 

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -30,6 +30,16 @@ def PrintHWModuleGraph : Pass<"hw-print-module-graph", "mlir::ModuleOp"> {
   ];
 }
 
+def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
+  let summary = "Flattens hw::Structure typed in- and output ports.";
+  let constructor =  "circt::hw::createFlattenIOPass()";
+  
+  let options = [
+    Option<"verboseEdges", "verbose-edges", "bool", "false",
+      "Print information on SSA edges (types, operand #, ...)">,
+  ];
+}
+
 def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   let summary = "Specializes instances of parametric hw.modules";
   let constructor = "circt::hw::createHWSpecializePass()";

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   HWPrintInstanceGraph.cpp
   HWSpecialize.cpp
   PrintHWModuleGraph.cpp
+  FlattenIO.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -1,0 +1,287 @@
+//===- FlattenIO.cpp - HW I/O flattening pass -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+
+static bool isStructType(Type type) {
+  return hw::getCanonicalType(type).isa<hw::StructType>();
+}
+
+// Legal if no in- or output type is a struct.
+static bool isLegalFuncLikeOp(FunctionOpInterface moduleLikeOp) {
+  bool legalResults =
+      llvm::none_of(moduleLikeOp.getResultTypes(), isStructType);
+  bool legalArgs = llvm::none_of(moduleLikeOp.getArgumentTypes(), isStructType);
+
+  return legalResults && legalArgs;
+}
+
+static llvm::SmallVector<Type> getInnerTypes(hw::StructType t) {
+  llvm::SmallVector<Type> inner;
+  t.getInnerTypes(inner);
+  return inner;
+}
+
+namespace {
+
+// Replaces an output op with a new output with flattened (exploded) structs.
+struct OutputOpConversion : public OpConversionPattern<hw::OutputOp> {
+  OutputOpConversion(TypeConverter &typeConverter, MLIRContext *context,
+                     DenseSet<Operation *> *outputOpVisited)
+      : OpConversionPattern(typeConverter, context),
+        outputOpVisited(outputOpVisited) {}
+
+  LogicalResult
+  matchAndRewrite(hw::OutputOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    llvm::SmallVector<Value> convOperands;
+
+    // Flatten the operands.
+    for (auto operand : adaptor.getOperands()) {
+      if (auto structType = operand.getType().dyn_cast<hw::StructType>()) {
+        auto explodedStruct = rewriter.create<hw::StructExplodeOp>(
+            op.getLoc(), getInnerTypes(structType), operand);
+        llvm::copy(explodedStruct.getResults(),
+                   std::back_inserter(convOperands));
+      } else {
+        convOperands.push_back(operand);
+      }
+    }
+
+    // And replace.
+    rewriter.replaceOpWithNewOp<hw::OutputOp>(op, convOperands);
+    outputOpVisited->insert(op->getParentOp());
+    return success();
+  }
+  mutable DenseSet<Operation *> *outputOpVisited;
+};
+
+using IOTypes = std::pair<TypeRange, TypeRange>;
+
+struct IOInfo {
+  // A mapping between an arg/res index and the struct type of the given field.
+  DenseMap<unsigned, hw::StructType> argStructs, resStructs;
+
+  // Records of the original arg/res types.
+  TypeRange argTypes, resTypes;
+};
+
+class FlattenIOTypeConverter : public TypeConverter {
+public:
+  FlattenIOTypeConverter() {
+    addConversion([](Type type, SmallVectorImpl<Type> &results) {
+      auto structType = hw::getCanonicalType(type).dyn_cast<hw::StructType>();
+      if (!structType)
+        results.push_back(type);
+      else {
+        for (auto field : structType.getElements())
+          results.push_back(field.type);
+      }
+      return success();
+    });
+
+    addTargetMaterialization([](OpBuilder &builder, hw::StructType type,
+                                ValueRange inputs, Location loc) {
+      auto result = builder.create<hw::StructCreateOp>(loc, type, inputs);
+      return result.getResult();
+    });
+  }
+};
+
+} // namespace
+
+template <typename... TOp>
+static void addSignatureConversion(DenseMap<Operation *, IOInfo> &ioMap,
+                                   ConversionTarget &target,
+                                   RewritePatternSet &patterns,
+                                   FlattenIOTypeConverter &typeConverter) {
+  (mlir::populateFunctionOpInterfaceTypeConversionPattern<TOp>(patterns,
+                                                               typeConverter),
+   ...);
+
+  // Legality is defined by a module having been processed once. This is due to
+  // that a pattern cannot be applied multiple times (a 'pattern was already
+  // applied' error - a case that would occur for nested structs). Additionally,
+  // if a pattern could be applied multiple times, this would complicate
+  // updating arg/res names.
+
+  // Instead, we define legality as when a module has had a modification to its
+  // top-level i/o. This ensures that only a single level of structs are
+  // processed during signature conversion, which then allows us to use the
+  // signature conversion in a recursive manner.
+  target.addDynamicallyLegalOp<TOp...>([&](FunctionOpInterface moduleLikeOp) {
+    if (isLegalFuncLikeOp(moduleLikeOp))
+      return true;
+
+    // This op is involved in conversion. Check if the signature has changed.
+    auto ioInfoIt = ioMap.find(moduleLikeOp);
+    if (ioInfoIt == ioMap.end()) {
+      // Op wasn't primed in the map. Do the safe thing, assume
+      // that it's not considered in this pass, and mark it as legal
+      return true;
+    }
+    auto ioInfo = ioInfoIt->second;
+
+    auto compareTypes = [&](TypeRange oldTypes, TypeRange newTypes) {
+      for (auto [oldType, newType] : llvm::zip(oldTypes, newTypes))
+        if (oldType != newType) // A conversion took place
+          return true;
+      return false;
+    };
+    if (compareTypes(moduleLikeOp.getResultTypes(), ioInfo.resTypes) ||
+        compareTypes(moduleLikeOp.getArgumentTypes(), ioInfo.argTypes))
+      return true;
+
+    // We're pre-conversion for an op that was primed in the map - it will
+    // always be illegal since it has to-be-converted struct types at its I/O.
+    return false;
+  });
+}
+
+template <typename T>
+static bool hasUnconvertedOps(mlir::ModuleOp module) {
+  return llvm::any_of(module.getBody()->getOps<T>(),
+                      [](T op) { return !isLegalFuncLikeOp(op); });
+}
+
+template <typename T>
+static DenseMap<Operation *, IOTypes> populateIOMap(mlir::ModuleOp module) {
+  DenseMap<Operation *, IOTypes> ioMap;
+  for (auto op : module.getOps<T>())
+    ioMap[op] = {op.getArgumentTypes(), op.getResultTypes()};
+  return ioMap;
+}
+
+static void updateNameAttribute(FunctionOpInterface op, StringRef attrName,
+                                DenseMap<unsigned, hw::StructType> &structMap) {
+  llvm::SmallVector<Attribute> newNames;
+  auto oldNames = op.getOperation()
+                      ->getAttrOfType<ArrayAttr>(attrName)
+                      .getAsValueRange<StringAttr>();
+  for (auto [i, oldName] : llvm::enumerate(oldNames)) {
+    // Was this arg/res index a struct?
+    auto it = structMap.find(i);
+    if (it == structMap.end()) {
+      // No, keep old name.
+      newNames.push_back(StringAttr::get(op.getContext(), oldName));
+      continue;
+    } else {
+      // Yes - create new names from the struct fields and the old name at the
+      // index.
+      auto structType = it->second;
+      for (auto field : structType.getElements())
+        newNames.push_back(
+            StringAttr::get(op.getContext(), oldName + "." + field.name.str()));
+    }
+  }
+  op.getOperation()->setAttr(attrName,
+                             ArrayAttr::get(op.getContext(), newNames));
+}
+
+template <typename T>
+static DenseMap<Operation *, IOInfo> populateIOInfoMap(mlir::ModuleOp module) {
+  DenseMap<Operation *, IOInfo> ioInfoMap;
+  for (auto op : module.getOps<T>()) {
+    IOInfo ioInfo;
+    ioInfo.argTypes = op.getArgumentTypes();
+    ioInfo.resTypes = op.getResultTypes();
+    for (auto [i, arg] : llvm::enumerate(ioInfo.argTypes)) {
+      auto structType =
+          hw::getCanonicalType(arg).template dyn_cast<hw::StructType>();
+      if (structType)
+        ioInfo.argStructs[i] = structType;
+    }
+    for (auto [i, res] : llvm::enumerate(ioInfo.resTypes)) {
+      auto structType =
+          hw::getCanonicalType(res).template dyn_cast<hw::StructType>();
+      if (structType)
+        ioInfo.resStructs[i] = structType;
+    }
+    ioInfoMap[op] = ioInfo;
+  }
+  return ioInfoMap;
+}
+
+template <typename T>
+static LogicalResult flattenOpsOfType(ModuleOp module) {
+  auto *ctx = module.getContext();
+  FlattenIOTypeConverter typeConverter;
+
+  // Recursively (in case of nested structs) lower the module. We do this one
+  // conversion at a time to allow for updating the arg/res names of the
+  // module in between flattening each level of structs.
+  while (hasUnconvertedOps<T>(module)) {
+    ConversionTarget target(*ctx);
+    RewritePatternSet patterns(ctx);
+    target.addLegalDialect<hw::HWDialect>();
+
+    // Record any struct types at the module signature. This will be used
+    // post-conversion to update the argument and result names.
+    auto ioInfoMap = populateIOInfoMap<T>(module);
+
+    // Signature conversion and legalization patterns.
+    addSignatureConversion<T>(ioInfoMap, target, patterns, typeConverter);
+
+    // Argument conversion for output ops. Similarly to the signature
+    // conversion, legality is based on the op having been visited once, due to
+    // the possibility of nested structs.
+    DenseSet<Operation *> outputOpVisited;
+    patterns.add<OutputOpConversion>(typeConverter, ctx, &outputOpVisited);
+    target.addDynamicallyLegalOp<hw::OutputOp>(
+        [&](auto op) { return outputOpVisited.contains(op->getParentOp()); });
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+      return failure();
+
+    // Update the arg/res names of the module.
+    for (auto op : module.getOps<T>()) {
+      auto ioInfo = ioInfoMap[op];
+      updateNameAttribute(op, "argNames", ioInfo.argStructs);
+      updateNameAttribute(op, "resultNames", ioInfo.resStructs);
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass driver
+//===----------------------------------------------------------------------===//
+
+template <typename... TOps>
+static bool flattenIO(ModuleOp module) {
+  return (failed(flattenOpsOfType<TOps>(module)) || ...);
+}
+
+namespace {
+
+class FlattenIOPass : public circt::hw::FlattenIOBase<FlattenIOPass> {
+public:
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    if (flattenIO<hw::HWModuleOp, hw::HWModuleExternOp,
+                  hw::HWModuleGeneratedOp>(module))
+      signalPassFailure();
+  };
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Pass initialization
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<Pass> circt::hw::createFlattenIOPass() {
+  return std::make_unique<FlattenIOPass>();
+}

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -1,0 +1,37 @@
+// RUN: circt-opt --hw-flatten-io %s | FileCheck %s
+
+// Ensure that non-struct-using modules pass cleanly through the pass.
+
+// CHECK-LABEL: hw.module @level0(%arg0: i32) -> (out0: i32) {
+// CHECK-NEXT:    hw.output %arg0 : i32
+// CHECK-NEXT:  }
+hw.module @level0(%arg0 : i32) -> (out0 : i32) {
+    hw.output %arg0: i32
+}
+
+// CHECK-LABEL: hw.module @level1(%arg0: i32, %in.a: i1, %in.b: i2, %arg1: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32) {
+// CHECK-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %1:2 = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    hw.output %arg0, %1#0, %1#1, %arg1 : i32, i1, i2, i32
+// CHECK-NEXT:  }
+!Struct1 = !hw.struct<a: i1, b: i2>
+hw.module @level1(%arg0 : i32, %in : !Struct1, %arg1: i32) -> (out0 : i32,out: !Struct1, out1: i32) {
+    hw.output %arg0, %in, %arg1 : i32, !Struct1, i32
+}
+
+// CHECK-LABEL: hw.module @level2(%in.aa.a: i1, %in.aa.b: i2, %in.bb.a: i1, %in.bb.b: i2) -> (out.aa.a: i1, out.aa.b: i2, out.bb.a: i1, out.bb.b: i2) {
+// CHECK-NEXT:    %0 = hw.struct_create (%in.aa.a, %in.aa.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %1 = hw.struct_create (%in.bb.a, %in.bb.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %2 = hw.struct_create (%0, %1) : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
+// CHECK-NEXT:    %3:2 = hw.struct_explode %2 : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
+// CHECK-NEXT:    %4:2 = hw.struct_explode %3#0 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %5:2 = hw.struct_explode %3#1 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    hw.output %4#0, %4#1, %5#0, %5#1 : i1, i2, i1, i2
+// CHECK-NEXT:  }
+!Struct2 = !hw.struct<aa: !Struct1, bb: !Struct1>
+hw.module @level2(%in : !Struct2) -> (out: !Struct2) {
+    hw.output %in : !Struct2
+}
+
+// CHECK-LABEL: hw.module.extern @level1_extern(%arg0: i32, %in.a: i1, %in.b: i2, %arg1: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
+hw.module.extern @level1_extern(%arg0 : i32, %in : !Struct1, %arg1: i32) -> (out0 : i32,out: !Struct1, out1: i32)

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --hw-flatten-io %s | FileCheck %s
+// RUN: circt-opt --hw-flatten-io="recursive=true" %s | FileCheck %s
 
 // Ensure that non-struct-using modules pass cleanly through the pass.
 

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -35,3 +35,18 @@ hw.module @level2(%in : !Struct2) -> (out: !Struct2) {
 
 // CHECK-LABEL: hw.module.extern @level1_extern(%arg0: i32, %in.a: i1, %in.b: i2, %arg1: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
 hw.module.extern @level1_extern(%arg0 : i32, %in : !Struct1, %arg1: i32) -> (out0 : i32,out: !Struct1, out1: i32)
+
+
+hw.type_scope @foo {
+  hw.typedecl @bar : !Struct1
+}
+!ScopedStruct = !hw.typealias<@foo::@bar,!Struct1>
+
+// CHECK-LABEL: hw.module @scoped(%arg0: i32, %in.a: i1, %in.b: i2, %arg1: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32) {
+// CHECK-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
+// CHECK-NEXT:  }
+  hw.module @scoped(%arg0 : i32, %in : !ScopedStruct, %arg1: i32) -> (out0 : i32,out: !ScopedStruct, out1: i32) {
+  hw.output %arg0, %in, %arg1 : i32, !ScopedStruct, i32
+}

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -11,8 +11,8 @@ hw.module @level0(%arg0 : i32) -> (out0 : i32) {
 
 // CHECK-LABEL: hw.module @level1(%arg0: i32, %in.a: i1, %in.b: i2, %arg1: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32) {
 // CHECK-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %1:2 = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    hw.output %arg0, %1#0, %1#1, %arg1 : i32, i1, i2, i32
+// CHECK-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
 // CHECK-NEXT:  }
 !Struct1 = !hw.struct<a: i1, b: i2>
 hw.module @level1(%arg0 : i32, %in : !Struct1, %arg1: i32) -> (out0 : i32,out: !Struct1, out1: i32) {
@@ -23,10 +23,10 @@ hw.module @level1(%arg0 : i32, %in : !Struct1, %arg1: i32) -> (out0 : i32,out: !
 // CHECK-NEXT:    %0 = hw.struct_create (%in.aa.a, %in.aa.b) : !hw.struct<a: i1, b: i2>
 // CHECK-NEXT:    %1 = hw.struct_create (%in.bb.a, %in.bb.b) : !hw.struct<a: i1, b: i2>
 // CHECK-NEXT:    %2 = hw.struct_create (%0, %1) : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
-// CHECK-NEXT:    %3:2 = hw.struct_explode %2 : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
-// CHECK-NEXT:    %4:2 = hw.struct_explode %3#0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %5:2 = hw.struct_explode %3#1 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    hw.output %4#0, %4#1, %5#0, %5#1 : i1, i2, i1, i2
+// CHECK-NEXT:    %aa, %bb = hw.struct_explode %2 : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
+// CHECK-NEXT:    %a, %b = hw.struct_explode %aa : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    %a_0, %b_1 = hw.struct_explode %bb : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:    hw.output %a, %b, %a_0, %b_1 : i1, i2, i1, i2
 // CHECK-NEXT:  }
 !Struct2 = !hw.struct<aa: !Struct1, bb: !Struct1>
 hw.module @level2(%in : !Struct2) -> (out: !Struct2) {


### PR DESCRIPTION
My specific usecase for this is to be able to correctly lower ESI ports that are nested within a struct - may or may not end up using it, depending on how that work fleshes out. However, I assume this is generally useful (FIRRTL has an equivalent pass `--firrtl-lower-types`), hence the PR.

Not super happy about how legalization of the signature conversion is implemented (nested structs complicate things...), but I was unable to come up with a better approach than what is in this PR. See code comment for more info on the whats/whys of this.