### PR TITLE
[SystemC] Add SensitiveOp to register sensitivity events for unspawned processes

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -65,6 +65,28 @@ def ThreadOp : SystemCOp<"thread", []> {
   let assemblyFormat = "$funcHandle attr-dict";
 }
 
+def SensitiveOp : SystemCOp<"sensitive", [HasParent<"CtorOp">]> {
+  let summary = "Describes the static sensitivity of an unspawned process.";
+  let description = [{
+    This operation allows to specify the static sensitivity of unspawned
+    processes. An unspawned process is one created by the `SC_METHOD`,
+    `SC_THREAD`, or `SC_CTHREAD` macro. The operands to this operation are
+    registered as sensitivities to the process last created (in control-flow
+    order).
+    Each `SC_MODULE` contains an instance of the `sc_sensitive` class to do the
+    registration. For a description of the `sc_sensitive` class refer to
+    IEEE 1666-2011 §5.4. For a description of the `sensitive` data member of
+    `SC_MODULE` refer to IEEE 1666-2011 §5.2.14.
+  }];
+
+  let arguments = (ins Variadic<ChannelType>:$sensitivities);
+  let assemblyFormat = [{
+    $sensitivities attr-dict ( `:` qualified(type($sensitivities))^ )?
+  }];
+
+  let hasCanonicalizeMethod = 1;
+}
+
 def InstanceDeclOp : SystemCOp<"instance.decl", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<HWInstanceLike>,

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -111,3 +111,11 @@ systemc.module @MemberAccess () {
     systemc.cpp.assign %result = %2 : !emitc.opaque<"int">
   }
 }
+
+systemc.module @Sensitive (%in: !systemc.in<i1>, %inout: !systemc.inout<i1>) {
+  systemc.ctor {
+    systemc.method %update
+    systemc.sensitive %in, %inout : !systemc.in<i1>, !systemc.inout<i1>
+  }
+  %update = systemc.func {}
+}

--- a/lib/Conversion/HWToSystemC/HWToSystemC.cpp
+++ b/lib/Conversion/HWToSystemC/HWToSystemC.cpp
@@ -90,6 +90,14 @@ struct ConvertHWModule : public OpConversionPattern<HWModuleOp> {
         scModule.getOrCreateCtor().getBodyBlock());
     rewriter.create<MethodOp>(scModule.getLoc(), scFunc.getHandle());
 
