### PR TITLE
[Windows] Don't build LLVM with debug symbols

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -57,9 +57,9 @@ jobs:
           cmake ..\llvm -GNinja `
             -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="host" `
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS=ON `
+            -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON `
             -DLLVM_INSTALL_UTILS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
-          cmake --build . --target install --config RelWithDebInfo
+          cmake --build . --target install --config Release
 
       # --------
       # Build and test CIRCT in both debug and release mode.


### PR DESCRIPTION
These debug symbols take up too much memory and prevent us from running in the CI container.  I enabled debug symbols a couple days ago, and the issue has surfaced once LLVM was bumped.  This still builds CIRCT in RelWithDebInfo mode.