### PR TITLE
[LowerToHW] Lower source subindex into array_get instead of read_inout and array_index

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1710,4 +1710,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %1 = arith.addf %in, %w1 : f32
     firrtl.strictconnect %w1, %1 : f32
   }
+
+  // CHECK-LABEL: LowerReadArrayInoutIntoArrayGet
+  firrtl.module @LowerReadArrayInoutIntoArrayGet(in %a: !firrtl.uint<10>, out %b: !firrtl.uint<10>) {
+    %r = firrtl.wire   : !firrtl.vector<uint<10>, 1>
+    %0 = firrtl.subindex %r[0] : !firrtl.vector<uint<10>, 1>
+    // CHECK: %r = sv.wire  : !hw.inout<array<1xi10>>
+    // CHECK: %[[WIRE_VAL:.+]] = sv.read_inout %r : !hw.inout<array<1xi10>>
+    // CHECK: %[[RET:.+]] = hw.array_get %[[WIRE_VAL]][%false] : !hw.array<1xi10>, i1
+    // CHECK: hw.output %[[RET]]
+    firrtl.strictconnect %0, %a : !firrtl.uint<10>
+    firrtl.strictconnect %b, %0 : !firrtl.uint<10>
+  }
 }


### PR DESCRIPTION
This PR changes the way of lowering of subindex. Currently a subindex operation is lowered into an array index inout operation but this PR exchanges the order (e.g. `read_inout(array_index_inout a[i])` -> `array_get(read_inout a)[i]`).

Previously when we lower subindex operations used as source values, we dereference the inout operations with read_inout. Alternatively this PR lowers a source value subindex into an array_get operation. This modification invokes a lot of optimizations at SV/Comb/HW since usually dataflow analysis is blocked by inout operations. This PR solves https://github.com/llvm/circt/issues/4001 by not creating problematic IR in the first place.

Example:
```mlir
firrtl.module @LowerReadArrayInoutIntoArrayGet(in %a: !firrtl.uint<10>, out %b: !firrtl.uint<10>) {
    %r = firrtl.wire   : !firrtl.vector<uint<10>, 1>
    %0 = firrtl.subindex %r[0] : !firrtl.vector<uint<10>, 1>
    firrtl.strictconnect %0, %a : !firrtl.uint<10>
    firrtl.strictconnect %b, %0 : !firrtl.uint<10>
  }
```
After:
```mlir
 hw.module @LowerReadArrayInoutIntoArrayGet(%a: i10) -> (b: i10) {
    %false = hw.constant false
    %r = sv.wire  : !hw.inout<array<1xi10>>
    %0 = sv.read_inout %r : !hw.inout<array<1xi10>>
    %1 = sv.array_index_inout %r[%false] : !hw.inout<array<1xi10>>, i1
    %2 = hw.array_get %0[%false] : !hw.array<1xi10>, i1
    sv.assign %1, %a : i10
    hw.output %2 : i10
  }
```
Before:
```mlir
  hw.module @LowerReadArrayInoutIntoArrayGet(%a: i10) -> (b: i10) {
    %false = hw.constant false
    %r = sv.wire  : !hw.inout<array<1xi10>>
    %0 = sv.array_index_inout %r[%false] : !hw.inout<array<1xi10>>, i1
    %1 = sv.read_inout %0 : !hw.inout<i10>
    sv.assign %0, %a : i10
    hw.output %1 : i10
  }
```
