### PR TITLE
[ExportVerilog][NFC] Remove blockDeclaration* tracking as unused.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2738,11 +2738,6 @@ private:
   /// This is the index of the start of the current statement being emitted.
   RearrangableOStream::Cursor statementBeginning;
 
-  /// This is the index of the end of the declaration region of the current
-  /// 'begin' block, used to emit variable declarations.
-  RearrangableOStream::Cursor blockDeclarationInsertPoint;
-  unsigned blockDeclarationIndentLevel = INDENT_AMOUNT;
-
   /// This keeps track of the number of statements emitted, important for
   /// determining if we need to put out a begin/end marker in a block
   /// declaration.
@@ -3385,13 +3380,6 @@ void StmtEmitter::emitBlockAsStatement(Block *block,
   // emit the begin, and if so, emit the begin retroactively.
   RearrangableOStream::Cursor beginInsertPoint = rearrangableStream.getCursor();
   emitLocationInfoAndNewLine(locationOps);
-
-  // Change the blockDeclarationInsertPointIndex for the statements in this
-  // block, and restore it back when we move on to code after the block.
-  llvm::SaveAndRestore<RearrangableOStream::Cursor> x(
-      blockDeclarationInsertPoint, rearrangableStream.getCursor());
-  llvm::SaveAndRestore<unsigned> x2(blockDeclarationIndentLevel,
-                                    state.currentIndent + INDENT_AMOUNT);
 
   auto numEmittedBefore = getNumStatementsEmitted();
   emitStatementBlock(*block);
@@ -4137,7 +4125,7 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
 bool StmtEmitter::emitDeclarationForTemporary(Operation *op) {
   StringRef declWord = getVerilogDeclWord(op, state.options);
 
-  os.indent(blockDeclarationIndentLevel) << declWord;
+  indent() << declWord;
   if (!declWord.empty())
     os << ' ';
   if (emitter.printPackedType(stripUnpackedTypes(op->getResult(0).getType()),
@@ -4261,13 +4249,6 @@ void StmtEmitter::collectNamesEmitDecls(Block &block) {
     os << ';';
     emitLocationInfoAndNewLine(opsForLocation);
     ++numStatementsEmitted;
-
-    // If any sub-expressions are too large to fit on a line and need a
-    // temporary declaration, put it after the already-emitted declarations.
-    // This is important to maintain incrementally after each statement, because
-    // each statement can generate spills when they are overly-long.
-    blockDeclarationInsertPoint = rearrangableStream.getCursor();
-    blockDeclarationIndentLevel = state.currentIndent;
   }
 
   os << '\n';


### PR DESCRIPTION
Small cleanup In StmtEmitter:
* `blockDeclarationInsertPoint` is only written, never used
* `blockDeclarationIndentLevel` is used but is same as normal indent (likely because we aren't inserting to different point anymore)