### PR TITLE
[SSP] Define ChainingProblem's properties.

### DIFF
--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -69,6 +69,25 @@ def InitiationIntervalProp : InstanceProperty<SSPDialect,
   let mnemonic = "II";
 }
 
+// ChainingProblem
+let
+  unwrapValue = [{ (float) getValue().getValueAsDouble() }],
+  wrapValue = [{ ::mlir::FloatAttr::get(::mlir::Float32Type::get(ctx), value) }]
+in {
+  def StartTimeInCycleProp : OperationProperty<SSPDialect,
+    "StartTimeInCycle", "::mlir::FloatAttr", "::circt::scheduling::ChainingProblem"> {
+    let mnemonic = "z";
+  }
+  def IncomingDelayProp : OperatorTypeProperty<SSPDialect,
+    "IncomingDelay", "::mlir::FloatAttr", "::circt::scheduling::ChainingProblem"> {
+    let mnemonic = "zIn";
+  }
+  def OutgoingDelayProp : OperatorTypeProperty<SSPDialect,
+    "OutgoingDelay", "::mlir::FloatAttr", "::circt::scheduling::ChainingProblem"> {
+    let mnemonic = "zOut";
+  }
+}
+
 // SharedOperatorsProblem
 def LimitProp : OperatorTypeProperty<SSPDialect,
   "Limit", "unsigned", "::circt::scheduling::SharedOperatorsProblem"> {

--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -80,11 +80,11 @@ in {
   }
   def IncomingDelayProp : OperatorTypeProperty<SSPDialect,
     "IncomingDelay", "::mlir::FloatAttr", "::circt::scheduling::ChainingProblem"> {
-    let mnemonic = "zIn";
+    let mnemonic = "incDelay";
   }
   def OutgoingDelayProp : OperatorTypeProperty<SSPDialect,
     "OutgoingDelay", "::mlir::FloatAttr", "::circt::scheduling::ChainingProblem"> {
-    let mnemonic = "zOut";
+    let mnemonic = "outDelay";
   }
 }
 

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -481,6 +481,20 @@ struct Default<scheduling::CyclicProblem> {
 };
 
 template <>
