### PR TITLE
[SSP] Allow standalone use of `OperatorLibraryOp`.

### DIFF
--- a/docs/Dialects/SSP/RationaleSSP.md
+++ b/docs/Dialects/SSP/RationaleSSP.md
@@ -126,15 +126,24 @@ problem instances?
 
 ### Use of container-like operations instead of regions in `InstanceOp`
 
-This dialect defines the `OperatorLibraryOp` and `DependenceGraphOp` to
-serve exclusively as the first and second operation in an `InstanceOp`'s region. 
-The alternative of using two regions on the `InstanceOp` is not applicable,
-because the `InstanceOp` then needs to provide a symbol table, but the upstream
+This dialect defines the `OperatorLibraryOp` and `DependenceGraphOp` to serve as
+the first and second operation in an `InstanceOp`'s region. The alternative of
+using two regions on the `InstanceOp` is not applicable, because the
+`InstanceOp` then needs to provide a symbol table, but the upstream
 `SymbolTable` trait enforces single-region ops. Lastly, we also considered using
 a single graph region to hold both `OperatorTypeOp`s and `OperationOp`s, but
 discarded that design because it cannot be safely roundtripped via a
 `circt::scheduling::Problem` (internally, registered operator types and
 operations are separate lists).
+
+### Stand-alone use of the `OperatorLibraryOp`
+
+The `OperatorLibraryOp` can be named and used outside of an `InstanceOp`. This
+is useful to share operator type definitions across multiple instances. In
+addition, until CIRCT gains better infrastructure to manage predefined hardware
+modules and their properties, such a stand-alone `OperatorLibraryOp` can also
+act as an interim solution to represent operator libraries for scheduling
+clients.
 
 ### Use of SSA operands _and_ symbol references to encode dependences
 

--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -45,7 +45,7 @@ include "PropertyBase.td"
 
 // Problem
 def LinkedOperatorTypeProp : OperationProperty<SSPDialect,
-  "LinkedOperatorType", "::mlir::FlatSymbolRefAttr", "::circt::scheduling::Problem"> {
+  "LinkedOperatorType", "::mlir::SymbolRefAttr", "::circt::scheduling::Problem"> {
   let mnemonic = "opr";
   let unwrapValue = [{ getValue().getLeafReference() }];
   let wrapValue = [{ ::mlir::FlatSymbolRefAttr::get(ctx, value) }];

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -86,11 +86,58 @@ def InstanceOp : SSPOp<"instance",
   ];
 }
 
-class ContainerOp<string mnemonic, list<Trait> traits = []>
-    : SSPOp<mnemonic, traits # [NoRegionArguments, SingleBlock, NoTerminator,
-     SymbolTable, OpAsmOpInterface, HasParent<"InstanceOp">]> {
+def OperatorLibraryOp : SSPOp<"library",
+    [NoRegionArguments, SingleBlock,
+     NoTerminator, OpAsmOpInterface, SymbolTable, Symbol]> {
+  let summary = "Container for operator types.";
+  let description = [{
+    The operator library abstracts the characteristics of the target
+    architecture/IR (onto which the source graph is scheduled), represented by
+    the individual `OperatorTypeOp`s.
+    
+    This operation may be used outside of an `InstanceOp`. An optional name
+    symbol can be set to allow qualified references to the contained
+    `OperatorTypeOp`s.
+  }];
+  
+  let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name);
+  let assemblyFormat = "($sym_name^)? $body attr-dict";
   let regions = (region SizedRegion<1>:$body);
+
+  let extraClassDeclaration = [{
+    // OpAsmOpInterface
+    static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
+
+    // SymbolOpInterface
+    static bool isOptionalSymbol() { return true; }
+
+    // Convenience
+    ::mlir::Block *getBodyBlock() {
+      return &getBody().getBlocks().front();
+    }
+  }];
+
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins ), [{
+      ::mlir::Region* region = $_state.addRegion();
+      region->push_back(new ::mlir::Block());
+    }]>
+  ];
+}
+
+def DependenceGraphOp : SSPOp<"graph",
+    [HasOnlyGraphRegion, NoRegionArguments,
+     SingleBlock, NoTerminator, OpAsmOpInterface, SymbolTable,
+     HasParent<"InstanceOp">]> {
+  let summary = "Container for (scheduling) operations.";
+  let description = [{
+    The dependence graph is spanned by `OperationOp`s (vertices) and a
+    combination of MLIR value uses and symbol references (edges).
+  }];
+
   let assemblyFormat = "$body attr-dict";
+  let regions = (region SizedRegion<1>:$body);
 
   let extraClassDeclaration = [{
     // OpAsmOpInterface
@@ -109,24 +156,6 @@ class ContainerOp<string mnemonic, list<Trait> traits = []>
       region->push_back(new ::mlir::Block());
     }]>
   ];
-}
-
-def OperatorLibraryOp : ContainerOp<"library"> {
-  let summary = "Container for operator types.";
-  let description = [{
-    The operator library abstracts the characteristics of the target
-    architecture/IR (onto which the source graph is scheduled), represented by
-    the individual `OperatorTypeOp`s.
-  }];
-}
-
-def DependenceGraphOp : ContainerOp<"graph",
-    [RegionKindInterface, HasOnlyGraphRegion]> {
-  let summary = "Container for (scheduling) operations.";
-  let description = [{
-    The dependence graph is spanned by `OperationOp`s (vertices) and a
-    combination of MLIR value uses and symbol references (edges).
-  }];
 }
 
 def OperatorTypeOp : SSPOp<"operator_type",

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -104,6 +104,8 @@ def OperatorLibraryOp : SSPOp<"library",
   let assemblyFormat = "($sym_name^)? $body attr-dict";
   let regions = (region SizedRegion<1>:$body);
 
