### PR TITLE
Link gtest against portable threading lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif ()
       add_llvm_library(llvm_gtest
         ${UNITTEST_DIR}/googletest/src/gtest-all.cc
         ${UNITTEST_DIR}/googlemock/src/gmock-all.cc
-        LINK_LIBS pthread
+        LINK_LIBS Threads:Threads
         LINK_COMPONENTS Support # llvm::raw_ostream
         BUILDTREE_ONLY
       )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ endif ()
       add_llvm_library(llvm_gtest
         ${UNITTEST_DIR}/googletest/src/gtest-all.cc
         ${UNITTEST_DIR}/googlemock/src/gmock-all.cc
-        LINK_LIBS Threads:Threads
         LINK_COMPONENTS Support # llvm::raw_ostream
         BUILDTREE_ONLY
       )
@@ -106,6 +105,7 @@ endif ()
         "${UNITTEST_DIR}/googletest"
         "${UNITTEST_DIR}/googlemock"
       )
+      target_link_libraries(llvm_gtest PUBLIC Threads::Threads)
       add_llvm_library(llvm_gtest_main
         ${UNITTEST_DIR}/UnitTestMain/TestMain.cpp
         LINK_LIBS llvm_gtest


### PR DESCRIPTION
When we build CIRCT as a standalone project (not a unified build), we build gtest from scratch for our unit tests.  This is currently hard-coded to link against pthreads, which does not work on Windows. We can use the built in `Threads::Threads` cmake library which is more portable.  This fixes the unit test linking on Windows.