### PR TITLE
[SV] Update SVExtractTestCode to not extract instances with syms.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -179,6 +179,10 @@ static void addInstancesToCloneSet(
     if (opsToClone.contains(instance))
       continue;
 
+    // If the instance had a symbol, we can't extract it without more work.
+    if (instance.getInnerSym().has_value())
+      continue;
+
     // Compute the instance's forward slice. If it wasn't fully contained in
     // the clone set, move along.
     SetVector<Operation *> forwardSlice;
@@ -413,7 +417,7 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
       continue;
     }
 
-    // If the instance had a symbol, we can't inline it.
+    // If the instance had a symbol, we can't inline it without more work.
     hw::InstanceOp inst = cast<hw::InstanceOp>(instLike.getOperation());
     if (inst.getInnerSym().has_value()) {
       allInlined = false;

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -232,6 +232,12 @@ module {
 // CHECK-SAME: (%[[clock:.+]]: i1, %[[in:.+]]: i1)
 // CHECK: hw.instance {{.+}} @MultiResultExtracted_cover([[clock]]: %[[clock]]: i1, [[in]]: %[[in]]: i1)
 
+// In SymNotExtracted, instance foo should not be extracted because it has a sym.
+// CHECK-LABEL: @SymNotExtracted_cover
+// CHECK-NOT: hw.instance "foo"
+// CHECK-LABEL: @SymNotExtracted
+// CHECK: hw.instance "foo"
+
 module attributes {
   firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
 } {
@@ -314,6 +320,13 @@ module attributes {
     sv.always posedge %clock {
       sv.cover %qux.b, immediate
       sv.cover %qux.c, immediate
+    }
+  }
+
+  hw.module @SymNotExtracted(%clock: i1, %in: i1) {
+    %foo.b = hw.instance "foo" sym @foo @Foo(a: %in: i1) -> (b: i1)
+    sv.always posedge %clock {
+      sv.cover %foo.b, immediate
     }
   }
 }


### PR DESCRIPTION
If the instance has an inner symbol attribute, something is referring to it non-locally. Without further analysis or updates, we can't safely move such instances.

This adopts the same conservative approach we already have in place
for inlining: if we see a symbol, just skip it.