### PR TITLE
[ExportVerilog] Add more zero-valued logic pruning patterns

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -301,10 +301,8 @@ static bool haveMatchingDims(Type a, Type b, Location loc) {
   return aDims == bDims;
 }
 
-/// Return true if this is a zero bit type, e.g. a zero bit integer or array
-/// thereof.
 // NOLINTBEGIN(misc-no-recursion)
-static bool isZeroBitType(Type type) {
+bool ExportVerilog::isZeroBitType(Type type) {
   if (auto intType = type.dyn_cast<IntegerType>())
     return intType.getWidth() == 0;
   if (auto inout = type.dyn_cast<hw::InOutType>())

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -315,6 +315,10 @@ static inline bool isConstantExpression(Operation *op) {
 /// MemoryEffects should be checked if a client cares.
 bool isVerilogExpression(Operation *op);
 
+/// Return true if this is a zero bit type, e.g. a zero bit integer or array
+/// thereof.
+bool isZeroBitType(Type type);
+
 /// Return true if this expression should be emitted inline into any statement
 /// that uses it.
 bool isExpressionEmittedInline(Operation *op);

--- a/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
+++ b/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
@@ -24,16 +24,15 @@ using namespace mlir;
 using namespace circt;
 using namespace hw;
 
-// Returns true if 't' is zero-width logic.
-// For now, this strictly relies on the announced bit-width of the type.
-static bool isZeroWidthLogic(Type t) {
-  if (!t.isa<IntegerType>())
-    return false;
-  return t.getIntOrFloatBitWidth() == 0;
+// Returns true if 'op' is a legal user of an I0 value.
+static bool isLegalI0User(Operation *op) {
+  return isa<hw::OutputOp, hw::ArrayGetOp, sv::ArrayIndexInOutOp,
+             hw::InstanceOp>(op);
 }
 
 static bool noI0Type(TypeRange types) {
-  return llvm::none_of(types, [](Type type) { return isZeroWidthLogic(type); });
+  return llvm::none_of(
+      types, [](Type type) { return ExportVerilog::isZeroBitType(type); });
 }
 
 static bool noI0TypedValue(ValueRange values) {
@@ -46,7 +45,7 @@ class PruneTypeConverter : public mlir::TypeConverter {
 public:
   PruneTypeConverter() {
     addConversion([&](Type type, SmallVectorImpl<Type> &results) {
-      if (!isZeroWidthLogic(type))
+      if (!ExportVerilog::isZeroBitType(type))
         results.push_back(type);
       return success();
     });
@@ -54,7 +53,7 @@ public:
 };
 
 // The NoI0OperandsConversionPattern will aggressively remove any operation
-// which has a zero-valued operand.
+// which has a zero-width operand.
 template <typename TOp>
 struct NoI0OperandsConversionPattern : public OpConversionPattern<TOp> {
 public:
@@ -67,7 +66,7 @@ public:
     if (noI0TypedValue(adaptor.getOperands()))
       return failure();
 
-    // Part of i0-typed logic - prune!
+    // Part of i0-typed logic - prune it!
     rewriter.eraseOp(op);
     return success();
   }
@@ -90,6 +89,58 @@ struct NoI0OperandPruningPattern {
   }
 };
 
+// The NoI0ResultsConversionPattern will aggressively remove any operation
+// which has a zero-width result. Furthermore, it will recursively erase any
+// downstream users of the operation.
+template <typename TOp>
+struct NoI0ResultsConversionPattern : public OpConversionPattern<TOp> {
+public:
+  using OpConversionPattern<TOp>::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<TOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(TOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (noI0TypedValue(op->getResults()))
+      return failure();
+
+    // Part of i0-typed logic - prune!
+    // If the operation defines a value which is used by a valid user, we
+    // replace it with a zero-width constant.
+    for (auto res : op->getResults()) {
+      for (auto *user : res.getUsers()) {
+        if (isLegalI0User(user)) {
+          assert(op->getNumResults() == 1 &&
+                 "expected single result if using rewriter.replaceOpWith");
+          rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+              op, APInt(0, 0, /*isSigned=*/false));
+          return success();
+        }
+      }
+    }
+
+    // Else, just erase the op.
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+template <typename... TOp>
+static void addNoI0ResultsLegalizationPattern(ConversionTarget &target) {
+  target.addDynamicallyLegalOp<TOp...>(
+      [&](auto op) { return noI0TypedValue(op->getResults()); });
+}
+
+// A generic pruning pattern which prunes any operation that returns an i0
+// value.
+template <typename TOp>
+struct NoI0ResultPruningPattern {
+  using ConversionPattern = NoI0ResultsConversionPattern<TOp>;
+  static void addLegalizer(ConversionTarget &target) {
+    addNoI0ResultsLegalizationPattern<TOp>(target);
+  }
+};
+
 // Adds a pruning pattern to the conversion target. TPattern is expected to
 // provides ConversionPattern definition and an addLegalizer function.
 template <typename... TPattern>
@@ -101,6 +152,17 @@ static void addPruningPattern(ConversionTarget &target,
    ...);
   (TPattern::addLegalizer(target), ...);
 }
+
+template <typename... TOp>
+static void addNoI0ResultPruningPattern(ConversionTarget &target,
+                                        RewritePatternSet &patterns,
+                                        PruneTypeConverter &typeConverter) {
+  (patterns.add<typename NoI0ResultPruningPattern<TOp>::ConversionPattern>(
+       typeConverter, patterns.getContext()),
+   ...);
+  (NoI0ResultPruningPattern<TOp>::addLegalizer(target), ...);
+}
+
 } // namespace
 
 void ExportVerilog::pruneZeroValuedLogic(hw::HWModuleOp module) {
@@ -109,13 +171,19 @@ void ExportVerilog::pruneZeroValuedLogic(hw::HWModuleOp module) {
   PruneTypeConverter typeConverter;
 
   target.addLegalDialect<sv::SVDialect, comb::CombDialect, hw::HWDialect>();
-
-  // Generic conversion and legalization patterns for operations that we
-  // expect to be using i0 valued logic.
   addPruningPattern<NoI0OperandPruningPattern<sv::PAssignOp>,
                     NoI0OperandPruningPattern<sv::BPAssignOp>,
                     NoI0OperandPruningPattern<sv::AssignOp>>(target, patterns,
                                                              typeConverter);
+
+  addNoI0ResultPruningPattern<
+      // SV ops
+      sv::WireOp, sv::RegOp, sv::ReadInOutOp,
+      // Prune all zero-width combinational logic.
+      comb::AddOp, comb::AndOp, comb::ConcatOp, comb::DivSOp, comb::DivUOp,
+      comb::ExtractOp, comb::ModSOp, comb::ModUOp, comb::MulOp, comb::MuxOp,
+      comb::OrOp, comb::ParityOp, comb::ReplicateOp, comb::ShlOp, comb::ShrSOp,
+      comb::ShrUOp, comb::SubOp, comb::XorOp>(target, patterns, typeConverter);
 
   (void)applyPartialConversion(module, target, std::move(patterns));
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -513,7 +513,7 @@ hw.module @TestZeroStructInstance(%structZero: !hw.struct<>, %structZeroNest: !h
 // CHECK-NEXT:                            out1
 // CHECK-NEXT:   // output /*Zero Width*/ out2
 
-// CHECK:   assign out = arg1[/*Zero width: arg0 + arg0*/ 1'b0];	
+// CHECK:   assign out = arg1[/*Zero width: 0'h0*/ 1'b0];	
 // CHECK-NEXT:   assign out1 = arg1[/*Zero width: arg0*/ 1'b0];	
 // CHECK-NEXT:   // Zero width: assign out2 = arg0;	
 

--- a/test/Conversion/ExportVerilog/pruning.mlir
+++ b/test/Conversion/ExportVerilog/pruning.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --export-verilog --verify-diagnostics -o %t | FileCheck %s --strict-whitespace
+// RUN: circt-opt --export-verilog --verify-diagnostics %s -o %t | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module zeroWidthPAssign(
 // CHECK:       always_ff @(posedge clk) begin        
@@ -11,12 +11,11 @@ hw.module @zeroWidthPAssign(%arg0: i0, %clk: i1) -> (out: i0) {
   %1 = sv.read_inout %0 : !hw.inout<i0>
   hw.output %1 : i0
 }
-// CHECK-LABEL: module zeroWidthAssign(
-// CHECK:       // Zero width: wire /*Zero Width*/ _GEN;      
-// CHECK-NEXT:  // Zero width: assign out = _GEN;     
-hw.module @zeroWidthAssign(%arg0: i0, %clk: i1, %a: i0, %b: i1) -> (out: i0) {
-  sv.assign %0, %1 : i0
-  %0 = sv.wire  {hw.verilogName = "_GEN"} : !hw.inout<i0>
-  %1 = sv.read_inout %0 : !hw.inout<i0>
-  hw.output %1 : i0
+// CHECK-LABEL: module zeroWidthLogic(
+// CHECK-NOT: reg
+hw.module @zeroWidthLogic(%arg0: i0, %sel : i1, %clk: i1) -> (out: i0) {
+  %r = sv.reg : !hw.inout<i0>
+  %rr = sv.read_inout %r : !hw.inout<i0>
+  %2 = comb.mux %sel, %rr, %arg0 : i0
+  hw.output %2 : i0
 }


### PR DESCRIPTION
This commit adds additional patterns for pruning operations that may be contained within a cone of zero-valued logic. Any operation which generates an `i0` result that is used by an operation that may legally use `i0` valued logic (output, indexing operations), values is replaced by an `i0` constant.