### PR TITLE
[HW] Refactor InstanceOp implementation to enable code reuse

### DIFF
--- a/include/circt/Dialect/HW/CustomDirectiveImpl.h
+++ b/include/circt/Dialect/HW/CustomDirectiveImpl.h
@@ -1,0 +1,83 @@
+//===- CustomDirectiveImpl.h - Table-gen custom directive impl --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides common custom directives for table-gen assembly formats.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_CUSTOMDIRECTIVEIMPL_H
+#define CIRCT_DIALECT_HW_CUSTOMDIRECTIVEIMPL_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace circt {
+
+//===----------------------------------------------------------------------===//
+// InputPortList Custom Directive
+//===----------------------------------------------------------------------===//
+
+/// Parse a list of instance input ports.
+/// input-list ::= `(` ( input-element (`,` input-element )* )? `)`
+/// input-element ::= identifier `:` value `:` type
+ParseResult
+parseInputPortList(OpAsmParser &parser,
+                   SmallVector<OpAsmParser::UnresolvedOperand, 4> &inputs,
+                   SmallVector<Type, 1> &inputTypes, ArrayAttr &inputNames);
+
+/// Print a list of instance input ports.
+void printInputPortList(OpAsmPrinter &p, Operation *op, OperandRange inputs,
+                        TypeRange inputTypes, ArrayAttr inputNames);
+
+//===----------------------------------------------------------------------===//
+// OutputPortList Custom Directive
+//===----------------------------------------------------------------------===//
+
+/// Parse a list of instance output ports.
+/// output-list ::= `(` ( output-element (`,` output-element )* )? `)`
+/// output-element ::= identifier `:` type
+ParseResult parseOutputPortList(OpAsmParser &parser,
+                                SmallVector<Type, 1> &resultTypes,
+                                ArrayAttr &resultNames);
+
+/// Print a list of instance output ports.
+void printOutputPortList(OpAsmPrinter &p, Operation *op, TypeRange resultTypes,
+                         ArrayAttr resultNames);
+
+//===----------------------------------------------------------------------===//
+// OptionalParameterList Custom Directive
+//===----------------------------------------------------------------------===//
+
+/// Parse an parameter list if present.
+/// module-parameter-list ::= `<` parameter-decl (`,` parameter-decl)* `>`
+/// parameter-decl ::= identifier `:` type
+/// parameter-decl ::= identifier `:` type `=` attribute
+ParseResult parseOptionalParameterList(OpAsmParser &parser,
+                                       ArrayAttr &parameters);
+
+/// Print a parameter list for a module or instance.
+void printOptionalParameterList(OpAsmPrinter &p, Operation *op,
+                                ArrayAttr parameters);
+
+//===----------------------------------------------------------------------===//
+// ImplicitSSAName Custom Directive
+//===----------------------------------------------------------------------===//
+
+inline ParseResult parseImplicitSSAName(OpAsmParser &parser,
+                                        StringAttr &nameAttr) {
+  nameAttr = parser.getBuilder().getStringAttr(parser.getResultName(0).first);
+  return success();
+}
+
+inline void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
+                                 StringAttr nameAttr) {}
+
+} // namespace circt
+
+#endif // CIRCT_DIALECT_HW_CUSTOMDIRECTIVEIMPL_H

