### PR TITLE
[HW] Concatenate slice ops in array_concat

### DIFF
--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1588,4 +1588,27 @@ hw.module @MuxOfUniformArray(%cond: i1, %a: i1, %b: i1) -> (res: !hw.array<3xi1>
   hw.output %mux : !hw.array<3xi1>
 }
 
+// CHECK-LABEL: @ConcatOfSlicesAndGets
+hw.module @ConcatOfSlicesAndGets(%a: !hw.array<5xi1>, %b: !hw.array<5xi1>, %c: !hw.array<5xi1>) -> (res: !hw.array<13xi1>) {
+  %c1_i3 = hw.constant 1 : i3
+  %c3_i3 = hw.constant 3 : i3
+  %c4_i3 = hw.constant 4 : i3
 
+  %slice_a0 = hw.array_slice %a[%c1_i3] : (!hw.array<5xi1>) -> !hw.array<2xi1>
+  %slice_a1 = hw.array_slice %a[%c3_i3] : (!hw.array<5xi1>) -> !hw.array<1xi1>
+  %get_a = hw.array_get %a[%c4_i3] : !hw.array<5xi1>, i3
+  %wrap_a = hw.array_create %get_a : i1
+
+  %slice_b = hw.array_slice %b[%c1_i3] : (!hw.array<5xi1>) -> !hw.array<3xi1>
+  %get_b = hw.array_get %b[%c4_i3] : !hw.array<5xi1>, i3
+  %wrap_b = hw.array_create %get_b : i1
+
+  // CHECK-DAG: [[SLICE_A:%.+]] = hw.array_slice %a[%c1_i3] : (!hw.array<5xi1>) -> !hw.array<4xi1>
+  // CHECK-DAG: [[SLICE_B:%.+]] = hw.array_slice %b[%c1_i3] : (!hw.array<5xi1>) -> !hw.array<4xi1>
+  // CHECK-DAG: [[CONCAT:%.+]] = hw.array_concat %c, [[SLICE_B]], [[SLICE_A]] : !hw.array<5xi1>, !hw.array<4xi1>, !hw.array<4xi1>
+  // CHECK-DAG: hw.output [[CONCAT]] : !hw.array<13xi1>
+  %result = hw.array_concat %c, %wrap_b, %slice_b, %wrap_a, %slice_a1, %slice_a0 :
+      !hw.array<5xi1>, !hw.array<1xi1>, !hw.array<3xi1>, !hw.array<1xi1>, !hw.array<1xi1>, !hw.array<2xi1>
+
+  hw.output %result : !hw.array<13xi1>
+}


### PR DESCRIPTION
If a concat operation merges consecutive slices or elements, the arguments are concatenated for readability.