### PR TITLE
[CI] Fix llvm-lit path for Windows build.

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            llvm/build/Release/bin/llvm-lit.py
+            llvm/build/bin/llvm-lit.py
             llvm/install
           key: ${{ runner.os }}-llvm-relobj-${{ steps.get-llvm-hash.outputs.hash }}
 
@@ -77,7 +77,7 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=ON `
             -DMLIR_DIR="$(pwd)/../llvm/install/lib/cmake/mlir/" `
             -DLLVM_DIR="$(pwd)/../llvm/install/lib/cmake/llvm/" `
-            -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/Release/bin/llvm-lit.py" `
+            -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/bin/llvm-lit.py" `
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
 


### PR DESCRIPTION
Fixes #4028 .

Tests still are not run, as they do not work on Windows (see #376).