### PR TITLE
[FIRRTL] Add TraceNames Pass to Implement Chisel's Trace API

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -42,6 +42,10 @@ constexpr const char *decodeTableAnnotation =
     "chisel3.util.experimental.decode.DecodeTableAnnotation";
 constexpr const char *flattenAnnoClass = "firrtl.transforms.FlattenAnnotation";
 constexpr const char *inlineAnnoClass = "firrtl.passes.InlineAnnotation";
+constexpr const char *traceNameAnnoClass =
+    "chisel3.experimental.Trace$TraceNameAnnotation";
+constexpr const char *traceAnnoClass =
+    "chisel3.experimental.Trace$TraceAnnotation";
 
 constexpr const char *omirAnnoClass =
     "freechips.rocketchip.objectmodel.OMIRAnnotation";

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -241,6 +241,9 @@ LogicalResult applyGCTSignalMappings(const AnnoPathValue &target,
 LogicalResult applyOMIR(const AnnoPathValue &target, DictionaryAttr anno,
                         ApplyState &state);
 
+LogicalResult applyTraceName(const AnnoPathValue &target, DictionaryAttr anno,
+                             ApplyState &state);
+
 /// Implements the same behavior as DictionaryAttr::getAs<A> to return the
 /// value of a specific type associated with a key in a dictionary. However,
 /// this is specialized to print a useful error message, specific to custom

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -140,6 +140,9 @@ std::unique_ptr<mlir::Pass> createIMDeadCodeElimPass();
 std::unique_ptr<mlir::Pass> createRandomizeRegisterInitPass();
 
 std::unique_ptr<mlir::Pass> createLowerXMRPass();
+
+std::unique_ptr<mlir::Pass>
+createResolveTracesPass(StringRef outputAnnotationFilename = "");
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -568,8 +568,8 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
   }];
   let constructor = "circt::firrtl::createDropNamesPass()";
   let options = [
-    Option<"preserveMode", "preserve-values", "PreserveValues::PreserveMode", 
-           "PreserveValues::None", 
+    Option<"preserveMode", "preserve-values", "PreserveValues::PreserveMode",
+           "PreserveValues::None",
            "specify the values which can be optimized away", [{
             ::llvm::cl::values(
               clEnumValN(PreserveValues::None, "none",
@@ -607,6 +607,24 @@ def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
     This pass lowers RefType ops and ports to verbatim encoded XMRs.
   }];
   let constructor = "circt::firrtl::createLowerXMRPass()";
+}
+
+def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
+  let summary = "Write out TraceAnnotations to an output annotation file";
+  let description = [{
+    This pass implements Chisel's Trace API.  It collects all TraceAnnotations
+    that exist in the circuit, updates them with information about the final
+    target in a design, and writes these to an output annotation file.  This
+    exists for Chisel users to build tooling around them that needs to query the
+    final output name/path of some component in a Chisel circuit.
+
+    Note: this pass and API are expected to be eventually replaced via APIs and
+    language bindings that enable users to directly query the MLIR.
+  }];
+  let constructor = "circt::firrtl::createResolveTracesPass()";
+  let options = [Option<"outputAnnotationFilename", "file", "std::string", "",
+      "Output file for the JSON-serialized Trace Annotations">];
+  let dependentDialects = ["sv::SVDialect"];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   PrintInstanceGraph.cpp
   PrintNLATable.cpp
   RandomizeRegisterInit.cpp
+  ResolveTraces.cpp
   RemoveUnusedPorts.cpp
   SFCCompat.cpp
   WireDFT.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -398,7 +398,9 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
     {ignoreFullAsyncResetAnnoClass,
      {stdResolve, applyWithoutTarget<true, FModuleOp>}},
     {decodeTableAnnotation, {noResolve, drop}},
-    {blackBoxTargetDirAnnoClass, NoTargetAnnotation}
+    {blackBoxTargetDirAnnoClass, NoTargetAnnotation},
+    {traceNameAnnoClass, {stdResolve, applyTraceName}},
+    {traceAnnoClass, {stdResolve, applyWithoutTarget<true>}},
 
 }};
 

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -1,0 +1,332 @@
+//===- ResolveTraces.cpp - Resolve TraceAnnotations -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Find any TraceAnnotations in the design, update their targets, and write the
+// annotations out to an output annotation file.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/JSON.h"
+
+#define DEBUG_TYPE "firrtl-resolve-traces"
+
+using namespace circt;
+using namespace firrtl;
+
+/// Expand a TraceNameAnnotation (which has don't touch semantics) into a
+/// TraceAnnotation (which does NOT have don't touch semantics) and separate
+/// DontTouchAnnotations for targets that are not modules, external modules, or
+/// instances (as these targets are not valid for a don't touch).
+LogicalResult circt::firrtl::applyTraceName(const AnnoPathValue &target,
+                                            DictionaryAttr anno,
+                                            ApplyState &state) {
+
+  auto *context = anno.getContext();
+
+  NamedAttrList trace, dontTouch;
+  for (auto namedAttr : anno.getValue()) {
+    if (namedAttr.getName() == "class") {
+      trace.append("class", StringAttr::get(context, traceAnnoClass));
+      dontTouch.append("class", StringAttr::get(context, dontTouchAnnoClass));
+      continue;
+    }
+    trace.append(namedAttr);
+
+    // When we see the "target", check to see if this is not targeting a module,
+    // extmodule, or instance (as these are invalid "don't touch" targets).  If
+    // it is not, then add a DontTouchAnnotation.
+    if (namedAttr.getName() == "target" &&
+        !target.isOpOfType<FModuleOp, FExtModuleOp, InstanceOp>()) {
+      dontTouch.append(namedAttr);
+      state.addToWorklistFn(DictionaryAttr::getWithSorted(context, dontTouch));
+    }
+  }
+
+  state.addToWorklistFn(DictionaryAttr::getWithSorted(context, trace));
+
+  return success();
+}
+
+struct ResolveTracesPass : public ResolveTracesBase<ResolveTracesPass> {
+  using ResolveTracesBase::outputAnnotationFilename;
+
+  void runOnOperation() override;
+
+private:
+  /// Stores a pointer to an NLA Table.  This is populated during
+  /// runOnOperation.
+  NLATable *nlaTable;
+
+  /// Internal implementation that updates an Annotation to add a "target" field
+  /// based on the current location of the annotation in the circuit.  The value
+  /// of the "target" will be a local target if the Annotation is local and a
+  /// non-local target if the Annotation is non-local.
+  bool updateTargetImpl(Annotation &anno, FModuleLike &module,
+                        FIRRTLBaseType type, StringRef name) {
+    if (!anno.isClass(traceAnnoClass))
+      return false;
+
+    LLVM_DEBUG(llvm::dbgs() << "  - before: " << anno.getDict() << "\n");
+
+    SmallString<64> newTarget("~");
+    newTarget.append(module->getParentOfType<CircuitOp>().getName());
+    newTarget.append("|");
+
+    if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
+      HierPathOp path = nlaTable->getNLA(nla.getAttr());
+      for (auto part : path.getNamepath().getValue().drop_back()) {
+        auto inst = cast<hw::InnerRefAttr>(part);
+        newTarget.append(inst.getModule());
+        newTarget.append("/");
+        newTarget.append(inst.getName());
+        newTarget.append(":");
+      }
+    }
+    newTarget.append(module.moduleName());
+    newTarget.append(">");
+
+    newTarget.append(name);
+
+    // Add information if this is an aggregate.
+    auto targetFieldID = anno.getFieldID();
+    while (targetFieldID) {
+      TypeSwitch<FIRRTLBaseType>(type)
+          .Case<FVectorType>([&](FVectorType vector) {
+            auto index = vector.getIndexForFieldID(targetFieldID);
+            newTarget.append("[");
+            newTarget.append(Twine(index).str());
+            newTarget.append("]");
+            type = vector.getElementType();
+            targetFieldID -= vector.getFieldID(index);
+          })
+          .Case<BundleType>([&](BundleType bundle) {
+            auto index = bundle.getIndexForFieldID(targetFieldID);
+            newTarget.append(".");
+            newTarget.append(bundle.getElementName(index));
+            type = bundle.getElementType(index);
+            targetFieldID -= bundle.getFieldID(index);
+          })
+          .Default([&](auto) { targetFieldID = 0; });
+    }
+
+    anno.setMember("target", StringAttr::get(module->getContext(), newTarget));
+
+    LLVM_DEBUG(llvm::dbgs() << "    after:  " << anno.getDict() << "\n");
+
+    return true;
+  }
+
+  /// Add a "target" field to a port Annotation that indicates the current
+  /// location of the port in the circuit.
+  bool updatePortTarget(FModuleLike &module, Annotation &anno,
+                        unsigned portIdx) {
+
+    FIRRTLBaseType type =
+        TypeSwitch<Type, FIRRTLBaseType>(module.getPortType(portIdx))
+            .Case<FIRRTLBaseType>([](FIRRTLBaseType t) { return t; })
+            .Case<RefType>([](RefType t) { return t.getType(); });
+
+    return updateTargetImpl(anno, module, type, module.getPortName(portIdx));
+  }
+
+  /// Add a "target" field to an Annotation that indicates the current location
+  /// of a component in the circuit.
+  bool updateTarget(FModuleLike &module, Operation *op, Annotation &anno) {
+
+    // If this is operation doesn't have a single result (and no way to know
+    // what its type is) or if it doesn't have a name, then do nothing.
+    if (op->getNumResults() != 1)
+      return false;
+    StringAttr name = op->getAttrOfType<StringAttr>("name");
+    if (!name)
+      return false;
+
+    FIRRTLBaseType type =
+        TypeSwitch<Type, FIRRTLBaseType>(op->getResultTypes()[0])
+            .Case<FIRRTLBaseType>([](FIRRTLBaseType t) { return t; })
+            .Case<RefType>([](RefType t) { return t.getType(); });
+
+    return updateTargetImpl(anno, module, type, name);
+  }
+
+  /// Add a "target" field to an Annotation on a Module that indicates the
+  /// current location of the module.  This will be local or non-local depending
+  /// on the Annotation.
+  bool updateModuleTarget(FModuleLike &module, Annotation &anno) {
+
+    if (!anno.isClass(traceAnnoClass))
+      return false;
+
+    LLVM_DEBUG(llvm::dbgs() << "  - before: " << anno.getDict() << "\n");
+
+    SmallString<64> newTarget("~");
+    newTarget.append(module->getParentOfType<CircuitOp>().getName());
+    newTarget.append("|");
+
+    if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
+      HierPathOp path = nlaTable->getNLA(nla.getAttr());
+      for (auto part : path.getNamepath().getValue().drop_back()) {
+        auto inst = cast<hw::InnerRefAttr>(part);
+        newTarget.append(inst.getModule());
+        newTarget.append("/");
+        newTarget.append(inst.getName());
+        newTarget.append(":");
+      }
+    }
+    newTarget.append(module.moduleName());
+
+    anno.setMember("target", StringAttr::get(module->getContext(), newTarget));
+
+    LLVM_DEBUG(llvm::dbgs() << "    after:  " << anno.getDict() << "\n");
+
+    return true;
+  }
+};
+
+void ResolveTracesPass::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "==----- Running ResolveTraces "
+                      "-----------------------------------------------===\n");
+
+  // Populate the NLA Table.
+  nlaTable = &getAnalysis<NLATable>();
+
+  // Grab the circuit (as this is used a few times below).
+  CircuitOp circuit = getOperation();
+  MLIRContext *context = circuit.getContext();
+
+  // Function to find all Trace Annotations in the circuit, add a "target" field
+  // to them indicating the current local/non-local target of the operation/port
+  // the Annotation is attached to, copy the annotation into an
+  // "outputAnnotations" return vector, and delete the original Annotation.  If
+  // a component or port is targeted by a Trace Annotation it will be given a
+  // symbol to prevent the output Trace Annotation from being made invalid by a
+  // later optimization.
+  auto onModule = [&](FModuleLike moduleLike) {
+    // Output Trace Annotations from this module only.
+    SmallVector<Annotation> outputAnnotations;
+
+    // A lazily constructed module namespace.
+    Optional<ModuleNamespace> moduleNamespace = None;
+
+    // Return a cached module namespace, lazily constructing it if needed.
+    auto getNamespace = [&](FModuleLike module) -> ModuleNamespace & {
+      if (!moduleNamespace)
+        moduleNamespace = ModuleNamespace(module);
+      return moduleNamespace.value();
+    };
+
+    // Visit the module.
+    AnnotationSet::removeAnnotations(moduleLike, [&](Annotation anno) {
+      if (!updateModuleTarget(moduleLike, anno))
+        return false;
+
+      outputAnnotations.push_back(anno);
+      return true;
+    });
+
+    // Visit port annotations.
+    AnnotationSet::removePortAnnotations(
+        moduleLike, [&](unsigned portIdx, Annotation anno) {
+          if (!updatePortTarget(moduleLike, anno, portIdx))
+            return false;
+
+          getOrAddInnerSym(moduleLike, portIdx, moduleLike.getPortName(portIdx),
+                           getNamespace);
+          outputAnnotations.push_back(anno);
+          return true;
+        });
+
+    // Visit component annotations.
+    moduleLike.walk([&](Operation *component) {
+      AnnotationSet::removeAnnotations(component, [&](Annotation anno) {
+        if (!updateTarget(moduleLike, component, anno))
+          return false;
+
+        auto module = cast<FModuleOp>(moduleLike);
+        getOrAddInnerSym(
+            component, component->getAttrOfType<StringAttr>("name").getValue(),
+            module, getNamespace);
+        outputAnnotations.push_back(anno);
+        return true;
+      });
+    });
+
+    return outputAnnotations;
+  };
+
+  // Function to append one vector after another.  This is used to merge results
+  // from parallel executions of "onModule".
+  auto appendVecs = [](auto &&a, auto &&b) {
+    a.append(b.begin(), b.end());
+    return std::forward<decltype(a)>(a);
+  };
+
+  // Process all the modules in parallel or serially, depending on the
+  // multithreading context.
+  SmallVector<FModuleLike, 0> mods(circuit.getOps<FModuleLike>());
+  auto outputAnnotations = transformReduce(
+      context, mods, SmallVector<Annotation>{}, appendVecs, onModule);
+
+  // Do not generate an output Annotation file if no Annotations exist.
+  if (outputAnnotations.empty())
+    return markAllAnalysesPreserved();
+
+  // Write out all the Trace Annotations to a JSON buffer.
+  std::string jsonBuffer;
+  llvm::raw_string_ostream jsonStream(jsonBuffer);
+  llvm::json::OStream json(jsonStream, /*IndentSize=*/2);
+  json.arrayBegin();
+  for (auto anno : outputAnnotations) {
+    json.objectBegin();
+    json.attribute("class", anno.getClass());
+    json.attribute("target", anno.getMember<StringAttr>("target").getValue());
+    json.attribute("chiselTarget",
+                   anno.getMember<StringAttr>("chiselTarget").getValue());
+    json.objectEnd();
+  }
+  json.arrayEnd();
+
+  // Write the JSON-encoded Trace Annotation to a file called
+  // "$circuitName.anno.json".  (This is implemented via an SVVerbatimOp that is
+  // inserted before the FIRRTL circuit.
+  OpBuilder b(circuit);
+  auto verbatimOp = b.create<sv::VerbatimOp>(b.getUnknownLoc(), jsonBuffer);
+  hw::OutputFileAttr fileAttr;
+  if (this->outputAnnotationFilename.empty())
+    fileAttr = hw::OutputFileAttr::getFromFilename(
+        context, circuit.getName() + ".anno.json",
+        /*excludeFromFilelist=*/true, false);
+  else
+    fileAttr = hw::OutputFileAttr::getFromFilename(
+        context, outputAnnotationFilename,
+        /*excludeFromFilelist=*/true, false);
+  verbatimOp->setAttr("output_file", fileAttr);
+
+  return markAllAnalysesPreserved();
+}
+
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createResolveTracesPass(StringRef outputAnnotationFilename) {
+  auto pass = std::make_unique<ResolveTracesPass>();
+  if (!outputAnnotationFilename.empty())
+    pass->outputAnnotationFilename = outputAnnotationFilename.str();
+  return pass;
+}

