### PR TITLE
[FIRRTL][CheckCombCycles] Fix missed iterator increment

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -208,8 +208,12 @@ public:
   }
 
   InstanceNodeIterator &operator++() {
-    ++portIt;
-    skipToNextValidPort();
+    if (!child.isAtEnd())
+      ++child;
+    else {
+      ++portIt;
+      skipToNextValidPort();
+    }
     return *this;
   }
 
@@ -277,7 +281,10 @@ public:
   }
 
   SubfieldNodeIterator &operator++() {
-    child = ChildIterator();
+    if (!child.isAtEnd())
+      ++child;
+    else
+      child = ChildIterator();
     return *this;
   }
 


### PR DESCRIPTION
This fixes a bug in #7bab284c6aff9e96311e88474d655d5397c41563, add the missed child iterator increment.