### PR TITLE
[Handshake] Drop ctrl requirement from InstanceOp

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -182,8 +182,6 @@ def InstanceOp : Handshake_Op<"instance", [
   let assemblyFormat = [{
     $module `(` $opOperands `)` attr-dict `:` functional-type($opOperands, results)
   }];
-
-  let hasVerifier = 1;
 }
 
 // This is almost exactly like a standard FuncOp, except that it has some

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1548,17 +1548,6 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-LogicalResult InstanceOp::verify() {
-  if ((*this)->getNumOperands() == 0)
-    return emitOpError() << "must provide at least a control operand.";
-
-  if (!getControl().getType().dyn_cast<NoneType>())
-    return emitOpError()
-           << "last operand must be a control (none-typed) operand.";
-
-  return success();
-}
-
 FunctionType InstanceOp::getModuleType() {
   return FunctionType::get(getContext(), getOperandTypes(), getResultTypes());
 }

--- a/test/Dialect/Handshake/call.mlir
+++ b/test/Dialect/Handshake/call.mlir
@@ -1,0 +1,42 @@
+// RUN: circt-opt %s --split-input-file | FileCheck %s
+
+
+// CHECK-LABEL:   handshake.func @foo(...)
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   handshake.func @invalid_instance_op(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32, ...) -> i32
+// CHECK:           instance @foo() : () -> ()
+// CHECK:           return %[[VAL_0]] : i32
+// CHECK:         }
+handshake.func @foo() {
+  return
+}
+
+handshake.func @invalid_instance_op(%arg0 : i32) -> i32 {
+  instance @foo() : () -> ()
+  return %arg0 : i32
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @foo(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32, ...) -> i32
+// CHECK:           return %[[VAL_0]] : i32
+// CHECK:         }
+
+// CHECK-LABEL:   handshake.func @invalid_instance_op(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32, ...) -> i32
+// CHECK:           %[[VAL_1:.*]] = instance @foo(%[[VAL_0]]) : (i32) -> i32
+// CHECK:           return %[[VAL_0]] : i32
+// CHECK:         }
+
+handshake.func @foo(%ctrl : i32) -> i32 {
+  return %ctrl : i32
+}
+
+handshake.func @invalid_instance_op(%arg0 : i32) -> i32 {
+  instance @foo(%arg0) : (i32) -> (i32)
+  return %arg0 : i32
+}

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -30,18 +30,6 @@ handshake.func @foo(%ctrl : none) -> none{
 }
 
 handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
-  // expected-error @+1 {{'handshake.instance' op last operand must be a control (none-typed) operand.}}
-  instance @foo(%ctrl, %arg0) : (none, i32) -> ()
-  return %ctrl : none
-}
-
-// -----
-
-handshake.func @foo(%ctrl : none) -> none{
-  return %ctrl : none
-}
-
-handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
   // expected-error @+1 {{'handshake.instance' op incorrect number of operands for the referenced handshake function}}
   instance @foo(%arg0, %ctrl) : (i32, none) -> ()
   return %ctrl : none
@@ -82,18 +70,6 @@ handshake.func @foo(%ctrl : none) -> (i32, none) {
 handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
   // expected-error @+1 {{'handshake.instance' op result type mismatch: expected result type 'i32', but provided 'i64' for result number 0}}
   %0, %outCtrl = instance @foo(%ctrl) : (none) -> (i64, none)
-  return %ctrl : none
-}
-
-// -----
-
-handshake.func @foo(%ctrl : none) -> none{
-  return %ctrl : none
-}
-
-handshake.func @invalid_instance_op(%ctrl : none) -> none {
-  // expected-error @+1 {{'handshake.instance' op must provide at least a control operand.}}
-  instance @foo() : () -> ()
   return %ctrl : none
 }
 


### PR DESCRIPTION
This commit drops the outdated control signal requirement from `InstanceOp`.