### PR TITLE
[Calyx] Fix CombComponent Builder

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -484,7 +484,8 @@ static SmallVector<T> concat(const SmallVectorImpl<T> &a,
 }
 
 static void buildComponentLike(OpBuilder &builder, OperationState &result,
-                               StringAttr name, ArrayRef<PortInfo> ports) {
+                               StringAttr name, ArrayRef<PortInfo> ports,
+                               bool combinational) {
   using namespace mlir::function_interface_impl;
 
   result.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), name);
@@ -533,7 +534,8 @@ static void buildComponentLike(OpBuilder &builder, OperationState &result,
   IRRewriter::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(body);
   builder.create<WiresOp>(result.location);
-  builder.create<ControlOp>(result.location);
+  if (!combinational)
+    builder.create<ControlOp>(result.location);
 }
 
 //===----------------------------------------------------------------------===//
@@ -690,7 +692,7 @@ LogicalResult ComponentOp::verify() {
 
 void ComponentOp::build(OpBuilder &builder, OperationState &result,
                         StringAttr name, ArrayRef<PortInfo> ports) {
-  buildComponentLike(builder, result, name, ports);
+  buildComponentLike(builder, result, name, ports, false);
 }
 
 void ComponentOp::getAsmBlockArgumentNames(
@@ -803,7 +805,7 @@ LogicalResult CombComponentOp::verify() {
 
 void CombComponentOp::build(OpBuilder &builder, OperationState &result,
                             StringAttr name, ArrayRef<PortInfo> ports) {
-  buildComponentLike(builder, result, name, ports);
+  buildComponentLike(builder, result, name, ports, true);
 }
 
 void CombComponentOp::getAsmBlockArgumentNames(

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -692,7 +692,7 @@ LogicalResult ComponentOp::verify() {
 
 void ComponentOp::build(OpBuilder &builder, OperationState &result,
                         StringAttr name, ArrayRef<PortInfo> ports) {
-  buildComponentLike(builder, result, name, ports, false);
+  buildComponentLike(builder, result, name, ports, /*combinational=*/false);
 }
 
 void ComponentOp::getAsmBlockArgumentNames(
@@ -805,7 +805,7 @@ LogicalResult CombComponentOp::verify() {
 
 void CombComponentOp::build(OpBuilder &builder, OperationState &result,
                             StringAttr name, ArrayRef<PortInfo> ports) {
-  buildComponentLike(builder, result, name, ports, true);
+  buildComponentLike(builder, result, name, ports, /*combinational=*/true);
 }
 
 void CombComponentOp::getAsmBlockArgumentNames(


### PR DESCRIPTION
When adding CombComponents, I missed this issue where the builder adds a ControlOp no matter if it is building a CombComponent or a regular Component. This change only has an effect when a CombComponent is built within circt, imported mlir works fine.