### PR TITLE
[SV] Update ExtractTestCode to extract input only modules.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -1450,6 +1450,11 @@ modules. This attribute has type `OutputFileAttr`.
 Used by SVExtractTestCode.  Specifies the output directory for extracted
 modules. This attribute has type `OutputFileAttr`.
 
+### firrtl.extract.testbench
+
+Used by SVExtractTestCode.  Specifies the output directory for extracted
+testbench only modules. This attribute has type `OutputFileAttr`.
+
 ### firrtl.extract.assert.bindfile
 
 Used by SVExtractTestCode.  Specifies the output file for extracted

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -526,6 +526,7 @@ void FIRRTLModuleLowering::runOnOperation() {
   circuitAnno.removeAnnotationsWithClass(
       extractAssertAnnoClass, extractAssumeAnnoClass, extractCoverageAnnoClass);
 
+  // Pass along the testbench directory for ExtractTestCode to use later.
   if (state.testBenchDirectory)
     getOperation()->setAttr("firrtl.extract.testbench",
                             state.testBenchDirectory);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -527,9 +527,13 @@ void FIRRTLModuleLowering::runOnOperation() {
       extractAssertAnnoClass, extractAssumeAnnoClass, extractCoverageAnnoClass);
 
   // Pass along the testbench directory for ExtractTestCode to use later.
-  if (state.testBenchDirectory)
-    getOperation()->setAttr("firrtl.extract.testbench",
-                            state.testBenchDirectory);
+  if (auto tbAnno = circuitAnno.getAnnotation(testBenchDirAnnoClass)) {
+    auto dirName = tbAnno.getMember<StringAttr>("dirname");
+    auto testBenchDir = hw::OutputFileAttr::getAsDirectory(
+        &getContext(), dirName.getValue(), /*excludeFromFileList=*/true,
+        /*includeReplicatedOps=*/true);
+    getOperation()->setAttr("firrtl.extract.testbench", testBenchDir);
+  }
 
   state.processRemainingAnnotations(circuit, circuitAnno);
   // Iterate through each operation in the circuit body, transforming any

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -526,6 +526,10 @@ void FIRRTLModuleLowering::runOnOperation() {
   circuitAnno.removeAnnotationsWithClass(
       extractAssertAnnoClass, extractAssumeAnnoClass, extractCoverageAnnoClass);
 
+  if (state.testBenchDirectory)
+    getOperation()->setAttr("firrtl.extract.testbench",
+                            state.testBenchDirectory);
+
   state.processRemainingAnnotations(circuit, circuitAnno);
   // Iterate through each operation in the circuit body, transforming any
   // FModule's we come across. If any module fails to lower, return early.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -269,6 +269,17 @@ static void migrateOps(hw::HWModuleOp oldMod, hw::HWModuleOp newMod,
     }
 }
 
+// Move any old modules that are test code only to the test code area.
+static void maybeMoveToTestCode(hw::HWModuleOp oldMod, Attribute path) {
+  // Ensure we have a valid test code path.
+  if (!path)
+    return;
+
+  // Check if the module only has inputs. If so, move it to the test code path.
+  if (oldMod.getNumOutputs() == 0)
+    oldMod->setAttr("output_file", path);
+}
+
 //===----------------------------------------------------------------------===//
 // StubExternalModules Pass
 //===----------------------------------------------------------------------===//
@@ -322,6 +333,8 @@ private:
     // erase old operations of interest
     for (auto op : roots)
       op->erase();
+    // Move any old modules that are test code only to the test code area.
+    maybeMoveToTestCode(module, path);
   }
 };
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -444,6 +444,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       op.removeAttr("firrtl.extract.cover.extra");
       op.removeAttr("firrtl.extract.assume.extra");
     }
+  top->removeAttr("firrtl.extract.testbench");
 }
 
 std::unique_ptr<Pass> circt::sv::createSVExtractTestCodePass() {

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -293,7 +293,7 @@ struct SVExtractTestCodeImplPass
 private:
   void doModule(hw::HWModuleOp module, std::function<bool(Operation *)> fn,
                 StringRef suffix, Attribute path, Attribute bindFile,
-                Attribute testbenchDir) {
+                Attribute testBenchDir) {
     bool hasError = false;
     // Find Operations of interest.
     SetVector<Operation *> roots;
@@ -335,7 +335,7 @@ private:
     for (auto op : roots)
       op->erase();
     // Move any old modules that are test code only to the test code area.
-    maybeMoveToTestCode(module, testbenchDir);
+    maybeMoveToTestCode(module, testBenchDir);
   }
 };
 
@@ -350,7 +350,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.assume");
   auto coverDir =
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.cover");
-  auto testbenchDir =
+  auto testBenchDir =
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.testbench");
   auto assertBindFile =
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.assert.bindfile");
@@ -429,11 +429,11 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       }
 
       doModule(rtlmod, isAssert, "_assert", assertDir, assertBindFile,
-               testbenchDir);
+               testBenchDir);
       doModule(rtlmod, isAssume, "_assume", assumeDir, assumeBindFile,
-               testbenchDir);
+               testBenchDir);
       doModule(rtlmod, isCover, "_cover", coverDir, coverBindFile,
-               testbenchDir);
+               testBenchDir);
     }
   }
   // We have to wait until all the instances are processed to clean up the

