### PR TITLE
[FIRRTL][GrandCentral]  Get the correct Subinterface name

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1592,7 +1592,7 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
             auto iface = traverseBundle(bundle, id, prefix, path);
             assert(iface && *iface);
             (void)iface;
-            return VerbatimType({getInterfaceName(prefix, bundle), true});
+            return VerbatimType({iface->getNameAttr().str(), true});
           })
       .Case<AugmentedStringTypeAttr>([&](auto field) -> TypeSum {
         return unsupported(field.getName().getValue(), "string");

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1401,6 +1401,140 @@ firrtl.circuit "ZeroWidth" attributes {annotations = [
 
 // -----
 
+firrtl.circuit "Top" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "MyInterface_w1",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+          defName = "SameName",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              id = 1 : i64,
+              name = "uint"
+            }
+          ],
+          name = "SameName"
+        }
+      ],
+      id = 0 : i64,
+      name = "View_w1"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "MyInterface_w2",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+          defName = "SameName",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              id = 3 : i64,
+              name = "uint"
+            }
+          ],
+          name = "SameName"
+        }
+      ],
+      id = 2 : i64,
+      name = "View_w2"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+      directory = ".",
+      filename = "bindings.sv"
+    }
+  ]
+} {
+  firrtl.module @Companion_w1(in %_gen_uint: !firrtl.ref<uint<1>>) attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        id = 0 : i64,
+        name = "View_w1"
+      }
+    ]
+  } {
+    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.ref<uint<1>>
+    %view_uintrefPort = firrtl.node  %0  {
+      annotations = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 1 : i64
+        }
+      ]
+    } : !firrtl.uint<1>
+  }
+  firrtl.module @Companion_w2(in %_gen_uint: !firrtl.ref<uint<2>>) attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        id = 2 : i64,
+        name = "View_w2"
+      }
+    ]
+  } {
+    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.ref<uint<2>>
+    %view_uintrefPort = firrtl.node  %0  {
+      annotations = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 3 : i64
+        }
+      ]
+    } : !firrtl.uint<2>
+  }
+  firrtl.module private @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 0 : i64,
+        name = "View_w1"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 2 : i64,
+        name = "View_w2"
+      }
+    ]
+  } {
+    %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %a_w1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
+    firrtl.strictconnect %a_w1, %c0_ui1 : !firrtl.uint<1>
+    %a_w2 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
+    firrtl.strictconnect %a_w2, %c0_ui2 : !firrtl.uint<2>
+    %companion_w1__gen_uint = firrtl.instance companion_w1  @Companion_w1(in _gen_uint: !firrtl.ref<uint<1>>)
+    %companion_w2__gen_uint = firrtl.instance companion_w2  @Companion_w2(in _gen_uint: !firrtl.ref<uint<2>>)
+    %0 = firrtl.ref.send %a_w1 : !firrtl.uint<1>
+    firrtl.connect %companion_w1__gen_uint, %0 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.send %a_w2 : !firrtl.uint<2>
+    firrtl.connect %companion_w2__gen_uint, %1 : !firrtl.ref<uint<2>>, !firrtl.ref<uint<2>>
+  }
+  firrtl.module @Top() {
+    firrtl.instance dut  @DUT()
+  }
+}
+
+// Check that the correct subinterface name is used when aliasing is possible.
+// Here, SameName is used twice as a sub-interface name and we need to make sure
+// that MyInterface_w2 uses the uniqued name of SameName.
+//
+// See: https://github.com/llvm/circt/issues/4234
+
+// CHECK-LABEL:  sv.interface @MyInterface_w1 {{.+}} {
+// CHECK-NEXT:     sv.verbatim "SameName SameName();"
+// CHECK-NEXT:   }
+// CHECK-LABEL:  sv.interface @MyInterface_w2 {{.+}} {
+// CHECK-NEXT:     sv.verbatim "SameName_0 SameName();"
+// CHECK-NEXT:   }
+
+// -----
+
 firrtl.circuit "YAMLOutputEmptyInterface" attributes {
   annotations = [
     {class = "sifive.enterprise.grandcentral.AugmentedBundleType",


### PR DESCRIPTION
Get the interface name directly from the `InterfaceOp`, instead of deriving from the string. This ensures renamed interface names are correctly used in the  `VerbatimOp`.
Fixes https://github.com/llvm/circt/issues/4234
