### PR TITLE
[ExportVerilog] Emit `hw.type_scope` with include guards

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2883,7 +2883,7 @@ LogicalResult StmtEmitter::visitStmt(OutputOp op) {
 }
 
 LogicalResult StmtEmitter::visitStmt(TypeScopeOp op) {
-  auto typescopeDef = "_TYPESCOPE_" + op.getSymName();
+  auto typescopeDef = ("_TYPESCOPE_" + op.getSymName()).str();
   os << "`ifndef " << typescopeDef << '\n';
   os << "`define " << typescopeDef << '\n';
   emitStatementBlock(*op.getBodyBlock());

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2884,10 +2884,10 @@ LogicalResult StmtEmitter::visitStmt(OutputOp op) {
 
 LogicalResult StmtEmitter::visitStmt(TypeScopeOp op) {
   auto typescopeDef = ("_TYPESCOPE_" + op.getSymName()).str();
-  os << "`ifndef " << typescopeDef << '\n';
-  os << "`define " << typescopeDef << '\n';
+  indent() << "`ifndef " << typescopeDef << '\n';
+  indent() << "`define " << typescopeDef << '\n';
   emitStatementBlock(*op.getBodyBlock());
-  os << "`endif // " << typescopeDef << '\n';
+  indent() << "`endif // " << typescopeDef << '\n';
   return success();
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2883,7 +2883,11 @@ LogicalResult StmtEmitter::visitStmt(OutputOp op) {
 }
 
 LogicalResult StmtEmitter::visitStmt(TypeScopeOp op) {
+  auto typescopeDef = "_TYPESCOPE_" + op.getSymName();
+  os << "`ifndef " << typescopeDef << '\n';
+  os << "`define " << typescopeDef << '\n';
   emitStatementBlock(*op.getBodyBlock());
+  os << "`endif // " << typescopeDef << '\n';
   return success();
 }
 

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -1,5 +1,7 @@
 // RUN: circt-opt %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
+// CHECK: `ifndef _TYPESCOPE___hw_typedecls
+// CHECK: `define _TYPESCOPE___hw_typedecls
 hw.type_scope @__hw_typedecls {
   // CHECK: typedef logic foo;
   hw.typedecl @foo : i1
@@ -20,11 +22,15 @@ hw.type_scope @__hw_typedecls {
   // CHECK: typedef enum {myEnum_A, myEnum_B, myEnum_C} myEnum;
   hw.typedecl @myEnum : !hw.enum<A, B, C>
 }
+// CHECK: `endif // _TYPESCOPE___hw_typedecls
 
+// CHECK: `ifndef _TYPESCOPE__other_scope
+// CHECK: `define _TYPESCOPE__other_scope
 hw.type_scope @_other_scope {
   // CHECK: typedef logic [1:0] _other_scope_foo;
   hw.typedecl @foo, "_other_scope_foo" : i2
 }
+// CHECK: `endif // _TYPESCOPE__other_scope
 
 // CHECK: `ifndef __PYCDE_TYPES__
 // CHECK:   typedef struct packed {logic a; } exTypedef;

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -971,8 +971,11 @@ hw.module @ConstantDefBeforeUse() {
 // Mixing !hw.enum types which alias in their fields - one anonymous enum
 // and two aliasing named enums.
 
+// CHECK: `ifndef _TYPESCOPE___AnFSMTypedecl
+// CHECK: `define _TYPESCOPE___AnFSMTypedecl
 // CHECK: typedef enum {_state1_A, _state1_B} _state1;
 // CHECK: typedef enum {_state2_A, _state2_B} _state2;
+// CHECK: `endif // _TYPESCOPE___AnFSMTypedecl
 // CHECK-LABEL: module AnFSM
 // CHECK:   enum {A, B} reg_0;
 // OLD:   _state1     reg_state1;


### PR DESCRIPTION
This commit adds include guards to a `hw.type_scope` when emitted.
```mlir
hw.type_scope @_other_scope {
  hw.typedecl @foo, "_other_scope_foo" : i2
}
```
emits as
```sv
`ifndef _TYPESCOPE__other_scope
`define _TYPESCOPE__other_scope
typedef logic [1:0] _other_scope_foo;
`endif // _TYPESCOPE__other_scope
```

 There's no attribute to disable this - I didn't see the need for that, but if someone has an example of where such guards on the emitted typedefs would break stuff, then an attribute could obviously be added.

I considered the alternative of making the include guards and guard definition a part of the IR and require the source generator (in our case `FSMToSV`)  to ensure scoping of the typescope:

```mlir
  sv.ifdef "_fsm_enum_typedefs" {
    sv.verbatim "`define _fsm_enum_typedefs"
    hw.type_scope @fsm_enum_typedecls {
      hw.typedecl @top_state_t : !hw.enum<A, B, C>
    }
  } {output_file = #hw.output_file<"fsm_enum_typedefs.sv">}
```

Issues here are:
- The `@fsm_enum_typedecls` cannot be referenced from outside the `sv.ifdef`. 
- Even though `FSMToSV` lowers to `SV` (SV ops are used to emit state machine with behavioral semantics), an abstraction lowering to `hw` shouldn't be concerned about `sv` scoping semantics (`FSMToSV` uses `hw` for anything typing related).

