### PR TITLE
[SV] Fix SVExtractTestCode to handle inlining cycles.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -321,15 +321,27 @@ static void addBlockMapping(BlockAndValueMapping &cutMap, Operation *oldOp,
   }
 }
 
+// Check if op has any operand using a value that isn't yet defined.
 static bool hasOoOArgs(hw::HWModuleOp newMod, Operation *op) {
   for (auto arg : op->getOperands()) {
-    auto argOp = arg.getDefiningOp(); // may be null
+    auto *argOp = arg.getDefiningOp(); // may be null
     if (!argOp)
       continue;
     if (argOp->getParentOfType<hw::HWModuleOp>() != newMod)
       return true;
   }
   return false;
+}
+
+// Update any operand which was emitted before its defining op was.
+static void updateOoOArgs(SmallVectorImpl<Operation *> &lateBoundOps,
+                          BlockAndValueMapping &cutMap) {
+  for (auto *op : lateBoundOps)
+    for (unsigned argidx = 0, e = op->getNumOperands(); argidx < e; ++argidx) {
+      Value arg = op->getOperand(argidx);
+      if (cutMap.contains(arg))
+        op->setOperand(argidx, cutMap.lookup(arg));
+    }
 }
 
 // Do the cloning, which is just a pre-order traversal over the module looking
@@ -348,13 +360,7 @@ static void migrateOps(hw::HWModuleOp oldMod, hw::HWModuleOp newMod,
         lateBoundOps.push_back(newOp);
     }
   });
-  // update any operand which was emitted before it's defining op was.
-  for (auto op : lateBoundOps)
-    for (unsigned argidx = 0, e = op->getNumOperands(); argidx < e; ++argidx) {
-      Value arg = op->getOperand(argidx);
-      if (cutMap.contains(arg))
-        op->setOperand(argidx, cutMap.lookup(arg));
-    }
+  updateOoOArgs(lateBoundOps, cutMap);
 }
 
 // Check if the module has already been bound.
@@ -406,6 +412,7 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
     // Inline the body at the instantiation site.
     hw::HWModuleOp instParent =
         cast<hw::HWModuleOp>(use->getParent()->getModule());
+    SmallVector<Operation *, 16> lateBoundOps;
     b.setInsertionPoint(inst);
     for (auto &op : *oldMod.getBodyBlock()) {
       // For instances in the bind table, update the bind with the new parent.
@@ -423,9 +430,17 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
       }
 
       // For all ops besides the output, clone into the parent body.
-      if (!isa<hw::OutputOp>(op))
-        b.clone(op, mapping);
+      if (!isa<hw::OutputOp>(op)) {
+        Operation *clonedOp = b.clone(op, mapping);
+        // If some of the operands haven't been cloned over yet, due to cycles,
+        // remember to revisit this op.
+        if (hasOoOArgs(instParent, clonedOp))
+          lateBoundOps.push_back(clonedOp);
+      }
     }
+
+    // Map over any ops that didn't have their operands mapped when cloned.
+    updateOoOArgs(lateBoundOps, mapping);
 
     // Erase the old instantiation site.
     assert(inst.use_empty() && "inlined instance should have no uses");


### PR DESCRIPTION
This was raised on the issue that originally landed the inlining feature, but we weren't able to find an example of this in the wild. Of course, it has turned up: some modules only have inputs, feed test code, and thus meet the criteria for inlining. But they also might have internal signals that are not extracted, and form cycles in the SSA graph. The test case is the most trivial example, but more complex structures also hit the same bug and are fixed in the same way.

The solution is to use the same helpers that the main extraction logic uses to deal with comb cycles. These can be dropped in to the little inlining helper as-is and resolve the issue.