### PR TITLE
[PrepareForEmission] Add option to spill mux expressions.

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -92,6 +92,7 @@ The current set of "style" Lowering Options is:
    declaration when possible.
  * `printDebugInfo` (default=`false`). If true, emit additional debug information
    (e.g. inner symbols) into comments.
+ * `disallowInlineMux` (default=`false`).  If true, always spill mux expressions.
 
 The current set of "lint warnings fix" Lowering Options is:
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -143,6 +143,9 @@ struct LoweringOptions {
   /// Some lint tools dislike expressions being inlined into input ports so this
   /// option avoids such warnings.
   bool disallowExpressionInliningInPorts = false;
+
+  /// If true, do not emit mux operations inline (spill to wire).
+  bool disallowInlineMux = false;
 };
 
 /// Register commandline options for the verilog emitter.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -73,9 +73,10 @@ static bool shouldSpillWire(Operation &op, const LoweringOptions &options) {
     return true;
 
   // Don't inline mux operations if requested not to, unless RHS of an assign.
-  if (options.disallowInlineMux && isa<MuxOp>(op) && !isOnlyUsedInAssignment(op))
+  if (options.disallowInlineMux && isa<MuxOp>(op) &&
+      !isOnlyUsedInAssignment(op))
     return true;
- 
+
   // Work around Verilator #3405. Large expressions inside a concat is worst
   // case O(n^2) in a certain Verilator optimization, and can effectively hang
   // Verilator on large designs. Verilator 4.224+ works around this by having a

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -102,6 +102,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       useOldEmissionMode = true;
     } else if (option == "disallowExpressionInliningInPorts") {
       disallowExpressionInliningInPorts = true;
+    } else if (option == "disallowInlineMux") {
+      disallowInlineMux = true;
     } else if (option.consume_front("maximumNumberOfVariadicOperands=")) {
       if (option.getAsInteger(10, maximumNumberOfVariadicOperands)) {
         errorHandler("expected integer for number of variadic operands");
@@ -158,6 +160,8 @@ std::string LoweringOptions::toString() const {
     options += "wireSpillingHeuristic=spillLargeTermsWithNamehints,";
   if (disallowExpressionInliningInPorts)
     options += "disallowExpressionInliningInPorts,";
+  if (disallowInlineMux)
+    options += "disallowInlineMux,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
@@ -228,7 +232,7 @@ struct LoweringCLOptions {
           "emitReplicatedOpsToHeader, "
           "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
           "disallowPortDeclSharing, printDebugInfo, useOldEmissionMode, "
-          "disallowExpressionInliningInPorts"),
+          "disallowExpressionInliningInPorts, disallowInlineMux"),
       llvm::cl::value_desc("option")};
 };
 } // namespace

--- a/test/Conversion/ExportVerilog/disallow-inline-mux.mlir
+++ b/test/Conversion/ExportVerilog/disallow-inline-mux.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt %s -export-verilog -verify-diagnostics -o %t.mlir --lowering-options=disallowInlineMux | FileCheck %s
+
+// CHECK-LABEL
+
+// CHECK-LABEL: module ShiftMux
+hw.module @ShiftMux(%p: i1, %x: i45) -> (o: i45) {
+  // CHECK: wire [44:0] [[GEN:.+]] = p ? 45'h5 : 45'h8
+  // CHECK: assign o = $signed($signed(x) >>> [[GEN]]
+  %c5_i45 = hw.constant 5 : i45
+  %c8_i45 = hw.constant 8 : i45
+  %0 = comb.mux %p, %c5_i45, %c8_i45 : i45
+  %1 = comb.shrs %x, %0 : i45
+  hw.output %1 : i45
+}
+
+// CHECK-LABEL: module AssignMux
+hw.module @AssignMux(%p: i1, %x: i45) -> (o: i45) {
+  // CHECK-NOT: wire
+  // CHECK: assign o = p ? 45'h5 : x
+  %c5_i45 = hw.constant 5 : i45
+  %0 = comb.mux %p, %c5_i45, %x : i45
+  hw.output %0 : i45
+}


### PR DESCRIPTION
Adds `disallowInlineMux` lowering option to request mux expressions are spilled (unless only used in RHS of assign).

Defaults to false (off, existing behavior).