+  let hasVerifier = true;
+
   let extraClassDeclaration = [{
     // OpAsmOpInterface
     static ::llvm::StringRef getDefaultDialect() { return "ssp"; }

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -95,9 +95,9 @@ def OperatorLibraryOp : SSPOp<"library",
     architecture/IR (onto which the source graph is scheduled), represented by
     the individual `OperatorTypeOp`s.
     
-    This operation may be used outside of an `InstanceOp`. An optional name
-    symbol can be set to allow qualified references to the contained
-    `OperatorTypeOp`s.
+    This operation may be used outside of an `InstanceOp`. Then, a name symbol
+    must be set to allow references to the contained `OperatorTypeOp`s. Operator
+    libraries inside an `InstanceOp` must not be named.
   }];
   
   let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name);
@@ -196,7 +196,10 @@ def OperationOp : SSPOp<"operation",
     The `linkedOperatorType` property in the root `Problem` class is central to
     the problem models, because it links operations to their properties in the
     target IR. Therefore, the referenced operator type symbol is parsed/printed
-    right after the operation keyword in the custom assembly syntax.
+    right after the operation keyword in the custom assembly syntax. Flat symbol
+    references are resolved by name in the surrounding instance's operator
+    library. Nested references can point to arbitrary operator libraries outside
+    of the current instance.
 
     **Examples**
     ```mlir
@@ -211,6 +214,9 @@ def OperationOp : SSPOp<"operation",
     
     // dependence properties
     operation<@Barrier>(%2 [dist<1>], %5#1, @store_A [dist<3>])
+
+    // operator type in standalone library
+    %7 = operation<@MathLib::@Sqrt>(%6)
     ```
   }];
 

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -34,7 +34,7 @@ def InstanceOp : SSPOp<"instance",
     **Example**
     ```mlir
     ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
-      library @_ {
+      library {
         operator_type @MemPort [latency<1>, limit<1>]
         operator_type @Add [latency<1>]
       }
@@ -100,13 +100,16 @@ def OperatorLibraryOp : SSPOp<"library",
     `InstanceOp`.
   }];
   
-  let arguments = (ins SymbolNameAttr:$sym_name);
-  let assemblyFormat = "$sym_name $body attr-dict";
+  let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name);
+  let assemblyFormat = "($sym_name^)? $body attr-dict";
   let regions = (region SizedRegion<1>:$body);
 
   let extraClassDeclaration = [{
     // OpAsmOpInterface
     static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
+
+    // SymbolUserOpInterface
+    static bool isOptionalSymbol() { return true; }
 
     // Convenience
     ::mlir::Block *getBodyBlock() {
@@ -116,8 +119,7 @@ def OperatorLibraryOp : SSPOp<"library",
 
   let skipDefaultBuilders = true;
   let builders = [
-    OpBuilder<(ins "::mlir::StringAttr":$sym_name), [{
-      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), sym_name);
+    OpBuilder<(ins ), [{
       ::mlir::Region* region = $_state.addRegion();
       region->push_back(new ::mlir::Block());
     }]>

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -212,7 +212,7 @@ def OperationOp : SSPOp<"operation",
     // dependence properties
     operation<@Barrier>(%2 [dist<1>], %5#1, @store_A [dist<3>])
 
-    // operator type in standalone library
+    // operator type in stand-alone library
     %7 = operation<@MathLib::@Sqrt>(%6)
     ```
   }];

--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -19,7 +19,7 @@ class SSPOp<string mnemonic, list<Trait> traits = []> :
 
 def InstanceOp : SSPOp<"instance",
     [NoRegionArguments, SingleBlock, NoTerminator,
-     IsolatedFromAbove, OpAsmOpInterface]> {
+     IsolatedFromAbove, OpAsmOpInterface, SymbolTable, Symbol]> {
   let summary = "Instance of a static scheduling problem.";
   let description = [{
     This operation represents an instance of a static scheduling problem,
@@ -33,8 +33,8 @@ def InstanceOp : SSPOp<"instance",
     
     **Example**
     ```mlir
-    ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-      library {
+    ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
+      library @_ {
         operator_type @MemPort [latency<1>, limit<1>]
         operator_type @Add [latency<1>]
       }
@@ -48,11 +48,11 @@ def InstanceOp : SSPOp<"instance",
     ```
   }];
 
-  let arguments = (ins StrAttr:$instanceName, StrAttr:$problemName,
+  let arguments = (ins SymbolNameAttr:$sym_name, StrAttr:$problemName,
                        OptionalAttr<ArrayAttr>:$properties);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $instanceName `of` $problemName custom<Properties>($properties) $body attr-dict
+    $sym_name `of` $problemName custom<Properties>($properties) $body attr-dict
   }];
   
   let hasVerifier = true;
@@ -66,6 +66,9 @@ def InstanceOp : SSPOp<"instance",
       return &getBody().getBlocks().front();
     }
 
+    // The symbol is actually the "instance name"
+    ::mlir::StringAttr getInstanceNameAttr() { return getSymNameAttr(); }
+
     // Access to container ops
     ::circt::ssp::OperatorLibraryOp getOperatorLibrary();
     ::circt::ssp::DependenceGraphOp getDependenceGraph();
@@ -76,7 +79,7 @@ def InstanceOp : SSPOp<"instance",
     OpBuilder<(ins "::mlir::StringAttr":$instanceName,
                    "::mlir::StringAttr":$problemName,
                    CArg<"::mlir::ArrayAttr", "::mlir::ArrayAttr()">:$properties), [{
-      $_state.addAttribute($_builder.getStringAttr("instanceName"), instanceName);
+      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), instanceName);
       $_state.addAttribute($_builder.getStringAttr("problemName"), problemName);
       if (properties)
         $_state.addAttribute($_builder.getStringAttr("properties"), properties);
@@ -93,25 +96,17 @@ def OperatorLibraryOp : SSPOp<"library",
   let description = [{
     The operator library abstracts the characteristics of the target
     architecture/IR (onto which the source graph is scheduled), represented by
-    the individual `OperatorTypeOp`s.
-    
-    This operation may be used outside of an `InstanceOp`. Then, a name symbol
-    must be set to allow references to the contained `OperatorTypeOp`s. Operator
-    libraries inside an `InstanceOp` must not be named.
+    the individual `OperatorTypeOp`s. This operation may be used outside of an
+    `InstanceOp`.
   }];
   
