### PR TITLE
[FIRRTL] limit useless locs in dedup

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -577,12 +577,12 @@ struct Equivalence {
 // Deduplication
 //===----------------------------------------------------------------------===//
 
+// Custom location merging.  This only keeps track of 8 annotations from ".fir"
+// files, and however many annotations come from "real" sources.  When
+// deduplicating, modules tend not to have scala source locators, so we wind
+// up fusing source locators for a module from every copy being deduped.  There
+// is little value in this (all the modules are identical by definition).
 static Location mergeLoc(MLIRContext *context, Location to, Location from) {
-  //    llvm::errs() << "TESTING \n";
-  //    to->dump();
-  //    from->dump();
-  //    llvm::errs() << "\n";
-
   // Unique the set of locations to be fused.
   llvm::SmallSetVector<Location, 4> decomposedLocs;
   // only track 8 "fir" locations

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -605,6 +605,15 @@ static Location mergeLoc(MLIRContext *context, Location to, Location from) {
       }
       continue;
     }
+
+    // Might need to skip this fir.
+    if (FileLineColLoc fileLoc = loc.dyn_cast<FileLineColLoc>()) {
+      if (fileLoc.getFilename().strref().endswith(".fir")) {
+        ++seenFIR;
+        if (seenFIR > 8)
+          continue;
+      }
+    }
     // Otherwise, only add known locations to the set.
     if (!loc.isa<UnknownLoc>())
       decomposedLocs.insert(loc);

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -577,6 +577,51 @@ struct Equivalence {
 // Deduplication
 //===----------------------------------------------------------------------===//
 
+static Location mergeLoc(MLIRContext* context, Location to, Location from) {
+//    llvm::errs() << "TESTING \n";
+//    to->dump();
+//    from->dump();
+//    llvm::errs() << "\n";
+
+  // Unique the set of locations to be fused.
+  llvm::SmallSetVector<Location, 4> decomposedLocs;
+  // only track 8 "fir" locations
+  unsigned seenFIR = 0;
+  for (auto loc : {to, from}) {
+    // If the location is a fused location we decompose it if it has no
+    // metadata or the metadata is the same as the top level metadata.
+    if (auto fusedLoc = loc.dyn_cast<FusedLoc>()) {
+        // UnknownLoc's have already been removed from FusedLocs so we can
+        // simply add all of the internal locations.
+        for (auto loc : fusedLoc.getLocations()) {
+            if (FileLineColLoc fileLoc = loc.dyn_cast<FileLineColLoc>()) {
+              if (fileLoc.getFilename().strref().endswith(".fir")) {
+                ++seenFIR;
+                if (seenFIR > 8)
+                  continue;
+              }
+            }
+            decomposedLocs.insert(loc);
+        }
+        continue;
+    }
+    // Otherwise, only add known locations to the set.
+    if (!loc.isa<UnknownLoc>())
+      decomposedLocs.insert(loc);
+  }
+
+  auto locs = decomposedLocs.getArrayRef();
+
+  // Handle the simple cases of less than two locations. Ensure the metadata (if
+  // provided) is not dropped.
+  if (locs.empty())
+    return UnknownLoc::get(context);
+  if (locs.size() == 1)
+    return locs.front();
+
+  return FusedLoc::get(context, locs);
+}
+
 struct Deduper {
 
   using RenameMap = DenseMap<StringAttr, StringAttr>;
@@ -1016,9 +1061,9 @@ private:
                 SmallVectorImpl<FlatSymbolRefAttr> &toNLAs, Operation *to,
                 FModuleLike fromModule,
                 SmallVectorImpl<FlatSymbolRefAttr> &fromNLAs, Operation *from) {
-    // Merge the operation locations if they are different.
+    // Merge the operation locations.
     if (to->getLoc() != from->getLoc())
-      to->setLoc(FusedLoc::get(context, {to->getLoc(), from->getLoc()}));
+    to->setLoc(mergeLoc(context, to->getLoc(), from->getLoc()));
 
     // Recurse into any regions.
     for (auto regions : llvm::zip(to->getRegions(), from->getRegions()))

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -577,11 +577,11 @@ struct Equivalence {
 // Deduplication
 //===----------------------------------------------------------------------===//
 
-static Location mergeLoc(MLIRContext* context, Location to, Location from) {
-//    llvm::errs() << "TESTING \n";
-//    to->dump();
-//    from->dump();
-//    llvm::errs() << "\n";
+static Location mergeLoc(MLIRContext *context, Location to, Location from) {
+  //    llvm::errs() << "TESTING \n";
+  //    to->dump();
+  //    from->dump();
+  //    llvm::errs() << "\n";
 
   // Unique the set of locations to be fused.
   llvm::SmallSetVector<Location, 4> decomposedLocs;
@@ -591,19 +591,19 @@ static Location mergeLoc(MLIRContext* context, Location to, Location from) {
     // If the location is a fused location we decompose it if it has no
     // metadata or the metadata is the same as the top level metadata.
     if (auto fusedLoc = loc.dyn_cast<FusedLoc>()) {
-        // UnknownLoc's have already been removed from FusedLocs so we can
-        // simply add all of the internal locations.
-        for (auto loc : fusedLoc.getLocations()) {
-            if (FileLineColLoc fileLoc = loc.dyn_cast<FileLineColLoc>()) {
-              if (fileLoc.getFilename().strref().endswith(".fir")) {
-                ++seenFIR;
-                if (seenFIR > 8)
-                  continue;
-              }
-            }
-            decomposedLocs.insert(loc);
+      // UnknownLoc's have already been removed from FusedLocs so we can
+      // simply add all of the internal locations.
+      for (auto loc : fusedLoc.getLocations()) {
+        if (FileLineColLoc fileLoc = loc.dyn_cast<FileLineColLoc>()) {
+          if (fileLoc.getFilename().strref().endswith(".fir")) {
+            ++seenFIR;
+            if (seenFIR > 8)
+              continue;
+          }
         }
-        continue;
+        decomposedLocs.insert(loc);
+      }
+      continue;
     }
     // Otherwise, only add known locations to the set.
     if (!loc.isa<UnknownLoc>())
@@ -1063,7 +1063,7 @@ private:
                 SmallVectorImpl<FlatSymbolRefAttr> &fromNLAs, Operation *from) {
     // Merge the operation locations.
     if (to->getLoc() != from->getLoc())
-    to->setLoc(mergeLoc(context, to->getLoc(), from->getLoc()));
+      to->setLoc(mergeLoc(context, to->getLoc(), from->getLoc()));
 
     // Recurse into any regions.
     for (auto regions : llvm::zip(to->getRegions(), from->getRegions()))

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-dedup)' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-dedup)' %s -mlir-print-debuginfo | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Empty"
 firrtl.circuit "Empty" {
@@ -489,3 +489,53 @@ firrtl.circuit "Foo"  {
     firrtl.instance y1 @Y()
   }
 }
+
+
+// Check that locations are limited.
+// CHECK-LABEL: firrtl.circuit "LimitLoc"
+firrtl.circuit "LimitLoc" {
+  // CHECK: @Simple0
+  // CHECK-NEXT: loc(#loc[[num:.+]])
+  firrtl.module @Simple0() { } loc(#loc0) 
+  // CHECK-NOT: @Simple1
+  firrtl.module @Simple1() { } loc(#loc1) 
+  // CHECK-NOT: @Simple2
+  firrtl.module @Simple2() { } loc(#loc2) 
+  // CHECK-NOT: @Simple3
+  firrtl.module @Simple3() { } loc(#loc3) 
+  // CHECK-NOT: @Simple4
+  firrtl.module @Simple4() { } loc(#loc4) 
+  // CHECK-NOT: @Simple5
+  firrtl.module @Simple5() { } loc(#loc5) 
+  // CHECK-NOT: @Simple6
+  firrtl.module @Simple6() { } loc(#loc6) 
+  // CHECK-NOT: @Simple7
+  firrtl.module @Simple7() { } loc(#loc7) 
+  // CHECK-NOT: @Simple8
+  firrtl.module @Simple8() { } loc(#loc8) 
+  // CHECK-NOT: @Simple9
+  firrtl.module @Simple9() { } loc(#loc9) 
+  firrtl.module @LimitLoc() {
+    firrtl.instance simple0 @Simple0()
+    firrtl.instance simple1 @Simple1()
+    firrtl.instance simple2 @Simple2()
+    firrtl.instance simple3 @Simple3()
+    firrtl.instance simple4 @Simple4()
+    firrtl.instance simple5 @Simple5()
+    firrtl.instance simple6 @Simple6()
+    firrtl.instance simple7 @Simple7()
+    firrtl.instance simple8 @Simple8()
+    firrtl.instance simple9 @Simple9()
+  }
+}
+  #loc0 = loc("A.fir":0:1)
+  #loc1 = loc("A.fir":1:1)
+  #loc2 = loc("A.fir":2:1)
+  #loc3 = loc("A.fir":3:1)
+  #loc4 = loc("A.fir":4:1)
+  #loc5 = loc("A.fir":5:1)
+  #loc6 = loc("A.fir":6:1)
+  #loc7 = loc("A.fir":7:1)
+  #loc8 = loc("A.fir":8:1)
+  #loc9 = loc("A.fir":9:1)
+// CHECK: loc[[num]] = loc(fused["A.fir":0:1, "A.fir":1:1, "A.fir":2:1, "A.fir":3:1, "A.fir":4:1, "A.fir":5:1, "A.fir":6:1, "A.fir":7:1])


### PR DESCRIPTION
Limit locations from .fir files when deduplicating modules.  These locations add little value.  This has the unfortunate side-effect of embedding special handling of location data based on filename string, but I don't see a better way right now.

End-to-end performance increase on a large core: 15%
Memory reduction on a large core: 50%