### PR TITLE
[FIRRTL] Move CircuitOp verify to verifyRegions.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -48,7 +48,7 @@ def CircuitOp : FIRRTLOp<"circuit",
   }];
 
   let assemblyFormat = "$name custom<CircuitOpAttrs>(attr-dict) $body";
-  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
 def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -302,7 +302,7 @@ static void printCircuitOpAttrs(OpAsmPrinter &p, Operation *op,
   p.printOptionalAttrDictWithKeyword(op->getAttrs(), elidedAttrs);
 }
 
-LogicalResult CircuitOp::verify() {
+LogicalResult CircuitOp::verifyRegions() {
   StringRef main = getName();
 
   // Check that the circuit has a non-empty name.

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1054,3 +1054,12 @@ firrtl.circuit "Bar" {
   }
 }
 
+// -----
+// Issue 4174-- handle duplicate module names.
+
+firrtl.circuit "hi" {
+    // expected-note @below {{see existing symbol definition here}}
+    firrtl.module @hi() {}
+    // expected-error @below {{redefinition of symbol named 'hi'}}
+    firrtl.module @hi() {}
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -24,8 +24,7 @@ firrtl.module @X(in %b : !firrtl.uint<32>, in %d : !firrtl.uint<16>, in %out : !
 // expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name 'MyCircuit'}}
 firrtl.circuit "MyCircuit" {
 
-"firrtl.module"() ( {
-}) { type = () -> ()} : () -> ()
+firrtl.module @X() {}
 
 }
 


### PR DESCRIPTION
Checks constraints are checked before running the verifier, in particular that SymbolTable is checked before assuming we can build it.

Fixes #4174.

See: https://mlir.llvm.org/docs/OpDefinitions/#verification-ordering .