### PR TITLE
[FIRRTL] Fix GCT output dir for mod/extmod

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1632,17 +1632,14 @@ GrandCentralPass::traverseBundle(AugmentedBundleTypeAttr bundle, IntegerAttr id,
       !instancePaths->instanceGraph.isAncestor(companionIDMap[id].companion,
                                                cast<hw::HWModuleLike>(*dut)) &&
       testbenchDir)
-    iface->setAttr("output_file",
-                   hw::OutputFileAttr::getFromDirectoryAndFilename(
-                       &getContext(), testbenchDir.getValue(),
-                       iFaceName + ".sv",
-                       /*excludFromFileList=*/true));
+    iface->setAttr("output_file", hw::OutputFileAttr::getAsDirectory(
+                                      &getContext(), testbenchDir.getValue(),
+                                      /*excludeFromFileList=*/true));
   else if (maybeExtractInfo)
     iface->setAttr("output_file",
-                   hw::OutputFileAttr::getFromDirectoryAndFilename(
+                   hw::OutputFileAttr::getAsDirectory(
                        &getContext(), getOutputDirectory().getValue(),
-                       iFaceName + ".sv",
-                       /*excludFromFileList=*/true));
+                       /*excludeFromFileList=*/true));
   iface.setCommentAttr(builder.getStringAttr("VCS coverage exclude_file"));
 
   builder.setInsertionPointToEnd(cast<sv::InterfaceOp>(iface).getBodyBlock());
@@ -1769,6 +1766,8 @@ void GrandCentralPass::runOnOperation() {
         removalError = true;
         return false;
       }
+      if (directory.getValue().empty())
+        directory = StringAttr::get(circuitOp.getContext(), ".");
 
       maybeExtractInfo = {directory, filename};
       // Do not delete this annotation.  Extraction info may be needed later.
@@ -2084,10 +2083,9 @@ void GrandCentralPass::runOnOperation() {
                       &getContext(), maybeExtractInfo->bindFilename.getValue(),
                       /*excludeFromFileList=*/true));
               op->setAttr("output_file",
-                          hw::OutputFileAttr::getFromDirectoryAndFilename(
+                          hw::OutputFileAttr::getAsDirectory(
                               &getContext(),
                               maybeExtractInfo->directory.getValue(),
-                              op.getName() + ".sv",
                               /*excludeFromFileList=*/true,
                               /*includeReplicatedOps=*/true));
               op->setAttr("comment",

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -226,12 +226,12 @@ circuit Top :
 
     ; EXTRACT:        FILE ".{{[/\]}}BlackBox_DUT.v"
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}BlackBox_GCT.v"
-    ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}BlackBox_DUTAndGCT.v"
+    ; EXTRACT:        FILE ".{{[/\]}}BlackBox_DUTAndGCT.v"
 
     ; EXTRACT:        FILE "firrtl_black_box_resource_files.f"
     ; EXTRACT-NOT:    FILE
     ; EXTRACT:          BlackBox_DUT.v
-    ; EXTRACT-NEXT:     Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}BlackBox_DUTAndGCT.v
+    ; EXTRACT-NEXT:     BlackBox_DUTAndGCT.v
     ; EXTRACT-NEXT:     Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}BlackBox_GCT.v
 
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}MyView_companion.sv"

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -61,7 +61,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
 // CHECK-SAME: {
 
 // CHECK: firrtl.module private @View_companion
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}View_companion.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.interface.instance sym @__View_Foo__ {name = "View"} : !sv.interface<@Foo>
 // CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
 // CHECK-SAME:   #hw.innerNameRef<@View_companion::@__View_Foo__>
@@ -87,7 +87,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// description of foo"
 // CHECK-NEXT: sv.interface.signal @foo : i2
 // CHECK-NEXT: sv.verbatim "// multi\0A// line\0A// description\0A// of\0A// bar"
@@ -154,7 +154,7 @@ firrtl.circuit "InterfaceVectorType" attributes {
 // CHECK-SAME: {
 
 // CHECK: firrtl.module private @View_companion
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}View_companion.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 
 // All Grand Central annotations are removed from the registers.
 // CHECK: firrtl.module private @DUT
@@ -165,7 +165,7 @@ firrtl.circuit "InterfaceVectorType" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// description of foo"
 // CHECK-NEXT: sv.interface.signal @foo : !hw.uarray<2xi1>
 
@@ -238,13 +238,13 @@ firrtl.circuit "InterfaceBundleType" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// description of Bar"
 // CHECK-NEXT: Bar bar();
 
 // CHECK: sv.interface @Bar
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Bar.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.interface.signal @b : i2
 // CHECK-NEXT: sv.interface.signal @a : i1
 
