### PR TITLE
[FIRRTL] Fix GCT View Directory Behavior for DUT

### DIFF
--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1123,6 +1123,220 @@ firrtl.circuit "SubmoduleDirectoryBehavior" attributes {
 
 // -----
 
+firrtl.circuit "DirectoryBehaviorWithDUT" attributes {
+  annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [],
+     id = 0 : i64,
+     name = "View"},
+    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+     directory = "gct-dir",
+     filename = "bindings.sv"}]} {
+
+  // Each of these modules is instantiated in a different location.  A leading
+  // "E" indicates that this is an external module.  A leading "M" indicates
+  // that this is a module.  The instantiation location is indicated by three
+  // binary bits with an "_" indicating the absence of instantiation:
+  //   1) "T" indicates this is instantiated in the "Top" (above the DUT)
+  //   2) "D" indicates this is instantiated in the "DUT"
+  //   3) "C" indicates this is instantiated in the "Companion"
+  // E.g., "ET_C" is an external module instantiated above the DUT and in the
+  // Companion.
+  firrtl.module @MT__() {}
+  firrtl.module @M_D_() {}
+  firrtl.module @M__C() {}
+  firrtl.module @MTD_() {}
+  firrtl.module @M_DC() {}
+  firrtl.module @MT_C() {}
+  firrtl.module @MTDC() {}
+  firrtl.extmodule @ET__() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ET__.v", text = ""}
+  ]}
+  firrtl.extmodule @E_D_() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "E_D_.v", text = ""}
+  ]}
+  firrtl.extmodule @E__C() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "E__C.v", text = ""}
+  ]}
+  firrtl.extmodule @ETD_() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ETD_.v", text = ""}
+  ]}
+  firrtl.extmodule @E_DC() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "E_DC.v", text = ""}
+  ]}
+  firrtl.extmodule @ET_C() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ET_C.v", text = ""}
+  ]}
+  firrtl.extmodule @ETDC() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ETDC.v", text = ""}
+  ]}
+
+  // The Grand Central Companion module.
+  firrtl.module private @Companion() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+       defName = "Foo",
+       id = 0 : i64,
+       name = "View"}]} {
+
+    firrtl.instance m__c @M__C()
+    firrtl.instance m_dc @M_DC()
+    firrtl.instance mt_c @MT_C()
+    firrtl.instance mtdc @MTDC()
+
+    firrtl.instance e__c @E__C()
+    firrtl.instance e_dc @E_DC()
+    firrtl.instance et_c @ET_C()
+    firrtl.instance etdc @ETDC()
+  }
+
+  // The Design-under-test as indicated by the MarkDUTAnnotation
+  firrtl.module private @DUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+       id = 0 : i64,
+       name = "view"},
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]} {
+    firrtl.instance companion @Companion()
+
+    firrtl.instance m_d_ @M_D_()
+    firrtl.instance mtd_ @MTD_()
+    firrtl.instance m_dc @M_DC()
+    firrtl.instance mtdc @MTDC()
+
+    firrtl.instance e_d_ @E_D_()
+    firrtl.instance etd_ @ETD_()
+    firrtl.instance e_dc @E_DC()
+    firrtl.instance etdc @ETDC()
+  }
+
+  // The Top module that instantiates the DUT
+  firrtl.module @DirectoryBehaviorWithDUT() {
+    firrtl.instance dut @DUT()
+
+    firrtl.instance mt__ @MT__()
+    firrtl.instance mtd_ @MTD_()
+    firrtl.instance mt_c @MT_C()
+    firrtl.instance mtdc @MTDC()
+
+    firrtl.instance et__ @ET__()
+    firrtl.instance etd_ @ETD_()
+    firrtl.instance et_c @ET_C()
+    firrtl.instance etdc @ETDC()
+  }
+}
+
+// Any module instantiated by the Companion, but not instantiated by the DUT is
+// moved to the same directory as the Companion.  I.e., only "*__C" and "*T_C"
+// modules should be moved into the "gct-dir".
+//
+// CHECK-LABEL: "DirectoryBehaviorWithDUT"
+//
+// CHECK-NOT:    output_file
+// CHECK:      firrtl.module @M__C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+// CHECK-NOT:    output_file
+// CHECK:      firrtl.module @MT_C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+//
+// CHECK-NOT:    output_file
+// CHECK:      firrtl.extmodule @E__C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}">
+// CHECK-NOT:    output_file
+// CHECK:      firrtl.extmodule @ET_C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}">
+// CHECK-NOT:    output_file
+//
+// CHECK:      firrtl.module
+
+// -----
+
+firrtl.circuit "DirectoryBehaviorWithoutDUT" attributes {
+  annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [],
+     id = 0 : i64,
+     name = "View"},
+    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+     directory = "gct-dir",
+     filename = "bindings.sv"}]} {
+
+  // Each of these modules is instantiated in a different location.  A leading
+  // "E" indicates that this is an external module.  A leading "M" indicates
+  // that this is a module.  The instantiation location is indicated by three
+  // binary bits with an "_" indicating the absence of instantiation:
+  //   1) "T" indicates this is instantiated in the "Top"
+  //   2) "C" indicates this is instantiated in the "Companion"
+  // E.g., "E_C" is an external module instantiated only in the Companion.
+  firrtl.module @MT_() {}
+  firrtl.module @M_C() {}
+  firrtl.module @MTC() {}
+  firrtl.extmodule @ET_() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ET_.v", text = ""}
+  ]}
+  firrtl.extmodule @E_C() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "E_C.v", text = ""}
+  ]}
+  firrtl.extmodule @ETC() attributes {annotations = [
+    {class = "firrtl.transforms.BlackBoxInlineAnno", name = "ETC.v", text = ""}
+  ]}
+
+  // The Grand Central Companion module.
+  firrtl.module private @Companion() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+       defName = "Foo",
+       id = 0 : i64,
+       name = "View"}]} {
+
+    firrtl.instance m__c @M_C()
+    firrtl.instance m_dc @MTC()
+
+    firrtl.instance e__c @E_C()
+    firrtl.instance e_dc @ETC()
+  }
+
+  // This is the DUT in the previous example, but is no longer marked as the
+  // DUT.
+  firrtl.module @DirectoryBehaviorWithoutDUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+       id = 0 : i64,
+       name = "view"}
+    ]} {
+    firrtl.instance companion @Companion()
+
+    firrtl.instance m_d_ @MT_()
+    firrtl.instance m_dc @MTC()
+
+    firrtl.instance e_d_ @ET_()
+    firrtl.instance e_dc @ETC()
+  }
+
+}
+
+// Any module instantiated by the Companion, but not instantiated by the DUT is
+// moved to the same directory as the Companion.  I.e., only "*_C" modules
+// should be moved into the "gct-dir".
+//
+// CHECK-LABEL: "DirectoryBehaviorWithoutDUT"
+//
+// CHECK-NOT:    output_file
+// CHECK:      firrtl.module @M_C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+// CHECK-NOT:    output_file
+//
+// CHECK:      firrtl.extmodule @E_C
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}">
+// CHECK-NOT:    output_file
+//
+// CHECK:      firrtl.module
+
+// -----
+
 firrtl.circuit "InterfaceInTestHarness" attributes {
   annotations = [
     {class = "sifive.enterprise.grandcentral.AugmentedBundleType",


### PR DESCRIPTION
Fix the behavior of Grand Central (GCT) Views directory placement for modules which are instantiated in the GCT View Companion module and also in the testbench, but not the DUT (as indicated by a MarkDUTAnnotation). Previously, the check would only move modules exclusively instantiated under the companion.  This would cause modules instantiated in the testbench (above the DUT) to wind up in the DUT directory and cause problems for downstream physical design tooling that wants to only see design Verilog in the DUT directory.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This PR leaves in old tests that were added/updated in https://github.com/llvm/circt/pull/4180. This is intentional to indicate that there is no functionality change to existing tests. The large tests added in _this PR_ are a superset of the behavior tested there. I'll remove the old tests in an NFC commit after this PR lands.

Also, the `allUnder` utility is now (again) only used by WireDFT. I don't think it makes sense to revert https://github.com/llvm/circt/commit/6391f15976b8ac126bcd25e7d4b07b587b2dfe18, but we could. I do think `allUnder` is a generally useful function to have even if it only has the one use. The conditional depth-first walk I'm doing here (to walk everything from the DUT to the companions) does seem like it could be generalized into a utility `walkConditional(DenseSet<hw::HWModuleLike> &modules, ...)`. However, I'll wait to do anything until we have a use case.