### PR TITLE
[ExportVerilog] emit comments on `else and `endif for readability

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3344,11 +3344,11 @@ LogicalResult StmtEmitter::emitIfDef(Operation *op, MacroIdentAttr cond) {
 
   if (!op->getRegion(1).empty()) {
     if (!hasEmptyThen)
-      indent() << "`else\n";
+      indent() << "`else  // " << ident << "\n";
     emitStatementBlock(op->getRegion(1).front());
   }
 
-  indent() << "`endif\n";
+  indent() << "`endif // " << (hasEmptyThen ? "not def " : "") << ident << "\n";
 
   // We don't know how many statements we emitted, so assume conservatively
   // that a lot got put out. This will make sure we get a begin/end block around

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1552,6 +1552,20 @@ hw.module private @InlineReadInout() -> () {
   }
 }
 
+// CHECK-LABEL: module ConditionalComments(
+hw.module @ConditionalComments() {
+  sv.ifdef "FOO"  {             // CHECK-NEXT: `ifdef FOO
+    sv.verbatim "`define FOO_A" // CHECK-NEXT:   `define FOO_A
+  } else  {                     // CHECK-NEXT: `else  // FOO
+    sv.verbatim "`define FOO_B" // CHECK-NEXT:   `define FOO_B
+  }                             // CHECK-NEXT: `endif // FOO
+
+  sv.ifdef "BAR"  {             // CHECK-NEXT: `ifndef BAR
+  } else  {
+    sv.verbatim "`define X"     // CHECK-NEXT:   `define X
+  }                             // CHECK-NEXT: `endif // not def BAR
+}
+
 hw.module @bindInMod() {
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst>
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst3>


### PR DESCRIPTION
For larger or nested conditionals, comments help more easily understand what's going on.
