### PR TITLE
[ExportVerilog] Fixup parameter parens/precedence, fix missing clog2 paren, omit double parens sometimes.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1455,6 +1455,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   VerilogPrecedence subprecedence = ForceEmitMultiUse;
   Optional<SubExprSignResult> operandSign;
   bool isUnary = false;
+  bool isFunction = false;
 
   switch (expr.getOpcode()) {
   case PEO::Add:
@@ -1516,11 +1517,11 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     operatorStr = "$clog2";
     operandSign = IsUnsigned;
     isUnary = true;
+    isFunction = true;
     break;
   case PEO::StrConcat:
     operatorStr = ", ";
     subprecedence = Symbol;
-    isUnary = false;
     break;
   }
 
@@ -1544,7 +1545,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   if (isUnary)
     os << operatorStr;
 
-  if (subprecedence > parenthesizeIfLooserThan)
+  if (subprecedence > parenthesizeIfLooserThan || isFunction)
     os << '(';
   if (expr.getOpcode() == PEO::StrConcat)
     os << '{';
@@ -1569,9 +1570,9 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   }
   if (expr.getOpcode() == PEO::StrConcat)
     os << '}';
-  if (subprecedence > parenthesizeIfLooserThan) {
+  if (subprecedence > parenthesizeIfLooserThan || isFunction) {
     os << ')';
-    subprecedence = Symbol;
+    subprecedence = Selection;
   }
   return {subprecedence, allOperandsSigned ? IsSigned : IsUnsigned};
 }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1452,7 +1452,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   }
 
   StringRef operatorStr;
-  VerilogPrecedence subprecedence = ForceEmitMultiUse;
+  VerilogPrecedence subprecedence = LowestPrecedence;
   Optional<SubExprSignResult> operandSign;
   bool isUnary = false;
   bool isFunction = false;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1454,7 +1454,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   StringRef operatorStr;
   StringRef openStr, closeStr;
   VerilogPrecedence subprecedence = LowestPrecedence;
-  VerilogPrecedence prec; // outer prec, when has open/close.
+  VerilogPrecedence prec; // precedence of the emitted expression.
   Optional<SubExprSignResult> operandSign;
   bool isUnary = false;
   bool hasOpenClose = false;
@@ -1527,14 +1527,18 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     closeStr = "}";
     hasOpenClose = true;
     operatorStr = ", ";
-    // We don't have Concat precedence, so use Lowest. (SV Table 11-2).
+    // We don't have Concat precedence, but it's lowest anyway. (SV Table 11-2).
     subprecedence = LowestPrecedence;
     prec = Symbol;
     break;
   }
   if (!hasOpenClose)
     prec = subprecedence;
+
+  // unary -> one element.
   assert(!isUnary || llvm::hasSingleElement(expr.getOperands()));
+  // one element -> {unary || open/close}.
+  assert(isUnary || hasOpenClose || !llvm::hasSingleElement(expr.getOperands()));
 
   // Emit the specified operand with a $signed() or $unsigned() wrapper around
   // it if context requires a specific signedness to compute the right value.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1531,13 +1531,15 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   // TODO: This could try harder to omit redundant casts like the mainline
   // expression emitter.
   auto emitOperand = [&](Attribute operand) -> bool {
+    // If surrounding with signed/unsigned, inner expr doesn't need parens.
+    auto subprec = operandSign.has_value() ? LowestPrecedence : subprecedence;
     if (operandSign.has_value())
-      os << (operandSign.value() == IsSigned ? "$signed(" : "$unsigned(");
+      os << (*operandSign == IsSigned ? "$signed(" : "$unsigned(");
     auto signedness =
-        printParamValue(operand, os, subprecedence, emitError).signedness;
+        printParamValue(operand, os, subprec, emitError).signedness;
     if (operandSign.has_value()) {
       os << ')';
-      signedness = operandSign.value();
+      signedness = *operandSign;
     }
     return signedness == IsSigned;
   };

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1516,7 +1516,6 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   case PEO::CLog2:
     operatorStr = "$clog2";
     operandSign = IsUnsigned;
-    isUnary = true;
     isFunction = true;
     break;
   case PEO::StrConcat:
@@ -1544,11 +1543,12 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     return signedness == IsSigned;
   };
 
