### PR TITLE
[ExportVerilog] Use pretty-printer for improved output formatting.

### DIFF
--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -126,6 +126,11 @@ public:
 
   //===- Groups -----------------------------------------------------------===//
 
+  /// Start a IndentStyle::Block group with specified offset.
+  void bbox(int32_t offset = 0, Breaks breaks = Breaks::Consistent) {
+    add<BeginToken>(offset, breaks, IndentStyle::Block);
+  }
+
   /// Start a consistent group with specified offset.
   void cbox(int32_t offset = 0, IndentStyle style = IndentStyle::Visual) {
     add<BeginToken>(offset, Breaks::Consistent, style);
@@ -168,6 +173,7 @@ public:
 /// Send one of these to TokenStream to add the corresponding token.
 /// See TokenBuilder for details of each.
 enum class PP {
+  bbox2,
   cbox0,
   cbox2,
   end,
@@ -236,6 +242,9 @@ public:
   /// Convenience for inline streaming of builder methods.
   TokenStream &operator<<(PP s) {
     switch (s) {
+    case PP::bbox2:
+      Base::bbox(2);
+      break;
     case PP::cbox0:
       Base::cbox(0);
       break;

--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -136,6 +136,10 @@ public:
     add<BeginToken>(offset, Breaks::Inconsistent, style);
   }
 
+  /// Start a group that cannot break, including nested groups.
+  /// Use sparingly.
+  void neverbox() { add<BeginToken>(0, Breaks::Never); }
+
   /// End a group.
   void end() { add<EndToken>(); }
 };
@@ -171,6 +175,7 @@ enum class PP {
   ibox0,
   ibox2,
   nbsp,
+  neverbox,
   neverbreak,
   newline,
   space,
@@ -251,6 +256,9 @@ public:
       break;
     case PP::nbsp:
       Base::nbsp();
+      break;
+    case PP::neverbox:
+      Base::neverbox();
       break;
     case PP::neverbreak:
       Base::neverbreak();

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -57,7 +57,6 @@ using namespace pretty;
 
 #define DEBUG_TYPE "export-verilog"
 
-constexpr int indentAmount = 2;
 StringRef circtHeader = "circt_header.svh";
 StringRef circtHeaderInclude = "`include \"circt_header.svh\"\n";
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3881,8 +3881,8 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
             });
           })
           .Case<CaseEnumPattern>([&](auto enumPattern) {
-            ps << emitter.fieldNameResolver.getEnumFieldName(
-                enumPattern->attr().template cast<hw::EnumFieldAttr>());
+            ps << PPExtString(emitter.fieldNameResolver.getEnumFieldName(
+                enumPattern->attr().template cast<hw::EnumFieldAttr>()));
           })
           .Case<CaseDefaultPattern>([&](auto) { ps << "default"; })
           .Default([&](auto) { assert(false && "unhandled case pattern"); });
