### PR TITLE
[SV] Fix potential to erase ops multiple times in SVExtractTestCode.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -371,7 +371,8 @@ static bool isBound(hw::HWModuleLike op, hw::InstanceGraph &instanceGraph) {
 // Inline any modules that only have inputs for test code.
 static void inlineInputOnly(hw::HWModuleOp oldMod,
                             hw::InstanceGraph &instanceGraph,
-                            BindTable &bindTable) {
+                            BindTable &bindTable,
+                            SmallPtrSetImpl<Operation *> &opsToErase) {
   // Check if the module only has inputs.
   if (oldMod.getNumOutputs() != 0)
     return;
@@ -429,13 +430,13 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
     // Erase the old instantiation site.
     assert(inst.use_empty() && "inlined instance should have no uses");
     use->erase();
-    inst.erase();
+    opsToErase.insert(inst);
   }
 
   // If all instances were inlined, remove the module.
   if (allInlined) {
     instanceGraph.erase(node);
-    oldMod->erase();
+    opsToErase.insert(oldMod);
   }
 }
 
@@ -453,7 +454,8 @@ private:
   // Run the extraction on a module, and return true if test code was extracted.
   bool doModule(hw::HWModuleOp module, std::function<bool(Operation *)> fn,
                 StringRef suffix, Attribute path, Attribute bindFile,
-                BindTable &bindTable) {
+                BindTable &bindTable,
+                SmallPtrSetImpl<Operation *> &opsToErase) {
     bool hasError = false;
     // Find Operations of interest.
     SetVector<Operation *> roots;
@@ -488,7 +490,6 @@ private:
 
     // Find instances that directly feed the clone set, and add them if
     // possible.
-    SmallPtrSet<Operation *, 32> opsToErase;
     addInstancesToCloneSet(inputs, opsToClone, opsToErase, extractedInstances);
     numOpsExtracted += opsToClone.size();
     numOpsErased += opsToErase.size();
@@ -500,16 +501,8 @@ private:
     // do the clone
     migrateOps(module, bmod, opsToClone, cutMap);
     // erase old operations of interest
-    for (auto op : roots)
-      op->erase();
-
-    // Erase any instances that were extracted, and their forward dataflow.
-    for (auto *op : opsToErase) {
-      if (roots.contains(op))
-        continue;
-      op->dropAllUses();
-      op->erase();
-    }
+    for (auto *op : roots)
+      opsToErase.insert(op);
 
     return true;
   }
@@ -626,17 +619,32 @@ void SVExtractTestCodeImplPass::runOnOperation() {
         continue;
       }
 
+      SmallPtrSet<Operation *, 32> opsToErase;
       bool anyThingExtracted = false;
       anyThingExtracted |= doModule(rtlmod, isAssert, "_assert", assertDir,
-                                    assertBindFile, bindTable);
+                                    assertBindFile, bindTable, opsToErase);
       anyThingExtracted |= doModule(rtlmod, isAssume, "_assume", assumeDir,
-                                    assumeBindFile, bindTable);
+                                    assumeBindFile, bindTable, opsToErase);
       anyThingExtracted |= doModule(rtlmod, isCover, "_cover", coverDir,
-                                    coverBindFile, bindTable);
+                                    coverBindFile, bindTable, opsToErase);
 
       // Inline any modules that only have inputs for test code.
       if (anyThingExtracted)
-        inlineInputOnly(rtlmod, instanceGraph, bindTable);
+        inlineInputOnly(rtlmod, instanceGraph, bindTable, opsToErase);
+
+      // Erase any instances that were extracted, and their forward dataflow.
+      // Also erase old instances that were inlined and can now be cleaned up.
+      // Parts of the forward dataflow may have been nested under other ops to
+      // erase, so keep track of what's being erased as we go to avoid erasing
+      // children of ops that were already erased.
+      SmallPtrSet<Operation *, 32> erasedOps;
+      for (auto *op : opsToErase) {
+        if (erasedOps.contains(op))
+          continue;
+        op->walk([&](Operation *erasedOp) { erasedOps.insert(erasedOp); });
+        op->dropAllUses();
+        op->erase();
+      }
     }
   }
 


### PR DESCRIPTION
When we decide to extract an instance, we must erase it and its forward dataflow. However, it's possible for the forward dataflow to contain nested ops. In this case, we might try to erase children after they've been erased as part of their parent. The erasing loop is updated to track all ops that are already erased to avoid this.

There is also an issue with having the erasing logic buried inside doModule, because the new code to conditionally inline some modules might try to clone ops that have been erased. Instead, the set of ops to erase is threaded through all calls to doModule as well as inlineInputOnly, and only after all the IR mutation is complete, do we finally clean up by erasing the instances and their forward dataflow.