--- a/include/circt/Dialect/HW/CustomDirectiveImpl.h
+++ b/include/circt/Dialect/HW/CustomDirectiveImpl.h
@@ -28,8 +28,8 @@ namespace circt {
 /// input-element ::= identifier `:` value `:` type
 ParseResult
 parseInputPortList(OpAsmParser &parser,
-                   SmallVector<OpAsmParser::UnresolvedOperand, 4> &inputs,
-                   SmallVector<Type, 1> &inputTypes, ArrayAttr &inputNames);
+                   SmallVectorImpl<OpAsmParser::UnresolvedOperand> &inputs,
+                   SmallVectorImpl<Type> &inputTypes, ArrayAttr &inputNames);
 
 /// Print a list of instance input ports.
 void printInputPortList(OpAsmPrinter &p, Operation *op, OperandRange inputs,
@@ -43,7 +43,7 @@ void printInputPortList(OpAsmPrinter &p, Operation *op, OperandRange inputs,
 /// output-list ::= `(` ( output-element (`,` output-element )* )? `)`
 /// output-element ::= identifier `:` type
 ParseResult parseOutputPortList(OpAsmParser &parser,
-                                SmallVector<Type, 1> &resultTypes,
+                                SmallVectorImpl<Type> &resultTypes,
                                 ArrayAttr &resultNames);
 
 /// Print a list of instance output ports.

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -187,6 +187,18 @@ LogicalResult checkParameterInContext(Attribute value, Operation *module,
                                       Operation *usingOp,
                                       bool disallowParamRefs = false);
 
+/// Check parameter specified by `value` to see if it is valid according to the
+/// module's parameters.  If not, emit an error to the diagnostic provided as an
+/// argument to the lambda 'instanceError' and return failure, otherwise return
+/// success.
+///
+/// If `disallowParamRefs` is true, then parameter references are not allowed.
+LogicalResult checkParameterInContext(
+    Attribute value, ArrayAttr moduleParameters,
+    const std::function<void(std::function<bool(InFlightDiagnostic &)>)>
+        &instanceError,
+    bool disallowParamRefs = false);
+
 /// Return the symbol (if exists, else null) on the corresponding input port
 /// argument.
 StringAttr getArgSym(Operation *op, unsigned i);

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -409,7 +409,7 @@ def InstanceOp : HWOp<"instance", [
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<SymbolNameAttr>:$inner_sym);
-  let results = (outs Variadic<AnyType>);
+  let results = (outs Variadic<AnyType>:$results);
 
   let builders = [
     /// Create a instance that refers to a known module.

--- a/include/circt/Dialect/HW/InstanceImplementation.h
+++ b/include/circt/Dialect/HW/InstanceImplementation.h
@@ -1,0 +1,107 @@
+//===- InstanceImplementation.h - Instance-like Op utilities ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides utility functions for implementing instance-like
+// operations, in particular, parsing, and printing common to instance-like
+// operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_INSTANCEIMPLEMENTATION_H
+#define CIRCT_DIALECT_HW_INSTANCEIMPLEMENTATION_H
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+namespace hw {
+// Forward declarations.
+class HWSymbolCache;
+
+namespace instance_like_impl {
+
+/// Whenever the nested function returns true, a note referring to the
+/// referenced module is attached to the error.
+using EmitErrorFn =
+    std::function<void(std::function<bool(InFlightDiagnostic &)>)>;
+
+/// Convenience function to query the input and result names of a HW module (as
+/// determined by 'hw::isAnyModule').
+std::pair<ArrayAttr, ArrayAttr> getHWModuleArgAndResultNames(Operation *module);
+
+/// Return a pointer to the referenced module operation.
+Operation *getReferencedModule(const HWSymbolCache *cache,
+                               Operation *instanceOp,
+                               mlir::FlatSymbolRefAttr moduleName);
+
+/// Verify that the instance refers to a valid HW module as determined by the
+/// 'hw::isAnyModule' function.
+LogicalResult verifyReferencedModule(Operation *instanceOp,
+                                     SymbolTableCollection &symbolTable,
+                                     mlir::FlatSymbolRefAttr moduleName,
+                                     Operation *&module);
+
+/// Stores a resolved version of each type in @param types wherein any parameter
+/// reference has been evaluated based on the set of provided @param parameters
+/// in @param resolvedTypes
+LogicalResult resolveParametricTypes(Location loc, ArrayAttr parameters,
+                                     ArrayRef<Type> types,
+                                     SmallVectorImpl<Type> &resolvedTypes,
+                                     const EmitErrorFn &emitError);
+
+/// Verify that the list of inputs of the instance and the module match in terms
+/// of length, names, and types.
+LogicalResult verifyInputs(ArrayAttr argNames, ArrayAttr moduleArgNames,
+                           TypeRange inputTypes,
+                           ArrayRef<Type> moduleInputTypes,
+                           const EmitErrorFn &emitError);
+
+/// Verify that the list of outputs of the instance and the module match in
+/// terms of length, names, and types.
+LogicalResult verifyOutputs(ArrayAttr resultNames, ArrayAttr moduleResultNames,
+                            TypeRange resultTypes,
+                            ArrayRef<Type> moduleResultTypes,
+                            const EmitErrorFn &emitError);
+
+/// Verify that the parameter lists of the instance and the module match in
+/// terms of length, names, and types.
+LogicalResult verifyParameters(ArrayAttr parameters, ArrayAttr moduleParameters,
+                               const EmitErrorFn &emitError);
+
+/// Combines verifyReferencedModule, verifyInputs, verifyOutputs, and
+/// verifyParameters. It is only allowed to call this function when the instance
+/// refers to a HW module. The @param parameters attribute may be null in which
+/// case not parameters are verified.
+LogicalResult verifyInstanceOfHWModule(
+    Operation *instance, FlatSymbolRefAttr moduleRef, OperandRange inputs,
+    TypeRange results, ArrayAttr argNames, ArrayAttr resultNames,
+    ArrayAttr parameters, SymbolTableCollection &symbolTable);
+
+/// Check that all the parameter values specified to the instance are
+/// structurally valid.
+LogicalResult verifyParameterStructure(ArrayAttr parameters,
+                                       ArrayAttr moduleParameters,
+                                       const EmitErrorFn &emitError);
+
+/// Return the name at the specified index of the ArrayAttr or null if it cannot
+/// be determined.
+StringAttr getName(ArrayAttr names, size_t idx);
+
+/// Change the name at the specified index of the @param oldNames ArrayAttr to
+/// @param name
+ArrayAttr updateName(ArrayAttr oldNames, size_t i, StringAttr name);
+
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void getAsmResultNames(OpAsmSetValueNameFn setNameFn, StringRef instanceName,
+                       ArrayAttr resultNames, ValueRange results);
+
+} // namespace instance_like_impl
+} // namespace hw
+} // namespace circt
+
+#endif // CIRCT_DIALECT_HW_INSTANCEIMPLEMENTATION_H

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(
   CIRCTHW
+  CustomDirectiveImpl.cpp
   HWAttributes.cpp
   HWDialect.cpp
   HWInstanceGraph.cpp
@@ -7,6 +8,7 @@ add_circt_dialect_library(
   HWOps.cpp
   HWTypes.cpp
   InstanceGraphBase.cpp
+  InstanceImplementation.cpp
   ModuleImplementation.cpp
   
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/HW/CustomDirectiveImpl.cpp
+++ b/lib/Dialect/HW/CustomDirectiveImpl.cpp
@@ -1,0 +1,137 @@
+//===- CustomDirectiveImpl.cpp - Custom directive definitions -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/CustomDirectiveImpl.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+
+using namespace circt;
+using namespace circt::hw;
+
+ParseResult circt::parseInputPortList(
+    OpAsmParser &parser, SmallVector<OpAsmParser::UnresolvedOperand, 4> &inputs,
+    SmallVector<Type, 1> &inputTypes, ArrayAttr &inputNames) {
+
+  SmallVector<Attribute> argNames;
+  auto parseInputPort = [&]() -> ParseResult {
+    std::string portName;
+    if (parser.parseKeywordOrString(&portName))
+      return failure();
+    argNames.push_back(StringAttr::get(parser.getContext(), portName));
+    inputs.push_back({});
+    inputTypes.push_back({});
+    return failure(parser.parseColon() || parser.parseOperand(inputs.back()) ||
+                   parser.parseColon() || parser.parseType(inputTypes.back()));
+  };
+  llvm::SMLoc inputsOperandsLoc;
+  if (parser.getCurrentLocation(&inputsOperandsLoc) ||
+      parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren,
+                                     parseInputPort))
+    return failure();
+
+  inputNames = ArrayAttr::get(parser.getContext(), argNames);
+
+  return success();
+}
+
+void circt::printInputPortList(OpAsmPrinter &p, Operation *op,
+                               OperandRange inputs, TypeRange inputTypes,
+                               ArrayAttr inputNames) {
+  p << "(";
+  llvm::interleaveComma(llvm::zip(inputs, inputNames), p, [&](auto input) {
+    Value val = std::get<0>(input);
+    p.printKeywordOrString(
+        std::get<1>(input).template cast<StringAttr>().getValue());
+    p << ": " << val << ": " << val.getType();
+  });
+  p << ")";
+}
+
+ParseResult circt::parseOutputPortList(OpAsmParser &parser,
+                                       SmallVector<Type, 1> &resultTypes,
+                                       ArrayAttr &resultNames) {
+
+  SmallVector<Attribute> names;
+  auto parseResultPort = [&]() -> ParseResult {
+    std::string portName;
+    if (parser.parseKeywordOrString(&portName))
+      return failure();
+    names.push_back(StringAttr::get(parser.getContext(), portName));
+    resultTypes.push_back({});
+    return parser.parseColonType(resultTypes.back());
+  };
+  llvm::SMLoc inputsOperandsLoc;
+  if (parser.getCurrentLocation(&inputsOperandsLoc) ||
+      parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren,
+                                     parseResultPort))
+    return failure();
+
+  resultNames = ArrayAttr::get(parser.getContext(), names);
+
+  return success();
+}
+
+void circt::printOutputPortList(OpAsmPrinter &p, Operation *op,
+                                TypeRange resultTypes, ArrayAttr resultNames) {
+  p << "(";
+  llvm::interleaveComma(
+      llvm::zip(resultTypes, resultNames), p, [&](auto result) {
+        p.printKeywordOrString(
+            std::get<1>(result).template cast<StringAttr>().getValue());
+        p << ": " << std::get<0>(result);
+      });
+  p << ")";
+}
+
+ParseResult circt::parseOptionalParameterList(OpAsmParser &parser,
+                                              ArrayAttr &parameters) {
+  SmallVector<Attribute> params;
+  if (failed(parser.parseCommaSeparatedList(
+          OpAsmParser::Delimiter::OptionalLessGreater, [&]() {
+            std::string name;
+            Type type;
+            Attribute value;
+
+            if (parser.parseKeywordOrString(&name) ||
+                parser.parseColonType(type))
+              return failure();
+
+            // Parse the default value if present.
+            if (succeeded(parser.parseOptionalEqual())) {
+              if (parser.parseAttribute(value, type))
+                return failure();
+            }
+
+            auto &builder = parser.getBuilder();
+            params.push_back(ParamDeclAttr::get(builder.getContext(),
+                                                builder.getStringAttr(name),
+                                                type, value));
+            return success();
+          })))
+    return failure();
+
+  parameters = ArrayAttr::get(parser.getContext(), params);
+
+  return success();
+}
+
+void circt::printOptionalParameterList(OpAsmPrinter &p, Operation *op,
+                                       ArrayAttr parameters) {
+  if (parameters.empty())
+    return;
+
+  p << '<';
+  llvm::interleaveComma(parameters, p, [&](Attribute param) {
+    auto paramAttr = param.cast<ParamDeclAttr>();
+    p << paramAttr.getName().getValue() << ": " << paramAttr.getType();
+    if (auto value = paramAttr.getValue()) {
+      p << " = ";
+      p.printAttributeWithoutType(value);
+    }
+  });
+  p << '>';
+}

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -189,7 +189,7 @@ LogicalResult hw::checkParameterInContext(Attribute value, Operation *module,
                                           Operation *usingOp,
                                           bool disallowParamRefs) {
   instance_like_impl::EmitErrorFn emitError =
-      [&](std::function<bool(InFlightDiagnostic &)> fn) {
+      [&](const std::function<bool(InFlightDiagnostic &)> &fn) {
         if (usingOp) {
           auto diag = usingOp->emitOpError();
           if (fn(diag))
@@ -1261,7 +1261,7 @@ LogicalResult InstanceOp::verify() {
   auto module = (*this)->getParentOfType<HWModuleOp>();
   auto moduleParameters = module->getAttrOfType<ArrayAttr>("parameters");
   instance_like_impl::EmitErrorFn emitError =
-      [&](std::function<bool(InFlightDiagnostic &)> fn) {
+      [&](const std::function<bool(InFlightDiagnostic &)> &fn) {
         auto diag = emitOpError();
         if (fn(diag))
           diag.attachNote(module->getLoc()) << "module declared here";

--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -233,7 +233,7 @@ LogicalResult instance_like_impl::verifyInstanceOfHWModule(
   // is being referenced. The error message on the instance is added by the
   // verification function this lambda is passed to.
   EmitErrorFn emitError =
-      [&](std::function<bool(InFlightDiagnostic & diag)> fn) {
+      [&](const std::function<bool(InFlightDiagnostic & diag)> &fn) {
         auto diag = instance->emitOpError();
         if (fn(diag))
           diag.attachNote(module->getLoc()) << "module declared here";

--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -1,0 +1,358 @@
+//===- InstanceImplementation.cpp - Utilities for instance-like ops -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/InstanceImplementation.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWSymCache.h"
+
+using namespace circt;
+using namespace circt::hw;
+
+std::pair<ArrayAttr, ArrayAttr>
+instance_like_impl::getHWModuleArgAndResultNames(Operation *module) {
+  assert(isAnyModule(module) && "Can only reference a module");
+
+  return {module->getAttrOfType<ArrayAttr>("argNames"),
+          module->getAttrOfType<ArrayAttr>("resultNames")};
+}
+
+Operation *
+instance_like_impl::getReferencedModule(const HWSymbolCache *cache,
+                                        Operation *instanceOp,
+                                        mlir::FlatSymbolRefAttr moduleName) {
+  if (cache)
+    if (auto *result = cache->getDefinition(moduleName))
+      return result;
+
+  auto topLevelModuleOp = instanceOp->getParentOfType<ModuleOp>();
+  return topLevelModuleOp.lookupSymbol(moduleName.getValue());
+}
+
+LogicalResult instance_like_impl::verifyReferencedModule(
+    Operation *instanceOp, SymbolTableCollection &symbolTable,
+    mlir::FlatSymbolRefAttr moduleName, Operation *&module) {
+  module = symbolTable.lookupNearestSymbolFrom(instanceOp, moduleName);
+  if (module == nullptr)
+    return instanceOp->emitError("Cannot find module definition '")
+           << moduleName.getValue() << "'";
+
+  // It must be some sort of module.
+  if (!hw::isAnyModule(module))
+    return instanceOp->emitError("symbol reference '")
+           << moduleName.getValue() << "' isn't a module";
+
+  return success();
+}
+
+LogicalResult instance_like_impl::resolveParametricTypes(
+    Location loc, ArrayAttr parameters, ArrayRef<Type> types,
+    SmallVectorImpl<Type> &resolvedTypes, const EmitErrorFn &emitError) {
+  for (auto type : types) {
+    auto expectedType = evaluateParametricType(loc, parameters, type);
+    if (failed(expectedType)) {
+      emitError([&](auto &diag) {
+        diag << "failed to resolve parametric input of instantiated module";
+        return true;
+      });
+      return failure();
+    }
+
+    resolvedTypes.push_back(*expectedType);
+  }
+
+  return success();
+}
+
+LogicalResult instance_like_impl::verifyInputs(ArrayAttr argNames,
+                                               ArrayAttr moduleArgNames,
+                                               TypeRange inputTypes,
+                                               ArrayRef<Type> moduleInputTypes,
+                                               const EmitErrorFn &emitError) {
+  // Check operand types first.
+  if (moduleInputTypes.size() != inputTypes.size()) {
+    emitError([&](auto &diag) {
+      diag << "has a wrong number of operands; expected "
+           << moduleInputTypes.size() << " but got " << inputTypes.size();
+      return true;
+    });
+    return failure();
+  }
+
+  if (argNames.size() != inputTypes.size()) {
+    emitError([&](auto &diag) {
+      diag << "has a wrong number of input port names; expected "
+           << inputTypes.size() << " but got " << argNames.size();
+      return true;
+    });
+    return failure();
+  }
+
+  for (size_t i = 0; i != inputTypes.size(); ++i) {
+    auto expectedType = moduleInputTypes[i];
+    auto operandType = inputTypes[i];
+
+    if (operandType != expectedType) {
+      emitError([&](auto &diag) {
+        diag << "operand type #" << i << " must be " << expectedType
+             << ", but got " << operandType;
+        return true;
+      });
+      return failure();
+    }
+
+    if (argNames[i] != moduleArgNames[i]) {
+      emitError([&](auto &diag) {
+        diag << "input label #" << i << " must be " << moduleArgNames[i]
+             << ", but got " << argNames[i];
+        return true;
+      });
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult instance_like_impl::verifyOutputs(
+    ArrayAttr resultNames, ArrayAttr moduleResultNames, TypeRange resultTypes,
+    ArrayRef<Type> moduleResultTypes, const EmitErrorFn &emitError) {
+  // Check result types and labels.
+  if (moduleResultTypes.size() != resultTypes.size()) {
+    emitError([&](auto &diag) {
+      diag << "has a wrong number of results; expected "
+           << moduleResultTypes.size() << " but got " << resultTypes.size();
+      return true;
+    });
+    return failure();
+  }
+
+  if (resultNames.size() != resultTypes.size()) {
+    emitError([&](auto &diag) {
+      diag << "has a wrong number of results port labels; expected "
+           << resultTypes.size() << " but got " << resultNames.size();
+      return true;
+    });
+    return failure();
+  }
+
+  for (size_t i = 0; i != resultTypes.size(); ++i) {
+    auto expectedType = moduleResultTypes[i];
+    auto resultType = resultTypes[i];
+
+    if (resultType != expectedType) {
+      emitError([&](auto &diag) {
+        diag << "result type #" << i << " must be " << expectedType
+             << ", but got " << resultType;
+        return true;
+      });
+      return failure();
+    }
+
+    if (resultNames[i] != moduleResultNames[i]) {
+      emitError([&](auto &diag) {
+        diag << "input label #" << i << " must be " << moduleResultNames[i]
+             << ", but got " << resultNames[i];
+        return true;
+      });
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult
+instance_like_impl::verifyParameters(ArrayAttr parameters,
+                                     ArrayAttr moduleParameters,
+                                     const EmitErrorFn &emitError) {
+  // Check parameters match up.
+  auto numParameters = parameters.size();
+  if (numParameters != moduleParameters.size()) {
+    emitError([&](auto &diag) {
+      diag << "expected " << moduleParameters.size() << " parameters but had "
+           << numParameters;
+      return true;
+    });
+    return failure();
+  }
+
+  for (size_t i = 0; i != numParameters; ++i) {
+    auto param = parameters[i].cast<ParamDeclAttr>();
+    auto modParam = moduleParameters[i].cast<ParamDeclAttr>();
+
+    auto paramName = param.getName();
+    if (paramName != modParam.getName()) {
+      emitError([&](auto &diag) {
+        diag << "parameter #" << i << " should have name " << modParam.getName()
+             << " but has name " << paramName;
+        return true;
+      });
+      return failure();
+    }
+
+    if (param.getType() != modParam.getType()) {
+      emitError([&](auto &diag) {
+        diag << "parameter " << paramName << " should have type "
+             << modParam.getType() << " but has type " << param.getType();
+        return true;
+      });
+      return failure();
+    }
+
+    // All instance parameters must have a value.  Specify the same value as
+    // a module's default value if you want the default.
+    if (!param.getValue()) {
+      emitError([&](auto &diag) {
+        diag << "parameter " << paramName << " must have a value";
+        return false;
+      });
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult instance_like_impl::verifyInstanceOfHWModule(
+    Operation *instance, FlatSymbolRefAttr moduleRef, OperandRange inputs,
+    TypeRange results, ArrayAttr argNames, ArrayAttr resultNames,
+    ArrayAttr parameters, SymbolTableCollection &symbolTable) {
+  // Verify that we reference some kind of HW module and get the module on
+  // success.
+  Operation *module;
+  if (failed(instance_like_impl::verifyReferencedModule(instance, symbolTable,
+                                                        moduleRef, module)))
+    return failure();
+
+  // Emit an error message on the instance, with a note indicating which module
+  // is being referenced. The error message on the instance is added by the
+  // verification function this lambda is passed to.
+  EmitErrorFn emitError =
+      [&](std::function<bool(InFlightDiagnostic & diag)> fn) {
+        auto diag = instance->emitOpError();
+        if (fn(diag))
+          diag.attachNote(module->getLoc()) << "module declared here";
+      };
+
+  // Check that input types are consistent with the referenced module.
+  auto [modArgNames, modResultNames] =
+      instance_like_impl::getHWModuleArgAndResultNames(module);
+
+  ArrayRef<Type> resolvedModInputTypesRef = getModuleType(module).getInputs();
+  SmallVector<Type> resolvedModInputTypes;
+  if (parameters) {
+    if (failed(instance_like_impl::resolveParametricTypes(
+            instance->getLoc(), parameters, getModuleType(module).getInputs(),
+            resolvedModInputTypes, emitError)))
+      return failure();
+    resolvedModInputTypesRef = resolvedModInputTypes;
+  }
+  if (failed(instance_like_impl::verifyInputs(
+          argNames, modArgNames, inputs.getTypes(), resolvedModInputTypesRef,
+          emitError)))
+    return failure();
+
+  // Check that result types are consistent with the referenced module.
+  ArrayRef<Type> resolvedModResultTypesRef = getModuleType(module).getResults();
+  SmallVector<Type> resolvedModResultTypes;
+  if (parameters) {
+    if (failed(instance_like_impl::resolveParametricTypes(
+            instance->getLoc(), parameters, getModuleType(module).getResults(),
+            resolvedModResultTypes, emitError)))
+      return failure();
+    resolvedModResultTypesRef = resolvedModResultTypes;
+  }
+  if (failed(instance_like_impl::verifyOutputs(
+          resultNames, modResultNames, results, resolvedModResultTypesRef,
+          emitError)))
+    return failure();
+
+  if (parameters) {
+    // Check that the parameters are consistent with the referenced module.
+    ArrayAttr modParameters = module->getAttrOfType<ArrayAttr>("parameters");
+    if (failed(instance_like_impl::verifyParameters(parameters, modParameters,
+                                                    emitError)))
+      return failure();
+  }
+
+  return success();
+}
+
+LogicalResult
+instance_like_impl::verifyParameterStructure(ArrayAttr parameters,
+                                             ArrayAttr moduleParameters,
+                                             const EmitErrorFn &emitError) {
+  // Check that all the parameter values specified to the instance are
+  // structurally valid.
+  for (auto param : parameters) {
+    auto paramAttr = param.cast<ParamDeclAttr>();
+    auto value = paramAttr.getValue();
+    // The SymbolUses verifier which checks that this exists may not have been
+    // run yet. Let it issue the error.
+    if (!value)
+      continue;
+
+    auto typedValue = value.dyn_cast<mlir::TypedAttr>();
+    if (!typedValue) {
+      emitError([&](auto &diag) {
+        diag << "parameter " << paramAttr
+             << " should have a typed value; has value " << value;
+        return false;
+      });
+      return failure();
+    }
+
+    if (typedValue.getType() != paramAttr.getType()) {
+      emitError([&](auto &diag) {
+        diag << "parameter " << paramAttr << " should have type "
+             << paramAttr.getType() << "; has type " << typedValue.getType();
+        return false;
+      });
+      return failure();
+    }
+
+    if (failed(checkParameterInContext(value, moduleParameters, emitError)))
+      return failure();
+  }
+  return success();
+}
+
+StringAttr instance_like_impl::getName(ArrayAttr names, size_t idx) {
+  // Tolerate malformed IR here to enable debug printing etc.
+  if (names && idx < names.size())
+    return names[idx].cast<StringAttr>();
+  return StringAttr();
+}
+
+ArrayAttr instance_like_impl::updateName(ArrayAttr oldNames, size_t i,
+                                         StringAttr name) {
+  SmallVector<Attribute> newNames(oldNames.begin(), oldNames.end());
+  if (newNames[i] == name)
+    return oldNames;
+  newNames[i] = name;
+  return ArrayAttr::get(oldNames.getContext(), oldNames);
+}
+
+void instance_like_impl::getAsmResultNames(OpAsmSetValueNameFn setNameFn,
+                                           StringRef instanceName,
+                                           ArrayAttr resultNames,
+                                           ValueRange results) {
+  // Provide default names for instance results.
+  std::string name = instanceName.str() + ".";
+  size_t baseNameLen = name.size();
+
+  for (size_t i = 0, e = resultNames.size(); i != e; ++i) {
+    auto resName = getName(resultNames, i);
+    name.resize(baseNameLen);
+    if (resName && !resName.getValue().empty())
+      name += resName.getValue().str();
+    else
+      name += std::to_string(i);
+    setNameFn(results[i], name);
+  }
+}

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/SystemC/SystemCOps.h"
+#include "circt/Dialect/HW/CustomDirectiveImpl.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/ModuleImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
@@ -18,19 +19,6 @@
 
 using namespace circt;
 using namespace circt::systemc;
-
-//===----------------------------------------------------------------------===//
-// ImplicitSSAName Custom Directive
-//===----------------------------------------------------------------------===//
-
-static ParseResult parseImplicitSSAName(OpAsmParser &parser,
-                                        StringAttr &nameAttr) {
-  nameAttr = parser.getBuilder().getStringAttr(parser.getResultName(0).first);
-  return success();
-}
-
-static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
-                                 StringAttr nameAttr) {}
 
 //===----------------------------------------------------------------------===//
 // SCModuleOp


### PR DESCRIPTION
Move implementation code of the InstanceOp to a new InstanceImplementation file such that it can be included and reused in other dialects that need to implement a similar instance operation. It tries to extract code parts in a way that basic checks like same length of operand and argNames arrays, matching types, etc. are performed in a way that it does not need to know about the module or instance operations and thus are also applicable in more generic cases. However, it also provides functions that require the instantiated module to be a HW module and thus allow for more code reuse for instance operations that can only refer to those.
Useful custom directives for table-gen assembly formats are collected in a separate file that should only be included in cpp files, while the InstanceImplementation could also be included in the header file.