### PR TITLE
[ExportVerilog] Fix zero-width `hw.constant` emission

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -186,6 +186,11 @@ static StringRef getSymOpName(Operation *symOp) {
       });
 }
 
+/// Emits a known-safe token that is legal when indexing into singleton arrays.
+static void emitZeroWidthIndexingValue(llvm::raw_svector_ostream &os) {
+  os << "/*Zero width*/ 1\'b0";
+}
+
 /// Return the verilog name of the port for the module.
 StringRef getPortVerilogName(Operation *module, ssize_t portArgNum) {
   auto numInputs = hw::getModuleNumInputs(module);
@@ -2287,6 +2292,18 @@ SubExprInfo ExprEmitter::visitTypeOp(ConstantOp op) {
 
   bool isNegated = false;
   const APInt &value = op.getValue();
+
+  // We currently only allow zero width values to be handled as special cases in
+  // the various operations that may come across them. If we reached this point
+  // in the emitter, the value should be considered illegal to emit.
+  // if (value.getBitWidth() == 0) {
+  //   emitOpError(op, "will not emit zero width constants in the general
+  //   case"); os << "<<unsupported zero width constant: " <<
+  //   op->getName().getStringRef()
+  //      << ">>";
+  //   return {Unary, IsUnsigned};
+  // }
+
   // If this is a negative signed number and not MININT (e.g. -128), then print
   // it as a negated positive number.
   if (signPreference == RequireSigned && value.isNegative() &&
@@ -2340,16 +2357,9 @@ SubExprInfo ExprEmitter::visitTypeOp(ArraySliceOp op) {
 SubExprInfo ExprEmitter::visitTypeOp(ArrayGetOp op) {
   emitSubExpr(op.getInput(), Selection);
   os << '[';
-  if (isZeroBitType(op.getIndex().getType())) {
-    // Due to the singleton memory, [1'b0] will always be syntactically valid
-    // as an indexing into the provided array.
-    // Emit the index expression as a comment for tracability (all other i0
-    // values referenced within the index expression will similarly be commented
-    // out).
-    os << "/*Zero width: ";
-    emitSubExpr(op.getIndex(), LowestPrecedence);
-    os << "*/ 1\'b0";
-  } else
+  if (isZeroBitType(op.getIndex().getType()))
+    emitZeroWidthIndexingValue(os);
+  else
     emitSubExpr(op.getIndex(), LowestPrecedence);
   os << ']';
   emitSVAttributes(op);
@@ -2392,9 +2402,13 @@ SubExprInfo ExprEmitter::visitSV(ArrayIndexInOutOp op) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
+  auto index = op.getIndex();
   auto arrayPrec = emitSubExpr(op.getInput(), Selection);
   os << '[';
-  emitSubExpr(op.getIndex(), LowestPrecedence);
+  if (isZeroBitType(index.getType()))
+    emitZeroWidthIndexingValue(os);
+  else
+    emitSubExpr(index, LowestPrecedence);
   os << ']';
   return {Selection, arrayPrec.signedness};
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -818,6 +818,13 @@ hw.module @Chi() -> (Chi_output : i0) {
   // CHECK: endmodule
 }
 
+// CHECK-LABEL: module Choochoo(
+hw.module @Choochoo() -> (out : i0) {
+  %0 = hw.constant 0 : i0
+  // CHECK: // Zero width: assign out = /*Zero width*/;
+  hw.output %0 : i0
+}
+
 // CHECK-LABEL: module Foo1360(
 // Issue #1360: https://github.com/llvm/circt/issues/1360
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -185,7 +185,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-NEXT:      assign r38 = {[[WIRE0]], [[WIRE0]]};
 // CHECK-NEXT:      assign r40 = '{foo: structA.foo, bar: a};
 // CHECK-NEXT:      assign r41 = '{foo: [[WIRE1]].foo, bar: b};
-// CHECK-NEXT:      assign r42 = array1[/*Zero width: 0'h0*/ 1'b0];
+// CHECK-NEXT:      assign r42 = array1[/*Zero width*/ 1'b0];
 // CHECK-NEXT: endmodule
 
 
@@ -513,8 +513,8 @@ hw.module @TestZeroStructInstance(%structZero: !hw.struct<>, %structZeroNest: !h
 // CHECK-NEXT:                            out1
 // CHECK-NEXT:   // output /*Zero Width*/ out2
 
-// CHECK:   assign out = arg1[/*Zero width: 0'h0*/ 1'b0];	
-// CHECK-NEXT:   assign out1 = arg1[/*Zero width: arg0*/ 1'b0];	
+// CHECK:   assign out = arg1[/*Zero width*/ 1'b0];	
+// CHECK-NEXT:   assign out1 = arg1[/*Zero width*/ 1'b0];	
 // CHECK-NEXT:   // Zero width: assign out2 = arg0;	
 
 hw.module @testZeroArrayGet(%arg0: i0, %arg1 : !hw.array<1xi32>) -> (out: i32, out1: i32, out2: i0) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1340,6 +1340,17 @@ hw.module.extern @extInst(%_h: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> ()
 // CHECK-NEXT:                          _k
 hw.module @extInst2(%signed: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> () {}
 
+// CHECK-LABEL: module zeroWidthArrayIndex
+hw.module @zeroWidthArrayIndex(%clock : i1, %data : i64) -> () {
+  %reg = sv.reg  : !hw.inout<uarray<1xi64>>
+  sv.alwaysff(posedge %clock) {
+    %c0_i0_1 = hw.constant 0 : i0
+    // CHECK: reg_0[/*Zero width*/ 1'b0] <= data;
+    %0 = sv.array_index_inout %reg[%c0_i0_1] : !hw.inout<uarray<1xi64>>, i0
+    sv.passign %0, %data : i64
+  }
+}
+
 // CHECK-LABEL: module remoteInstDut
 hw.module @remoteInstDut(%i: i1, %j: i1, %z: i0) -> () {
   %mywire = sv.wire : !hw.inout<i1>


### PR DESCRIPTION
Previously, the zero-width constant value had only been handled through a special case in `hw.array_get`. However, an i0 value may also be used elsewhere where emission is delegated all the way through to the `hw.constant` op. This commit adds the required special case handling, and a test for `sv.array_index_inout`.