### PR TITLE
[FIRRTL] dedup speedup

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
+#include <utility>
 
 namespace circt {
 namespace firrtl {
@@ -533,6 +534,28 @@ struct DenseMapInfo<circt::firrtl::Annotation> {
     return mlir::hash_value(val.getAttr());
   }
   static bool isEqual(Annotation LHS, Annotation RHS) { return LHS == RHS; }
+};
+
+/// Make `AnnoTarget` hash.
+template <>
+struct DenseMapInfo<circt::firrtl::AnnoTarget> {
+  using AnnoTarget = circt::firrtl::AnnoTarget;
+  using AnnoTargetImpl = circt::firrtl::detail::AnnoTargetImpl;
+  static AnnoTarget getEmptyKey() {
+    auto *o = DenseMapInfo<mlir::Operation *>::getEmptyKey();
+    auto i = DenseMapInfo<unsigned>::getEmptyKey();
+    return AnnoTarget(AnnoTargetImpl(o, i));
+  }
+  static AnnoTarget getTombstoneKey() {
+    auto *o = DenseMapInfo<mlir::Operation *>::getTombstoneKey();
+    auto i = DenseMapInfo<unsigned>::getTombstoneKey();
+    return AnnoTarget(AnnoTargetImpl(o, i));
+  }
+  static unsigned getHashValue(AnnoTarget val) {
+    auto impl = val.getImpl();
+    return hash_combine(impl.getOp(), impl.getPortNo());
+  }
+  static bool isEqual(AnnoTarget lhs, AnnoTarget rhs) { return lhs == rhs; }
 };
 
 } // namespace llvm

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -17,7 +17,6 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
-#include <utility>
 
 namespace circt {
 namespace firrtl {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD
+#define CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD
+
 include "mlir/IR/OpBase.td"
 
 def FModuleLike : OpInterface<"FModuleLike"> {
@@ -430,3 +433,5 @@ def FNamableOp : OpInterface<"FNamableOp"> {
     }]>
   ];
 }
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD
-#define CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD
-
 include "mlir/IR/OpBase.td"
 
 def FModuleLike : OpInterface<"FModuleLike"> {
@@ -433,5 +430,3 @@ def FNamableOp : OpInterface<"FNamableOp"> {
     }]>
   ];
 }
-
-#endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -966,12 +966,10 @@ private:
                         AnnoTarget from, AnnotationSet fromAnnos) {
     // This is a list of all the annotations which will be added to `to`.
     SmallVector<Annotation> newAnnotations;
+
     // We have special case handling of DontTouch to prevent it from being
     // turned into a non-local annotation.
     bool hasDontTouch = false;
-
-    // This records if any annotation was ac
-    bool madeNonlocal = false;
 
     // Iterate the `to` annotations, transforming non-common annotations into
     // non-local ones.  We want to make sure that we keep the order of the
@@ -985,6 +983,7 @@ private:
         // as is since it doesn't matter.
         newAnnotations.push_back(anno);
         hasDontTouch = true;
+        continue;
       }
       // If the annotation is already non-local, we add it as is.  It is already
       // added to the target map.
@@ -1005,6 +1004,7 @@ private:
         // as is since it doesn't matter.
         newAnnotations.push_back(anno);
         hasDontTouch = true;
+        continue;
       }
       // If the annotation is already non-local, we add it as is.  It is already
       // added to the target map.

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -356,8 +356,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath private @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.hierpath private @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath private @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
@@ -380,8 +380,7 @@ circuit Top : %[[
 
 ; // -----
 ; "The deduping module A and A_ should rename internal signals that have
-; different names".  This is checking that an NLA is not created even though
-; structural deduplication changes the name of "A_>b" to "A>a".
+; different names".
 ;
 ; CHECK-LABEL: firrtl.circuit "Top"
 circuit Top : %[[
@@ -397,6 +396,8 @@ circuit Top : %[[
   }
 ]]
   ; CHECK-NOT: firrtl.hierpath
+  ; CHECK: firrtl.hierpath private @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a1sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath private @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym]], @A]
   module Top :
     inst a1 of A
     a1 is invalid
