### PR TITLE
[ExportVerilog] Fix i0 value emission of struct operations

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -492,15 +492,19 @@ hw.module @TestZeroStruct(%structZero: !hw.struct<>, %structZeroNest: !hw.struct
 // CHECK-LABEL: module zeroElements
 // CHECK-NEXT:   // input  /*Zero Width*/                                                                                              in0,
 // CHECK-NEXT:      input  [31:0]                                                                                                      in1,
-// CHECK-NEXT:      output struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ } out0);
-hw.module @zeroElements(%in0: i0, %in1: i32) -> (out0: !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>) {
-  // CHECK:      // Zero width: wire /*Zero Width*/ _GEN = '{};
-  // CHECK-NEXT: wire struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ } _GEN_0 = '{a: in1, b: in1};
-  // CHECK-NEXT: assign out0 = '{a: in1, b: _GEN_0.b};
+// CHECK-NEXT:      output struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } out0)
+hw.module @zeroElements(%in0: i0, %in1: i32) -> (out0: !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>, d: !hw.struct<d1:i32, z:i0>>) {
+  // CHECK:      // Zero width: wire /*Zero Width*/
+  // CHECK-SAME: _GEN = '{};
+  // CHECK-NEXT: wire struct packed {logic [31:0] d1; /*z: Zero Width;*/ }
+  // CHECK-SAME: _GEN_0 = '{d1: in1};
+  // CHECK-NEXT: wire struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } _GEN_1 = '{a: in1, b: in1, d: _GEN_0};
+  // CHECK-NEXT: assign out0 = '{a: in1, b: _GEN_1.b, d: _GEN_1.d};
   %0 = hw.struct_create (%in0) : !hw.struct<z: i0>
-  %1 = hw.struct_create (%in0, %in1, %in0, %in1, %0) : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
-  %2 = hw.struct_inject %1["a"], %in1 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
-  hw.output %2 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
+  %1 = hw.struct_create (%in1, %in0) : !hw.struct<d1:i32, z:i0>
+  %2 = hw.struct_create (%in0, %in1, %in0, %in1, %0, %1) : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>, d: !hw.struct<d1:i32, z:i0>>
+  %3 = hw.struct_inject %2["a"], %in1 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>, d: !hw.struct<d1:i32, z:i0>>
+  hw.output %3 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>, d: !hw.struct<d1:i32, z:i0>>
 }
 
 // CHECK-LABEL: TestZeroStructInstance

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -475,10 +475,10 @@ hw.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !hw.array<3xi0>)
 }
 
 // CHECK: module TestZeroStruct(
-// CHECK-NEXT:  // input  /*Zero Width*/                           structZero,
-// CHECK-NEXT:  // input  struct packed {logic /*Zero Width*/ a; } structZeroNest,
-// CHECK-NEXT:  // output /*Zero Width*/                           structZero_0,
-// CHECK-NEXT:  // output struct packed {logic /*Zero Width*/ a; } structZeroNest_0
+// CHECK-NEXT:  // input  /*Zero Width*/ structZero,
+// CHECK-NEXT:  // input  /*Zero Width*/ structZeroNest,
+// CHECK-NEXT:  // output /*Zero Width*/ structZero_0,
+// CHECK-NEXT:  // output /*Zero Width*/ structZeroNest_0
 // CHECK-NEXT: );
 hw.module @TestZeroStruct(%structZero: !hw.struct<>, %structZeroNest: !hw.struct<a: !hw.struct<>>)
   -> (structZero_0: !hw.struct<>, structZeroNest_0: !hw.struct<a: !hw.struct<>>) {
@@ -487,6 +487,20 @@ hw.module @TestZeroStruct(%structZero: !hw.struct<>, %structZeroNest: !hw.struct
   // CHECK:      // Zero width: assign structZero_0 = structZero;
   // CHECK-NEXT: // Zero width: assign structZeroNest_0 = structZeroNest;
   // CHECK-NEXT: endmodule
+}
+
+// CHECK-LABEL: module zeroElements
+// CHECK-NEXT:   // input  /*Zero Width*/                                                                                              in0,
+// CHECK-NEXT:      input  [31:0]                                                                                                      in1,
+// CHECK-NEXT:      output struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ } out0);
+hw.module @zeroElements(%in0: i0, %in1: i32) -> (out0: !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>) {
+  // CHECK:      // Zero width: wire /*Zero Width*/ _GEN = '{};
+  // CHECK-NEXT: wire struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ } _GEN_0 = '{a: in1, b: in1};
+  // CHECK-NEXT: assign out0 = '{a: in1, b: _GEN_0.b};
+  %0 = hw.struct_create (%in0) : !hw.struct<z: i0>
+  %1 = hw.struct_create (%in0, %in1, %in0, %in1, %0) : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
+  %2 = hw.struct_inject %1["a"], %in1 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
+  hw.output %2 : !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>>
 }
 
 // CHECK-LABEL: TestZeroStructInstance


### PR DESCRIPTION
This PR fixes invalid emission of i0 values contained in structs. Currently i0 value in struct types are emitted as `logic` but 
`logic` is 1bit width value so it causes width missmatches in many cases. This fixes that issue by just eliding the field entirely and emit them as comments. 

Fixes https://github.com/llvm/circt/issues/4203 and https://github.com/llvm/circt/issues/2504