### PR TITLE
[SV] Fix SVExtractTestCode to extract all results of instances.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -191,7 +191,8 @@ static void addInstancesToCloneSet(
     opsToClone.insert(instance);
     for (auto operand : instance.getOperands())
       inputsToAdd.push_back(operand);
-    inputsToRemove.push_back(value);
+    for (auto result : instance.getResults())
+      inputsToRemove.push_back(result);
     extractedInstances[instance.getModuleNameAttr().getAttr()].insert(instance);
 
     // Mark the instance and its forward dataflow to be erased from the pass.

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -202,6 +202,13 @@ module {
 // CHECK-NOT: hw.instance "child"
 // CHECK: hw.instance {{.+}} @ShouldBeInlined_cover
 
+// In MultiResultExtracted, instance qux should be extracted without leaving null operands to the extracted instance
+// CHECK-LABEL: @MultiResultExtracted_cover
+// CHECK: hw.instance "qux"
+// CHECK-LABEL: @MultiResultExtracted
+// CHECK-SAME: (%[[clock:.+]]: i1, %[[in:.+]]: i1)
+// CHECK: hw.instance {{.+}} @MultiResultExtracted_cover([[clock]]: %[[clock]]: i1, [[in]]: %[[in]]: i1)
+
 module attributes {
   firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
 } {
@@ -212,6 +219,8 @@ module attributes {
   hw.module.extern private @Bar(%a: i1) -> (b: i1)
 
   hw.module.extern private @Baz(%a: i1) -> (b: i1)
+
+  hw.module.extern private @Qux(%a: i1) -> (b: i1, c: i1)
 
   hw.module @AllExtracted(%clock: i1, %in: i1) {
     %foo.b = hw.instance "foo" @Foo(a: %in: i1) -> (b: i1)
@@ -257,5 +266,13 @@ module attributes {
 
   hw.module @ChildShouldInline(%clock: i1, %in: i1) {
     hw.instance "child" @ShouldBeInlined(clock: %clock: i1, in: %in: i1) -> ()
+  }
+
+  hw.module @MultiResultExtracted(%clock: i1, %in: i1) {
+    %qux.b, %qux.c = hw.instance "qux" @Qux(a: %in: i1) -> (b: i1, c: i1)
+    sv.always posedge %clock {
+      sv.cover %qux.b, immediate
+      sv.cover %qux.c, immediate
+    }
   }
 }


### PR DESCRIPTION
When we decide we can extract an instance, we must remove results of the instance from  the set of inputs to the extracted instance. Previously, we only removed one result at a time, as we iterated over the set of inputs. This is problematic when instances have multiple results, and all of them feed the test code. Because we add the instance to the test code set the first time we encounter one result and decide the instance should be extracted, the next iterations that visit the same instance do nothing, since we've already marked it for extraction.

The solution is simple: as soon as we've proved we can extract an instance, remove all of its results from the set of inputs to the extracted instance.