### PR TITLE
[FIRRTL][IMConstProp] Mark Verbatim Expr as overdefined

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -401,7 +401,7 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
       for (auto result : cast.getResults())
         markOverdefined(result);
     else if (auto verbatim = dyn_cast<VerbatimExprOp>(op))
-      return markOverdefined(verbatim.getResult());
+      markOverdefined(verbatim.getResult());
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -400,6 +400,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
     else if (auto cast = dyn_cast<mlir::UnrealizedConversionCastOp>(op))
       for (auto result : cast.getResults())
         markOverdefined(result);
+    else if (auto verbatim = dyn_cast<VerbatimExprOp>(op))
+      return markOverdefined(verbatim.getResult());
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -402,6 +402,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
         markOverdefined(result);
     else if (auto verbatim = dyn_cast<VerbatimExprOp>(op))
       markOverdefined(verbatim.getResult());
+    else if (auto verbatim = dyn_cast<VerbatimWireOp>(op))
+      markOverdefined(verbatim.getResult());
   }
 }
 

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -603,7 +603,7 @@ firrtl.circuit "Verbatim"  {
     firrtl.strictconnect %fizz, %tap : !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %tap, %[[v0]] : !firrtl.uint<1>
     firrtl.strictconnect %tap, %0 : !firrtl.uint<1>
-    // CHECK: firrtl.verbatim.wire "randomBar.b" : () -> !firrtl.uint<1> {symbols = []}
+    // CHECK: firrtl.verbatim.wire "randomBar.b"
     %1 = firrtl.verbatim.wire "randomBar.b" : () -> !firrtl.uint<1> {symbols = []}
     // CHECK: %tap2 = firrtl.wire   : !firrtl.uint<1>
     %tap2 = firrtl.wire   : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -589,3 +589,16 @@ firrtl.circuit "ForwardRef" {
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
+
+firrtl.circuit "Top"  {
+  firrtl.module @Top(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} {
+    // CHECK: %[[v0:.+]] = firrtl.verbatim.expr
+    %0 = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
+    // CHECK: %tap = firrtl.wire   : !firrtl.uint<1>
+    %tap = firrtl.wire   : !firrtl.uint<1>
+    %fizz = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
+    firrtl.strictconnect %fizz, %tap : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %tap, %[[v0]] : !firrtl.uint<1>
+    firrtl.strictconnect %tap, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -590,8 +590,11 @@ firrtl.circuit "ForwardRef" {
   }
 }
 
-firrtl.circuit "Top"  {
-  firrtl.module @Top(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} {
+// -----
+
+// Verbatim expressions should not be optimized away.
+firrtl.circuit "Verbatim"  {
+  firrtl.module @Verbatim() {
     // CHECK: %[[v0:.+]] = firrtl.verbatim.expr
     %0 = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
     // CHECK: %tap = firrtl.wire   : !firrtl.uint<1>
@@ -600,5 +603,10 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %fizz, %tap : !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %tap, %[[v0]] : !firrtl.uint<1>
     firrtl.strictconnect %tap, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.verbatim.wire "randomBar.b" : () -> !firrtl.uint<1> {symbols = []}
+    %1 = firrtl.verbatim.wire "randomBar.b" : () -> !firrtl.uint<1> {symbols = []}
+    // CHECK: %tap2 = firrtl.wire   : !firrtl.uint<1>
+    %tap2 = firrtl.wire   : !firrtl.uint<1>
+    firrtl.strictconnect %tap2, %1 : !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
`firrtl.verbatim.expr` result must be marked as over-defined, otherwise it will be  dropped!
Fixes https://github.com/llvm/circt/issues/4157