### PR TITLE
Revert "[NFC] Make prepareforemission an embedded pass...", breaks -verbose-pass-executions

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -13,15 +13,12 @@
 #ifndef CIRCT_TRANSLATION_EXPORTVERILOG_H
 #define CIRCT_TRANSLATION_EXPORTVERILOG_H
 
-#include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
 
 std::unique_ptr<mlir::Pass> createTestPrepareForEmissionPass();
-std::unique_ptr<mlir::Pass>
-createPrepareForEmissionPass(LoweringOptions options = LoweringOptions());
 
 std::unique_ptr<mlir::Pass> createExportVerilogPass(llvm::raw_ostream &os);
 std::unique_ptr<mlir::Pass> createExportVerilogPass();

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -90,26 +90,6 @@ def TestPrepareForEmission : Pass<"test-prepare-for-emission",
   ];
 }
 
-def PrepareForEmission : Pass<"prepare-for-emission",
-                              "hw::HWModuleOp"> {
-  let summary = "Prepare IR for ExportVerilog";
-  let description = [{
-    This pass runs only PrepareForEmission logic.
-    It is not necessary for users to run this pass explicitly since
-    ExportVerilog internally schedules PrepareForEmission.
-  }];
-
-  let constructor = "createPrepareForEmissionPass()";
-  let dependentDialects = [
-    "circt::sv::SVDialect", "circt::comb::CombDialect", "circt::hw::HWDialect"
-  ];
-  let options = [
-    Option<"options", "opts", "LoweringOptions",
-            "", "Lowering options">
- ];
-
-}
-
 def ExportVerilog : Pass<"export-verilog", "mlir::ModuleOp"> {
   let summary = "Emit the IR to a (System)Verilog file";
   let description = [{

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -34,7 +34,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
@@ -5002,14 +5001,26 @@ void SharedEmitterState::emitOps(EmissionList &thingsToEmit, raw_ostream &os,
   }
 }
 
+/// Prepare the given MLIR module for emission.
+static void prepareForEmission(ModuleOp module,
+                               const LoweringOptions &options) {
+  SmallVector<HWModuleOp> modulesToPrepare;
+  module.walk([&](HWModuleOp op) { modulesToPrepare.push_back(op); });
+  parallelForEach(module->getContext(), modulesToPrepare,
+                  [&](auto op) { prepareHWModule(op, options); });
+}
+
 //===----------------------------------------------------------------------===//
 // Unified Emitter
 //===----------------------------------------------------------------------===//
 
-static LogicalResult exportVerilogImpl(ModuleOp module, llvm::raw_ostream &os) {
+LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
+  // Prepare the ops in the module for emission and legalize the names that will
+  // end up in the output.
+  LoweringOptions options(module);
+  prepareForEmission(module, options);
   GlobalNameTable globalNames = legalizeGlobalNames(module);
 
-  LoweringOptions options(module);
   SharedEmitterState emitter(module, options, std::move(globalNames));
   emitter.gatherFiles(false);
 
@@ -5045,15 +5056,6 @@ static LogicalResult exportVerilogImpl(ModuleOp module, llvm::raw_ostream &os) {
   return failure(emitter.encounteredError);
 }
 
-LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
-  LoweringOptions options(module);
-  SmallVector<HWModuleOp> modulesToPrepare;
-  module.walk([&](HWModuleOp op) { modulesToPrepare.push_back(op); });
-  parallelForEach(module->getContext(), modulesToPrepare,
-                  [&](auto op) { prepareHWModule(op, options); });
-  return exportVerilogImpl(module, os);
-}
-
 namespace {
 
 struct ExportVerilogPass : public ExportVerilogBase<ExportVerilogPass> {
@@ -5064,15 +5066,7 @@ struct ExportVerilogPass : public ExportVerilogBase<ExportVerilogPass> {
     // TODO: This should be moved up to circt-opt and circt-translate.
     applyLoweringCLOptions(getOperation());
 
-    // Prepare the ops in the module for emission.
-    LoweringOptions options(getOperation());
-    mlir::OpPassManager preparePM("builtin.module");
-    auto &modulePM = preparePM.nest<hw::HWModuleOp>();
-    modulePM.addPass(createPrepareForEmissionPass(options));
-    if (failed(runPipeline(preparePM, getOperation())))
-      signalPassFailure();
-
-    if (failed(exportVerilogImpl(getOperation(), os)))
+    if (failed(exportVerilog(getOperation(), os)))
       signalPassFailure();
   }
 
@@ -5140,11 +5134,11 @@ static void createSplitOutputFile(StringAttr fileName, FileInfo &file,
   output->keep();
 }
 
-static LogicalResult exportSplitVerilogImpl(ModuleOp module,
-                                            StringRef dirname) {
+LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
   // Prepare the ops in the module for emission and legalize the names that will
   // end up in the output.
   LoweringOptions options(module);
+  prepareForEmission(module, options);
   GlobalNameTable globalNames = legalizeGlobalNames(module);
 
   SharedEmitterState emitter(module, options, std::move(globalNames));
@@ -5204,15 +5198,6 @@ static LogicalResult exportSplitVerilogImpl(ModuleOp module,
   return failure(emitter.encounteredError);
 }
 
-LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
-  LoweringOptions options(module);
-  SmallVector<HWModuleOp> modulesToPrepare;
-  module.walk([&](HWModuleOp op) { modulesToPrepare.push_back(op); });
-  parallelForEach(module->getContext(), modulesToPrepare,
-                  [&](auto op) { prepareHWModule(op, options); });
-  return exportSplitVerilogImpl(module, dirname);
-}
-
 namespace {
 
 struct ExportSplitVerilogPass
@@ -5225,15 +5210,6 @@ struct ExportSplitVerilogPass
     // on the command line.
     // TODO: This should be moved up to circt-opt and circt-translate.
     applyLoweringCLOptions(getOperation());
-
-    // Prepare the ops in the module for emission.
-    LoweringOptions options(getOperation());
-    mlir::OpPassManager preparePM("builtin.module");
-    auto &modulePM = preparePM.nest<hw::HWModuleOp>();
-    modulePM.addPass(createPrepareForEmissionPass(options));
-    if (failed(runPipeline(preparePM, getOperation())))
-      signalPassFailure();
-
     if (failed(exportSplitVerilog(getOperation(), directoryName)))
       signalPassFailure();
   }

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -21,6 +21,7 @@
 #include "ExportVerilogInternals.h"
 #include "circt/Conversion/ExportVerilog.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -1029,22 +1030,8 @@ struct TestPrepareForEmissionPass
     prepareHWModule(module, options);
   }
 };
-
-struct PrepareForEmissionPass
-    : public PrepareForEmissionBase<PrepareForEmissionPass> {
-  PrepareForEmissionPass(LoweringOptions options) : options(options) {}
-  void runOnOperation() override { prepareHWModule(getOperation(), options); }
-
-protected:
-  LoweringOptions options;
-};
 } // end anonymous namespace
 
 std::unique_ptr<mlir::Pass> circt::createTestPrepareForEmissionPass() {
   return std::make_unique<TestPrepareForEmissionPass>();
-}
-
-std::unique_ptr<mlir::Pass>
-circt::createPrepareForEmissionPass(LoweringOptions options) {
-  return std::make_unique<PrepareForEmissionPass>(options);
 }

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -10,7 +10,6 @@
 #ifndef CONVERSION_PASSDETAIL_H
 #define CONVERSION_PASSDETAIL_H
 
-#include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"

--- a/test/firtool/verbose-pass-executions.fir
+++ b/test/firtool/verbose-pass-executions.fir
@@ -1,0 +1,6 @@
+; RUN: firtool %s --verbose-pass-executions 2>&1 | FileCheck %s
+;
+; CHECK: [firtool] Running
+
+circuit Empty:
+  module Empty:


### PR DESCRIPTION
Add simple test that helps CI check this in the future, crashes without the revert.

LoweringOptions as a PassOption crashes when printing (parsing from a pipeline probably doesn't work either), because it doesn't know how to handle it.

Specializing `cl::parser` might do the trick, or manually specifying our existing `LoweringOptionsParser` (unclear how to do this with ODS), or changing how these options reach the pass?

Regardless, revert until this is sorted.