-  let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name);
-  let assemblyFormat = "($sym_name^)? $body attr-dict";
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let assemblyFormat = "$sym_name $body attr-dict";
   let regions = (region SizedRegion<1>:$body);
-
-  let hasVerifier = true;
 
   let extraClassDeclaration = [{
     // OpAsmOpInterface
     static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
-
-    // SymbolOpInterface
-    static bool isOptionalSymbol() { return true; }
 
     // Convenience
     ::mlir::Block *getBodyBlock() {
@@ -121,7 +116,8 @@ def OperatorLibraryOp : SSPOp<"library",
 
   let skipDefaultBuilders = true;
   let builders = [
-    OpBuilder<(ins ), [{
+    OpBuilder<(ins "::mlir::StringAttr":$sym_name), [{
+      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), sym_name);
       ::mlir::Region* region = $_state.addRegion();
       region->push_back(new ::mlir::Block());
     }]>
@@ -198,8 +194,7 @@ def OperationOp : SSPOp<"operation",
     target IR. Therefore, the referenced operator type symbol is parsed/printed
     right after the operation keyword in the custom assembly syntax. Flat symbol
     references are resolved by name in the surrounding instance's operator
-    library. Nested references can point to arbitrary operator libraries outside
-    of the current instance.
+    library. Nested references can point to arbitrary operator libraries.
 
     **Examples**
     ```mlir

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -136,6 +136,12 @@ void loadOperatorType(ProblemT &prob, OperatorTypeOp oprOp,
 /// elements may therefore be unitialized objects. The template instantiation
 /// fails if properties are incompatible with \p ProblemT.
 ///
+/// Operations may link to operator types in standalone libraries outside of the
+/// current instance. Note that the origin of an operator type is not preserved
+/// in the problem instance, hence `@Lib1::@Foo` and `@Lib2::@Foo` will be
+/// merged into the same operator type "Foo", causing undefined behavior.
+/// TODO: Detect and report this situation.
+///
 /// Example: To load an instance of the `circt::scheduling::CyclicProblem` with
 /// all its input and solution properties, call this as follows:
 ///

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -119,10 +119,10 @@ OperatorType loadOperatorType(ProblemT &prob, OperatorTypeOp oprOp,
 /// elements may therefore be unitialized objects. The template instantiation
 /// fails if properties are incompatible with \p ProblemT.
 ///
-/// Operations may link to operator types in standalone libraries outside of the
-/// current instance, but the origin of an operator type will not be preserved
-/// in the problem instance. Such external operator types will be automatically
-/// renamed in the returned instance to prevent conflicts.
+/// Operations may link to operator types in other libraries, but the origin of
+/// an operator type will not be preserved in the problem instance. As this
+/// could lead to conflicts, operator types will be automatically renamed in the
+/// returned instance.
 ///
 /// Example: To load an instance of the `circt::scheduling::CyclicProblem` with
 /// all its input and solution properties, call this as follows:
@@ -185,7 +185,7 @@ ProblemT loadProblem(InstanceOp instOp,
     // 2) Try to resolve a nested reference to the instance's library.
     if (!oprOp)
       oprOp = SymbolTable::lookupSymbolIn(instOp, oprRef);
-    // 3) Lastly, look outside of the instance.
+    // 3) Look outside of the instance.
     if (!oprOp)
       oprOp =
           SymbolTable::lookupNearestSymbolFrom(instOp->getParentOp(), oprRef);

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -329,7 +329,7 @@ saveProblem(ProblemT &prob, StringAttr instanceName, StringAttr problemName,
 
   // Emit operator types.
   b.setInsertionPointToEnd(instOp.getBodyBlock());
-  auto libraryOp = b.create<OperatorLibraryOp>(b.getStringAttr("_"));
+  auto libraryOp = b.create<OperatorLibraryOp>();
   b.setInsertionPointToStart(libraryOp.getBodyBlock());
 
   for (auto opr : prob.getOperatorTypes())

--- a/lib/Dialect/SSP/SSPOps.cpp
+++ b/lib/Dialect/SSP/SSPOps.cpp
@@ -49,6 +49,20 @@ DependenceGraphOp InstanceOp::getDependenceGraph() {
 }
 
 //===----------------------------------------------------------------------===//
+// OperatorLibraryOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult OperatorLibraryOp::verify() {
+  bool isInInstance = isa_and_nonnull<InstanceOp>((*this)->getParentOp());
+  bool hasSymbol = static_cast<bool>(getSymNameAttr());
+  if (isInInstance && hasSymbol)
+    return emitOpError() << "in 'ssp.instance' cannot be named";
+  if (!isInInstance && !hasSymbol)
+    return emitOpError() << "outside of 'ssp.instance' must be named";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // OperationOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SSP/SSPOps.cpp
+++ b/lib/Dialect/SSP/SSPOps.cpp
@@ -283,7 +283,7 @@ OperationOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     // 2) Try to resolve a nested reference to the instance's library.
     if (!oprOp)
       oprOp = symbolTable.lookupSymbolIn(instanceOp, oprRef);
-    // 3) Lastly, look outside of the instance.
+    // 3) Look outside of the instance.
     if (!oprOp)
       oprOp = symbolTable.lookupNearestSymbolFrom(instanceOp->getParentOp(),
                                                   oprRef);

--- a/test/Dialect/SSP/errors.mlir
+++ b/test/Dialect/SSP/errors.mlir
@@ -1,5 +1,10 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
+// expected-error @+1 {{outside of 'ssp.instance' must be named}}
+ssp.library {}
+
+// -----
+
 // expected-error @+1 {{must contain exactly one 'library' op and one 'graph' op}}
 ssp.instance "containers_empty" of "Problem" {}
 
@@ -9,6 +14,14 @@ ssp.instance "containers_empty" of "Problem" {}
 ssp.instance "containers_wrong_order" of "Problem" {
   graph {}
   library {}
+}
+
+// -----
+
+ssp.instance "named_internal_library" of "Problem" {
+  // expected-error @+1 {{in 'ssp.instance' cannot be named}}
+  library @myLibrary {}
+  graph {}
 }
 
 // -----
@@ -71,5 +84,16 @@ ssp.instance "linked_opr_invalid" of "Problem" {
   graph {
     // expected-error @+1 {{Linked operator type property references invalid operator type: @InvalidOpr}}
     operation<@InvalidOpr>()
+  }
+}
+
+// -----
+
+ssp.library @standalone {}
+ssp.instance "standalone_opr_invalid" of "Problem" {
+  library {}
+  graph {
+    // expected-error @+1 {{Linked operator type property references invalid operator type: @standalone::@InvalidOpr}}
+    operation<@standalone::@InvalidOpr>()
   }
 }

--- a/test/Dialect/SSP/errors.mlir
+++ b/test/Dialect/SSP/errors.mlir
@@ -1,33 +1,20 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-// expected-error @+1 {{outside of 'ssp.instance' must be named}}
-ssp.library {}
-
-// -----
-
 // expected-error @+1 {{must contain exactly one 'library' op and one 'graph' op}}
-ssp.instance "containers_empty" of "Problem" {}
+ssp.instance @containers_empty of "Problem" {}
 
 // -----
 
 // expected-error @+1 {{must contain the 'library' op followed by the 'graph' op}}
-ssp.instance "containers_wrong_order" of "Problem" {
+ssp.instance @containers_wrong_order of "Problem" {
   graph {}
-  library {}
+  library @_ {}
 }
 
 // -----
 
-ssp.instance "named_internal_library" of "Problem" {
-  // expected-error @+1 {{in 'ssp.instance' cannot be named}}
-  library @myLibrary {}
-  graph {}
-}
-
-// -----
-
-ssp.instance "deps_out_of_bounds" of "Problem" {
-  library {}
+ssp.instance @deps_out_of_bounds of "Problem" {
+  library @_ {}
   graph {
     // expected-error @+1 {{Operand index is out of bounds for def-use dependence attribute}}
     "ssp.operation"() {dependences = [#ssp.dependence<2>]} : () -> ()
@@ -36,8 +23,8 @@ ssp.instance "deps_out_of_bounds" of "Problem" {
 
 // -----
 
-ssp.instance "deps_defuse_not_increasing" of "Problem" {
-  library {}
+ssp.instance @deps_defuse_not_increasing of "Problem" {
+  library @_ {}
   graph {
     %0:2 = ssp.operation<>()
     // expected-error @+1 {{Def-use operand indices in dependence attribute are not monotonically increasing}}
@@ -47,8 +34,8 @@ ssp.instance "deps_defuse_not_increasing" of "Problem" {
 
 // -----
 
-ssp.instance "deps_interleaved" of "Problem" {
-  library {}
+ssp.instance @deps_interleaved of "Problem" {
+  library @_ {}
   graph {
     %0 = operation<> @Op()
     // expected-error @+1 {{Auxiliary dependence from @Op is interleaved with SSA operands}}
@@ -58,8 +45,8 @@ ssp.instance "deps_interleaved" of "Problem" {
 
 // -----
 
-ssp.instance "deps_aux_not_consecutive" of "Problem" {
-  library {}
+ssp.instance @deps_aux_not_consecutive of "Problem" {
+  library @_ {}
   graph {
     operation<> @Op()
     // expected-error @+1 {{Auxiliary operand indices in dependence attribute are not consecutive}}
@@ -69,8 +56,8 @@ ssp.instance "deps_aux_not_consecutive" of "Problem" {
 
 // -----
 
-ssp.instance "deps_aux_invalid" of "Problem" {
-  library {}
+ssp.instance @deps_aux_invalid of "Problem" {
+  library @_ {}
   graph {
     // expected-error @+1 {{Auxiliary dependence references invalid source operation: @InvalidOp}}
     operation<>(@InvalidOp)
@@ -79,8 +66,8 @@ ssp.instance "deps_aux_invalid" of "Problem" {
 
 // -----
 
-ssp.instance "linked_opr_invalid" of "Problem" {
-  library {}
+ssp.instance @linked_opr_invalid of "Problem" {
+  library @_ {}
   graph {
     // expected-error @+1 {{Linked operator type property references invalid operator type: @InvalidOpr}}
     operation<@InvalidOpr>()
@@ -90,8 +77,8 @@ ssp.instance "linked_opr_invalid" of "Problem" {
 // -----
 
 ssp.library @standalone {}
-ssp.instance "standalone_opr_invalid" of "Problem" {
-  library {}
+ssp.instance @standalone_opr_invalid of "Problem" {
+  library @_ {}
   graph {
     // expected-error @+1 {{Linked operator type property references invalid operator type: @standalone::@InvalidOpr}}
     operation<@standalone::@InvalidOpr>()

--- a/test/Dialect/SSP/errors.mlir
+++ b/test/Dialect/SSP/errors.mlir
@@ -8,13 +8,13 @@ ssp.instance @containers_empty of "Problem" {}
 // expected-error @+1 {{must contain the 'library' op followed by the 'graph' op}}
 ssp.instance @containers_wrong_order of "Problem" {
   graph {}
-  library @_ {}
+  library {}
 }
 
 // -----
 
 ssp.instance @deps_out_of_bounds of "Problem" {
-  library @_ {}
+  library {}
   graph {
     // expected-error @+1 {{Operand index is out of bounds for def-use dependence attribute}}
     "ssp.operation"() {dependences = [#ssp.dependence<2>]} : () -> ()
@@ -24,7 +24,7 @@ ssp.instance @deps_out_of_bounds of "Problem" {
 // -----
 
 ssp.instance @deps_defuse_not_increasing of "Problem" {
-  library @_ {}
+  library {}
   graph {
     %0:2 = ssp.operation<>()
     // expected-error @+1 {{Def-use operand indices in dependence attribute are not monotonically increasing}}
@@ -35,7 +35,7 @@ ssp.instance @deps_defuse_not_increasing of "Problem" {
 // -----
 
 ssp.instance @deps_interleaved of "Problem" {
-  library @_ {}
+  library {}
   graph {
     %0 = operation<> @Op()
     // expected-error @+1 {{Auxiliary dependence from @Op is interleaved with SSA operands}}
@@ -46,7 +46,7 @@ ssp.instance @deps_interleaved of "Problem" {
 // -----
 
 ssp.instance @deps_aux_not_consecutive of "Problem" {
-  library @_ {}
+  library {}
   graph {
     operation<> @Op()
     // expected-error @+1 {{Auxiliary operand indices in dependence attribute are not consecutive}}
@@ -57,7 +57,7 @@ ssp.instance @deps_aux_not_consecutive of "Problem" {
 // -----
 
 ssp.instance @deps_aux_invalid of "Problem" {
-  library @_ {}
+  library {}
   graph {
     // expected-error @+1 {{Auxiliary dependence references invalid source operation: @InvalidOp}}
     operation<>(@InvalidOp)
@@ -67,7 +67,7 @@ ssp.instance @deps_aux_invalid of "Problem" {
 // -----
 
 ssp.instance @linked_opr_invalid of "Problem" {
-  library @_ {}
+  library {}
   graph {
     // expected-error @+1 {{Linked operator type property references invalid operator type: @InvalidOpr}}
     operation<@InvalidOpr>()
@@ -78,7 +78,7 @@ ssp.instance @linked_opr_invalid of "Problem" {
 
 ssp.library @standalone {}
 ssp.instance @standalone_opr_invalid of "Problem" {
-  library @_ {}
+  library {}
   graph {
     // expected-error @+1 {{Linked operator type property references invalid operator type: @standalone::@InvalidOpr}}
     operation<@standalone::@InvalidOpr>()

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -4,8 +4,8 @@
 // 1) tests the plain parser/printer roundtrip.
 // 2) roundtrips via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
 
-// CHECK: ssp.instance "no properties" of "Problem" {
-// CHECK:   library {  
+// CHECK: ssp.instance @"no properties" of "Problem" {
+// CHECK:   library @_ {  
 // CHECK:     operator_type @NoProps
 // CHECK:   }
 // CHECK:   graph {
@@ -15,8 +15,8 @@
 // CHECK:     operation<>(%[[op_0]], @Op0)
 // CHECK:   }
 // CHECK: }
-ssp.instance "no properties" of "Problem" {
-  library {
+ssp.instance @"no properties" of "Problem" {
+  library @_ {
     operator_type @NoProps
   }
   graph {
@@ -27,8 +27,8 @@ ssp.instance "no properties" of "Problem" {
   }
 }
 
-// CHECK: ssp.instance "arbitrary_latencies" of "Problem" {
-// CHECK:   library {
+// CHECK: ssp.instance @arbitrary_latencies of "Problem" {
+// CHECK:   library @_ {
 // CHECK:     operator_type @unit [latency<1>]
 // CHECK:     operator_type @extr [latency<0>]
 // CHECK:     operator_type @add [latency<3>]
@@ -45,8 +45,8 @@ ssp.instance "no properties" of "Problem" {
 // CHECK:     operation<@unit>(%[[op_5]]) [t<60>]
 // CHECK:   }
 // CHECK: }
-ssp.instance "arbitrary_latencies" of "Problem" {
-  library {
+ssp.instance @arbitrary_latencies of "Problem" {
+  library @_ {
     operator_type @unit [latency<1>]
     operator_type @extr [latency<0>]
     operator_type @add [latency<3>]
@@ -64,8 +64,8 @@ ssp.instance "arbitrary_latencies" of "Problem" {
   }
 }
 
-// CHECK: ssp.instance "self_arc" of "CyclicProblem" [II<3>] {
-// CHECK:   library {
+// CHECK: ssp.instance @self_arc of "CyclicProblem" [II<3>] {
+// CHECK:   library @_ {
 // CHECK:     operator_type @unit [latency<1>]
 // CHECK:     operator_type @_3 [latency<3>]
 // CHECK:   }
@@ -75,8 +75,8 @@ ssp.instance "arbitrary_latencies" of "Problem" {
 // CHECK:     operation<@unit>(%[[op_1]]) [t<4>]
 // CHECK:   }
 // CHECK: }
-ssp.instance "self_arc" of "CyclicProblem" [II<3>] {
-  library {
+ssp.instance @self_arc of "CyclicProblem" [II<3>] {
+  library @_ {
     operator_type @unit [latency<1>]
     operator_type @_3 [latency<3>]
   }
@@ -87,8 +87,8 @@ ssp.instance "self_arc" of "CyclicProblem" [II<3>] {
   }
 }
 
-// CHECK: ssp.instance "multiple_oprs" of "SharedOperatorsProblem" {
-// CHECK:   library {
+// CHECK: ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
+// CHECK:   library @_ {
 // CHECK:     operator_type @slowAdd [latency<3>, limit<2>]
 // CHECK:     operator_type @fastAdd [latency<1>, limit<1>]
 // CHECK:     operator_type @_0 [latency<0>]
@@ -104,8 +104,8 @@ ssp.instance "self_arc" of "CyclicProblem" [II<3>] {
 // CHECK:     operation<@_1>() [t<10>]
 // CHECK:   }
 // CHECK: }
-ssp.instance "multiple_oprs" of "SharedOperatorsProblem" {
-  library {
+ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
+  library @_ {
     operator_type @slowAdd [latency<3>, limit<2>]
     operator_type @fastAdd [latency<1>, limit<1>]
     operator_type @_0 [latency<0>]
@@ -122,8 +122,8 @@ ssp.instance "multiple_oprs" of "SharedOperatorsProblem" {
   }
 }
 
-// CHECK: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-// CHECK:   library {
+// CHECK: ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
+// CHECK:   library @_ {
 // CHECK:     operator_type @MemPort [latency<1>, limit<1>]
 // CHECK:     operator_type @Add [latency<1>]
 // CHECK:     operator_type @Implicit [latency<0>]
@@ -136,8 +136,8 @@ ssp.instance "multiple_oprs" of "SharedOperatorsProblem" {
 // CHECK:     operation<@Implicit> @last(@store_A) [t<5>]
 // CHECK:   }
 // CHECK: }
-ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-  library {
+ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
+  library @_ {
     operator_type @MemPort [latency<1>, limit<1>]
     operator_type @Add [latency<1>]
     operator_type @Implicit [latency<0>]

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -5,7 +5,7 @@
 // 2) roundtrips via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
 
 // CHECK: ssp.instance @"no properties" of "Problem" {
-// CHECK:   library @_ {  
+// CHECK:   library {  
 // CHECK:     operator_type @NoProps
 // CHECK:   }
 // CHECK:   graph {
@@ -16,7 +16,7 @@
 // CHECK:   }
 // CHECK: }
 ssp.instance @"no properties" of "Problem" {
-  library @_ {
+  library {
     operator_type @NoProps
   }
   graph {
@@ -28,7 +28,7 @@ ssp.instance @"no properties" of "Problem" {
 }
 
 // CHECK: ssp.instance @arbitrary_latencies of "Problem" {
-// CHECK:   library @_ {
+// CHECK:   library {
 // CHECK:     operator_type @unit [latency<1>]
 // CHECK:     operator_type @extr [latency<0>]
 // CHECK:     operator_type @add [latency<3>]
@@ -46,7 +46,7 @@ ssp.instance @"no properties" of "Problem" {
 // CHECK:   }
 // CHECK: }
 ssp.instance @arbitrary_latencies of "Problem" {
-  library @_ {
+  library {
     operator_type @unit [latency<1>]
     operator_type @extr [latency<0>]
     operator_type @add [latency<3>]
@@ -65,7 +65,7 @@ ssp.instance @arbitrary_latencies of "Problem" {
 }
 
 // CHECK: ssp.instance @self_arc of "CyclicProblem" [II<3>] {
-// CHECK:   library @_ {
+// CHECK:   library {
 // CHECK:     operator_type @unit [latency<1>]
 // CHECK:     operator_type @_3 [latency<3>]
 // CHECK:   }
@@ -76,7 +76,7 @@ ssp.instance @arbitrary_latencies of "Problem" {
 // CHECK:   }
 // CHECK: }
 ssp.instance @self_arc of "CyclicProblem" [II<3>] {
-  library @_ {
+  library {
     operator_type @unit [latency<1>]
     operator_type @_3 [latency<3>]
   }
@@ -88,7 +88,7 @@ ssp.instance @self_arc of "CyclicProblem" [II<3>] {
 }
 
 // CHECK: ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
-// CHECK:   library @_ {
+// CHECK:   library {
 // CHECK:     operator_type @slowAdd [latency<3>, limit<2>]
 // CHECK:     operator_type @fastAdd [latency<1>, limit<1>]
 // CHECK:     operator_type @_0 [latency<0>]
@@ -105,7 +105,7 @@ ssp.instance @self_arc of "CyclicProblem" [II<3>] {
 // CHECK:   }
 // CHECK: }
 ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
-  library @_ {
+  library {
     operator_type @slowAdd [latency<3>, limit<2>]
     operator_type @fastAdd [latency<1>, limit<1>]
     operator_type @_0 [latency<0>]
@@ -123,7 +123,7 @@ ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
 }
 
 // CHECK: ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
-// CHECK:   library @_ {
+// CHECK:   library {
 // CHECK:     operator_type @MemPort [latency<1>, limit<1>]
 // CHECK:     operator_type @Add [latency<1>]
 // CHECK:     operator_type @Implicit [latency<0>]
@@ -137,7 +137,7 @@ ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
 // CHECK:   }
 // CHECK: }
 ssp.instance @canis14_fig2 of "ModuloProblem" [II<3>] {
-  library @_ {
+  library {
     operator_type @MemPort [latency<1>, limit<1>]
     operator_type @Add [latency<1>]
     operator_type @Implicit [latency<0>]

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -8,17 +8,19 @@
 // CHECK: module @SomeModule {
 // CHECK:   ssp.library @Lib {
 // CHECK:     operator_type @Add [latency<1>]
+// CHECK:     operator_type @MemPort [latency<1>, limit<2>]
 // CHECK:   }
 // CHECK: }
 // CHECK: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
 // CHECK:   library {
 // CHECK:     operator_type @Implicit [latency<0>]
+// CHECK:     operator_type @MemPort [latency<1>, limit<3>]
 // CHECK:   }
 // CHECK:   graph {
 // CHECK:     %[[op_0:.*]] = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
-// CHECK:     %[[op_1:.*]] = operation<@Lib::@MemPort> @load_B() [t<0>]
+// CHECK:     %[[op_1:.*]] = operation<@SomeModule::@Lib::@MemPort> @load_B() [t<0>]
 // CHECK:     %[[op_2:.*]] = operation<@SomeModule::@Lib::@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
-// CHECK:     operation<@Lib::@MemPort> @store_A(%[[op_2]]) [t<4>]
+// CHECK:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
 // CHECK:     operation<@Implicit> @last(@store_A) [t<5>]
 // CHECK:   }
 // CHECK: }
@@ -28,12 +30,14 @@
 // INFRA: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
 // INFRA:   library {
 // INFRA:     operator_type @Implicit [latency<0>]
-// INFRA:     operator_type @MemPort [latency<1>, limit<1>]
+// INFRA:     operator_type @MemPort [latency<1>, limit<3>]
+// INFRA:     operator_type @MemPort_0 [latency<1>, limit<1>]
+// INFRA:     operator_type @MemPort_1 [latency<1>, limit<2>]
 // INFRA:     operator_type @Add [latency<1>]
 // INFRA:   }
 // INFRA:   graph {
-// INFRA:     %[[op_0:.*]] = operation<@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
-// INFRA:     %[[op_1:.*]] = operation<@MemPort> @load_B() [t<0>]
+// INFRA:     %[[op_0:.*]] = operation<@MemPort_0> @load_A(@store_A [dist<1>]) [t<2>]
+// INFRA:     %[[op_1:.*]] = operation<@MemPort_1> @load_B() [t<0>]
 // INFRA:     %[[op_2:.*]] = operation<@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
 // INFRA:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
 // INFRA:     operation<@Implicit> @last(@store_A) [t<5>]
@@ -46,17 +50,19 @@ ssp.library @Lib {
 module @SomeModule {
   ssp.library @Lib {
     operator_type @Add [latency<1>]
+    operator_type @MemPort [latency<1>, limit<2>]
   }
 }
 ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
   library {
     operator_type @Implicit [latency<0>]
+    operator_type @MemPort [latency<1>, limit<3>]
   }
   graph {
     %0 = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
-    %1 = operation<> @load_B() [t<0>, opr<@Lib::@MemPort>]
+    %1 = operation<@SomeModule::@Lib::@MemPort> @load_B() [t<0>]
     %2 = operation<@SomeModule::@Lib::@Add> @add(%0, %1) [t<3>]
-    operation<@Lib::@MemPort> @store_A(%2) [t<4>]
+    operation<@MemPort> @store_A(%2) [t<4>]
     operation<@Implicit> @last(@store_A) [t<5>]
   }
 }

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+// RUN: circt-opt %s -test-ssp-roundtrip | circt-opt | FileCheck %s --check-prefix=INFRA
+
+// 1) tests the plain parser/printer roundtrip.
+// CHECK: ssp.library @Lib {
+// CHECK:   operator_type @MemPort [latency<1>, limit<1>]
+// CHECK: }
+// CHECK: module @SomeModule {
+// CHECK:   ssp.library @Lib {
+// CHECK:     operator_type @Add [latency<1>]
+// CHECK:   }
+// CHECK: }
+// CHECK: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
+// CHECK:   library {
+// CHECK:     operator_type @Implicit [latency<0>]
+// CHECK:   }
+// CHECK:   graph {
+// CHECK:     %[[op_0:.*]] = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
+// CHECK:     %[[op_1:.*]] = operation<@Lib::@MemPort> @load_B() [t<0>]
+// CHECK:     %[[op_2:.*]] = operation<@SomeModule::@Lib::@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
+// CHECK:     operation<@Lib::@MemPort> @store_A(%[[op_2]]) [t<4>]
+// CHECK:     operation<@Implicit> @last(@store_A) [t<5>]
+// CHECK:   }
+// CHECK: }
+
+// 2) Import/export via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
+//    Operator types from standalone libraries are appended to the instance's internal library.
+// INFRA: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
+// INFRA:   library {
+// INFRA:     operator_type @Implicit [latency<0>]
+// INFRA:     operator_type @MemPort [latency<1>, limit<1>]
+// INFRA:     operator_type @Add [latency<1>]
+// INFRA:   }
+// INFRA:   graph {
+// INFRA:     %[[op_0:.*]] = operation<@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
+// INFRA:     %[[op_1:.*]] = operation<@MemPort> @load_B() [t<0>]
+// INFRA:     %[[op_2:.*]] = operation<@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
+// INFRA:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
+// INFRA:     operation<@Implicit> @last(@store_A) [t<5>]
+// INFRA:   }
+// INFRA: }
+
+ssp.library @Lib {
+  operator_type @MemPort [latency<1>, limit<1>]
+}
+module @SomeModule {
+  ssp.library @Lib {
+    operator_type @Add [latency<1>]
+  }
+}
+ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
+  library {
+    operator_type @Implicit [latency<0>]
+  }
+  graph {
+    %0 = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
+    %1 = operation<> @load_B() [t<0>, opr<@Lib::@MemPort>]
+    %2 = operation<@SomeModule::@Lib::@Add> @add(%0, %1) [t<3>]
+    operation<@Lib::@MemPort> @store_A(%2) [t<4>]
+    operation<@Implicit> @last(@store_A) [t<5>]
+  }
+}

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -31,13 +31,13 @@
 // INFRA:   library {
 // INFRA:     operator_type @Implicit [latency<0>]
 // INFRA:     operator_type @MemPort [latency<1>, limit<3>]
-// INFRA:     operator_type @MemPort_0 [latency<1>, limit<1>]
-// INFRA:     operator_type @MemPort_1 [latency<1>, limit<2>]
+// INFRA:     operator_type @MemPort_1 [latency<1>, limit<1>]
+// INFRA:     operator_type @MemPort_2 [latency<1>, limit<2>]
 // INFRA:     operator_type @Add [latency<1>]
 // INFRA:   }
 // INFRA:   graph {
-// INFRA:     %[[op_0:.*]] = operation<@MemPort_0> @load_A(@store_A [dist<1>]) [t<2>]
-// INFRA:     %[[op_1:.*]] = operation<@MemPort_1> @load_B() [t<0>]
+// INFRA:     %[[op_0:.*]] = operation<@MemPort_1> @load_A(@store_A [dist<1>]) [t<2>]
+// INFRA:     %[[op_1:.*]] = operation<@MemPort_2> @load_B() [t<0>]
 // INFRA:     %[[op_2:.*]] = operation<@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
 // INFRA:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
 // INFRA:     operation<@Implicit> @last(@store_A) [t<5>]

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -26,7 +26,7 @@
 // 2) Import/export via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
 //    Operator types from standalone libraries are appended to the instance's internal library, whose name is not preserved.
 // INFRA: ssp.instance @SomeInstance of "ModuloProblem" {
-// INFRA:   library @_ {
+// INFRA:   library {
 // INFRA:     operator_type @Opr [latency<3>, limit<3>]
 // INFRA:     operator_type @Opr_1 [latency<1>, limit<1>]
 // INFRA:     operator_type @Opr_2 [latency<2>, limit<2>]

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -3,66 +3,60 @@
 
 // 1) tests the plain parser/printer roundtrip.
 // CHECK: ssp.library @Lib {
-// CHECK:   operator_type @MemPort [latency<1>, limit<1>]
+// CHECK:   operator_type @Opr [latency<1>, limit<1>]
 // CHECK: }
 // CHECK: module @SomeModule {
 // CHECK:   ssp.library @Lib {
-// CHECK:     operator_type @Add [latency<1>]
-// CHECK:     operator_type @MemPort [latency<1>, limit<2>]
+// CHECK:     operator_type @Opr [latency<2>, limit<2>]
 // CHECK:   }
 // CHECK: }
-// CHECK: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-// CHECK:   library {
-// CHECK:     operator_type @Implicit [latency<0>]
-// CHECK:     operator_type @MemPort [latency<1>, limit<3>]
+// CHECK: ssp.instance @SomeInstance of "ModuloProblem" {
+// CHECK:   library @InternalLib {
+// CHECK:     operator_type @Opr [latency<3>, limit<3>]
 // CHECK:   }
 // CHECK:   graph {
-// CHECK:     %[[op_0:.*]] = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
-// CHECK:     %[[op_1:.*]] = operation<@SomeModule::@Lib::@MemPort> @load_B() [t<0>]
-// CHECK:     %[[op_2:.*]] = operation<@SomeModule::@Lib::@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
-// CHECK:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
-// CHECK:     operation<@Implicit> @last(@store_A) [t<5>]
+// CHECK:     operation<@Opr>()
+// CHECK:     operation<@InternalLib::@Opr>()
+// CHECK:     operation<@SomeInstance::@InternalLib::@Opr>()
+// CHECK:     operation<@Lib::@Opr>()
+// CHECK:     operation<@SomeModule::@Lib::@Opr>()
 // CHECK:   }
 // CHECK: }
 
 // 2) Import/export via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
-//    Operator types from standalone libraries are appended to the instance's internal library.
-// INFRA: ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-// INFRA:   library {
-// INFRA:     operator_type @Implicit [latency<0>]
-// INFRA:     operator_type @MemPort [latency<1>, limit<3>]
-// INFRA:     operator_type @MemPort_1 [latency<1>, limit<1>]
-// INFRA:     operator_type @MemPort_2 [latency<1>, limit<2>]
-// INFRA:     operator_type @Add [latency<1>]
+//    Operator types from standalone libraries are appended to the instance's internal library, whose name is not preserved.
+// INFRA: ssp.instance @SomeInstance of "ModuloProblem" {
+// INFRA:   library @_ {
+// INFRA:     operator_type @Opr [latency<3>, limit<3>]
+// INFRA:     operator_type @Opr_1 [latency<1>, limit<1>]
+// INFRA:     operator_type @Opr_2 [latency<2>, limit<2>]
 // INFRA:   }
 // INFRA:   graph {
-// INFRA:     %[[op_0:.*]] = operation<@MemPort_1> @load_A(@store_A [dist<1>]) [t<2>]
-// INFRA:     %[[op_1:.*]] = operation<@MemPort_2> @load_B() [t<0>]
-// INFRA:     %[[op_2:.*]] = operation<@Add> @add(%[[op_0]], %[[op_1]]) [t<3>]
-// INFRA:     operation<@MemPort> @store_A(%[[op_2]]) [t<4>]
-// INFRA:     operation<@Implicit> @last(@store_A) [t<5>]
+// INFRA:     operation<@Opr>()
+// INFRA:     operation<@Opr>()
+// INFRA:     operation<@Opr>()
+// INFRA:     operation<@Opr_1>()
+// INFRA:     operation<@Opr_2>()
 // INFRA:   }
 // INFRA: }
 
 ssp.library @Lib {
-  operator_type @MemPort [latency<1>, limit<1>]
+  operator_type @Opr [latency<1>, limit<1>]
 }
 module @SomeModule {
   ssp.library @Lib {
-    operator_type @Add [latency<1>]
-    operator_type @MemPort [latency<1>, limit<2>]
+    operator_type @Opr [latency<2>, limit<2>]
   }
 }
-ssp.instance "canis14_fig2" of "ModuloProblem" [II<3>] {
-  library {
-    operator_type @Implicit [latency<0>]
-    operator_type @MemPort [latency<1>, limit<3>]
+ssp.instance @SomeInstance of "ModuloProblem" {
+  library @InternalLib {
+    operator_type @Opr [latency<3>, limit<3>]
   }
   graph {
-    %0 = operation<@Lib::@MemPort> @load_A(@store_A [dist<1>]) [t<2>]
-    %1 = operation<@SomeModule::@Lib::@MemPort> @load_B() [t<0>]
-    %2 = operation<@SomeModule::@Lib::@Add> @add(%0, %1) [t<3>]
-    operation<@MemPort> @store_A(%2) [t<4>]
-    operation<@Implicit> @last(@store_A) [t<5>]
+    operation<@Opr>()
+    operation<@InternalLib::@Opr>()
+    operation<@SomeInstance::@InternalLib::@Opr>()
+    operation<@Lib::@Opr>()
+    operation<@SomeModule::@Lib::@Opr>()
   }
 }

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -24,7 +24,7 @@
 // CHECK: }
 
 // 2) Import/export via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
-//    Operator types from standalone libraries are appended to the instance's internal library, whose name is not preserved.
+//    Operator types from stand-alone libraries are appended to the instance's internal library, whose name is not preserved.
 // INFRA: ssp.instance @SomeInstance of "ModuloProblem" {
 // INFRA:   library {
 // INFRA:     operator_type @Opr [latency<3>, limit<3>]


### PR DESCRIPTION
Motivated by: https://github.com/llvm/circt/pull/4216#issuecomment-1298244329

Draft status because I have to think about potential problems/benefits of allowing named operator libraries inside an ssp.instance`.