### PR TITLE
[FIRRTL][GrandCentral] Revert MemTap sink to array attribute

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -273,7 +273,6 @@ static FailureOr<Literal> parseIntegerLiteral(MLIRContext *context,
   return lit;
 }
 
-
 LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
                                                   DictionaryAttr anno,
                                                   ApplyState &state) {
@@ -683,13 +682,9 @@ LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
   if (!srcTarget)
     return mlir::emitError(loc, "cannot resolve source target path '")
            << sourceTargetStr << "'";
-  auto tapsAttr = tryGetAs<StringAttr>(anno, anno, "sink", loc, memTapClass);
-  if (!tapsAttr) {
-    return mlir::emitError(loc, "Annotation '" + Twine(memTapClass) +
-                                    "contained an unknown sink attribute.")
-               .attachNote()
-           << "The full Annotation is reprodcued here: " << anno << "\n";
-  }
+  auto tapsAttr = tryGetAs<ArrayAttr>(anno, anno, "sink", loc, memTapClass);
+  if (!tapsAttr || tapsAttr.empty())
+    return mlir::emitError(loc, "sink must have at least one entry");
   if (auto combMem = dyn_cast<chirrtl::CombMemOp>(srcTarget->ref.getOp())) {
     if (!combMem.getType().getElementType().isGround())
       return combMem.emitOpError(
@@ -715,12 +710,24 @@ LogicalResult applyGCTMemTapsWithWires(const AnnoPathValue &target,
             "exist and unique instance cannot be resolved");
       srcTarget->instances.append(path.back().begin(), path.back().end());
     }
+    if (tapsAttr.size() != combMem.getType().getNumElements())
+      return mlir::emitError(
+          loc, "sink cannot specify more taps than the depth of the memory");
   } else
     return srcTarget->ref.getOp()->emitOpError(
         "unsupported operation, only CombMem can be used as the source of "
         "MemTap");
 
-  auto wireTargetStr = canonicalizeTarget(tapsAttr.getValue());
+  auto tap = tapsAttr[0].dyn_cast_or_null<StringAttr>();
+  if (!tap) {
+    return mlir::emitError(
+               loc, "Annotation '" + Twine(memTapClass) +
+                        "' with path '.taps[0" +
+                        "]' contained an unexpected type (expected a string).")
+               .attachNote()
+           << "The full Annotation is reprodcued here: " << anno << "\n";
+  }
+  auto wireTargetStr = canonicalizeTarget(tap.getValue());
   if (!tokenizePath(wireTargetStr))
     return failure();
   Optional<AnnoPathValue> wireTarget = resolvePath(

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -13,7 +13,16 @@ circuit Top : %[[
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
     "source":"~Top|DUTModule>rf",
-    "sink": "~Top|Top>memTap"
+    "sink":[
+      "~Top|Top>memTap[0]",
+      "~Top|Top>memTap[1]",
+      "~Top|Top>memTap[2]",
+      "~Top|Top>memTap[3]",
+      "~Top|Top>memTap[4]",
+      "~Top|Top>memTap[5]",
+      "~Top|Top>memTap[6]",
+      "~Top|Top>memTap[7]"
+    ]
   }
 ]]
   module DUTModule :

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -12,7 +12,16 @@ circuit Top : %[[
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
     "source":"~Top|DUTModule>rf",
-    "sink":"~Top|Top>memTap"
+    "sink":[
+      "~Top|Top>memTap[0]",
+      "~Top|Top>memTap[1]",
+      "~Top|Top>memTap[2]",
+      "~Top|Top>memTap[3]",
+      "~Top|Top>memTap[4]",
+      "~Top|Top>memTap[5]",
+      "~Top|Top>memTap[6]",
+      "~Top|Top>memTap[7]"
+    ]
   }
 ]]
   module DUTModule :


### PR DESCRIPTION
This commit reverts the changes to MemTap annotation introduced in https://github.com/llvm/circt/pull/4006.
MemTap sink should be an array attribute instead of a string attribute.
 ``"sink": "~Top|Top>memTap"``  instead of  `` 
"sink":[  "~Top|Top>memTap[0]",  "~Top|Top>memTap[1]", ...] 
``