### PR TITLE
[PrepareForEmission] Improve namehints heuristic and add mux heuristic

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -93,7 +93,7 @@ The current set of "style" Lowering Options is:
  * `printDebugInfo` (default=`false`). If true, emit additional debug information
    (e.g. inner symbols) into comments.
  * `wireSpillingHeuristic` (default=`spillNone`). This controls extra wire spilling performed
-   in PrepareForEmission to improve readablitiy and debuggability. It is possible to combine
+   in PrepareForEmission to improve readability and debuggability. It is possible to combine
    several heuristics by specifying `wireSpillingHeuristic` multiple times.
    (e.g. `wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux`).
    * `spillLargeTermsWithNamehints`: If spillLargeTermsWithNamehints is specified, expressions

--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -92,6 +92,15 @@ The current set of "style" Lowering Options is:
    declaration when possible.
  * `printDebugInfo` (default=`false`). If true, emit additional debug information
    (e.g. inner symbols) into comments.
+ * `wireSpillingHeuristic` (default=`spillNone`). This controls extra wire spilling performed
+   in PrepareForEmission to improve readablitiy and debuggability. It is possible to combine
+   several heuristics by specifying `wireSpillingHeuristic` multiple times.
+   (e.g. `wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux`).
+   * `spillLargeTermsWithNamehints`: If spillLargeTermsWithNamehints is specified, expressions
+     with meaningful namehints (i.e. names which start with "\_") are spilled to wires.
+     For a namehint with "\_" prefix, if the term size is greater than `wireSpillingNamehintTermLimit`
+     (default=3), then the expression is spilled.
+   * `spillAllMux`: If enabled, spill wires for all muxes.
 
 The current set of "lint warnings fix" Lowering Options is:
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -130,14 +130,13 @@ struct LoweringOptions {
   /// This controls extra wire spilling performed in PrepareForEmission to
   /// improve readablitiy and debuggability.
   enum WireSpillingHeuristic : unsigned {
-    SpillNone = 0,                    // Default
     SpillLargeTermsWithNamehints = 1, // Spill wires for expressions with
                                       // namehints if the term size is greater
                                       // than `wireSpillingNamehintTermLimit`.
     SpillAllMux = 1 << 1,             //  Spill wires for all ternary mux.
   };
 
-  unsigned wireSpillingHeuristicSet = SpillNone;
+  unsigned wireSpillingHeuristicSet = 0;
 
   bool isWireSpillingHeuristicEnabled(WireSpillingHeuristic heurisic) const {
     return static_cast<bool>(wireSpillingHeuristicSet & heurisic);

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -129,12 +129,19 @@ struct LoweringOptions {
 
   /// This controls extra wire spilling performed in PrepareForEmission to
   /// improve readablitiy and debuggability.
-  enum WireSpillingHeuristic {
-    SpillNone,                   // Default
-    SpillLargeTermsWithNamehints // Spill wires for expressions with
-                                 // namehints if the term size is greater
-                                 // than `wireSpillingNamehintTermLimit`.
-  } wireSpillingHeuristic = SpillNone;
+  enum WireSpillingHeuristic : unsigned {
+    SpillNone = 0,                    // Default
+    SpillLargeTermsWithNamehints = 1, // Spill wires for expressions with
+                                      // namehints if the term size is greater
+                                      // than `wireSpillingNamehintTermLimit`.
+    SpillAllMux = 1 << 1,             //  Spill wires for all ternary mux.
+  };
+
+  unsigned wireSpillingHeuristicSet = SpillNone;
+
+  bool isWireSpillingHeuristicEnabled(WireSpillingHeuristic heurisic) const {
+    return static_cast<bool>(wireSpillingHeuristicSet & heurisic);
+  }
 
   enum { DEFAULT_NAMEHINT_TERM_LIMIT = 3 };
   unsigned wireSpillingNamehintTermLimit = DEFAULT_NAMEHINT_TERM_LIMIT;
@@ -143,7 +150,7 @@ struct LoweringOptions {
   /// Some lint tools dislike expressions being inlined into input ports so this
   /// option avoids such warnings.
   bool disallowExpressionInliningInPorts = false;
-};
+}; // namespace circt
 
 /// Register commandline options for the verilog emitter.
 void registerLoweringCLOptions();

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -48,6 +48,7 @@ parseWireSpillingHeuristic(StringRef option) {
       .Case("spillNone", LoweringOptions::SpillNone)
       .Case("spillLargeTermsWithNamehints",
             LoweringOptions::SpillLargeTermsWithNamehints)
+      .Case("spillAllMux", LoweringOptions::SpillAllMux)
       .Default(llvm::None);
 }
 
@@ -109,9 +110,10 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       }
     } else if (option.consume_front("wireSpillingHeuristic=")) {
       if (auto heuristic = parseWireSpillingHeuristic(option)) {
-        wireSpillingHeuristic = *heuristic;
+        wireSpillingHeuristicSet |= *heuristic;
       } else {
-        errorHandler("expected 'spillNone' or 'spillLargeTermsWithNamehints'");
+        errorHandler("expected 'spillNone', 'spillLargeTermsWithNamehints' or "
+                     "'spillAllMux'");
       }
     } else if (option.consume_front("wireSpillingNamehintTermLimit=")) {
       if (option.getAsInteger(10, wireSpillingNamehintTermLimit)) {
@@ -153,9 +155,11 @@ std::string LoweringOptions::toString() const {
     options += "printDebugInfo,";
   if (useOldEmissionMode)
     options += "useOldEmissionMode,";
-  if (wireSpillingHeuristic ==
-      WireSpillingHeuristic::SpillLargeTermsWithNamehints)
+  if (isWireSpillingHeuristicEnabled(
+          WireSpillingHeuristic::SpillLargeTermsWithNamehints))
     options += "wireSpillingHeuristic=spillLargeTermsWithNamehints,";
+  if (isWireSpillingHeuristicEnabled(WireSpillingHeuristic::SpillAllMux))
+    options += "wireSpillingHeuristic=spillAllMux,";
   if (disallowExpressionInliningInPorts)
     options += "disallowExpressionInliningInPorts,";
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -45,7 +45,6 @@ static Optional<LoweringOptions::WireSpillingHeuristic>
 parseWireSpillingHeuristic(StringRef option) {
   return llvm::StringSwitch<
              llvm::Optional<LoweringOptions::WireSpillingHeuristic>>(option)
-      .Case("spillNone", LoweringOptions::SpillNone)
       .Case("spillLargeTermsWithNamehints",
             LoweringOptions::SpillLargeTermsWithNamehints)
       .Case("spillAllMux", LoweringOptions::SpillAllMux)

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -131,13 +131,45 @@ module attributes {circt.loweringOptions =
                   "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingNamehintTermLimit=3"} {
   // CHECK-LABEL: namehints
   hw.module @namehints(%a: i8) -> (b: i8) {
-    // "foo" should not be spilled because the term size is 2.
-    // CHECK-NOT: %foo = sv.wire
+    // "foo" should be spilled because it has a meaningfull name.
+    // CHECK: %foo = sv.wire
     %0 = comb.add %a, %a {sv.namehint = "foo" } : i8
-    // "bar" should be spilled because the term size is 3.
-    // CHECK: %bar = sv.wire
-    %1 = comb.add %a, %a, %a {sv.namehint = "bar" } : i8
-    %2 = comb.add %0, %1 : i8
+    // "_foo" should not be spilled because it has a name which starts with "_" and the term size is 2.
+    // CHECK-NOT: %_foo = sv.wire
+    %3 = comb.add %a, %a {sv.namehint = "_foo" } : i8
+    // "_bar" should be spilled because the term size is 3.
+    // CHECK: %_bar = sv.wire
+    %1 = comb.add %a, %a, %a {sv.namehint = "_bar" } : i8
+    %2 = comb.add %0, %1, %3 : i8
+    hw.output %2 : i8
+  }
+}
+
+// -----
+module attributes {circt.loweringOptions =
+                  "wireSpillingHeuristic=spillAllMux"} {
+  // CHECK-LABEL: mux
+  hw.module @mux(%c: i1, %b: i8, %a: i8) -> (d: i8) {
+    // CHECK: %mux = sv.wire
+    %0 = comb.mux %c, %a, %b {sv.namehint = "mux"} : i8
+    %1 = comb.add %0, %a : i8
+    hw.output %1 : i8
+  }
+}
+
+// -----
+// Check that multiple heuristics are applied.
+// CHECK: "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux"
+module attributes {circt.loweringOptions =
+                  "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux"} {
+  hw.module @combine(%c: i1, %b: i8, %a: i8) -> (d: i8) {
+    // Meaningful names should be spilled
+    // CHECK: %foo = sv.wire
+    // Mux should be spilled
+    // CHECK: sv.wire
+    %0 = comb.add %a, %a {sv.namehint = "foo" } : i8
+    %1 = comb.mux %c, %0, %b : i8
+    %2 = comb.add %1, %a : i8
     hw.output %2 : i8
   }
 }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -131,7 +131,7 @@ module attributes {circt.loweringOptions =
                   "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingNamehintTermLimit=3"} {
   // CHECK-LABEL: namehints
   hw.module @namehints(%a: i8) -> (b: i8) {
-    // "foo" should be spilled because it has a meaningfull name.
+    // "foo" should be spilled because it has a meaningful name.
     // CHECK: %foo = sv.wire
     %0 = comb.add %a, %a {sv.namehint = "foo" } : i8
     // "_foo" should not be spilled because it has a name which starts with "_" and the term size is 2.


### PR DESCRIPTION
This PR improves namehints heuristic and add a heuristic to spill wires for mux. Namehint heuristic is modified to spill wires for namehints that doesn't have "\_" prefix regardless of term sizes. For expressions with "\_" prefix, if the term is greater than a threshold, the expression is spilled to a wire. Also this PR adds a heuristic option to spill all mux.