### PR TITLE
[HW][Comb] Canonicalize muxes of arrays

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -283,5 +283,5 @@ def MuxOp : CombOp<"mux",
     "(`bin` $twoState^)? $cond `,` $trueValue `,` $falseValue  attr-dict `:` qualified(type($result))";
 
   let hasFolder = true;
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
 }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2144,7 +2144,35 @@ static bool foldCommonMuxOperation(MuxOp mux, Operation *trueOp,
   return false;
 }
 
-LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
+// If both arguments of the mux are arrays with the same elements, sink the
+// mux and return a uniform array initializing all elements to it.
+static bool foldMuxOfUniformArrays(MuxOp op, PatternRewriter &rewriter) {
+  auto trueVec = op.getTrueValue().getDefiningOp<hw::ArrayCreateOp>();
+  auto falseVec = op.getFalseValue().getDefiningOp<hw::ArrayCreateOp>();
+  if (!trueVec || !falseVec)
+    return false;
+  if (!trueVec.isUniform() || !falseVec.isUniform())
+    return false;
+
+  auto mux = rewriter.create<MuxOp>(
+      op.getLoc(), op.getCond(), trueVec.getUniformElement(),
+      falseVec.getUniformElement(), op.getTwoState());
+
+  SmallVector<Value> values(trueVec.getInputs().size(), mux);
+  rewriter.replaceOpWithNewOp<hw::ArrayCreateOp>(op, values);
+  return true;
+}
+
+namespace {
+struct MuxRewriter : public mlir::OpRewritePattern<MuxOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MuxOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
+                                           PatternRewriter &rewriter) const {
   APInt value;
 
   if (matchPattern(op.getTrueValue(), m_RConstant(value))) {
@@ -2328,7 +2356,77 @@ LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
   if (narrowOperationWidth(op, true, rewriter))
     return success();
 
+  // mux(cond, repl(n, a1), repl(n, a2)) -> repl(n, mux(cond, a1, a2))
+  if (foldMuxOfUniformArrays(op, rewriter))
+    return success();
+
   return failure();
+}
+
+static bool foldArrayOfMuxes(hw::ArrayCreateOp op, PatternRewriter &rewriter) {
+  // Do not fold uniform or singleton arrays to avoid duplicating muxes.
+  if (op.getInputs().empty() || op.isUniform())
+    return false;
+  auto inputs = op.getInputs();
+  if (inputs.size() <= 1)
+    return false;
+
+  // Check the operands to the array create.  Ensure all of them are the
+  // same op with the same number of operands.
+  auto first = inputs[0].getDefiningOp<comb::MuxOp>();
+  if (!first)
+    return false;
+
+  // Check whether all operands are muxes with the same condition.
+  for (size_t i = 1, n = inputs.size(); i < n; ++i) {
+    auto input = inputs[i].getDefiningOp<comb::MuxOp>();
+    if (!input || first.getCond() != input.getCond())
+      return false;
+  }
+
+  // Collect the true and the false branches into arrays.
+  SmallVector<Value> trues{first.getTrueValue()};
+  SmallVector<Value> falses{first.getFalseValue()};
+  SmallVector<Location> locs{first->getLoc()};
+  bool isTwoState = true;
+  for (size_t i = 1, n = inputs.size(); i < n; ++i) {
+    auto input = inputs[i].getDefiningOp<comb::MuxOp>();
+    trues.push_back(input.getTrueValue());
+    falses.push_back(input.getFalseValue());
+    locs.push_back(input->getLoc());
+    if (!input.getTwoState())
+      isTwoState = false;
+  }
+
+  // Define the location of the array create as the aggregate of all muxes.
+  auto loc = FusedLoc::get(op.getContext(), locs);
+
+  // Replace the create with an aggregate operation.  Push the create op
+  // into the operands of the aggregate operation.
+  auto arrayTy = op.getType();
+  auto trueValues = rewriter.create<hw::ArrayCreateOp>(loc, arrayTy, trues);
+  auto falseValues = rewriter.create<hw::ArrayCreateOp>(loc, arrayTy, falses);
+  rewriter.replaceOpWithNewOp<comb::MuxOp>(op, arrayTy, first.getCond(),
+                                           trueValues, falseValues, isTwoState);
+  return true;
+}
+
+struct ArrayRewriter : public mlir::OpRewritePattern<hw::ArrayCreateOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(hw::ArrayCreateOp op,
+                                PatternRewriter &rewriter) const override {
+    if (foldArrayOfMuxes(op, rewriter))
+      return success();
+    return failure();
+  }
+};
+} // namespace
+
+void MuxOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  results.insert<MuxRewriter>(context);
+  results.insert<ArrayRewriter>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1560,3 +1560,30 @@ hw.module @CreateOfSlices(%arr0: !hw.array<3xi1>, %arr1: !hw.array<5xi1>) -> (re
   hw.output %6 : !hw.array<6xi1>
 }
 
+// CHCEK-LABEL: @MuxOfArrays
+hw.module @MuxOfArrays(%cond: i1, %a0: i1, %a1: i1, %a2: i1, %b0: i1, %b1: i1, %b2: i1) -> (res: !hw.array<3xi1>) {
+  %mux0 = comb.mux %cond, %a0, %b0 : i1
+  %mux1 = comb.mux %cond, %a1, %b1 : i1
+  %mux2 = comb.mux %cond, %a2, %b2 : i1
+  %array = hw.array_create %mux2, %mux1, %mux0 : i1
+
+  // CHECK:      [[TRUE:%.+]] = hw.array_create %a2, %a1, %a0 : i1
+  // CHECK-NEXT: [[FALSE:%.+]] = hw.array_create %b2, %b1, %b0 : i1
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.mux %cond, [[TRUE]], [[FALSE]] : !hw.array<3xi1>
+  // CHECK-NEXT: hw.output [[RESULT]] : !hw.array<3xi1>
+
+  hw.output %array : !hw.array<3xi1>
+}
+
+// CHCEK-LABEL: @MuxOfUniformArray
+hw.module @MuxOfUniformArray(%cond: i1, %a: i1, %b: i1) -> (res: !hw.array<3xi1>) {
+  %array_a = hw.array_create %a, %a, %a : i1
+  %array_b = hw.array_create %b, %b, %b : i1
+  %mux = comb.mux %cond, %array_a, %array_b : !hw.array<3xi1>
+
+  // CHECK:      [[MUX:%.+]] = comb.mux %cond, %a, %b : i1
+  // CHECK-NEXT: [[ARRAY:%.+]] = hw.array_create [[MUX]], [[MUX]], [[MUX]] : i1
+  // CHECK-NEXT: hw.output [[ARRAY]] : !hw.array<3xi1>
+
+  hw.output %mux : !hw.array<3xi1>
+}


### PR DESCRIPTION
Array create operations which build arrays from muxes with identical conditions are turned into muxes of arrays.
An inverse transformation scalarizes the muxes if their array arguments are uniform.