### PR TITLE
[SV][ExportVerilog] Add ReadMemOp to model $readmemb, $readmemh

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -722,3 +722,28 @@ def DepositOp : SVOp<"nonstandard.deposit",
   let results = (outs);
   let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
 }
+
+
+//===----------------------------------------------------------------------===//
+// Memory loading system tasks
+//===----------------------------------------------------------------------===//
+
+def MemBaseBin: I32EnumAttrCase<"MemBaseBin", 0>;
+def MemBaseHex: I32EnumAttrCase<"MemBaseHex", 1>;
+def MemBaseTypeAttr :
+    I32EnumAttr<"MemBaseTypeAttr", "the numeric base of a memory file",
+                [MemBaseBin, MemBaseHex]>;
+
+def ReadMemOp : SVOp<"readmem", [ProceduralOp]> {
+  let summary = "load a memory from a file in either binary or hex format";
+  let description = [{
+    Load a memory from a file using either `$readmemh` or `$readmemb` based on
+    an attribute.
+
+    See Section 21.4 of IEEE 1800-2017 for more information.
+  }];
+  let arguments =
+    (ins SymbolNameAttr:$inner_sym, StrAttr:$filename, MemBaseTypeAttr:$base);
+  let results = (outs);
+  let assemblyFormat = "$inner_sym `,` $filename `,` $base attr-dict";
+}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -52,6 +52,8 @@ public:
             StopOp, FinishOp, ExitOp,
             // Severity message tasks
             FatalOp, ErrorOp, WarningOp, InfoOp,
+            // Memory loading tasks
+            ReadMemOp,
             // Generate statements
             GenerateOp, GenerateCaseOp,
             // Sampled value functiions
@@ -151,6 +153,9 @@ public:
   HANDLE(ErrorOp, Unhandled);
   HANDLE(WarningOp, Unhandled);
   HANDLE(InfoOp, Unhandled);
+
+  // Memory loading tasks
+  HANDLE(ReadMemOp, Unhandled);
 
   // Generate statements
   HANDLE(GenerateOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2755,6 +2755,8 @@ private:
   LogicalResult visitSV(WarningOp op);
   LogicalResult visitSV(InfoOp op);
 
+  LogicalResult visitSV(ReadMemOp op);
+
   LogicalResult visitSV(GenerateOp op);
   LogicalResult visitSV(GenerateCaseOp op);
 
@@ -3171,6 +3173,34 @@ LogicalResult StmtEmitter::visitSV(WarningOp op) {
 LogicalResult StmtEmitter::visitSV(InfoOp op) {
   return emitSeverityMessageTask(op, "$info", {}, op.getMessageAttr(),
                                  op.getSubstitutions());
+}
+
+LogicalResult StmtEmitter::visitSV(ReadMemOp op) {
+  SmallPtrSet<Operation *, 8> ops({op});
+
+  indent() << "$readmem";
+  switch (op.getBaseAttr().getValue()) {
+  case MemBaseTypeAttr::MemBaseBin:
+    os << "b";
+    break;
+  case MemBaseTypeAttr::MemBaseHex:
+    os << "h";
+    break;
+  }
+  os << "(";
+  os << "\"" << op.getFilename() << "\""
+     << ", ";
+
+  auto *reg =
+      state.symbolCache
+          .getInnerDefinition(op->getParentOfType<HWModuleOp>().getNameAttr(),
+                              op.getInnerSymAttr())
+          .getOp();
+  os << names.getName(reg);
+
+  os << ");";
+  emitLocationInfoAndNewLine(ops);
+  return success();
 }
 
 LogicalResult StmtEmitter::visitSV(GenerateOp op) {

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -474,6 +474,22 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
   hw.output
 }
 
+// CHECK-LABEL: module ReadMem()
+hw.module @ReadMem() {
+
+  // CHECK:      initial begin
+  // CHECK-NEXT:   reg [31:0] memForReadMem[0:7];
+  // CHECK-NEXT:   $readmemb("file1.txt", memForReadMem);
+  // CHECK-NEXT:   $readmemh("file2.txt", memForReadMem);
+  // CHECK-NEXT: end
+  sv.initial {
+    %memForReadMem = sv.reg sym @MemForReadMem : !hw.inout<uarray<8xi32>>
+    sv.readmem @MemForReadMem, "file1.txt", MemBaseBin
+    sv.readmem @MemForReadMem, "file2.txt", MemBaseHex
+  }
+
+}
+
 // CHECK-LABEL: module UninitReg1(
 hw.module @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   %c-1_i2 = hw.constant -1 : i2

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -267,6 +267,18 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
     sv.info "hello %d"(%arg0) : i1
   }
 
+  // Tests for ReadMemOp ($readmemb/$readmemh)
+  // CHECK-NEXT: sv.initial {
+  // CHECK-NEXT:   %memForReadMem = sv.reg
+  // CHECK-NEXT:   sv.readmem @MemForReadMem, "file1.txt", MemBaseBin
+  // CHECK-NEXT:   sv.readmem @MemForReadMem, "file2.txt", MemBaseHex
+  // CHECK-NEXT: }
+  sv.initial {
+    %memForReadMem = sv.reg sym @MemForReadMem : !hw.inout<uarray<8xi32>>
+    sv.readmem @MemForReadMem, "file1.txt", MemBaseBin
+    sv.readmem @MemForReadMem, "file2.txt", MemBaseHex
+  }
+
   // CHECK-NEXT: hw.output
   hw.output
 }


### PR DESCRIPTION
Add a new operation to the SystemVerilog Dialect: ReadMemOp.  This
operation exists to model both "$readmemb" and "$readmemh".  These
operations cause a specific memory to be loaded with the contents of a
file.

These operations do not (yet) model the ability of their Verilog
counterparts to load part of a memory.

Add emission of the SystemVerilog Dialect's ReadMemOp.  This emits as
either "$readmemb" or "$readmemh" depending on a mandatory enum used to
build the operation.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>