### PR TITLE
[Seq] Add `seq.fifo` ODS and rationale

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -312,13 +312,13 @@ The FIFO interface consists of:
   - read/write enable
 - **Outputs**:
   - output data
-  - full, almost full, empty, almost empty flags
+  - full, empty flags
+  - optional almost full, almost empty flags
 
 The fifo operation is configurable with the following parameters:
 1. Depth (cycles)
 2. Differing in- and output widths
-3. Almost empty/full thresholds (optional). If not provided, these will
-    be asserted when the FIFO is empty/full.
+3. Almost empty/full thresholds (optional)
 
 Like `seq.hlmem` there are no guarantees that all possible fifo configuration
 are able to be lowered. Available lowering passes will pattern match on the

--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -298,3 +298,28 @@ specialization is needed) attached to the memory symbol.
   ```mlir
   %mem = seq.debug @myMemory : !seq.hlmem<4xi32>
   ```
+
+## The FIFO operation
+The `seq.fifo` operation intends to capture the semantics of a FIFO which
+eventually map to some form of on-chip resources. By having a FIFO abstraction,
+we provide an abstraction that can be targeted for target-specialized implementations,
+as well as default behavioral lowerings (based on `seq.hlmem`).
+
+The FIFO interface consists of:
+- **Inputs**:
+  - clock, reset
+  - input data
+  - read/write enable
+- **Outputs**:
+  - output data
+  - full, almost full, empty, almost empty flags
+
+The fifo operation is configurable with the following parameters:
+1. Depth (cycles)
+2. Differing in- and output widths
+3. Almost empty/full thresholds (optional). If not provided, these will
+    be asserted when the FIFO is empty/full.
+
+Like `seq.hlmem` there are no guarantees that all possible fifo configuration
+are able to be lowered. Available lowering passes will pattern match on the
+requested fifo configuration and attempt to provide a legal lowering.

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -156,9 +156,12 @@ def FirRegOp : SeqOp<"firreg",
 }
 
 def FIFOOp : SeqOp<"fifo", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+    TypesMatchWith<"Input type should match output type",
