### PR TITLE
Build CIRCT on Windows with debug symbols

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -57,9 +57,9 @@ jobs:
           cmake ..\llvm -GNinja `
             -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="host" `
-            -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS=ON `
             -DLLVM_INSTALL_UTILS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
-          cmake --build . --target install --config Release
+          cmake --build . --target install --config RelWithDebInfo
 
       # --------
       # Build and test CIRCT in both debug and release mode.
@@ -78,7 +78,7 @@ jobs:
             -DMLIR_DIR="$(pwd)/../llvm/install/lib/cmake/mlir/" `
             -DLLVM_DIR="$(pwd)/../llvm/install/lib/cmake/llvm/" `
             -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/bin/llvm-lit.py" `
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build . --config Release
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake --build . --config RelWithDebInfo
 
     # --- end of build-circt job.


### PR DESCRIPTION
Building with debug symbols makes it much easier to debug a crash in CI, which is sometimes necessary when you don't have access to a Windows machine to reproduce on.