### PR TITLE
[Handshake][NFC] Touchups to address error/warnings.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -580,7 +580,7 @@ static Value createPriorityArbiter(ArrayRef<Value> inputs, Value defaultValue,
 
   for (size_t i = numInputs; i > 0; --i) {
     size_t inputIndex = i - 1;
-    size_t oneHotIndex = 1 << inputIndex;
+    size_t oneHotIndex = size_t{1} << inputIndex;
 
     auto constIndex = createConstantOp(indexType, APInt(numInputs, oneHotIndex),
                                        insertLoc, rewriter);

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -787,6 +787,7 @@ static Value createZeroDataConst(RTLBuilder &s, Location loc, Type type) {
       .Default([&](Type) -> Value {
         emitError(loc) << "unsupported type for zero value: " << type;
         assert(false);
+        return {};
       });
 }
 

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -1038,7 +1038,7 @@ public:
 
     for (size_t i = numInputs; i > 0; --i) {
       size_t inputIndex = i - 1;
-      size_t oneHotIndex = 1 << inputIndex;
+      size_t oneHotIndex = size_t{1} << inputIndex;
       auto constIndex = s.constant(numInputs, oneHotIndex);
       indexMapping[inputIndex] = constIndex;
       priorityArb = s.mux(inputs[inputIndex], {constIndex, priorityArb});


### PR DESCRIPTION
Windows builder is currently complaining and failing:
```
[363/501] Building CXX object lib\Conversion\HandshakeToFIRRTL\CMakeFiles\obj.CIRCTHandshakeToFIRRTL.dir\HandshakeToFIRRTL.cpp.obj
D:\a\circt\circt\lib\Conversion\HandshakeToFIRRTL\HandshakeToFIRRTL.cpp(583): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
[364/501] Building CXX object lib\Conversion\HandshakeToHW\CMakeFiles\obj.CIRCTHandshakeToHW.dir\HandshakeToHW.cpp.obj
FAILED: lib/Conversion/HandshakeToHW/CMakeFiles/obj.CIRCTHandshakeToHW.dir/HandshakeToHW.cpp.obj 
C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe  /nologo /TP -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -ID:\a\circt\circt\llvm\install\include -ID:\a\circt\circt\include -ID:\a\circt\circt\build_release\include /DWIN32 /D_WINDOWS     /Zc:inline /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4351 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4709 -wd4324 -w14062 -we4238 /Gw /MD /O2 /Ob2  /EHs-c- /GR- -UNDEBUG -std:c++17 /showIncludes /Folib\Conversion\HandshakeToHW\CMakeFiles\obj.CIRCTHandshakeToHW.dir\HandshakeToHW.cpp.obj /Fdlib\Conversion\HandshakeToHW\CMakeFiles\obj.CIRCTHandshakeToHW.dir\ /FS -c D:\a\circt\circt\lib\Conversion\HandshakeToHW\HandshakeToHW.cpp
D:\a\circt\circt\lib\Conversion\HandshakeToHW\HandshakeToHW.cpp(1088): warning C4927: illegal conversion; more than one user-defined conversion has been implicitly applied
D:\a\circt\circt\lib\Conversion\HandshakeToHW\HandshakeToHW.cpp(1088): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
D:\a\circt\circt\lib\Conversion\HandshakeToHW\HandshakeToHW.cpp(790) : error C4716: '<lambda_d66b3b4ac8abb5a25caec2c7234ec3da>::operator()': must return a value
[365/501] Building CXX object lib\Conversion\SCFToCalyx\CMakeFiles\obj.CIRCTSCFToCalyx.dir\SCFToCalyx.cpp.obj
[366/501] Building CXX object lib\Conversion\PipelineToCalyx\CMakeFiles\obj.CIRCTPipelineToCalyx.dir\PipelineToCalyx.cpp.obj
```