--- a/test/Dialect/FIRRTL/SFCTests/trace-api.fir
+++ b/test/Dialect/FIRRTL/SFCTests/trace-api.fir
@@ -1,0 +1,53 @@
+; RUN: firtool --output-annotation-file=Baz.anno.json %s | FileCheck %s
+
+; Test that a wire in an inlined instance get the proper Trace Annotation.
+circuit Foo: %[[
+  {
+    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
+    "target":"~Foo|Foo/bar:Bar>_x",
+    "chiselTarget":"~Foo|Foo/bar:Bar>_x_v1"
+  },
+  {
+    "class":"chisel3.experimental.Trace$TraceAnnotation",
+    "target":"~Foo|Foo/bar:Bar>_x",
+    "chiselTarget":"~Foo|Foo/bar:Bar>_x_v2"
+  },
+  {
+    "class": "firrtl.passes.InlineAnnotation",
+    "target": "~Foo|Bar"
+  }
+]]
+  module Bar:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    node _x = a
+    b <= _x
+
+  module Foo:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    inst bar of Bar
+
+    bar.a <= a
+    b <= bar.b
+
+; Wire "_x" should not be optimized away.
+;
+; CHECK-LABEL: module Foo
+; CHECK:         wire [[_x:[A-Za-z0-9_]+]]
+
+; The final Annotation, in either the original TraceNameAnnotation or
+; TraceAnnotation variant the wire name.  The former is serialized as a
+; TraceAnnotation.  This is due to this version of the annotation being
+; deprecated in upstream Chisel.  Chisel APIs have been updated to support
+; reading both of these and treating them as the same.
+;
+; CHECK-LABEL: FILE "Baz.anno.json"
+; CHECK:         "class": "chisel3.experimental.Trace$TraceAnnotation",
+; CHECK-NEXT:    "target": "~Foo|Foo>[[_x]]",
+; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar>_x_v1"
+; CHECK:         "class": "chisel3.experimental.Trace$TraceAnnotation",
+; CHECK-NEXT:    "target": "~Foo|Foo>[[_x]]",
+; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar>_x_v2"

