### PR TITLE
[SSP] Reduce code duplication in property definitions.

### DIFF
--- a/include/circt/Dialect/SSP/PropertyBase.td
+++ b/include/circt/Dialect/SSP/PropertyBase.td
@@ -33,6 +33,13 @@ class PropertyBase<Dialect dialect,
   string propertyType = type;
   string problemClassName = problem;
 
+  // Unwrap the data in this attribute's `$value` parameter in order to pass it 
+  // to the corresponding setter on the problem class.
+  code unwrapValue = [{ getValue() }];
+  // Wrap the `value` returned by the getter on the problem class in order to
+  // store it in this attribute's `$value` parameter.
+  code wrapValue = [{ value }];
+
   let summary = "Models the `" # propertyName # "` property in `" # problemClassName # "`.";
 
   let parameters = (ins propertyType:$value);
@@ -45,12 +52,14 @@ class OperationProperty<Dialect dialect, string name, string type, string proble
     : PropertyBase<dialect, name, type, problem, traits> {
   let extraClassDeclaration = [{
     void setInProblem(}] # problemClassName # [{ &prob, ::mlir::Operation *op) {
-      prob.set}] # propertyName # [{(op, getValue());
+      prob.set}] # propertyName # [{(op, }] # unwrapValue # [{);
     }
     static ::mlir::Attribute getFromProblem(}] # problemClassName # [{ &prob,
                                             ::mlir::Operation *op, ::mlir::MLIRContext *ctx) {
-      if (auto value = prob.get}] # propertyName # [{(op))
-        return }] # cppClassName # [{::get(ctx, *value);
+      if (auto optValue = prob.get}] # propertyName # [{(op)) {
+        auto value = *optValue;
+        return }] # cppClassName # [{::get(ctx, }] # wrapValue # [{);
+      }
       return {};
     }
   }];
@@ -62,13 +71,15 @@ class OperatorTypeProperty<Dialect dialect, string name, string type, string pro
   let extraClassDeclaration = [{
     void setInProblem(}] # problemClassName # [{ &prob,
                       ::circt::scheduling::Problem::OperatorType opr) {
-      prob.set}] # propertyName # [{(opr, getValue());
+      prob.set}] # propertyName # [{(opr, }] # unwrapValue # [{);
     }
     static ::mlir::Attribute getFromProblem(}] # problemClassName # [{ &prob,
                                             ::circt::scheduling::Problem::OperatorType opr,
                                             ::mlir::MLIRContext *ctx) {
-      if (auto value = prob.get}] # propertyName # [{(opr))
-        return }] # cppClassName # [{::get(ctx, *value);
+      if (auto optValue = prob.get}] # propertyName # [{(opr)) {
+        auto value = *optValue;
+        return }] # cppClassName # [{::get(ctx, }] # wrapValue # [{);
+      }
       return {};
     }
   }];
@@ -80,13 +91,15 @@ class DependenceProperty<Dialect dialect, string name, string type, string probl
   let extraClassDeclaration = [{
     void setInProblem(}] # problemClassName # [{ &prob,
                       ::circt::scheduling::Problem::Dependence dep) {
-      prob.set}] # propertyName # [{(dep, getValue());
+      prob.set}] # propertyName # [{(dep, }] # unwrapValue # [{);
     }
     static ::mlir::Attribute getFromProblem(}] # problemClassName # [{ &prob,
                                             ::circt::scheduling::Problem::Dependence dep,
                                             ::mlir::MLIRContext *ctx) {
-      if (auto value = prob.get}] # propertyName # [{(dep))
-        return }] # cppClassName # [{::get(ctx, *value);
+      if (auto optValue = prob.get}] # propertyName # [{(dep)) {
+        auto value = *optValue;
+        return }] # cppClassName # [{::get(ctx, }] # wrapValue # [{);
+      }
       return {};
     }
   }];
@@ -97,12 +110,14 @@ class InstanceProperty<Dialect dialect, string name, string type, string problem
     : PropertyBase<dialect, name, type, problem, traits> {
   let extraClassDeclaration = [{
     void setInProblem(}] # problemClassName # [{ &prob) {
-      prob.set}] # propertyName # [{(getValue());
+      prob.set}] # propertyName # [{(}] # unwrapValue # [{);
     }
     static ::mlir::Attribute getFromProblem(}] # problemClassName # [{ &prob,
                                             ::mlir::MLIRContext *ctx) {
-      if (auto value = prob.get}] # propertyName # [{())
-        return }] # cppClassName # [{::get(ctx, *value);
+      if (auto optValue = prob.get}] # propertyName # [{()) {
+        auto value = *optValue;
+        return }] # cppClassName # [{::get(ctx, }] # wrapValue # [{);
+      }
       return {};
     }
   }];

--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -47,18 +47,8 @@ include "PropertyBase.td"
 def LinkedOperatorTypeProp : OperationProperty<SSPDialect,
   "LinkedOperatorType", "::mlir::FlatSymbolRefAttr", "::circt::scheduling::Problem"> {
   let mnemonic = "opr";
-  // Need to override the default implementation because to (un)wrap the
-  // StringAttr from/for the symbol reference
-  let extraClassDeclaration = [{
-    void setInProblem(}] # problemClassName # [{ &prob, ::mlir::Operation *op) {
-      prob.set}] # propertyName # [{(op, getValue().getLeafReference());
-    }
-    static ::mlir::Attribute getFromProblem(}] # problemClassName # [{ &prob, ::mlir::Operation *op, ::mlir::MLIRContext *ctx) {
-      if (auto value = prob.get}] # propertyName # [{(op))
-        return }] # cppClassName # [{::get(ctx, ::mlir::FlatSymbolRefAttr::get(ctx, *value));
-      return {};
-    }
-  }];
+  let unwrapValue = [{ getValue().getLeafReference() }];
+  let wrapValue = [{ ::mlir::FlatSymbolRefAttr::get(ctx, value) }];
 }
 def StartTimeProp : OperationProperty<SSPDialect,
   "StartTime", "unsigned", "::circt::scheduling::Problem"> {


### PR DESCRIPTION
Allow properties to specifically override the converter expressions used to convert between the C++ problem model and MLIR attribute worlds.