### PR TITLE
[ExportVerilog] Improve error message for emitting unsupported ops

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -716,7 +716,7 @@ private:
           << " Not found in name table! Most likely indicates that the given "
              "op did not have an emitter in ExportVerilog, and should have "
              "been lowered away before reaching this point.";
-      assert(false);
+      assert(false && "name not found (see above error)");
     }
     return entry->getSecond();
   }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -706,8 +706,18 @@ private:
   /// added.
   StringRef getName(ValueOrOp valueOrOp) {
     auto entry = nameTable.find(valueOrOp);
-    assert(entry != nameTable.end() &&
-           "value expected a name but doesn't have one");
+    if (entry == nameTable.end()) {
+      llvm::errs() << "Name: ";
+      if (auto v = valueOrOp.dyn_cast<Value>())
+        v.print(llvm::errs());
+      else
+        valueOrOp.get<Operation *>()->print(llvm::errs());
+      llvm::errs()
+          << " Not found in name table! Most likely indicates that the given "
+             "op did not have an emitter in ExportVerilog, and should have "
+             "been lowered away before reaching this point.";
+      assert(false);
+    }
     return entry->getSecond();
   }
 


### PR DESCRIPTION
Been annoyed by this assert being thrown for a long time. If unsupported operations is fed to the ExportVerilog pass (may happen if some other lowering pass wasn't run or export verilog is missing an implementation for lowering some op), a very unhelpful assert would be thrown stating `value expected a name but doesn't have one` - telling us nothing about which op actually violated the condition.

Modifies this to actually printing the op + an error message indicating the most likely cause for tripping this assert.