+      "input", "output", [{ $_self }]>,
+    AttrSizedResultSegments
   ]> {
-  let summary = "Instantiate a FIFO";
+  let summary = "A high-level FIFO operation";
   let description = [{
     This operation represents a high-level abstraction of a FIFO. Access to the
     FIFO is structural, and thus may be composed with other core RTL dialect
@@ -166,8 +169,8 @@ def FIFOOp : SeqOp<"fifo", [
     The fifo operation is configurable with the following parameters:
     1. Depth (cycles)
     2. Differing in- and output widths
-    3. Almost empty/full thresholds (optional). If not provided, these will
-       be asserted when the FIFO is empty/full.
+    3. Almost full/empty thresholds (optional). If not provided, these will
+       be asserted when the FIFO is full/empty.
 
     Like `seq.hlmem` there are no guarantees that all possible fifo configuration
     are able to be lowered. Available lowering passes will pattern match on the
@@ -177,20 +180,28 @@ def FIFOOp : SeqOp<"fifo", [
   let arguments = (ins
     HWIntegerType:$input, I1:$rdEn, I1:$wrEn, I1:$clk, I1:$rst,
     ConfinedAttr<I64Attr, [IntMinValue<1>]>:$depth,
-    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$almostEmptyThreshold,
-    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$almostFullThreshold
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<0>]>>:$almostFullThreshold,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<0>]>>:$almostEmptyThreshold
   );
 
   let results = (outs
-    Variadic<HWIntegerType>:$outputs, I1:$empty, I1:$full, I1:$almostEmpty, I1:$almostFull);
+    HWIntegerType:$output, I1:$full, I1:$empty, Optional<I1>:$almostFull, Optional<I1>:$almostEmpty);
 
   let builders = [
     OpBuilder<(ins "Value":$clk, "Value":$rst, "StringRef":$symName,
                    "llvm::ArrayRef<int64_t>":$shape, "Type":$elementType)>
   ];
 
-  let assemblyFormat = " `[` $depth `]``(` $input `,` $rdEn `,` $wrEn `)` $clk `,` $rst attr-dict `:` functional-type($input, $outputs)";
+  let assemblyFormat = [{
+    `depth` $depth
+    custom<FIFOAFThreshold>($almostFullThreshold, type($almostFull))
+    custom<FIFOAEThreshold>($almostEmptyThreshold, type($almostEmpty))
+    `in` $input `rdEn` $rdEn `wrEn` $wrEn `clk` $clk `rst` $rst attr-dict `:` type($input)
+  }];
   let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
+
+
 }
 
 def HLMemOp : SeqOp<"hlmem", [

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -168,8 +168,7 @@ def FIFOOp : SeqOp<"fifo", [
     operations.
     The fifo operation is configurable with the following parameters:
     1. Depth (cycles)
-    2. Differing in- and output widths
-    3. Almost full/empty thresholds (optional). If not provided, these will
+    2. Almost full/empty thresholds (optional). If not provided, these will
        be asserted when the FIFO is full/empty.
 
     Like `seq.hlmem` there are no guarantees that all possible fifo configuration
@@ -185,12 +184,8 @@ def FIFOOp : SeqOp<"fifo", [
   );
 
   let results = (outs
-    HWIntegerType:$output, I1:$full, I1:$empty, Optional<I1>:$almostFull, Optional<I1>:$almostEmpty);
-
-  let builders = [
-    OpBuilder<(ins "Value":$clk, "Value":$rst, "StringRef":$symName,
-                   "llvm::ArrayRef<int64_t>":$shape, "Type":$elementType)>
-  ];
+    HWIntegerType:$output, I1:$full, I1:$empty, Optional<I1>:$almostFull,
+    Optional<I1>:$almostEmpty);
 
   let assemblyFormat = [{
     `depth` $depth
@@ -199,9 +194,6 @@ def FIFOOp : SeqOp<"fifo", [
     `in` $input `rdEn` $rdEn `wrEn` $wrEn `clk` $clk `rst` $rst attr-dict `:` type($input)
   }];
   let hasVerifier = 1;
-  let skipDefaultBuilders = 1;
-
-
 }
 
 def HLMemOp : SeqOp<"hlmem", [

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -155,6 +155,44 @@ def FirRegOp : SeqOp<"firreg",
   }];
 }
 
