### PR TITLE
[Seq] Replace uninitialized aggregate registers with constant zeros

### DIFF
--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -298,6 +298,12 @@ LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
   // canonicalization to the folder.
   if (op.getNext() == op.getResult() ||
       op.getClk().getDefiningOp<hw::ConstantOp>()) {
+    // If the register has a reset value, we can replace it with that.
+    if (auto resetValue = op.getResetValue()) {
+      rewriter.replaceOp(op, resetValue);
+      return success();
+    }
+
     auto constant = rewriter.create<hw::ConstantOp>(
         op.getLoc(), APInt::getZero(hw::getBitWidth(op.getType())));
     rewriter.replaceOpWithNewOp<hw::BitcastOp>(op, op.getType(), constant);

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -288,6 +288,22 @@ LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
     }
   }
 
+  // If the register has a symbol, we can't optimize it away.
+  if (op.getInnerSymAttr())
+    return failure();
+
+  // Replace a register with a trivial feedback or constant clock with a
+  // constant zero.
+  // TODO: Once HW aggregate constant values are supported, move this
+  // canonicalization to the folder.
+  if (op.getNext() == op.getResult() ||
+      op.getClk().getDefiningOp<hw::ConstantOp>()) {
+    auto constant = rewriter.create<hw::ConstantOp>(
+        op.getLoc(), APInt::getZero(hw::getBitWidth(op.getType())));
+    rewriter.replaceOpWithNewOp<hw::BitcastOp>(op, op.getType(), constant);
+    return success();
+  }
+
   return failure();
 }
 

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -65,12 +65,12 @@ hw.module @FirRegReset(%clk: i1, %in: i32, %r : i1, %v : i32) {
   // CHECK: hw.instance "reg3b" @Observe(x: %v: i32) -> ()
 }
 
-// This should not optimize anything until we have constant aggregate attribute
-// support.
 // CHECK-LABEL: @FirRegAggregate
 hw.module @FirRegAggregate(%clk: i1) -> (out : !hw.struct<foo: i32>) {
-  // CHECK: %reg = seq.firreg %reg clock %clk : !hw.struct<foo: i32>
-  // CHECK: hw.output %reg : !hw.struct<foo: i32>
+  // TODO: Use constant aggregate attribute once supported.
+  // CHECK:      %c0_i32 = hw.constant 0 : i32
+  // CHECK-NEXT: %0 = hw.bitcast %c0_i32 : (i32) -> !hw.struct<foo: i32>
+  // CHECK-NEXT: hw.output %0
   %reg = seq.firreg %reg clock %clk : !hw.struct<foo: i32>
   hw.output %reg : !hw.struct<foo: i32>
 }


### PR DESCRIPTION
This PR implements a canonicalization to replace uninitialized aggregate registers with constant zeros. 
This fixes lint warnings with aggregate preservation builds. Eventually the canonicalization should be moved to a folder once aggregate constant is added. 