### PR TITLE
[Seq] Add behavioral `seq.hlmem` lowering

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -21,6 +21,7 @@ namespace seq {
 
 std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
 std::unique_ptr<mlir::Pass> createSeqFIRRTLLowerToSVPass();
+std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -27,4 +27,10 @@ def LowerSeqFIRRTLToSV: Pass<"lower-seq-firrtl-to-sv", "hw::HWModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {
+  let summary = "Lowers seq.hlmem operations.";
+  let constructor = "circt::seq::createLowerSeqHLMemPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+}
+
 #endif // CIRCT_DIALECT_SEQ_SEQPASSES

--- a/lib/Dialect/Seq/SeqTypes.cpp
+++ b/lib/Dialect/Seq/SeqTypes.cpp
@@ -58,24 +58,24 @@ llvm::SmallVector<Type> HLMemType::getAddressTypes() const {
   return addressTypes;
 }
 
-Type HLMemType::parse(mlir::AsmParser &p) {
+Type HLMemType::parse(mlir::AsmParser &odsParser) {
   llvm::SmallVector<int64_t> shape;
   Type elementType;
-  if (p.parseLess() ||
-      p.parseDimensionList(shape, /*allowDynamic=*/false,
-                           /*withTrailingX=*/true) ||
-      p.parseType(elementType) || p.parseGreater())
+  if (odsParser.parseLess() ||
+      odsParser.parseDimensionList(shape, /*allowDynamic=*/false,
+                                   /*withTrailingX=*/true) ||
+      odsParser.parseType(elementType) || odsParser.parseGreater())
     return {};
 
-  return HLMemType::get(p.getContext(), shape, elementType);
+  return HLMemType::get(odsParser.getContext(), shape, elementType);
 }
 
-void HLMemType::print(AsmPrinter &p) const {
-  p << '<';
+void HLMemType::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << '<';
   for (auto dim : getShape())
-    p << dim << 'x';
-  p << getElementType();
-  p << '>';
+    odsPrinter << dim << 'x';
+  odsPrinter << getElementType();
+  odsPrinter << '>';
 }
 
 LogicalResult

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTSeqTransforms
   LowerSeqToSV.cpp
+  LowerSeqHLMem.cpp
 
   DEPENDS
   CIRCTSeqTransformsIncGen

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -1,0 +1,156 @@
+//===- LowerSeqHLMem.cpp - seq.hlmem lowering -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass pattern matches lowering patterns on seq.hlmem ops and referencing
+// ports.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace seq;
+
+namespace {
+
+struct SimpleBehavioralMemoryLowering
+    : public OpConversionPattern<seq::HLMemOp> {
+  // A simple behavioral SV implementation of a HLMemOp. This is intended as a
+  // fall-back pattern if any other higher benefit/target-specific patterns
+  // failed to match.
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(seq::HLMemOp mem, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+
+    // Only support unidimensional memories.
+    auto memType = mem.getMemType();
+    if (memType.getShape().size() != 1)
+      return failure();
+    auto size = memType.getShape()[0];
+
+    // Gather up the referencing ops.
+    llvm::SmallVector<seq::ReadPortOp> readOps;
+    llvm::SmallVector<seq::WritePortOp> writeOps;
+    for (auto *user : mem.getHandle().getUsers()) {
+      auto res = llvm::TypeSwitch<Operation *, LogicalResult>(user)
+                     .Case([&](seq::ReadPortOp op) {
+                       readOps.push_back(op);
+                       return success();
+                     })
+                     .Case([&](seq::WritePortOp op) {
+                       writeOps.push_back(op);
+                       return success();
+                     })
+                     .Default([&](Operation *op) { return failure(); });
+      if (failed(res))
+        return rewriter.notifyMatchFailure(user, "unsupported port type");
+    }
+
+    auto clk = mem.getClk();
+    auto rst = mem.getRst();
+    auto memName = mem.getName();
+
+    // Create the SV memory.
+    hw::UnpackedArrayType memArrType =
+        hw::UnpackedArrayType::get(memType.getElementType(), size);
+    auto svMem =
+        rewriter.create<sv::RegOp>(mem.getLoc(), memArrType, mem.getNameAttr())
+            .getResult();
+
+    // Create write ports by gathering up the write port inputs and
+    // materializing the writes inside a single always ff block.
+    struct WriteTuple {
+      Location loc;
+      Value addr;
+      Value data;
+      Value en;
+    };
+    llvm::SmallVector<WriteTuple> writeTuples;
+    for (auto writeOp : writeOps) {
+      if (writeOp.getLatency() != 1)
+        return rewriter.notifyMatchFailure(
+            writeOp, "only supports write ports with latency == 1");
+      auto addr = writeOp.getAddresses()[0];
+      auto data = writeOp.getInData();
+      auto en = writeOp.getWrEn();
+      writeTuples.push_back({writeOp.getLoc(), addr, data, en});
+      rewriter.eraseOp(writeOp);
+    }
+
+    rewriter.create<sv::AlwaysFFOp>(
+        mem.getLoc(), sv::EventControl::AtPosEdge, clk, ResetType::SyncReset,
+        sv::EventControl::AtPosEdge, rst, [&] {
+          for (auto [loc, address, data, en] : writeTuples) {
+            Value a = address, d = data; // So the lambda can capture.
+            Location l = loc;
+            // Perform write upon write enable being high.
+            rewriter.create<sv::IfOp>(loc, en, [&] {
+              Value memLoc =
+                  rewriter.create<sv::ArrayIndexInOutOp>(l, svMem, a);
+              rewriter.create<sv::PAssignOp>(l, memLoc, d);
+            });
+          }
+        });
+
+    // Create read ports.
+    for (auto [ri, readOp] : llvm::enumerate(readOps)) {
+      rewriter.setInsertionPointAfter(readOp);
+      auto loc = readOp.getLoc();
+
+      // Create a combinational read.
+      Value memLoc = rewriter.create<sv::ArrayIndexInOutOp>(
+          loc, svMem, readOp.getAddresses()[0]);
+      Value readData = rewriter.create<sv::ReadInOutOp>(loc, memLoc);
+
+      // Materialize any delays on the read port.
+      for (int i = 0, e = readOp.getLatency(); i < e; ++i)
+        readData = rewriter.create<seq::CompRegOp>(
+            loc, readData, clk,
+            rewriter.getStringAttr(memName + "_rd" + std::to_string(ri) +
+                                   "_dly" + std::to_string(i)));
+      rewriter.replaceOp(readOp, {readData});
+    }
+
+    rewriter.eraseOp(mem);
+    return success();
+  }
+};
+
+struct LowerSeqHLMemPass : public LowerSeqHLMemBase<LowerSeqHLMemPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void LowerSeqHLMemPass::runOnOperation() {
+  hw::HWModuleOp top = getOperation();
+
+  MLIRContext &ctxt = getContext();
+  ConversionTarget target(ctxt);
+
+  // Lowering patterns must lower away all HLMem-related operations.
+  target.addIllegalOp<seq::HLMemOp, seq::ReadPortOp, seq::WritePortOp>();
+  target.addLegalDialect<sv::SVDialect, seq::SeqDialect>();
+  RewritePatternSet patterns(&ctxt);
+  patterns.add<SimpleBehavioralMemoryLowering>(&ctxt);
+
+  if (failed(applyPartialConversion(top, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::seq::createLowerSeqHLMemPass() {
+  return std::make_unique<LowerSeqHLMemPass>();
+}

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -38,7 +38,8 @@ public:
     // Only support unidimensional memories.
     auto memType = mem.getMemType();
     if (memType.getShape().size() != 1)
-      return failure();
+      return rewriter.notifyMatchFailure(
+          mem, "only unidimensional memories are supported");
     auto size = memType.getShape()[0];
 
     // Gather up the referencing ops.

--- a/test/Dialect/Seq/lower-hlmem.mlir
+++ b/test/Dialect/Seq/lower-hlmem.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt --lower-seq-hlmem %s | FileCheck %s
+
+hw.module @d1(%clk : i1, %rst : i1) -> () {
+  // CHECK:           %[[VAL_2:.*]] = sv.reg  : !hw.inout<uarray<4xi32>>
+  %myMemory = seq.hlmem @myMemory %clk, %rst : <4xi32>
+  
+  // CHECK:           sv.alwaysff(posedge %clk) {
+  // CHECK:             sv.if %[[VAL_3:.*]] {
+  // CHECK:               %[[VAL_4:.*]] = sv.array_index_inout %myMemory[%c0_i2] : !hw.inout<uarray<4xi32>>, i2
+  // CHECK:               sv.passign %[[VAL_4]], %c42_i32 : i32
+  // CHECK:             }
+  // CHECK:           }(syncreset : posedge %rst) {
+  // CHECK:           }
+  seq.write %myMemory[%c0_i2] %c42_i32 wren %c1_i1 { latency = 1 } : !seq.hlmem<4xi32>
+
+  %c0_i2 = hw.constant 0 : i2
+  %c1_i1 = hw.constant 1 : i1
+  %c42_i32 = hw.constant 42 : i32
+
+  // CHECK:           %[[VAL_10:.*]] = sv.array_index_inout %myMemory[%c0_i2] : !hw.inout<uarray<4xi32>>, i2
+  // CHECK:           %[[VAL_11:.*]] = sv.read_inout %[[VAL_10]] : !hw.inout<i32>
+  %myMemory_rdata = seq.read %myMemory[%c0_i2] rden %c1_i1 { latency = 0} : !seq.hlmem<4xi32>
+
+  // CHECK:           %[[VAL_12:.*]] = sv.array_index_inout %myMemory[%c0_i2] : !hw.inout<uarray<4xi32>>, i2
+  // CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
+  // CHECK:           %[[VAL_14:.*]] = seq.compreg sym @myMemory_rd0_dly0 %[[VAL_13]], %clk : i32
+  // CHECK:           %[[VAL_15:.*]] = seq.compreg sym @myMemory_rd0_dly1 %[[VAL_14]], %clk : i32
+  %myMemory_rdata2 = seq.read %myMemory[%c0_i2] rden %c1_i1 { latency = 2} : !seq.hlmem<4xi32>
+  hw.output
+}


### PR DESCRIPTION
This commit adds a fallback/default pattern for lowering `seq.hlmem` operations. The implementation is based on the ESI ram service lowering, and provides a behavioral lowering. The intention of this lowering is to provide a pattern that will almost guarantee to synthesize on FPGAs - QoR not guaranteed. "Better"/target-specific patterns can be added by adding patterns with higher benefit - which will match with higher priority.

Read ports with arbitrary (N) latency are realized by performing a combinational read, and registering the read value N times.
Write ports are only supported for latency == 1.