### PR TITLE
[Handshake] Add `handshake.extmem` lowering pass

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -35,6 +35,20 @@
 namespace circt {
 namespace handshake {
 
+struct ExtMemLoadInterface {
+  unsigned index;
+  mlir::Value addressIn;
+  mlir::Value dataOut;
+  mlir::Value doneOut;
+};
+
+struct ExtMemStoreInterface {
+  unsigned index;
+  mlir::Value addressIn;
+  mlir::Value dataIn;
+  mlir::Value doneOut;
+};
+
 class TerminatorOp;
 
 #include "circt/Dialect/Handshake/HandshakeInterfaces.h.inc"

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -665,7 +665,7 @@ def MemoryOp : Handshake_Op<"memory", [
     The memory op represents a flat, unidimensional memory.
     Operands: all stores (stdata1, staddr1, stdata2, staddr2, ...), then all loads (ldaddr1, ldaddr2,...)
     Outputs: all load outputs, ordered the same as
-    load addresses (lddata1, lddata2, ...), followed by all none outputs,
+    load data (lddata1, lddata2, ...), followed by all none outputs,
     ordered as operands (stnone1, stnone2,...ldnone1, ldnone2,...)
   }];
   let arguments = (ins Variadic<AnyType> : $inputs,
@@ -727,6 +727,9 @@ def ExternalMemoryOp : Handshake_Op<"extmemory", [
     mlir::MemRefType getMemRefType() {
       return getMemref().getType().cast<mlir::MemRefType>();
     }
+
+    llvm::SmallVector<handshake::ExtMemLoadInterface> getLoadPorts();
+    llvm::SmallVector<handshake::ExtMemStoreInterface> getStorePorts();
   }];
 }
 

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -30,6 +30,7 @@ std::unique_ptr<mlir::Pass> createHandshakeMaterializeForksSinksPass();
 std::unique_ptr<mlir::Pass> createHandshakeDematerializeForksSinksPass();
 std::unique_ptr<mlir::Pass> createHandshakeRemoveBuffersPass();
 std::unique_ptr<mlir::Pass> createHandshakeAddIDsPass();
+std::unique_ptr<mlir::Pass> createHandshakeLowerExtmemToHWPass();
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeInsertBuffersPass(const std::string &strategy = "all",
                                  unsigned bufferSize = 2);

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -62,6 +62,17 @@ def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp
   let constructor = "circt::handshake::createHandshakeRemoveBuffersPass()";
 }
 
