### PR TITLE
[SV] Fix SVExtractTestCode to keep the instance graph up to date.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -200,10 +200,16 @@ static void addInstancesToCloneSet(
     // this case, we have to proactively erase them. The instances must be
     // erased because we can't canonicalize away instances with unused results
     // in general. The forward dataflow must be erased because the instance is
-    // being erased, and we can't leave null operands after this pass.
+    // being erased, and we can't leave null operands after this pass. Also
+    // erase any intermediate parents of the forward slice.
     opsToErase.insert(instance);
     for (auto *forwardOp : forwardSlice)
       opsToErase.insert(forwardOp);
+
+    SetVector<Operation *> forwardSliceParents;
+    blockSlice(forwardSlice, forwardSliceParents);
+    for (auto *forwardOpParent : forwardSliceParents)
+      opsToErase.insert(forwardOpParent);
   }
 
   // Remove any inputs marked for removal.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -637,6 +637,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
     if (auto error = dyn_cast<ErrorOp>(op)) {
       if (auto message = error.getMessage())
         return message->startswith("assert:") ||
+               message->startswith("assert failed (verification library)") ||
                message->startswith("Assertion failed") ||
                message->startswith("assertNotX:") ||
                message->contains("[verif-library-assert]");

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -291,8 +291,13 @@ module attributes {
 
   hw.module private @ShouldBeInlined2(%clock: i1, %in: i1) {
     %bozo.b = hw.instance "bozo" @Bozo(a: %in: i1) -> (b: i1)
-    sv.always posedge %clock {
-      sv.cover %bozo.b, immediate
+    sv.ifdef "SYNTHESIS" {
+    } else {
+      sv.always posedge %clock {
+        sv.if %bozo.b {
+          sv.cover %bozo.b, immediate
+        }
+      }
     }
   }
 

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -193,6 +193,10 @@ module {
 // CHECK-LABEL: @Baz
 // CHECK-SAME: output_file = #hw.output_file<"testbench{{/|\\\\}}", excludeFromFileList, includeReplicatedOps>
 
+// All instances of Bozo should be extracted, but a copy of it is left in @ChildShouldInline2. It should not be output to the testbench in the current state.
+// CHECK-LABEL: @Bozo
+// CHECK-NOT: #hw.output_file<"testbench
+
 // In AllExtracted, instances foo, bar, and baz should be extracted.
 // CHECK-LABEL: @AllExtracted_cover
 // CHECK: hw.instance "foo"
@@ -216,6 +220,10 @@ module {
 // CHECK-LABEL: @ChildShouldInline
 // CHECK-NOT: hw.instance "child"
 // CHECK: hw.instance {{.+}} @ShouldBeInlined_cover
+
+// In ChildShouldInline2, instance bozo comes from the inlined child. The bozo instance shouldn't be duplicated like this, and when it's fixed, the below should become a check not.
+// CHECK-LABEL: hw.module @ChildShouldInline2
+// CHECK: hw.instance "bozo"
 
 // In MultiResultExtracted, instance qux should be extracted without leaving null operands to the extracted instance
 // CHECK-LABEL: @MultiResultExtracted_cover

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -237,6 +237,8 @@ module attributes {
 
   hw.module.extern private @Qux(%a: i1) -> (b: i1, c: i1)
 
+  hw.module.extern private @Bozo(%a: i1) -> (b: i1)
+
   hw.module @AllExtracted(%clock: i1, %in: i1) {
     %foo.b = hw.instance "foo" @Foo(a: %in: i1) -> (b: i1)
     %bar.b = hw.instance "bar" @Bar(a: %in: i1) -> (b: i1)
@@ -279,8 +281,19 @@ module attributes {
     }
   }
 
+  hw.module private @ShouldBeInlined2(%clock: i1, %in: i1) {
+    %bozo.b = hw.instance "bozo" @Bozo(a: %in: i1) -> (b: i1)
+    sv.always posedge %clock {
+      sv.cover %bozo.b, immediate
+    }
+  }
+
   hw.module @ChildShouldInline(%clock: i1, %in: i1) {
     hw.instance "child" @ShouldBeInlined(clock: %clock: i1, in: %in: i1) -> ()
+  }
+
+  hw.module @ChildShouldInline2(%clock: i1, %in: i1) {
+    hw.instance "child" @ShouldBeInlined2(clock: %clock: i1, in: %in: i1) -> ()
   }
 
   hw.module @MultiResultExtracted(%clock: i1, %in: i1) {

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -193,9 +193,9 @@ module {
 // CHECK-LABEL: @Baz
 // CHECK-SAME: output_file = #hw.output_file<"testbench{{/|\\\\}}", excludeFromFileList, includeReplicatedOps>
 
-// All instances of Bozo should be extracted, but a copy of it is left in @ChildShouldInline2. It should not be output to the testbench in the current state.
+// All instances of Bozo are extracted, so it should be output to the testbench.
 // CHECK-LABEL: @Bozo
-// CHECK-NOT: #hw.output_file<"testbench
+// CHECK: #hw.output_file<"testbench
 
 // In AllExtracted, instances foo, bar, and baz should be extracted.
 // CHECK-LABEL: @AllExtracted_cover
@@ -221,9 +221,9 @@ module {
 // CHECK-NOT: hw.instance "child"
 // CHECK: hw.instance {{.+}} @ShouldBeInlined_cover
 
-// In ChildShouldInline2, instance bozo comes from the inlined child. The bozo instance shouldn't be duplicated like this, and when it's fixed, the below should become a check not.
+// In ChildShouldInline2, instance bozo should not be inlined, since it was also extracted.
 // CHECK-LABEL: hw.module @ChildShouldInline2
-// CHECK: hw.instance "bozo"
+// CHECK-NOT: hw.instance "bozo"
 
 // In MultiResultExtracted, instance qux should be extracted without leaving null operands to the extracted instance
 // CHECK-LABEL: @MultiResultExtracted_cover


### PR DESCRIPTION
Notably, when inlining the body of a module, any instances in the body should be added to the new parent module in the instance graph. The instances in the old body are already being removed from the instance graph when we remove the old module. This fixes an issue where instances that were inlined appeared to have no uses, and were erroneously moved to the testbench.

This also makes sure to add modules created to hold extracted test code to the instance graph. This bookeeping is important so the above can work, and find the newly created module during inlining.

Finally, this makes sure not to duplicate instances that have been extracted when their parent module is inlined.