--- a/test/Dialect/FIRRTL/resolve-traces.mlir
+++ b/test/Dialect/FIRRTL/resolve-traces.mlir
@@ -1,0 +1,113 @@
+// RUN: circt-opt %s -firrtl-resolve-traces | FileCheck %s
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() attributes {annotations = [
+    {
+      class = "chisel3.experimental.Trace$TraceAnnotation",
+      chiselTarget = "~Foo|Original"
+    }
+  ]} {}
+}
+
+// Test that a local module annotation is resolved.
+//
+// CHECK:      class{{.*}}:{{.*}}chisel3.experimental.Trace$TraceAnnotation
+// CHECK-SAME: target{{.*}}:{{.*}}~Foo|Foo
+// CHECK-SAME: chiselTarget{{.*}}:{{.*}}~Foo|Original
+
+// Test that the output file is set to include the circuit name.
+//
+// CHECK-SAME: #hw.output_file<{{.*}}Foo.anno.json
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.hierpath @path [@Foo::@bar, @Bar]
+  firrtl.module @Bar() attributes {annotations = [
+    {
+      class = "chisel3.experimental.Trace$TraceAnnotation",
+      chiselTarget = "~Foo|Original",
+      circt.nonlocal = @path
+    }
+  ]} {}
+  firrtl.module @Foo() {
+    firrtl.instance bar sym @bar @Bar()
+  }
+}
+
+// Test that a non-local module annotation is resolved.
+//
+// CHECK: ~Foo|Foo/bar:Bar{{.*}}~Foo|Original
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(
+    in %a: !firrtl.uint<1> [
+      {
+        class = "chisel3.experimental.Trace$TraceAnnotation",
+        chiselTarget = "~Foo|Foo>original"
+      }
+    ]
+  ) {}
+}
+
+// Test that a local port annotation is resolved.
+//
+// CHECK: ~Foo|Foo>a{{.*}}~Foo|Foo>original
+
+// Test that the port receives a symbol.
+//
+// CHECK: in %a: !firrtl.uint<1> sym
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+    %a = firrtl.wire {annotations = [
+      {
+        class = "chisel3.experimental.Trace$TraceAnnotation",
+        chiselTarget = "~Foo|Foo>original"
+      }
+    ]} : !firrtl.uint<1>
+  }
+}
+
+// Test that a local wire annotation is resolved.
+//
+// CHECK: ~Foo|Foo>a{{.*}}~Foo|Foo>original
+
+// Test that the wire receives a symbol.
+//
+// CHECK: %a = firrtl.wire sym
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+    %a = firrtl.wire {annotations = [
+      {
+        class = "chisel3.experimental.Trace$TraceAnnotation",
+        chiselTarget = "~Foo|Foo>0",
+        circt.fieldID = 0
+      },
+      {
+        class = "chisel3.experimental.Trace$TraceAnnotation",
+        chiselTarget = "~Foo|Foo>4",
+        circt.fieldID = 4
+      },
+      {
+        class = "chisel3.experimental.Trace$TraceAnnotation",
+        chiselTarget = "~Foo|Foo>5",
+        circt.fieldID = 6
+      }
+    ]} : !firrtl.vector<bundle<a: uint<1>, b: uint<1>>, 2>
+  }
+}
+
+// Test that a local wire annotation on an aggregate is resolved for different
+// values of field ID.
+//
+// CHECK:      ~Foo|Foo>a{{.*}}~Foo|Foo>0
+// CHECK-SAME: ~Foo|Foo>a[1]{{.*}}~Foo|Foo>4
+// CHECK-SAME: ~Foo|Foo>a[1].b{{.*}}~Foo|Foo>5

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -360,6 +360,10 @@ static cl::list<std::string> inputAnnotationFilenames(
     "annotation-file", cl::desc("Optional input annotation file"),
     cl::CommaSeparated, cl::value_desc("filename"), cl::cat(mainCategory));
 
