### PR TITLE
[FIRRTL][InferResets] Don't abort on foreign types

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -326,6 +326,19 @@ firrtl.module @ShouldAdjustExtModule2() {
   firrtl.connect %x_reset, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }
 
+// Should not crash if there are connects with foreign types.
+// CHECK-LABEL: firrtl.module @ForeignTypes
+firrtl.module @ForeignTypes(out %out: !firrtl.reset) {
+  %0 = firrtl.wire : index
+  %1 = firrtl.wire : index
+  firrtl.strictconnect %0, %1 : index
+  // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
+  // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
+  // CHECK-NEXT: firrtl.strictconnect [[W0]], [[W1]] : index
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
+}
+
 
 //===----------------------------------------------------------------------===//
 // Full Async Reset


### PR DESCRIPTION
Make the `InferResets` pass properly ignore foreign types which by definition don't contribute to the resets being inferred. Before this change the pass would abort on various `cast<FIRRTLType>()` calls. These all become `dyn_cast<FIRRTLType>()` now with graceful handling of the non-FIRRTL type case, which makes the pass more robust.