### PR TITLE
[HW] Add `hw.struct_explode` canonicalizer

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -209,6 +209,7 @@ def StructExplodeOp : HWOp<"struct_explode", [NoSideEffect]> {
   let arguments = (ins StructType:$input);
   let results = (outs Variadic<HWNonInOutType>:$result);
   let hasCustomAssemblyFormat = 1;
+  let hasCanonicalizeMethod = 1;
  }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2082,7 +2082,7 @@ void StructExplodeOp::print(OpAsmPrinter &printer) {
 LogicalResult StructExplodeOp::canonicalize(StructExplodeOp op,
                                             PatternRewriter &rewriter) {
   auto *inputOp = op.getInput().getDefiningOp();
-  auto elements = op.getInput().getType().cast<StructType>().getElements();
+  auto elements = type_cast<StructType>(op.getInput().getType()).getElements();
   for (auto [element, res] : llvm::zip(elements, op.getResults())) {
     if (auto foldResult = foldStructExtract(inputOp, element.name.str()))
       res.replaceAllUsesWith(foldResult);

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1071,6 +1071,14 @@ hw.module @struct_extract1(%a0: i3, %a1: i5) -> (r0: i3) {
   hw.output %r0 : i3
 }
 
+// CHECK-LABEL: hw.module @struct_explode(%a0: i3, %a1: i5) -> (r0: i3)
+// CHECK-NEXT:    hw.output %a0 : i3
+hw.module @struct_explode(%a0: i3, %a1: i5) -> (r0: i3) {
+  %s = hw.struct_create (%a0, %a1) : !hw.struct<foo: i3, bar: i5>
+  %r0:2 = hw.struct_explode %s : !hw.struct<foo: i3, bar: i5>
+  hw.output %r0#0 : i3
+}
+
 // Ensure that canonicalizer works with hw.enum.constant.
 
 hw.module @enum_constant() -> () {


### PR DESCRIPTION
Leverages the same logic used for folding `hw.struct_extract`, fixes #4008.