### PR TITLE
[FIRRTL] Add folds for aggregate constants and subaccesses

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -161,7 +161,7 @@ def BundleCreateOp : FIRRTLOp<"bundlecreate"> {
 
   let assemblyFormat = "$fields attr-dict `:` functional-type($fields, $result)";
   let hasVerifier = 1;
-  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def VectorCreateOp : FIRRTLOp<"vectorcreate"> {
@@ -180,7 +180,7 @@ def VectorCreateOp : FIRRTLOp<"vectorcreate"> {
 
   let assemblyFormat = "$fields attr-dict `:` functional-type($fields, $result)";
   let hasVerifier = 1;
-  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 
@@ -216,6 +216,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
 
   let arguments = (ins BundleType:$input, I32Attr:$fieldIndex);
   let results = (outs FIRRTLBaseType:$result);
+  let hasFolder = 1;
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
   
@@ -260,6 +261,7 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
 
   let arguments = (ins FIRRTLBaseType:$input, I32Attr:$index);
   let results = (outs FIRRTLBaseType:$result);
+  let hasFolder = 1;
   let hasCanonicalizer = 1;
 
   // TODO: Could drop the result type, inferring it from the source.

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -80,6 +80,12 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
   if (auto invalidValue = value.dyn_cast<InvalidValueAttr>())
     return builder.create<InvalidValueOp>(loc, type);
 
+  // Aggregate constants.
+  if (auto arrayAttr = value.dyn_cast<ArrayAttr>()) {
+    if (type.isa<BundleType, FVectorType>())
+      return builder.create<AggregateConstantOp>(loc, type, arrayAttr);
+  }
+
   return nullptr;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Support/APInt.h"
 #include "circt/Support/LLVM.h"
@@ -1849,59 +1850,60 @@ void SubindexOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.insert<SubindexAggOneShot>(context);
 }
+
+OpFoldResult SubindexOp::fold(ArrayRef<Attribute> operands) {
+  auto attr = operands[0].dyn_cast_or_null<ArrayAttr>();
+  if (!attr)
+    return {};
+  auto groundCountPerElement = getType().getGroundFields();
+  auto array = attr.getValue().slice(getIndex() * groundCountPerElement,
+                                     groundCountPerElement);
+  if (getType().isa<IntType>())
+    return array[0];
+  return ArrayAttr::get(getContext(), array);
+}
+
+OpFoldResult SubfieldOp::fold(ArrayRef<Attribute> operands) {
+  auto attr = operands[0].dyn_cast_or_null<ArrayAttr>();
+  if (!attr)
+    return {};
+  auto index = getFieldIndex();
+  auto bundleType = getInput().getType().cast<BundleType>();
+  unsigned start = 0;
+  for (unsigned i = 0; i < index; ++i)
+    start += bundleType.getElement(i).type.getGroundFields();
+  auto array = attr.getValue().slice(
+      start, bundleType.getElement(index).type.getGroundFields());
+  if (getType().isa<IntType>())
+    return array[0];
+  return ArrayAttr::get(getContext(), array);
+}
+
 void SubfieldOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.insert<SubfieldAggOneShot>(context);
 }
 
-namespace {
-
-// Convert bundle Wire to be written once
-struct ConstAgg : public mlir::RewritePattern {
-  ConstAgg(StringRef name, int weight, MLIRContext *context)
-      : RewritePattern(name, weight, context) {}
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    SmallVector<Attribute> values;
-    for (auto v : op->getOperands()) {
-      if (!isConstant(v))
-        return failure();
-      TypeSwitch<Operation *>(v.getDefiningOp())
-          .Case<ConstantOp>(
-              [&](ConstantOp c) { values.push_back(c.getValueAttr()); })
-          .Case<SpecialConstantOp>(
-              [&](SpecialConstantOp c) { values.push_back(c.getValueAttr()); })
-          .Case<AggregateConstantOp>([&](AggregateConstantOp c) {
-            for (auto attr : c.getFields())
-              values.push_back(attr.template cast<IntegerAttr>());
-          });
-    }
-
-    replaceOpWithNewOpAndCopyName<AggregateConstantOp>(
-        rewriter, op, op->getResult(0).getType(),
-        rewriter.getArrayAttr(values));
-    return success();
+static Attribute collectFields(MLIRContext *context,
+                               ArrayRef<Attribute> operands) {
+  SmallVector<Attribute> fields;
+  for (auto operand : operands) {
+    if (!operand)
+      return {};
+    if (auto array = operand.dyn_cast<ArrayAttr>())
+      llvm::append_range(fields, array.getValue());
+    else
+      fields.push_back(operand);
   }
-};
-
-struct ConstBundleAgg : public ConstAgg {
-  ConstBundleAgg(MLIRContext *context)
-      : ConstAgg(BundleCreateOp::getOperationName(), 0, context) {}
-};
-struct ConstVectorAgg : public ConstAgg {
-  ConstVectorAgg(MLIRContext *context)
-      : ConstAgg(VectorCreateOp::getOperationName(), 0, context) {}
-};
-} // namespace
-
-void BundleCreateOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                 MLIRContext *context) {
-  results.insert<ConstBundleAgg>(context);
+  return ArrayAttr::get(context, fields);
 }
 
-void VectorCreateOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                 MLIRContext *context) {
-  results.insert<ConstVectorAgg>(context);
+OpFoldResult BundleCreateOp::fold(ArrayRef<Attribute> operands) {
+  return collectFields(getContext(), operands);
+}
+
+OpFoldResult VectorCreateOp::fold(ArrayRef<Attribute> operands) {
+  return collectFields(getContext(), operands);
 }
 
 namespace {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -735,6 +735,42 @@ firrtl.module @subaccess(out %result: !firrtl.uint<8>, in %vec0: !firrtl.vector<
   firrtl.connect %result, %1 :!firrtl.uint<8>, !firrtl.uint<8>
 }
 
+// CHECK-LABEL: firrtl.module @subindex
+firrtl.module @subindex(out %out : !firrtl.uint<8>) {
+  // CHECK: %c8_ui8 = firrtl.constant 8 : !firrtl.uint<8>
+  // CHECK: firrtl.strictconnect %out, %c8_ui8 : !firrtl.uint<8>
+  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
+  %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 1>
+  firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+}
+
+// CHECK-LABEL: firrtl.module @subindex_agg
+firrtl.module @subindex_agg(out %out : !firrtl.bundle<a: uint<8>>) {
+  // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
+  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.bundle<a: uint<8>>
+  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<bundle<a: uint<8>>, 1>
+  %1 = firrtl.subindex %0[0] : !firrtl.vector<bundle<a: uint<8>>, 1>
+  firrtl.strictconnect %out, %1 : !firrtl.bundle<a: uint<8>>
+}
+
+// CHECK-LABEL: firrtl.module @subfield
+firrtl.module @subfield(out %out : !firrtl.uint<8>) {
+  // CHECK: %c8_ui8 = firrtl.constant 8 : !firrtl.uint<8>
+  // CHECK: firrtl.strictconnect %out, %c8_ui8 : !firrtl.uint<8>
+  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
+  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+  firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+}
+
+// CHECK-LABEL: firrtl.module @subfield_agg
+firrtl.module @subfield_agg(out %out : !firrtl.vector<uint<8>, 1>) {
+  // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
+  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.vector<uint<8>, 1>
+  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: vector<uint<8>, 1>>
+  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a: vector<uint<8>, 1>>) -> !firrtl.vector<uint<8>, 1>
+  firrtl.strictconnect %out, %1 : !firrtl.vector<uint<8>, 1>
+}
+
 // CHECK-LABEL: firrtl.module @issue326
 firrtl.module @issue326(out %tmp57: !firrtl.sint<1>) {
   %c29_si7 = firrtl.constant 29 : !firrtl.sint<7>


### PR DESCRIPTION
This PR moves the aggregate creation when all arguments are constants from a canonicalization to a folder, and adds folders of subindex and subfield of constants.