### PR TITLE
[FIRRTL] Implement out-of-bounds as array extension

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3423,6 +3423,20 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
   auto size = hw::type_cast<hw::ArrayType>(array.getType()).getSize();
   auto valWire = builder.create<sv::WireOp>(
       hw::type_cast<hw::ArrayType>(array.getType()).getElementType());
+
+  // Extend to power of 2
+  if (!llvm::isPowerOf2_64(size)) {
+    auto extElem =
+        builder.create<hw::ConstantOp>(APInt(llvm::Log2_64_Ceil(size), 0));
+    auto extValue = builder.create<hw::ArrayGetOp>(array, extElem);
+    SmallVector<Value> temp(llvm::NextPowerOf2(size) - size, extValue);
+    auto ext = builder.create<hw::ArrayCreateOp>(temp);
+    SmallVector<Value> temp2;
+    temp2.push_back(ext.getResult());
+    temp2.push_back(array);
+    array = builder.create<hw::ArrayConcatOp>(temp2);
+  }
+
   auto arrayGet = builder.create<hw::ArrayGetOp>(array, index);
 
   // Use SV attributes to annotate pragmas.
@@ -3437,30 +3451,7 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
                                                 {"synopsys infer_mux_override"},
                                                 /*emitAsComments=*/true));
 
-  Value inBoundsRead = builder.create<sv::ReadInOutOp>(valWire);
-
-  // If the array indexing can never have an out-of-bounds read, then lower it
-  // into a hw.array_get.
-  if (llvm::isPowerOf2_64(size))
-    return inBoundsRead;
-
-  // If the array indexing can have an out-of-bounds read (the size of the array
-  // is not a power-of-two), then generate a mux that will return the zeroth
-  // element for any out-of-bounds reads.  This is done to match SFC behavior
-  // for subaccesses.
-  //
-  // TODO: Explore alternatives that don't rely on SFC-exact behavior or guard
-  // against this situation happeneing, e.g., by emitting an SV assertion to
-  // error if an out-of-bounds read ever occurs.
-  Value zerothRead = builder.create<hw::ArrayGetOp>(
-      array,
-      getOrCreateIntConstant(index.getType().getIntOrFloatBitWidth(), 0));
-  Value isOutOfBounds = builder.create<comb::ICmpOp>(
-      ICmpPredicate::uge, index,
-      getOrCreateIntConstant(index.getType().getIntOrFloatBitWidth(), size),
-      true);
-  return builder.create<comb::MuxOp>(inBoundsRead.getType(), isOutOfBounds,
-                                     zerothRead, inBoundsRead, true);
+  return builder.create<sv::ReadInOutOp>(valWire);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(MultibitMuxOp op) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3433,9 +3433,7 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
     auto extValue = builder.create<hw::ArrayGetOp>(array, extElem);
     SmallVector<Value> temp(llvm::NextPowerOf2(size) - size, extValue);
     auto ext = builder.create<hw::ArrayCreateOp>(temp);
-    SmallVector<Value> temp2;
-    temp2.push_back(ext.getResult());
-    temp2.push_back(array);
+    Value temp2[] = {ext.getResult(), array};
     array = builder.create<hw::ArrayConcatOp>(temp2);
   }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -32,6 +32,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-DAG: hw.constant 2 : i3
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
 
+
     // CHECK: %out4 = sv.wire sym @__Simple__out4 : !hw.inout<i4>
     // CHECK: %out5 = sv.wire sym @__Simple__out5 : !hw.inout<i4>
     %out4 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
@@ -290,8 +291,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      %[[ZEXT_INDEX:.+]] = comb.concat %false, {{.*}} : i1, i1
     // CHECK-NEXT: %[[ARRAY:.+]] = hw.array_create %false, %false, %false
     // CHECK-NEXT: %[[WIRE:.+]] = sv.wire
-    // CHECK-NEXT: %[[C0:.+]] = hw.constant 0 : i2
-    // CHECK-NEXT: %[[GET0:.+]] = hw.array_get %[[ARRAY]][%[[C0]]]
+    // CHECK-NEXT: %[[GET0:.+]] = hw.array_get %[[ARRAY]][%c0_i2]
     // CHECK-NEXT: %[[FILLER:.+]] = hw.array_create %[[GET0]] : i1
     // CHECK-NEXT: %[[EXT:.+]] = hw.array_concat %[[FILLER]], %[[ARRAY]]
     // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[EXT]][%[[ZEXT_INDEX]]]