+static cl::opt<std::string> outputAnnotationFilename(
+    "output-annotation-file", cl::desc("Optional output annotation file"),
+    cl::CommaSeparated, cl::value_desc("filename"), cl::cat(mainCategory));
+
 static cl::list<std::string> inputOMIRFilenames(
     "omir-file", cl::desc("Optional input object model 2.0 file"),
     cl::CommaSeparated, cl::value_desc("filename"), cl::cat(mainCategory));
@@ -731,6 +735,14 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
+
+    // Remove TraceAnnotations and write their updated paths to an output
+    // annotation file.
+    if (outputAnnotationFilename.empty())
+      pm.nest<firrtl::CircuitOp>().addPass(firrtl::createResolveTracesPass());
+    else
+      pm.nest<firrtl::CircuitOp>().addPass(
+          firrtl::createResolveTracesPass(outputAnnotationFilename.getValue()));
 
     // Lower the ref.resolve and ref.send ops and remove the RefType ports.
     // LowerToHW cannot handle RefType so, this pass must be run to remove all


### PR DESCRIPTION
Add the ResolveTraces pass that implements Chisel's [Trace API](https://www.chisel-lang.org/api/latest/chisel3/experimental/Trace$.html).  This
pass updates TraceNameAnnotations with a "target" field indicating the
current FIRRTL Target value of the thing the Annotation is attached to.
The pass then writes these Annotations to a JSON verbatim blob outside
the circuit that will be written to a file derived from the Circuit
name.  The original Annotations are removed.
    
