### PR TITLE
[SV] Add feature flags to new SVExtractTestCode features.

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -29,7 +29,9 @@ std::unique_ptr<mlir::Pass>
 createHWMemSimImplPass(bool replSeqMem = false,
                        bool ignoreReadEnableMem = false,
                        bool stripMuxPragmas = false);
-std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
+std::unique_ptr<mlir::Pass>
+createSVExtractTestCodePass(bool disableInstanceExtraction = false,
+                            bool disableModuleInlining = false);
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -114,6 +114,12 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
 
   let constructor = "circt::sv::createSVExtractTestCodePass()";
   let dependentDialects = ["circt::sv::SVDialect"];
+  let options = [
+    Option<"disableInstanceExtraction", "disable-instance-extraction", "bool",
+           "false", "Disable extracting instances only that feed test code">,
+    Option<"disableModuleInlining", "disable-module-inlining", "bool",
+           "false", "Disable inlining modules that only feed test code">
+  ];
   let statistics = [
     Statistic<"numOpsExtracted", "num-ops-extracted", "Number of ops extracted">,
     Statistic<"numOpsErased", "num-ops-erased", "Number of ops erased">

--- a/test/firtool/extract-test-code.fir
+++ b/test/firtool/extract-test-code.fir
@@ -1,0 +1,57 @@
+; RUN: firtool %s -extract-test-code | FileCheck %s
+; RUN: firtool %s -extract-test-code -etc-disable-instance-extraction | FileCheck %s --check-prefix=DISABLEINSTANCE
+; RUN: firtool %s -extract-test-code -etc-disable-module-inlining | FileCheck %s --check-prefix=DISABLEMODULE
+
+circuit Top:
+  module Foo:
+    input a : UInt<1>
+    output b : UInt<1>
+    b <= a
+
+  ; Ensure foo is extracted by default.
+  ; CHECK-LABEL: module InstanceExtracted_assert(
+  ; CHECK: Foo foo
+
+  ; Ensure foo is not extracted when disabled.
+  ; DISABLEINSTANCE-LABEL: module InstanceExtracted(
+  ; DISABLEINSTANCE: Foo foo
+
+  module InstanceExtracted:
+    input clock : Clock
+    input cond : UInt<1>
+    output out : UInt<1>
+
+    wire b : UInt<1>
+    inst foo of Foo
+    foo.a <= cond
+    b <= foo.b
+
+    assert(clock, cond, b, "Some assertion")
+
+    out <= cond
+
+  ; Ensure InputOnly is inlined by default.
+  ; CHECK-NOT: module InputOnly(
+
+  ; Ensure InputOnly is not inlined when disabled.
+  ; DISABLEMODULE-LABEL: module InputOnly(
+
+  module InputOnly:
+    input clock : Clock
+    input cond : UInt<1>
+    assert(clock, cond, cond, "Some assertion")
+
+  module Top:
+    input clock : Clock
+    input cond : UInt<1>
+    output out : UInt<1>
+
+    inst instance_extracted of InstanceExtracted
+    instance_extracted.clock <= clock
+    instance_extracted.cond <= cond
+    out <= instance_extracted.out
+
+    inst input_only of InputOnly
+    input_only.clock <= clock
+    input_only.cond <= cond
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -312,6 +312,16 @@ static cl::opt<bool> disableInferRW("disable-infer-rw",
                                     cl::init(false), cl::Hidden,
                                     cl::cat(mainCategory));
 
+static cl::opt<bool> etcDisableInstanceExtraction(
+    "etc-disable-instance-extraction",
+    cl::desc("Disable extracting instances only that feed test code"),
+    cl::init(false), cl::cat(mainCategory));
+
+static cl::opt<bool> etcDisableModuleInlining(
+    "etc-disable-module-inlining",
+    cl::desc("Disable inlining modules that only feed test code"),
+    cl::init(false), cl::cat(mainCategory));
+
 enum OutputFormatKind {
   OutputParseOnly,
   OutputIRFir,
@@ -751,7 +761,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
                                             stripMuxPragmas));
 
       if (extractTestCode)
-        pm.addPass(sv::createSVExtractTestCodePass());
+        pm.addPass(sv::createSVExtractTestCodePass(etcDisableInstanceExtraction,
+                                                   etcDisableModuleInlining));
 
       // If enabled, run the optimizer.
       if (!disableOptimization) {


### PR DESCRIPTION
These new additions are both fairly significant departures from past behavior, so add an ability to disable them. They remain enabled by default. The new flags are plumbed out to firtool flags so they can be disabled from firtool, and a test is added that this behavior can be controlled from firtool.