### PR TITLE
[FIRRTL][LowerXMR] Copy DenseMap to temporary before insertion

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -433,8 +433,13 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         // following path, that implies the path ends at this node, so copy the
         // xmrPathSuffix and end the path here.
         auto xmrIter = xmrPathSuffix.find(continueFrom.value());
-        if (xmrIter != xmrPathSuffix.end())
-          xmrPathSuffix[indx] = xmrIter->getSecond().str();
+        if (xmrIter != xmrPathSuffix.end()) {
+          SmallString<128> xmrSuffix = xmrIter->getSecond();
+          // The following assignment to the DenseMap can potentially reallocate
+          // the map, that might invalidate the `xmrIter`. So, copy the result
+          // to a temp, and then insert it back to the Map.
+          xmrPathSuffix[indx] = xmrSuffix;
+        }
         continueFrom = None;
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -434,7 +434,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         // xmrPathSuffix and end the path here.
         auto xmrIter = xmrPathSuffix.find(continueFrom.value());
         if (xmrIter != xmrPathSuffix.end())
-          xmrPathSuffix[indx] = xmrIter->getSecond();
+          xmrPathSuffix[indx] = xmrIter->getSecond().str();
         continueFrom = None;
       }
     }


### PR DESCRIPTION
The DenseMap can get reassigned during assignment, so avoid any stale iterator reads.
This commit fixes a bug and an invalid memory read due to DenseMap reallocation by copying the value to a temporary before inserting it back to the DenseMap.