### PR TITLE
[HWArith] Propagate (and improve) sv.namehints in HW lowering

### DIFF
--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -35,7 +35,7 @@ using namespace hwarith;
 static void
 improveNamehint(Value oldValue, Operation *newOp,
                 llvm::function_ref<std::string(StringRef)> namehintCallback) {
-  if (auto sourceOp = oldValue.getDefiningOp()) {
+  if (auto *sourceOp = oldValue.getDefiningOp()) {
     if (auto namehint =
             sourceOp->getAttrOfType<mlir::StringAttr>("sv.namehint")) {
       auto newNamehint = namehintCallback(namehint.strref());
@@ -53,7 +53,7 @@ static Value extractBits(OpBuilder &builder, Location loc, Value value,
   Value extractedValue = result[0];
   if (extractedValue != value) {
     // only change namehint if a new operation was created.
-    auto newOp = extractedValue.getDefiningOp();
+    auto *newOp = extractedValue.getDefiningOp();
     improveNamehint(value, newOp, [&](StringRef oldNamehint) {
       return (oldNamehint + "_" + std::to_string(startBit) + "_to_" +
               std::to_string(startBit + bitWidth))

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -28,12 +28,39 @@ using namespace hwarith;
 // Utility functions
 //===----------------------------------------------------------------------===//
 
+// Function for setting the 'sv.namehint' attribute on 'newOp' based on any
+// currently existing 'sv.namehint' attached to the source operation of 'value'.
+// The user provides a callback which returns a new namehint based on the old
+// namehint.
+static void
+improveNamehint(Value oldValue, Operation *newOp,
+                llvm::function_ref<std::string(StringRef)> namehintCallback) {
+  if (auto sourceOp = oldValue.getDefiningOp()) {
+    if (auto namehint =
+            sourceOp->getAttrOfType<mlir::StringAttr>("sv.namehint")) {
+      auto newNamehint = namehintCallback(namehint.strref());
+      newOp->setAttr("sv.namehint",
+                     StringAttr::get(oldValue.getContext(), newNamehint));
+    }
+  }
+}
+
 // Extract a bit range, specified via start bit and width, from a given value.
 static Value extractBits(OpBuilder &builder, Location loc, Value value,
                          unsigned startBit, unsigned bitWidth) {
   SmallVector<Value, 1> result;
   builder.createOrFold<comb::ExtractOp>(result, loc, value, startBit, bitWidth);
-  return result[0];
+  Value extractedValue = result[0];
+  if (extractedValue != value) {
+    // only change namehint if a new operation was created.
+    auto newOp = extractedValue.getDefiningOp();
+    improveNamehint(value, newOp, [&](StringRef oldNamehint) {
+      return (oldNamehint + "_" + std::to_string(startBit) + "_to_" +
+              std::to_string(startBit + bitWidth))
+          .str();
+    });
+  }
+  return extractedValue;
 }
 
 // Perform the specified bit-extension (either sign- or zero-extension) for a
@@ -63,8 +90,15 @@ static Value extendTypeWidth(OpBuilder &builder, Location loc, Value value,
                             loc, builder.getIntegerType(extensionLength), 0)
                         ->getOpResult(0);
   }
-  return builder.create<comb::ConcatOp>(loc, extensionBits, value)
-      ->getOpResult(0);
+
+  auto extOp = builder.create<comb::ConcatOp>(loc, extensionBits, value);
+  improveNamehint(value, extOp, [&](StringRef oldNamehint) {
+    return (oldNamehint + "_" + (signExtension ? "sext_" : "zext_") +
+            std::to_string(targetWidth))
+        .str();
+  });
+
+  return extOp->getOpResult(0);
 }
 
 //===----------------------------------------------------------------------===//
@@ -125,6 +159,9 @@ struct DivOpLowering : public OpConversionPattern<DivOp> {
     else
       divResult = rewriter.create<comb::DivUOp>(loc, lhsValue, rhsValue, false)
                       ->getOpResult(0);
+
+    // Carry over any attributes from the original div op.
+    divResult.getDefiningOp()->setAttrs(op->getAttrs());
 
     // finally truncate back to the expected result size!
     Value truncateResult = extractBits(rewriter, loc, divResult, /*startBit=*/0,
@@ -222,8 +259,11 @@ struct ICmpOpLowering : public OpConversionPattern<ICmpOp> {
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.getRhs(), cmpWidth,
                                      rhsType.isSigned());
 
-    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, combPred, lhsValue, rhsValue,
-                                              false);
+    auto newOp = rewriter.replaceOpWithNewOp<comb::ICmpOp>(
+        op, combPred, lhsValue, rhsValue, false);
+    auto predAttr = newOp.getPredicateAttr();
+    newOp->setAttrs(op->getAttrs());
+    newOp->setAttr(newOp.getPredicateAttrName(), predAttr);
 
     return success();
   }
@@ -253,7 +293,9 @@ struct BinaryOpLowering : public OpConversionPattern<BinOp> {
                                      targetWidth, isLhsTypeSigned);
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.getInputs()[1],
                                      targetWidth, isRhsTypeSigned);
-    rewriter.replaceOpWithNewOp<ReplaceOp>(op, lhsValue, rhsValue, false);
+    auto newOp =
+        rewriter.replaceOpWithNewOp<ReplaceOp>(op, lhsValue, rhsValue, false);
+    newOp->setAttrs(op->getAttrs());
     return success();
   }
 };

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -161,7 +161,7 @@ struct DivOpLowering : public OpConversionPattern<DivOp> {
                       ->getOpResult(0);
 
     // Carry over any attributes from the original div op.
-    divResult.getDefiningOp()->setAttrs(op->getAttrs());
+    divResult.getDefiningOp()->setDialectAttrs(op->getDialectAttrs());
 
     // finally truncate back to the expected result size!
     Value truncateResult = extractBits(rewriter, loc, divResult, /*startBit=*/0,
@@ -261,9 +261,7 @@ struct ICmpOpLowering : public OpConversionPattern<ICmpOp> {
 
     auto newOp = rewriter.replaceOpWithNewOp<comb::ICmpOp>(
         op, combPred, lhsValue, rhsValue, false);
-    auto predAttr = newOp.getPredicateAttr();
-    newOp->setAttrs(op->getAttrs());
-    newOp->setAttr(newOp.getPredicateAttrName(), predAttr);
+    newOp->setDialectAttrs(op->getDialectAttrs());
 
     return success();
   }
@@ -295,7 +293,7 @@ struct BinaryOpLowering : public OpConversionPattern<BinOp> {
                                      targetWidth, isRhsTypeSigned);
     auto newOp =
         rewriter.replaceOpWithNewOp<ReplaceOp>(op, lhsValue, rhsValue, false);
-    newOp->setAttrs(op->getAttrs());
+    newOp->setDialectAttrs(op->getDialectAttrs());
     return success();
   }
 };


### PR DESCRIPTION
This commit propagates attributes from source ops to the "main" generated comb operations. Furthermore, tries to create meaningful names for bit extractions and width extensions.

Fixes #4225.