### PR TITLE
[LLHD] Update signal buffer loading to use LoadIntFromMemory helper.

### DIFF
--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -127,10 +127,8 @@ int Engine::simulate(int n, uint64_t maxTime) {
     while (i < e) {
       const auto sigIndex = pop.changes[i].first;
       auto &curr = state->signals[sigIndex];
-      APInt buff(
-          curr.getSize() * 8,
-          llvm::makeArrayRef(reinterpret_cast<uint64_t *>(curr.getValue()),
-                             llvm::divideCeil(curr.getSize(), 8)));
+      APInt buff(curr.getSize() * 8, 0);
+      llvm::LoadIntFromMemory(buff, curr.getValue(), curr.getSize());
 
       // Apply the changes to the buffer until we reach the next signal.
       while (i < e && pop.changes[i].first == sigIndex) {


### PR DESCRIPTION
This code is tripping ASAN warnings. Taking a suggestion from @youngar in the linked issue, it seems like there is a helper in LLVM to do what we want here. If I drop that suggestion in, the tests still pass and the ASAN warnings are fixed. I haven't thought about it deeply, but this seems to make sense. The comment suggested some concerns about handling big endian systems, which LoadIntFromMemory appears to already take into account.

Closes https://github.com/llvm/circt/issues/1071.