### PR TITLE
PrettyPrinterTest: fix raw string for MSVC.

### DIFF
--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -367,19 +367,8 @@ TEST(PrettyPrinterTest, StreamQuoted) {
   PrettyPrinter pp(os, 20);
   TokenStringSaver saver;
   TokenStream<> ps(pp, saver);
-  out = "\n";
-  {
-    ps << PP::ibox2;
-    ps << "test" << PP::space;
-    ps.writeQuotedEscaped("quote\"me");
-    ps << PP::space << "test";
-    ps << PP::end;
-  }
-  ps << PP::newline << PP::eof;
-  EXPECT_EQ(out.str(), StringRef(R"""(
-test "quote"me"
-  test
-)"""));
+  ps.writeQuotedEscaped("quote\"me", false, "'", "'");
+  EXPECT_EQ(out.str(), "'quote\\\"me'");
 }
 
 TEST(PrettyPrinterTest, LargeStream) {

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -377,7 +377,7 @@ TEST(PrettyPrinterTest, StreamQuoted) {
   }
   ps << PP::newline << PP::eof;
   EXPECT_EQ(out.str(), StringRef(R"""(
-test "quote\"me"
+test "quote"me"
   test
 )"""));
 }


### PR DESCRIPTION
Maybe this: https://developercommunity.visualstudio.com/t/c2017-illegal-escape-sequence-when-using-in-a-raw/919371 .

Anyway, simplify test so no raw string needed.

Windows build: https://github.com/llvm/circt/actions/runs/3374258722/jobs/5599694000 .