This API works by enabling users to attach "traces" to their Chisel
design to enable them to recover the final target in the compiled
Verilog.  This is intended to the be the low-level basis on top of which
Chsiel users can build their own tools that require information about
the final locations of things in Verilog, e.g., generating TCL scripts.

# Example

In this example, there is a module `Foo_Anon` that is inlined into `Foo`. An aggregate wire, an instance, and a module are all marked as being traced. This shows several things:

1. Optimizations are not blocked on traced things until _after_ trace resolution. E.g., the wire `w` is traced, but will get dropped.
2. Traces are updated with final values.
3. This works with and without aggregate preservation.

```scala
//> using scala 2.13
//> using lib "edu.berkeley.cs::chisel3::3.5.4"

import chisel3._
import chisel3.experimental.Trace
import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
import chisel3.util.experimental.InlineInstance

class Aggregate extends Bundle {
  val a = Bool()
  val b = Bool()
}

class Bar extends Module {
  val a = IO(Input(Vec(1, new Aggregate)))
  val b = IO(Output(Vec(1, new Aggregate)))

  val w = WireInit(a)
  Trace.traceName(w)

  b := a
}

class Foo extends Module {
  val a = IO(Input(Vec(1, new Aggregate)))
  val b = IO(Output(Vec(1, new Aggregate)))

  val bar = Module(new Bar with InlineInstance)
  bar.a := a
  b := bar.b

  Trace.traceName(a)
  Trace.traceName(this)
  Trace.traceName(bar)
}

object Main extends App {
  (new ChiselStage).execute(
    Array("--target-dir", "build/firrtl", "--no-run-firrtl"),
    Seq(ChiselGeneratorAnnotation(() => new Foo))
  )
  (new ChiselStage).execute(
    Array("--target-dir", "build/verilog"),
    Seq(ChiselGeneratorAnnotation(() => new Foo))
  )
}
```