--- a/test/Dialect/SV/hw-extract-test-code-error.mlir
+++ b/test/Dialect/SV/hw-extract-test-code-error.mlir
@@ -1,20 +1,9 @@
-// RUN:  circt-opt --sv-extract-test-code --debug-only=extract-test-code %s -verify-diagnostics
-module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, firrtl.extract.assume.bindfile = #hw.output_file<"file4", excludeFromFileList>, firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>} {
+// RUN:  circt-opt --sv-extract-test-code %s -verify-diagnostics
+module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, firrtl.extract.assume.bindfile = #hw.output_file<"file4", excludeFromFileList>} {
   hw.module.extern @foo_cover(%a : i1) -> (b : i1) attributes {"firrtl.extract.cover.extra"} 
   hw.module @extract_return(%clock: i1) -> (c : i1) {
 // expected-error @+1 {{Extracting op with result}}
     %b = hw.instance "bar_cover" @foo_cover(a: %clock : i1) -> (b : i1)
     hw.output %b : i1
-  }
-// expected-warning @+1 {{already bound, skipping}}
-  hw.module @input_only(%clock: i1, %cond: i1) -> () {
-    sv.always posedge %clock  {
-      sv.assert %cond, immediate
-      sv.assume %cond, immediate
-    }
-  }
-  hw.module @input_only_top(%clock: i1, %cond: i1) -> (foo: i1) {
-    hw.instance "input_only" @input_only(clock: %clock: i1, cond: %cond: i1) -> ()
-    hw.output %cond : i1
   }
 }

--- a/test/Dialect/SV/hw-extract-test-code-error.mlir
+++ b/test/Dialect/SV/hw-extract-test-code-error.mlir
@@ -1,9 +1,20 @@
-// RUN:  circt-opt --sv-extract-test-code %s -verify-diagnostics
-module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, firrtl.extract.assume.bindfile = #hw.output_file<"file4", excludeFromFileList>} {
+// RUN:  circt-opt --sv-extract-test-code --debug-only=extract-test-code %s -verify-diagnostics
+module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, firrtl.extract.assume.bindfile = #hw.output_file<"file4", excludeFromFileList>, firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>} {
   hw.module.extern @foo_cover(%a : i1) -> (b : i1) attributes {"firrtl.extract.cover.extra"} 
   hw.module @extract_return(%clock: i1) -> (c : i1) {
 // expected-error @+1 {{Extracting op with result}}
     %b = hw.instance "bar_cover" @foo_cover(a: %clock : i1) -> (b : i1)
     hw.output %b : i1
+  }
+// expected-warning @+1 {{already bound, skipping}}
+  hw.module @input_only(%clock: i1, %cond: i1) -> () {
+    sv.always posedge %clock  {
+      sv.assert %cond, immediate
+      sv.assume %cond, immediate
+    }
+  }
+  hw.module @input_only_top(%clock: i1, %cond: i1) -> (foo: i1) {
+    hw.instance "input_only" @input_only(clock: %clock: i1, cond: %cond: i1) -> ()
+    hw.output %cond : i1
   }
 }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -132,3 +132,20 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
     }
   }
 }
+
+// -----
+// Check "empty" modules are extracted
+
+// CHECK-LABEL: @WillBeEmpty(
+// CHECK-SAME: output_file = #hw.output_file<"cover/", excludeFromFileList, includeReplicatedOps>
+module attributes {firrtl.extract.cover = #hw.output_file<"cover/", excludeFromFileList, includeReplicatedOps>} {
+  hw.module @WillBeEmpty(%clock: i1, %cond: i1) -> () {
+    sv.always posedge %clock  {
+      sv.cover %cond, immediate
+    }
+  }
+
+  hw.module @Top(%clock: i1, %cond: i1) -> () {
+    hw.instance "empty" @WillBeEmpty(clock: %clock: i1, cond: %cond: i1) -> ()
+  }
+}

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -136,16 +136,22 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // -----
 // Check "empty" modules are extracted
 
-// CHECK-LABEL: @WillBeEmpty(
+// CHECK-LABEL: @InputOnly(
 // CHECK-SAME: output_file = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
-module attributes {firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>} {
-  hw.module @WillBeEmpty(%clock: i1, %cond: i1) -> () {
+// CHECK: hw.instance "input_only" sym @[[sym_name:[^ ]+]] @InputOnly
+// CHECK: sv.bind <@Top::@[[sym_name]]> {output_file = #hw.output_file<"cover/bind.sv", excludeFromFileList, includeReplicatedOps>}
+module attributes {
+  firrtl.extract.cover.bindfile = #hw.output_file<"cover/bind.sv", excludeFromFileList, includeReplicatedOps>,
+  firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
+} {
+  hw.module @InputOnly(%clock: i1, %cond: i1) -> () {
     sv.always posedge %clock  {
       sv.cover %cond, immediate
     }
   }
 
-  hw.module @Top(%clock: i1, %cond: i1) -> () {
-    hw.instance "empty" @WillBeEmpty(clock: %clock: i1, cond: %cond: i1) -> ()
+  hw.module @Top(%clock: i1, %cond: i1) -> (foo: i1) {
+    hw.instance "input_only" @InputOnly(clock: %clock: i1, cond: %cond: i1) -> ()
+    hw.output %cond : i1
   }
 }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -137,8 +137,8 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // Check "empty" modules are extracted
 
 // CHECK-LABEL: @WillBeEmpty(
-// CHECK-SAME: output_file = #hw.output_file<"cover/", excludeFromFileList, includeReplicatedOps>
-module attributes {firrtl.extract.cover = #hw.output_file<"cover/", excludeFromFileList, includeReplicatedOps>} {
+// CHECK-SAME: output_file = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
+module attributes {firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>} {
   hw.module @WillBeEmpty(%clock: i1, %cond: i1) -> () {
     sv.always posedge %clock  {
       sv.cover %cond, immediate


### PR DESCRIPTION
If a module has only inputs after extraction, it can and should be moved to the test code area. Such modules are marked to be output into the test code path.

Closes https://github.com/llvm/circt/issues/2351.