### PR TITLE
[FIRRTL] Add Aggregate creation ops and aggregate constants

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -356,6 +356,8 @@ def WireOp : ReferableDeclOp<"wire"> {
                        OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs AnyType:$result);
 
+  let hasCanonicalizer = true;
+
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                       CArg<"StringRef", "{}">:$name,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -17,6 +17,11 @@ def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
   let cppNamespace = "::circt::firrtl";
 }
 
+class IndexConstraint<string value, string resultValue>
+  : TypesMatchWith<"type should be element of vector type",
+                   value, resultValue,
+                   "firrtl::getVectorElementType($_self)">;
+
 // A common base class for operations that implement type inference and parsed
 // argument validation.
 class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
@@ -120,6 +125,65 @@ def SpecialConstantOp : FIRRTLOp<"specialconstant",
   let hasFolder = 1;
 }
 
+def AggregateConstantOp : FIRRTLOp<"aggregateconstant", [Pure, ConstantLike]> {
+  let summary = "Produce a constant of a passive aggregate value";
+  let description = [{
+    The constant operations produces a constant value of an aggregate type.  The
+    type must be passive.  Clock and reset values are supported.
+    For nested aggregates, values are applied in depth-first fassion.
+    ```
+      %result = firrtl.aggregateconstant 1, 2, 3 : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<4>>
+      %result = firrtl.aggregateconstant 1, 2, 3 : !firrtl.vector<uint<8>, 3>
+
+    ```
+  }];
+
+  let arguments = (ins TypedArrayAttrBase<APSIntAttr, "field constants">:$fields);
+  let results = (outs AggregateType:$result);
+
+  let assemblyFormat = "$fields attr-dict `:` type($result)";
+  let hasFolder = 1;
+  let hasVerifier = 1;
+}
+
+def BundleCreateOp : FIRRTLOp<"bundlecreate"> {
+  let summary = "Produce a bundle value";
+  let description = [{
+    Create an bundle from component values.  This is equivalent in terms of
+    flow to creating a node.
+    ```
+      %result = firrtl.bundlecreate %1, %2, %3 : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<4>>
+    ```
+  }];
+
+  let arguments = (ins Variadic<FIRRTLBaseType>:$fields);
+  let results = (outs BundleType:$result);
+
+  let assemblyFormat = "$fields attr-dict `:` functional-type($fields, $result)";
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+}
+
+def VectorCreateOp : FIRRTLOp<"vectorcreate"> {
+  let summary = "Produce a vector value";
+  let description = [{
+    Create a vector from component values.  This is equivalent in terms of
+    flow to creating a node.
+    ```
+      %result = firrtl.vectorcreate %1, %2, %3 : !firrtl.vector<uint<8>, 3>
+
+    ```
+  }];
+
+  let arguments = (ins Variadic<FIRRTLBaseType>:$fields);
+  let results = (outs FVectorType:$result);
+
+  let assemblyFormat = "$fields attr-dict `:` functional-type($fields, $result)";
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+}
+
+
 def InvalidValueOp : FIRRTLOp<"invalidvalue",
       [Pure, ConstantLike, HasCustomSSAName]> {
   let summary = "InvalidValue primitive";
@@ -152,7 +216,9 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
 
   let arguments = (ins BundleType:$input, I32Attr:$fieldIndex);
   let results = (outs FIRRTLBaseType:$result);
-
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+  
   // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
     "$input `(` $fieldIndex `)` attr-dict `:` functional-type($input, $result)";
@@ -176,14 +242,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
                                             .getFieldID(getFieldIndex()));
     }
   }];
-
-  let hasVerifier = 1;
 }