+struct Default<scheduling::ChainingProblem> {
+  static constexpr auto operationProperties =
+      std::tuple_cat(Default<scheduling::Problem>::operationProperties,
+                     std::make_tuple(StartTimeInCycleAttr()));
+  static constexpr auto operatorTypeProperties =
+      std::tuple_cat(Default<scheduling::Problem>::operatorTypeProperties,
+                     std::make_tuple(IncomingDelayAttr(), OutgoingDelayAttr()));
+  static constexpr auto dependenceProperties =
+      Default<scheduling::Problem>::dependenceProperties;
+  static constexpr auto instanceProperties =
+      Default<scheduling::Problem>::instanceProperties;
+};
+
+template <>
 struct Default<scheduling::SharedOperatorsProblem> {
   static constexpr auto operationProperties =
       Default<scheduling::Problem>::operationProperties;

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -605,6 +605,8 @@ void TestSSPRoundtripPass::runOnOperation() {
       roundtrip<Problem>(op);
     else if (probName.equals("CyclicProblem"))
       roundtrip<CyclicProblem>(op);
+    else if (probName.equals("ChainingProblem"))
+      roundtrip<ChainingProblem>(op);
     else if (probName.equals("SharedOperatorsProblem"))
       roundtrip<SharedOperatorsProblem>(op);
     else if (probName.equals("ModuloProblem"))

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -89,9 +89,9 @@ ssp.instance @self_arc of "CyclicProblem" [II<3>] {
 
 // CHECK: ssp.instance @mco_outgoing_delays of "ChainingProblem" {
 // CHECK:   library {
-// CHECK:     operator_type @add [latency<2>, zIn<1.000000e-01 : f32>, zOut<1.000000e-01 : f32>]
-// CHECK:     operator_type @mul [latency<3>, zIn<5.000000e+00 : f32>, zOut<1.000000e-01 : f32>]
-// CHECK:     operator_type @ret [latency<0>, zIn<0.000000e+00 : f32>, zOut<0.000000e+00 : f32>]
+// CHECK:     operator_type @add [latency<2>, incDelay<1.000000e-01 : f32>, outDelay<1.000000e-01 : f32>]
+// CHECK:     operator_type @mul [latency<3>, incDelay<5.000000e+00 : f32>, outDelay<1.000000e-01 : f32>]
+// CHECK:     operator_type @ret [latency<0>, incDelay<0.000000e+00 : f32>, outDelay<0.000000e+00 : f32>]
 // CHECK:   }
 // CHECK:   graph {
 // CHECK:     %[[op_0:.*]] = operation<@add>() [t<0>, z<0.000000e+00 : f32>]
@@ -102,9 +102,9 @@ ssp.instance @self_arc of "CyclicProblem" [II<3>] {
 // CHECK: }
 ssp.instance @mco_outgoing_delays of "ChainingProblem" {
   library {
-    operator_type @add [latency<2>, zIn<1.000000e-01 : f32>, zOut<1.000000e-01 : f32>]
-    operator_type @mul [latency<3>, zIn<5.000000e+00 : f32>, zOut<1.000000e-01 : f32>]
-    operator_type @ret [latency<0>, zIn<0.000000e+00 : f32>, zOut<0.000000e+00 : f32>]
+    operator_type @add [latency<2>, incDelay<1.000000e-01 : f32>, outDelay<1.000000e-01 : f32>]
+    operator_type @mul [latency<3>, incDelay<5.000000e+00 : f32>, outDelay<1.000000e-01 : f32>]
+    operator_type @ret [latency<0>, incDelay<0.000000e+00 : f32>, outDelay<0.000000e+00 : f32>]
   }
   graph {
     %0 = operation<@add>() [t<0>, z<0.000000e+00 : f32>]

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -87,6 +87,33 @@ ssp.instance @self_arc of "CyclicProblem" [II<3>] {
   }
 }
 
+// CHECK: ssp.instance @mco_outgoing_delays of "ChainingProblem" {
+// CHECK:   library {
+// CHECK:     operator_type @add [latency<2>, zIn<1.000000e-01 : f32>, zOut<1.000000e-01 : f32>]
+// CHECK:     operator_type @mul [latency<3>, zIn<5.000000e+00 : f32>, zOut<1.000000e-01 : f32>]
+// CHECK:     operator_type @ret [latency<0>, zIn<0.000000e+00 : f32>, zOut<0.000000e+00 : f32>]
+// CHECK:   }
+// CHECK:   graph {
+// CHECK:     %[[op_0:.*]] = operation<@add>() [t<0>, z<0.000000e+00 : f32>]
+// CHECK:     %[[op_1:.*]] = operation<@mul>(%[[op_0]], %[[op_0]]) [t<3>, z<0.000000e+00 : f32>]
+// CHECK:     %[[op_2:.*]] = operation<@add>(%[[op_1]], %[[op_1]]) [t<6>, z<1.000000e-01 : f32>]
+// CHECK:     operation<@ret>(%[[op_2]]) [t<8>, z<1.000000e-01 : f32>]
+// CHECK:   }
+// CHECK: }
+ssp.instance @mco_outgoing_delays of "ChainingProblem" {
+  library {
+    operator_type @add [latency<2>, zIn<1.000000e-01 : f32>, zOut<1.000000e-01 : f32>]
+    operator_type @mul [latency<3>, zIn<5.000000e+00 : f32>, zOut<1.000000e-01 : f32>]
+    operator_type @ret [latency<0>, zIn<0.000000e+00 : f32>, zOut<0.000000e+00 : f32>]
+  }
+  graph {
+    %0 = operation<@add>() [t<0>, z<0.000000e+00 : f32>]
+    %1 = operation<@mul>(%0, %0) [t<3>, z<0.000000e+00 : f32>]
+    %2 = operation<@add>(%1, %1) [t<6>, z<1.000000e-01 : f32>]
+    operation<@ret>(%2) [t<8>, z<1.000000e-01 : f32>]
+  }
+}
+
 // CHECK: ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
 // CHECK:   library {
 // CHECK:     operator_type @slowAdd [latency<3>, limit<2>]


### PR DESCRIPTION
This PR adds the missing dialect attribute definitions for the `ChainingProblem`'s properties. I had to model the payload as a `FloatAttr` (and use custom wrap/unwrap expressions) instead of a plain `float` value due to lack of support in the generic attribute parser.