+def HandshakeLowerExtmemToHW : Pass<"handshake-lower-extmem-to-hw", "mlir::ModuleOp"> {
+  let summary = "Lowers handshake.extmem and memref inputs to ports.";
+  let description = [{
+    Lowers handshake.extmem and memref inputs to a hardware-targeting
+    memory accessing scheme (explicit load- and store ports on the top
+    level interface).
+  }];
+  let constructor = "circt::handshake::createHandshakeLowerExtmemToHWPass()";
+  let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 def HandshakeAddIDs : Pass<"handshake-add-ids", "handshake::FuncOp"> {
   let summary = "Add an ID to each operation in a handshake function.";
   let description = [{

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   CIRCTHandshakeTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTHW
   CIRCTHandshake
   CIRCTSupport
   MLIRIR

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   Materialization.cpp
   Buffers.cpp
   LockFunctions.cpp
+  LowerExtmemToHW.cpp
 
   DEPENDS
   CIRCTHandshakeTransformsIncGen

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -1,0 +1,255 @@
+//===- LowerExtmemToHW.cpp - lock functions pass ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the lower extmem pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "circt/Dialect/Handshake/HandshakePasses.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace circt;
+using namespace handshake;
+using namespace mlir;
+namespace {
+using NamedType = std::pair<StringAttr, Type>;
+struct HandshakeMemType {
+  llvm::SmallVector<NamedType> inputTypes, outputTypes;
+};
+
+struct LoadNames {
+  StringAttr dataIn;
+  StringAttr addrOut;
+
+  static LoadNames get(MLIRContext *ctx, unsigned idx) {
+    return {StringAttr::get(ctx, "ld" + std::to_string(idx) + ".data"),
+            StringAttr::get(ctx, "ld" + std::to_string(idx) + ".addr")};
+  }
+};
+
+struct StoreNames {
+  StringAttr doneIn;
+  StringAttr out;
+
+  static StoreNames get(MLIRContext *ctx, unsigned idx) {
+    return {StringAttr::get(ctx, "st" + std::to_string(idx) + ".done"),
+            StringAttr::get(ctx, "st" + std::to_string(idx))};
+  }
+};
+
+} // namespace
+
+static HandshakeMemType getMemTypeForExtmem(Value v) {
+  auto *ctx = v.getContext();
+  assert(v.getType().isa<mlir::MemRefType>() && "Value is not a memref type");
+  auto extmemOp = cast<handshake::ExternalMemoryOp>(*v.getUsers().begin());
+  HandshakeMemType memType;
+  llvm::SmallVector<hw::detail::FieldInfo> inFields, outFields;
+
+  // Add load ports.
+  for (auto [i, ldif] : llvm::enumerate(extmemOp.getLoadPorts())) {
+    auto names = LoadNames::get(ctx, i);
+    memType.inputTypes.push_back({names.dataIn, ldif.dataOut.getType()});
+    memType.outputTypes.push_back({names.addrOut, ldif.addressIn.getType()});
+  }
+
+  // Add store ports.
+  for (auto [i, stif] : llvm::enumerate(extmemOp.getStorePorts())) {
+    auto names = StoreNames::get(ctx, i);
+
+    // Incoming store data and address
+    llvm::SmallVector<hw::StructType::FieldInfo> storeOutFields;
+    storeOutFields.push_back(
+        {StringAttr::get(ctx, "data"), stif.dataIn.getType()});
+    storeOutFields.push_back(
+        {StringAttr::get(ctx, "addr"), stif.addressIn.getType()});
+    auto inType = hw::StructType::get(ctx, storeOutFields);
+    memType.outputTypes.push_back({names.out, inType});
+    memType.inputTypes.push_back({names.doneIn, stif.doneOut.getType()});
+  }
+  return memType;
+}
+
+namespace {
+
+struct HandshakeLowerExtmemToHWPass
+    : public HandshakeLowerExtmemToHWBase<HandshakeLowerExtmemToHWPass> {
+  void runOnOperation() override {
+    auto op = getOperation();
+    for (auto func : op.getOps<handshake::FuncOp>()) {
+      if (failed(LowerExtmemToHW(func))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  };
+
+  LogicalResult LowerExtmemToHW(handshake::FuncOp func);
+};
+
+static Value plumbLoadPort(Location loc, OpBuilder &b,
+                           const handshake::ExtMemLoadInterface &ldif,
+                           Value loadData) {
+  // We need to feed both the load data and the load done outputs.
+  // Fork the extracted load data into two, and 'join' the second one to
+  // generate a none-typed output to drive the load done.
+  auto dataFork = b.create<ForkOp>(loc, loadData, 2);
+
+  auto dataOut = dataFork.getResult()[0];
+  llvm::SmallVector<Value> joinArgs = {dataFork.getResult()[1]};
+  auto dataDone = b.create<JoinOp>(loc, joinArgs);
+
+  ldif.dataOut.replaceAllUsesWith(dataOut);
+  ldif.doneOut.replaceAllUsesWith(dataDone);
+
+  // Return load address, to be fed to the top-level output.
+  return ldif.addressIn;
+}
+
+static Value plumbStorePort(Location loc, OpBuilder &b,
+                            const handshake::ExtMemStoreInterface &stif,
+                            Value done, Type outType) {
+  stif.doneOut.replaceAllUsesWith(done);
+  // Return the store and data to be fed to the top-level output.
+  llvm::SmallVector<Value> structArgs = {stif.dataIn, stif.addressIn};
+  return b
+      .create<hw::StructCreateOp>(loc, outType.cast<hw::StructType>(),
+                                  structArgs)
+      .getResult();
+}
+
+static void appendToStringArrayAttr(Operation *op, StringRef attrName,
+                                    StringRef attrVal) {
+  auto *ctx = op->getContext();
+  llvm::SmallVector<Attribute> newArr;
+  llvm::copy(op->getAttrOfType<ArrayAttr>(attrName).getValue(),
+             std::back_inserter(newArr));
+  newArr.push_back(StringAttr::get(ctx, attrVal));
+  op->setAttr(attrName, ArrayAttr::get(ctx, newArr));
+}
+
+static void insertInStringArrayAttr(Operation *op, StringRef attrName,
+                                    StringRef attrVal, unsigned idx) {
+  auto *ctx = op->getContext();
+  llvm::SmallVector<Attribute> newArr;
+  llvm::copy(op->getAttrOfType<ArrayAttr>(attrName).getValue(),
+             std::back_inserter(newArr));
+  newArr.insert(newArr.begin() + idx, StringAttr::get(ctx, attrVal));
+  op->setAttr(attrName, ArrayAttr::get(ctx, newArr));
+}
+
+static void eraseFromArrayAttr(Operation *op, StringRef attrName,
+                               unsigned idx) {
+  auto *ctx = op->getContext();
+  llvm::SmallVector<Attribute> newArr;
+  llvm::copy(op->getAttrOfType<ArrayAttr>(attrName).getValue(),
+             std::back_inserter(newArr));
+  newArr.erase(newArr.begin() + idx);
+  op->setAttr(attrName, ArrayAttr::get(ctx, newArr));
+}
+
+LogicalResult
+HandshakeLowerExtmemToHWPass::LowerExtmemToHW(handshake::FuncOp func) {
+  // Gather memref ports to be converted.
+  llvm::DenseMap<unsigned, Value> memrefArgs;
+  for (auto [i, arg] : llvm::enumerate(func.getArguments())) {
+    if (arg.getType().isa<MemRefType>())
+      memrefArgs[i] = arg;
+  }
+
+  if (memrefArgs.empty())
+    return success(); // nothing to do.
+
+  OpBuilder b(func);
+  for (auto it : memrefArgs) {
+    // Do not use structured bindings for 'it' - cannot reference inside lambda.
+    unsigned i = it.first;
+    auto arg = it.second;
+    auto loc = arg.getLoc();
+    // Get the attached extmemory external module.
+    auto extmemOp = cast<handshake::ExternalMemoryOp>(*arg.getUsers().begin());
+    OpBuilder b(extmemOp);
+    b.setInsertionPoint(extmemOp);
+
+    // Add memory input - this is the output of the extmemory op.
+    auto memIOTypes = getMemTypeForExtmem(arg);
+
+    auto oldReturnOp =
+        cast<handshake::ReturnOp>(func.getBody().front().getTerminator());
+    llvm::SmallVector<Value> newReturnOperands = oldReturnOp.getOperands();
+    unsigned addedInPorts = 0;
+    auto memName = func.getArgName(i);
+    auto addArgRes = [&](unsigned id, NamedType &argType, NamedType &resType) {
+      // Function argument
+      unsigned newArgIdx = i + addedInPorts;
+      func.insertArgument(newArgIdx, argType.second, {}, arg.getLoc());
+      insertInStringArrayAttr(func, "argNames",
+                              memName.str() + "_" + argType.first.str(),
+                              newArgIdx);
+      auto newInPort = func.getArgument(newArgIdx);
+      ++addedInPorts;
+
+      // Function result.
+      func.insertResult(func.getNumResults(), resType.second, {});
+      appendToStringArrayAttr(func, "resNames",
+                              memName.str() + "_" + resType.first.str());
+      return newInPort;
+    };
+
+    // Plumb load ports.
+    unsigned portIdx = 0;
+    for (auto loadPort : extmemOp.getLoadPorts()) {
+      auto newInPort = addArgRes(loadPort.index, memIOTypes.inputTypes[portIdx],
+                                 memIOTypes.outputTypes[portIdx]);
+      newReturnOperands.push_back(plumbLoadPort(loc, b, loadPort, newInPort));
+      ++portIdx;
+    }
+
+    // Plumb store ports.
+    for (auto storePort : extmemOp.getStorePorts()) {
+      auto newInPort =
+          addArgRes(storePort.index, memIOTypes.inputTypes[portIdx],
+                    memIOTypes.outputTypes[portIdx]);
+      newReturnOperands.push_back(
+          plumbStorePort(loc, b, storePort, newInPort,
+                         memIOTypes.outputTypes[portIdx].second));
+      ++portIdx;
+    }
+
+    // Replace the return op of the function with a new one that returns the
+    // memory output struct.
+    b.setInsertionPoint(oldReturnOp);
+    b.create<ReturnOp>(arg.getLoc(), newReturnOperands);
+    oldReturnOp.erase();
+
+    // Erase the extmemory operation since I/O plumbing has replaced all of its
+    // results.
+    extmemOp.erase();
+
+    // Erase the original memref argument of the top-level i/o now that it's
+    // use has been removed.
+    func.eraseArgument(i + addedInPorts);
+    eraseFromArrayAttr(func, "argNames", i + addedInPorts);
+  }
+
+  return success();
+}
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+circt::handshake::createHandshakeLowerExtmemToHWPass() {
+  return std::make_unique<HandshakeLowerExtmemToHWPass>();
+}

--- a/lib/Dialect/Handshake/Transforms/PassDetails.h
+++ b/lib/Dialect/Handshake/Transforms/PassDetails.h
@@ -16,6 +16,7 @@
 #ifndef DIALECT_HANDSHAKE_TRANSFORMS_PASSDETAILS_H
 #define DIALECT_HANDSHAKE_TRANSFORMS_PASSDETAILS_H
 
+#include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "mlir/Pass/Pass.h"
 

--- a/test/Dialect/Handshake/lower-extmem.mlir
+++ b/test/Dialect/Handshake/lower-extmem.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt -handshake-lower-extmem-to-hw %s | FileCheck %s
+
+// CHECK-LABEL:   handshake.func @main(
+// CHECK-SAME:           %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, %[[VAL_5:.*]]: none, ...) -> (none, index, !hw.struct<data: i32, addr: index>) attributes {argNames = ["arg0", "arg1", "v", "mem_ld0.data", "mem_st0.done", "argCtrl"], resNames = ["out0", "mem_ld0.addr", "mem_st0"]} {
+// CHECK:           %[[VAL_6:.*]]:2 = fork [2] %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = join %[[VAL_6]]#1 : i32
+// CHECK:           %[[VAL_8:.*]] = hw.struct_create (%[[VAL_9:.*]], %[[VAL_10:.*]]) : !hw.struct<data: i32, addr: index>
+// CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_5]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = load {{\[}}%[[VAL_0]]] %[[VAL_6]]#0, %[[VAL_11]]#0 : index, i32
+// CHECK:           %[[VAL_9]], %[[VAL_10]] = store {{\[}}%[[VAL_1]]] %[[VAL_2]], %[[VAL_11]]#1 : index, i32
+// CHECK:           sink %[[VAL_12]] : i32
+// CHECK:           %[[VAL_14:.*]] = join %[[VAL_4]], %[[VAL_7]] : none, none
+// CHECK:           return %[[VAL_14]], %[[VAL_13]], %[[VAL_8]] : none, index, !hw.struct<data: i32, addr: index>
+// CHECK:         }
+
+handshake.func @main(%arg0: index, %arg1: index, %v: i32, %mem : memref<10xi32>, %argCtrl: none) -> none {
+  %ldData, %stCtrl, %ldCtrl = handshake.extmemory[ld=1, st=1](%mem : memref<10xi32>)(%storeData, %storeAddr, %loadAddr) {id = 0 : i32} : (i32, index, index) -> (i32, none, none)
+  %fCtrl:2 = fork [2] %argCtrl : none
+  %loadData, %loadAddr = load [%arg0] %ldData, %fCtrl#0 : index, i32
+  %storeData, %storeAddr = store [%arg1] %v, %fCtrl#1 : index, i32
+  sink %loadData : i32
+  %finCtrl = join %stCtrl, %ldCtrl : none, none
+  return %finCtrl : none
+}


### PR DESCRIPTION
This is intended to be a lowering used on the path of transforming Handshake to hardware. The transformation materializes the top-level `memref` to a new set of in- and output arguments, and plumbs this to the in- and output values of the `handshake.extmem` operation which referenced the memref. This is essentially what is was done by `HandshakeToFIRRTL`/`HandshakeToHW` but moved as a preprocessing step, lowering away the "high-level" semantics associated with the `memref` argument/`handshake.extmem` operation.

Another motivation for doing so is to create a more natural interface for external users to interact with:
- Store ports now have a single handshake'd output port with combined addr+data.
- Load ports now only requires a single handshake'd data input. This input is then forked into its data+control parts to feed the load- and store operations.

In doing so, we also use `!hw.struct` types to ensure that correct names are being maintained for the in- and output values. This is opposed to using tuples, which does not have named fields. The tuple requires use of `hw.struct_create` - in HandshakeToHW, lowering `hw.struct_create` can be supported identically to `handshake.pack` which itself uses `hw.struct_create` after tuple types have been lowered to structs.