-
-class IndexConstraint<string value, string resultValue>
-  : TypesMatchWith<"type should be element of vector type",
-                   value, resultValue,
-                   "firrtl::getVectorElementType($_self)">;
 
 def SubindexOp : FIRRTLExprOp<"subindex", [
     IndexConstraint<"input", "result">
@@ -201,6 +260,7 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
 
   let arguments = (ins FIRRTLBaseType:$input, I32Attr:$index);
   let results = (outs FIRRTLBaseType:$result);
+  let hasCanonicalizer = 1;
 
   // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -140,6 +140,11 @@ public:
   /// child.
   std::pair<unsigned, bool> rootChildFieldID(unsigned fieldID, unsigned index);
 
+  /// Get the number of ground (non-aggregate) fields in the type.  A field
+  /// which is a bundle or vector is not counted, but the recursive ground
+  /// fields of are.
+  unsigned getGroundFields() const;
+
 protected:
   using FIRRTLType::FIRRTLType;
 };

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -63,6 +63,13 @@ def BundleType : FIRRTLDialectType<CPred<"$_self.isa<BundleType>()">,
 def FVectorType : FIRRTLDialectType<CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
+def AggregateType : FIRRTLDialectType<
+  Or<[
+    CPred<"$_self.isa<FVectorType>()">,
+    CPred<"$_self.isa<BundleType>()">
+  ]>,
+  "a aggregate type", "::circt::firrtl::FIRRTLBaseType">;
+
 def ConnectableType : FIRRTLDialectType<
   Or<[
     CPred<"$_self.isa<FIRRTLBaseType>()">,

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -30,10 +30,8 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         // Basic Expressions
         .template Case<
-            ConstantOp, SpecialConstantOp, AggregateConstantOp,
-            InvalidValueOp, SubfieldOp,
-            SubindexOp, SubaccessOp, 
-            BundleCreateOp, VectorCreateOp,
+            ConstantOp, SpecialConstantOp, AggregateConstantOp, InvalidValueOp,
+            SubfieldOp, SubindexOp, SubaccessOp, BundleCreateOp, VectorCreateOp,
             MultibitMuxOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -30,8 +30,11 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         // Basic Expressions
         .template Case<
-            ConstantOp, SpecialConstantOp, InvalidValueOp, SubfieldOp,
-            SubindexOp, SubaccessOp, MultibitMuxOp,
+            ConstantOp, SpecialConstantOp, AggregateConstantOp,
+            InvalidValueOp, SubfieldOp,
+            SubindexOp, SubaccessOp, 
+            BundleCreateOp, VectorCreateOp,
+            MultibitMuxOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
@@ -89,6 +92,9 @@ public:
   // Basic expressions.
   HANDLE(ConstantOp, Unhandled);
   HANDLE(SpecialConstantOp, Unhandled);
+  HANDLE(AggregateConstantOp, Unhandled);
+  HANDLE(BundleCreateOp, Unhandled);
+  HANDLE(VectorCreateOp, Unhandled);
   HANDLE(SubfieldOp, Unhandled);
   HANDLE(SubindexOp, Unhandled);
   HANDLE(SubaccessOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1492,6 +1492,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(SubindexOp op);
   LogicalResult visitExpr(SubaccessOp op);
   LogicalResult visitExpr(SubfieldOp op);
+  LogicalResult visitExpr(VectorCreateOp op);
+  LogicalResult visitExpr(BundleCreateOp op);
   LogicalResult visitUnhandledOp(Operation *op) { return failure(); }
   LogicalResult visitInvalidOp(Operation *op) { return failure(); }
 
@@ -2507,6 +2509,30 @@ LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {
       op, resultType, value,
       op.getInput().getType().cast<BundleType>().getElementName(
           op.getFieldIndex()));
+}
+
+LogicalResult FIRRTLLowering::visitExpr(VectorCreateOp op) {
+  auto resultType = lowerType(op.getResult().getType());
+  SmallVector<Value> operands;
+  for (auto oper : op.getOperands()) {
+    auto val = getLoweredValue(oper);
+    if (!val)
+      return failure();
+    operands.push_back(val);
+  }
+  return setLoweringTo<hw::ArrayCreateOp>(op, resultType, operands);
+}
+
+LogicalResult FIRRTLLowering::visitExpr(BundleCreateOp op) {
+  auto resultType = lowerType(op.getResult().getType());
+  SmallVector<Value> operands;
+  for (auto oper : op.getOperands()) {
+    auto val = getLoweredValue(oper);
+    if (!val)
+      return failure();
+    operands.push_back(val);
+  }
+  return setLoweringTo<hw::StructCreateOp>(op, resultType, operands);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1867,10 +1867,11 @@ struct ConstAgg : public mlir::RewritePattern {
       if (!isConstant(v))
         return failure();
       TypeSwitch<Operation *>(v.getDefiningOp())
-          .Case<ConstantOp>([&](auto c) { values.push_back(c.getValueAttr()); })
+          .Case<ConstantOp>(
+              [&](ConstantOp c) { values.push_back(c.getValueAttr()); })
           .Case<SpecialConstantOp>(
-              [&](auto c) { values.push_back(c.getValueAttr()); })
-          .Case<AggregateConstantOp>([&](auto c) {
+              [&](SpecialConstantOp c) { values.push_back(c.getValueAttr()); })
+          .Case<AggregateConstantOp>([&](AggregateConstantOp c) {
             for (auto attr : c.getFields())
               values.push_back(attr.template cast<IntegerAttr>());
           });

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -522,6 +522,20 @@ std::pair<unsigned, bool> FIRRTLBaseType::rootChildFieldID(unsigned fieldID,
       });
 }
 
+unsigned FIRRTLBaseType::getGroundFields() const {
+  return TypeSwitch<FIRRTLBaseType, unsigned>(*this)
+      .Case<BundleType>([](auto type) {
+        unsigned sum = 0;
+        for (auto &field : type.getElements())
+          sum += field.type.getGroundFields();
+        return sum;
+      })
+      .Case<FVectorType>([](auto type) {
+        return type.getNumElements() * type.getElementType().getGroundFields();
+      })
+      .Default([](Type) { return 1; });
+}
+
 /// Helper to implement the equivalence logic for a pair of bundle elements.
 /// Note that the FIRRTL spec requires bundle elements to have the same
 /// orientation, but this only compares their passive types. The FIRRTL dialect

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1724,4 +1724,32 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.strictconnect %0, %a : !firrtl.uint<10>
     firrtl.strictconnect %b, %0 : !firrtl.uint<10>
   }
+
+  // CHECK-LABEL: hw.module @MergeBundle
+  firrtl.module @MergeBundle(out %o: !firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i: !firrtl.uint<1>) 
+  {
+    %a = firrtl.wire   : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    %0 = firrtl.bundlecreate %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    // CHECK:  %a = sv.wire : !hw.inout<struct<valid: i1, ready: i1>> 
+    // CHECK:  %0 = sv.read_inout %a : !hw.inout<struct<valid: i1, ready: i1>> 
+    // CHECK:  %1 = hw.struct_create (%i, %i) : !hw.struct<valid: i1, ready: i1> 
+    // CHECK:  sv.assign %a, %1 : !hw.struct<valid: i1, ready: i1> 
+    // CHECK:  hw.output %0 : !hw.struct<valid: i1, ready: i1> 
+  }
+ 
+  // CHECK-LABEL: hw.module @MergeVector
+  firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>) {
+    %a = firrtl.wire   : !firrtl.vector<uint<1>, 3>
+    firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+    %0 = firrtl.vectorcreate %i, %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
+    firrtl.strictconnect %a, %0 : !firrtl.vector<uint<1>, 3>
+    // CHECK:  %a = sv.wire : !hw.inout<array<3xi1>> 
+    // CHECK:  %0 = sv.read_inout %a : !hw.inout<array<3xi1>> 
+    // CHECK:  %1 = hw.array_create %i, %i, %i : i1 
+    // CHECK:  sv.assign %a, %1 : !hw.array<3xi1> 
+    // CHECK:  hw.output %0 : !hw.array<3xi1> 
+  }
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2151,6 +2151,61 @@ firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, dat
   // CHECK: firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
 }
 
