### PR TITLE
[SystemC] Add interop.verilated operation

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCOps.h
+++ b/include/circt/Dialect/SystemC/SystemCOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_SYSTEMC_SYSTEMCOPS_H
 
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/InstanceImplementation.h"
 #include "circt/Dialect/SystemC/SystemCAttributes.h"
 #include "circt/Dialect/SystemC/SystemCDialect.h"
 #include "circt/Dialect/SystemC/SystemCOpInterfaces.h"

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -173,6 +173,102 @@ def SCFuncOp : SystemCOp<"func", [
 }
 
 //===----------------------------------------------------------------------===//
+// Interoperability operations
+//===----------------------------------------------------------------------===//
+
+def InteropVerilatedOp : SystemCOp<"interop.verilated", [
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Instantiates a verilated module.";
+  let description = [{
+    Instantiates a verilated module represented by a hw.module operation
+    (usually the extern variant).
+
+    This operation also encodes the interoparability layer to connect its
+    context (i.e. the surrounding operation, input values, result values, and
+    types) to the C++ code of the verilated module.
+    When residing in a context that understands C++ (e.g., inside a SystemC
+    module), this refers to the instantiation of the class, assignment of the
+    input ports, the call to the eval() function and reading the output ports.
+
+    Additionally, properties of the verilated module can be specified in
+    a config attribute which influences the interop layer code generation
+    (not yet implemented).
+  }];
+
+  let arguments = (ins StrAttr:$instanceName,
+                       FlatSymbolRefAttr:$moduleName,
+                       StrArrayAttr:$inputNames,
+                       StrArrayAttr:$resultNames,
+                       Variadic<AnyType>:$inputs);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let builders = [
+    /// Create a instance that refers to a known module.
+    OpBuilder<(ins "Operation*":$module, "StringAttr":$name,
+                   "ArrayRef<Value>":$inputs)>,
+    /// Create a instance that refers to a known module.
+    OpBuilder<(ins "Operation*":$module, "StringRef":$name,
+                   "ArrayRef<Value>":$inputs), [{
+      build($_builder, $_state, module, $_builder.getStringAttr(name), inputs);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the name of the specified input port or null if it cannot be
+    /// determined.
+    StringAttr getInputName(size_t i) {
+      return hw::instance_like_impl::getName(getInputNames(), i);
+    }
+
+    /// Return the name of the specified result or null if it cannot be
+    /// determined.
+    StringAttr getResultName(size_t i) {
+      return hw::instance_like_impl::getName(getResultNames(), i);
+    }
+
+    /// Change the name of the specified input port.
+    void setInputName(size_t i, StringAttr name) {
+      setInputNamesAttr(
+        hw::instance_like_impl::updateName(getInputNames(), i, name));
+    }
+
+    /// Change the name of the specified output port.
+    void setResultName(size_t i, StringAttr name) {
+      setResultNamesAttr(
+        hw::instance_like_impl::updateName(getResultNames(), i, name));
+    }
+
+    /// Lookup the module or extmodule for the symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedModule(const hw::HWSymbolCache *cache) {
+      return hw::instance_like_impl::getReferencedModule(cache, *this,
+                                                        getModuleNameAttr());
+    }
+    Operation *getReferencedModule() { return getReferencedModule(nullptr); }
+
+    /// Get the instances's name.
+    StringAttr getName() { return getInstanceNameAttr(); }
+
+    /// Set the instance's name.
+    void setName(StringAttr name) { setInstanceNameAttr(name); }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// An InstanceOp may optionally define a symbol.
+    bool isOptionalSymbol() { return true; }
+  }];
+
+  let assemblyFormat = [{
+    $instanceName $moduleName
+    custom<InputPortList>($inputs, type($inputs), $inputNames) `->`
+    custom<OutputPortList>(type($results), $resultNames) attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Operations that model C++-level features.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -155,7 +155,7 @@ LogicalResult instance_like_impl::verifyOutputs(
 
     if (resultNames[i] != moduleResultNames[i]) {
       emitError([&](auto &diag) {
-        diag << "input label #" << i << " must be " << moduleResultNames[i]
+        diag << "result label #" << i << " must be " << moduleResultNames[i]
              << ", but got " << resultNames[i];
         return true;
       });

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -591,6 +591,35 @@ LogicalResult VariableOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// InteropVerilatedOp
+//===----------------------------------------------------------------------===//
+
+/// Create a instance that refers to a known module.
+void InteropVerilatedOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                               Operation *module, StringAttr name,
+                               ArrayRef<Value> inputs) {
+  auto [argNames, resultNames] =
+      hw::instance_like_impl::getHWModuleArgAndResultNames(module);
+  build(odsBuilder, odsState, hw::getModuleType(module).getResults(), name,
+        FlatSymbolRefAttr::get(SymbolTable::getSymbolName(module)), argNames,
+        resultNames, inputs);
+}
+
+LogicalResult
+InteropVerilatedOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return hw::instance_like_impl::verifyInstanceOfHWModule(
+      *this, getModuleNameAttr(), getInputs(), getResultTypes(),
+      getInputNames(), getResultNames(), ArrayAttr(), symbolTable);
+}
+
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void InteropVerilatedOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  hw::instance_like_impl::getAsmResultNames(setNameFn, getInstanceName(),
+                                            getResultNames(), getResults());
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -329,6 +329,36 @@ module {
 
 // -----
 
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongResultLabel() {
+  // expected-error @+1 {{result label #0 must be "out0", but got "o"}}
+  %inst0.out0 = hw.instance "inst0" @submodule () -> (o: i32)
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongNumberOfResultNames() {
+  // expected-error @+1 {{has a wrong number of results port labels; expected 1 but got 0}}
+  "hw.instance"() {instanceName="inst0", moduleName=@submodule, argNames=[], resultNames=[], parameters=[]} : () -> i32
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule (%arg0: i32) -> ()
+
+hw.module @wrongNumberOfInputNames(%arg0: i32) {
+  // expected-error @+1 {{has a wrong number of input port names; expected 1 but got 0}}
+  "hw.instance"(%arg0) {instanceName="inst0", moduleName=@submodule, argNames=[], resultNames=[], parameters=[]} : (i32) -> ()
+}
+
+// -----
+
 // expected-error @+1 {{unsupported dimension kind in hw.array}}
 hw.module @bab<param: i32, N: i32> ( %array2d: !hw.array<i3 x i4>) {}
 

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -385,96 +385,11 @@ func.func @invalidType (%arg0: !systemc.value_base>) {}
 
 // -----
 
+// Check that the verifySymbolUses function calls the instance impl library
+
 systemc.module @submodule () { }
 
 hw.module @verilatedCannotReferenceNonHWModule() {
   // expected-error @+1 {{symbol reference 'submodule' isn't a module}}
   systemc.interop.verilated "verilated" @submodule () -> ()
-}
-
-// -----
-
-hw.module @referenceNonExistentSymbol() {
-  // expected-error @+1 {{Cannot find module definition 'submodule'}}
-  systemc.interop.verilated "verilated" @submodule () -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule (%arg0: i32) -> ()
-
-hw.module @wrongNumberOfOperands() {
-  // expected-error @+1 {{op has a wrong number of operands; expected 1 but got 0}}
-  systemc.interop.verilated "verilated" @submodule () -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule (%arg0: i32) -> ()
-
-hw.module @wrongNumberOfInputNames(%arg0: i32) {
-  // expected-error @+1 {{has a wrong number of input port names; expected 1 but got 0}}
-  "systemc.interop.verilated"(%arg0) {instanceName="verilated", moduleName=@submodule, inputNames=[], resultNames=[]} : (i32) -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule (%arg0: i32) -> ()
-
-hw.module @wrongOperandType(%arg0: i8) {
-  // expected-error @+1 {{operand type #0 must be 'i32', but got 'i8'}}
-  systemc.interop.verilated "verilated" @submodule (arg0: %arg0: i8) -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule (%arg0: i32) -> ()
-
-hw.module @wrongOperandLabel(%arg0: i32) {
-  // expected-error @+1 {{input label #0 must be "arg0", but got "a"}}
-  systemc.interop.verilated "verilated" @submodule (a: %arg0: i32) -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule () -> (out0: i32)
-
-hw.module @wrongNumResults() {
-  // expected-error @+1 {{has a wrong number of results; expected 1 but got 0}}
-  systemc.interop.verilated "verilated" @submodule () -> ()
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule () -> (out0: i32)
-
-hw.module @wrongResultType() {
-  // expected-error @+1 {{result type #0 must be 'i32', but got 'i8'}}
-  %verilated.out0 = systemc.interop.verilated "verilated" @submodule () -> (out0: i8)
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule () -> (out0: i32)
-
-hw.module @wrongNumberOfResultNames() {
-  // expected-error @+1 {{has a wrong number of results port labels; expected 1 but got 0}}
-  "systemc.interop.verilated"() {instanceName="verilated", moduleName=@submodule, inputNames=[], resultNames=[]} : () -> i32
-}
-
-// -----
-
-// expected-note @+1 {{module declared here}}
-hw.module.extern @submodule () -> (out0: i32)
-
-hw.module @wrongResultLabel() {
-  // expected-error @+1 {{input label #0 must be "out0", but got "o"}}
-  %verilated.out0 = systemc.interop.verilated "verilated" @submodule () -> (o: i32)
 }

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -382,3 +382,99 @@ systemc.module @variableNameCollision () {
 
 // expected-error @+1 {{unknown type `value_base` in dialect `systemc`}}
 func.func @invalidType (%arg0: !systemc.value_base>) {}
+
+// -----
+
+systemc.module @submodule () { }
+
+hw.module @verilatedCannotReferenceNonHWModule() {
+  // expected-error @+1 {{symbol reference 'submodule' isn't a module}}
+  systemc.interop.verilated "verilated" @submodule () -> ()
+}
+
+// -----
+
+hw.module @referenceNonExistentSymbol() {
+  // expected-error @+1 {{Cannot find module definition 'submodule'}}
+  systemc.interop.verilated "verilated" @submodule () -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule (%arg0: i32) -> ()
+
+hw.module @wrongNumberOfOperands() {
+  // expected-error @+1 {{op has a wrong number of operands; expected 1 but got 0}}
+  systemc.interop.verilated "verilated" @submodule () -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule (%arg0: i32) -> ()
+
+hw.module @wrongNumberOfInputNames(%arg0: i32) {
+  // expected-error @+1 {{has a wrong number of input port names; expected 1 but got 0}}
+  "systemc.interop.verilated"(%arg0) {instanceName="verilated", moduleName=@submodule, inputNames=[], resultNames=[]} : (i32) -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule (%arg0: i32) -> ()
+
+hw.module @wrongOperandType(%arg0: i8) {
+  // expected-error @+1 {{operand type #0 must be 'i32', but got 'i8'}}
+  systemc.interop.verilated "verilated" @submodule (arg0: %arg0: i8) -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule (%arg0: i32) -> ()
+
+hw.module @wrongOperandLabel(%arg0: i32) {
+  // expected-error @+1 {{input label #0 must be "arg0", but got "a"}}
+  systemc.interop.verilated "verilated" @submodule (a: %arg0: i32) -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongNumResults() {
+  // expected-error @+1 {{has a wrong number of results; expected 1 but got 0}}
+  systemc.interop.verilated "verilated" @submodule () -> ()
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongResultType() {
+  // expected-error @+1 {{result type #0 must be 'i32', but got 'i8'}}
+  %verilated.out0 = systemc.interop.verilated "verilated" @submodule () -> (out0: i8)
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongNumberOfResultNames() {
+  // expected-error @+1 {{has a wrong number of results port labels; expected 1 but got 0}}
+  "systemc.interop.verilated"() {instanceName="verilated", moduleName=@submodule, inputNames=[], resultNames=[]} : () -> i32
+}
+
+// -----
+
+// expected-note @+1 {{module declared here}}
+hw.module.extern @submodule () -> (out0: i32)
+
+hw.module @wrongResultLabel() {
+  // expected-error @+1 {{input label #0 must be "out0", but got "o"}}
+  %verilated.out0 = systemc.interop.verilated "verilated" @submodule () -> (o: i32)
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -146,3 +146,18 @@ systemc.module @member_access () {
     %1 = systemc.cpp.member_access %ptrmember arrow "clear" : (!emitc.ptr<!emitc.opaque<"std::vector<int>">>) -> (() -> ())
   }
 }
+
+hw.module.extern @inst() -> ()
+hw.module.extern @instWithArgs(%a: i32, %b: i8) -> (c: i32, d: i8)
+
+// CHECK-LABEL: @verilatorInteropInHwModule
+hw.module @verilatorInteropInHwModule(%arg0: i32, %arg1: i8) -> () {
+  // CHECK-NEXT: %verilated.c, %verilated.d = systemc.interop.verilated "verilated" @instWithArgs (a: %arg0: i32, b: %arg1: i8) -> (c: i32, d: i8)
+  %verilated.c, %verilated.d = systemc.interop.verilated "verilated" @instWithArgs (a: %arg0: i32, b: %arg1: i8) -> (c: i32, d: i8)
+}
+
+// CHECK-LABEL: @verilatorInteropInSystemCModule
+systemc.module @verilatorInteropInSystemCModule() {
+  // CHECK-NEXT: systemc.interop.verilated "verilated" @inst () -> ()
+  systemc.interop.verilated "verilated" @inst () -> ()
+}


### PR DESCRIPTION
This operation instantiates a hw module that is or will be verilated and allows to generate the necessary interoperability layer to talk to the verilated module in various contexts, i.e., in a SystemC module, a Verilog module, inside a CIRCT based simulator, etc. Having a separate instance operation avoids transformations performed on the regular hw instance such as inlining, etc. and allows to add more attributes to specify the configuration under which the instantiated module was verilated.