### PR TITLE
[PrettyPrinter] constexpr instead of giant array literal.

### DIFF
--- a/lib/Support/PrettyPrinterHelpers.cpp
+++ b/lib/Support/PrettyPrinterHelpers.cpp
@@ -34,14 +34,13 @@ void detail::emitNBSP(unsigned n, llvm::function_ref<void(Token)> add) {
     return s;
   })();
 
-  auto size = std::size(spaces);
-  if (n < size) {
+  if (n < numSpaces) {
     if (n != 0)
       add(StringToken({spaces.data(), n}));
     return;
   }
   while (n) {
-    auto chunk = std::min<uint32_t>(n, size - 1);
+    auto chunk = std::min<uint32_t>(n, numSpaces - 1);
     add(StringToken({spaces.data(), chunk}));
     n -= chunk;
   }

--- a/lib/Support/PrettyPrinterHelpers.cpp
+++ b/lib/Support/PrettyPrinterHelpers.cpp
@@ -26,26 +26,23 @@ void TokenStringSaver::clear() { alloc.Reset(); }
 
 /// Add multiple non-breaking spaces as a single token.
 void detail::emitNBSP(unsigned n, llvm::function_ref<void(Token)> add) {
-  static const char spaces[] = {
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-  };
+  constexpr size_t numSpaces = 128;
+  static const std::array<char, numSpaces> spaces = ([]() constexpr {
+    std::array<char, numSpaces> s = {};
+    for (auto &c : s)
+      c = ' ';
+    return s;
+  })();
+
   auto size = std::size(spaces);
   if (n < size) {
     if (n != 0)
-      add(StringToken({spaces, n}));
+      add(StringToken({spaces.data(), n}));
     return;
   }
   while (n) {
     auto chunk = std::min<uint32_t>(n, size - 1);
-    add(StringToken({spaces, chunk}));
+    add(StringToken({spaces.data(), chunk}));
     n -= chunk;
   }
 }

--- a/lib/Support/PrettyPrinterHelpers.cpp
+++ b/lib/Support/PrettyPrinterHelpers.cpp
@@ -34,13 +34,13 @@ void detail::emitNBSP(unsigned n, llvm::function_ref<void(Token)> add) {
     return s;
   })();
 
-  if (n < numSpaces) {
+  if (n <= numSpaces) {
     if (n != 0)
       add(StringToken({spaces.data(), n}));
     return;
   }
   while (n) {
-    auto chunk = std::min<uint32_t>(n, numSpaces - 1);
+    auto chunk = std::min<uint32_t>(n, numSpaces);
     add(StringToken({spaces.data(), chunk}));
     n -= chunk;
   }


### PR DESCRIPTION
Don't make folks count these out :).

Per review feedback: https://github.com/llvm/circt/pull/4192#discussion_r1011004597 .

Also, tweak comparison against character count to use them all not `N-1`, modulo that NFCI.