### PR TITLE
[SV] Add iverilog trace instrumentation pass

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -23,6 +23,7 @@ std::unique_ptr<mlir::Pass> createPrettifyVerilogPass();
 std::unique_ptr<mlir::Pass> createHWCleanupPass();
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
+std::unique_ptr<mlir::Pass> createSVTraceIVerilogPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass>
 createHWMemSimImplPass(bool replSeqMem = false,

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -114,7 +114,7 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
-def SVTraceIVerilog : Pass<"sv-trace-iverilog", "ModuleOp"> {
+def SVTraceIVerilog : Pass<"sv-trace-iverilog", "hw::HWModuleOp"> {
   let summary = "Add tracing to an iverilog simulated module";
   let description = [{
     This pass adds the necessary instrumentation to a HWModule to trigger

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -114,6 +114,23 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def SVTraceIVerilog : Pass<"sv-trace-iverilog", "ModuleOp"> {
+  let summary = "Add tracing to an iverilog simulated module";
+  let description = [{
+    This pass adds the necessary instrumentation to a HWModule to trigger
+    tracing in an iverilog simulation.
+  }];
+
+  let constructor = "circt::sv::createSVTraceIVerilogPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+  let options = [
+    Option<"targetModuleName", "module", "std::string", "",
+            "Module to trace. If not provided, will trace all modules">,
+    Option<"directoryName", "dir-name", "std::string", "\"./\"",
+            "Directory to emit into">
+  ];
+}
+
 def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
                                    "mlir::ModuleOp"> {
   let summary = "Export module and instance hierarchy information";

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   PrettifyVerilog.cpp
   SVExtractTestCode.cpp
   HWExportModuleHierarchy.cpp
+  SVTraceIVerilog.cpp
 
   DEPENDS
   CIRCTSVTransformsIncGen

--- a/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
@@ -1,0 +1,59 @@
+//===- SVTraceIVerilog.cpp - Generator Callout Pass -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass adds the necessary instrumentation to a HWModule to trigger
+// tracing in an iverilog simulation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "mlir/IR/Builders.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
+
+using namespace circt;
+using namespace sv;
+using namespace hw;
+
+//===----------------------------------------------------------------------===//
+// SVTraceIVerilogPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct SVTraceIVerilogPass
+    : public sv::SVTraceIVerilogBase<SVTraceIVerilogPass> {
+  void runOnOperation() override;
+};
+
+} // end anonymous namespace
+
+void SVTraceIVerilogPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  for (auto mod : module.getOps<hw::HWModuleOp>()) {
+    if (!targetModuleName.empty() &&
+        mod.getName() != targetModuleName.getValue())
+      continue;
+
+    OpBuilder builder(mod.getBodyBlock(), mod.getBodyBlock()->begin());
+    std::string traceMacro;
+    llvm::raw_string_ostream ss(traceMacro);
+    auto modName = mod.getName();
+    ss << "initial begin\n  $dumpfile (\"" << directoryName.getValue()
+       << modName << ".vcd\");\n  $dumpvars (0, " << modName
+       << ");\n  #1;\nend\n";
+    builder.create<sv::VerbatimOp>(mod.getLoc(), ss.str());
+  }
+}
+
+std::unique_ptr<Pass> circt::sv::createSVTraceIVerilogPass() {
+  return std::make_unique<SVTraceIVerilogPass>();
+}

--- a/test/Dialect/SV/sv-trace-iverilog.mlir
+++ b/test/Dialect/SV/sv-trace-iverilog.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt --sv-trace-iverilog --export-verilog %s | FileCheck %s
+
+// CHECK-LABEL: module top();
+// CHECK:       initial begin
+// CHECK-NEXT:    $dumpfile ("./top.vcd");
+// CHECK-NEXT:    $dumpvars (0, top);
+// CHECK-NEXT:    #1;
+// CHECK-NEXT:  end
+
+hw.module @top () {}


### PR DESCRIPTION
Adds a macro to HWModules which enables tracing for iverilog (see https://docs.cocotb.org/en/stable/simulator_support.html#waveforms).