### PR TITLE
[SV] Fix SVExtractTestCode to not duplicate when inlining.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -507,9 +507,11 @@ private:
                                    bindFile, bindTable);
     // do the clone
     migrateOps(module, bmod, opsToClone, cutMap);
-    // erase old operations of interest
-    for (auto *op : roots)
-      opsToErase.insert(op);
+    // erase old operations of interest eagerly, removing from erase set.
+    for (auto *op : roots) {
+      opsToErase.erase(op);
+      op->erase();
+    }
 
     return true;
   }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -146,6 +146,7 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // CHECK: hw.instance "{{[^ ]+}}" sym @[[input_only_assert:[^ ]+]] @InputOnly_assert
 // CHECK: hw.instance "{{[^ ]+}}" sym @[[input_only_cover:[^ ]+]] @InputOnly_cover
 // CHECK: hw.instance "{{[^ ]+}}" {{.+}} @InputOnlySym
+// CHECK-NOT: hw.instance {{.+}} @Top{{.*}}
 // CHECK-NOT: sv.bind <@InputOnly::
 // CHECK-DAG: sv.bind <@Top::@[[input_only_assert]]>
 // CHECK-DAG: sv.bind <@Top::@[[input_only_cover]]>


### PR DESCRIPTION
We previously switched from eagerly erasing ops to clean up to lazily doing so after all IR mutations to fix a bug. This is important for any instances we extract and their forward dataflow, but as part of that change we also made the erasure of test code roots themselves lazy (the assert, assume, and cover statements). This causes issues in case any module with test code gets inlined later; the test code roots are revisited, extracted again, and duplicated. This is illegal, because some test code may include side effects, like printing to the console.

The solution is simple: make sure to eagerly erase all test code roots, and remove them from the set of ops to erase lazily, if they were reachable from an instance that is being extracted. The latter change is to prevent doubly erasing the same op.