### PR TITLE
Bump LLVM

### DIFF
--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "NoMems" attributes {annotations = [
     filename = "sram.txt"
   }]} {
   firrtl.module @NoMems() {}
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
 }
 
 // Test for when there is a memory but no ports are added. The output file
@@ -25,7 +25,7 @@ firrtl.circuit "NoAddedPorts" attributes {annotations = [
   firrtl.module @NoAddedPorts() {
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
 }
 
 // Test for when there is no memory and we try to add ports. The output file
@@ -45,7 +45,7 @@ firrtl.circuit "NoMemory" attributes {annotations = [
   }]} {
   firrtl.module @NoMemory() {
   }
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
 }
 
 // Test for a single added port.

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -37,13 +37,13 @@ firrtl.circuit "Foo" attributes {annotations = [
     firrtl.instance foo3 @ExtFoo3()
     firrtl.instance dut @DUTBlackboxes()
   }
-  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"..{{/|\\\\}}testbench{{/|\\\\}}hello.v">, symbols = []}
-  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover{{/|\\\\}}hello2.v">, symbols = []}
-  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"..{{/|\\\\}}testbench{{/|\\\\}}hello3.v">, symbols = []}
-  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<".{{/|\\\\}}hello_dut.v">, symbols = []}
-  // CHECK: sv.verbatim "/* Bar */\0A" {output_file = #hw.output_file<"bar{{/|\\\\}}Bar.v">, symbols = []}
-  // CHECK: sv.verbatim "/* Baz */{{(\\0D)?}}\0A" {output_file = #hw.output_file<"baz{{/|\\\\}}Baz.sv">, symbols = []}
-  // CHECK: sv.verbatim "/* Qux */\0A" {output_file = #hw.output_file<"qux{{/|\\\\}}NotQux.jpeg">, symbols = []}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"..{{/|\\\\}}testbench{{/|\\\\}}hello.v">}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover{{/|\\\\}}hello2.v">}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"..{{/|\\\\}}testbench{{/|\\\\}}hello3.v">}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<".{{/|\\\\}}hello_dut.v">}
+  // CHECK: sv.verbatim "/* Bar */\0A" {output_file = #hw.output_file<"bar{{/|\\\\}}Bar.v">}
+  // CHECK: sv.verbatim "/* Baz */{{(\\0D)?}}\0A" {output_file = #hw.output_file<"baz{{/|\\\\}}Baz.sv">}
+  // CHECK: sv.verbatim "/* Qux */\0A" {output_file = #hw.output_file<"qux{{/|\\\\}}NotQux.jpeg">}
   // CHECK: sv.verbatim "..{{/|\\\\}}testbench{{/|\\\\}}hello.v\0A
   // CHECK-SAME:         ..{{/|\\\\}}testbench{{/|\\\\}}hello3.v\0A
   // CHECK-SAME:         hello_dut.v\0A

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -48,9 +48,9 @@ firrtl.circuit "DUTBlackboxes" attributes { annotations = [{
   firrtl.module @DUTBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
   }
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>, symbols = []}
-// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>, symbols = []}
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>, symbols = []}
+// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
+// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>}
+// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
 }
 
 // CHECK-LABEL: firrtl.circuit "TestBlackboxes"  {
@@ -61,9 +61,9 @@ firrtl.circuit "TestBlackboxes" attributes { annotations = [{
   firrtl.module @TestBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
   }
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>, symbols = []}
-// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>, symbols = []}
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>, symbols = []}
+// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
+// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>}
+// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
 }
 
 // CHECK-LABEL: firrtl.circuit "BasicBlackboxes"   {
@@ -95,13 +95,13 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @NoDefName()
 
   firrtl.extmodule @TestBlackbox() attributes {defname = "TestBlackbox"}
-  // CHECK: sv.verbatim "[\0A \22TestBlackbox\22\0A]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "[\0A \22TestBlackbox\22\0A]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>}
 
   // Should be de-duplicated and sorted.
   firrtl.extmodule @DUTBlackbox_0() attributes {defname = "DUTBlackbox2"}
   firrtl.extmodule @DUTBlackbox_1() attributes {defname = "DUTBlackbox1"}
   firrtl.extmodule @DUTBlackbox_2() attributes {defname = "DUTBlackbox1"}
