### PR TITLE
[FIRRTL][GrandCentral] Process data taps in order

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -208,6 +208,9 @@ struct ApplyState {
   InstancePathCache &instancePathCache;
   DenseMap<Attribute, FlatSymbolRefAttr> instPathToNLAMap;
   size_t numReusedHierPaths = 0;
+  // Record all the data taps, to sort them later before adding the RefType
+  // ports. This will be very large and defaults to heap allocation.
+  SmallVector<DictionaryAttr, 0> listOfDataTaps;
 
   ModuleNamespace &getNamespace(FModuleLike module) {
     auto &ptr = namespaces[module];
@@ -231,6 +234,12 @@ LogicalResult applyGCTView(const AnnoPathValue &target, DictionaryAttr anno,
 
 LogicalResult applyGCTDataTaps(const AnnoPathValue &target, DictionaryAttr anno,
                                ApplyState &state);
+
+// Sort the list of recorded data taps and then add the RefType connections.
+LogicalResult applyDataTaps(ApplyState &state);
+
+LogicalResult recordGCTDataTaps(const AnnoPathValue &target,
+                                DictionaryAttr anno, ApplyState &state);
 
 LogicalResult applyGCTMemTaps(const AnnoPathValue &target, DictionaryAttr anno,
                               ApplyState &state);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -275,7 +275,7 @@ static FailureOr<Literal> parseIntegerLiteral(MLIRContext *context,
 
 LogicalResult circt::firrtl::applyDataTaps(ApplyState &state) {
   auto loc = state.circuit.getLoc();
-  auto context = state.circuit.getContext();
+  auto *context = state.circuit.getContext();
 
   auto noDedupAnnoClassName = StringAttr::get(context, noDedupAnnoClass);
   auto noDedupAnno = DictionaryAttr::get(
@@ -301,7 +301,7 @@ LogicalResult circt::firrtl::applyDataTaps(ApplyState &state) {
     return (srcA == srcB ? sinkA < sinkB : srcA < srcB);
   });
   // Process all the taps.
-  for (auto dataTapAnno : llvm::enumerate(state.listOfDataTaps)) {
+  for (const auto &dataTapAnno : llvm::enumerate(state.listOfDataTaps)) {
     auto anno = dataTapAnno.value();
     auto classAttr = anno.getAs<StringAttr>("class");
     auto sinkNameAttr =

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -512,6 +512,9 @@ void LowerAnnotationsPass::runOnOperation() {
       ++numFailures;
   }
 
+  if (applyDataTaps(state).failed())
+    ++numFailures;
+
   // Update statistics
   numRawAnnotations += annotations.size();
   numAddedAnnos += numAdded;

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
@@ -238,21 +238,21 @@ circuit Top : %[[
     ; CHECK-NEXT: wire tap_4 = 1'h0
     ; CHECK:      assign tap_0 = Submodule.wire_Submodule
     ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
-    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
     ; CHECK-NEXT: assign tap_5 = Top.port_Top
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
 
     ; CHECK: module DUT
     ; CHECK:      wire tap_3 = 1'h0
     ; CHECK-NEXT: wire tap_4 = 1'h0
     ; CHECK:      assign tap_0 = DUT.submodule.wire_Submodule
     ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
-    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
     ; CHECK-NEXT: assign tap_5 = Top.port_Top
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
 
     ; CHECK: module Top
     ; CHECK:      wire tap_3 = 1'h0
     ; CHECK-NEXT: wire tap_4 = 1'h0
     ; CHECK:      assign tap_0 = Top.dut.submodule.wire_Submodule
     ; CHECK-NEXT: assign tap_1 = Top.dut.wire_DUT
-    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
     ; CHECK-NEXT: assign tap_5 = Top.port_Top
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1343,30 +1343,42 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
     {
        class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
        source = "~Top|Top/foo:Foo/b:Bar>inv", sink = "~Top|Top>tap"
+    },
+    {
+       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+       source = "~Top|Top/foo:Foo/b:Bar>anv", sink = "~Top|Top>atap"
     }
   ]}]} {
   // CHECK-LABEL: firrtl.circuit "Top"  {
   // CHECK-NOT:   "sifive.enterprise.grandcentral.DataTapsAnnotation"
-  // CHECK:  firrtl.module private @Bar(out %_gen_tap: !firrtl.ref<uint<1>>)
+  // CHECK:  firrtl.module private @Bar(out %_gen_atap: !firrtl.ref<uint<1>>, out %_gen_tap: !firrtl.ref<uint<1>>)
   firrtl.module private @Bar() {
     %inv = firrtl.wire interesting_name  : !firrtl.uint<1>
-    // CHECK:  %0 = firrtl.ref.send %inv : !firrtl.uint<1>
-    // CHECK:  firrtl.connect %_gen_tap, %0 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  %[[v0:.+]] = firrtl.ref.send %inv : !firrtl.uint<1>
+    %anv = firrtl.wire interesting_name  : !firrtl.uint<1>
+    // CHECK:  %[[v1:.+]] = firrtl.ref.send %anv : !firrtl.uint<1>
+    // CHECK:  firrtl.connect %_gen_atap, %[[v1]] : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.connect %_gen_tap, %[[v0]] : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
-  // CHECK-LABEL: firrtl.module private @Foo
+  // CHECK-LABEL:  firrtl.module private @Foo(out %_gen_atap: !firrtl.ref<uint<1>>, out %_gen_tap: !firrtl.ref<uint<1>>)
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
-    // CHECK:  %b__gen_tap = firrtl.instance b interesting_name  @Bar(out _gen_tap: !firrtl.ref<uint<1>>)
+    // CHECK:  %b__gen_atap, %b__gen_tap = firrtl.instance b interesting_name  @Bar(out _gen_atap: !firrtl.ref<uint<1>>, out _gen_tap: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.connect %_gen_atap, %b__gen_atap : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
     // CHECK:  firrtl.connect %_gen_tap, %b__gen_tap : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
   // CHECK: firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]}
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
-    // CHECK:  %foo__gen_tap = firrtl.instance foo interesting_name  @Foo(out _gen_tap: !firrtl.ref<uint<1>>)
-    // CHECK:  %0 = firrtl.ref.resolve %foo__gen_tap : !firrtl.ref<uint<1>>
+    %atap = firrtl.wire interesting_name  : !firrtl.uint<1>
+    // CHECK:  %foo__gen_atap, %foo__gen_tap = firrtl.instance foo interesting_name  @Foo(out _gen_atap: !firrtl.ref<uint<1>>, out _gen_tap: !firrtl.ref<uint<1>>)
+    // CHECK:  %[[v0:.+]] = firrtl.ref.resolve %foo__gen_tap : !firrtl.ref<uint<1>>
+    // CHECK:  %[[v1:.+]] = firrtl.ref.resolve %foo__gen_atap : !firrtl.ref<uint<1>>
     // CHECK:  %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
-    // CHECK:  firrtl.connect %tap, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:  %atap = firrtl.wire interesting_name  : !firrtl.uint<1>
+    // CHECK:  firrtl.connect %atap, %[[v1]] : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:  firrtl.connect %tap, %[[v0]] : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 


### PR DESCRIPTION
Record all the data tap annotations and process them after sorting the list. This ensures that the data taps are processed in a deterministic order. This is required to ensure that the modules with exactly the same data taps can dedup. If the `RefType` ports corresponding to the data taps are not added in exactly the same order on the two modules, they will fail to dedup, because of mismatch in ports. Sorting the data taps based on the source path ensures that the data taps for all modules can be processed in the same order.