### PR TITLE
[Seq] Add FirReg no-update canonicalizer

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -111,6 +111,7 @@ def FirRegOp : SeqOp<"firreg",
   let results = (outs AnyType:$data);
 
   let skipDefaultBuilders = 1;
+  let hasCanonicalizeMethod = true;
   let builders = [
     OpBuilder<(ins "Value":$next, "Value":$clk,
                    "StringAttr":$name,

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 
 #include "llvm/ADT/SmallString.h"
 
@@ -263,6 +265,29 @@ void FirRegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // If the register has an optional 'name' attribute, use it.
   if (!getName().empty())
     setNameFn(getResult(), getName());
+}
+
+LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
+  // If the register's value is itself, we can replace the register.
+  if (op.getNext().getDefiningOp() != op)
+    return failure();
+
+  // If the register has a reset value, we can replace it with that.
+  if (auto resetValue = op.getResetValue()) {
+    rewriter.replaceOp(op, resetValue);
+    return success();
+  }
+
+  auto type = op.getType();
+
+  // Otherwise we want to replae the register with a constant 0. For now this
+  // only works with integer types.
+  auto intType = type.dyn_cast<IntegerType>();
+  if (!intType)
+    return failure();
+
+  rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, intType, 0);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt -canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @FirReg
+hw.module @FirReg(%clk: i1) -> (out : i32) {
+  // CHECK: %c0_i32 = hw.constant 0 : i32
+  // CHECK: hw.output %c0_i32 : i32
+  %reg = seq.firreg %reg clock %clk : i32
+  hw.output %reg : i32
+}
+
+// CHECK-LABEL: @FirRegReset
+hw.module @FirRegReset(%clk: i1, %r : i1, %v : i32) -> (out : i32) {
+  // CHECK: hw.output %v : i32
+  %reg = seq.firreg %reg clock %clk reset sync %r, %v : i32
+  hw.output %reg : i32
+}
+
+// This should not optimize anything until we have constant aggregate attribute
+// support.
+// CHECK-LABEL: @FirRegAggregate
+hw.module @FirRegAggregate(%clk: i1) -> (out : !hw.struct<foo: i32>) {
+  // CHECK: %reg = seq.firreg %reg clock %clk : !hw.struct<foo: i32>
+  // CHECK: hw.output %reg : !hw.struct<foo: i32>
+  %reg = seq.firreg %reg clock %clk : !hw.struct<foo: i32>
+  hw.output %reg : !hw.struct<foo: i32>
+}


### PR DESCRIPTION
When a FIRRTL register has no next value, we optimize it away by replacing it with its reset value if it has one, or zero.  This adds a `seq.firreg` canonicalizer to cover this situation.  This helps fix a phase ordering problem between the more powerful canonicalizers that exist in the `comb` dialect and where this optimization is applied in `firrtl` dialect canonicalizers.