-  // CHECK: sv.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>}
 }
 
 //===----------------------------------------------------------------------===//
@@ -113,9 +113,9 @@ firrtl.circuit "top"
 {
   firrtl.module @top() { }
   // When there are no memories, we still need to emit the memory metadata.
-  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>, symbols = []}
-  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>, symbols = []}
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>}
+  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
 }
 
 // CHECK-LABEL: firrtl.circuit "OneMemory"
@@ -154,9 +154,9 @@ firrtl.circuit "top" {
     firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     // CHECK: sv.verbatim "[\0A  {\0A    \22module_name\22: \22head_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: false,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22top.mem1.head_ext\22\0A    ]\0A  },\0A  {\0A    \22module_name\22: \22head_0_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: false,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22top.mem2.head_0_ext\22\0A    ]\0A  }\0A]"
-    // CHECK-SAME:  {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>, symbols = []}
+    // CHECK-SAME:  {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>}
     // CHECK: sv.verbatim "[\0A  {\0A    \22module_name\22: \22memory_ext\22,\0A    \22depth\22: 16,\0A    \22width\22: 8,\0A    \22masked\22: false,\0A    \22read\22: true,\0A    \22write\22: false,\0A    \22readwrite\22: true,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22DUT.mem1.memory_ext\22\0A    ]\0A  },\0A  {\0A    \22module_name\22: \22dumm_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: true,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22DUT.mem1.dumm_ext\22\0A    ]\0A  }\0A]"
-    // CHECK-SAME: output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>, symbols = []
+    // CHECK-SAME: output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>
     // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname dumm_ext depth 20 width 5 ports write,read\0Aname head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0A"
-    // CHECK-SAME: {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>, symbols = []}
+    // CHECK-SAME: {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
 }

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -114,7 +114,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:  sv.ifdef "SYNTHESIS" {
 //CHECK-NEXT:  } else {
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_MEM_INIT" {
-//CHECK-NEXT:      sv.verbatim "integer [[INITVAR:.+]];\0A" {{.+}}
+//CHECK-NEXT:      sv.verbatim "integer [[INITVAR:.+]];\0A"
 //CHECK-NEXT:      %[[RANDOM_MEM:.+]] = sv.reg sym @[[_RANDOM_MEM:.+]] : !hw.inout<i32>
 //CHECK-NEXT:    }
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -63,11 +63,11 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
   // CHECK-NEXT:          %_RANDOM_0 = sv.logic  : !hw.inout<i32>
@@ -119,7 +119,7 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -155,11 +155,11 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:        %_RANDOM_0 = sv.logic  : !hw.inout<i32>
@@ -171,7 +171,7 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT:      }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -259,11 +259,11 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
@@ -290,7 +290,7 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -310,11 +310,11 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK-NEXT:         %_RANDOM_0 = sv.logic  : !hw.inout<i32>
@@ -331,7 +331,7 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -361,11 +361,11 @@ hw.module private @regInitRandomReuse(%clock: i1, %a: i1) -> (o1: i2, o2: i4, o3
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK:              %9 = comb.extract %8 from 0 : (i32) -> i2
@@ -379,7 +379,7 @@ hw.module private @regInitRandomReuse(%clock: i1, %a: i1) -> (o1: i2, o2: i4, o3
   // CHECK:           }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -400,11 +400,11 @@ hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.arra
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i2
@@ -412,7 +412,7 @@ hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.arra
   // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -432,11 +432,11 @@ hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b:
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
   // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i1
@@ -444,7 +444,7 @@ hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b:
   // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
@@ -462,11 +462,11 @@ hw.module private @initStruct(%clock: i1) {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
   // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
-  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
   // CHECK:              %2 = comb.extract %1 from 0 : (i32) -> i1
@@ -474,7 +474,7 @@ hw.module private @initStruct(%clock: i1) {
   // CHECK:            }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }


### PR DESCRIPTION
MLIR no longer prints the empty `symbols = []` attribute for SV verbatim operations.