+def FIFOOp : SeqOp<"fifo", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  ]> {
+  let summary = "Instantiate a FIFO";
+  let description = [{
+    This operation represents a high-level abstraction of a FIFO. Access to the
+    FIFO is structural, and thus may be composed with other core RTL dialect
+    operations.
+    The fifo operation is configurable with the following parameters:
+    1. Depth (cycles)
+    2. Differing in- and output widths
+    3. Almost empty/full thresholds (optional). If not provided, these will
+       be asserted when the FIFO is empty/full.
+
+    Like `seq.hlmem` there are no guarantees that all possible fifo configuration
+    are able to be lowered. Available lowering passes will pattern match on the
+    requested fifo configuration and attempt to provide a legal lowering.
+  }];
+
+  let arguments = (ins
+    HWIntegerType:$input, I1:$rdEn, I1:$wrEn, I1:$clk, I1:$rst,
+    ConfinedAttr<I64Attr, [IntMinValue<1>]>:$depth,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$almostEmptyThreshold,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$almostFullThreshold
+  );
+
+  let results = (outs
+    Variadic<HWIntegerType>:$outputs, I1:$empty, I1:$full, I1:$almostEmpty, I1:$almostFull);
+
+  let builders = [
+    OpBuilder<(ins "Value":$clk, "Value":$rst, "StringRef":$symName,
+                   "llvm::ArrayRef<int64_t>":$shape, "Type":$elementType)>
+  ];
+
+  let assemblyFormat = " `[` $depth `]``(` $input `,` $rdEn `,` $wrEn `)` $clk `,` $rst attr-dict `:` functional-type($input, $outputs)";
+  let hasVerifier = 1;
+}
+
 def HLMemOp : SeqOp<"hlmem", [
      Symbol,
      Clocked,

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -220,6 +220,35 @@ void HLMemOp::build(OpBuilder &builder, OperationState &result, Value clk,
 }
 
 //===----------------------------------------------------------------------===//
+// FIFOOp
+//===----------------------------------------------------------------------===//
+
+void FIFOOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  if (getOutputs().size() == 1)
+    setNameFn(getOutputs()[0], "out");
+  else {
+    for (auto [i, output] : llvm::enumerate(getOutputs()))
+      setNameFn(output, "out" + std::to_string(i));
+  }
+  setNameFn(getEmpty(), "empty");
+  setNameFn(getFull(), "full");
+  setNameFn(getAlmostEmpty(), "almostEmpty");
+  setNameFn(getAlmostFull(), "almostFull");
+}
+
+LogicalResult FIFOOp::verify() {
+  unsigned outputWidth = 0;
+  unsigned inputWidth = getInput().getType().getIntOrFloatBitWidth();
+  for (auto output : getOutputs())
+    outputWidth += output.getType().getIntOrFloatBitWidth();
+  if (outputWidth != inputWidth)
+    return emitOpError(
+               "combined output width must match input width (expected ")
+           << inputWidth << " but got " << outputWidth << ")";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CompRegOp
 
 template <bool ClockEnabled>

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -228,7 +228,7 @@ static ParseResult parseFIFOFlagThreshold(OpAsmParser &parser,
                                           IntegerAttr &threshold,
                                           Type &outputFlagType,
                                           StringRef directive) {
-  // look for an optional "almost_full $threshold>" group.
+  // look for an optional "almost_full $threshold" group.
   if (succeeded(parser.parseOptionalKeyword(directive))) {
     int64_t thresholdValue;
     if (succeeded(parser.parseInteger(thresholdValue))) {
@@ -255,20 +255,20 @@ ParseResult parseFIFOAEThreshold(OpAsmParser &parser, IntegerAttr &threshold,
                                 "almost_empty");
 }
 
-static void printFIFOFlagThreshold(OpAsmPrinter &p, Operation *op,
-                                   IntegerAttr threshold, StringRef directive) {
-  if (threshold)
-    p << directive << " " << threshold.getInt();
-}
-
 void printFIFOAFThreshold(OpAsmPrinter &p, Operation *op, IntegerAttr threshold,
                           Type outputFlagType) {
-  printFIFOFlagThreshold(p, op, threshold, "almost_full");
+  if (threshold) {
+    p << "almost_full"
+      << " " << threshold.getInt();
+  }
 }
 
 void printFIFOAEThreshold(OpAsmPrinter &p, Operation *op, IntegerAttr threshold,
                           Type outputFlagType) {
-  printFIFOFlagThreshold(p, op, threshold, "almost_empty");
+  if (threshold) {
+    p << "almost_empty"
+      << " " << threshold.getInt();
+  }
 }
 
 void FIFOOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
@@ -664,11 +664,11 @@ OpFoldResult FirRegOp::fold(FoldAdaptor adaptor) {
 
   // If the register is held in permanent reset, replace it with its reset
   // value. This works trivially if the reset is asynchronous and therefore
-  // level-sensitive, in which case it will always immediately assume the
-  // reset value in silicon. If it is synchronous, the register value is
-  // undefined until the first clock edge at which point it becomes the reset
-  // value, in which case we simply define the initial value to already be the
-  // reset value.
+  // level-sensitive, in which case it will always immediately assume the reset
+  // value in silicon. If it is synchronous, the register value is undefined
+  // until the first clock edge at which point it becomes the reset value, in
+  // which case we simply define the initial value to already be the reset
+  // value.
   if (auto reset = getReset())
     if (auto constOp = reset.getDefiningOp<hw::ConstantOp>())
       if (constOp.getValue().isOne())

--- a/test/Dialect/Seq/errors.mlir
+++ b/test/Dialect/Seq/errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
+  // expected-error @+1 {{'seq.fifo' op combined output width must match input width (expected 32 but got 24)}}
+  %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i8)
+}

--- a/test/Dialect/Seq/errors.mlir
+++ b/test/Dialect/Seq/errors.mlir
@@ -1,6 +1,20 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
+hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
+  // expected-error @+1 {{operation defines 3 results but was provided 5 to bind}}
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+}
+
+// -----
+
 hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
-  // expected-error @+1 {{'seq.fifo' op combined output width must match input width (expected 32 but got 24)}}
-  %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i8)
+  // expected-error @+1 {{'seq.fifo' op almost full threshold must be <= FIFO depth}}
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 4 almost_empty 1 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+}
+
+// -----
+
+hw.module @fifo3(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
+  // expected-error @+1 {{'seq.fifo' op almost empty threshold must be <= FIFO depth}}
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 1 almost_empty 4 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
 }

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -54,3 +54,13 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %test_enable: i1) {
   %cg0 = seq.clock_gate %clock, %enable
   %cg1 = seq.clock_gate %clock, %enable, %test_enable
 }