This produces the following FIRRTL IR and Annotation file:

```scala
circuit Foo :
  module Foo_Anon :
    input clock : Clock
    input reset : Reset
    input a : { a : UInt<1>, b : UInt<1>}[1]
    output b : { a : UInt<1>, b : UInt<1>}[1]

    wire w : { a : UInt<1>, b : UInt<1>}[1]
    w[0].b <= a[0].b
    w[0].a <= a[0].a
    b <= a @[Trace.scala 21:5]

  module Foo :
    input clock : Clock
    input reset : UInt<1>
    input a : { a : UInt<1>, b : UInt<1>}[1]
    output b : { a : UInt<1>, b : UInt<1>}[1]

    inst bar of Foo_Anon @[Trace.scala 28:19]
    bar.clock <= clock
    bar.reset <= reset
    bar.a[0].b <= a[0].b @[Trace.scala 29:9]
    bar.a[0].a <= a[0].a @[Trace.scala 29:9]
    b <= bar.b @[Trace.scala 30:5]
```

```json
[
  {
    "class":"firrtl.passes.InlineAnnotation",
    "target":"Foo.Foo_Anon"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo/bar:Foo_Anon>w",
    "chiselTarget":"~Foo|Foo/bar:Foo_Anon>w"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo/bar:Foo_Anon>w[0]",
    "chiselTarget":"~Foo|Foo/bar:Foo_Anon>w[0]"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo/bar:Foo_Anon>w[0].b",
    "chiselTarget":"~Foo|Foo/bar:Foo_Anon>w[0].b"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo/bar:Foo_Anon>w[0].a",
    "chiselTarget":"~Foo|Foo/bar:Foo_Anon>w[0].a"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo>a",
    "chiselTarget":"~Foo|Foo>a"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo>a[0]",
    "chiselTarget":"~Foo|Foo>a[0]"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo>a[0].b",
    "chiselTarget":"~Foo|Foo>a[0].b"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo>a[0].a",
    "chiselTarget":"~Foo|Foo>a[0].a"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo",
    "chiselTarget":"~Foo|Foo"
  },
  {
    "class":"chisel3.experimental.Trace$TraceNameAnnotation",
    "target":"~Foo|Foo/bar:Foo_Anon",
    "chiselTarget":"~Foo|Foo/bar:Foo_Anon"
  }
]
```