@@ -422,7 +422,7 @@ firrtl.circuit "InterfaceNode" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// some expression"
 // CHECK-NEXT: sv.interface.signal @foo : i2
 
@@ -479,7 +479,7 @@ firrtl.circuit "InterfacePort" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// description of foo"
 // CHECK-NEXT: sv.interface.signal @foo : i4
 
@@ -534,7 +534,7 @@ firrtl.circuit "UnsupportedTypes" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.verbatim "// <unsupported string type> string;"
 // CHECK-NEXT: sv.verbatim "// <unsupported boolean type> boolean;"
 // CHECK-NEXT: sv.verbatim "// <unsupported integer type> integer;"
@@ -609,7 +609,7 @@ firrtl.circuit "BindInterfaceTest"  attributes {
 // The interface is added.
 // CHECK: sv.interface @InterfaceName
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}InterfaceName.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 // CHECK-NEXT: sv.interface.signal @_a : i8
 
 // -----
@@ -673,11 +673,11 @@ firrtl.circuit "MultipleGroundTypeInterfaces" attributes {
 
 // CHECK: sv.interface @Foo
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Foo.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 
 // CHECK: sv.interface @Bar
 // CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}Bar.sv"
+// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 
 // -----
 
@@ -1161,7 +1161,7 @@ firrtl.circuit "InterfaceInTestHarness" attributes {
 // CHECK-NOT:       lowerToBind
 // CHECK-NEXT:  }
 // CHECK:       sv.interface
-// CHECK-SAME:    output_file = #hw.output_file<"testbenchDir{{/|\\\\}}Foo.sv", excludeFromFileList>
+// CHECK-SAME:    output_file = #hw.output_file<"testbenchDir{{/|\\\\}}", excludeFromFileList>
 
 // -----
 


### PR DESCRIPTION
Change Grand Central (GCT) View behavior that determines which output
directories are used for blackboxes which are instantiated by both
inside and outside the View's companion module.  Previously, if in both
then the blackbox was placed in the View's directory.  This is changed
to not modify the output directory of the blackbox.  Only blackboxes
which are _exclusively_ instantiated by the View are moved.

Change modules to also have the above behavior.  Previously, module
submodules were not moved.

This moves closer to SFC behavior.  In the SFC, modules instantiated
exclusively in the View are moved.  Modules instantiated in both are
copied in both output directories.

This includes a preliminary commit, intended to land separately, that moves a WireDFT utility to make it more widely available:

Move a utility for computing if all instances of a module are
instantiated under another module from a static function inside the
WireDFT pass into a separate utility.  This is done because this is also
needed in the Grand Central (Views) pass.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Note: the fact that the output directory stuff is happening in the annotation walk is not ideal. However, this was the original structure of the code. I would like to move this out into a separate step that happens after the companion is found. This also makes the debug prints easier to manage as they can happen in the unified debug printing region.

## Example

There is an included test (only operating on `.mlir`). However, a larger test I've been using is:

```
circuit Foo :
  module Submodule_Companion :
    input a : UInt<1>

    skip

  module Submodule_Both :
    input a : UInt<1>

    skip

  extmodule BBox_Companion :
    input a : UInt<1>
    defname = BBox_Companion

  extmodule BBox_Both :
    input a : UInt<1>
    defname = BBox_Both

  module View_companion :

    inst submodule_companion of Submodule_Companion @[Submodule.scala 44:41]
    inst submodule_both of Submodule_Both @[Submodule.scala 45:36]
    inst bbox_companion of BBox_Companion @[Submodule.scala 46:36]
    bbox_companion.a is invalid
    inst bbox_both of BBox_Both @[Submodule.scala 47:31]
    bbox_both.a is invalid
    wire tap_a : UInt<1> @[Submodule.scala 50:26]
    tap_a is invalid @[Submodule.scala 50:26]
    submodule_companion.a <= tap_a @[Submodule.scala 53:31]
    submodule_both.a <= tap_a @[Submodule.scala 54:26]
    bbox_companion.a <= tap_a @[Submodule.scala 55:29]
    bbox_both.a <= tap_a @[Submodule.scala 56:24]

  module Submodule_Foo :
    input a : UInt<1>

    skip

  extmodule BBox_Foo :
    input a : UInt<1>
    defname = BBox_Foo

  module Submodule_Both_1 :
    input a : UInt<1>

    skip

  extmodule BBox_Both_1 :
    input a : UInt<1>
    defname = BBox_Both

  module Foo :
    input clock : Clock
    input reset : UInt<1>
    input a : UInt<1>

    inst View_companion of View_companion @[GrandCentral.scala 448:34]
    inst submodule_foo of Submodule_Foo @[Submodule.scala 61:31]
    inst bbox_foo of BBox_Foo @[Submodule.scala 62:26]
    bbox_foo.a is invalid
    inst submodule_both of Submodule_Both_1 @[Submodule.scala 63:32]
    inst bbox_both of BBox_Both_1 @[Submodule.scala 64:27]
    bbox_both.a is invalid
    submodule_foo.a <= a @[Submodule.scala 65:21]
    bbox_foo.a <= a @[Submodule.scala 66:19]
    submodule_both.a <= a @[Submodule.scala 67:22]
    bbox_both.a <= a @[Submodule.scala 68:20]
```

```json
[
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Submodule_Companion>a"
  },
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Submodule_Both>a"
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"Foo.BBox_Companion",
    "name":"BBox_Companion.v",
    "text":"module BBox_Companion();\nendmodule"
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"Foo.BBox_Both",
    "name":"BBox_Both.v",
    "text":"module BBox_Both();\nendmodule"
  },
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|View_companion>tap_a"
  },
  {
    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
    "keys":[
      {
        "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
        "source":"~Foo|Foo>a",
        "sink":"~Foo|View_companion>tap_a",
        "info":"@[Submodule.scala 50:26]"
      }
    ]
  },
  {
    "class":"firrtl.transforms.NoDedupAnnotation",
    "target":"~Foo|Submodule_Companion"
  },
  {
    "class":"sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
    "name":"View",
    "companion":"~Foo|View_companion",
    "parent":"~Foo|Foo",
    "view":"{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"MyInterface\",\"elements\":[]}"
  },
  {
    "class":"firrtl.transforms.NoDedupAnnotation",
    "target":"~Foo|View_companion"
  },
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Submodule_Foo>a"
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"Foo.BBox_Foo",
    "name":"BBox_Foo.v",
    "text":"module BBox_Foo();\nendmodule"
  },
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Submodule_Both_1>a"
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"Foo.BBox_Both_1",
    "name":"BBox_Both.v",
    "text":"module BBox_Both();\nendmodule"
  },
  {
    "class":"firrtl.transforms.NoDedupAnnotation",
    "target":"~Foo|Submodule_Foo"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"firrtl.transforms.BlackBoxSourceHelper"
  },
  {
    "class":"sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
    "directory":"gct",
    "filename":"bindings.sv"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"sifive.enterprise.grandcentral.WrapGrandCentralAnnos"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"sifive.enterprise.grandcentral.GrandCentralTransform"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"sifive.enterprise.firrtl.cprop.CalculateConstPropResult"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"sifive.enterprise.firrtl.DeadCodeEliminationBeforeConstProp"
  },
  {
    "class":"firrtl.stage.RunFirrtlTransformAnnotation",
    "transform":"firrtl.SystemVerilogEmitter"
  }
]
```

The SFC output structure for this is:

```
verilog
├── BBox_Both.v
├── BBox_Companion.v
├── BBox_Foo.v
├── Foo.anno.json
├── Foo.fir
├── Foo.sv
├── Submodule_Both.sv
├── Submodule_Companion.sv
├── Submodule_Foo.sv
├── bindings.sv
├── firrtl_black_box_resource_files.f
└── gct
    ├── BBox_Companion.v
    ├── DataTap.sv
    ├── MyInterface.sv
    ├── Submodule_Companion.sv
    ├── View_companion_0.sv
    ├── View_mapping.sv
    └── firrtl_black_box_resource_files.f
```

After this patch, the MFC output structure is:
```
mfc-new
├── BBox_Both.v
├── BBox_Foo.v
├── Foo.sv
├── Submodule_Both.sv
├── Submodule_Foo.sv
├── bindings.sv
├── extern_modules.sv
├── filelist.f
├── firrtl_black_box_resource_files.f
└── gct
    ├── BBox_Companion.v
    ├── MyInterface.sv
    ├── Submodule_Companion.sv
    └── View_companion.sv
```

Without this patch, the MFC output structure is:
```
mfc-old
├── BBox_Foo.v
├── Foo.sv
├── Submodule_Both.sv
├── Submodule_Companion.sv
├── Submodule_Foo.sv
├── bindings.sv
├── extern_modules.sv
├── filelist.f
├── firrtl_black_box_resource_files.f
└── gct
    ├── BBox_Both.v
    ├── BBox_Companion.v
    ├── MyInterface.sv
    └── View_companion.sv
```