### PR TITLE
[CI] Enable `check-circt` on Windows, disable FIRRTL related tests

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -80,5 +80,6 @@ jobs:
             -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/bin/llvm-lit.py" `
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
+          cmake --build . --target check-circt
 
     # --- end of build-circt job.

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --dedup --emit-omir -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --dedup --emit-omir -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --dedup --emit-omir -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: rm -rf %t
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
 ; RUN: firtool --preserve-values=named --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
 ; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
 ; RUN: firtool --preserve-values=named --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
 ; RUN: firtool --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML

--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool -split-input-file -verilog %s | FileCheck %s
 
 ; This test checks end-to-end compliance with the Scala FIRRTL Compiler (SFC)

--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool -split-input-file -verilog %s | FileCheck %s
 
 ; This test checks end-to-end compliance with the Scala FIRRTL Compiler (SFC)

--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool -split-input-file -verilog %s | FileCheck %s
 
 ; This test checks end-to-end compliance with the Scala FIRRTL Compiler (SFC)

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt -firrtl-add-seqmem-ports %s | FileCheck %s
 
 // Should create the output file even if there are no seqmems.

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt -firrtl-add-seqmem-ports %s | FileCheck %s
 
 // Should create the output file even if there are no seqmems.

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt -firrtl-add-seqmem-ports %s | FileCheck %s
 
 // Should create the output file even if there are no seqmems.

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: split-file %s %t
 // RUN: sed 's?@DIR@?%t?' %t/Foo.mlir.orig > %t/Foo.mlir
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %t/Foo.mlir | FileCheck %t/Foo.mlir

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: split-file %s %t
 // RUN: sed 's?@DIR@?%t?' %t/Foo.mlir.orig > %t/Foo.mlir
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %t/Foo.mlir | FileCheck %t/Foo.mlir

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: split-file %s %t
 // RUN: sed 's?@DIR@?%t?' %t/Foo.mlir.orig > %t/Foo.mlir
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %t/Foo.mlir | FileCheck %t/Foo.mlir

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="metadata/dut.conf"})' %s | FileCheck %s
 
 firrtl.circuit "empty" {

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="metadata/dut.conf"})' %s | FileCheck %s
 
 firrtl.circuit "empty" {

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="metadata/dut.conf"})' %s | FileCheck %s
 
 firrtl.circuit "empty" {

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' -verify-diagnostics --split-input-file %s
 
 // This test is checking each kind of declaration to ensure that it is caught

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' -verify-diagnostics --split-input-file %s
 
 // This test is checking each kind of declaration to ensure that it is caught

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' -verify-diagnostics --split-input-file %s
 
 // This test is checking each kind of declaration to ensure that it is caught

--- a/test/Dialect/FIRRTL/expand-whens-locations.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-locations.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' --mlir-print-local-scope  --mlir-print-debuginfo %s | FileCheck %s
 
 firrtl.circuit "Basic"  {

--- a/test/Dialect/FIRRTL/expand-whens-locations.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-locations.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' --mlir-print-local-scope  --mlir-print-debuginfo %s | FileCheck %s
 
 firrtl.circuit "Basic"  {

--- a/test/Dialect/FIRRTL/expand-whens-locations.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-locations.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' --mlir-print-local-scope  --mlir-print-debuginfo %s | FileCheck %s
 
 firrtl.circuit "Basic"  {

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' %s | FileCheck %s
 firrtl.circuit "ExpandWhens" {
 firrtl.module @ExpandWhens () {}

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' %s | FileCheck %s
 firrtl.circuit "ExpandWhens" {
 firrtl.module @ExpandWhens () {}

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' %s | FileCheck %s
 firrtl.circuit "ExpandWhens" {
 firrtl.module @ExpandWhens () {}

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-grand-central-signal-mappings)' --split-input-file %s | FileCheck %s
 
 firrtl.circuit "SubCircuit" attributes {

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-grand-central-signal-mappings)' --split-input-file %s | FileCheck %s
 
 firrtl.circuit "SubCircuit" attributes {

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-grand-central-signal-mappings)' --split-input-file %s | FileCheck %s
 
 firrtl.circuit "SubCircuit" attributes {

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt %s --firrtl-grand-central-taps --symbol-dce --split-input-file | FileCheck %s
 
 firrtl.circuit "TestHarness" attributes {

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt %s --firrtl-grand-central-taps --symbol-dce --split-input-file | FileCheck %s
 
 firrtl.circuit "TestHarness" attributes {

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt %s --firrtl-grand-central-taps --symbol-dce --split-input-file | FileCheck %s
 
 firrtl.circuit "TestHarness" attributes {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
 
 firrtl.circuit "InterfaceGroundType" attributes {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
 
 firrtl.circuit "InterfaceGroundType" attributes {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
 
 firrtl.circuit "InterfaceGroundType" attributes {

--- a/test/circt-reduce/annotation-remover.mlir
+++ b/test/circt-reduce/annotation-remover.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.wire  :" --keep-best=0 --include annotation-remover | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/annotation-remover.mlir
+++ b/test/circt-reduce/annotation-remover.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.wire  :" --keep-best=0 --include annotation-remover | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/annotation-remover.mlir
+++ b/test/circt-reduce/annotation-remover.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.wire  :" --keep-best=0 --include annotation-remover | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/connect-source-operand-forward.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder --test-must-fail | FileCheck %s
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo

--- a/test/circt-reduce/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/connect-source-operand-forward.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder --test-must-fail | FileCheck %s
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo

--- a/test/circt-reduce/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/connect-source-operand-forward.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder --test-must-fail | FileCheck %s
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo

--- a/test/circt-reduce/issue-3555.mlir
+++ b/test/circt-reduce/issue-3555.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --include root-port-pruner --test-must-fail | FileCheck %s
 
 // https://github.com/llvm/circt/issues/3555

--- a/test/circt-reduce/issue-3555.mlir
+++ b/test/circt-reduce/issue-3555.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --include root-port-pruner --test-must-fail | FileCheck %s
 
 // https://github.com/llvm/circt/issues/3555

--- a/test/circt-reduce/issue-3555.mlir
+++ b/test/circt-reduce/issue-3555.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --include root-port-pruner --test-must-fail | FileCheck %s
 
 // https://github.com/llvm/circt/issues/3555

--- a/test/circt-reduce/memory-stubber.mlir
+++ b/test/circt-reduce/memory-stubber.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Basic" --keep-best=0 --include memory-stubber --test-must-fail | FileCheck %s
 
 firrtl.circuit "Basic"   {

--- a/test/circt-reduce/memory-stubber.mlir
+++ b/test/circt-reduce/memory-stubber.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Basic" --keep-best=0 --include memory-stubber --test-must-fail | FileCheck %s
 
 firrtl.circuit "Basic"   {

--- a/test/circt-reduce/memory-stubber.mlir
+++ b/test/circt-reduce/memory-stubber.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Basic" --keep-best=0 --include memory-stubber --test-must-fail | FileCheck %s
 
 firrtl.circuit "Basic"   {

--- a/test/circt-reduce/node-symbol-remover.mlir
+++ b/test/circt-reduce/node-symbol-remover.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/node-symbol-remover.mlir
+++ b/test/circt-reduce/node-symbol-remover.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/node-symbol-remover.mlir
+++ b/test/circt-reduce/node-symbol-remover.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/port-pruner.mlir
+++ b/test/circt-reduce/port-pruner.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/port-pruner.mlir
+++ b/test/circt-reduce/port-pruner.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/port-pruner.mlir
+++ b/test/circt-reduce/port-pruner.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/trivial.mlir
+++ b/test/circt-reduce/trivial.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/trivial.mlir
+++ b/test/circt-reduce/trivial.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/circt-reduce/trivial.mlir
+++ b/test/circt-reduce/trivial.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --test %S/test.sh --test-arg firtool --test-arg "error: sink \"x1.x\" not fully initialized" --keep-best=0 --test-must-fail | FileCheck %s
 
 firrtl.circuit "Foo" {

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: not-windows
 // RUN: rm -rf %t
 // RUN: firtool %s --split-verilog -o=%t --blackbox-path=%S
 // RUN: FileCheck %s --check-prefix=VERILOG-TOP < %t/test_mod.sv

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: linux
 // RUN: rm -rf %t
 // RUN: firtool %s --split-verilog -o=%t --blackbox-path=%S
 // RUN: FileCheck %s --check-prefix=VERILOG-TOP < %t/test_mod.sv

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: not-windows
+// UNSUPPORTED: system-windows
 // RUN: rm -rf %t
 // RUN: firtool %s --split-verilog -o=%t --blackbox-path=%S
 // RUN: FileCheck %s --check-prefix=VERILOG-TOP < %t/test_mod.sv

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -disable-imdce %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -disable-imdce %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" -disable-imdce %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --format=fir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json,%s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json --annotation-file %s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --format=fir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json,%s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json --annotation-file %s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --format=fir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json,%s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --parse-only --annotation-file %s.anno.json --annotation-file %s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
 
 circuit Qux: %[[{

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
 
 circuit Qux: %[[{

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
 
 circuit Qux: %[[{

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" |  FileCheck %s
 
 circuit test:

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" |  FileCheck %s
 
 circuit test:

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" |  FileCheck %s
 
 circuit test:

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" |  FileCheck %s
 
 

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" |  FileCheck %s
 
 

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" |  FileCheck %s
 
 

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --format=fir --ir-fir | FileCheck %s
 
 ; Temporary wires should not be introduced by type lowering, and if they are,

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --format=fir --ir-fir | FileCheck %s
 
 ; Temporary wires should not be introduced by type lowering, and if they are,

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --format=fir --ir-fir | FileCheck %s
 
 ; Temporary wires should not be introduced by type lowering, and if they are,

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -1,4 +1,4 @@
-; REQUIRES: linux
+; REQUIRES: not-windows
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-fir | FileCheck %s 
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-sv | FileCheck --check-prefix=HW %s
 

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -1,4 +1,4 @@
-; REQUIRES: not-windows
+; UNSUPPORTED: system-windows
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-fir | FileCheck %s 
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-sv | FileCheck --check-prefix=HW %s
 

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -1,3 +1,4 @@
+; REQUIRES: linux
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-fir | FileCheck %s 
 ; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-sv | FileCheck --check-prefix=HW %s
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,5 +79,4 @@ if config.llhd_sim_enabled:
   config.available_features.add('llhd-sim')
   tools.append('llhd-sim')
 
-
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,7 +79,5 @@ if config.llhd_sim_enabled:
   config.available_features.add('llhd-sim')
   tools.append('llhd-sim')
 
-if 'Windows' not in config.host_os:
-  config.available_features.add("not-windows")
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,7 +79,7 @@ if config.llhd_sim_enabled:
   config.available_features.add('llhd-sim')
   tools.append('llhd-sim')
 
-if 'Linux' in config.host_os:
-  config.available_features.add("linux")
+if 'Windows' not in config.host_os:
+  config.available_features.add("not-windows")
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,4 +79,7 @@ if config.llhd_sim_enabled:
   config.available_features.add('llhd-sim')
   tools.append('llhd-sim')
 
+if 'Linux' in config.host_os:
+    config.available_features.add("linux")
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -80,6 +80,6 @@ if config.llhd_sim_enabled:
   tools.append('llhd-sim')
 
 if 'Linux' in config.host_os:
-    config.available_features.add("linux")
+  config.available_features.add("linux")
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)


### PR DESCRIPTION
Rather than disabling all testing on Windows due to failing FIRRTL tests, it seems more reasonable to make FIRRTL tests require linux, and then by default require the rest of CIRCT run successfully on Windows.