### PR TITLE
[Seq] Add const-clock and const-reset folders for FirRegOp

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -112,6 +112,7 @@ def FirRegOp : SeqOp<"firreg",
 
   let skipDefaultBuilders = 1;
   let hasCanonicalizeMethod = true;
+  let hasFolder = true;
   let builders = [
     OpBuilder<(ins "Value":$next, "Value":$clk,
                    "StringAttr":$name,

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -268,30 +268,57 @@ void FirRegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
-  // If the register has a symbol, we can't optimize it away.
-  if (op.getInnerSymAttr())
-    return failure();
-
-  // If the register's value is itself, we can replace the register.
-  if (op.getNext().getDefiningOp() != op)
-    return failure();
-
-  // If the register has a reset value, we can replace it with that.
-  if (auto resetValue = op.getResetValue()) {
-    rewriter.replaceOp(op, resetValue);
-    return success();
+  // If the register has a constant zero reset, drop the reset and reset value
+  // altogether.
+  if (auto reset = op.getReset()) {
+    if (auto constOp = reset.getDefiningOp<hw::ConstantOp>()) {
+      if (constOp.getValue().isZero()) {
+        rewriter.replaceOpWithNewOp<FirRegOp>(op, op.getNext(), op.getClk(),
+                                              op.getNameAttr(),
+                                              op.getInnerSymAttr());
+        return success();
+      }
+    }
   }
 
-  auto type = op.getType();
+  return failure();
+}
 
-  // Otherwise we want to replae the register with a constant 0. For now this
+OpFoldResult FirRegOp::fold(ArrayRef<Attribute> constants) {
+  // If the register has a symbol, we can't optimize it away.
+  if (getInnerSymAttr())
+    return {};
+
+  // If the register is held in permanent reset, replace it with its reset
+  // value. This works trivially if the reset is asynchronous and therefore
+  // level-sensitive, in which case it will always immediately assume the reset
+  // value in silicon. If it is synchronous, the register value is undefined
+  // until the first clock edge at which point it becomes the reset value, in
+  // which case we simply define the initial value to already be the reset
+  // value.
+  if (auto reset = getReset())
+    if (auto constOp = reset.getDefiningOp<hw::ConstantOp>())
+      if (constOp.getValue().isOne())
+        return getResetValue();
+
+  // If the register's next value is trivially it's current value, or the
+  // register is never clocked, we can replace the register with a constant
+  // value.
+  bool isTrivialFeedback = (getNext() == getResult());
+  bool isNeverClocked = !!constants[1]; // clock operand is constant
+  if (!isTrivialFeedback && !isNeverClocked)
+    return {};
+
+  // If the register has a reset value, we can replace it with that.
+  if (auto resetValue = getResetValue())
+    return resetValue;
+
+  // Otherwise we want to replace the register with a constant 0. For now this
   // only works with integer types.
-  auto intType = type.dyn_cast<IntegerType>();
+  auto intType = getType().dyn_cast<IntegerType>();
   if (!intType)
-    return failure();
-
-  rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, intType, 0);
-  return success();
+    return {};
+  return IntegerAttr::get(intType, 0);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -1,12 +1,24 @@
 // RUN: circt-opt -canonicalize %s | FileCheck %s
 
-// Should optimize registers that never update to 0.
+hw.module.extern @Observe(%x: i32)
+
 // CHECK-LABEL: @FirReg
-hw.module @FirReg(%clk: i1) -> (out : i32) {
-  // CHECK: %c0_i32 = hw.constant 0 : i32
-  // CHECK: hw.output %c0_i32 : i32
-  %reg = seq.firreg %reg clock %clk : i32
-  hw.output %reg : i32
+hw.module @FirReg(%clk: i1, %in: i32) {
+  %false = hw.constant false
+  %true = hw.constant true
+
+  // Registers that update to themselves should be replaced with a constant 0.
+  %reg0 = seq.firreg %reg0 clock %clk : i32
+  hw.instance "reg0" @Observe(x: %reg0: i32) -> ()
+  // CHECK: hw.instance "reg0" @Observe(x: %c0_i32: i32) -> ()
+
+  // Registers that are never clocked should be replaced with a constant 0.
+  %reg1a = seq.firreg %in clock %false : i32
+  %reg1b = seq.firreg %in clock %true : i32
+  hw.instance "reg1a" @Observe(x: %reg1a: i32) -> ()
+  hw.instance "reg1b" @Observe(x: %reg1b: i32) -> ()
+  // CHECK: hw.instance "reg1a" @Observe(x: %c0_i32: i32) -> ()
+  // CHECK: hw.instance "reg1b" @Observe(x: %c0_i32: i32) -> ()
 }
 
 // Should not optimize away the register if it has a symbol.
@@ -18,13 +30,39 @@ hw.module @FirRegSymbol(%clk: i1) -> (out : i32) {
   hw.output %reg : i32
 }
 
-// Should replace registers with a reset value that never update with their
-// reset value.
 // CHECK-LABEL: @FirRegReset
-hw.module @FirRegReset(%clk: i1, %r : i1, %v : i32) -> (out : i32) {
-  // CHECK: hw.output %v : i32
-  %reg = seq.firreg %reg clock %clk reset sync %r, %v : i32
-  hw.output %reg : i32
+hw.module @FirRegReset(%clk: i1, %in: i32, %r : i1, %v : i32) {
+  %false = hw.constant false
+  %true = hw.constant true
+
+  // Registers that update to themselves should be replaced with their reset
+  // value.
+  %reg0 = seq.firreg %reg0 clock %clk reset sync %r, %v : i32
+  hw.instance "reg0" @Observe(x: %reg0: i32) -> ()
+  // CHECK: hw.instance "reg0" @Observe(x: %v: i32) -> ()
+
+  // Registers that never reset should drop their reset value.
+  %reg1 = seq.firreg %in clock %clk reset sync %false, %v : i32
+  hw.instance "reg1" @Observe(x: %reg1: i32) -> ()
+  // CHECK: %reg1 = seq.firreg %in clock %clk : i32
+  // CHECK: hw.instance "reg1" @Observe(x: %reg1: i32) -> ()
+
+  // Registers that are permanently reset should be replaced with their reset
+  // value.
+  %reg2a = seq.firreg %in clock %clk reset sync %true, %v : i32
+  %reg2b = seq.firreg %in clock %clk reset async %true, %v : i32
+  hw.instance "reg2a" @Observe(x: %reg2a: i32) -> ()
+  hw.instance "reg2b" @Observe(x: %reg2b: i32) -> ()
+  // CHECK: hw.instance "reg2a" @Observe(x: %v: i32) -> ()
+  // CHECK: hw.instance "reg2b" @Observe(x: %v: i32) -> ()
+
+  // Registers that are never clocked should be replaced with their reset value.
+  %reg3a = seq.firreg %in clock %false reset sync %r, %v : i32
+  %reg3b = seq.firreg %in clock %true reset sync %r, %v : i32
+  hw.instance "reg3a" @Observe(x: %reg3a: i32) -> ()
+  hw.instance "reg3b" @Observe(x: %reg3b: i32) -> ()
+  // CHECK: hw.instance "reg3a" @Observe(x: %v: i32) -> ()
+  // CHECK: hw.instance "reg3b" @Observe(x: %v: i32) -> ()
 }
 
 // This should not optimize anything until we have constant aggregate attribute


### PR DESCRIPTION
Introduce additional folders and canonicalizers for the `FirRegOp` that deal with registers that have a constant clock or reset value. The FIRRTL spec states that the value of a register before the first clock edge is undefined (unless reset through an async reset), which allows us to pick a convenient value in the cases where a register is provably never clocked or never reset.

This also moves the canonicalizer for self-referential registers into the folder since it does not need to create arbitrary operations.