### PR TITLE
PrettyPrinterBuilder.h: init PPBuilder, PPBuilderStringSaver, PPStream

### DIFF
--- a/include/circt/Support/PrettyPrinterBuilder.h
+++ b/include/circt/Support/PrettyPrinterBuilder.h
@@ -1,0 +1,218 @@
+//===- PrettyPrinterBuilder.h - Pretty printing builder -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Helper classes for using PrettyPrinter.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PRETTYPRINTERBUILDER_H
+#define CIRCT_SUPPORT_PRETTYPRINTERBUILDER_H
+
+#include "circt/Support/PrettyPrinter.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/StringSaver.h"
+
+namespace circt {
+namespace pretty {
+
+//===----------------------------------------------------------------------===//
+// Convenience builders.
+//===----------------------------------------------------------------------===//
+
+class PPBuilder : protected PrettyPrinter::Listener {
+  PrettyPrinter pp;
+
+public:
+  PPBuilder(llvm::raw_ostream &os, uint32_t margin) : pp(os, margin, this){};
+
+  /// Add new token.
+  template <typename T, typename... Args>
+  typename std::enable_if_t<std::is_base_of_v<Token, T>> add(Args &&...args) {
+    pp.add(T(std::forward<Args>(args)...));
+  }
+  void addToken(Token &t) { pp.add(t); }
+
+  /// End of a stream.
+  void eof() { pp.eof(); }
+
+  /// Add a literal (with external storage).
+  void literal(StringRef str) { add<StringToken>(str); }
+
+  /// Add a non-breaking space.
+  void nbsp() { literal(" "); }
+
+  /// Add a newline (break too wide to fit, always breaks).
+  void newline() { add<BreakToken>(PrettyPrinter::kInfinity); }
+
+  /// End a group.
+  void end() { add<EndToken>(); }
+
+  /// Add breakable spaces.
+  void spaces(uint32_t n) { add<BreakToken>(n); }
+
+  /// Add a breakable space.
+  void space() { spaces(1); }
+
+  /// Add a break that is zero-wide if not broken.
+  void zerobreak() { add<BreakToken>(0); }
+
+  /// Start a consistent group with specified offset.
+  void cbox(int32_t offset = 0) { add<BeginToken>(offset, Breaks::Consistent); }
+
+  /// Start an inconsistent group with specified offset.
+  void ibox(int32_t offset = 0) {
+    add<BeginToken>(offset, Breaks::Inconsistent);
+  }
+
+  /// Open a cbox that closes when returned object goes out of scope.
+  [[nodiscard]] auto scopedCBox(int32_t offset = 0) {
+    cbox(offset);
+    return llvm::make_scope_exit([&]() { end(); });
+  }
+
+  /// Open an ibox that closes when returned object goes out of scope.
+  [[nodiscard]] auto scopedIBox(int32_t offset = 0) {
+    ibox(offset);
+    return llvm::make_scope_exit([&]() { end(); });
+  }
+};
+
+/// Variant that saves strings that are live in the pretty-printer.
+/// Once they're no longer referenced, memory is reset.
+/// Allows differentiating between strings to save and external strings.
+class PPBuilderStringSaver : public PPBuilder {
+  llvm::BumpPtrAllocator alloc;
+  llvm::StringSaver strings;
+
+public:
+  PPBuilderStringSaver(llvm::raw_ostream &os, uint32_t margin)
+      : PPBuilder(os, margin), strings(alloc){};
+
+  /// Add string, save in storage.
+  void savedWord(StringRef str) { add<StringToken>(strings.save(str)); }
+
+protected:
+  /// PrettyPrinter::Listener::clear -- indicates no external refs.
+  void clear() override;
+};
+
+//===----------------------------------------------------------------------===//
+// Streaming support.
+//===----------------------------------------------------------------------===//
+
+/// Send one of these to PPStream to add the corresponding token.
+/// See PPBuilder for details of each.
+enum class PP {
+  space,
+  nbsp,
+  newline,
+  ibox0,
+  ibox2,
+  cbox0,
+  cbox2,
+  end,
+  zerobreak,
+  eof
+};
+
+/// String wrapper to indicate string has external storage.
+struct PPExtString {
+  StringRef str;
+  explicit PPExtString(StringRef str) : str(str) {}
+};
+
+/// String wrapper to indicate string needs to be saved.
+struct PPSaveString {
+  StringRef str;
+  explicit PPSaveString(StringRef str) : str(str) {}
+};
+
+class PPStream : public PPBuilderStringSaver {
+public:
+  PPStream(llvm::raw_ostream &os, uint32_t margin)
+      : PPBuilderStringSaver(os, margin) {}
+
+  /// Add a string literal (external storage).
+  PPStream &operator<<(const char *s) {
+    literal(s);
+    return *this;
+  }
+  /// Add a string token (saved to storage).
+  PPStream &operator<<(StringRef s) {
+    savedWord(s);
+    return *this;
+  }
+
+  /// String has external storage.
+  PPStream &operator<<(PPExtString &&str) {
+    literal(str.str);
+    return *this;
+  }
+
+  /// String must be saved.
+  PPStream &operator<<(PPSaveString &&str) {
+    savedWord(str.str);
+    return *this;
+  }
+
+  /// Convenience for inline streaming of builder methods.
+  PPStream &operator<<(PP s) {
+    switch (s) {
+    case PP::space:
+      space();
+      break;
+    case PP::nbsp:
+      nbsp();
+      break;
+    case PP::newline:
+      newline();
+      break;
+    case PP::ibox0:
+      ibox();
+      break;
+    case PP::ibox2:
+      ibox(2);
+      break;
+    case PP::cbox0:
+      cbox();
+      break;
+    case PP::cbox2:
+      cbox(2);
+      break;
+    case PP::end:
+      end();
+      break;
+    case PP::zerobreak:
+      zerobreak();
+      break;
+    case PP::eof:
+      eof();
+      break;
+    }
+    return *this;
+  }
+
+  /// Stream support for user-created Token's.
+  PPStream &operator<<(Token &t) {
+    addToken(t);
+    return *this;
+  }
+
+  /// Write escaped versions of the string, saved in storage.
+  PPStream &writeEscaped(StringRef str, bool useHexEscapes = false) {
+    return writeQuotedEscaped(str, useHexEscapes, "", "");
+  }
+  PPStream &writeQuotedEscaped(StringRef str, bool useHexEscapes = false,
+                               StringRef left = "\"", StringRef right = "\"");
+};
+
+} // end namespace pretty
+} // end namespace circt
+
+#endif // CIRCT_SUPPORT_PRETTYPRINTERBUILDER_H

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_library(CIRCTSupport
   LoweringOptions.cpp
   Path.cpp
   PrettyPrinter.cpp
+  PrettyPrinterBuilder.cpp
   SymCache.cpp
   ValueMapper.cpp
   "${VERSION_CPP}"

--- a/lib/Support/PrettyPrinterBuilder.cpp
+++ b/lib/Support/PrettyPrinterBuilder.cpp
@@ -1,0 +1,44 @@
+//===- PrettyPrinterBuilder.cpp - Pretty printing builder -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Helper classes for using PrettyPrinter.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/PrettyPrinterBuilder.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace circt {
+namespace pretty {
+
+//===----------------------------------------------------------------------===//
+// Convenience builders.
+//===----------------------------------------------------------------------===//
+
+void PPBuilderStringSaver::clear() { alloc.Reset(); }
+
+//===----------------------------------------------------------------------===//
+// Streaming support.
+//===----------------------------------------------------------------------===//
+
+PPStream &PPStream::writeQuotedEscaped(StringRef str, bool useHexEscapes,
+                                       StringRef left, StringRef right) {
+  SmallString<64> ss;
+  {
+    llvm::raw_svector_ostream os(ss);
+    os << left;
+    os.write_escaped(str, useHexEscapes);
+    os << right;
+  }
+  return *this << ss;
+}
+
+} // end namespace pretty
+} // end namespace circt

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Support/PrettyPrinter.h"
+#include "circt/Support/PrettyPrinterBuilder.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
@@ -324,6 +325,125 @@ TEST(CIRCTSupportTests, TrailingSpace) {
   pp.addTokens(tokens);
   pp.eof();
   EXPECT_EQ(out.str(), StringRef("test test\n"));
+}
+
+TEST(CIRCTSupportTests, Builder) {
+  SmallString<128> out;
+  raw_svector_ostream os(out);
+
+  PPBuilder b(os, 7);
+
+  {
+    auto ib = b.scopedIBox();
+    b.literal("test");
+    b.space();
+    b.literal("test");
+    b.space();
+    b.literal("test");
+  }
+  EXPECT_EQ(out.str(), StringRef("test\ntest\ntest"));
+}
+
+TEST(CIRCTSupportTests, Stream) {
+  SmallString<128> out;
+  raw_svector_ostream os(out);
+
+  PPStream ps(os, 20);
+  {
+    auto ib = ps.scopedIBox();
+    ps << "test" << PP::space << "test" << PP::space << "test";
+  }
+  ps << PP::eof;
+  EXPECT_EQ(out.str(), StringRef("test test test"));
+}
+
+TEST(CIRCTSupportTests, StreamQuoted) {
+  SmallString<128> out;
+  raw_svector_ostream os(out);
+
+  PPStream ps(os, 20);
+  out = "\n";
+  {
+    auto ib = ps.scopedIBox(2);
+    ps << "test" << PP::space;
+    ps.writeQuotedEscaped("quote\"me");
+    ps << PP::space << "test";
+  }
+  ps << PP::newline << PP::eof;
+  EXPECT_EQ(out.str(), StringRef(R"""(
+test "quote\"me"
+  test
+)"""));
+}
+
+TEST(CIRCTSupportTests, Expr) {
+  SmallString<128> out;
+  raw_svector_ostream os(out);
+
+  auto sumExpr = [](auto &ps) {
+    ps << "(";
+    {
+      auto ib = ps.scopedIBox(0);
+      auto vars = {"a", "b", "c", "d", "e", "f"};
+      llvm::interleave(
+          vars, [&](const char *each) { ps << each; },
+          [&]() { ps << PP::space << "+" << PP::space; });
+    }
+    ps << ")";
+  };
+
+  auto test = [&](const char *id, auto margin) {
+    PPStream ps(os, margin);
+    out = "\n";
+    {
+      auto ib = ps.scopedIBox(2);
+      {
+        // TODO: let this wrap.
+        ps << "assign" << PP::nbsp << id << PP::nbsp << "=";
+      }
+      ps << PP::space;
+      auto ib3 = ps.scopedIBox(0);
+      sumExpr(ps);
+      ps << PP::space << "*" << PP::space;
+      sumExpr(ps);
+      ps << ";";
+    }
+    ps << PP::newline << PP::eof;
+  };
+
+  test("foo", 8);
+  EXPECT_EQ(out.str(), StringRef(R"""(
+assign foo =
+  (a + b
+   + c +
+   d + e
+   + f)
+  *
+  (a + b
+   + c +
+   d + e
+   + f);
+)"""));
+  test("foo", 12);
+  EXPECT_EQ(out.str(), StringRef(R"""(
+assign foo =
+  (a + b + c
+   + d + e +
+   f) *
+  (a + b + c
+   + d + e +
+   f);
+)"""));
+  test("foo", 30);
+  EXPECT_EQ(out.str(), StringRef(R"""(
+assign foo =
+  (a + b + c + d + e + f) *
+  (a + b + c + d + e + f);
+)"""));
+  test("foo", 80);
+  EXPECT_EQ(out.str(), StringRef(R"""(
+assign foo = (a + b + c + d + e + f) * (a + b + c + d + e + f);
+)"""));
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
PPBuilder wraps PrettyPrinter with some convenience methods, including RAII/scope-based helpers for assisting in managing begin/end tokens. The "literal" helper adds string tokens that have external storage.

PPBuilderStringSaver extends that with ability to save strings in storage, which is automatically cleared when buffered tokens no longer need it.

PPStream provides a stream-like interface for pretty-printing, further simplifying usage.  One noteworthy quirk is it assumes anything streamed to it as a "char *" has external storage, but other strings (StringRef) will be saved in storage.  Wrapping StringRef's in PPExtString or PPSaveString makes the behavior explicit.

Extend unit test to demonstrate and explore more printing behavior.

(draft, targets the PrettyPrinter branch so only relevant commits are shown)