### PR TITLE
[ExportVerilog] Don't combine location info across if/elseif chains.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3316,7 +3316,6 @@ LogicalResult StmtEmitter::visitSV(IfOp op) {
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   SmallPtrSet<Operation *, 8> ops;
-  ops.insert(op);
 
   indent() << "if (";
 
@@ -3324,6 +3323,9 @@ LogicalResult StmtEmitter::visitSV(IfOp op) {
   // it (either "if (" or "else if (") was printed already.
   IfOp ifOp = op;
   for (;;) {
+    ops.clear();
+    ops.insert(ifOp);
+
     // Emit the condition and the then block.
     emitExpression(ifOp.getCond(), ops);
     os << ')';

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3334,19 +3334,20 @@ LogicalResult StmtEmitter::visitSV(IfOp op) {
     if (!ifOp.hasElse())
       break;
 
-    // The else block does not contain an if-else that can be flattened.
     Block *elseBlock = ifOp.getElseBlock();
-    ifOp = findNestedElseIf(elseBlock);
-    if (!ifOp) {
+    auto nestedElseIfOp = findNestedElseIf(elseBlock);
+    if (!nestedElseIfOp) {
+      // The else block does not contain an if-else that can be flattened.
+      ops.clear();
+      ops.insert(ifOp);
       indent() << "else";
       emitBlockAsStatement(elseBlock, ops);
       break;
     }
 
-    // Introduce the 'else if', but iteratively continue unfolding any if-else
-    // statements inside of it.  Any wires that would have been generated to
-    // represent the condition will be hoisted to the parent scope of the outer
-    // `if` instead of being placed in a new block scope.
+    // Introduce the 'else if', and iteratively continue unfolding any if-else
+    // statements inside of it.
+    ifOp = nestedElseIfOp;
     indent() << "else if (";
   }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1454,6 +1454,41 @@ hw.module @NestedElseIfHoist(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1, %f
   hw.output
 }
 
+// CHECK-LABEL: ElseIfLocations
+// CHECK: if (~flag1)
+// CHECK-SAME: // Flag:1:1, If:1:1
+// CHECK: else if (~flag2)
+// CHECK-SAME: // Flag:2:2, If:2:2
+// CHECK: else if (~flag3)
+// CHECK-SAME: // Flag:3:3, If:3:3
+// CHECK: else
+// CHECK-SAME: // Flag:3:3, If:3:3
+hw.module @ElseIfLocations(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1) {
+  %fd = hw.constant 0x80000002 : i32
+  %true = hw.constant 1 : i1
+
+  sv.always posedge %clock {
+    %0 = comb.xor %flag1, %true : i1 loc("Flag":1:1)
+    sv.if %0 {
+      sv.fwrite %fd, "A"
+    } else {
+      %1 = comb.xor %flag2, %true : i1 loc("Flag":2:2)
+      sv.if %1 {
+        sv.fwrite %fd, "B"
+      } else {
+        %2 = comb.xor %flag3, %true : i1 loc("Flag":3:3)
+        sv.if %2 {
+          sv.fwrite %fd, "C"
+        } else {
+          sv.fwrite %fd, "D"
+        } loc("If":3:3)
+      } loc("If":2:2)
+    } loc("If":1:1)
+  }
+
+  hw.output
+}
+
 // CHECK-LABEL: ReuseExistingInOut
 // CHECK: input {{.+}},
 // CHECK:        [[INPUT:[:alnum:]+]],

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1462,7 +1462,7 @@ hw.module @NestedElseIfHoist(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1, %f
 // CHECK: else if (~flag3)
 // CHECK-SAME: // Flag:3:3, If:3:3
 // CHECK: else
-// CHECK-SAME: // Flag:3:3, If:3:3
+// CHECK-SAME: // If:3:3
 hw.module @ElseIfLocations(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1) {
   %fd = hw.constant 0x80000002 : i32
   %true = hw.constant 1 : i1


### PR DESCRIPTION
When emitting IfOp, we recursively look for another IfOp in the else branch so we can emit a nicer `else if`.

While doing this, reset the set of operations contributing to location information to those for the active IfOp and its condition.

The final `else` will have the information for the last IfOp processed.

(also ensures the "hoisted" IfOp is included in the set, which it isn't currently)