### PR TITLE
[LowerToHW, HWMemSimImpl] Remove mux pragmas when size is 1

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3452,9 +3452,10 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
   }
 
   Value inBoundsRead;
-  // If `stripMuxPragmas` is specified, just lower to a vanilla array
-  // indexing.
-  if (circuitState.stripMuxPragmas) {
+  // If `stripMuxPragmas` is specified, just lower to a vanilla array indexing.
+  // Also remove mux pragmas if the array size is 1 since it causes a
+  // complication failure.
+  if (circuitState.stripMuxPragmas || size <= 1) {
     inBoundsRead = builder.create<hw::ArrayGetOp>(array, index);
   } else {
     auto arrayGet = builder.create<hw::ArrayGetOp>(array, index);

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -127,7 +127,11 @@ static Value getMemoryRead(ImplicitLocOpBuilder &b, Value memory, Value addr,
   auto slot =
       b.create<sv::ReadInOutOp>(b.create<sv::ArrayIndexInOutOp>(memory, addr));
   // If we don't want to add mux pragmas, just return the read value.
-  if (stripMuxPragmas)
+  if (stripMuxPragmas || memory.getType()
+                                 .cast<hw::InOutType>()
+                                 .getElementType()
+                                 .cast<hw::UnpackedArrayType>()
+                                 .getSize() <= 1)
     return slot;
   circt::sv::setSVAttributes(
       slot, sv::SVAttributesAttr::get(b.getContext(), {"cadence map_to_mux"},

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1102,16 +1102,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %r2, %0 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %o1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %o2, %r2 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
-    // CHECK:      %r1 = seq.firreg %5 clock %clock : i1
-    // CHECK-NEXT: %r2 = seq.firreg %2 clock %clock : !hw.array<1xi1>
-    // CHECK-NEXT: %[[ARRAY_GET1:.+]] = hw.array_get %a[%x] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>}
-    // CHECK-NEXT: %[[WIRE1:.+]] = sv.wire
-    // CHECK-NEXT: sv.assign %[[WIRE1]], %[[ARRAY_GET1]] {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
-    // CHECK-NEXT: %[[VAL1:.+]] = sv.read_inout %[[WIRE1]] : !hw.inout<array<1xi1>>
-    // CHECK-NEXT: %[[ARRAY_GET2:.+]] = hw.array_get %[[VAL1]][%y] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>}
-    // CHECK-NEXT: %[[WIRE2:.+]] = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: sv.assign %[[WIRE2]], %[[ARRAY_GET2]] {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
-    // CHECK-NEXT: %[[VAL2:.+]] = sv.read_inout %[[WIRE2]] : !hw.inout<i1>
+    // CHECK:      %r1 = seq.firreg %1 clock %clock : i1
+    // CHECK-NEXT: %r2 = seq.firreg %0 clock %clock : !hw.array<1xi1>
+    // CHECK-NEXT: %0 = hw.array_get %a[%x] : !hw.array<1xarray<1xi1>>, i1
+    // CHECK-NEXT: %1 = hw.array_get %0[%y] : !hw.array<1xi1>, i1
     // CHECK-NEXT: hw.output %r1, %r2 : i1, !hw.array<1xi1>
   }
 

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -156,6 +156,10 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_2_4_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:    [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]] : !hw.inout<i4>
 //CHECK-NEXT:    {{%.+}} = sv.array_index_inout %Memory[[[ADDR_1R]]] : !hw.inout<uarray<10xi16>>, i4
 
+hw.module.generated @FIRRTLMem_1_1_1_16_1_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_0: i1,%rw_addr_0: i4, %rw_en_0: i1,  %rw_clock_0: i1, %rw_wmode_0: i1, %rw_wdata_0: i16,  %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1, %wo_data_0: i16) -> (ro_data_0: i16, rw_rdata_0: i16) attributes {depth = 1 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 0 : i32}
+// CHECK-LABEL: @FIRRTLMem_1_1_1_16_1_0_1_0_0
+// CHECK-NOT: sv.attributes
+
 hw.module.generated @FIRRTLMemOneAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1,%wo_data_0: i8, %wo_addr_1: i4,  %wo_en_1: i1, %wo_clock_1: i1, %wo_data_1: i8) attributes {depth = 16 : i64, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 //CHECK-LABEL: @FIRRTLMemOneAlways


### PR DESCRIPTION
This fixes an issue that mux pragmas cause a complication failure when the array size is 1. Ideally such array/memory should be canonicalized in the first place though