### PR TITLE
[FIRRTL][CheckCombCycles] Use special class for End Iterator

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -326,7 +326,7 @@ class EndIterator
     : public llvm::iterator_facade_base<NodeIterator, std::forward_iterator_tag,
                                         Node> {
 public:
-  explicit EndIterator() {}
+  explicit EndIterator() = default;
 
   using llvm::iterator_facade_base<NodeIterator, std::forward_iterator_tag,
                                    Node>::operator++;

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -663,6 +663,8 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
         LLVM_DEBUG(llvm::dbgs() << "\n Module :" << module.getNameAttr());
         NodeContext context(&map, &instanceGraph);
         for (auto connect : module.getOps<FConnectLike>()) {
+          if (context.connects.count(connect))
+            continue;
           LLVM_DEBUG(llvm::dbgs()
                      << "\n Start traversal from dest of " << connect);
           auto entryNode = Node(connect.getDest(), &context);

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -421,33 +421,27 @@ public:
 
   bool operator==(const CombGraphIterator &rhs) const {
     // Comparing with EndIterator, implies just check isAtEnd.
-    if (rhs.impl.index() == 0 &&
-        std::get<NodeIterator>(rhs.impl).isEndIterator())
-      switch (impl.index()) {
+    auto isAtEnd = [](const CombGraphIterator &a,
+                      const CombGraphIterator &endIt) {
+      switch (a.impl.index()) {
       case 0:
-        return std::get<NodeIterator>(impl).isAtEnd();
+        return std::get<NodeIterator>(a.impl).isAtEnd();
       case 1:
-        return std::get<InstanceNodeIterator>(impl).isAtEnd();
+        return std::get<InstanceNodeIterator>(a.impl).isAtEnd();
       case 2:
-        return std::get<SubfieldNodeIterator>(impl).isAtEnd();
+        return std::get<SubfieldNodeIterator>(a.impl).isAtEnd();
       case 3:
-        return std::get<DummySourceNodeIterator>(impl).isAtEnd();
+        return std::get<DummySourceNodeIterator>(a.impl).isAtEnd();
       default:
         return llvm_unreachable("invalid iterator variant"), true;
       }
+    };
+
+    if (rhs.impl.index() == 0 &&
+        std::get<NodeIterator>(rhs.impl).isEndIterator())
+      return isAtEnd(*this, rhs);
     if (impl.index() == 0 && std::get<NodeIterator>(impl).isEndIterator())
-      switch (rhs.impl.index()) {
-      case 0:
-        return std::get<NodeIterator>(rhs.impl).isAtEnd();
-      case 1:
-        return std::get<InstanceNodeIterator>(rhs.impl).isAtEnd();
-      case 2:
-        return std::get<SubfieldNodeIterator>(rhs.impl).isAtEnd();
-      case 3:
-        return std::get<DummySourceNodeIterator>(rhs.impl).isAtEnd();
-      default:
-        return true;
-      }
+      return isAtEnd(rhs, *this);
     return impl == rhs.impl;
   }
   bool operator!=(const CombGraphIterator &rhs) const {


### PR DESCRIPTION
This commit uses the NULL  `Node` to denote `GraphTraits::child_end` to `CheckCombCycles`. This avoids the unnecessary objects constructed by `SCCIterator` to indicate the end of iteration.
This saves >35% runtime on large designs.