### PR TITLE
[PrettyPrinter] Add scopedBox helper, to replace previous scoped helpers.

### DIFF
--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -310,6 +310,14 @@ public:
     });
     return *this;
   }
+
+  /// Open a box, invoke the lambda, and close it after.
+  template <typename T, typename Callable>
+  auto scopedBox(T &&t, Callable &&c, Token close = EndToken()) {
+    *this << std::forward<T>(t);
+    auto done = llvm::make_scope_exit([&]() { *this << close; });
+    return std::invoke(std::forward<Callable>(c));
+  }
 };
 
 } // end namespace pretty

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -352,10 +352,9 @@ TEST(PrettyPrinterTest, Stream) {
   PrettyPrinter pp(os, 20);
   TokenStringSaver saver;
   TokenStream<> ps(pp, saver);
-  {
-    ps << PP::ibox0 << "test" << PP::space << "test" << PP::space << "test"
-       << PP::end;
-  }
+  ps.scopedBox(PP::ibox0, [&]() {
+    ps << "test" << PP::space << "test" << PP::space << "test";
+  });
   ps << PP::eof;
   EXPECT_EQ(out.str(), StringRef("test test test"));
 }
@@ -547,17 +546,17 @@ TEST(PrettyPrinterTest, Expr) {
     TokenStringSaver saver;
     TokenStream<> ps(pp, saver);
     out = "\n";
-    {
-      ps << PP::ibox2;
+    ps.scopedBox(PP::ibox2, [&]() {
       ps << "assign" << PP::nbsp << id << PP::nbsp << "=";
       ps << PP::space;
-      ps << PP::ibox0;
-      sumExpr(ps);
-      ps << PP::space << "*" << PP::space;
-      sumExpr(ps);
-      ps << ";";
-      ps << PP::end << PP::end;
-    }
+      ps.scopedBox(PP::ibox0, [&]() {
+        ps << PP::ibox0;
+        sumExpr(ps);
+        ps << PP::space << "*" << PP::space;
+        sumExpr(ps);
+        ps << ";";
+      });
+    });
     ps << PP::newline << PP::eof;
   };
 

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -550,7 +550,6 @@ TEST(PrettyPrinterTest, Expr) {
       ps << "assign" << PP::nbsp << id << PP::nbsp << "=";
       ps << PP::space;
       ps.scopedBox(PP::ibox0, [&]() {
-        ps << PP::ibox0;
         sumExpr(ps);
         ps << PP::space << "*" << PP::space;
         sumExpr(ps);


### PR DESCRIPTION
Useful for ExportVerilog and generally making it easier to track "box" scopes and ensure they're closed.