### PR TITLE
[SV] Allow packed arrays for index part select inout

### DIFF
--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1391,11 +1391,19 @@ void ArrayIndexInOutOp::build(OpBuilder &builder, OperationState &result,
 // IndexedPartSelectInOutOp
 //===----------------------------------------------------------------------===//
 
+static Type inferReturn(Type type, int32_t width) {
+  auto elemTy = type.cast<hw::InOutType>().getElementType();
+  if (elemTy.isa<IntegerType>())
+    return hw::InOutType::get(IntegerType::get(type.getContext(), width));
+  if (elemTy.isa<hw::ArrayType>())
+    return hw::InOutType::get(hw::ArrayType::get(
+        elemTy.cast<hw::ArrayType>().getElementType(), width));
+  return {};
+}
 void IndexedPartSelectInOutOp::build(OpBuilder &builder, OperationState &result,
                                      Value input, Value base, int32_t width,
                                      bool decrement) {
-  auto resultType =
-      hw::InOutType::get(IntegerType::get(builder.getContext(), width));
+  Type resultType = inferReturn(input.getType(), width);
   build(builder, result, resultType, input, base, width, decrement);
 }
 
@@ -1407,27 +1415,30 @@ LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
   if (!width)
     return failure();
 
-  results.push_back(hw::InOutType::get(
-      IntegerType::get(context, width.cast<IntegerAttr>().getInt())));
+  auto typ = inferReturn(operands[0].getType(),
+                         width.cast<IntegerAttr>().getValue().getZExtValue());
+  if (!typ)
+    return failure();
+  results.push_back(typ);
   return success();
 }
 
 LogicalResult IndexedPartSelectInOutOp::verify() {
   unsigned inputWidth = 0, resultWidth = 0;
   auto opWidth = getWidth();
-
-  if (auto i = getInput()
-                   .getType()
-                   .cast<InOutType>()
-                   .getElementType()
-                   .dyn_cast<IntegerType>())
+  auto inputElemTy = getInput().getType().cast<InOutType>().getElementType();
+  auto resultElemTy = getType().cast<InOutType>().getElementType();
+  if (auto i = inputElemTy.dyn_cast<IntegerType>())
     inputWidth = i.getWidth();
+  else if (auto i = hw::type_cast<hw::ArrayType>(inputElemTy))
+    inputWidth = i.getSize();
   else
     return emitError("input element type must be Integer");
 
-  if (auto resType =
-          getType().cast<InOutType>().getElementType().dyn_cast<IntegerType>())
+  if (auto resType = resultElemTy.dyn_cast<IntegerType>())
     resultWidth = resType.getWidth();
+  else if (auto resType = hw::type_cast<hw::ArrayType>(resultElemTy))
+    resultWidth = resType.getSize();
   else
     return emitError("result element type must be Integer");
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1552,6 +1552,18 @@ hw.module private @InlineReadInout() -> () {
   }
 }
 
+// CHECK-LABEL: IndexPartSelectInoutArray
+hw.module @IndexPartSelectInoutArray(%a: !hw.array<2xi1>, %c: i1, %d: i1) {
+  %c0_i2 = hw.constant 0 : i2
+  %r1 = sv.reg  : !hw.inout<array<3xi1>>
+  sv.always posedge %d {
+    // CHECK: r1[2'h0 +: 2] <= a;
+    %1 = sv.indexed_part_select_inout %r1[%c0_i2 : 2] : !hw.inout<array<3xi1>>, i2
+    sv.passign %1, %a : !hw.array<2xi1>
+  }
+  hw.output
+}
+
 // CHECK-LABEL: module ConditionalComments(
 hw.module @ConditionalComments() {
   sv.ifdef "FOO"  {             // CHECK-NEXT: `ifdef FOO


### PR DESCRIPTION
Currently part select inout operations are restricted to integer types. This PR extends index part selects operators to arrays. 