### PR TITLE
[FIRRTL] Update addPortsToModule to work with FModuleLike

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -290,7 +290,7 @@ A tryGetAs(DictionaryAttr &dict, const Attribute &root, StringRef key,
 /// `instOnPath`. This does not connect the new ports to anything. Replace
 /// the old instances with the new cloned instance in all the caches.
 InstanceOp addPortsToModule(
-    FModuleOp mod, InstanceOp instOnPath, FIRRTLType portType, Direction dir,
+    FModuleLike mod, InstanceOp instOnPath, FIRRTLType portType, Direction dir,
     StringRef newName, InstancePathCache &instancePathcache,
     llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace,
     CircuitTargetCache *targetCaches = nullptr);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -314,14 +314,14 @@ Optional<AnnoPathValue> firrtl::resolvePath(StringRef rawPath,
 }
 
 InstanceOp firrtl::addPortsToModule(
-    FModuleOp mod, InstanceOp instOnPath, FIRRTLType portType, Direction dir,
+    FModuleLike mod, InstanceOp instOnPath, FIRRTLType portType, Direction dir,
     StringRef newName, InstancePathCache &instancePathcache,
     llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace,
     CircuitTargetCache *targetCaches) {
   // To store the cloned version of `instOnPath`.
   InstanceOp clonedInstOnPath;
   // Get a new port name from the Namespace.
-  auto portName = [&](FModuleOp nameForMod) {
+  auto portName = [&](FModuleLike nameForMod) {
     return StringAttr::get(nameForMod.getContext(),
                            getNamespace(nameForMod).newName("_gen_" + newName));
   };
@@ -332,7 +332,7 @@ InstanceOp firrtl::addPortsToModule(
   if (targetCaches)
     targetCaches->insertPort(mod, portNo);
   // Now update all the instances of `mod`.
-  for (auto *use : instancePathcache.instanceGraph.lookup(mod)->uses()) {
+  for (auto *use : instancePathcache.instanceGraph.lookup(cast<hw::HWModuleLike>((Operation *)mod))->uses()) {
     InstanceOp useInst = cast<InstanceOp>(use->getInstance());
     auto clonedInst = useInst.cloneAndInsertPorts({{portNo, portInfo}});
     if (useInst == instOnPath)

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -332,7 +332,9 @@ InstanceOp firrtl::addPortsToModule(
   if (targetCaches)
     targetCaches->insertPort(mod, portNo);
   // Now update all the instances of `mod`.
-  for (auto *use : instancePathcache.instanceGraph.lookup(cast<hw::HWModuleLike>((Operation *)mod))->uses()) {
+  for (auto *use : instancePathcache.instanceGraph
+                       .lookup(cast<hw::HWModuleLike>((Operation *)mod))
+                       ->uses()) {
     InstanceOp useInst = cast<InstanceOp>(use->getInstance());
     auto clonedInst = useInst.cloneAndInsertPorts({{portNo, portInfo}});
     if (useInst == instOnPath)


### PR DESCRIPTION
Update the `FModuleOp` input of `addPortsToModule` to `FModuleLike`. This ensures that new ports can be added to extern modules also.