### PR TITLE
[LowerSeqToSV] Add an option to keep register self assignments

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -20,7 +20,8 @@ namespace circt {
 namespace seq {
 
 std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
-std::unique_ptr<mlir::Pass> createSeqFIRRTLLowerToSVPass();
+std::unique_ptr<mlir::Pass>
+createSeqFIRRTLLowerToSVPass(bool keepRegisterSelfAssignments = false);
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -25,6 +25,10 @@ def LowerSeqFIRRTLToSV: Pass<"lower-seq-firrtl-to-sv", "hw::HWModuleOp"> {
   let summary = "Lower sequential firrtl ops to SV.";
   let constructor = "circt::seq::createSeqFIRRTLLowerToSVPass()";
   let dependentDialects = ["circt::sv::SVDialect"];
+   let options = [Option<"keepRegisterSelfAssignments",
+      "keep-register-self-assignments", "bool", "false",
+      "If true, keep register self assignments to workaround xprop build failures">
+  ];
 }
 
 def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s -verify-diagnostics --lower-seq-firrtl-to-sv | FileCheck %s
+// RUN: circt-opt %s -verify-diagnostics -pass-pipeline='hw.module(lower-seq-firrtl-to-sv{keep-register-self-assignments})' | FileCheck %s --check-prefix=KEEP
 
 // CHECK-LABEL: hw.module @lowering
 hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
@@ -146,6 +147,10 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
+  // KEEP:       %count = sv.reg sym @count : !hw.inout<i2>
+  // KEEP-NEXT:  %0 = sv.read_inout %count : !hw.inout<i2>
+  // KEEP:       sv.always posedge %clock {
+  // KEEP:       sv.passign %count, %0 : i2
 
   %count = seq.firreg %2 clock %clock sym @count : i2
   %1 = comb.mux bin %cond, %value, %count : i2

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -407,6 +407,11 @@ static cl::opt<bool> stripDebugInfo(
     cl::desc("Disable source locator information in output Verilog"),
     cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool> keepRegisterSelfAssignments(
+    "keep-register-self-assignments",
+    cl::desc("Keep register self assignments to workaround xprop build failures"),
+    cl::init(false), cl::cat(mainCategory));
+
 // Build mode options.
 enum BuildMode { BuildModeDebug, BuildModeRelease };
 static cl::opt<BuildMode> buildMode(
@@ -768,7 +773,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createCSEPass());
       }
 
-      pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass());
+      pm.nest<hw::HWModuleOp>().addPass(
+          seq::createSeqFIRRTLLowerToSVPass(keepRegisterSelfAssignments));
       pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem,
                                             stripMuxPragmas));
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -409,7 +409,8 @@ static cl::opt<bool> stripDebugInfo(
 
 static cl::opt<bool> keepRegisterSelfAssignments(
     "keep-register-self-assignments",
-    cl::desc("Keep register self assignments to workaround xprop build failures"),
+    cl::desc(
+        "Keep register self assignments to workaround xprop build failures"),
     cl::init(false), cl::cat(mainCategory));
 
 // Build mode options.


### PR DESCRIPTION
This adds an option to keep self connections in the lower-seq-to-sv. This is useful to run xprop simulations while debug mode where uninitialized registers remain.