-  if (isUnary)
+  if (isFunction)
     os << operatorStr;
-
   if (subprecedence > parenthesizeIfLooserThan || isFunction)
     os << '(';
+  if (isUnary)
+    os << operatorStr;
   if (expr.getOpcode() == PEO::StrConcat)
     os << '{';
   bool allOperandsSigned = emitOperand(expr.getOperands()[0]);

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1238,6 +1238,9 @@ hw.module @ParamsParensPrecedence<param: i32>() {
 
   // CHECK: = $clog2($unsigned($clog2($unsigned(param + 8))));
   %3 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.expr.clog2<#hw.param.expr.add<#hw.param.decl.ref<"param">,8>>>
+
+  // CHECK: = $signed(param) >>> $signed(param & 8);
+  %4 = hw.param.value i32 = #hw.param.expr.shrs<#hw.param.decl.ref<"param">,#hw.param.expr.and<8,#hw.param.decl.ref<"param">>>
 }
 
 // CHECK-LABEL: module ArrayGetInline

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1231,6 +1231,15 @@ hw.module @ParamConcatInst<name: none = "top">() -> () {
   hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.str.concat<".", #hw.param.decl.ref<"name">, ".", "child">>() -> ()
 }
 
+// CHECK-LABEL: module ParamsParensPrecedence
+hw.module @ParamsParensPrecedence<param: i32>() {
+  // CHECK: = $clog2($unsigned(param));
+  %1 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
+
+  // CHECK: = $clog2($unsigned($clog2($unsigned(param + 8))));
+  %3 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.expr.clog2<#hw.param.expr.add<#hw.param.decl.ref<"param">,8>>>
+}
+
 // CHECK-LABEL: module ArrayGetInline
 hw.module @ArrayGetInline(%a: !hw.array<4xstruct<a: i32>>) -> (out: i32) {
   %c0_i2 = hw.constant 0 : i2


### PR DESCRIPTION
Primarily:
* Fix missing paren for clog2 when nested.
* Fix double parens when adding `$signed()` around an operand.

See test, here's relevant before/after:

Before:

```systemverilog
module ParamsParensPrecedence
  #(parameter /*integer*/ param) ();	// ./test/Conversion/ExportVerilog/hw-dialect.mlir:1235:1
  wire [31:0] _GEN = $clog2($unsigned(param));	// ./test/Conversion/ExportVerilog/hw-dialect.mlir:1237:8
  wire [31:0] _GEN_0 = $clog2($unsigned($clog2$unsigned(param + 8)));	// ./test/Conversion/ExportVerilog/hw-dialect.mlir:1240:8
  wire [31:0] _GEN_1 = $signed(param) >>> $signed((param & 8));	// ./test/Conversion/ExportVerilog/hw-dialect.mlir:1243:8
endmodule
```

After:
```systemverilog
module ParamsParensPrecedence
  #(parameter /*integer*/ param) ();    // ./test/Conversion/ExportVerilog/hw-dialect.mlir:1235:1
  wire [31:0] _GEN = $clog2($unsigned(param));  // ./test/Conversion/ExportVerilog/hw-dialect.mlir:1237:8
  wire [31:0] _GEN_0 = $clog2($unsigned($clog2($unsigned(param + 8)))); // ./test/Conversion/ExportVerilog/hw-dialect.mlir:1240:8
  wire [31:0] _GEN_1 = $signed(param) >>> $signed(param & 8);   // ./test/Conversion/ExportVerilog/hw-dialect.mlir:1243:8
endmodule
```

---

Bit more:

`clog2` needs parens regardless of inner expression, since it's a function.  Instead of getting this to happen by giving this `ForceEmitMultiUse` precedence (so it's lower than default `LowestPredence`), handle operations with outer syntax differently.

Separate out operations that are "unary" (`!`, etc.) from functions and Concat with `hasOpenClose`.  We do not currently support any unary (non-function) operators presently.

When wrapping the expression in parens, the returned precedence should be `Selection`.

While visiting, fix emission of extra parens in some cases by setting parenthesize-if-looser-than appropriately when emitting within `$signed`/$unsigned` which add parentheses already.

As a bonus, drops the only (useful) use of `ForceEmitMultiUse` which will be removed in a follow-up.