### PR TITLE
[FIRRTL] Ignore TestBenchDirAnno if no DUT in BlackBoxReader

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -22,6 +22,7 @@ namespace circt {
 namespace firrtl {
 
 class AnnotationSetIterator;
+class FModuleOp;
 class FModuleLike;
 class MemOp;
 class InstanceOp;
@@ -477,6 +478,20 @@ struct PortAnnoTarget : public AnnoTarget {
     return annoTarget.getImpl().isPort();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Utilities for Specific Annotations
+//
+// TODO: Remove these in favor of first-class annotations.
+//===----------------------------------------------------------------------===//
+
+/// Utility that searches for a MarkDUTAnnotation on a specific module, `mod`,
+/// and tries to update a design-under-test (DUT), `dut`, with this module if
+/// the module is the DUT.  This function returns success if either no DUT was
+/// found or if the DUT was found and a previous DUT was not set (if `dut` is
+/// null).  This returns failure if a DUT was found and a previous DUT was set.
+/// This function generates an error message in the failure case.
+LogicalResult extractDUT(FModuleOp mod, FModuleOp &dut);
 
 } // namespace firrtl
 } // namespace circt

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -684,3 +684,29 @@ bool circt::firrtl::isOMIRStringEncodedPassthrough(StringRef type) {
          type == "OMLong" || type == "OMString" || type == "OMDouble" ||
          type == "OMBigDecimal" || type == "OMDeleted" || type == "OMConstant";
 }
+
+//===----------------------------------------------------------------------===//
+// Utilities for Specific Annotations
+//
+// TODO: Remove these in favor of first-class annotations.
+//===----------------------------------------------------------------------===//
+
+LogicalResult circt::firrtl::extractDUT(const FModuleOp mod, FModuleOp &dut) {
+  if (!AnnotationSet(mod).hasAnnotation(dutAnnoClass))
+    return success();
+
+  // TODO: This check is duplicated multiple places, e.g., in
+  // WireDFT.  This should be factored out as part of the annotation
+  // lowering pass.
+  if (dut) {
+    auto diag = emitError(mod->getLoc())
+                << "is marked with a '" << dutAnnoClass << "', but '"
+                << dut.moduleName()
+                << "' also had such an annotation (this should "
+                   "be impossible!)";
+    diag.attachNote(dut.getLoc()) << "the first DUT was found here";
+    return failure();
+  }
+  dut = mod;
+  return success();
+}

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -48,7 +48,7 @@ struct BlackBoxReaderPass : public BlackBoxReaderBase<BlackBoxReaderPass> {
                        bool isCover);
   VerbatimOp loadFile(Operation *op, StringRef inputPath, OpBuilder &builder);
   void setOutputFile(VerbatimOp op, Operation *origOp, StringAttr fileNameAttr,
-                     bool isDut = false, bool isCover = false);
+                     bool isCover = false);
   // Check if module or any of its parents in the InstanceGraph is a DUT.
   bool isDut(Operation *module);
 
@@ -271,7 +271,7 @@ bool BlackBoxReaderPass::runOnAnnotation(Operation *op, Annotation anno,
     // Create an IR node to hold the contents.  Use "unknown location" so that
     // no file info will unnecessarily print.
     auto verbatim = builder.create<VerbatimOp>(builder.getUnknownLoc(), text);
-    setOutputFile(verbatim, op, name, isDut(op), isCover);
+    setOutputFile(verbatim, op, name, isCover);
     return true;
   }
 
@@ -293,7 +293,7 @@ bool BlackBoxReaderPass::runOnAnnotation(Operation *op, Annotation anno,
       return false;
     }
     auto name = builder.getStringAttr(llvm::sys::path::filename(path));
-    setOutputFile(verbatim, op, name, isDut(op), isCover);
+    setOutputFile(verbatim, op, name, isCover);
     return true;
   }
 
@@ -332,8 +332,7 @@ VerbatimOp BlackBoxReaderPass::loadFile(Operation *op, StringRef inputPath,
 ///  2. Record that the file has been generated to avoid duplicates.
 ///  3. Add each file name to the generated "file list" file.
 void BlackBoxReaderPass::setOutputFile(VerbatimOp op, Operation *origOp,
-                                       StringAttr fileNameAttr, bool isDut,
-                                       bool isCover) {
+                                       StringAttr fileNameAttr, bool isCover) {
   // If the output file was set on the original operation then either: (1) copy
   // this to the new op if it is a filename or (2) use this directory (since it
   // is a directory) as the lowest priority directory to put this file.
@@ -356,7 +355,7 @@ void BlackBoxReaderPass::setOutputFile(VerbatimOp op, Operation *origOp,
   // testbench dir annotation, not have a blackbox target directory annotation
   // (or one set to the current directory), have a DUT annotation, and the
   // module needs to be in or under the DUT.
-  if (!testBenchDir.empty() && targetDir.equals(".") && dut && !isDut)
+  if (!testBenchDir.empty() && targetDir.equals(".") && dut && !isDut(origOp))
     outDir = testBenchDir;
   else if (isCover)
     outDir = coverDir;

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -360,6 +360,7 @@ void BlackBoxReaderPass::setOutputFile(VerbatimOp op, Operation *origOp,
 }
 
 /// Return true if module is in the DUT hierarchy.
+/// NOLINTNEXTLINE(misc-no-recursion)
 bool BlackBoxReaderPass::isDut(Operation *module) {
   // Check if result already cached.
   auto iter = dutModuleMap.find(module);


### PR DESCRIPTION
Change BlackBoxReader pass to ignore a TestBenchDirAnnotation if no MarkDUTAnnotation exists.  This comes up for some internal designs where the former exists, but the latter does not.

The first commit is ~NFC and just factors out DUT-finding logic from GCT to make it usable in BlackBoxReader.