@@ -4148,7 +4148,7 @@ LogicalResult StmtEmitter::visitSV(AssignInterfaceSignalOp op) {
   // TODO: emit like emitAssignLike does, maybe refactor.
   ps << "assign ";
   emitExpression(op.getIface(), emitted);
-  ps << "." << StringRef(op.getSignalName()) << " = ";
+  ps << "." << PPExtString(op.getSignalName()) << " = ";
   emitExpression(op.getRhs(), emitted);
   ps << ";";
   setPendingNewline();
@@ -4165,7 +4165,7 @@ void StmtEmitter::emitStatement(Operation *op) {
     return;
 
   emitOpError(op, "cannot emit this operation to Verilog");
-  ps << "unknown MLIR operation " << op->getName().getStringRef();
+  ps << "unknown MLIR operation " << PPExtString(op->getName().getStringRef());
   setPendingNewline();
 }
 
@@ -4449,14 +4449,15 @@ void ModuleEmitter::emitStatement(Operation *op) {
 void ModuleEmitter::emitHWExternModule(HWModuleExternOp module) {
   auto verilogName = module.getVerilogModuleNameAttr();
   startStatement();
-  ps << "// external module " << verilogName.getValue() << PP::newline;
+  ps << "// external module " << PPExtString(verilogName.getValue())
+     << PP::newline;
   setPendingNewline();
 }
 
 void ModuleEmitter::emitHWGeneratedModule(HWModuleGeneratedOp module) {
   auto verilogName = module.getVerilogModuleNameAttr();
   startStatement();
-  ps << "// external generated module " << verilogName.getValue()
+  ps << "// external generated module " << PPExtString(verilogName.getValue())
      << PP::newline;
   setPendingNewline();
 }
@@ -4656,7 +4657,7 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
     emitError(module, "SV attributes emission is unimplemented for the op");
 
   startStatement();
-  ps << "module " << getVerilogModuleName(module);
+  ps << "module " << PPExtString(getVerilogModuleName(module));
 
   // If we have any parameters, print them on their own line.
   if (!module.getParameters().empty()) {
@@ -4724,8 +4725,8 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
               if (scratch.size() < maxTypeWidth)
                 ps.nbsp(maxTypeWidth - scratch.size());
 
-              ps << state.globalNames.getParameterVerilogName(
-                  module, paramAttr.getName());
+              ps << PPExtString(state.globalNames.getParameterVerilogName(
+                  module, paramAttr.getName()));
 
               if (defaultValue) {
                 ps << " = ";
@@ -4812,13 +4813,14 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
           (hasZeroWidth ? 3 : 0) + (hasOutputs ? 7 : 6) + maxTypeWidth;
 
       // Emit the name.
-      ps << getPortVerilogName(module, portInfo[portIdx]);
+      ps << PPExtString(getPortVerilogName(module, portInfo[portIdx]));
       ps.invokeWithStringOS(
           [&](auto &os) { printUnpackedTypePostfix(portType, os); });
 
       if (state.options.printDebugInfo && portInfo[portIdx].sym &&
           !portInfo[portIdx].sym.getValue().empty())
-        ps << " /* inner_sym: " << portInfo[portIdx].sym.getValue() << " */";
+        ps << " /* inner_sym: " << PPExtString(portInfo[portIdx].sym.getValue())
+           << " */";
 
       ++portIdx;
 
@@ -4838,15 +4840,15 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
           ps << ",";
           ps << PP::newline;
           ps.nbsp(startOfNamePos);
-          ps << name;
+          ps << PPExtString(name);
           ps.invokeWithStringOS([&](auto &os) {
             printUnpackedTypePostfix(portInfo[portIdx].type, os);
           });
 
           if (state.options.printDebugInfo && portInfo[portIdx].sym &&
               !portInfo[portIdx].sym.getValue().empty())
-            ps << " /* inner_sym: " << portInfo[portIdx].sym.getValue()
-               << " */";
+            ps << " /* inner_sym: "
+               << PPExtString(portInfo[portIdx].sym.getValue()) << " */";
 
           ++portIdx;
         }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4307,7 +4307,7 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
   ps.scopedBox(isZeroBit ? PP::neverbox : PP::ibox2, [&]() {
     if (!isZeroBit) {
       if (!word.empty())
-        ps << PPExtString(word); // TODO: maybe have it return this to be clear.
+        ps << PPExtString(word);
       auto extraIndent = word.empty() ? 0 : 1;
       ps.spaces(maxDeclNameWidth - word.size() + extraIndent);
     } else {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1742,7 +1742,8 @@ public:
   ///
   void emitExpression(Value exp, VerilogPrecedence parenthesizeIfLooserThan) {
     assert(tokens.empty());
-    ps << PP::ibox0; // TODO: revisit
+    // Wrap to this column.
+    ps << PP::ibox0;
     emitSubExpr(exp, parenthesizeIfLooserThan,
                 /*signRequirement*/ NoRequirement,
                 /*isSelfDeterminedUnsignedValue*/ false);
@@ -3184,7 +3185,12 @@ LogicalResult StmtEmitter::visitSV(FWriteOp op) {
   ps << "," << PP::space;
   ps.writeQuotedEscaped(op.getFormatString());
 
-  // TODO: good comma/wrapping behavior as elsewhere.
+  // TODO: if any of these breaks, it'd be "nice" to break
+  // after the comma, instead of:
+  // $fwrite(5, "...", a + b,
+  //         longexpr_goes
+  //         + here, c);
+  // (without forcing breaking between all elements, like braced list)
   for (auto operand : op.getSubstitutions()) {
     ps << "," << PP::space;
     emitExpression(operand, ops);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3798,22 +3798,24 @@ LogicalResult StmtEmitter::visitSV(AlwaysFFOp op) {
   else {
     ps << " begin";
     emitLocationInfoAndNewLine(ops);
-    ps << BeginToken(indentAmount, Breaks::Consistent, IndentStyle::Block);
-    startStatement();
-    ps << "if (";
-    // TODO: group, like normal 'if'.
-    // Negative edge async resets need to invert the reset condition.  This is
-    // noted in the op description.
-    if (op.getResetStyle() == ResetType::AsyncReset &&
-        *op.getResetEdge() == EventControl::AtNegEdge)
-      ps << "!";
-    emitExpression(op.getReset(), ops);
-    ps << ")";
-    emitBlockAsStatement(op.getResetBlock(), ops);
-    startStatement();
-    ps << "else";
-    emitBlockAsStatement(op.getBodyBlock(), ops);
-    ps << PP::end;
+    ps.scopedBox(
+        BeginToken(indentAmount, Breaks::Consistent, IndentStyle::Block),
+        [&]() {
+          startStatement();
+          ps << "if (";
+          // TODO: group, like normal 'if'.
+          // Negative edge async resets need to invert the reset condition. This
+          // is noted in the op description.
+          if (op.getResetStyle() == ResetType::AsyncReset &&
+              *op.getResetEdge() == EventControl::AtNegEdge)
+            ps << "!";
+          emitExpression(op.getReset(), ops);
+          ps << ")";
+          emitBlockAsStatement(op.getResetBlock(), ops);
+          startStatement();
+          ps << "else";
+          emitBlockAsStatement(op.getBodyBlock(), ops);
+        });
 
     startStatement();
     ps << "end";

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4479,10 +4479,10 @@ void ModuleEmitter::emitBind(BindOp op) {
   Operation *childMod = inst.getReferencedModule(&state.symbolCache);
   auto childVerilogName = getVerilogModuleNameAttr(childMod);
 
-  // TODO: revisit!
   startStatement();
-  ps << "bind " << parentVerilogName.getValue() << PP::nbsp
-     << childVerilogName.getValue() << PP::nbsp << getSymOpName(inst) << " (";
+  ps << "bind " << PPExtString(parentVerilogName.getValue()) << PP::nbsp
+     << PPExtString(childVerilogName.getValue()) << PP::nbsp
+     << PPExtString(getSymOpName(inst)) << " (";
   bool isFirst = true; // True until we print a port.
   ps.scopedBox(PP::bbox2, [&]() {
     ModulePortInfo parentPortInfo = parentMod.getPorts();
@@ -4536,14 +4536,14 @@ void ModuleEmitter::emitBind(BindOp op) {
         ps << PP::neverbox << "//";
       }
 
-      ps << "." << elt.getName();
+      ps << "." << PPExtString(elt.getName());
       ps.nbsp(maxNameLength - elt.getName().size());
       ps << " (";
 
       // Emit the value as an expression.
       auto name = getNameRemotely(portVal, parentPortInfo, parentMod);
       assert(!name.empty() && "bind port connection must have a name");
-      ps << name << ")";
+      ps << PPExtString(name) << ")";
 
       if (isZeroWidth)
         ps << PP::end; // Close never-break group.
@@ -4617,11 +4617,10 @@ void ModuleEmitter::emitBindInterface(BindInterfaceOp op) {
   auto instantiator = instance->getParentOfType<HWModuleOp>().getName();
   auto *interface = op->getParentOfType<ModuleOp>().lookupSymbol(
       instance.getInterfaceType().getInterface());
-  // TODO:
   startStatement();
-  ps << "bind " << instantiator << " "
-     << cast<InterfaceOp>(*interface).getSymName() << " "
-     << getSymOpName(instance) << " (.*);" << PP::newline;
+  ps << "bind " << PPExtString(instantiator) << PP::nbsp
+     << PPExtString(cast<InterfaceOp>(*interface).getSymName()) << PP::nbsp
+     << PPExtString(getSymOpName(instance)) << " (.*);" << PP::newline;
   setPendingNewline();
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -29,7 +29,7 @@
 #include "circt/Support/LLVM.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/Path.h"
-#include "circt/Support/PrettyPrinterBuilder.h"
+#include "circt/Support/PrettyPrinterHelpers.h"
 #include "circt/Support/Version.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -871,7 +871,7 @@ public:
 
   /// String storage backing Tokens built from temporary strings.
   /// PrettyPrinter will clear this as appropriate.
-  PPBuilderStringSaver saver;
+  TokenStringSaver saver;
 
   /// Pretty printer.
   PrettyPrinter pp;
@@ -894,7 +894,7 @@ public:
   VerilogEmitterState &state;
 
   /// Stream helper (pp, saver).
-  PPStream<> ps;
+  TokenStream<> ps;
 
   explicit EmitterBase(VerilogEmitterState &state)
       : state(state), ps(state.pp, state.saver) {}
@@ -2000,7 +2000,7 @@ private:
   BufferingPP buffer;
 
   /// Stream to emit expressions into, will add to buffer.
-  PPStream<BufferingPP> ps;
+  TokenStream<BufferingPP> ps;
 
   // Track legalized names.
   ModuleNameManager &names;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1846,7 +1846,7 @@ private:
   /// {
   ///   a + b,
   ///   x + y,
-  ///   c,
+  ///   c
   /// }
   /// ```
   template <typename Container, typename OpenFunc, typename CloseFunc,

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3798,7 +3798,7 @@ LogicalResult StmtEmitter::visitSV(AlwaysFFOp op) {
   else {
     ps << " begin";
     emitLocationInfoAndNewLine(ops);
-    ps << BeginToken(2, Breaks::Consistent, IndentStyle::Block);
+    ps << BeginToken(indentAmount, Breaks::Consistent, IndentStyle::Block);
     startStatement();
     ps << "if (";
     // TODO: group, like normal 'if'.
@@ -3867,32 +3867,35 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
   });
   emitLocationInfoAndNewLine(ops);
 
-  ps.scopedBox(BeginToken(2, Breaks::Consistent, IndentStyle::Block), [&]() {
-    for (auto &caseInfo : op.getCases()) {
-      startStatement();
-      auto &pattern = caseInfo.pattern;
+  ps.scopedBox(
+      BeginToken(indentAmount, Breaks::Consistent, IndentStyle::Block), [&]() {
+        for (auto &caseInfo : op.getCases()) {
+          startStatement();
+          auto &pattern = caseInfo.pattern;
 
-      llvm::TypeSwitch<CasePattern *>(pattern.get())
-          .Case<CaseBitPattern>([&](auto bitPattern) {
-            // TODO: We could emit in hex if/when the size is a multiple of 4
-            // and there are no x's crossing nibble boundaries.
-            ps.invokeWithStringOS([&](auto &os) {
-              os << bitPattern->getWidth() << "'b";
-              for (size_t bit = 0, e = bitPattern->getWidth(); bit != e; ++bit)
-                os << getLetter(bitPattern->getBit(e - bit - 1));
-            });
-          })
-          .Case<CaseEnumPattern>([&](auto enumPattern) {
-            ps << emitter.fieldNameResolver.getEnumFieldName(
-                enumPattern->attr().template cast<hw::EnumFieldAttr>());
-          })
-          .Case<CaseDefaultPattern>([&](auto) { ps << "default"; })
-          .Default([&](auto) { assert(false && "unhandled case pattern"); });
+          llvm::TypeSwitch<CasePattern *>(pattern.get())
+              .Case<CaseBitPattern>([&](auto bitPattern) {
+                // TODO: We could emit in hex if/when the size is a multiple of
+                // 4 and there are no x's crossing nibble boundaries.
+                ps.invokeWithStringOS([&](auto &os) {
+                  os << bitPattern->getWidth() << "'b";
+                  for (size_t bit = 0, e = bitPattern->getWidth(); bit != e;
+                       ++bit)
+                    os << getLetter(bitPattern->getBit(e - bit - 1));
+                });
+              })
+              .Case<CaseEnumPattern>([&](auto enumPattern) {
+                ps << emitter.fieldNameResolver.getEnumFieldName(
+                    enumPattern->attr().template cast<hw::EnumFieldAttr>());
+              })
+              .Case<CaseDefaultPattern>([&](auto) { ps << "default"; })
+              .Default(
+                  [&](auto) { assert(false && "unhandled case pattern"); });
 
-      ps << ":";
-      emitBlockAsStatement(caseInfo.block, emptyOps);
-    }
-  });
+          ps << ":";
+          emitBlockAsStatement(caseInfo.block, emptyOps);
+        }
+      });
 
   startStatement();
   ps << "endcase";
@@ -3933,7 +3936,8 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
       // Handle # if this is the first parameter we're printing.
       if (!printed) {
-        ps << " #(" << BeginToken(2, Breaks::Inconsistent, IndentStyle::Block)
+        ps << " #("
+           << BeginToken(indentAmount, Breaks::Inconsistent, IndentStyle::Block)
            << PP::newline;
         printed = true;
       } else {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1822,9 +1822,9 @@ private:
 
   /// Emit a range of values separated by commas and a breakable space.
   /// Each value is emitted by invoking `eachFn`.
-  template <typename EachFn>
-  void interleaveComma(ValueRange ops, EachFn eachFn) {
-    llvm::interleave(ops, eachFn, [&]() { ps << "," << PP::space; });
+  template <typename Container, typename EachFn>
+  void interleaveComma(const Container &c, EachFn eachFn) {
+    llvm::interleave(c, eachFn, [&]() { ps << "," << PP::space; });
   }
 
   /// Emit a range of values separated by commas and a breakable space.
@@ -1849,13 +1849,14 @@ private:
   ///   c,
   /// }
   /// ```
-  template <typename OpenFunc, typename CloseFunc, typename EachFunc>
-  void emitBracedList(ValueRange ops, OpenFunc openFn, EachFunc eachFn,
+  template <typename Container, typename OpenFunc, typename CloseFunc,
+            typename EachFunc>
+  void emitBracedList(const Container &c, OpenFunc openFn, EachFunc eachFn,
                       CloseFunc closeFn) {
     ps << PP::cbox2;
     openFn();
     ps << PP::zerobreak;
-    interleaveComma(ops, eachFn);
+    interleaveComma(c, eachFn);
     ps << BreakToken(0, -2) << PP::end;
     closeFn();
   }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4530,7 +4530,6 @@ void ModuleEmitter::emitBind(BindOp op) {
         // If this is a real port we're printing, then it isn't the first
         // one. Any subsequent ones will need a comma.
         isFirst = false;
-        // os << "  ";
       } else {
         // We comment out zero width ports, so their presence and
         // initializer expressions are still emitted textually.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4327,12 +4327,8 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     // Emit the type.
     if (!typeString.empty())
       ps << typeString;
-    if (typeString.size() < maxTypeWidth) {
-      if (isZeroBitType(type))
-        ps.nbsp(maxTypeWidth - typeString.size());
-      else
-        ps.spaces(maxTypeWidth - typeString.size());
-    }
+    if (typeString.size() < maxTypeWidth)
+      ps.spaces(maxTypeWidth - typeString.size());
 
     // Emit the name.
     ps << PPExtString(names.getName(value));

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3343,27 +3343,30 @@ LogicalResult StmtEmitter::visitSV(InfoOp op) {
 LogicalResult StmtEmitter::visitSV(ReadMemOp op) {
   SmallPtrSet<Operation *, 8> ops({op});
 
-  indent() << "$readmem";
+  startStatement();
+  ps << "$readmem";
   switch (op.getBaseAttr().getValue()) {
   case MemBaseTypeAttr::MemBaseBin:
-    os << "b";
+    ps << "b";
     break;
   case MemBaseTypeAttr::MemBaseHex:
-    os << "h";
+    ps << "h";
     break;
   }
-  os << "(";
-  os << "\"" << op.getFilename() << "\""
-     << ", ";
+  ps << "(";
+  ps.scopedBox(PP::ibox0, [&]() {
+    ps.writeQuotedEscaped(op.getFilename());
+    ps << "," << PP::space;
 
-  auto *reg =
-      state.symbolCache
-          .getInnerDefinition(op->getParentOfType<HWModuleOp>().getNameAttr(),
-                              op.getInnerSymAttr())
-          .getOp();
-  os << names.getName(reg);
+    auto *reg =
+        state.symbolCache
+            .getInnerDefinition(op->getParentOfType<HWModuleOp>().getNameAttr(),
+                                op.getInnerSymAttr())
+            .getOp();
+    ps << PPExtString(names.getName(reg));
+  });
 
-  os << ");";
+  ps << ");";
   emitLocationInfoAndNewLine(ops);
   return success();
 }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2891,12 +2891,12 @@ private:
                             SmallPtrSetImpl<Operation *> &ops,
                             bool isConcurrent);
   template <typename Op>
-  LogicalResult emitImmediateAssertion(Op op, StringRef opName);
+  LogicalResult emitImmediateAssertion(Op op, PPExtString opName);
   LogicalResult visitSV(AssertOp op);
   LogicalResult visitSV(AssumeOp op);
   LogicalResult visitSV(CoverOp op);
   template <typename Op>
-  LogicalResult emitConcurrentAssertion(Op op, StringRef opName);
+  LogicalResult emitConcurrentAssertion(Op op, PPExtString opName);
   LogicalResult visitSV(AssertConcurrentOp op);
   LogicalResult visitSV(AssumeConcurrentOp op);
   LogicalResult visitSV(CoverConcurrentOp op);
@@ -3481,7 +3481,7 @@ void StmtEmitter::emitAssertionMessage(StringAttr message, ValueRange args,
 }
 
 template <typename Op>
-LogicalResult StmtEmitter::emitImmediateAssertion(Op op, StringRef opName) {
+LogicalResult StmtEmitter::emitImmediateAssertion(Op op, PPExtString opName) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
@@ -3489,9 +3489,9 @@ LogicalResult StmtEmitter::emitImmediateAssertion(Op op, StringRef opName) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
   ps.scopedBox(PP::ibox2, [&]() {
-    emitAssertionLabel(op, opName);
+    emitAssertionLabel(op, opName.str);
     ps.scopedBox(PP::cbox0, [&]() {
-      ps << opName; // TODO: PPExtString ?
+      ps << opName;
       switch (op.getDefer()) {
       case DeferAssert::Immediate:
         break;
@@ -3516,19 +3516,19 @@ LogicalResult StmtEmitter::emitImmediateAssertion(Op op, StringRef opName) {
 }
 
 LogicalResult StmtEmitter::visitSV(AssertOp op) {
-  return emitImmediateAssertion(op, "assert");
+  return emitImmediateAssertion(op, PPExtString("assert"));
 }
 
 LogicalResult StmtEmitter::visitSV(AssumeOp op) {
-  return emitImmediateAssertion(op, "assume");
+  return emitImmediateAssertion(op, PPExtString("assume"));
 }
 
 LogicalResult StmtEmitter::visitSV(CoverOp op) {
-  return emitImmediateAssertion(op, "cover");
+  return emitImmediateAssertion(op, PPExtString("cover"));
 }
 
 template <typename Op>
-LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, StringRef opName) {
+LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, PPExtString opName) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
@@ -3536,7 +3536,7 @@ LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, StringRef opName) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
   ps.scopedBox(PP::ibox2, [&]() {
-    emitAssertionLabel(op, opName);
+    emitAssertionLabel(op, opName.str);
     ps.scopedBox(PP::cbox0, [&]() {
       ps << opName << PP::nbsp << "property (";
       ps.scopedBox(PP::ibox0, [&]() {
@@ -3557,15 +3557,15 @@ LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, StringRef opName) {
 }
 
 LogicalResult StmtEmitter::visitSV(AssertConcurrentOp op) {
-  return emitConcurrentAssertion(op, "assert");
+  return emitConcurrentAssertion(op, PPExtString("assert"));
 }
 
 LogicalResult StmtEmitter::visitSV(AssumeConcurrentOp op) {
-  return emitConcurrentAssertion(op, "assume");
+  return emitConcurrentAssertion(op, PPExtString("assume"));
 }
 
 LogicalResult StmtEmitter::visitSV(CoverConcurrentOp op) {
-  return emitConcurrentAssertion(op, "cover");
+  return emitConcurrentAssertion(op, PPExtString("cover"));
 }
 
 LogicalResult StmtEmitter::emitIfDef(Operation *op, MacroIdentAttr cond) {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2564,7 +2564,7 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   // The ?: operator is right associative.
-#if 0
+#if 1
   // Layout:
   // cond ? a : b
   // (long
@@ -2576,12 +2576,12 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
   // + cond
   //   ? a
   //   : b
-  auto box = ps.scopedCBox(2);
+  auto box = ps.scopedCBox(0);
   {
-    auto innerbox = ps.scopedIBox(-2);
+    auto innerbox = ps.scopedIBox(0);
     emitSubExpr(op.getCond(), VerilogPrecedence(Conditional - 1));
   }
-  ps << PP::space;
+  ps << BreakToken(1, 2);
 #else
   // cond ? a : b
   // cond ? a
@@ -2595,7 +2595,7 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
   auto lhsInfo =
       emitSubExpr(op.getTrueValue(), VerilogPrecedence(Conditional - 1));
   ps << PP::end;
-  ps << PP::space << ": " << PP::ibox0;
+  ps << BreakToken(1, 2) << ": " << PP::ibox0;
   auto rhsInfo = emitSubExpr(op.getFalseValue(), Conditional);
   ps << PP::end;
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3202,6 +3202,7 @@ LogicalResult StmtEmitter::visitSV(VerbatimOp op) {
   startStatement();
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
+  ps << BeginToken(0, Breaks::Never);
 
   // Drop an extraneous \n off the end of the string if present.
   StringRef string = op.getFormatString();
@@ -3219,7 +3220,9 @@ LogicalResult StmtEmitter::visitSV(VerbatimOp op) {
     if (isFirst)
       isFirst = false;
     else {
+      ps << PP::end;
       ps << PP::newline;
+      ps << BeginToken(0, Breaks::Never);
     }
 
     // Emit each chunk of the line.
@@ -3229,6 +3232,8 @@ LogicalResult StmtEmitter::visitSV(VerbatimOp op) {
         names);
     string = lhsRhs.second;
   }
+
+  ps << PP::end;
 
   emitLocationInfoAndNewLine(ops);
   return success();

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3107,8 +3107,7 @@ LogicalResult StmtEmitter::visitStmt(OutputOp op) {
     ps << PP::ibox2;
     bool isZeroBit = isZeroBitType(port.type);
     if (isZeroBit) {
-      ps << BeginToken(0, Breaks::Never);
-      ps << "// Zero width: ";
+      ps << PP::neverbox << "// Zero width: ";
     }
     // TODO: Close to emitAssignLike...
     ps << "assign" << PP::space;
@@ -3204,7 +3203,7 @@ LogicalResult StmtEmitter::visitSV(VerbatimOp op) {
   startStatement();
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
-  ps << BeginToken(0, Breaks::Never);
+  ps << PP::neverbox;
 
   // Drop an extraneous \n off the end of the string if present.
   StringRef string = op.getFormatString();
@@ -3222,9 +3221,7 @@ LogicalResult StmtEmitter::visitSV(VerbatimOp op) {
     if (isFirst)
       isFirst = false;
     else {
-      ps << PP::end;
-      ps << PP::newline;
-      ps << BeginToken(0, Breaks::Never);
+      ps << PP::end << PP::newline << PP::neverbox;
     }
 
     // Emit each chunk of the line.
@@ -4005,8 +4002,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
     } else {
       // We comment out zero width ports, so their presence and initializer
       // expressions are still emitted textually.
-      ps << BeginToken(0, Breaks::Never);
-      ps << "//";
+      ps << PP::neverbox << "//";
     }
 
     auto portName = getPortVerilogName(moduleOp, elt);
@@ -4098,7 +4094,7 @@ LogicalResult StmtEmitter::visitSV(InterfaceSignalOp op) {
 
   startStatement();
   if (isZeroBitType(op.getType()))
-    ps << BeginToken(0, Breaks::Never) << "// ";
+    ps << PP::neverbox << "// ";
   ps.invokeWithStringOS([&](auto &os) {
     emitter.printPackedType(stripUnpackedTypes(op.getType()), os, op->getLoc(),
                             Type(), false);
@@ -4298,8 +4294,7 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     auto extraIndent = word.empty() ? 0 : 1;
     ps.spaces(maxDeclNameWidth - word.size() + extraIndent);
   } else {
-    ps << BeginToken(0, Breaks::Never) << "// Zero width: " << PPExtString(word)
-       << PP::space;
+    ps << PP::neverbox << "// Zero width: " << PPExtString(word) << PP::space;
   }
 
   SmallString<8> typeString;
@@ -4525,7 +4520,7 @@ void ModuleEmitter::emitBind(BindOp op) {
     } else {
       // We comment out zero width ports, so their presence and initializer
       // expressions are still emitted textually.
-      ps << BeginToken(0, Breaks::Never) << "//";
+      ps << PP::neverbox << "//";
     }
 
     ps << "." << elt.getName();
@@ -4776,7 +4771,7 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
     if (hasZeroWidth) {
       isZeroWidth = isZeroBitType(portType);
       if (isZeroWidth)
-        ps << BeginToken(0, Breaks::Never);
+        ps << PP::neverbox;
       ps << (isZeroWidth ? "// " : "   ");
     }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1853,12 +1853,13 @@ private:
             typename EachFunc>
   void emitBracedList(const Container &c, OpenFunc openFn, EachFunc eachFn,
                       CloseFunc closeFn) {
-    ps << PP::cbox2;
-    openFn();
-    ps << PP::zerobreak;
-    interleaveComma(c, eachFn);
-    ps << BreakToken(0, -2) << PP::end;
-    closeFn();
+    ps.scopedBox(PP::cbox2, [&]() {
+      openFn();
+      ps << PP::zerobreak;
+      interleaveComma(c, eachFn);
+      ps << BreakToken(0, -2);
+      closeFn();
+    });
   }
 
   /// Emit braced list of values surrounded by specified open/close.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s
+// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100' -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)
@@ -412,8 +412,9 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   %a3 = comb.divu %a1, %a2: i4
   sv.assign %awire, %a3: i4
 
-  // CHECK: assign awire = $unsigned($signed(in1) / $signed(in2) + $signed(in1) / $signed(in2)) /
-  // CHECK-NEXT:           $unsigned($signed(in1) / $signed(in2) * $signed(in1) / $signed(in2));
+  // CHECK:       assign awire =
+  // CHECK-NEXT:    $unsigned($signed(in1) / $signed(in2) + $signed(in1) / $signed(in2))
+  // CHECK-NEXT:    / $unsigned($signed(in1) / $signed(in2) * $signed(in1) / $signed(in2));
   %b1a = comb.divs %in1, %in2: i4
   %b1b = comb.divs %in1, %in2: i4
   %b1c = comb.divs %in1, %in2: i4
@@ -578,11 +579,11 @@ hw.module @cyclic(%a: i1) -> (b: i1) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longExpressions
 hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
-  // CHECK:  assign b = (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
-  // CHECK-NEXT:        * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT:        a) | (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT:        + a) * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT:        a + a);
+  // CHECK:      assign b =
+  // CHECK-NEXT:   (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
+  // CHECK-NEXT:   * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
+  // CHECK-NEXT:   | (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
+  // CHECK-NEXT:   * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a);
 
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
   %2 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
@@ -597,9 +598,10 @@ hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longvariadic
 hw.module @longvariadic(%a: i8) -> (b: i8) {
-  // CHECK:  assign b =
-  // CHECK-COUNT-11: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT:     a + a + a;
+  // CHECK:          assign b =
+  // CHECK-NEXT:       a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-COUNT-9:    + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT:       + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
@@ -682,14 +684,15 @@ hw.module @noTemporaryIfReadInOutIsAfterUse(%clock: i1, %x: i1) {
 hw.module @largeConstant(%a: i100000, %b: i16) -> (x: i100000, y: i16) {
   // Large constant is inlined on multiple lines.
 
-  // CHECK: assign x = a + 100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
-  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000;
+  // CHECK:      assign x =
+  // CHECK-NEXT:   a + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000
+  // CHECK-NEXT:   + 100000'h2CD76FE086B93CE2F768A00B22A00000000000;
   %c = hw.constant 1000000000000000000000000000000000000000000000 : i100000
   %1 = comb.add %a, %c, %c, %c, %c, %c, %c, %c, %c : i100000
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -513,8 +513,10 @@ hw.module @zeroElements(%in0: i0, %in1: i32) -> (out0: !hw.struct<z1: i0, a: i32
   // CHECK:      // Zero width: wire /*Zero Width*/
   // CHECK-SAME: _GEN = '{};
   // CHECK-NEXT: wire struct packed {logic [31:0] d1; /*z: Zero Width;*/ }
-  // CHECK-SAME: _GEN_0 = '{d1: in1};
-  // CHECK-NEXT: wire struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } _GEN_1 = '{a: in1, b: in1, d: _GEN_0};
+  // CHECK-NEXT:   _GEN_0 = '{d1: in1};
+  //      CHECK: wire
+  // CHECK-NEXT:   struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } 
+  // CHECK-NEXT:   _GEN_1 = '{a: in1, b: in1, d: _GEN_0};
   // CHECK-NEXT: assign out0 = '{a: in1, b: _GEN_1.b, d: _GEN_1.d};
   %0 = hw.struct_create (%in0) : !hw.struct<z: i0>
   %1 = hw.struct_create (%in1, %in0) : !hw.struct<d1:i32, z:i0>

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -15,32 +15,43 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 
 // CHECK-LABEL: module longvariadic
 
-// SHORT:       assign b = a + a + a + a + a + a + a + a + a + a + a
-// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT-NEXT:             a + a + a + a + a + a + a + a + a + a + a
-// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT-NEXT:             a + a + a + a + a + a + a + a + a + a + a
-// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT-NEXT:             a;
+//               ---------------------------------------v
+// SHORT:          assign b =
+// SHORT-NEXT:       a + a + a + a + a + a + a + a + a
+// SHORT-COUNT-6:    + a + a + a + a + a + a + a + a + a
+// SHORT-NEXT:       + a;
 
-// DEFAULT:       assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT-NEXT:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT-NEXT:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+//              -----------------------------------------------------------------------------------------v
+// DEFAULT:       assign b =
+// DEFAULT-NEXT:    a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// DEFAULT-NEXT:    + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// DEFAULT-NEXT:    + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
-// LONG:       assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-// LONG-NEXT:             + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+//           -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------v
+// LONG:       assign b =
+// LONG-NEXT:    a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// LONG-NEXT:    + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
-// LIMIT_SHORT:       wire [7:0] _GEN = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                       + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_SHORT-NEXT:                       a + a + a + a + a + a + a + a + a + a + a;
-// LIMIT_SHORT-NEXT:  wire [7:0] _GEN_0 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                       + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_SHORT-NEXT:                       a + a + a + a + a + a + a + a + a + a + a;
+//                  ---------------------------------------v
+// LIMIT_SHORT:       wire [7:0] _GEN =
+// LIMIT_SHORT-NEXT:    a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a;
+
+//                  ---------------------------------------v
+// LIMIT_SHORT-NEXT:  wire [7:0] _GEN_0 =
+// LIMIT_SHORT-NEXT:    a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:    + a + a + a + a + a;
 // LIMIT_SHORT-NEXT:  assign b = _GEN + _GEN_0;
 
-// LIMIT_LONG:        assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG-NEXT:                 a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG-NEXT:                 a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+//                  -----------------------------------------------------------------------------------------v
+// LIMIT_LONG:        assign b =
+// LIMIT_LONG-NEXT:     a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_LONG-NEXT:     + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_LONG-NEXT:     + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
 hw.module @moduleWithComment()
   attributes {comment = "The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} {}

--- a/test/Conversion/ExportVerilog/no-wrap.mlir
+++ b/test/Conversion/ExportVerilog/no-wrap.mlir
@@ -1,0 +1,61 @@
+// RUN: circt-opt -export-verilog --split-input-file %s | FileCheck %s
+// RUN: circt-opt -test-apply-lowering-options='options=emittedLineLength=10' -export-verilog --split-input-file %s | FileCheck %s
+
+// https://github.com/llvm/circt/issues/4181
+
+// CHECK{LITERAL}: //  {{
+// CHECK-NEXT: endmodule
+hw.module @VerbatimWrapping(%clock : i1, %cond : i1, %val : i8, %a : i3, %b : i3) {
+      %x = comb.add %a, %b : i3
+      %y = comb.xor %a, %b : i3
+      %arr = hw.array_create %x, %y, %x, %y, %x, %y, %x, %y, %x, %y, %x, %y : i3
+      sv.verbatim "// {{0}}" (%arr) : !hw.array<12xi3>
+}
+
+// -----
+// https://github.com/llvm/circt/issues/4182
+
+// CHECK-LABEL: TestZero(
+
+// CHECK:      input  /*Zero Width*/      zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime
+// CHECK-NEXT: input  [2:0]/*Zero Width*/ arrZero
+
+// CHECK:      // Zero width: assign rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo
+// CHECK-SAME: ;
+// CHECK-NEXT: // Zero width: assign
+// CHECK-SAME: ;
+// CHECK-NEXT: endmodule
+hw.module @TestZero(%a: i4, %zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime: i0, %arrZero: !hw.array<3xi0>)
+  -> (r0: i4, rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo: i0, arrZero_0: !hw.array<3xi0>) {
+
+  %b = comb.add %a, %a : i4
+  %c = comb.add %zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime, %zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime : i0
+  hw.output %b, %c, %arrZero : i4, i0, !hw.array<3xi0>
+}
+
+// Module ports:
+// CHECK-LABEL: TestZeroInstance(
+// CHECK:      // input  /*Zero Width*/      azeroBit
+// CHECK-NEXT: // input  [2:0]/*Zero Width*/ aarrZero
+// CHECK:      // output /*Zero Width*/      rZeroOutputWithAVeryLongNameYepThisToo
+
+// Wire:
+// CHECK: // Zero width: wire /*Zero Width*/ [[ZERO_WIRE:.+]];
+
+// Instance ports:
+// CHECK: //.zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime (azeroBit),
+// CHECK: //.rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo ([[ZERO_WIRE]])
+
+// Output:
+// CHECK: // Zero width: assign
+// CHECK-SAME: ;
+// CHECK-NEXT: endmodule
+hw.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !hw.array<3xi0>)
+  -> (r0: i4, rZeroOutputWithAVeryLongNameYepThisToo: i0, arrZero_0: !hw.array<3xi0>) {
+
+
+  %o1, %o2, %o3 = hw.instance "iii" @TestZero(a: %aa: i4, zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime: %azeroBit: i0, arrZero: %aarrZero: !hw.array<3xi0>) -> (r0: i4, rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo: i0, arrZero_0: !hw.array<3xi0>)
+ %c = comb.add %o2, %o2 : i0
+
+  hw.output %o1, %c, %o3 : i4, i0, !hw.array<3xi0>
+}

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -1,0 +1,41 @@
+// RUN: circt-opt -export-verilog --split-input-file %s | FileCheck %s --strict-whitespace --match-full-lines
+
+sv.interface @IValidReady_Struct  {
+  sv.interface.signal @data : !hw.struct<foo: !hw.array<72xi1>, bar: !hw.array<128xi1>, baz: !hw.array<224xi1>>
+}
+
+// CHECK-LABEL:module structs({{.*}}
+// CHECK:  assign _GEN =
+// CHECK-NEXT:    '{
+// CHECK-NEXT:      foo: ({_GEN_1, _GEN_0}),
+// CHECK-NEXT:      bar: ({_GEN_0, _GEN_0}),
+// CHECK-NEXT:      baz:
+// CHECK-NEXT:        ({
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_1,
+// CHECK-NEXT:           _GEN_0,
+// CHECK-NEXT:           _GEN_0
+// CHECK-NEXT:         })
+// CHECK-NEXT:    };{{.*}}
+hw.module @structs(%clk: i1, %rstn: i1) {
+  %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>
+  sv.interface.signal.assign %0(@IValidReady_Struct::@data) = %s : !hw.struct<foo: !hw.array<72xi1>, bar: !hw.array<128xi1>, baz: !hw.array<224xi1>>
+  %c0 = hw.constant 0 : i8
+  %c64 = hw.constant 100000 : i64
+  %16 = hw.bitcast %c64 : (i64) -> !hw.array<64xi1>
+  %58 = hw.bitcast %c0 : (i8) -> !hw.array<8xi1>
+  %90 = hw.array_concat %58, %16 : !hw.array<8xi1>, !hw.array<64xi1>
+  %91 = hw.array_concat %16, %16 : !hw.array<64xi1>, !hw.array<64xi1>
+  %92 = hw.array_concat %58, %58, %58, %58, %58, %58, %58, %58, %58, %58, %58, %58, %16, %16 : !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<8xi1>, !hw.array<64xi1>, !hw.array<64xi1>
+  %s = hw.struct_create (%90, %91, %92) : !hw.struct<foo: !hw.array<72xi1>, bar: !hw.array<128xi1>, baz: !hw.array<224xi1>>
+}

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -5,7 +5,7 @@ sv.interface @IValidReady_Struct  {
 }
 
 // CHECK-LABEL:module structs({{.*}}
-// CHECK:  assign _GEN =
+//      CHECK:  assign _GEN =
 // CHECK-NEXT:    '{
 // CHECK-NEXT:      foo: ({_GEN_1, _GEN_0}),
 // CHECK-NEXT:      bar: ({_GEN_0, _GEN_0}),
@@ -57,13 +57,13 @@ hw.module @CoverAssert(
     %4 = comb.and bin %0, %2 : i1
     %5 = comb.and bin %1, %3 : i1
 
-// CHECK:  cover__information_label:
+//      CHECK:  cover__information_label:
 // CHECK-NEXT:    cover property (@(posedge clock)
 // CHECK-NEXT:                    eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
 // CHECK-NEXT:                    & ~reset);{{.*}}
     sv.cover.concurrent posedge %clock, %4 label "cover__information_label"
 
-// CHECK:  assert__label:
+//      CHECK:  assert__label:
 // CHECK-NEXT:    assert property (@(posedge clock)
 // CHECK-NEXT:                     eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
 // CHECK-NEXT:                     & ~reset)

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -133,7 +133,8 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       %sub_inner = comb.sub %val, %c42 : i8
       %sub = comb.sub %sub_inner, %c42 : i8
 
-      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(8'(val - 8'h2A) - 8'h2A));
+      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A),
+      // CHECK-NEXT:         8'(8'(val - 8'h2A) - 8'h2A));
       sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
     }
 
@@ -300,7 +301,8 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.fwrite %fd, "%d" (%c1) : i1
       // CHECK-NEXT: fwrite(32'h80000002, "%d", "THING");
       %c2 = sv.verbatim.expr "\"VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE\"" : () -> i1
-      // CHECK-NEXT: _GEN = "VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE";
+      // CHECK-NEXT: _GEN = 
+      // CHECK-NEXT:   "VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE";
       // CHECK-NEXT: fwrite(32'h80000002, "%d", _GEN);
       sv.fwrite %fd, "%d" (%c2) : i1
       // CHECK-NEXT: `endif
@@ -819,12 +821,12 @@ hw.module @issue720ifdef(%clock: i1, %arg1: i1, %arg2: i1, %arg3: i1) {
 hw.module @issue728(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija: i1) {
   %fd = hw.constant 0x80000002 : i32
 
-  // CHECK:  always @(posedge clock) begin
-  // CHECK:    $fwrite(32'h80000002, "force output");
-  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
-  // CHECK:        asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
-  // CHECK:      $fwrite(32'h80000002, "this cond is split");
-  // CHECK:  end // always @(posedge)
+  // CHECK:       always @(posedge clock) begin
+  // CHECK-NEXT:    $fwrite(32'h80000002, "force output");
+  // CHECK-NEXT:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa
+  // CHECK-NEXT:        & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
+  // CHECK-NEXT:      $fwrite(32'h80000002, "this cond is split");
+  // CHECK-NEXT:  end // always @(posedge)
   sv.always posedge %clock  {
      sv.fwrite %fd, "force output"
      %cond = comb.and %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija, %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija, %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija : i1
@@ -839,14 +841,14 @@ hw.module @issue728(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija:
 hw.module @issue728ifdef(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija: i1) {
   %fd = hw.constant 0x80000002 : i32
 
-  // CHECK: always @(posedge clock) begin
-  // CHECK:    $fwrite(32'h80000002, "force output");
-  // CHECK:    `ifdef FUN_AND_GAMES
-  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
-  // CHECK:        asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
-  // CHECK:        $fwrite(32'h80000002, "this cond is split");
-  // CHECK:    `endif
-  // CHECK: end // always @(posedge)
+  // CHECK:      always @(posedge clock) begin
+  // CHECK-NEXT:    $fwrite(32'h80000002, "force output");
+  // CHECK-NEXT:    `ifdef FUN_AND_GAMES
+  // CHECK-NEXT:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa
+  // CHECK-NEXT:         & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
+  // CHECK-NEXT:        $fwrite(32'h80000002, "this cond is split");
+  // CHECK-NEXT:    `endif
+  // CHECK-NEXT: end // always @(posedge)
   sv.always posedge %clock  {
      sv.fwrite %fd, "force output"
      sv.ifdef.procedural "FUN_AND_GAMES" {
@@ -948,8 +950,9 @@ hw.module @TooLongConstExpr() {
   %myreg = sv.reg : !hw.inout<i4200>
   // CHECK: always @*
   sv.always {
-    // CHECK-NEXT: myreg <= 4200'(4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4 +
-    // CHECK-NEXT:                             4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4);
+    // CHECK-NEXT: myreg <=
+    // CHECK-NEXT:   4200'(4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4
+    // CHECK-NEXT:         + 4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4);
     %0 = hw.constant 15894191981981165163143546843135416146464164161464654561818646486465164684484 : i4200
     %1 = comb.add %0, %0 : i4200
     sv.passign %myreg, %1 : i4200
@@ -1241,7 +1244,8 @@ hw.module @InlineAutomaticLogicInit(%a : i42, %b: i42, %really_really_long_port:
     // CHECK: [[THING]] = `THING;
     // CHECK: [[THING3]] = 42'([[THING]] + {{..}}31{really_really_long_port[10]}}
     // CHECK-SAME: really_really_long_port})
-    // CHECK: [[MANYTHING]] = [[THING]] | [[THING]] |
+    // CHECK: [[MANYTHING]] =
+    // CHECK-NEXT: [[THING]] | [[THING]] |
 
     // Check the indentation level of temporaries.  Issue #1625
     %thing = sv.verbatim.expr.se "`THING" : () -> i42
@@ -1550,8 +1554,10 @@ hw.module @ProhibitReuseOfExistingInOut(%a: i1) -> (out1: i1) {
 
 // See https://github.com/verilator/verilator/issues/3405.
 // CHECK-LABEL: Verilator3405
-// CHECK-DAG: wire [[GEN0:.+]] = {{.+}} | {{.+}} | {{.+}}
-// CHECK-DAG: wire [[GEN1:.+]] = {{.+}} | {{.+}} | {{.+}}
+// CHECK-DAG: wire [[GEN0:.+]] =
+// CHECK-DAG-NEXT: {{.+}} | {{.+}} | {{.+}}
+// CHECK-DAG: wire [[GEN1:.+]] =
+// CHECK-DAG-NEXT: {{.+}} | {{.+}} | {{.+}}
 
 // CHECK: assign out = {[[GEN0]], [[GEN1]]}
 hw.module @Verilator3405(

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,5 +1,5 @@
-; RUN: firtool --verify-diagnostics --verilog %s | FileCheck %s
-; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s | FileCheck %s --check-prefix=SVA
+; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=200 | FileCheck %s
+; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s --lowering-options=emittedLineLength=200 | FileCheck %s --check-prefix=SVA
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
 

--- a/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --verify-diagnostics --verilog %s | FileCheck %s
+; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=500 | FileCheck %s
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssumesSpec.scala
 


### PR DESCRIPTION
Builds on top of the pretty-printing code in #4192 .

Produces much more readable in many cases (IMHO) especially with complex expressions and statements containing non-trivial expressions.

Can see before/after differences here: https://dtzsifive.github.io/circt-pp-results/ (pages may change as things develop, output not final, etc.).  Also, [chipyard](https://gist.githubusercontent.com/dtzSiFive/edde310272aff78182b2e3235c2ba6fd/) which has things like `if` statements.

Not everything is possible, but there are a lot of decisions/stylistic choices (to be) made, if you're interested please take a look / give it a go and let me know what you think so we can iterate towards our preferred output.

Testing / feedback on specifics or in general is greatly appreciated!

Fixes #4181.
Fixes #4182.

Next steps:
* [x] make CI happy / fix tests.
* [x] Fix wrapping verbatim / zero-width "commented-out" lines (similar to #4181, #4182, but much easier to encounter).
* [x] Revisit emission of statements marked TODO as they work but were ported quickly and should be tweaked for better output.

* [x] Testing: functional (generated output "should be" equivalent when flattened, but...)
* [x] Testing: performance / memory.  One goal was to not make emission slower (faster would be nice :wink:), as we especially need to scale well on large designs.  In my testing so far things look good, but this has not been extensively or carefully measured yet.
* [x] Testing: linters?