### PR TITLE
[FIRRTL][LowerTypes] Pass through foreign types in lowerProducer

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -558,7 +558,9 @@ bool TypeLoweringVisitor::lowerProducer(
     llvm::function_ref<Operation *(const FlatBundleFieldEntry &, ArrayAttr)>
         clone) {
   // If this is not a bundle, there is nothing to do.
-  auto srcType = op->getResult(0).getType().cast<FIRRTLType>();
+  auto srcType = op->getResult(0).getType().dyn_cast<FIRRTLType>();
+  if (!srcType)
+    return false;
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
 
   if (!peelType(srcType, fieldTypes, aggregatePreservationMode))

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1106,6 +1106,12 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>
   }
 
+  // CHECK-LABEL: firrtl.module private @ForeignTypes
+  firrtl.module private @ForeignTypes() {
+    // CHECK-NEXT: firrtl.wire : index
+    %0 = firrtl.wire : index
+  }
+
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last


### PR DESCRIPTION
Adjust the `lowerProducer` function such that it properly passes through foreign types like it passes through any non-bundle type.