### PR TITLE
[FIRRTL] Fix GCT Instance Name Prefix

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -304,36 +304,8 @@ void PrefixModulesPass::renameModule(FModuleOp module) {
 
   // If this module contains a Grand Central interface, then also apply renames
   // to that, but only if there are prefixes to apply.
-  AnnotationSet annotations(module);
-  if (!annotations.hasAnnotation(parentAnnoClass) &&
-      !annotations.hasAnnotation(companionAnnoClass))
-    return;
-  SmallVector<Attribute> newAnnotations;
-  for (auto anno : annotations) {
-    if (!anno.isClass(parentAnnoClass) && !anno.isClass(companionAnnoClass)) {
-      newAnnotations.push_back(anno.getDict());
-      continue;
-    }
-
-    NamedAttrList newAnno;
-    for (auto attr : anno) {
-      if (attr.getName() == "name") {
-        newAnno.append(attr.getName(),
-                       (Attribute)builder.getStringAttr(
-                           Twine(prefixFull) +
-                           attr.getValue().cast<StringAttr>().getValue()));
-        continue;
-      }
-      newAnno.append(attr.getName(), attr.getValue());
-    }
-    newAnnotations.push_back(
-        DictionaryAttr::getWithSorted(builder.getContext(), newAnno));
-
-    // Record that we need to apply this prefix to the interface definition.
-    if (anno.getMember<StringAttr>("type").getValue() == "parent")
-      interfacePrefixMap[anno.getMember<IntegerAttr>("id")] = prefixFull;
-  }
-  AnnotationSet(newAnnotations, builder.getContext()).applyToOperation(module);
+  if (auto anno = AnnotationSet(module).getAnnotation(parentAnnoClass))
+    interfacePrefixMap[anno.getMember<IntegerAttr>("id")] = prefixFull;
 }
 
 /// Apply prefixes from the `prefixMap` to an external module.  No modifications

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Prefix.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Prefix.anno.json
@@ -1,0 +1,18 @@
+[
+  {
+    "class":"sifive.enterprise.firrtl.NestedPrefixModulesAnnotation",
+    "target":"~Top|Top",
+    "prefix":"FOO_",
+    "inclusive":true
+  },
+  {
+    "class":"sifive.enterprise.firrtl.NestedPrefixModulesAnnotation",
+    "target":"~Top|DUT",
+    "prefix":"BAR_",
+    "inclusive":true
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.PrefixInterfacesAnnotation",
+    "prefix":"BAZ_"
+  }
+]

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -2,6 +2,7 @@
 ; RUN: firtool --preserve-values=named --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
 ; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
 ; RUN: firtool --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
+; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Prefix.anno.json %s | FileCheck %s --check-prefixes PREFIX
 
 circuit Top :
   extmodule BlackBox_DUT :
@@ -182,6 +183,9 @@ circuit Top :
     out.multivec[1][2] <= dut.out.multivec[1][2]
     out.uint <= dut.out.uint
 
+    ; PREFIX:         module FOO_BAR_MyView_companion();
+    ; PREFIX:           FOO_BAR_BAZ_MyInterface MyView();
+
     ; NOEXTRACT:      module MyView_companion();
     ; NOEXTRACT:        MyInterface MyView();
     ; NOEXTRACT:        assign MyView.uint = DUT.w_uint;
@@ -270,6 +274,7 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyInterface.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/MyInterface.sv
+    ; PREFIX:         interface FOO_BAR_BAZ_MyInterface;
     ; CHECK:          interface MyInterface;
     ; CHECK-NEXT:       // a wire called 'uint'
     ; CHECK-NEXT:       logic uint;
@@ -292,6 +297,7 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/VecOfBundle.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/VecOfBundle.sv
+    ; PREFIX:         interface FOO_BAR_BAZ_VecOfBundle;
     ; CHECK:          interface VecOfBundle;
     ; CHECK-NEXT:       logic [1:0] sint;
     ; CHECK-NEXT:       logic [3:0] uint;
@@ -299,12 +305,14 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/OtherOther.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/OtherOther.sv
+    ; PREFIX:         interface FOO_BAR_BAZ_OtherOther;
     ; CHECK:          interface OtherOther;
     ; CHECK-NEXT:       Other other();
     ; CHECK:          endinterface
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/Other.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/Other.sv
+    ; PREFIX:         interface FOO_BAR_BAZ_Other;
     ; CHECK:          interface Other;
     ; CHECK-NEXT:       logic [1:0] sint;
     ; CHECK-NEXT:       logic [3:0] uint;
@@ -312,6 +320,7 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/Sub_vecOfBundle.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/Sub_vecOfBundle.sv
+    ; PREFIX:         interface FOO_BAR_BAZ_Sub_vecOfBundle;
     ; CHECK:          interface Sub_vecOfBundle;
     ; CHECK-NEXT:       logic [1:0] sint;
     ; CHECK-NEXT:       logic [3:0] uint;

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -164,9 +164,9 @@ firrtl.circuit "Top" {
 }
 
 
-// Updates should be made to a Grand Central interface to add a "prefix" field
-// and the annotations associated with the parent and companion should have
-// their "name" field prefixed.
+// Updates should be made to a Grand Central interface to add a "prefix" field.
+// The annotatinos associated with the parent and companion should be
+// unmodified.
 // CHECK-LABEL: firrtl.circuit "GCTInterfacePrefix"
 // CHECK-SAME:    name = "MyView", prefix = "FOO_"
 firrtl.circuit "GCTInterfacePrefix"
@@ -177,7 +177,7 @@ firrtl.circuit "GCTInterfacePrefix"
     id = 0 : i64,
     name = "MyView"}]}  {
   // CHECK:      firrtl.module @FOO_MyView_companion
-  // CHECK-SAME:   name = "FOO_MyView"
+  // CHECK-SAME:   name = "MyView"
   firrtl.module @MyView_companion()
     attributes {annotations = [{
       class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
@@ -185,7 +185,7 @@ firrtl.circuit "GCTInterfacePrefix"
       name = "MyView",
       type = "companion"}]} {}
   // CHECK:      firrtl.module @FOO_DUT
-  // CHECK-SAME:   name = "FOO_MyView"
+  // CHECK-SAME:   name = "MyView"
   firrtl.module @DUT()
     attributes {annotations = [
       {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",


### PR DESCRIPTION
Stop mangling the name of Grand Central (GCT) Views in the companion and parent annotations during the PrefixModules pass.  This fixes a bug where the prefix was incorrectly applied to the instance name of an interface.

Extend an existing end-to-end GCT View test case to also check that NestedModulePrefixAnnotation and PrefixInterfacesAnnotation apply and compose correctly.  Specifically, the prefix annotation is applied to all module names, but the prefix interfaces annotation is only applied to the interfaces.  The instance name should match the name of the view and not be prefixed.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

I was somewhat surprised that this whole code path for mangling the name of the view could be deleted. However, it makes sense given that there is no "mappings" file anymore (which I believe was relying on this). The companion is already prefixed (as it is a normal instance) meaning that there is no need to ever mangle the view. The unmodified name of the view is then picked up by the GCT Views pass.

CC: @mwachs5, @debs-sifive.