After compilation, lowering aggregates, `firtool` will now produce the following output which includes an output annotation file `Foo.anno.json`:

```verilog
module Foo(
  input  clock,
         reset,
         a_0_a,
         a_0_b,
  output b_0_a,
         b_0_b);

  assign b_0_a = a_0_a;
  assign b_0_b = a_0_b;
endmodule
```

```json
[
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo",
    "chiselTarget": "~Foo|Foo"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a[0].a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a[0].b"
  }
]
```

If aggregates are _not_ lowered, then the output is:

```verilog
module Foo(
  input                                          clock,
                                                 reset,
  input  struct packed {logic a; logic b; }[0:0] a,
  output struct packed {logic a; logic b; }[0:0] b);

  assign b = a;
endmodule
```

```json
[
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo",
    "chiselTarget": "~Foo|Foo"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0]",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0].b",
    "chiselTarget": "~Foo|Foo>a[0].b"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0].a",
    "chiselTarget": "~Foo|Foo>a[0].a"
  }
]
```

If instead I run with a debug build (which will preserve wire `w`), I get:

```verilog
module Foo(
  input  clock,
         reset,
         a_0_a,
         a_0_b,
  output b_0_a,
         b_0_b);

  wire bar_w_0_a = a_0_a;
  wire bar_w_0_b = a_0_b;
  assign b_0_a = a_0_a;
  assign b_0_b = a_0_b;
endmodule
```