@@ -406,7 +407,7 @@ circuit Top : %[[
   module A :
     input x: UInt<1>
     output y: UInt<1>
-    ; CHECK: firrtl.node {{.+}} {annotations = [{class = "circt.test", data = "hello"}]}
+    ; CHECK: firrtl.node {{.+}} {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.test", data = "hello"}, {circt.nonlocal = @[[nlaSym2]], class = "circt.test", data = "hello"}]}
     node a = add(x, UInt(1))
     y <= add(a, a)
   module A_ :
@@ -475,12 +476,12 @@ circuit Top : %[[
   module A_ :
     inst b_ of B_
   ; CHECK: firrtl.module private @B
-  ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_"}
   ; CHECK-SAME: {circt.nonlocal = @[[nla_a]], class = "circt.test", data = "B"}
+  ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_"}
   module B :
     ; CHECK: firrtl.node
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_.bar"}
     ; CHECK-SAME: {circt.nonlocal = @[[nla_a]], class = "circt.test", data = "B.foo"}
+    ; CHECK-SAME: {circt.nonlocal = @[[nla_a_]], class = "circt.test", data = "B_.bar"}
     node foo = UInt<1>(0)
   ; CHECK-NOT: firrtl.module private @B_
   module B_ :
@@ -717,12 +718,12 @@ circuit Top : %[[
     inst b_ of B_
 
   ; CHECK:        firrtl.module private @B()
-  ; CHECK-SAME:     [{circt.nonlocal = @[[nla_2]], class = "circt.test", data = "nla2"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_3]], class = "circt.test", data = "nla3"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.test", data = "nla4"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "circt.test", data = "nla1"},
+  ; CHECK-SAME:     [{circt.nonlocal = @[[nla_1]], class = "circt.test", data = "nla1"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_5]], class = "circt.test", data = "nla5"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_6]], class = "circt.test", data = "nla6"}]
+  ; CHECK-SAME:      {circt.nonlocal = @[[nla_6]], class = "circt.test", data = "nla6"},
+  ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "circt.test", data = "nla2"},
+  ; CHECK-SAME:      {circt.nonlocal = @[[nla_3]], class = "circt.test", data = "nla3"},
+  ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.test", data = "nla4"}]
   module B :
     ; CHECK-NEXT:   firrtl.instance c sym @[[BcSym]]
     ; CHECK-SAME:     @C()
@@ -763,10 +764,10 @@ circuit top : %[[
     "target":"~top|b>q.a"
   }
 ]]
-  ; CHECK:      firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK:      firrtl.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]], @a]
+  ; CHECK:      firrtl.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
@@ -789,8 +790,8 @@ circuit top : %[[
   ; CHECK:      firrtl.module private @a(
   ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
-  ; CHECK-SAME:     [{circt.fieldID = 1 : i32, circt.nonlocal = @[[nla_2]], class = "circt.test", data = "nla2"},
-  ; CHECK-SAME:      {circt.fieldID = 4 : i32, circt.nonlocal = @[[nla_1]], class = "circt.test", data = "nla1"}]
+  ; CHECK-SAME:     [{circt.fieldID = 4 : i32, circt.nonlocal = @[[nla_1]], class = "circt.test", data = "nla1"},
+  ; CHECK-SAME:      {circt.fieldID = 1 : i32, circt.nonlocal = @[[nla_2]], class = "circt.test", data = "nla2"}]
   module a:
     input i: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     output o: {z: {y: {x: UInt<1>}}, a: UInt<1>}


### PR DESCRIPTION
This change consists of a couple improvements to the speed of the deduplication pass.

1. Adds an NLA Cache, which maps a `namepath` attribute to an `HierPathOp` which matches. Dedup uses this to reuse HierPathOps in the circuit instead of creating new ones.  This used to cause problem by passes which assumed ops did not share NLAs.  This has an added effect of doing some `HierPathOp` garbage collection
2. The `targetMap`, which maps an NLA to the operations which use it, now uses a DenseSet.  The original logic could end up recording the same target multiple times.
3. Annotation merging used to merge identical annotations, now it keeps both annotations and makes them non-local.  The original behaviour is kept for only `DontTouch` annotations, where it will only keep one.
4. When a module is merged into another, the original modules annotations are now first instead of second in the annotation list.
5. Some simplification of functions, especially unused argument removal, and creating functions for common code.