### PR TITLE
[ExportVerilog][NFC] Appease clang-tidy

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -54,8 +54,8 @@ using namespace ExportVerilog;
 
 #define DEBUG_TYPE "export-verilog"
 
-constexpr int INDENT_AMOUNT = 2;
-constexpr int SPACE_PER_INDENT_IN_EXPRESSION_FORMATTING = 8;
+constexpr int indentAmount = 2;
+constexpr int spacePerIndentInExpressionFormatting = 8;
 StringRef circtHeader = "circt_header.svh";
 StringRef circtHeaderInclude = "`include \"circt_header.svh\"\n";
 
@@ -880,11 +880,11 @@ public:
 
   raw_ostream &indent() { return os.indent(state.currentIndent); }
 
-  void addIndent() { state.currentIndent += INDENT_AMOUNT; }
+  void addIndent() { state.currentIndent += indentAmount; }
   void reduceIndent() {
-    assert(state.currentIndent >= INDENT_AMOUNT &&
+    assert(state.currentIndent >= indentAmount &&
            "Unintended indent wrap-around.");
-    state.currentIndent -= INDENT_AMOUNT;
+    state.currentIndent -= indentAmount;
   }
 
   /// If we have location information for any of the specified operations,
@@ -1973,8 +1973,7 @@ void ExprEmitter::formatOutBuffer() {
         currentIndex + tokenLength > state.options.emittedLineLength) {
       // It breaks the line constraint, so insert a newline and indent.
       tmpOs << '\n';
-      tmpOs.indent(state.currentIndent *
-                   SPACE_PER_INDENT_IN_EXPRESSION_FORMATTING);
+      tmpOs.indent(state.currentIndent * spacePerIndentInExpressionFormatting);
       currentIndex = tokenLength;
       tmpOutBuffer.insert(tmpOutBuffer.end(), it, next);
     } else {
@@ -3621,7 +3620,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
       } else {
         os << ",\n";
       }
-      os.indent(state.currentIndent + INDENT_AMOUNT) << '.';
+      os.indent(state.currentIndent + indentAmount) << '.';
       os << state.globalNames.getParameterVerilogName(moduleOp,
                                                       param.getName());
       os << '(';

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -899,7 +899,7 @@ public:
   }
 
   void emitTextWithSubstitutions(StringRef string, Operation *op,
-                                 std::function<void(Value)> operandEmitter,
+                                 llvm::function_ref<void(Value)> operandEmitter,
                                  ArrayAttr symAttrs, ModuleNameManager &names);
 
   /// Emit the value of a StringAttr as one or more Verilog "one-line" comments
@@ -915,8 +915,9 @@ private:
 } // end anonymous namespace
 
 void EmitterBase::emitTextWithSubstitutions(
-    StringRef string, Operation *op, std::function<void(Value)> operandEmitter,
-    ArrayAttr symAttrs, ModuleNameManager &names) {
+    StringRef string, Operation *op,
+    llvm::function_ref<void(Value)> operandEmitter, ArrayAttr symAttrs,
+    ModuleNameManager &names) {
 
   // Perform operand substitions as we emit the line string.  We turn {{42}}
   // into the value of operand 42.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4241,13 +4241,13 @@ StringRef ModuleEmitter::getNameRemotely(Value value,
   return {};
 }
 
-void ModuleEmitter::emitBindInterface(BindInterfaceOp bind) {
-  if (hasSVAttributes(bind))
-    emitError(bind, "SV attributes emission is unimplemented for the op");
+void ModuleEmitter::emitBindInterface(BindInterfaceOp op) {
+  if (hasSVAttributes(op))
+    emitError(op, "SV attributes emission is unimplemented for the op");
 
-  auto instance = bind.getReferencedInstance(&state.symbolCache);
+  auto instance = op.getReferencedInstance(&state.symbolCache);
   auto instantiator = instance->getParentOfType<HWModuleOp>().getName();
-  auto *interface = bind->getParentOfType<ModuleOp>().lookupSymbol(
+  auto *interface = op->getParentOfType<ModuleOp>().lookupSymbol(
       instance.getInterfaceType().getInterface());
   os << "bind " << instantiator << " "
      << cast<InterfaceOp>(*interface).getSymName() << " "


### PR DESCRIPTION
Appease clang-tidy.

The recursion warnings are legitimate as the entire emission is very recursive, sometimes on the IR.

Used begin/end lint disable to ensure lambdas (common w/`TypeSwitch) don't trigger the warnings, I'm not sure if this is supposed to be necessary.
