### PR TITLE
Bump LLVM

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -25,12 +25,6 @@ class BinOp<string mnemonic, list<Trait> traits = []> :
 
   let assemblyFormat =
     "$lhs `,` $rhs (`bin` $twoState^)? attr-dict `:` functional-type($args, $results)";
-
-  let builders = [
-    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
-      return build($_builder, $_state, lhs, rhs, false);
-    }]>
-  ];
 }
 
 // Binary operator with uniform input/result types.
@@ -138,12 +132,6 @@ def ICmpOp : CombOp<"icmp", [NoSideEffect, SameTypeOperands]> {
 
   let assemblyFormat = "(`bin` $twoState^)? $predicate $lhs `,` $rhs attr-dict `:` qualified(type($lhs))";
 
-  let builders = [
-    OpBuilder<(ins "ICmpPredicate":$predicate, "Value":$lhs, "Value":$rhs), [{
-      return build($_builder, $_state, predicate, lhs, rhs, false);
-    }]>
-  ];
-
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
 
@@ -181,12 +169,6 @@ class UnaryI1ReductionOp<string mnemonic, list<Trait> traits = []> :
   let hasFolder = 1;
 
   let assemblyFormat = "(`bin` $twoState^)? $input attr-dict `:` qualified(type($input))";
-
-  let builders = [
-    OpBuilder<(ins "Value":$input), [{
-      return build($_builder, $_state, input, false);
-    }]>
-  ];
 }
 
 def ParityOp : UnaryI1ReductionOp<"parity">;
@@ -303,10 +285,4 @@ def MuxOp : CombOp<"mux",
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
-
-  let builders = [
-    OpBuilder<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue), [{
-      return build($_builder, $_state, cond, trueValue, falseValue, false);
-    }]>
-  ];
 }

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -196,11 +196,6 @@ def IndexedPartSelectOp
                       UnitAttr:$decrement);
   let results = (outs HWIntegerType:$result);
 
-  let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$base, "int32_t":$width,
-                                                CArg<"bool", "false">:$decrement)>
-  ];
-
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -157,11 +157,6 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
                       UnitAttr:$decrement);
   let results = (outs InOutType:$result);
 