+
+hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
+  // CHECK: %out, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> i32
+  %out, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> i32
+}
+
+hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
+  // CHECK: %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i16)
+  %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i16)
+}

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -56,11 +56,11 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %test_enable: i1) {
 }
 
 hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
-  // CHECK: %out, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> i32
-  %out, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> i32
+  // CHECK: %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
 }
 
 hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
-  // CHECK: %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i16)
-  %out0, %out1, %empty, %full, %almostEmpty, %almostFull = seq.fifo[3] (%in, %rdEn, %wrEn) %clk, %rst : (i32) -> (i16, i16)
+  // CHECK: %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 2 almost_empty 1 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 2 almost_empty 1 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
 }


### PR DESCRIPTION
The `seq.fifo` operation intends to capture the semantics of a FIFO which eventually map to some form of on-chip resources. By having a FIFO abstraction, we provide an abstraction that can be targeted for target-specialized implementations, as well as default behavioral lowerings (based on `seq.hlmem`).

## Option 1: A `seq.fifo` op

The `seq.fifo` in- and output values consists of:
- **Inputs**:
  - clock, reset
  - input data
  - read/write enable
- **Outputs**:
  - output data
  - full, almost full, empty, almost empty flags

To start with, the FIFO operation is configurable with the following parameters:
1. Depth (cycles)
2. Differing in- and output widths (e.g. write `i32`, read 2x`i16`).
3. Almost empty/full thresholds (optional). If not provided, these will
    be asserted when the FIFO is empty/full.

Generally speaking, additional attributes can be added freely in order to further specialize the configuration (that is, provide information to a specific lowering pass) so that should take care of any lowering-specific information that needs to be provided.  
However, this op should ideally capture all possible in/outputs ports that we want (.. do we want dual clock support ?).

Like `seq.hlmem` there are no guarantees that all possible fifo configuration are able to be lowered. Available lowering passes will pattern match on the requested fifo configuration - it is then up to the user to ensure that they're requesting a configuration which is realizable by some pass.

## Option 2: A `seq.fifo` and `seq.flag_fifo` op

The `seq.flag_fifo` would have the FIFO flags built in. Is it more appropriate (from an IR/compiler point of view) to have a single `count` output, and it is then the users responsibility to implement flags (`cmpi` ops) based on this count? We could also have two operations, a `seq.flag_fifo` and `seq.fifo` wherein the former will lower to the latter.

## Option 3: Fifo ports attached to an `seq.hlmem`

In this model, the `seq.hlmem` continues to be a memory declaration. However, we'll add additional fifo read/write ports - different ports may have different properties or in/output values (just like our existing read and write ops).

```mlir
%handle = seq.hlmem %clk, %rst : !seq.hlmem<4xi32>
%out, %full, %almost_full = seq.fifo.flagged_read %handle, %rden
%empty, %almost_empty = seq.fifo.flagged_write %handle, %wren
```

Additionally, this model would support mixing fifo access with normal read/write access to a given backing memory - something which may be needed in certain edge cases.

Let me know your thoughts - I hope this issue can be a place where we can land on a well-designed IR representation of a FIFO... and then actual lowering can come down the road.