### PR TITLE
[llhd-sim] Fix: reference binding to misaligned address

### DIFF
--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1552,6 +1552,9 @@ struct DrvOpConversion : public ConvertToLLVMPattern {
 
     auto oneConst = rewriter.create<LLVM::ConstantOp>(
         op->getLoc(), i32Ty, rewriter.getI32IntegerAttr(1));
+
+    // This assumes that alloca does always allocate full bytes (round up to a
+    // multiple of 8 bits).
     auto alloca = rewriter.create<LLVM::AllocaOp>(
         op->getLoc(), LLVM::LLVMPointerType::get(valTy), oneConst, 4);
     rewriter.create<LLVM::StoreOp>(op->getLoc(), castVal, alloca);


### PR DESCRIPTION
Fixes some incorrect code since dividing by 64 and ceiling may override the buffer since the allocation is not rounded up to a 64 bit boundary.

I could not reproduce #4108 locally, but looking at the stack trace there, this should fix it. Can you confirm @dtzSiFive?