### PR TITLE
[llvm] Bump LLVM to top-of-tree

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -19,7 +19,7 @@ def ParamDeclAttr : Attr<CPred<"$_self.isa<hw::ParamDeclAttr>()">>;
 def ParamDeclArrayAttr : TypedArrayAttrBase<ParamDeclAttr, "parameter array">;
 
 def UndefinedOp : CalyxOp<"undef", [
-    NoSideEffect
+    Pure
   ]> {
   let summary = "Calyx Undefined Value";
   let description = [{

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -19,7 +19,7 @@ include "mlir/IR/EnumAttr.td"
 
 // Base class for binary operators.
 class BinOp<string mnemonic, list<Trait> traits = []> :
-      CombOp<mnemonic, traits # [NoSideEffect]> {
+      CombOp<mnemonic, traits # [Pure]> {
   let arguments = (ins HWIntegerType:$lhs, HWIntegerType:$rhs, UnitAttr:$twoState);
   let results = (outs HWIntegerType:$result);
 
@@ -36,7 +36,7 @@ class UTBinOp<string mnemonic, list<Trait> traits = []> :
 
 // Base class for variadic operators.
 class VariadicOp<string mnemonic, list<Trait> traits = []> :
-      CombOp<mnemonic, traits # [NoSideEffect]> {
+      CombOp<mnemonic, traits # [Pure]> {
   let arguments = (ins Variadic<HWIntegerType>:$inputs, UnitAttr:$twoState);
   let results = (outs HWIntegerType:$result);
 }
@@ -114,7 +114,7 @@ def ICmpPredicate : I64EnumAttr<
      ICmpPredicateUGT, ICmpPredicateUGE, ICmpPredicateCEQ, ICmpPredicateCNE,
      ICmpPredicateWEQ, ICmpPredicateWNE]>;
 
-def ICmpOp : CombOp<"icmp", [NoSideEffect, SameTypeOperands]> {
+def ICmpOp : CombOp<"icmp", [Pure, SameTypeOperands]> {
   let summary = "Compare two integer values";
   let description = [{
     This operation compares two integers using a predicate.  If the predicate is
@@ -163,7 +163,7 @@ def ICmpOp : CombOp<"icmp", [NoSideEffect, SameTypeOperands]> {
 
 // Base class for unary reduction operations that produce an i1.
 class UnaryI1ReductionOp<string mnemonic, list<Trait> traits = []> :
-      CombOp<mnemonic, traits # [NoSideEffect]> {
+      CombOp<mnemonic, traits # [Pure]> {
   let arguments = (ins HWIntegerType:$input, UnitAttr:$twoState);
   let results = (outs I1:$result);
   let hasFolder = 1;
@@ -178,7 +178,7 @@ def ParityOp : UnaryI1ReductionOp<"parity">;
 //===----------------------------------------------------------------------===//
 
 // Extract a range of bits from the specified input.
-def ExtractOp : CombOp<"extract", [NoSideEffect]> {
+def ExtractOp : CombOp<"extract", [Pure]> {
   let summary = "Extract a range of bits into a smaller value, lowBit "
                 "specifies the lowest bit included.";
 
@@ -203,7 +203,7 @@ def ExtractOp : CombOp<"extract", [NoSideEffect]> {
 //===----------------------------------------------------------------------===//
 // Other Operations
 //===----------------------------------------------------------------------===//
-def ConcatOp : CombOp<"concat", [InferTypeOpInterface, NoSideEffect]> {
+def ConcatOp : CombOp<"concat", [InferTypeOpInterface, Pure]> {
   let summary = "Concatenate a variadic list of operands together.";
   let description = [{
     See the comb rationale document for details on operand ordering.
@@ -236,7 +236,7 @@ def ConcatOp : CombOp<"concat", [InferTypeOpInterface, NoSideEffect]> {
   }];
 }
 
-def ReplicateOp : CombOp<"replicate", [NoSideEffect]> {
+def ReplicateOp : CombOp<"replicate", [Pure]> {
   let summary = "Concatenate the operand a constant number of times";
 
   let arguments = (ins HWIntegerType:$input);
@@ -268,7 +268,7 @@ def ReplicateOp : CombOp<"replicate", [NoSideEffect]> {
 
 // Select one of two values based on a condition.
 def MuxOp : CombOp<"mux",
- [NoSideEffect, AllTypesMatch<["trueValue", "falseValue", "result"]>]> {
+ [Pure, AllTypesMatch<["trueValue", "falseValue", "result"]>]> {
   let summary = "Return one or the other operand depending on a selector bit";
   let description = [{
     ```

--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 def ChannelBufferOp : ESI_Abstract_Op<"buffer", [
-    NoSideEffect,
+    Pure,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "Control options for an ESI channel.";
@@ -50,7 +50,7 @@ def ChannelBufferOp : ESI_Abstract_Op<"buffer", [
 }
 
 def PipelineStageOp : ESI_Physical_Op<"stage", [
-    NoSideEffect,
+    Pure,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "An elastic buffer stage.";
@@ -97,7 +97,7 @@ def RtlBitArrayType : Type<CPred<"$_self.isa<::circt::hw::ArrayType>()"
  " && $_self.cast<::circt::hw::ArrayType>().getElementType() =="
  "   ::mlir::IntegerType::get($_self.getContext(), 1)">, "an HW bit array">;
 
-def CapnpDecodeOp : ESI_Physical_Op<"decode.capnp", [NoSideEffect]> {
+def CapnpDecodeOp : ESI_Physical_Op<"decode.capnp", [Pure]> {
   let summary = "Translate bits in Cap'nProto messages to HW typed data";
 
   let arguments = (ins I1:$clk, I1:$valid, RtlBitArrayType:$capnpBits);
@@ -109,7 +109,7 @@ def CapnpDecodeOp : ESI_Physical_Op<"decode.capnp", [NoSideEffect]> {
   }];
 }
 
-def CapnpEncodeOp : ESI_Physical_Op<"encode.capnp", [NoSideEffect]> {
+def CapnpEncodeOp : ESI_Physical_Op<"encode.capnp", [Pure]> {
   let summary = "Translate HW typed data to Cap'nProto";
 
   let arguments = (ins I1:$clk, I1:$valid, AnyType:$dataToEncode);
@@ -121,7 +121,7 @@ def CapnpEncodeOp : ESI_Physical_Op<"encode.capnp", [NoSideEffect]> {
   }];
 }
 
-def NullSourceOp : ESI_Physical_Op<"null", [NoSideEffect]> {
+def NullSourceOp : ESI_Physical_Op<"null", [Pure]> {
   let summary = "An op which never produces messages.";
 
   let arguments = (ins);

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -42,7 +42,7 @@ def ChannelType : ESI_Port<"Channel"> {
 // Operations on ports.
 
 def WrapValidReadyOp : ESI_Op<"wrap.vr", [
-    NoSideEffect,
+    Pure,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "Wrap a value into an ESI port";
@@ -63,7 +63,7 @@ def WrapValidReadyOp : ESI_Op<"wrap.vr", [
 }
 
 def UnwrapValidReadyOp : ESI_Op<"unwrap.vr", [
-    NoSideEffect,
+    Pure,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "Unwrap a value from an ESI port";
@@ -86,7 +86,7 @@ def ModportType:
   Type<CPred<"$_self.isa<::circt::sv::ModportType>()">, "sv.interface">;
 
 def WrapSVInterfaceOp: ESI_Op<"wrap.iface", [
-    NoSideEffect,
+    Pure,
     DeclareOpInterfaceMethods<ChannelOpInterface>
   ]> {
   let summary = "Wrap an SV interface into an ESI port";

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -20,7 +20,7 @@ def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
 // A common base class for operations that implement type inference and parsed
 // argument validation.
 class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
-    FIRRTLOp<mnemonic, traits # [HasCustomSSAName, InferTypeOpInterface, NoSideEffect]> {
+    FIRRTLOp<mnemonic, traits # [HasCustomSSAName, InferTypeOpInterface, Pure]> {
 
   // The narrow operation-specific type inference method. Operations can
   // override this with an inline declaration for the class header, or just
@@ -78,7 +78,7 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
 }
 
 def ConstantOp : FIRRTLOp<"constant",
-      [NoSideEffect, ConstantLike, FirstAttrDerivedResultType,
+      [Pure, ConstantLike, FirstAttrDerivedResultType,
        HasCustomSSAName]> {
   let summary = "Produce a constant value";
   let description = [{
@@ -102,7 +102,7 @@ def ConstantOp : FIRRTLOp<"constant",
 }
 
 def SpecialConstantOp : FIRRTLOp<"specialconstant",
-      [NoSideEffect, ConstantLike, HasCustomSSAName]> {
+      [Pure, ConstantLike, HasCustomSSAName]> {
   let summary = "Produce a constant Reset or Clock value";
   let description = [{
     The constant operation produces a constant value of Reset, AsyncReset, or
@@ -121,7 +121,7 @@ def SpecialConstantOp : FIRRTLOp<"specialconstant",
 }
 
 def InvalidValueOp : FIRRTLOp<"invalidvalue",
-      [NoSideEffect, ConstantLike, HasCustomSSAName]> {
+      [Pure, ConstantLike, HasCustomSSAName]> {
   let summary = "InvalidValue primitive";
   let description = [{
     The InvalidValue operation returns an invalid value of a specified type:
@@ -567,7 +567,7 @@ def IsXVerifOp : FIRRTLExprOp<"verif_isX"> {
 //===----------------------------------------------------------------------===//
 
 def VerbatimExprOp : FIRRTLOp<"verbatim.expr",
-                              [NoSideEffect, HasCustomSSAName]> {
+                              [Pure, HasCustomSSAName]> {
   let summary = "Expression that expands to a value given SystemVerilog text";
   let description = [{
     This operation produces a typed value expressed by a string of
@@ -600,7 +600,7 @@ def VerbatimExprOp : FIRRTLOp<"verbatim.expr",
 }
 
 def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
-                              [NoSideEffect, HasCustomSSAName]> {
+                              [Pure, HasCustomSSAName]> {
   let summary = "Expression with wire semantics that expands to a value given "
                 "SystemVerilog text";
   let description = [{
@@ -639,7 +639,7 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 
 // This operation converts from a struct to a bundle
 // type, or visa-versa.  FIRRTL source/destination types must be passive.
-def HWStructCastOp : FIRRTLOp<"hwStructCast", [NoSideEffect]> {
+def HWStructCastOp : FIRRTLOp<"hwStructCast", [Pure]> {
   let arguments = (ins AnyType:$input);
   let results = (outs AnyType:$result);
 
@@ -649,7 +649,7 @@ def HWStructCastOp : FIRRTLOp<"hwStructCast", [NoSideEffect]> {
   let hasVerifier = 1;
 }
 
-def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
+def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
   let summary = [{
     Reinterpret one value to another value of the same size and
     potentially different type. This op is lowered to hw::BitCastOp.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -73,7 +73,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
   }];
 }
 
-def SkipOp : FIRRTLOp<"skip", [NoSideEffect]> {
+def SkipOp : FIRRTLOp<"skip", [Pure]> {
   let summary = "Skip statement";
   let description = [{
     Skip Statement:
@@ -145,7 +145,7 @@ def CoverOp : VerifOp<"cover"> {
 }
 
 def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
-                               RecursiveSideEffects]> {
+                               RecursiveMemoryEffects, RecursivelySpeculatable]> {
   let summary = "When Statement";
   let description = [{
     The "firrtl.when" operation represents a conditional.  Connections within

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -15,7 +15,7 @@
 // Packed Array Processing Operations
 //===----------------------------------------------------------------------===//
 
-def ArrayCreateOp : HWOp<"array_create", [NoSideEffect, SameTypeOperands]> {
+def ArrayCreateOp : HWOp<"array_create", [Pure, SameTypeOperands]> {
   let summary = "Create an array from values";
   let description = [{
     Creates an array from a variable set of values. One or more values must be
@@ -49,7 +49,7 @@ def ArrayCreateOp : HWOp<"array_create", [NoSideEffect, SameTypeOperands]> {
   }];
 }
 
-def ArrayConcatOp : HWOp<"array_concat", [NoSideEffect]> {
+def ArrayConcatOp : HWOp<"array_concat", [Pure]> {
   let summary = "Concatenate some arrays";
   let description = [{
     Creates an array by concatenating a variable set of arrays. One or more
@@ -79,7 +79,7 @@ def ArrayConcatOp : HWOp<"array_concat", [NoSideEffect]> {
   let hasCanonicalizeMethod = 1;
 }
 
-def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
+def ArraySliceOp : HWOp<"array_slice", [Pure]> {
   let summary = "Get a range of values from an array";
   let description = [{
     Extracts a sub-range from an array. The range is from `lowIndex` to
@@ -129,7 +129,7 @@ class ArrayElementTypeConstraint<string result, string input>
 
 // hw.array_get does not work with unpacked arrays.
 def ArrayGetOp : HWOp<"array_get",
-    [NoSideEffect, IndexBitWidthConstraint<"index", "input">,
+    [Pure, IndexBitWidthConstraint<"index", "input">,
      ArrayElementTypeConstraint<"result", "input">]> {
   let summary = "Get the value in an array at the specified index";
   let arguments = (ins ArrayType:$input, HWIntegerType:$index);
@@ -151,7 +151,7 @@ def ArrayGetOp : HWOp<"array_get",
 // Structure Processing Operations
 //===----------------------------------------------------------------------===//
 
-def StructCreateOp : HWOp<"struct_create", [NoSideEffect]> {
+def StructCreateOp : HWOp<"struct_create", [Pure]> {
   let summary = "Create a struct from constituent parts.";
   let arguments = (ins Variadic<HWNonInOutType>:$input);
   let results = (outs StructType:$result);
@@ -161,7 +161,7 @@ def StructCreateOp : HWOp<"struct_create", [NoSideEffect]> {
 
 // Extract the value of a field of a structure.
 def StructExtractOp : HWOp<"struct_extract",
-    [NoSideEffect,
+    [Pure,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
   let summary = "Extract a named field from a struct.";
@@ -185,7 +185,7 @@ def StructExtractOp : HWOp<"struct_extract",
 }
 
 // Create a structure by replacing a field with a value in an existing one.
-def StructInjectOp : HWOp<"struct_inject", [NoSideEffect,
+def StructInjectOp : HWOp<"struct_inject", [Pure,
                            AllTypesMatch<["input", "result"]>]> {
   let summary = "Inject a value into a named field of a struct.";
   let description = [{
@@ -203,7 +203,7 @@ def StructInjectOp : HWOp<"struct_inject", [NoSideEffect,
   let hasCanonicalizeMethod = 1;
 }
 
-def StructExplodeOp : HWOp<"struct_explode", [NoSideEffect,
+def StructExplodeOp : HWOp<"struct_explode", [Pure,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
   let summary = "Expand a struct into its constituent parts.";
@@ -222,7 +222,7 @@ def StructExplodeOp : HWOp<"struct_explode", [NoSideEffect,
 // Union operations
 //===----------------------------------------------------------------------===//
 
-def UnionCreateOp : HWOp<"union_create", [NoSideEffect]> {
+def UnionCreateOp : HWOp<"union_create", [Pure]> {
   let summary = "Create a union with the specified value.";
   let description = [{
     Create a union with the value 'input', which can then be accessed via the
@@ -239,7 +239,7 @@ def UnionCreateOp : HWOp<"union_create", [NoSideEffect]> {
   let hasCustomAssemblyFormat = 1;
 }
 
-def UnionExtractOp : HWOp<"union_extract", [NoSideEffect]> {
+def UnionExtractOp : HWOp<"union_extract", [Pure]> {
   let summary = "Get a union member.";
   let description = [{
     Get the value of a union, interpreting it as the type of the specified

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 def ConstantOp
- : HWOp<"constant", [NoSideEffect, ConstantLike, FirstAttrDerivedResultType,
+ : HWOp<"constant", [Pure, ConstantLike, FirstAttrDerivedResultType,
          DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Produce a constant value";
   let description = [{
@@ -47,7 +47,7 @@ def ConstantOp
 def KnownBitWidthType : Type<CPred<[{getBitWidth($_self) != -1}]>,
   "Type wherein the bitwidth in hardware is known">;
 
-def BitcastOp: HWOp<"bitcast", [NoSideEffect]> {
+def BitcastOp: HWOp<"bitcast", [Pure]> {
   let summary = [{
     Reinterpret one value to another value of the same size and
     potentially different type.  See the `hw` dialect rationale document for
@@ -64,7 +64,7 @@ def BitcastOp: HWOp<"bitcast", [NoSideEffect]> {
 }
 
 def ParamValueOp : HWOp<"param.value",
-                        [FirstAttrDerivedResultType, NoSideEffect,
+                        [FirstAttrDerivedResultType, Pure,
                          ConstantLike]> {
   let summary = [{
     Return the value of a parameter expression as an SSA value that may be used
@@ -78,7 +78,7 @@ def ParamValueOp : HWOp<"param.value",
   let hasFolder = true;
 }
 
-def EnumConstantOp : HWOp<"enum.constant", [NoSideEffect, ConstantLike,
+def EnumConstantOp : HWOp<"enum.constant", [Pure, ConstantLike,
          DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Produce a constant enumeration value.";
   let description = [{

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -479,7 +479,7 @@ def InstanceOp : HWOp<"instance", [
 }
 
 def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
-                                NoSideEffect, ReturnLike]> {
+                                Pure, ReturnLike]> {
   let summary = "HW termination operation";
   let description = [{
     "hw.output" marks the end of a region in the HW dialect and the values

--- a/include/circt/Dialect/HWArith/HWArithOps.td
+++ b/include/circt/Dialect/HWArith/HWArithOps.td
@@ -19,7 +19,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def ConstantOp : HWArithOp<"constant",
-    [ConstantLike, NoSideEffect, FirstAttrDerivedResultType]> {
+    [ConstantLike, Pure, FirstAttrDerivedResultType]> {
   let summary = "Produce a constant value";
   let description = [{
     The constant operation produces a sign-aware constant value.
@@ -43,7 +43,7 @@ def ConstantOp : HWArithOp<"constant",
 
 // Base class for binary operators.
 class BinOp<string mnemonic, list<Trait> traits = []> :
-      HWArithOp<mnemonic, traits # [NoSideEffect, InferTypeOpInterface]> {
+      HWArithOp<mnemonic, traits # [Pure, InferTypeOpInterface]> {
   let arguments = (ins Variadic<HWArithIntegerType>:$inputs);
   let results = (outs HWArithIntegerType:$result);
 
@@ -165,7 +165,7 @@ def DivOp : BinOp<"div"> {
   }];
 }
 
-def HWArith_CastOp : HWArithOp<"cast", [NoSideEffect]> {
+def HWArith_CastOp : HWArithOp<"cast", [Pure]> {
   let arguments = (ins AnyInteger:$in);
   let results = (outs AnyInteger:$out);
 
@@ -221,7 +221,7 @@ def ICmpPredicate : I64EnumAttr<
     [ICmpPredicateEQ, ICmpPredicateNE, ICmpPredicateLT,
      ICmpPredicateGE, ICmpPredicateLE, ICmpPredicateGT]>;
 
-def ICmpOp : HWArithOp<"icmp", [NoSideEffect]> {
+def ICmpOp : HWArithOp<"icmp", [Pure]> {
   let summary = "Sign- and bitwidth-aware integer comparison.";
   let description = [{
     The `icmp` operation compares two integers using a predicate. If the

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -215,7 +215,7 @@ def BufferTypeEnum: I32EnumAttr<
 }
 def BufferTypeEnumAttr: EnumAttr<Handshake_Dialect, BufferTypeEnum, "buffer_type_enum">;
 
-def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
+def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>]> {
   let summary = "buffer operation";
@@ -267,7 +267,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
 }
 
 def ForkOp : Handshake_Op<"fork", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
   HasClock, DeclareOpInterfaceMethods<GeneralOpInterface>
 ]> {
   let summary = "fork operation";
@@ -295,7 +295,7 @@ def ForkOp : Handshake_Op<"fork", [
   let hasCustomAssemblyFormat = 1;
 }
 
-def LazyForkOp : Handshake_Op<"lazy_fork", [NoSideEffect]> {
+def LazyForkOp : Handshake_Op<"lazy_fork", [Pure]> {
   let summary = "lazy fork operation";
   let description = [{
     The lazy_fork operation represents a lazy fork operation.
@@ -319,7 +319,7 @@ def LazyForkOp : Handshake_Op<"lazy_fork", [NoSideEffect]> {
 }
 
 def MergeOp : Handshake_Op<"merge", [
-  NoSideEffect, MergeLikeOpInterface,
+  Pure, MergeLikeOpInterface,
   DeclareOpInterfaceMethods<ExecutableOpInterface>
 ]> {
   let summary = "merge operation";
@@ -347,7 +347,7 @@ def MergeOp : Handshake_Op<"merge", [
 }
 
 def MuxOp : Handshake_Op<"mux", [
-  NoSideEffect, MergeLikeOpInterface,
+  Pure, MergeLikeOpInterface,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>
 ]> {
@@ -389,7 +389,7 @@ def MuxOp : Handshake_Op<"mux", [
 }
 
 def ControlMergeOp : Handshake_Op<"control_merge", [
-  NoSideEffect, MergeLikeOpInterface, HasClock,
+  Pure, MergeLikeOpInterface, HasClock,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>
 ]> {
@@ -425,7 +425,7 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
 }
 
 def BranchOp : Handshake_Op<"br", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>,
   AllTypesMatch<["dataOperand", "dataResult"]>
   ]> {
@@ -454,7 +454,7 @@ def BranchOp : Handshake_Op<"br", [
 }
 
 def ConditionalBranchOp : Handshake_Op<"cond_br", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>,
   TypesMatchWith<"data operand type matches true branch result type",
@@ -489,7 +489,7 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
 }
 
 def SelectOp : Handshake_Op<"select", [
-  NoSideEffect,
+  Pure,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   TypesMatchWith<"data operand type matches true branch result type",
                     "trueOperand", "falseOperand", "$_self">,
@@ -547,7 +547,7 @@ def SinkOp
   let hasCustomAssemblyFormat = 1;
 }
 
-def SourceOp : Handshake_Op<"source", [NoSideEffect]> {
+def SourceOp : Handshake_Op<"source", [Pure]> {
   let summary = "source operation";
   let description = [{
     The source operation represents continuous token
@@ -561,7 +561,7 @@ def SourceOp : Handshake_Op<"source", [NoSideEffect]> {
   let builders = [OpBuilder<(ins)>];
 }
 
-def NeverOp : Handshake_Op<"never", [NoSideEffect]> {
+def NeverOp : Handshake_Op<"never", [Pure]> {
   let summary = "never operation";
   let description = [{
     The never operation represents disconnected data
@@ -574,7 +574,7 @@ def NeverOp : Handshake_Op<"never", [NoSideEffect]> {
 }
 
 def ConstantOp : Handshake_Op<"constant", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>
 ]> {
@@ -618,7 +618,7 @@ def EndOp
 }
 
 def StartOp : Handshake_Op<"start", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>
 ]> {
   let summary = "start operation";
   let description = [{

--- a/include/circt/Dialect/LLHD/IR/ExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/ExtractOps.td
@@ -48,7 +48,7 @@ class SmallerOrEqualResultTypeWidthConstraint<string result, string input>
 //===----------------------------------------------------------------------===//
 
 def LLHD_SigExtractOp : LLHD_Op<"sig.extract",
-    [NoSideEffect,
+    [Pure,
      SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
      SigPtrIndexBitWidthConstraint<"lowBit", "input">]> {
 
@@ -75,7 +75,7 @@ def LLHD_SigExtractOp : LLHD_Op<"sig.extract",
 }
 
 def LLHD_PtrExtractOp : LLHD_Op<"ptr.extract",
-    [NoSideEffect,
+    [Pure,
      SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
      SigPtrIndexBitWidthConstraint<"lowBit", "input">]> {
 
@@ -106,7 +106,7 @@ def LLHD_PtrExtractOp : LLHD_Op<"ptr.extract",
 //===----------------------------------------------------------------------===//
 
 def LLHD_SigArraySliceOp : LLHD_Op<"sig.array_slice",
-    [NoSideEffect,
+    [Pure,
      SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
      SameSigPtrArrayElementTypeConstraint<"result", "input">,
      SigPtrIndexBitWidthConstraint<"lowIndex", "input">]> {
@@ -157,7 +157,7 @@ def LLHD_SigArraySliceOp : LLHD_Op<"sig.array_slice",
 }
 
 def LLHD_PtrArraySliceOp : LLHD_Op<"ptr.array_slice",
-    [NoSideEffect,
+    [Pure,
      SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
      SameSigPtrArrayElementTypeConstraint<"result", "input">,
      SigPtrIndexBitWidthConstraint<"lowIndex", "input">]> {
@@ -208,7 +208,7 @@ def LLHD_PtrArraySliceOp : LLHD_Op<"ptr.array_slice",
 }
 
 def LLHD_SigArrayGetOp : LLHD_Op<"sig.array_get",
-    [NoSideEffect,
+    [Pure,
      SigPtrIndexBitWidthConstraint<"index", "input">,
      SigArrayElementTypeConstraint<"result", "input">]> {
 
@@ -240,7 +240,7 @@ def LLHD_SigArrayGetOp : LLHD_Op<"sig.array_get",
 }
 
 def LLHD_PtrArrayGetOp : LLHD_Op<"ptr.array_get",
-    [NoSideEffect,
+    [Pure,
      SigPtrIndexBitWidthConstraint<"index", "input">,
      PtrArrayElementTypeConstraint<"result", "input">]> {
 
@@ -275,7 +275,7 @@ def LLHD_PtrArrayGetOp : LLHD_Op<"ptr.array_get",
 // Structure Operations
 //===----------------------------------------------------------------------===//
 
-def LLHD_SigStructExtractOp : LLHD_Op<"sig.struct_extract", [NoSideEffect,
+def LLHD_SigStructExtractOp : LLHD_Op<"sig.struct_extract", [Pure,
   DeclareOpInterfaceMethods<InferTypeOpInterface>, InferTypeOpInterface]> {
   let summary = "Extract a field from a signal of a struct.";
   let description = [{
@@ -305,7 +305,7 @@ def LLHD_SigStructExtractOp : LLHD_Op<"sig.struct_extract", [NoSideEffect,
   }];
 }
 
-def LLHD_PtrStructExtractOp : LLHD_Op<"ptr.struct_extract", [NoSideEffect,
+def LLHD_PtrStructExtractOp : LLHD_Op<"ptr.struct_extract", [Pure,
   DeclareOpInterfaceMethods<InferTypeOpInterface>, InferTypeOpInterface]> {
   let summary = "Extract a field from a pointer to a struct.";
   let description = [{

--- a/include/circt/Dialect/LLHD/IR/ValueOps.td
+++ b/include/circt/Dialect/LLHD/IR/ValueOps.td
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 def LLHD_ConstantTimeOp : LLHD_Op<"constant_time",
-                                  [ConstantLike, NoSideEffect]> {
+                                  [ConstantLike, Pure]> {
   let summary = "Introduce a new time constant.";
   let description = [{
     The `llhd.constant_time` instruction introduces a new constant time value as

--- a/include/circt/Dialect/MSFT/MSFTConstructs.td
+++ b/include/circt/Dialect/MSFT/MSFTConstructs.td
@@ -45,7 +45,7 @@ def PEOutputOp: MSFTOp<"pe.output", [Terminator]> {
 }
 
 def ChannelOp: MSFTOp<"constructs.channel",
-    [NoSideEffect, Symbol, HasParent<"MSFTModuleOp">,
+    [Pure, Symbol, HasParent<"MSFTModuleOp">,
      AllTypesMatch<["input", "output"]>]> {
 
   let summary = "A pipeline-able connection";

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -238,7 +238,7 @@ def DesignPartitionOp : MSFTOp<"partition",
 }
 
 def OutputOp : MSFTOp<"output", [Terminator, ParentOneOf<["MSFTModuleOp", "LinearOp"]>,
-                                NoSideEffect, ReturnLike]> {
+                                Pure, ReturnLike]> {
   let summary = "termination operation";
 
   let arguments = (ins Variadic<AnyType>:$operands);

--- a/include/circt/Dialect/Moore/MIRExpressions.td
+++ b/include/circt/Dialect/Moore/MIRExpressions.td
@@ -13,7 +13,7 @@
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 
-def ConstantOp : MIROp<"constant", [NoSideEffect]> {
+def ConstantOp : MIROp<"constant", [Pure]> {
   let summary = "A constant value";
 
   let arguments = (ins I32Attr:$value);
@@ -22,7 +22,7 @@ def ConstantOp : MIROp<"constant", [NoSideEffect]> {
 }
 
 def ConcatOp : MIROp<"concat", [
-    NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>
+    Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>
 ]> {
   let summary = "A concatenation of expressions";
   let description = [{
@@ -49,7 +49,7 @@ def ConcatOp : MIROp<"concat", [
 //===----------------------------------------------------------------------===//
 
 class ShiftOp<string name> : MIROp<name, [
-    NoSideEffect, 
+    Pure, 
     TypesMatchWith<"value and result types must match",
                    "value", "result", "$_self">
 ]> {

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -30,7 +30,7 @@ def Pipeline_Dialect : Dialect {
 
 def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
     IsolatedFromAbove,
-    NoSideEffect,
+    Pure,
     SingleBlockImplicitTerminator<"ReturnOp">,
     RegionKindInterface,
     HasOnlyGraphRegion 

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -16,7 +16,7 @@ def HWValueOrInOutType : AnyTypeOf<[HWValueType, InOutType]>;
 def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface,
                          ["getAsmResultNames"]>;
 
-def VerbatimExprOp : SVOp<"verbatim.expr", [NoSideEffect, HasCustomSSAName]> {
+def VerbatimExprOp : SVOp<"verbatim.expr", [Pure, HasCustomSSAName]> {
   let summary = "Expression that expands to a value given SystemVerilog text";
   let description = [{
     This operation produces a typed value expressed by a string of
@@ -82,7 +82,7 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName]> {
   ];
 }
 
-def MacroRefExprOp : SVOp<"macro.ref", [NoSideEffect, HasCustomSSAName]> {
+def MacroRefExprOp : SVOp<"macro.ref", [Pure, HasCustomSSAName]> {
   let summary = "Expression to refer to a SystemVerilog macro";
   let description = [{
     This operation produces a value by referencing a named macro.
@@ -128,7 +128,7 @@ def MacroRefExprSEOp : SVOp<"macro.ref.se", [HasCustomSSAName]> {
   ];
 }
 
-def ConstantXOp : SVOp<"constantX", [NoSideEffect, HasCustomSSAName]> {
+def ConstantXOp : SVOp<"constantX", [Pure, HasCustomSSAName]> {
   let summary = "A constant of value 'x'";
   let description = [{
     This operation produces a constant value of 'x'.  This 'x' follows the
@@ -146,7 +146,7 @@ def ConstantXOp : SVOp<"constantX", [NoSideEffect, HasCustomSSAName]> {
   }];
 }
 
-def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
+def ConstantZOp : SVOp<"constantZ", [Pure, HasCustomSSAName]> {
   let summary = "A constant of value 'z'";
   let description = [{
     This operation produces a constant value of 'z'.  This 'z' follows the
@@ -165,7 +165,7 @@ def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
 }
 
 def LocalParamOp : SVOp<"localparam",
-      [FirstAttrDerivedResultType, NoSideEffect, HasCustomSSAName]> {
+      [FirstAttrDerivedResultType, Pure, HasCustomSSAName]> {
   let summary = "Declare a localparam";
   let description = [{
     The localparam operation produces a `localparam` declaration. See SV spec
@@ -184,7 +184,7 @@ def LocalParamOp : SVOp<"localparam",
 
 def IndexedPartSelectOp
  : SVOp<"indexed_part_select",
-        [NoSideEffect, InferTypeOpInterface]> {
+        [Pure, InferTypeOpInterface]> {
   let summary = "Read several contiguous bits of an int type."
                 "This is an indexed part-select operator."
                 "The base is an integer expression and the width is an "

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -103,7 +103,7 @@ def XMROp : SVOp<"xmr", []> {
 
 def ReadInOutOp
  : SVOp<"read_inout",
-        [NoSideEffect, InOutElementConstraint<"result", "input">]> {
+        [Pure, InOutElementConstraint<"result", "input">]> {
   let summary = "Get the value of from something of inout type (e.g. a wire or"
                 " inout port) as the value itself.";
   let arguments = (ins InOutType:$input);
@@ -129,7 +129,7 @@ class InOutIndexConstraint<string value, string inoutValue>
 
 def ArrayIndexInOutOp
  : SVOp<"array_index_inout",
-        [NoSideEffect, InOutIndexConstraint<"result", "input">]> {
+        [Pure, InOutIndexConstraint<"result", "input">]> {
   let summary = "Index an inout memory to produce an inout element";
   let description = "See SV Spec 11.5.2.";
   let arguments = (ins InOutArrayType:$input, HWIntegerType:$index);
@@ -144,7 +144,7 @@ def ArrayIndexInOutOp
 }
 
 def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
-                         [NoSideEffect, InferTypeOpInterface]> {
+                         [Pure, InferTypeOpInterface]> {
   let summary = "Address several contiguous bits of an inout type (e.g. a wire"
                 " or inout port). This is an indexed part-select operator."
                 "The base is an integer expression and the width is an "
@@ -179,7 +179,7 @@ def InOutStructType
          "an inout type with struct field", "::circt::hw::InOutType">;
 
 def StructFieldInOutOp : SVOp<"struct_field_inout",
-                              [NoSideEffect, InferTypeOpInterface]> {
+                              [Pure, InferTypeOpInterface]> {
   let summary = "Create an subfield inout memory to produce an inout element.";
   let description = "See SV Spec 7.2.";
 

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -193,8 +193,8 @@ def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
 
 
 def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
-                               RecursiveSideEffects, ProceduralRegion,
-                               NonProceduralOp]> {
+                               RecursiveMemoryEffects, RecursivelySpeculatable,
+                               ProceduralRegion, NonProceduralOp]> {
   let summary = "'always @' block";
   let description = "See SV Spec 9.2, and 9.4.2.2.";
 
@@ -228,7 +228,9 @@ def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
 }
 
 def AlwaysCombOp : SVOp<"alwayscomb", [SingleBlock, NoTerminator,
-                                       NoRegionArguments, RecursiveSideEffects,
+                                       NoRegionArguments,
+                                       RecursiveMemoryEffects,
+                                       RecursivelySpeculatable,
                                        ProceduralRegion, NonProceduralOp]> {
   let summary = "'alwayscomb block";
   let description = "See SV Spec 9.2, and 9.2.2.2.";
@@ -258,8 +260,8 @@ def ResetTypeAttr : I32EnumAttr<"ResetType", "reset type",
 
 
 def AlwaysFFOp : SVOp<"alwaysff", [SingleBlock, NoTerminator, NoRegionArguments,
-                                   RecursiveSideEffects, ProceduralRegion,
-                                   NonProceduralOp]> {
+                                   RecursiveMemoryEffects, RecursivelySpeculatable,
+                                   ProceduralRegion, NonProceduralOp]> {
   let summary = "'alwaysff @' block with optional reset";
   let description = [{
     alwaysff blocks represent always_ff verilog nodes, which enforce inference
@@ -303,8 +305,9 @@ def AlwaysFFOp : SVOp<"alwaysff", [SingleBlock, NoTerminator, NoRegionArguments,
 
 
 def InitialOp : SVOp<"initial", [SingleBlock, NoTerminator, NoRegionArguments,
-                                 RecursiveSideEffects, ProceduralRegion,
-                                 NonProceduralOp]> {
+                                 RecursiveMemoryEffects,
+                                 RecursivelySpeculatable,
+                                 ProceduralRegion, NonProceduralOp]> {
   let summary = "'initial' block";
   let description = "See SV Spec 9.2.1.";
 
@@ -363,7 +366,7 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;
-  
+
   let builders = [
     /// This ctor allows you to build a CaseZ with some number of cases, getting
     /// a callback for each case.
@@ -531,7 +534,7 @@ def VerbatimOp : SVOp<"verbatim"> {
 // Bind Statements
 //===----------------------------------------------------------------------===//
 
-def BindOp : SVOp<"bind", 
+def BindOp : SVOp<"bind",
     [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "indirect instantiation statement";
   let description = [{
@@ -557,7 +560,7 @@ def BindOp : SVOp<"bind",
   }];
 }
 
-def BindInterfaceOp : SVOp<"bind.interface", 
+def BindInterfaceOp : SVOp<"bind.interface",
     [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "indirectly instantiate an interface";
   let description = [{
@@ -706,7 +709,7 @@ def InfoOp : NonfatalMessageOp<"info"> {
   }] # messageDescription;
 }
 
-def DepositOp : SVOp<"nonstandard.deposit", 
+def DepositOp : SVOp<"nonstandard.deposit",
     [ProceduralOp, VendorExtension, InOutTypeConstraint<"src", "dest">]> {
   let summary = "`$deposit` system task";
   let description = [{

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -253,7 +253,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance"> {
   }];
 }
 
-def GetModportOp: SVOp<"modport.get", [NoSideEffect]> {
+def GetModportOp: SVOp<"modport.get", [Pure]> {
   let summary = "Get a modport out of an interface instance";
   let description = [{
     Use this to extract a modport view to an instantiated interface. For
@@ -313,7 +313,7 @@ def AssignInterfaceSignalOp : SVOp<"interface.signal.assign", []> {
   let hasVerifier = 1;
 }
 
-def ReadInterfaceSignalOp : SVOp<"interface.signal.read", [NoSideEffect]> {
+def ReadInterfaceSignalOp : SVOp<"interface.signal.read", [Pure]> {
   let summary = "Access the data in an interface's signal.";
   let description = [{
     This is an expression to access a signal inside of an interface.

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -37,7 +37,7 @@ class SeqOp<string mnemonic, list<Trait> traits = []> :
     Op<SeqDialect, mnemonic, traits>;
 
 def CompRegOp : SeqOp<"compreg",
-    [NoSideEffect, AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
+    [Pure, AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
      SameVariadicOperandSize,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
        // AllTypesMatch doesn't work with Optional types yet.
@@ -68,7 +68,7 @@ def CompRegOp : SeqOp<"compreg",
 }
 
 def FirRegOp : SeqOp<"firreg",
-    [NoSideEffect, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
+    [Pure, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
      SameVariadicOperandSize, MemoryEffects<[MemWrite, MemRead, MemAlloc]>,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
       // AllTypesMatch doesn't work with Optional types yet.

--- a/include/circt/Dialect/SystemC/SystemCExpressions.td
+++ b/include/circt/Dialect/SystemC/SystemCExpressions.td
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def SignalReadOp : SystemCOp<"signal.read", [NoSideEffect,
+def SignalReadOp : SystemCOp<"signal.read", [Pure,
                                              InferTypeOpInterface]> {
   let summary = "Returns the current value of a signal or port.";
   let description = [{
@@ -39,7 +39,7 @@ def SignalReadOp : SystemCOp<"signal.read", [NoSideEffect,
   }];
 }
 
-def ConvertOp : SystemCOp<"convert", [NoSideEffect]> {
+def ConvertOp : SystemCOp<"convert", [Pure]> {
   let summary = "Converts between various integer and bit vector types.";
   let description = [{
     Allows conversions between the various integer and bit vector types in
@@ -66,7 +66,7 @@ def ConvertOp : SystemCOp<"convert", [NoSideEffect]> {
 // Operations that model C++-level features.
 //===----------------------------------------------------------------------===//
 
-def NewOp : SystemCOp<"cpp.new", [NoSideEffect]> {
+def NewOp : SystemCOp<"cpp.new", [Pure]> {
   let summary = "A C++ 'new' expression.";
   let description = [{
     Creates and initializes C++ objects using dynamic storage.
@@ -90,7 +90,7 @@ def MemberAccessKindAttr : I32EnumAttr<"MemberAccessKind",
                                        "C++ member access kind",
                                        [Dot, Arrow]> {}
 
-def MemberAccessOp : SystemCOp<"cpp.member_access", [NoSideEffect]> {
+def MemberAccessOp : SystemCOp<"cpp.member_access", [Pure]> {
   let summary = "A C++ member access expression.";
   let description = [{
     Represents the C++ member access operators `.` and `->`.


### PR DESCRIPTION
Draft PR for bumping LLVM to top-of-tree.

This is scheduled to be merged on Friday 2022-10-14.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

## Summary of Changes

A new Conditionally Speculatable Interface was
added (https://reviews.llvm.org/D135505).  This required the following changes:

- Replace all usages of NoSideEffect with Pure.
- Replace usages of RecursiveSideEffects with RecursiveMemoryEffects and
  RecursivelySpeculatable.