### PR TITLE
[PrepareForEmission, LoweringOptions] Change spillAllMux to normal option

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -92,6 +92,8 @@ The current set of "style" Lowering Options is:
    declaration when possible.
  * `printDebugInfo` (default=`false`). If true, emit additional debug information
    (e.g. inner symbols) into comments.
+ * `disallowMuxInlining` (default=`false`). If true, every mux expression is spilled to a wire.
+   This is used to avoid emitting deeply nested mux expressions to improve readability.
  * `wireSpillingHeuristic` (default=`spillNone`). This controls extra wire spilling performed
    in PrepareForEmission to improve readability and debuggability. It is possible to combine
    several heuristics by specifying `wireSpillingHeuristic` multiple times.
@@ -100,7 +102,6 @@ The current set of "style" Lowering Options is:
      with meaningful namehints (i.e. names which start with "\_") are spilled to wires.
      For a namehint with "\_" prefix, if the term size is greater than `wireSpillingNamehintTermLimit`
      (default=3), then the expression is spilled.
-   * `spillAllMux`: If enabled, spill wires for all muxes.
 
 The current set of "lint warnings fix" Lowering Options is:
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -113,13 +113,15 @@ struct LoweringOptions {
   /// Print debug info.
   bool printDebugInfo = false;
 
+  /// If true, every mux expression is spilled to a wire.
+  bool disallowMuxInlining = false;
+
   /// This controls extra wire spilling performed in PrepareForEmission to
   /// improve readablitiy and debuggability.
   enum WireSpillingHeuristic : unsigned {
     SpillLargeTermsWithNamehints = 1, // Spill wires for expressions with
                                       // namehints if the term size is greater
                                       // than `wireSpillingNamehintTermLimit`.
-    SpillAllMux = 1 << 1,             //  Spill wires for all ternary mux.
   };
 
   unsigned wireSpillingHeuristicSet = 0;

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -47,7 +47,7 @@ struct LoweringOptionsOption
                 "explicitBitcast, emitReplicatedOpsToHeader, "
                 "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
                 "disallowPortDeclSharing, printDebugInfo, "
-                "disallowExpressionInliningInPorts"),
+                "disallowExpressionInliningInPorts, disallowMuxInlining"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}
 };
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -46,7 +46,6 @@ parseWireSpillingHeuristic(StringRef option) {
              llvm::Optional<LoweringOptions::WireSpillingHeuristic>>(option)
       .Case("spillLargeTermsWithNamehints",
             LoweringOptions::SpillLargeTermsWithNamehints)
-      .Case("spillAllMux", LoweringOptions::SpillAllMux)
       .Default(llvm::None);
 }
 
@@ -94,12 +93,13 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       printDebugInfo = true;
     } else if (option == "disallowExpressionInliningInPorts") {
       disallowExpressionInliningInPorts = true;
+    } else if (option == "disallowMuxInlining") {
+      disallowMuxInlining = true;
     } else if (option.consume_front("wireSpillingHeuristic=")) {
       if (auto heuristic = parseWireSpillingHeuristic(option)) {
         wireSpillingHeuristicSet |= *heuristic;
       } else {
-        errorHandler("expected 'spillNone', 'spillLargeTermsWithNamehints' or "
-                     "'spillAllMux'");
+        errorHandler("expected ''spillLargeTermsWithNamehints'");
       }
     } else if (option.consume_front("wireSpillingNamehintTermLimit=")) {
       if (option.getAsInteger(10, wireSpillingNamehintTermLimit)) {
@@ -142,10 +142,10 @@ std::string LoweringOptions::toString() const {
   if (isWireSpillingHeuristicEnabled(
           WireSpillingHeuristic::SpillLargeTermsWithNamehints))
     options += "wireSpillingHeuristic=spillLargeTermsWithNamehints,";
-  if (isWireSpillingHeuristicEnabled(WireSpillingHeuristic::SpillAllMux))
-    options += "wireSpillingHeuristic=spillAllMux,";
   if (disallowExpressionInliningInPorts)
     options += "disallowExpressionInliningInPorts,";
+  if (disallowMuxInlining)
+    options += "disallowMuxInlining,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -150,8 +150,13 @@ module attributes {circt.loweringOptions =
                   "disallowMuxInlining"} {
   // CHECK-LABEL: mux
   hw.module @mux(%c: i1, %b: i8, %a: i8) -> (d: i8) {
-    // CHECK: %mux = sv.wire
-    %0 = comb.mux %c, %a, %b {sv.namehint = "mux"} : i8
+    // CHECK:      %use_for_mux = sv.wire
+    // CHECK-NEXT: sv.assign %use_for_mux, %0 : i8
+    // CHECK-NEXT: %[[read:.+]] = sv.read_inout %use_for_mux : !hw.inout<i8>
+    // CHECK-NEXT: comb.add %[[read]], %a : i8
+    %0 = comb.mux %c, %a, %b : i8
+    %use_for_mux = sv.wire : !hw.inout<i8>
+    sv.assign %use_for_mux, %0 : i8
     %1 = comb.add %0, %a : i8
     hw.output %1 : i8
   }

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -147,7 +147,7 @@ module attributes {circt.loweringOptions =
 
 // -----
 module attributes {circt.loweringOptions =
-                  "wireSpillingHeuristic=spillAllMux"} {
+                  "disallowMuxInlining"} {
   // CHECK-LABEL: mux
   hw.module @mux(%c: i1, %b: i8, %a: i8) -> (d: i8) {
     // CHECK: %mux = sv.wire
@@ -158,10 +158,9 @@ module attributes {circt.loweringOptions =
 }
 
 // -----
-// Check that multiple heuristics are applied.
-// CHECK: "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux"
+// CHECK: "wireSpillingHeuristic=spillLargeTermsWithNamehints,disallowMuxInlining"
 module attributes {circt.loweringOptions =
-                  "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux"} {
+                  "wireSpillingHeuristic=spillLargeTermsWithNamehints,disallowMuxInlining"} {
   hw.module @combine(%c: i1, %b: i8, %a: i8) -> (d: i8) {
     // Meaningful names should be spilled
     // CHECK: %foo = sv.wire


### PR DESCRIPTION
This PR moves `spillAllMux` option to normal lowering options. At SiFive, inlining mux was positively accepted by designers to improve readability and interestingly it also increased simulation performance. Hence the option is changed from the category "heuristic" to a normal option. In addition to that, the place where spilling happens is also changed. This change makes `reuseExistingInout` applicable to mux spilling as well. 