### PR TITLE
Bump LLVM to c4ca3a2c4b00033c393f694c1d92d28ff55c69cd.

### DIFF
--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -37,12 +37,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 
-namespace mlir {
-namespace arith {
-class ArithmeticDialect;
-} // namespace arith
-} // namespace mlir
-
 namespace circt {
 
 // Generate the code for registering conversion passes.

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -29,7 +29,7 @@ def AffineToPipeline : Pass<"convert-affine-to-pipeline", "mlir::func::FuncOp"> 
   let constructor = "circt::createAffineToPipeline()";
   let dependentDialects = [
     "circt::pipeline::PipelineDialect",
-    "mlir::arith::ArithmeticDialect",
+    "mlir::arith::ArithDialect",
     "mlir::cf::ControlFlowDialect",
     "mlir::memref::MemRefDialect",
     "mlir::scf::SCFDialect",

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -19,7 +19,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/Pipeline/Pipeline.h"
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -79,7 +79,7 @@ def ComponentOp : CalyxOp<"component", [
 
   let extraClassDeclaration = [{
       using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::front;
-      using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::getBody;
+      using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::getFunctionBody;
 
       /// Returns the type of this function.
       FunctionType getFunctionType() {
@@ -104,13 +104,13 @@ def ComponentOp : CalyxOp<"component", [
 
       /// Returns the body of a Calyx component.
       Block *getBodyBlock() {
-        Region* region = &getOperation()->getRegion(0);
+        Region* region = getRegion();
         assert(region->hasOneBlock() && "The body should have one Block.");
         return &region->front();
       }
 
       /// Returns the region of a Calyx component.
-      Region *getRegion() { return &getOperation()->getRegion(0); }
+      Region *getRegion() { return &getFunctionBody(); }
 
       /// Returns the port information for this component.
       SmallVector<PortInfo> getPortInfo();

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -72,7 +72,7 @@ def HWModuleOp : HWModuleOpBase<"module",
 
   let extraModuleClassDeclaration = [{
     using mlir::detail::FunctionOpInterfaceTrait<HWModuleOp>::front;
-    using mlir::detail::FunctionOpInterfaceTrait<HWModuleOp>::getBody;
+    using mlir::detail::FunctionOpInterfaceTrait<HWModuleOp>::getFunctionBody;
 
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
@@ -129,9 +129,7 @@ def HWModuleOp : HWModuleOpBase<"module",
     void insertOutputs(unsigned index,
                        ArrayRef<std::pair<StringAttr, Value>> outputs);
 
-    // TODO(mlir): FunctionLike shouldn't produce a getBody() helper, it is
-    // squatting on the name.
-    Block *getBodyBlock() { return &getBody().front(); }
+    Block *getBodyBlock() { return &getFunctionBody().front(); }
 
     // Get the module's symbolic name as StringAttr.
     StringAttr getNameAttr() {

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -14,7 +14,7 @@
 #define CIRCT_DIALECT_HANDSHAKE_VISITORS_H
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -73,8 +73,8 @@ def LLHD_EntityOp : LLHD_Op<"entity", [
     /// Verifies the body of the function.
     LogicalResult verifyBody();
 
-    // Use FunctionOpInterface traits's getBody method.
-    using mlir::detail::FunctionOpInterfaceTrait<EntityOp>::getBody;
+    // Use FunctionOpInterface traits's getFunctionBody method.
+    using mlir::detail::FunctionOpInterfaceTrait<EntityOp>::getFunctionBody;
 
     /// Return the block corresponding to the region.
     Block *getBodyBlock() { return &getBody().front(); }

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -150,7 +150,7 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
 
   let extraModuleClassDeclaration = [{
     using mlir::detail::FunctionOpInterfaceTrait<MSFTModuleOp>::front;
-    using mlir::detail::FunctionOpInterfaceTrait<MSFTModuleOp>::getBody;
+    using mlir::detail::FunctionOpInterfaceTrait<MSFTModuleOp>::getFunctionBody;
 
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) {
@@ -174,7 +174,7 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
     SmallVector<unsigned>
     removePorts(llvm::BitVector inputs, llvm::BitVector outputs);
 
-    Block *getBodyBlock() { return &getBody().front(); }
+    Block *getBodyBlock() { return &getFunctionBody().front(); }
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -70,11 +70,11 @@ def SCModuleOp : SystemCOp<"module", [
       return getFunctionType().getResults();
     }
 
-    // Use FunctionOpInterface traits's getBody method.
-    using mlir::detail::FunctionOpInterfaceTrait<SCModuleOp>::getBody;
+    // Use FunctionOpInterface traits's getFunctionBody method.
+    using mlir::detail::FunctionOpInterfaceTrait<SCModuleOp>::getFunctionBody;
 
     /// Return the block corresponding to the region.
-    Block *getBodyBlock() { return &getBody().front(); }
+    Block *getBodyBlock() { return &getFunctionBody().front(); }
 
     /// Return the symbol name of this module as string.
     StringRef getModuleName();

--- a/lib/Conversion/AffineToPipeline/AffineToPipeline.cpp
+++ b/lib/Conversion/AffineToPipeline/AffineToPipeline.cpp
@@ -20,7 +20,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Affine/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -215,7 +215,7 @@ LogicalResult AffineToPipeline::lowerAffineStructures(
   auto op = getOperation();
 
   ConversionTarget target(*context);
-  target.addLegalDialect<AffineDialect, ArithmeticDialect, MemRefDialect,
+  target.addLegalDialect<AffineDialect, ArithDialect, MemRefDialect,
                          SCFDialect>();
   target.addIllegalOp<AffineIfOp, AffineLoadOp, AffineStoreOp>();
   target.addDynamicallyLegalOp<IfOp>(ifOpLegalityCallback);

--- a/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
@@ -10,7 +10,7 @@ add_circt_library(CIRCTHandshakeToFIRRTL
   CIRCTHandshakeTransforms
   MLIRIR
   MLIRPass
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRSupport

--- a/lib/Conversion/HandshakeToHW/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToHW/CMakeLists.txt
@@ -11,7 +11,7 @@ add_circt_library(CIRCTHandshakeToHW
   CIRCTHandshakeTransforms
   MLIRIR
   MLIRPass
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRSupport

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -22,7 +22,7 @@
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/ValueMapper.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/PassManager.h"

--- a/lib/Conversion/LLHDToLLVM/CMakeLists.txt
+++ b/lib/Conversion/LLHDToLLVM/CMakeLists.txt
@@ -13,7 +13,7 @@ add_circt_conversion_library(CIRCTLLHDToLLVM
   CIRCTCombToLLVM
   CIRCTHWToLLVM
   CIRCTHW
-  MLIRArithmeticToLLVM
+  MLIRArithToLLVM
   MLIRControlFlowToLLVM
   MLIRFuncToLLVM
   MLIRLLVMCommonConversion

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -17,7 +17,7 @@
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
 #include "circt/Support/LLVM.h"
-#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
@@ -2030,7 +2030,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
   target.addIllegalOp<InstOp>();
   target.addLegalOp<UnrealizedConversionCastOp>();
   cf::populateControlFlowToLLVMConversionPatterns(converter, patterns);
-  arith::populateArithmeticToLLVMConversionPatterns(converter, patterns);
+  arith::populateArithToLLVMConversionPatterns(converter, patterns);
 
   // Apply the partial conversion.
   if (failed(

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -16,7 +16,7 @@
 
 namespace mlir {
 namespace arith {
-class ArithmeticDialect;
+class ArithDialect;
 } // namespace arith
 
 namespace cf {

--- a/lib/Conversion/PipelineToCalyx/CMakeLists.txt
+++ b/lib/Conversion/PipelineToCalyx/CMakeLists.txt
@@ -13,7 +13,7 @@ add_circt_conversion_library(CIRCTPipelineToCalyx
   CIRCTPipelineOps
   MLIRIR
   MLIRPass
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRFuncDialect
   MLIRSupport
   MLIRTransforms

--- a/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
+++ b/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
@@ -20,7 +20,7 @@
 #include "circt/Dialect/Pipeline/Pipeline.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -394,7 +394,7 @@ private:
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      memref::LoadOp loadOp) const {
-  Value memref = loadOp.memref();
+  Value memref = loadOp.getMemref();
   auto memoryInterface =
       getState<ComponentLoweringState>().getMemoryInterface(memref);
   if (calyx::noStoresToMemory(memref) && calyx::singleLoadFromMemory(memref)) {
@@ -448,8 +448,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      memref::StoreOp storeOp) const {
-  auto memoryInterface =
-      getState<ComponentLoweringState>().getMemoryInterface(storeOp.memref());
+  auto memoryInterface = getState<ComponentLoweringState>().getMemoryInterface(
+      storeOp.getMemref());
   auto group = createGroupForOp<calyx::GroupOp>(rewriter, storeOp);
 
   // This is a sequential group, so register it as being scheduleable for the
@@ -1337,7 +1337,7 @@ class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
         /// values with their memoryOp readData output.
         loadOp.getResult().replaceAllUsesWith(
             getState<ComponentLoweringState>()
-                .getMemoryInterface(loadOp.memref())
+                .getMemoryInterface(loadOp.getMemref())
                 .readData());
       }
     });
@@ -1426,7 +1426,7 @@ public:
 
     // Only accept std operations which we've added lowerings for
     target.addIllegalDialect<FuncDialect>();
-    target.addIllegalDialect<ArithmeticDialect>();
+    target.addIllegalDialect<ArithDialect>();
     target.addLegalOp<AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp, AndIOp,
                       XOrIOp, OrIOp, ExtUIOp, TruncIOp, CondBranchOp, BranchOp,
                       MulIOp, DivUIOp, DivSIOp, RemUIOp, RemSIOp, ReturnOp,

--- a/lib/Conversion/SCFToCalyx/CMakeLists.txt
+++ b/lib/Conversion/SCFToCalyx/CMakeLists.txt
@@ -13,7 +13,7 @@ add_circt_conversion_library(CIRCTSCFToCalyx
   CIRCTPipelineOps
   MLIRIR
   MLIRPass
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRFuncDialect
   MLIRSupport
   MLIRTransforms

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -19,7 +19,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -295,7 +295,7 @@ private:
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      memref::LoadOp loadOp) const {
-  Value memref = loadOp.memref();
+  Value memref = loadOp.getMemref();
   auto memoryInterface =
       getState<ComponentLoweringState>().getMemoryInterface(memref);
   if (calyx::noStoresToMemory(memref) && calyx::singleLoadFromMemory(memref)) {
@@ -349,8 +349,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      memref::StoreOp storeOp) const {
-  auto memoryInterface =
-      getState<ComponentLoweringState>().getMemoryInterface(storeOp.memref());
+  auto memoryInterface = getState<ComponentLoweringState>().getMemoryInterface(
+      storeOp.getMemref());
   auto group = createGroupForOp<calyx::GroupOp>(rewriter, storeOp);
 
   // This is a sequential group, so register it as being scheduleable for the
@@ -1119,7 +1119,7 @@ class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
         /// values with their memoryOp readData output.
         loadOp.getResult().replaceAllUsesWith(
             getState<ComponentLoweringState>()
-                .getMemoryInterface(loadOp.memref())
+                .getMemoryInterface(loadOp.getMemref())
                 .readData());
       }
     });
@@ -1207,7 +1207,7 @@ public:
 
     // Only accept std operations which we've added lowerings for
     target.addIllegalDialect<FuncDialect>();
-    target.addIllegalDialect<ArithmeticDialect>();
+    target.addIllegalDialect<ArithDialect>();
     target.addLegalOp<AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp, AndIOp,
                       XOrIOp, OrIOp, ExtUIOp, TruncIOp, CondBranchOp, BranchOp,
                       MulIOp, DivUIOp, DivSIOp, RemUIOp, RemSIOp, ReturnOp,

--- a/lib/Conversion/StandardToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StandardToHandshake/CMakeLists.txt
@@ -12,7 +12,7 @@ add_circt_library(CIRCTStandardToHandshake
   CIRCTControlFlowLoopAnalysis
   MLIRIR
   MLIRPass
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRSupport

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -22,7 +22,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
 #include "mlir/Dialect/Affine/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -65,7 +65,7 @@ public:
     loweredOps.clear();
     addLegalDialect<HandshakeDialect>();
     addLegalDialect<mlir::func::FuncDialect>();
-    addLegalDialect<mlir::arith::ArithmeticDialect>();
+    addLegalDialect<mlir::arith::ArithDialect>();
     addIllegalDialect<mlir::scf::SCFDialect>();
     addIllegalDialect<mlir::AffineDialect>();
 

--- a/lib/Dialect/Calyx/CMakeLists.txt
+++ b/lib/Dialect/Calyx/CMakeLists.txt
@@ -14,7 +14,7 @@ set(Calyx_LinkLibs
   CIRCTComb
   CIRCTSV
   CIRCTHW
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRIR
   MLIRMemRefDialect
   MLIRTransforms

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -16,7 +16,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   CIRCTHW
   CIRCTPipelineOps
   CIRCTSupport
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRFuncDialect
   MLIRIR
   MLIRPass

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -27,7 +27,7 @@ set(ESI_LinkLibs
   MLIRTransforms
   MLIRControlFlowDialect
   MLIRFuncDialect
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRTranslateLib
 )
 

--- a/lib/Dialect/FSM/CMakeLists.txt
+++ b/lib/Dialect/FSM/CMakeLists.txt
@@ -11,7 +11,7 @@ add_circt_dialect_library(CIRCTFSM
   MLIRIR
   CIRCTHW
   MLIRFuncDialect
-  MLIRArithmeticDialect
+  MLIRArithDialect
   )
 
 add_subdirectory(Transforms)

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FSM/FSMOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -12,7 +12,7 @@
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -14,7 +14,7 @@
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -15,7 +15,7 @@
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
+++ b/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
@@ -15,7 +15,7 @@
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Support/LLVM.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -341,7 +341,7 @@ static void printModuleLikeOp(mlir::FunctionOpInterface moduleLike,
                           omittedAttrs);
 
   // Print the body if this is not an external function.
-  Region &mbody = moduleLike.getBody();
+  Region &mbody = moduleLike.getFunctionBody();
   if (!mbody.empty()) {
     p << ' ';
     p.printRegion(mbody, /*printEntryBlockArgs=*/false,

--- a/lib/Dialect/Pipeline/CMakeLists.txt
+++ b/lib/Dialect/Pipeline/CMakeLists.txt
@@ -13,7 +13,7 @@ add_circt_dialect_library(CIRCTPipelineOps
 
   LINK_LIBS PUBLIC
   CIRCTESI
-  MLIRArithmeticDialect
+  MLIRArithDialect
   MLIRFuncDialect
   MLIRIR
 

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -12,7 +12,7 @@
 
 #include "circt/Dialect/ESI/ESITypes.h"
 #include "circt/Dialect/Pipeline/Pipeline.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionImplementation.h"

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -14,7 +14,7 @@
 #include "circt/Support/Version.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::arith::ArithmeticDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -14,7 +14,7 @@
 #include "circt/Support/Version.h"
 #include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::arith::ArithmeticDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -15,7 +15,7 @@
 #include "circt/InitAllPasses.h"
 #include "circt/Support/LoweringOptions.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::arith::ArithmeticDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -15,7 +15,7 @@
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/Simulation.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -14,7 +14,7 @@
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -504,7 +504,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::AffineDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::arith::ArithmeticDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
 


### PR DESCRIPTION
This included three renames:
* Arithmetic -> Arith
* FunctionOpInterface::getBody -> FunctionOpInterface::getBodyBlock
* MemRef dialect switching to prefixed accessors (memref -> getMemref, etc.)