-  let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$base, "int32_t":$width,
-                                 CArg<"bool", "false">:$decrement)>
-  ];
-
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{

--- a/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
@@ -78,7 +78,8 @@ struct MaterializeCalyxToFSMPass
       if (guards.size() == 1)
         guardConjunction = guards.front();
       else
-        guardConjunction = b.create<comb::AndOp>(transition.getLoc(), guards);
+        guardConjunction =
+            b.create<comb::AndOp>(transition.getLoc(), guards, false);
       guardOp.setOperand(guardConjunction);
     }
   }

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -659,13 +659,13 @@ struct RTLBuilder {
 
   // Bitwise 'and'.
   Value bAnd(ValueRange values, std::optional<StringRef> name = {}) {
-    return buildNamedOp([&]() { return b.create<comb::AndOp>(loc, values); },
-                        name);
+    return buildNamedOp(
+        [&]() { return b.create<comb::AndOp>(loc, values, false); }, name);
   }
 
   Value bOr(ValueRange values, std::optional<StringRef> name = {}) {
-    return buildNamedOp([&]() { return b.create<comb::OrOp>(loc, values); },
-                        name);
+    return buildNamedOp(
+        [&]() { return b.create<comb::OrOp>(loc, values, false); }, name);
   }
 
   // Bitwise 'not'.
@@ -1220,7 +1220,10 @@ public:
     this->buildUnitRateJoinLogic(s, unwrappedIO, [&](ValueRange inputs) {
       // Create TOut - it is assumed that TOut trivially
       // constructs from the input data signals of TIn.
-      return s.b.create<TOut>(op.getLoc(), inputs);
+      // To disambiguate ambiguous builders with default arguments (e.g.,
+      // twoState UnitAttr), specify attribute array explicitly.
+      return s.b.create<TOut>(op.getLoc(), inputs,
+                              /* attributes */ ArrayRef<NamedAttribute>{});
     });
   };
 };

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -841,7 +841,7 @@ mlir::LogicalResult circt::calyx::exportCalyx(mlir::ModuleOp module,
 
 void circt::calyx::registerToCalyxTranslation() {
   static mlir::TranslateFromMLIRRegistration toCalyx(
-      "export-calyx",
+      "export-calyx", "export Calyx",
       [](ModuleOp module, llvm::raw_ostream &os) {
         return exportCalyx(module, os);
       },

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -466,8 +466,8 @@ MultipleGroupDonePattern::matchAndRewrite(calyx::GroupOp groupOp,
   SmallVector<Value> doneOpSrcs;
   llvm::transform(groupDoneOps, std::back_inserter(doneOpSrcs),
                   [](calyx::GroupDoneOp op) { return op.getSrc(); });
-  Value allDone =
-      rewriter.create<comb::AndOp>(groupDoneOps.front().getLoc(), doneOpSrcs);
+  Value allDone = rewriter.create<comb::AndOp>(groupDoneOps.front().getLoc(),
+                                               doneOpSrcs, false);
 
   /// Create a group done op with the complex expression as a guard.
   rewriter.create<calyx::GroupDoneOp>(

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1358,7 +1358,7 @@ LogicalResult AddOp::canonicalize(AddOp op, PatternRewriter &rewriter) {
         rewriter.create<hw::ConstantOp>(op.getLoc(), (one << value) + one);
 
     std::array<Value, 2> factors = {shlOp.getLhs(), rhs};
-    auto mulOp = rewriter.create<comb::MulOp>(op.getLoc(), factors);
+    auto mulOp = rewriter.create<comb::MulOp>(op.getLoc(), factors, false);
 
     SmallVector<Value, 4> newOperands(inputs.drop_back(/*n=*/2));
     newOperands.push_back(mulOp);
@@ -1376,7 +1376,7 @@ LogicalResult AddOp::canonicalize(AddOp op, PatternRewriter &rewriter) {
     APInt one(/*numBits=*/value.getBitWidth(), 1, /*isSigned=*/false);
     auto rhs = rewriter.create<hw::ConstantOp>(op.getLoc(), value + one);
     std::array<Value, 2> factors = {mulOp.getInputs()[0], rhs};
-    auto newMulOp = rewriter.create<comb::MulOp>(op.getLoc(), factors);
+    auto newMulOp = rewriter.create<comb::MulOp>(op.getLoc(), factors, false);
 
     SmallVector<Value, 4> newOperands(inputs.drop_back(/*n=*/2));
     newOperands.push_back(newMulOp);
@@ -2209,7 +2209,8 @@ LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
     };
 
     if (isa<AndOp>(condOp) && getInvertedOperands()) {
-      auto newOr = rewriter.createOrFold<OrOp>(op.getLoc(), invertedOperands);
+      auto newOr =
+          rewriter.createOrFold<OrOp>(op.getLoc(), invertedOperands, false);
       replaceOpWithNewOpAndCopyName<MuxOp>(rewriter, op, newOr,
                                            op.getFalseValue(),
                                            op.getTrueValue(), op.getTwoState());

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -184,8 +184,8 @@ LogicalResult circt::esi::exportCosimSchema(ModuleOp module,
 void circt::esi::registerESITranslations() {
 #ifdef CAPNP
   mlir::TranslateFromMLIRRegistration cosimToCapnp(
-      "export-esi-capnp", exportCosimSchema,
-      [](mlir::DialectRegistry &registry) {
+      "export-esi-capnp", "ESI Cosim Cap'nProto schema generation",
+      exportCosimSchema, [](mlir::DialectRegistry &registry) {
         registry.insert<ESIDialect, circt::hw::HWDialect, circt::sv::SVDialect,
                         mlir::func::FuncDialect, mlir::BuiltinDialect>();
       });

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -817,7 +817,7 @@ mlir::LogicalResult circt::firrtl::exportFIRFile(mlir::ModuleOp module,
 
 void circt::firrtl::registerToFIRFileTranslation() {
   static mlir::TranslateFromMLIRRegistration toFIR(
-      "export-firrtl",
+      "export-firrtl", "emit FIRRTL dialect operations to .fir output",
       [](ModuleOp module, llvm::raw_ostream &os) {
         return exportFIRFile(module, os);
       },

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3360,7 +3360,8 @@ circt::firrtl::importFIRFile(SourceMgr &sourceMgr, MLIRContext *context,
 
 void circt::firrtl::registerFromFIRFileTranslation() {
   static mlir::TranslateToMLIRRegistration fromFIR(
-      "import-firrtl", [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
+      "import-firrtl", "import .fir",
+      [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
         mlir::TimingScope ts;
         return importFIRFile(sourceMgr, context, ts);
       });

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1402,13 +1402,6 @@ static Type getElementTypeOfWidth(Type type, int32_t width) {
   return {};
 }
 
-void IndexedPartSelectInOutOp::build(OpBuilder &builder, OperationState &result,
-                                     Value input, Value base, int32_t width,
-                                     bool decrement) {
-  Type resultType = getElementTypeOfWidth(input.getType(), width);
-  build(builder, result, resultType, input, base, width, decrement);
-}
-
 LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
     MLIRContext *context, Optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
@@ -1461,13 +1454,6 @@ OpFoldResult IndexedPartSelectInOutOp::fold(ArrayRef<Attribute> constants) {
 //===----------------------------------------------------------------------===//
 // IndexedPartSelectOp
 //===----------------------------------------------------------------------===//
-
-void IndexedPartSelectOp::build(OpBuilder &builder, OperationState &result,
-                                Value input, Value base, int32_t width,
-                                bool decrement) {
-  auto resultType = (IntegerType::get(builder.getContext(), width));
-  build(builder, result, resultType, input, base, width, decrement);
-}
 
 LogicalResult IndexedPartSelectOp::inferReturnTypes(
     MLIRContext *context, Optional<Location> loc, ValueRange operands,

--- a/lib/Target/ExportSystemC/ExportSystemC.cpp
+++ b/lib/Target/ExportSystemC/ExportSystemC.cpp
@@ -132,7 +132,7 @@ void ExportSystemC::registerExportSystemCTranslation() {
       llvm::cl::init("./"));
 
   static mlir::TranslateFromMLIRRegistration toSystemC(
-      "export-systemc",
+      "export-systemc", "export SystemC",
       [](ModuleOp module, raw_ostream &output) {
         return ExportSystemC::exportSystemC(module, output);
       },
@@ -142,7 +142,7 @@ void ExportSystemC::registerExportSystemCTranslation() {
       });
 
   static mlir::TranslateFromMLIRRegistration toSplitSystemC(
-      "export-split-systemc",
+      "export-split-systemc", "export SystemC (split)",
       [](ModuleOp module, raw_ostream &output) {
         return ExportSystemC::exportSplitSystemC(module, directory);
       },


### PR DESCRIPTION
Translation registrations now need descriptions, added.

UnitAttr is now added as a default bool=false argument for builders (instead of nullable `UnitAttr`), leading to some ambiguity and redundant builders:

1) Drop builders now generated for us (bool for UnitAttr present/not, default=false).

2) Where needed specify extra argument to builders (Comb, due to twoState) to clarify-- one result of the upstream change is we now have builders identical in their arguments except their defaulted parameters so specify enough to pick one of them.

Resolves ambiguous builder calls like:

```
/build/sifive/.../tools/circt/include/circt/Dialect/Comb/Comb.h.inc:184:15: note: candidate function
  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange inputs, /*optional*/bool twoState = false);
              ^
/build/sifive/.../tools/circt/include/circt/Dialect/Comb/Comb.h.inc:185:15: note: candidate function
  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
  ```

See upstream MLIR 88f07a736bbc3f0062d7d8f4032f0b54aff5c018 .