### PR TITLE
[ExportVerilog] Fix use of wrong decl alignment after emitting a block.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4245,6 +4245,13 @@ void StmtEmitter::collectNamesEmitDecls(Block &block) {
 void StmtEmitter::emitStatementBlock(Block &body) {
   addIndent();
 
+  // Ensure decl alignment values are preserved after the block is emitted.
+  // These values were computed for and from all declarations in the current
+  // block (before/after this nested block), so be sure they're restored
+  // and not overwritten by the declaration alignment within the block.
+  llvm::SaveAndRestore x(maxDeclNameWidth);
+  llvm::SaveAndRestore x2(maxTypeWidth);
+
   // Build up the symbol table for all of the values that need names in the
   // module.  #ifdef's in procedural regions are special because local variables
   // are all emitted at the top of their enclosing blocks.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4249,8 +4249,8 @@ void StmtEmitter::emitStatementBlock(Block &body) {
   // These values were computed for and from all declarations in the current
   // block (before/after this nested block), so be sure they're restored
   // and not overwritten by the declaration alignment within the block.
-  llvm::SaveAndRestore x(maxDeclNameWidth);
-  llvm::SaveAndRestore x2(maxTypeWidth);
+  llvm::SaveAndRestore<size_t> x(maxDeclNameWidth);
+  llvm::SaveAndRestore<size_t> x2(maxTypeWidth);
 
   // Build up the symbol table for all of the values that need names in the
   // module.  #ifdef's in procedural regions are special because local variables

--- a/test/Conversion/ExportVerilog/decl-align.mlir
+++ b/test/Conversion/ExportVerilog/decl-align.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt %s -export-verilog | FileCheck %s --strict-whitespace
+
+// CHECK-LABEL module Decl
+hw.module @Decl() {
+  // CHECK: wire [3:0] x;
+  %x = sv.wire : !hw.inout<i4>
+  // CHECK: wire       y;
+  %y = sv.wire : !hw.inout<i1>
+  sv.ifdef "foo" {
+    // CHECK: wire [11:0][9:0][3:0] w;
+    %w = sv.wire : !hw.inout<array<12 x array<10xi4>>>
+  }
+  // CHECK: wire [5:0] z;
+  %z = sv.wire : !hw.inout<i6>
+}


### PR DESCRIPTION
Before emitting a block of statements, we scan for all declarations (wires, regs, ...) and calculate the max width of the types and names so we can align the types and names neatly across declarations.

Previously declarations were (generally) gathered and emitted at the top, but now occur throughout (new emission mode).

There's a bug with how this works presently:

When emitting nested blocks of statements (always, etc.) the newly calculated widths override the existing ones-- resulting in wires/regs after the block being aligned using the widths from declarations within the block-- instead of using widths calculated for, and from, the declarations outside the block.

To fix this, simply save the widths and restore them after the block.

These declarations are sometimes a bit far apart for the alignment to always be obvious locally, but as long as we align them all together per-block let's use the right alignment values not those from any nested blocks emitted along the way.