@@ -1135,13 +1135,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %0 = firrtl.subaccess %b[%x] : !firrtl.vector<uint<1>, 5>, !firrtl.uint<2>
     %1 = firrtl.subaccess %a[%y] : !firrtl.vector<uint<1>, 5>, !firrtl.uint<2>
     firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:      %[[EXTIndex:.+]] = hw.constant 0 : i3 
     // CHECK:      %.b.output = sv.wire  : !hw.inout<array<5xi1>>
     // CHECK-NEXT: %0 = sv.read_inout %.b.output
     // CHECK-NEXT: %[[indexExt:.+]] = comb.concat %false, %x : i1, i2
     // CHECK-NEXT: %2 = sv.array_index_inout %.b.output[%[[indexExt]]]
     // CHECK-NEXT: %3 = comb.concat %false, %y : i1, i2
     // CHECK-NEXT: %[[valWire:.+]] = sv.wire  : !hw.inout<i1>
-    // CHECK-NEXT: %[[EXTIndex:.+]] = hw.constant 0 : i3 
     // CHECK-NEXT: %[[EXTValue:.+]] = hw.array_get %a[%[[EXTIndex]]] 
     // CHECK-NEXT: %[[EXTArray:.+]] = hw.array_create %[[EXTValue]], %[[EXTValue]], %[[EXTValue]] 
     // CHECK-NEXT: %[[Array:.+]] = hw.array_concat %[[EXTArray]], %a 
@@ -1269,13 +1269,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %bar = firrtl.dshl %a, %b {name = "anothername"} : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
   }
 
-  // CHECK-LABEL: hw.module private @MutlibitMux(%source_0: i1, %source_1: i1, %source_2: i1, %index: i2) -> (sink: i1) {
-  firrtl.module private @MutlibitMux(in %source_0: !firrtl.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.uint<1>, out %sink: !firrtl.uint<1>, in %index: !firrtl.uint<2>) {
+  // CHECK-LABEL: hw.module private @MultibitMux(%source_0: i1, %source_1: i1, %source_2: i1, %index: i2) -> (sink: i1) {
+  firrtl.module private @MultibitMux(in %source_0: !firrtl.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.uint<1>, out %sink: !firrtl.uint<1>, in %index: !firrtl.uint<2>) {
     %0 = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %sink, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:      %c0_i2 = hw.constant 0 : i2 
     // CHECK:      %0 = hw.array_create %source_2, %source_1, %source_0 : i1
     // CHECK-NEXT: %1 = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2 
     // CHECK-NEXT: %2 = hw.array_get %0[%c0_i2]
     // CHECK-NEXT: %3 = hw.array_create %2 : i1 
     // CHECK-NEXT: %4 = hw.array_concat %3, %0

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -264,12 +264,12 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
     output b : UInt<1>
     b <= a[sel]
 ; VERILOG-LABEL: module MultibitMux(
-; VERILOG:  wire [2:0] [[T2:.*]] =
-; VERILOG-SAME{LITERAL}: {{a_2}, {a_1}, {a_0}};
-; VERILOG-NEXT:  wire [[T1:.*]];
+; VERILOG:  wire [[T1:.*]];
+; VERILOG:  wire [3:0] [[T2:.*]] =
+; VERILOG-SAME{LITERAL}: {{a_0}, {a_2}, {a_1}, {a_0}};
 ; VERILOG-NEXT:  /* synopsys infer_mux_override */
 ; VERILOG-NEXT:  assign [[T1]] = [[T2]][sel] /* cadence map_to_mux */;
-; VERILOG-NEXT:  assign b = (&sel) ? a_0 : [[T1]];
+; VERILOG-NEXT:  assign b = [[T1]];
 
   module UnusedPortsMod :
     input in : UInt<1>


### PR DESCRIPTION
Improve critical path through muxes and array indexes by not adding an out-of-bounds mux, but rather extend the arrays to power of two.