### PR TITLE
[SystemC] SC_NAMED support for signals

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -35,13 +35,17 @@ def SignalOp : SystemCOp<"signal", [HasCustomSSAName,
   let summary = "Declares a SystemC `sc_signal<T>`.";
   let description = [{
     Represents the `sc_signal` template as described in IEEE 1666-2011 §6.4.
+    Adding the 'named' attribute will lead to the signal being emitted with the
+    `SC_NAMED` convenience macro. Note that this macro is not part of
+    IEEE 1666-2011, but was added in version 2.3.3.
   }];
 
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$name, UnitAttr:$named);
   let results = (outs SignalType:$signal);
 
   let assemblyFormat = [{
-    custom<ImplicitSSAName>($name) attr-dict `:` qualified(type($signal))
+    custom<ImplicitSSAName>($name) ( `named` $named^ )? attr-dict
+    `:` qualified(type($signal))
   }];
 }
 

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -33,6 +33,10 @@ systemc.module @module (%port0: !systemc.in<i1>, %port1: !systemc.inout<!systemc
   }
 }
 
+systemc.module @namedSignal() {
+  %sigName = systemc.signal named : !systemc.signal<i1>
+}
+
 systemc.module @nativeCTypes (%port0: !systemc.in<i1>,
                               %port1: !systemc.in<i8>,
                               %port2: !systemc.in<i16>,

--- a/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/SystemCEmissionPatterns.cpp
@@ -219,7 +219,16 @@ struct SignalEmitter : OpEmissionPattern<SignalOp> {
 
   void emitStatement(SignalOp op, EmissionPrinter &p) override {
     p.emitType(op.getSignal().getType());
-    p << " " << op.getName() << ";\n";
+    p << " ";
+
+    if (op.getNamed()) {
+      // This style of emitting SC_NAMED requires the printed code to be
+      // compiled with at least C++11.
+      p << "SC_NAMED(" << op.getName() << ");\n";
+      return;
+    }
+
+    p << op.getName() << ";\n";
   }
 };
 

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -63,6 +63,9 @@ systemc.module @signals () {
   // CHECK-NEXT: %signal1 = systemc.signal : !systemc.signal<i1>
   %signal1 = systemc.signal : !systemc.signal<i1>
 
+  // CHECK-NEXT: %namedSignal = systemc.signal named : !systemc.signal<i1>
+  %namedSignal = systemc.signal named : !systemc.signal<i1>
+
   // CHECK-NEXT: systemc.func
   %funchandle = systemc.func {
     // CHECK-NEXT: [[READ:%.*]] = systemc.signal.read %signal0 : !systemc.signal<!systemc.uint<32>>

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -73,6 +73,12 @@ systemc.module @basic (%port0: !systemc.in<i1>, %port1: !systemc.inout<!systemc.
 // CHECK-NEXT: };
 }
 
+// CHECK-LABEL: namedSignal
+systemc.module @namedSignal() {
+  // CHECK-NEXT: sc_signal<bool> SC_NAMED(sigName);
+  %sigName = systemc.signal named : !systemc.signal<i1>
+}
+
 // CHECK-LABEL: SC_MODULE(nativeCTypes)
 // CHECK-NEXT: sc_in<bool> port0;
 // CHECK-NEXT: sc_in<uint8_t> port1;


### PR DESCRIPTION
This convenience macro is not part of the standard but heavily used. Thus I think it makes sense to add support for it here.

https://github.com/accellera-official/systemc/blob/master/RELEASENOTES#L281