### PR TITLE
[HW] Add a folder for array slice op

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -109,6 +109,7 @@ def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
   let results = (outs ArrayType:$dst);
 
   let hasVerifier = 1;
+  let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
 
   let assemblyFormat = [{

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1810,6 +1810,13 @@ LogicalResult ArraySliceOp::verify() {
   return success();
 }
 
+OpFoldResult ArraySliceOp::fold(ArrayRef<Attribute> constants) {
+  // If we are slicing the entire input, then return it.
+  if (getType() == getInput().getType())
+    return getInput();
+  return {};
+}
+
 LogicalResult ArraySliceOp::canonicalize(ArraySliceOp op,
                                          PatternRewriter &rewriter) {
   auto sliceTy = hw::type_cast<ArrayType>(op.getType());

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1483,3 +1483,11 @@ hw.module @GetOfUniformArray(%in: i42, %address: i2) -> (out: i42) {
   %1 = hw.array_get %0[%address] : !hw.array<4xi42>, i2
   hw.output %1 : i42
 }
+
+// CHECK-LABEL: ArraySlice
+hw.module @ArraySlice(%arr: !hw.array<128xi1>) -> (a: !hw.array<128xi1>) {
+  %c0_i7 = hw.constant 0 : i7
+  // CHECK: hw.output %arr
+  %1 = hw.array_slice %arr[%c0_i7] : (!hw.array<128xi1>) -> !hw.array<128xi1>
+  hw.output %1 : !hw.array<128xi1>
+}


### PR DESCRIPTION
This PR adds a folder for array slice op to fold slice op which extracts entire inputs.