+    // Register the sensitivities of above SC_METHOD registration.
+    SmallVector<Value> sensitivityValues(
+        llvm::make_filter_range(scModule.getArguments(), [](BlockArgument arg) {
+          return !arg.getType().isa<OutputType>();
+        }));
+    if (!sensitivityValues.empty())
+      rewriter.create<SensitiveOp>(scModule.getLoc(), sensitivityValues);
+
     // Move the block arguments of the systemc.func (that we got from the
     // hw.module) to the systemc.module
     rewriter.setInsertionPointToStart(scFunc.getBodyBlock());

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/HW/ModuleImplementation.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -555,6 +556,20 @@ StringRef BindPortOp::getPortName() {
       .cast<ModuleType>()
       .getPorts()[getPortId().getZExtValue()]
       .name.getValue();
+}
+
+//===----------------------------------------------------------------------===//
+// SensitiveOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SensitiveOp::canonicalize(SensitiveOp op,
+                                        PatternRewriter &rewriter) {
+  if (op.getSensitivities().empty()) {
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  return failure();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -180,6 +180,26 @@ struct MethodEmitter : OpEmissionPattern<MethodOp> {
   }
 };
 
+/// Emit a systemc.sensitive operation by using the 'sensitive' data member;
+struct SensitiveEmitter : OpEmissionPattern<SensitiveOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  void emitStatement(SensitiveOp op, EmissionPrinter &p) override {
+    if (op.getSensitivities().empty())
+      return;
+
+    p << "sensitive << ";
+    llvm::interleave(
+        op.getSensitivities(), p,
+        [&](Value sensitive) {
+          p.getInlinable(sensitive).emitWithParensOnLowerPrecedence(
+              Precedence::SHL);
+        },
+        " << ");
+    p << ";\n";
+  }
+};
+
 /// Emit a systemc.thread operation by using the SC_THREAD macro.
 struct ThreadEmitter : OpEmissionPattern<ThreadOp> {
   using OpEmissionPattern::OpEmissionPattern;
@@ -546,18 +566,17 @@ struct DynIntegerTypeEmitter : public TypeEmissionPattern<Ty> {
 
 void circt::ExportSystemC::populateSystemCOpEmitters(
     OpEmissionPatternSet &patterns, MLIRContext *context) {
-  patterns.add<SCModuleEmitter, CtorEmitter, SCFuncEmitter, MethodEmitter,
-               ThreadEmitter,
-               // Signal and port related emitters
-               SignalWriteEmitter, SignalReadEmitter, SignalEmitter,
-               // Instance-related emitters
-               InstanceDeclEmitter, BindPortEmitter,
-               // CPP-level operation emitters
-               AssignEmitter, VariableEmitter, NewEmitter, DestructorEmitter,
-               DeleteEmitter, MemberAccessEmitter,
-               // Function related emitters
-               FuncEmitter, ReturnEmitter, CallEmitter, CallIndirectEmitter>(
-      context);
+  patterns.add<
+      SCModuleEmitter, CtorEmitter, SCFuncEmitter, MethodEmitter, ThreadEmitter,
+      // Signal and port related emitters
+      SignalWriteEmitter, SignalReadEmitter, SignalEmitter, SensitiveEmitter,
+      // Instance-related emitters
+      InstanceDeclEmitter, BindPortEmitter,
+      // CPP-level operation emitters
+      AssignEmitter, VariableEmitter, NewEmitter, DestructorEmitter,
+      DeleteEmitter, MemberAccessEmitter,
+      // Function related emitters
+      FuncEmitter, ReturnEmitter, CallEmitter, CallIndirectEmitter>(context);
 }
 
 void circt::ExportSystemC::populateSystemCTypeEmitters(

--- a/test/Conversion/HWToSystemC/structure.mlir
+++ b/test/Conversion/HWToSystemC/structure.mlir
@@ -26,6 +26,7 @@ hw.module @onlyOutputs () -> (sum: i32) {
 hw.module @adder (%a: i32, %b: i32) -> (sum: i32) {
   // CHECK-NEXT: systemc.ctor {
   // CHECK-NEXT:   systemc.method %innerLogic
+  // CHECK-NEXT:   systemc.sensitive %a, %b : !systemc.in<!systemc.uint<32>>, !systemc.in<!systemc.uint<32>>
   // CHECK-NEXT: }
   // CHECK-NEXT: %innerLogic = systemc.func  {
   // CHECK-NEXT:   [[A:%.+]] = systemc.signal.read %a : !systemc.in<!systemc.uint<32>>
@@ -76,6 +77,7 @@ hw.module @instanceLowering (%port0: i32) -> (out0: i16, out1: i32, out2: i64) {
 // CHECK-NEXT:    %inst2_out2 = systemc.signal  : !systemc.signal<!systemc.uint<64>>
 // CHECK-NEXT:    systemc.ctor {
 // CHECK-NEXT:      systemc.method [[UPDATEFUNC:%.+]]
+// CHECK-NEXT:      systemc.sensitive %port0 : !systemc.in<!systemc.uint<32>>
 // CHECK-NEXT:      systemc.instance.bind_port %inst1["in0"] to %inst1_in0 : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<16>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<16>>, out1: !systemc.out<!systemc.uint<32>>, out2: !systemc.out<!systemc.uint<64>>)>, !systemc.signal<!systemc.uint<16>>
 // CHECK-NEXT:      systemc.instance.bind_port %inst1["in1"] to %inst1_in1 : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<16>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<16>>, out1: !systemc.out<!systemc.uint<32>>, out2: !systemc.out<!systemc.uint<64>>)>, !systemc.signal<!systemc.uint<32>>
 // CHECK-NEXT:      systemc.instance.bind_port %inst1["out0"] to %inst1_out0 : !systemc.module<submodule(in0: !systemc.in<!systemc.uint<16>>, in1: !systemc.in<!systemc.uint<32>>, out0: !systemc.out<!systemc.uint<16>>, out1: !systemc.out<!systemc.uint<32>>, out2: !systemc.out<!systemc.uint<64>>)>, !systemc.signal<!systemc.uint<16>>

--- a/test/Dialect/SystemC/canonicalize.mlir
+++ b/test/Dialect/SystemC/canonicalize.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @removeEmptySensitivityList
+systemc.module @removeEmptySensitivityList(%in: !systemc.in<i1>) {
+  // CHECK-NEXT: systemc.ctor {
+  systemc.ctor {
+    systemc.sensitive
+    // CHECK-NEXT: systemc.sensitive %in : !systemc.in<i1>
+    systemc.sensitive %in : !systemc.in<i1>
+  // CHECK-NEXT: }
+  }
+}

--- a/test/Dialect/SystemC/module-error.mlir
+++ b/test/Dialect/SystemC/module-error.mlir
@@ -393,3 +393,20 @@ hw.module @verilatedCannotReferenceNonHWModule() {
   // expected-error @+1 {{symbol reference 'submodule' isn't a module}}
   systemc.interop.verilated "verilated" @submodule () -> ()
 }
+
+// -----
+
+systemc.module @sensitivityNotInCtor() {
+  // expected-error @+1 {{expects parent op 'systemc.ctor'}}
+  systemc.sensitive
+}
+
+// -----
+
+systemc.module @sensitivityNoChannelType() {
+  systemc.ctor {
+    %var = systemc.cpp.variable : i1
+    // expected-error @+1 {{operand #0 must be a SystemC sc_in<T> type or a SystemC sc_inout<T> type or a SystemC sc_out<T> type or a SystemC sc_signal<T> type, but got 'i1'}}
+    systemc.sensitive %var : i1
+  }
+}

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -161,3 +161,14 @@ systemc.module @verilatorInteropInSystemCModule() {
   // CHECK-NEXT: systemc.interop.verilated "verilated" @inst () -> ()
   systemc.interop.verilated "verilated" @inst () -> ()
 }
+
+// CHECK-LABEL: @sensitivity
+systemc.module @sensitivity (%in: !systemc.in<i1>, %out: !systemc.out<i1>, %inout: !systemc.inout<i1>) {
+  %signal = systemc.signal : !systemc.signal<i1>
+  systemc.ctor {
+    // CHECK: systemc.sensitive %in, %out, %inout, %signal : !systemc.in<i1>, !systemc.out<i1>, !systemc.inout<i1>, !systemc.signal<i1>
+    systemc.sensitive %in, %out, %inout, %signal : !systemc.in<i1>, !systemc.out<i1>, !systemc.inout<i1>, !systemc.signal<i1>
+    // CHECK-NEXT: systemc.sensitive
+    systemc.sensitive
+  }
+}

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -252,4 +252,14 @@ systemc.module @MemberAccess () {
   }
 }
 
+// CHECK-LABEL: sensitivities
+systemc.module @sensitivities(%in: !systemc.in<i1>, %inout: !systemc.inout<i1>) {
+  systemc.ctor {
+    // CHECK: sensitive << in << inout;
+    systemc.sensitive %in, %inout : !systemc.in<i1>, !systemc.inout<i1>
+    // CHECK-NEXT: }
+    systemc.sensitive
+  }
+}
+
 // CHECK: #endif // STDOUT_H


### PR DESCRIPTION
Properly registering the sensitivities is important for emitting a correct SystemC module. This PR adds the operation to represent this in the IR, the emission pattern for it, and also adjusts the lowering from HW.

Useful specialized events such as `pos()` and `neg()` on boolean input channels are not supported yet, but can easily be added.