```json
[
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo",
    "chiselTarget": "~Foo|Foo"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_a",
    "chiselTarget": "~Foo|Foo>a[0].a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a_0_b",
    "chiselTarget": "~Foo|Foo>a[0].b"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_a",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_a",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_a",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0].a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_b",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_b",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w_0_b",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0].b"
  }
]
```

With aggregate preservation:
```verilog
module Foo(
  input                                          clock,
                                                 reset,
  input  struct packed {logic a; logic b; }[0:0] a,
  output struct packed {logic a; logic b; }[0:0] b);

  wire struct packed {logic a; logic b; }[0:0] bar_w = a;
  assign b = a;
endmodule
```

```json
[
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo",
    "chiselTarget": "~Foo|Foo"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a",
    "chiselTarget": "~Foo|Foo>a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0]",
    "chiselTarget": "~Foo|Foo>a[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0].b",
    "chiselTarget": "~Foo|Foo>a[0].b"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>a[0].a",
    "chiselTarget": "~Foo|Foo>a[0].a"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w[0]",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0]"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w[0].b",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0].b"
  },
  {
    "class": "chisel3.experimental.Trace$TraceNameAnnotation",
    "target": "~Foo|Foo>bar_w[0].a",
    "chiselTarget": "~Foo|Foo/bar:Foo_Anon>w[0].a"
  }
]
```