### PR TITLE
[FIRRTL][InferWidths] Exclude foreign types, add conversion cast support

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1211,7 +1211,12 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
     if (auto mux = dyn_cast<MuxPrimOp>(op))
       if (hasUninferredWidth(mux.getSel().getType()))
         allWidthsKnown = false;
-    if (!hasUninferredWidth(result.getType()))
+    // Only consider FIRRTL types for width constraints. Ignore any foreign
+    // types as they don't participate in the width inference process.
+    auto resultTy = result.getType().dyn_cast<FIRRTLType>();
+    if (!resultTy)
+      continue;
+    if (!hasUninferredWidth(resultTy))
       declareVars(result, op->getLoc());
     else
       allWidthsKnown = false;
@@ -1532,7 +1537,11 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         declareVars(op.getResult(), op.getLoc());
         constrainTypes(op.getResult(), op.getRef());
       })
-
+      .Case<mlir::UnrealizedConversionCastOp>([&](auto op) {
+        for (auto result : op.getResults())
+          if (result.getType().template isa<FIRRTLType>())
+            declareVars(result, op.getLoc());
+      })
       .Default([&](auto op) {
         op->emitOpError("not supported in width inference");
         mappingFailed = true;
@@ -1618,8 +1627,12 @@ void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
 ///
 /// This function is used to apply regular connects.
 void InferenceMapping::constrainTypes(Value larger, Value smaller) {
-  // Recurse to every leaf element and set larger >= smaller.
-  auto type = larger.getType().cast<FIRRTLType>();
+  // Recurse to every leaf element and set larger >= smaller. Ignore foreign
+  // types as these do not participate in width inference.
+  auto type = larger.getType().dyn_cast<FIRRTLType>();
+  if (!type)
+    return;
+
   auto fieldID = 0;
   std::function<void(FIRRTLBaseType, Value, Value)> constrain =
       [&](FIRRTLBaseType type, Value larger, Value smaller) {

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -825,4 +825,15 @@ firrtl.circuit "Foo" {
     %res = firrtl.ref.resolve %sub_x : !firrtl.ref<uint>
     firrtl.connect %r, %res : !firrtl.uint, !firrtl.uint
   }
+
+  // CHECK-LABEL: @ForeignTypes
+  firrtl.module @ForeignTypes(in %a: !firrtl.uint<42>, out %b: !firrtl.uint) {
+    %0 = firrtl.wire : index
+    %1 = firrtl.wire : index
+    firrtl.strictconnect %0, %1 : index
+    firrtl.connect %b, %a : !firrtl.uint, !firrtl.uint<42>
+    // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
+    // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
+    // CHECK-NEXT: firrtl.strictconnect [[W0]], [[W1]] : index
+  }
 }


### PR DESCRIPTION
The `InferWidths` pass should ignore any foreign types that might be present in the IR. These types cannot contribute any width constraints and don't participate in the width inference process in general, so this commit makes the pass ignore such types more explicitly.

Also add support for `UnrealizedConversionCastOp`. In case such a cast has a result of uninferred width, the pass would now assign a width to it as with any other operation. The applicability of this in practice is fairly limited since width inference can only affect the FIRRTL-typed results of the cast, but it can't propagate any information through the cast. However, in some applications a partial dialect lowering might be sensitive to the source type of the cast and do the right thing based on what width was assigned, making this a niche but useful change.