### PR TITLE
[LowerSeqToSV] Keep self assignments

### DIFF
--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -558,3 +558,10 @@ hw.module @DeeplyNestedIfs(%a_0: i1, %a_1: i1, %a_2: i1, %c_0_0: i1, %c_0_1: i1,
   %51 = comb.mux bin %a_0, %50, %r_1 : i1
   hw.output %r_0, %r_1 : i1, i1
 }
+
+// CHECK-LABEL @keepSelfConnection
+hw.module @keepSelfConnection(%a: i1, %clock: i1) -> (b: i1) {
+  // CHECK: passign %r
+  %r = seq.firreg %r clock %clock {firrtl.random_init_start = 0 : ui64} : i1
+  hw.output %r : i1
+}


### PR DESCRIPTION
This fixes the same issue for LowerSeqToSV as https://github.com/llvm/circt/pull/3763. Xprop build requires all registers to be assigned at least once. However LowerSeqToSV removed all self connections. This PR fixes the issue by keeping toplevel self assignments. 
For example:
```scala
circuit Foo:
  module Foo:
    input a: UInt<1>
    input clock: Clock
    output b: UInt<1>

    reg r: UInt<1>, clock
    r <= mux(bits(add(a, a), 0, 0), a, r)
    b <= r
```

w/o PR
```

module Foo(
  input  a,
         clock,
  output b);

  reg r;
 `ifndef SYNTHESIS
```

w/ PR:
```
  reg r;
  always @(posedge clock)
    r <= r;
  `ifndef SYNTHESIS
```
