### PR TITLE
[PruneZeroValuedLogic] Legalize concat/parity/icmp

### DIFF
--- a/test/Conversion/ExportVerilog/pruning.mlir
+++ b/test/Conversion/ExportVerilog/pruning.mlir
@@ -19,3 +19,25 @@ hw.module @zeroWidthLogic(%arg0: i0, %sel : i1, %clk: i1) -> (out: i0) {
   %2 = comb.mux %sel, %rr, %arg0 : i0
   hw.output %2 : i0
 }
+
+// CHECK-LABEL: module Concat(
+hw.module @Concat(%arg0: i0, %arg1: i1, %clk: i1) -> (out: i2) {
+  // CHECK:  assign out = {arg1, clk};
+  %1 = comb.concat %arg0, %arg1, %clk : i0, i1, i1
+  hw.output %1 : i2
+}
+
+// CHECK-LABEL: module icmp(
+hw.module @icmp(%a: i0) -> (y: i1) {
+  // CHECK: assign y = 1'h1;
+  %0 = comb.icmp eq %a, %a : i0
+  hw.output %0 : i1
+}
+
+
+// CHECK-LABEL: module parity(
+hw.module @parity(%arg0: i0) -> (out: i1) {
+  // CHECK: assign out = 1'h0;
+  %0 = comb.parity %arg0 : i0
+  hw.output %0 : i1
+}


### PR DESCRIPTION
This implements i0 value legalizations for concat/parity/icmp (ref: https://github.com/llvm/circt/pull/3935#issuecomment-1259835432). These operations can have i0 values as an operand but we cannot  just remove them since they produce non-i0 values. 

1. concat -> Filter non-i0 values
2. `partiy 0:i0` -> `0: i1`
3. ` icmp pred 0:i0, 0:i0` -> Calculate the result with `applyCmpPredicateToEqualOperands`