+// Check that we can create bundles directly
+// CHECK-LABEL: firrtl.module @MergeBundle
+firrtl.module @MergeBundle(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i:!firrtl.uint<1> ) {
+  %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a0 = firrtl.subfield %a(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a1 = firrtl.subfield %a(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  firrtl.strictconnect %a0, %i : !firrtl.uint<1>
+  firrtl.strictconnect %a1, %i : !firrtl.uint<1>
+  firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  // CHECK: %0 = firrtl.bundlecreate %i, %i
+  // CHECK-NEXT: firrtl.strictconnect %a, %0
+}
+
+// Check that we can create vectors directly
+// CHECK-LABEL: firrtl.module @MergeVector
+firrtl.module @MergeVector(out %o:!firrtl.vector<uint<1>, 3>, in %i:!firrtl.uint<1> ) {
+  %a = firrtl.wire : !firrtl.vector<uint<1>, 3>
+  %a0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 3>
+  %a1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 3>
+  %a2 = firrtl.subindex %a[2] : !firrtl.vector<uint<1>, 3>
+  firrtl.strictconnect %a0, %i : !firrtl.uint<1>
+  firrtl.strictconnect %a1, %i : !firrtl.uint<1>
+  firrtl.strictconnect %a2, %i : !firrtl.uint<1>
+  firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+  // CHECK: %0 = firrtl.vectorcreate %i, %i, %i
+  // CHECK-NEXT: firrtl.strictconnect %a, %0
+}
+
+// Check that we can create vectors directly
+// CHECK-LABEL: firrtl.module @MergeAgg
+firrtl.module @MergeAgg(out %o: !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3> ) {
+  %c = firrtl.constant 0 : !firrtl.uint<1>
+  %a = firrtl.wire : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+  %a0 = firrtl.subindex %a[0] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+  %a1 = firrtl.subindex %a[1] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+  %a2 = firrtl.subindex %a[2] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+  %a00 = firrtl.subfield %a0(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a01 = firrtl.subfield %a0(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a10 = firrtl.subfield %a1(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a11 = firrtl.subfield %a1(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a20 = firrtl.subfield %a2(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a21 = firrtl.subfield %a2(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  firrtl.strictconnect %a00, %c : !firrtl.uint<1>
+  firrtl.strictconnect %a01, %c : !firrtl.uint<1>
+  firrtl.strictconnect %a10, %c : !firrtl.uint<1>
+  firrtl.strictconnect %a11, %c : !firrtl.uint<1>
+  firrtl.strictconnect %a20, %c : !firrtl.uint<1>
+  firrtl.strictconnect %a21, %c : !firrtl.uint<1>
+  firrtl.strictconnect %o, %a :  !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK: %0 = firrtl.aggregateconstant [0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK-NEXT: %a = firrtl.wire   : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK-NEXT: firrtl.strictconnect %o, %a : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK-NEXT: firrtl.strictconnect %a, %0 : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+}
+
 // Issue #2197
 // CHECK-LABEL: @Issue2197
 firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1112,6 +1112,38 @@ firrtl.module private @is1436_FOO() {
     %0 = firrtl.wire : index
   }
 
+  // CHECK-LABEL: firrtl.module @MergeBundle
+  firrtl.module @MergeBundle(out %o: !firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i: !firrtl.uint<1>) 
+  {
+    %a = firrtl.wire   : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    %0 = firrtl.bundlecreate %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    // CHECK:  %a_valid = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  %a_ready = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %o_valid, %a_valid : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %o_ready, %a_ready : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %a_valid, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %a_ready, %i : !firrtl.uint<1>
+  }
+ 
+  // CHECK-LABEL: firrtl.module @MergeVector
+  firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>) {
+    %a = firrtl.wire   : !firrtl.vector<uint<1>, 3>
+    firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+    %0 = firrtl.vectorcreate %i, %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
+    firrtl.strictconnect %a, %0 : !firrtl.vector<uint<1>, 3>
+    // CHECK:  %a_0 = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  %a_1 = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  %a_2 = firrtl.wire   : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %o_0, %a_0 : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %o_1, %a_1 : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %o_2, %a_2 : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %a_0, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %a_1, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.strictconnect %a_2, %i : !firrtl.uint<1>
+  }
+
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last


### PR DESCRIPTION
Add support for directly making aggregates rather than having to use a wire.  Also support constant aggregates.  Add canonicalization to transform aggregate wires with field-wise writes to single writes.