### PR TITLE
[FIRRTL] Cleanup GCT Views Tests to RefType, NFC

### DIFF
--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,660 +1,695 @@
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
 
+// This is the main test that includes different interfaces of different
+// types. All the interfaces share a common, simple circuit that provides two
+// RefType signals, "foo" and "bar".
+
 firrtl.circuit "InterfaceGroundType" attributes {
   annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "description of foo",
-        name = "foo",
-        id = 1 : i64},
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "multi\nline\ndescription\nof\nbar",
-        name = "bar",
-        id = 2 : i64},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "baz",
-        id = 3 : i64}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {a},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64}]} : !firrtl.uint<2>
-    %b = firrtl.wire {annotations = [
-      {a},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 2 : i64}]} : !firrtl.uint<4>
-    %c = firrtl.wire  {annotations = [
-      {a},
-      {circt.fieldID = 4 : i32, class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3 : i64}
-    ]} : !firrtl.vector<bundle<d: uint<2>>, 2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfaceGroundType() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral remains.
-// CHECK-LABEL: firrtl.circuit "InterfaceGroundType" {{.+}} {annotations =
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// CHECK: firrtl.module private @View_companion
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.interface.instance sym @__View_Foo__ {name = "View"} : !sv.interface<@Foo>
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:   #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:   @DUT
-// CHECK-SAME:   #hw.innerNameRef<@DUT::@a>
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.bar = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:   #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:   @DUT
-// CHECK-SAME:   #hw.innerNameRef<@DUT::@b>
-// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.baz = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}[1].d;"
-// CHECK-SAME:   #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:   @DUT
-// CHECK-SAME:   #hw.innerNameRef<@DUT::@c>]
-
-// All Grand Central annotations are removed from the wires.
-// CHECK: firrtl.module private @DUT
-// CHECK: %a = firrtl.wire
-// CHECK-SAME: annotations = [{a}]
-// CHECK: %b = firrtl.wire
-// CHECK-SAME: annotations = [{a}]
-// CHECK: %c = firrtl.wire
-// CHECK-SAME: annotations = [{a}]
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// description of foo"
-// CHECK-NEXT: sv.interface.signal @foo : i2
-// CHECK-NEXT: sv.verbatim "// multi\0A// line\0A// description\0A// of\0A// bar"
-// CHECK-NEXT: sv.interface.signal @bar : i4
-
-// -----
-
-firrtl.circuit "InterfaceVectorType" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-        description = "description of foo",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-           id = 1 : i64,
-           name = "foo"},
-          {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-           id = 2 : i64,
-           name = "foo"}],
-        name = "foo"}],
-      id = 0 : i64,
-      name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a_0 = firrtl.reg %clock {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 1 : i64}]} : !firrtl.uint<1>
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %a_1 = firrtl.regreset %clock, %reset, %c0_ui1 {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 2 : i64}]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfaceVectorType() {
-    %dut_clock, %dut_reset = firrtl.instance dut @DUT(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral remains.
-// CHECK-LABEL: firrtl.circuit "InterfaceVectorType" {{.+}} {annotations =
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// CHECK: firrtl.module private @View_companion
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-
-// All Grand Central annotations are removed from the registers.
-// CHECK: firrtl.module private @DUT
-// CHECK: %a_0 = firrtl.reg
-// CHECK-SAME: annotations = [{a}]
-// CHECK: %a_1 = firrtl.regreset
-// CHECK-SAME: annotations = [{a}]
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// description of foo"
-// CHECK-NEXT: sv.interface.signal @foo : !hw.uarray<2xi1>
-
-// -----
-
-firrtl.circuit "InterfaceBundleType" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-        defName = "Bar",
-        description = "description of Bar",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-           id = 1 : i64,
-           name = "b"},
-          {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-           id = 2 : i64,
-           name = "a"}],
-        name = "bar"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]}  {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %x = firrtl.wire {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 2 : i64}]} : !firrtl.uint<1>
-    %y = firrtl.wire {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfaceBundleType() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral remains.
-// CHECK-LABEL: firrtl.circuit "InterfaceBundleType"
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// All Grand Central annotations are removed from the wires.
-// CHECK-LABEL: firrtl.module private @DUT
-// CHECK: %x = firrtl.wire
-// CHECK-SAME: annotations = [{a}]
-// CHECK: %y = firrtl.wire
-// CHECK-SAME: annotations = [{a}]
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// description of Bar"
-// CHECK-NEXT: Bar bar();
-
-// CHECK: sv.interface @Bar
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.interface.signal @b : i2
-// CHECK-NEXT: sv.interface.signal @a : i1
-
-// -----
-
-firrtl.circuit "InterfaceVecOfBundleType" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-           defName = "Bar",
-           elements = [
-             {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-              id = 1 : i64,
-              name = "b"}],
-           name = "bar"}],
-        name = "bar"}],
-     id = 0 : i64,
-     name = "View"}]}  {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %x = firrtl.wire {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfaceVecOfBundleType() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: firrtl.circuit "InterfaceVecOfBundleType"
-
-// CHECK: sv.interface @Foo
-// CHECK-NEXT: sv.verbatim "Bar bar[1]();"
-
-// CHECK: sv.interface @Bar
-
-// -----
-
-firrtl.circuit "VecOfVec" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-        description = "description of foo",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-           description = "description of foo",
-           elements = [
-             {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-              id = 1 : i64,
-              name = "foo"},
-             {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-              id = 2 : i64,
-              name = "foo"}],
-           name = "foo"}],
-        name = "foo"}],
-      id = 0 : i64,
-      name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 2 : i64}]} : !firrtl.uint<3>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @VecOfVec() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: firrtl.circuit "VecOfVec"
-
-// CHECK:      firrtl.module private @View_companion
-// CHECK-NEXT:    sv.interface.instance sym @__View_Foo__ {name = "View"} : !sv.interface<@Foo>
-// CHECK-NEXT:    assign {{[{][{]0[}][}]}}.foo[0][0]
-// CHECK-SAME:      #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-NEXT:    assign {{[{][{]0[}][}]}}.foo[0][1]
-// CHECK-SAME:      #hw.innerNameRef<@View_companion::@__View_Foo__>
-
-// CHECK:      sv.interface @Foo
-// CHECK:        sv.interface.signal @foo : !hw.uarray<1xuarray<2xi3>>
-
-// -----
-
-firrtl.circuit "InterfaceNode" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "some expression",
-        id = 1 : i64,
-        name = "foo"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire : !firrtl.uint<2>
-    %notA = firrtl.not %a : (!firrtl.uint<2>) -> !firrtl.uint<2>
-    %b = firrtl.node %notA {
-      annotations = [
-        {a},
-        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         defName = "Foo",
-         name = "foo",
-         id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfaceNode() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral remains.
-// CHECK-LABEL: firrtl.circuit "InterfaceNode" {{.+}} {annotations =
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// The Grand Central annotation is removed from the node.
-// CHECK: firrtl.node
-// CHECK-SAME: annotations = [{a}]
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// some expression"
-// CHECK-NEXT: sv.interface.signal @foo : i2
-
-// -----
-
-firrtl.circuit "InterfacePort" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "description of foo",
-        id = 1 : i64,
-        name = "foo"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT(in %a : !firrtl.uint<4>) attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ],
-    portAnnotations = [[
-      {a},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64}]] } {
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @InterfacePort() {
-    %dut_a = firrtl.instance dut @DUT(in a : !firrtl.uint<4>)
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral remains.
-// CHECK-LABEL: firrtl.circuit "InterfacePort" {{.+}} {annotations =
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// The Grand Central annotations are removed.
-// CHECK: firrtl.module private @DUT
-// CHECK-SAME: %a: !firrtl.uint<4> sym @a [{a}]
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// description of foo"
-// CHECK-NEXT: sv.interface.signal @foo : i4
-
-// -----
-
-firrtl.circuit "UnsupportedTypes" attributes {
-  annotations = [
-    {a},
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedStringType",
-        name = "string"},
-       {class = "sifive.enterprise.grandcentral.AugmentedBooleanType",
-        name = "boolean"},
-       {class = "sifive.enterprise.grandcentral.AugmentedIntegerType",
-        name = "integer"},
-       {class = "sifive.enterprise.grandcentral.AugmentedDoubleType",
-        name = "double"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @UnsupportedTypes() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// AugmentedBundleType is removed, ExtractGrandCentral and {a} remain.
-// CHECK-LABEL: firrtl.circuit "UnsupportedTypes" {{.+}} {annotations =
-// CHECK-SAME: {a}
-// CHECK-SAME: class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
-// CHECK-NOT: class = "sifive.enterprise.grandcentral.AugmentedBundleType"
-// CHECK-SAME: {
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.verbatim "// <unsupported string type> string;"
-// CHECK-NEXT: sv.verbatim "// <unsupported boolean type> boolean;"
-// CHECK-NEXT: sv.verbatim "// <unsupported integer type> integer;"
-// CHECK-NEXT: sv.verbatim "// <unsupported double type> double;"
-
-// -----
-
-firrtl.circuit "BindInterfaceTest"  attributes {
-  annotations = [{
-    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-    defName = "InterfaceName",
-    elements = [{
-      class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-      id = 1 : i64,
-      name = "_a"
-    }],
-    id = 0 : i64,
-    name = "View"
-  },
-  {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT(
-    in %a: !firrtl.uint<8>, out %b: !firrtl.uint<8>) attributes {
-      annotations = [{
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        defName = "InterfaceName",
-        id = 0 : i64,
-        name = "instanceName"}],
-      portAnnotations = [[
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "GroundView",
+      elements = [
         {
-          circt.fieldID = 0 : i32,
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          description = "description of foo",
+          name = "foo",
+          id = 1 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          description = "multi\nline\ndescription\nof\nbar",
+          name = "bar",
+          id = 2 : i64
+        }
+      ],
+      id = 0 : i64,
+      name = "GroundView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "VectorView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              name = "foo",
+              id = 4 : i64
+            },
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              name = "bar",
+              id = 5 : i64
+            }
+          ],
+          name = "vector"
+        }
+      ],
+      id = 3 : i64,
+      name = "VectorView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "BundleView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+          defName = "Bundle",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              name = "foo",
+              id = 7 : i64
+            },
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              name = "bar",
+              id = 8 : i64
+            }
+          ],
+          name = "bundle"
+        }
+      ],
+      id = 6 : i64,
+      name = "BundleView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "VectorOfBundleView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+              defName = "Bundle2",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "foo",
+                  id = 10 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "bar",
+                  id = 11 : i64
+                }
+              ],
+              name = "bundle2"
+            }
+          ],
+          name = "vector"
+        }
+      ],
+      id = 9 : i64,
+      name = "VectorOfBundleView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "VectorOfVectorView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+              defName = "Vector2",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "foo",
+                  id = 13 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "bar",
+                  id = 14 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "baz",
+                  id = 15 : i64
+                }
+              ],
+              name = "vector2"
+            },
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+              defName = "Vector2",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "foo",
+                  id = 16 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "bar",
+                  id = 17 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "baz",
+                  id = 18 : i64
+                }
+              ],
+              name = "vector2"
+            }
+          ],
+          name = "vector"
+        }
+      ],
+      id = 12 : i64,
+      name = "VectorOfVectorView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "ZeroWidthView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 20 : i64,
+          name = "zerowidth"
+        }
+      ],
+      id = 19 : i64,
+      name = "ZeroWidthView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "ConstantView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          description = "description of foo",
+          name = "foo",
+          id = 22 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          description = "multi\nline\ndescription\nof\nbar",
+          name = "bar",
+          id = 23 : i64
+        }
+      ],
+      id = 21 : i64,
+      name = "ConstantView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "UnsupportedView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedStringType",
+          name = "string"
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedBooleanType",
+          name = "boolean"
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedIntegerType",
+          name = "integer"
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedDoubleType",
+          name = "double"
+        }
+      ],
+      id = 24 : i64,
+      name = "UnsupporteView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "VectorOfVerbatimView",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+              defName = "Vector4",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                }
+              ],
+              name = "vector4"
+            },
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+              defName = "Vector4",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedStringType",
+                  name = "baz"
+                }
+              ],
+              name = "vector4"
+            }
+          ],
+          name = "vectorOfVerbatim"
+        }
+      ],
+      id = 25 : i64,
+      name = "VectorOfVerbatimView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+      directory = "gct-dir",
+      filename = "bindings.sv"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
+      filename = "gct.yaml"
+    }
+  ]
+} {
+  firrtl.module @Companion() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "GroundView",
+        id = 0 : i64,
+        name = "GroundView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "VectorView",
+        id = 3 : i64,
+        name = "VectorView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "BundleView",
+        id = 6 : i64,
+        name = "BundleView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "VectorOfBundleView",
+        id = 9 : i64,
+        name = "VectorOfBundleView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "VectorOfVectorView",
+        id = 12 : i64,
+        name = "VectorOfVectorView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "ZeroWidthView",
+        id = 19 : i64,
+        name = "ZeroWidthView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "ConstantView",
+        id = 21 : i64,
+        name = "ConstantView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "UnsupportedView",
+        id = 24 : i64,
+        name = "UnsupportedView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+        defName = "VectorOfVerbatimView",
+        id = 25 : i64,
+        name = "VectorOfVerbatimView"
+      }
+    ]
+  } {
+
+    // These are dummy references created for the purposes of the test.
+    %_ui0 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<0>
+    %_ui1 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<1>
+    %_ui2 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<2>
+    %ref_ui0 = firrtl.ref.send %_ui0 : !firrtl.uint<0>
+    %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
+    %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
+
+    %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
+    %foo = firrtl.node %ui1 {
+      annotations = [
+        {
           class = "sifive.enterprise.grandcentral.AugmentedGroundType",
           id = 1 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 4 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 5 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 7 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 10 : i64
         }
-      ], []
       ]
-    }
-      {
-    firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.instance View_companion @View_companion()
+    } : !firrtl.uint<1>
+
+    %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
+    %bar = firrtl.node %ui2 {
+      annotations = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 2 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 8 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 11 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 13 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 14 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 15 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 16 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 17 : i64
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 18 : i64
+        }
+      ]
+    } : !firrtl.uint<2>
+
+    %ui0 = firrtl.ref.resolve %ref_ui0 : !firrtl.ref<uint<0>>
+    %baz = firrtl.node %ui0 {
+      annotations = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 20 : i64
+        }
+      ]
+    } : !firrtl.uint<0>
+
   }
-  firrtl.module @BindInterfaceTest() {
-    %dut_a, %dut_b = firrtl.instance dut @DUT(in a: !firrtl.uint<8>, out b: !firrtl.uint<8>)
+  firrtl.module @InterfaceGroundType() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 0 : i64,
+        name = "GroundView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 3 : i64,
+        name = "VectorView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 6 : i64,
+        name = "BundleView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 9 : i64,
+        name = "VectorOfBundle"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 12 : i64,
+        name = "VectorOfVector"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 19 : i64,
+        name = "ZeroWidthView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 24 : i64,
+        name = "UnsupportedView"
+      },
+      {
+        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+        id = 25 : i64,
+        name = "VectorOfVerbatimView"
+      }
+    ]
+  } {
+    firrtl.instance companion @Companion()
   }
 }
 
-// CHECK: module {
-// CHECK-LABEL: firrtl.circuit "BindInterfaceTest"
-
-// Annotations are removed from the circuit.
-// CHECK-NOT: annotations
+// All AugmentedBundleType annotations are removed from the circuit.
+//
+// CHECK-LABEL: firrtl.circuit "InterfaceGroundType" {{.+}} {annotations =
+// CHECK-SAME:    class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation"
+// CHECK-NOT:     class = "sifive.enterprise.grandcentral.AugmentedBundleType"
 // CHECK-SAME: {
 
-// CHECK: firrtl.module private @View_companion()
-// CHECK-NEXT: sv.interface.instance sym @[[INTERFACE_INSTANCE_SYMBOL:.+]]
+// Check YAML Output.
+//
+// Note: Built-in vector serialization works slightly differently than
+// user-defined vector serialization.  This results in the verbose "[ ]" for the
+// empty dimensions vector, and the terse "[]" for the empty instances vector.
+//
+// CHECK:      sv.verbatim
+// CHECK-SAME:   - name: GroundView
+// CHECK-SAME:     fields:
+// CHECK-SAME:       - name: foo
+// CHECK-SAME:         description: description of foo
+// CHECK-SAME:         dimensions: [ ]
+// CHECK-SAME:         width: 1
+// CHECK-SAME:       - name: bar
+// CHECK-SAME:         description: \22multi\\nline\\ndescription\\nof\\nbar\22
+// CHECK-SAME:         dimensions: [ ]
+// CHECK-SAME:         width: 2
+// CHECK-SAME:     instances: []
+// CHECK-SAME:   - name: VectorView
+// CHECK-SAME:     fields:
+// CHECK-SAME:       - name: vector
+// CHECK-SAME:         dimensions: [ 2 ]
+// CHECK-SAME:         width: 1
+// CHECK-SAME:     instances: []
+// CHECK-SAME:   - name: BundleView
+// CHECK-SAME:     fields: []
+// CHECK-SAME:     instances:
+// CHECK-SAME:       - name: bundle
+// CHECK-SAME:         dimensions: [ ]
+// CHECK-SAME:         interface:
+// CHECK-SAME:           name: Bundle
+// CHECK-SAME:           fields:
+// CHECK-SAME:             - name: foo
+// CHECK-SAME:               dimensions: [ ]
+// CHECK-SAME:               width: 1
+// CHECK-SAME:             - name: bar
+// CHECK-SAME:               dimensions: [ ]
+// CHECK-SAME:               width: 2
+// CHECK-SAME:           instances: []
+// CHECK-SAME:   - name: VectorOfBundleView
+// CHECK-SAME:     fields: []
+// CHECK-SAME:     instances:
+// CHECK-SAME:       - name: vector
+// CHECK-SAME:         dimensions: [ 1 ]
+// CHECK-SAME:         interface:
+// CHECK-SAME:           name: Bundle2
+// CHECK-SAME:           fields:
+// CHECK-SAME:             - name: foo
+// CHECK-SAME:               dimensions: [ ]
+// CHECK-SAME:               width: 1
+// CHECK-SAME:             - name: bar
+// CHECK-SAME:               dimensions: [ ]
+// CHECK-SAME:               width: 2
+// CHECK-SAME:           instances: []
+// CHECK-SAME:   - name: VectorOfVectorView
+// CHECK-SAME:     fields:
+// CHECK-SAME:       - name: vector
+// CHECK-SAME:         dimensions: [ 3, 2 ]
+// CHECK-SAME:         width: 2
+// CHECK-SAME:     instances: []
+// CHECK-SAME:   - name: ZeroWidthView
+// CHECK-SAME:     fields:
+// CHECK-SAME:       - name: zerowidth
+// CHECK-SAME:         dimensions: [ ]
+// CHECK-SAME:         width: 0
+// CHECK-SAME:     instances: []
+// CHECK-SAME:   - name: UnsupportedView
+// CHECK-SAME:     fields: []
+// CHECK-SAME:     instances: []
+// CHECK-SAME:   - name: VectorOfVerbatimView
+// CHECK-SAME:     fields: []
+// CHECK-SAME:     instances: []
 
-// Annotations are removed from the module.
-// CHECK: firrtl.module private @DUT
-// CHECK-NOT: annotations
-// CHECK-SAME: %a
+// The shared companion contains all instantiated interfaaces.
+// AugmentedGroundType annotations are removed.  Interface is driven via XMRs
+// directly from ref resolve ops.
+//
+// CHECK:          firrtl.module @Companion
+// CHECK-SAME:       output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfVerbatim:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "VectorOfVerbatimView"} : !sv.interface<@VectorOfVerbatimView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[unsupportedSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "UnsupportedView"} : !sv.interface<@UnsupportedView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[zeroWidthSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "ZeroWidthView"} : !sv.interface<@ZeroWidthView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfVectorSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "VectorOfVectorView"} : !sv.interface<@VectorOfVectorView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfBundleSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "VectorOfBundleView"} : !sv.interface<@VectorOfBundleView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[bundleSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "BundleView"} : !sv.interface<@BundleView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[vectorSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "VectorView"} : !sv.interface<@VectorView>
+//
+// CHECK-NEXT:       sv.interface.instance sym @[[groundSym:[a-zA-Z0-9_]+]]
+// CHECK-SAME:         {name = "GroundView"} : !sv.interface<@GroundView>
+//
+// CHECK:            %[[foo_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.ref<uint<1>>
+// CHECK-NOT:        sifive.enterprise.grandcentral.AugmentedGroundType
+// CHECK:            %[[bar_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.ref<uint<2>>
+// CHECK-NOT:        sifive.enterprise.grandcentral.AugmentedGroundType
+//
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.foo = {{0}};"
+// CHECK-SAME:         (%[[foo_ref]]) : !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Companion::@[[groundSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.bar = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2> {symbols = [#hw.innerNameRef<@Companion::@[[groundSym]]>]}
+//
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0] = {{0}};"
+// CHECK-SAME:         (%[[foo_ref]]) : !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Companion::@[[vectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[1] = {{0}};"
+// CHECK-SAME:         (%[[foo_ref]]) : !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Companion::@[[vectorSym]]>]}
+//
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.bundle.foo = {{0}};"
+// CHECK-SAME:         (%[[foo_ref]]) : !firrtl.uint<1> {symbols = [#hw.innerNameRef<@Companion::@[[bundleSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.bundle.bar = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2> {symbols = [#hw.innerNameRef<@Companion::@[[bundleSym]]>]}
+//
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0].foo = {{0}};"
+// CHECK-SAME:         (%[[foo_ref]]) : !firrtl.uint<1>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfBundleSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0].bar = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfBundleSym]]>]}
+//
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0][0] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0][1] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[0][2] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[1][0] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[1][1] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vector[1][2] = {{0}};"
+// CHECK-SAME:         (%[[bar_ref]]) : !firrtl.uint<2>
+// CHECK-SAME:         {symbols = [#hw.innerNameRef<@Companion::@[[vectorOfVectorSym]]>]}
+//
+// There are no more verbatim assigns after this.  The zero-width view and any
+// "unsupported" types, e.g., AugmentedStringType, are not given XMRs.
+//
+// CHECK-NOT:        sv.verbatim "assign
 
-// The interface is added.
-// CHECK: sv.interface @InterfaceName
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-// CHECK-NEXT: sv.interface.signal @_a : i8
+// The companion instance is marked "lowerToBind" in the parent.  This instance
+// gets the correct output file.
+//
+// CHECK:          firrtl.module @InterfaceGroundType()
+// CHECK:            firrtl.instance companion
+// CHECK-SAME:         lowerToBind
+// CHECK-SAME:         output_file = #hw.output_file<"bindings.sv", excludeFromFileList>}
 
-// -----
-
-firrtl.circuit "MultipleGroundTypeInterfaces" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "foo",
-        id = 1 : i64}],
-     id = 0 : i64,
-     name = "View1"},
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Bar",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "foo",
-        id = 3 : i64}],
-     id = 2 : i64,
-     name = "View2"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View1"},
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Bar",
-       id = 2 : i64,
-       name = "View2"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"},
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 2 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {a},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64},
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 3 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @MultipleGroundTypeInterfaces() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK: sv.interface @Foo
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
-
-// CHECK: sv.interface @Bar
-// CHECK-SAME: comment = "VCS coverage exclude_file"
-// CHECK-SAME: output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+// The body of all interfaces are populated with the correct signals, names,
+// comments, and types.
+//
+// CHECK:      sv.interface @GroundView
+// CHECK-SAME:   comment = "VCS coverage exclude_file"
+// CHECK-SAME:   output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
+// CHECK-NEXT:   sv.verbatim "// description of foo"
+// CHECK-NEXT:   sv.interface.signal @foo : i1
+// CHECK-NEXT:   sv.verbatim "// multi\0A// line\0A// description\0A// of\0A// bar"
+// CHECK-NEXT:   sv.interface.signal @bar : i2
+//
+// CHECK:      sv.interface @VectorView
+// CHECK-NEXT:   sv.interface.signal @vector : !hw.uarray<2xi1>
+//
+// CHECK:      sv.interface @BundleView
+// CHECK-NEXT:   sv.verbatim "Bundle bundle();"
+//
+// CHECK:      sv.interface @Bundle
+// CHECK-NEXT:   sv.interface.signal @foo : i1
+// CHECK-NEXT:   sv.interface.signal @bar : i2
+//
+// CHECK:      sv.interface @VectorOfBundleView
+// CHECK-NEXT:   sv.verbatim "Bundle2 vector[1]();"
+//
+// CHECK:      sv.interface @Bundle2
+// CHECK-NEXT:   sv.interface.signal @foo : i1
+// CHECK-NEXT:   sv.interface.signal @bar : i2
+//
+// CHECK:      sv.interface @VectorOfVectorView
+// CHECK-NEXT:   sv.interface.signal @vector : !hw.uarray<2xuarray<3xi2>>
+//
+// CHECK:      sv.interface @ZeroWidthView
+// CHECK-NEXT:   sv.interface.signal @zerowidth : i0
+//
+// CHECK:      sv.interface @UnsupportedView
+// CHECK-NEXT:   sv.verbatim "// <unsupported string type> string;"
+// CHECK-NEXT:   sv.verbatim "// <unsupported boolean type> boolean;"
+// CHECK-NEXT:   sv.verbatim "// <unsupported integer type> integer;"
+// CHECK-NEXT:   sv.verbatim "// <unsupported double type> double;"
+//
+// CHECK:      sv.interface @VectorOfVerbatimView
+// CHECK-NEXT:   sv.verbatim "// <unsupported string type> vectorOfVerbatim[2][3];"
 
 // -----
 
@@ -699,323 +734,6 @@ firrtl.circuit "PrefixInterfacesAnnotation"
 
 // Interface "Bar" is prefixed.
 // CHECK:       sv.interface @PREFIX_Bar
-
-// -----
-
-
-firrtl.circuit "NestedInterfaceVectorTypes" attributes {annotations = [
-  {
-    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-    id = 0,
-    name = "View",
-    defName = "Foo",
-    elements = [{
-      class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-      name = "bar",
-      description = "description of bar",
-      elements = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-          name = "baz",
-          elements = [
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1, name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2, name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3, name = "baz"}
-          ]
-        },
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-          name = "baz",
-          elements = [
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4, name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5, name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 6, name = "baz"}
-          ]
-        }
-      ]
-    }]
-  },
-  {
-    class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-    directory = "gct-dir",
-    filename = "bindings.sv"
-  }
-]} {
-
-  firrtl.module private @View_companion() attributes {annotations = [
-    {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion", defName = "Foo", id = 0, name = "View"}
-  ]} {}
-
-  firrtl.module private @DUT() attributes {annotations = [
-    {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent", id = 0, name = "view"}
-  ]} {
-    %a0 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1}]} : !firrtl.uint<1>
-    %a1 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2}]} : !firrtl.uint<1>
-    %a2 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3}]} : !firrtl.uint<1>
-    %b0 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4}]} : !firrtl.uint<1>
-    %b1 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5}]} : !firrtl.uint<1>
-    %b2 = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 6}]} : !firrtl.uint<1>
-    firrtl.instance View_companion @View_companion()
-  }
-
-  firrtl.module @NestedInterfaceVectorTypes() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: firrtl.circuit "NestedInterfaceVectorTypes"
-// CHECK:         firrtl.module private @View_companion
-// CHECK-NEXT:      sv.interface.instance sym @__View_Foo__ {name = "View"} : !sv.interface<@Foo>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@a0>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@a1>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@a2>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@b0>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@b1>
-// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:        #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:        @DUT
-// CHECK-SAME:        #hw.innerNameRef<@DUT::@b2>
-// CHECK:         sv.interface @Foo
-// CHECK-NEXT:      sv.verbatim "// description of bar"
-// CHECK-NEXT:      sv.interface.signal @bar : !hw.uarray<2xuarray<3xi1>>
-
-// -----
-
-firrtl.circuit "VerbatimTypesInVector" attributes {annotations = [
-  {
-    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-    id = 0,
-    name = "View",
-    defName = "Foo",
-    elements = [{
-      class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-      name = "bar",
-      description = "description of bar",
-      elements = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-          name = "baz",
-          description = "description of baz",
-          elements = [
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"}
-          ]
-        },
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-          name = "baz",
-          description = "description of baz",
-          elements = [
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
-            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"}
-          ]
-        }
-      ]
-    }]
-  },
-  {
-    class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-    directory = "gct-dir",
-    filename = "bindings.sv"
-  }
-]} {
-
-  firrtl.module private @View_companion() attributes {annotations = [
-    {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion", defName = "Foo", id = 0, name = "View"}
-  ]} {}
-
-  firrtl.module private @DUT() attributes {annotations = [
-    {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent", id = 0, name = "view"}
-  ]} {
-    firrtl.instance View_companion @View_companion()
-  }
-
-  firrtl.module @VerbatimTypesInVector() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: firrtl.circuit "VerbatimTypesInVector"
-// CHECK:         sv.interface @Foo
-// CHECK-NEXT:      sv.verbatim "// description of bar"
-// CHECK-NEXT:      sv.verbatim "// <unsupported string type> bar[2][3];"
-
-// -----
-
-firrtl.circuit "ParentIsMainModule" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "foo",
-        id = 1 : i64}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module @ParentIsMainModule() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {a},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-}
-
-// Check that this doesn't error out and that the XMR is generated correctly.
-//
-// CHECK-LABEL: firrtl.circuit "ParentIsMainModule"
-// CHECK:       firrtl.module private @View_companion
-// CHECK-NEXT:    sv.interface.instance sym @__View_Foo__ {name = "View"} : !sv.interface<@Foo>
-// CHECK-NEXT:    sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
-// CHECK-SAME:      #hw.innerNameRef<@View_companion::@__View_Foo__>
-// CHECK-SAME:      @ParentIsMainModule
-// CHECK-SAME:      #hw.innerNameRef<@ParentIsMainModule::@a>
-
-// -----
-
-firrtl.circuit "DedupedPath" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "foo",
-        id = 1 : i64},
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "bar",
-        id = 2 : i64},
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "baz",
-        id = 3 : i64},
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        name = "qux",
-        id = 4 : i64}],
-     id = 0 : i64,
-     name = "View"}]} {
-  // TODO: Remove @nla_0 and @nla once NLAs are fully migrated to use hierpaths
-  // that end at the module.
-  firrtl.hierpath private @nla_0 [@DUT::@tile1, @Tile::@w]
-  firrtl.hierpath private @nla [@DUT::@tile2, @Tile::@w]
-  firrtl.hierpath private @nla_new_0 [@DUT::@tile1, @Tile]
-  firrtl.hierpath private @nla_new_1 [@DUT::@tile2, @Tile]
-  firrtl.module private @Tile() {
-    %w = firrtl.wire sym @w {
-      annotations = [
-        {
-          circt.fieldID = 0 : i32,
-          circt.nonlocal = @nla,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 2 : i64
-        },
-        {
-          circt.fieldID = 0 : i32,
-          circt.nonlocal = @nla_0,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 1 : i64
-        }]} : !firrtl.uint<8>
-    %x = firrtl.wire {
-      annotations = [
-        {
-          circt.fieldID = 0 : i32,
-          circt.nonlocal = @nla_new_0,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 3 : i64
-        },
-        {
-          circt.fieldID = 0 : i32,
-          circt.nonlocal = @nla_new_1,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 4 : i64
-        }]} : !firrtl.uint<8>
-  }
-  firrtl.module private @MyView_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       id = 0 : i64,
-       name = "MyView"},
-      {class = "firrtl.transforms.NoDedupAnnotation"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "MyView"},
-      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance tile1 sym @tile1 @Tile()
-    firrtl.instance tile2 sym @tile2 @Tile()
-    firrtl.instance MyView_companion  @MyView_companion()
-  }
-  firrtl.module @DedupedPath() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// Chceck that NLAs that encode a path to a Grand Central leaf work.  This
-// should result in two things:
-//   1) The compute XMR should include information from the NLA.
-//   2) The NLAs should be removed.
-//
-// CHECK-LABEL:          firrtl.circuit "DedupedPath"
-// CHECK-NOT:              firrtl.hierpath
-// CHECK-NEXT:             firrtl.module private @Tile()
-// CHECK-NOT:                circt.nonlocal
-// CHECK:                  firrtl.module private @MyView_companion
-// CHECK-NEXT:               sv.interface.instance sym @__MyView_Foo__ {name = "MyView"} : !sv.interface<@Foo>
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.foo = {{1}}.{{2}}.{{3}};"
-// CHECK-SAME:                 symbols = [#hw.innerNameRef<@MyView_companion::@__MyView_Foo__>,
-// CHECK-SAME:                   @DUT,
-// CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile1>,
-// CHECK-SAME:                   #hw.innerNameRef<@Tile::@w>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.bar = {{1}}.{{2}}.{{3}};"
-// CHECK-SAME:                 symbols = [#hw.innerNameRef<@MyView_companion::@__MyView_Foo__>,
-// CHECK-SAME:                   @DUT,
-// CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile2>,
-// CHECK-SAME:                   #hw.innerNameRef<@Tile::@w>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.baz = {{1}}.{{2}}.{{3}};"
-// CHECK-SAME:                 symbols = [#hw.innerNameRef<@MyView_companion::@__MyView_Foo__>,
-// CHECK-SAME:                   @DUT,
-// CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile1>,
-// CHECK-SAME:                   #hw.innerNameRef<@Tile::@x>]
-// CHECK-NEXT{LITERAL}:      sv.verbatim "assign {{0}}.qux = {{1}}.{{2}}.{{3}};"
-// CHECK-SAME:                 symbols = [#hw.innerNameRef<@MyView_companion::@__MyView_Foo__>,
-// CHECK-SAME:                   @DUT,
-// CHECK-SAME:                   #hw.innerNameRef<@DUT::@tile2>,
-// CHECK-SAME:                   #hw.innerNameRef<@Tile::@x>]
-// CHECK:                  firrtl.module private @DUT()
-// CHECK-NOT:                circt.nonlocal
-// CHECK:                  firrtl.module @DedupedPath
-// CHECK-NEXT:               firrtl.instance dut
-// CHECK-NOT:                  sym
 
 // -----
 
@@ -1233,174 +951,6 @@ firrtl.circuit "DirectoryBehaviorWithoutDUT" attributes {
 
 // -----
 
-firrtl.circuit "InterfaceInTestHarness" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "description of foo",
-        name = "foo",
-        id = 1 : i64}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.firrtl.TestBenchDirAnnotation",
-     dirname = "testbenchDir"}]} {
-  firrtl.module @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
-    ]} {
-  }
-  firrtl.module @InterfaceInTestHarness() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}]} {
-    firrtl.instance dut @DUT()
-    %a = firrtl.wire {annotations = [
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64},
-      {class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-}
-
-// Check that an interface, instantiated inside the test harness (technically,
-// in a module which is not a child of the marked Design Under Test), will not
-// be extracted via a bind.  Also, check that interfaces only inside the test
-// harness will be written to the test harness directory.
-//
-// CHECK-LABEL: "InterfaceInTestHarness"
-// CHECK:       firrtl.module @View_companion
-// CHECK:         sv.interface.instance
-// CHECK-NOT:       output_file
-// CHECK-NOT:       lowerToBind
-// CHECK-SAME:      !sv.interface
-// CHECK:       firrtl.module @InterfaceInTestHarness
-// CHECK:         firrtl.instance View_companion
-// CHECK-NOT:       output_file
-// CHECK-NOT:       lowerToBind
-// CHECK-NEXT:  }
-// CHECK:       sv.interface
-// CHECK-SAME:    output_file = #hw.output_file<"testbenchDir{{/|\\\\}}", excludeFromFileList>
-
-// -----
-
-firrtl.circuit "ZeroWidth" attributes {annotations = [
-  {
-    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-    defName = "MyInterface",
-    elements = [
-      {
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "a zero-width port",
-        id = 1 : i64,
-        name = "ground"
-      }
-    ],
-    id = 0 : i64,
-    name = "MyView"
-  }
-]} {
-  firrtl.module private @MyView_companion() attributes {annotations = [
-    {
-      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-      id = 0 : i64,
-      name = "MyView"}
-  ]} {}
-  firrtl.module @ZeroWidth() attributes {annotations = [
-    {
-      class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-      id = 0 : i64,
-      name = "MyView"}
-  ]} {
-    %w = firrtl.wire {annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 1 : i64
-      }
-    ]} : !firrtl.uint<0>
-    %invalid_ui0 = firrtl.invalidvalue : !firrtl.uint<0>
-    firrtl.strictconnect %w, %invalid_ui0 : !firrtl.uint<0>
-    firrtl.instance MyView_companion @MyView_companion()
-  }
-}
-
-// Check that a view of a zero-width thing produces a comment in the output and
-// not XMR.
-//
-// CHECK-LABEL: firrtl.circuit "ZeroWidth"
-//
-// CHECK:       firrtl.module private @MyView_companion() {
-// CHECK-NOT:     sv.verbatim
-// CHECK-NEXT:  }
-//
-// CHECK-LABEL: sv.interface @MyInterface
-// CHECK-NEXT:    sv.verbatim "// a zero-width port"
-// CHECK-NEXT:    sv.interface.signal @ground : i0
-
-// -----
-
-firrtl.circuit "ZeroWidth" attributes {annotations = [
-  {
-    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-    defName = "MyInterface",
-    elements = [
-      {
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 1 : i64,
-        name = "ground"
-      }
-    ],
-    id = 0 : i64,
-    name = "MyView"
-  }
-]} {
-  firrtl.module private @MyView_companion() attributes {annotations = [
-    {
-      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-      id = 0 : i64,
-      name = "MyView"}
-  ]} {}
-  firrtl.module @ZeroWidth() attributes {annotations = [
-    {
-      class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-      id = 0 : i64,
-      name = "MyView"}
-  ]} {
-    %w = firrtl.wire {annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 1 : i64
-      }
-    ]} : !firrtl.uint<1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.strictconnect %w, %c1_ui1 : !firrtl.uint<1>
-    firrtl.instance MyView_companion @MyView_companion()
-  }
-}
-
-// Check that a constant is sunk into the interface mapping module and that no
-// symbol is created on the viewed component.
-//
-// CHECK-LABEL:         firrtl.circuit "ZeroWidth"
-// CHECK:                 firrtl.module private @MyView_companion()
-// CHECK-NEXT:              sv.interface.instance
-// CHECK-NEXT{LITERAL}:     sv.verbatim "assign {{0}}.ground = 1'h1;
-// CHECK:                 firrtl.module @ZeroWidth()
-// CHECK-NEXT:            %w = firrtl.wire : !firrtl.uint<1>
-
-// -----
-
 firrtl.circuit "Top" attributes {
   annotations = [
     {
@@ -1532,407 +1082,6 @@ firrtl.circuit "Top" attributes {
 // CHECK-LABEL:  sv.interface @MyInterface_w2 {{.+}} {
 // CHECK-NEXT:     sv.verbatim "SameName_0 SameName();"
 // CHECK-NEXT:   }
-
-// -----
-
-firrtl.circuit "RefTypes" attributes {
-  annotations = [
-    {
-      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-      defName = "Interface",
-      elements = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          description = "a wire called 'uint'",
-          id = 1 : i64,
-          name = "uint"
-        },
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-          description = "a vector called 'vec'",
-          elements = [
-            {
-              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-              id = 2 : i64,
-              name = "vec"
-            },
-            {
-              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-              id = 3 : i64,
-              name = "vec"
-            }
-          ],
-          name = "vec"
-        },
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          description = "a wire called 'uint'",
-          id = 4 : i64,
-          name = "old"
-        }
-      ],
-      id = 0 : i64,
-      name = "View"
-    }
-  ]
-} {
-  firrtl.module @Companion(
-    in %_gen_uint: !firrtl.ref<uint<1>>,
-    in %_gen_vec: !firrtl.ref<uint<1>>,
-    in %_gen_vec_0: !firrtl.ref<uint<1>>
-  ) attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-        id = 0 : i64,
-        name = "View",
-        type = "companion.companion"
-      }
-    ]
-  } {
-    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.ref<uint<1>>
-    %view_uintrefPort = firrtl.node %0 {
-      annotations = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 1 : i64
-        }
-      ]
-    } : !firrtl.uint<1>
-    %1 = firrtl.ref.resolve %_gen_vec : !firrtl.ref<uint<1>>
-    %view_vecrefPort = firrtl.node %1 {
-      annotations = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 2 : i64
-        }
-      ]
-    } : !firrtl.uint<1>
-    %2 = firrtl.ref.resolve %_gen_vec_0 : !firrtl.ref<uint<1>>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %view_vecrefPort_0 = firrtl.node  %c1_ui1 {
-      annotations = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 3 : i64
-        }
-      ]
-    } : !firrtl.uint<1>
-    %b = firrtl.wire: !firrtl.uint<1>
-    %v1 = firrtl.node sym @v1 %b {
-      annotations = [
-        {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 4 : i64
-        }
-      ]
-    } : !firrtl.uint<1>
-  }
-  firrtl.module @RefTypes() attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 0 : i64,
-        name = "View"
-      }
-    ]
-  } {
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %_gen_uint, %_gen_vec, %_gen_vec_0 = firrtl.instance companion @Companion(
-      in _gen_uint: !firrtl.ref<uint<1>>,
-      in _gen_vec: !firrtl.ref<uint<1>>,
-      in _gen_vec_0: !firrtl.ref<uint<1>>
-    )
-  }
-}
-
-// CHECK-LABEL:    firrtl.module @Companion
-// CHECK:            sv.interface.instance sym @[[ifaceInstName:[a-zA-Z0-9_]+]] {name = "View"} : !sv.interface<@Interface>
-// CHECK:            %view_uintrefPort = firrtl.node %1 : !firrtl.uint<1>
-// CHECK:            %view_vecrefPort = firrtl.node %2 : !firrtl.uint<1>
-// CHECK:            %view_vecrefPort_0 = firrtl.node %c1_ui1 : !firrtl.uint<1>
-// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.uint = {{0}};"(%1) : !firrtl.uint<1>
-// CHECK-SAME:         symbols = [#hw.innerNameRef<@Companion::@[[ifaceInstName]]>]
-// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vec[0] = {{0}};"(%2) : !firrtl.uint<1>
-// CHECK-SAME:         symbols = [#hw.innerNameRef<@Companion::@[[ifaceInstName]]>]
-// CHECK{LITERAL}:   sv.verbatim "assign {{1}}.vec[1] = {{0}};"(%c1_ui1) : !firrtl.uint<1>
-// CHECK-SAME:         symbols = [#hw.innerNameRef<@Companion::@[[ifaceInstName]]>]
-// CHECK{LITERAL}:   sv.verbatim "assign {{0}}.old = {{1}}.{{2}}.{{3}};"
-// CHECK-SAME:         symbols = [#hw.innerNameRef<@Companion::@[[ifaceInstName]]>, @RefTypes, #hw.innerNameRef<@RefTypes::@companion>, #hw.innerNameRef<@Companion::@v1>]
-
-// -----
-
-firrtl.circuit "YAMLOutputEmptyInterface" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
-     filename = "gct.yaml"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @YAMLOutputEmptyInterface() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: module {
-// CHECK:        sv.verbatim
-// CHECK-SAME:      - name: Foo
-// CHECK-SAME:        fields: []
-// CHECK-SAME:        instances: []
-// CHECK-SAME:      {output_file = #hw.output_file<"gct.yaml"
-//
-// CHECK-NOT:  class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation"
-
-// -----
-
-firrtl.circuit "YAMLOutputTwoInterfaces" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Bar",
-     elements = [],
-     id = 1 : i64,
-     name = "View2"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
-     filename = "gct.yaml"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"},
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Bar",
-       id = 1 : i64,
-       name = "View2"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"},
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 1 : i64,
-       name = "view"}]} {
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @YAMLOutputTwoInterfaces() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: module {
-// CHECK:        sv.verbatim
-// CHECK-SAME:      - name: Foo
-// CHECK-SAME:        fields: []
-// CHECK-SAME:        instances: []
-// CHECK-SAME:      - name: Bar
-// CHECK-SAME:        fields: []
-// CHECK-SAME:        instances: []
-
-// -----
-
-firrtl.circuit "YAMLOutputScalarField" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        description = "description of foo",
-        name = "foo",
-        id = 1 : i64}
-     ],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
-     filename = "gct.yaml"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @YAMLOutputScalarField() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: module {
-// CHECK:        sv.verbatim
-// CHECK-SAME:      - name: Foo
-// CHECK-SAME:        fields:
-// CHECK-SAME:          - name: foo
-// CHECK-SAME:            description: description of foo
-// CHECK-SAME:            dimensions: [ ]
-// CHECK-SAME:            width: 2
-// CHECK-SAME:        instances: []
-//
-// Note: Built-in vector serialization works slightly differently than
-// user-defined vector serialization.  This results in the verbose "[ ]" for the
-// empty dimensions vector, and the terse "[]" for the empty instances vector.
-
-// -----
-
-firrtl.circuit "YAMLOutputVectorField" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-           elements = [
-             {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-             id = 1 : i64,
-             name = "foo"}],
-           name = "foo"
-          },
-          {class = "sifive.enterprise.grandcentral.AugmentedVectorType",
-           elements = [
-             {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-             id = 2 : i64,
-             name = "foo"}],
-           name = "foo"
-          }],
-        name = "foo"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
-     filename = "gct.yaml"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 2 : i64}]} : !firrtl.uint<8>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @YAMLOutputVectorField() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: module {
-// CHECK:        sv.verbatim
-// CHECK-SAME:      - name: Foo
-// CHECK-SAME:        fields:
-// CHECK-SAME:          - name: foo
-// CHECK-SAME:            dimensions: [ 1, 2 ]
-// CHECK-SAME:            width: 8
-// CHECK-SAME:        instances: []
-
-// -----
-
-firrtl.circuit "YAMLOutputInstance" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     elements = [
-       {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-        defName = "Bar",
-        elements = [
-          {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-           id = 1 : i64,
-           name = "baz"}],
-        name = "bar"}],
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "bindings.sv"},
-    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
-     filename = "gct.yaml"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire {annotations = [
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 1 : i64},
-      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-       id = 2 : i64}]} : !firrtl.uint<8>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @YAMLOutputInstance() {
-    firrtl.instance dut @DUT()
-  }
-}
-
-// CHECK-LABEL: module {
-// CHECK:        sv.verbatim
-// CHECK-SAME:      - name: Foo
-// CHECK-SAME:        fields: []
-// CHECK-SAME:        instances:
-// CHECK-SAME:          - name: bar
-// CHECK-SAME:            dimensions: [ ]
-// CHECK-SAME:            interface:
-// CHECK-SAME:              name: Bar
-// CHECK-SAME:              fields:
-// CHECK-SAME:                - name: baz
-// CHECK-SAME:                  dimensions: [ ]
-// CHECK-SAME:                  width: 8
-// CHECK-SAME:              instances: []
 
 // -----
 


### PR DESCRIPTION
Convert existing Grand Central (GCT) Views tests from the old Annotation-style to the new RefType style.  The old style is no longer generated by LowerAnnotations.  This commit is done in preparation to remove old Annotation-style handling code paths from the GrandCentral pass.

Remove all tests which are no longer necessary given that reference types are now used or that are redundant with more comprehensive tests.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

For more information, I am trying to entirely remove the legacy Annotation code path from the GrandCentral pass. Very precisely, this makes [this code path](https://github.com/llvm/circt/blob/11a95bfacba90067940351fa042251875e7fac41/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp#L1410-L1496) non-load-bearing. I'm testing this by successfully running tests with the following diff:

```diff
diff --git a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
index a9c7f6ea7..b6dbcf07f 100644
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1382,6 +1382,8 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
           }
         }
 
+        assert(false);
+
         // This case can only occur if ref.resolve is not introduced during
         // LowerAnnotations.
         //

```

While I would normally land an NFC change like this, there are pretty extensive changes to how the GrandCentral tests are written and I want to get feedback on if this is better / more maintainable. These tests are _extremely_ tedious to manage and I think the changes here will help. Summarizing what the PR does:

1) All tests which don't make sense anymore are removed.
2) All tests that need an actual circuit and collapsed into one omnibus test at the top. All different flavors of interfaces are then put in here. Previously, the same circuit was copied to create a new tests everytime. This makes the test long, but I tried to, using comments/spacing/line-breaks, keep the testing of each interface logically separate.
3) YAML tests are included with the omnibus test with the lone exception of the test that is asserting that the YAML file is created if no interfaces exist.

Note: it is likely easier to review this PR by looking at the actual file as opposed to the diff. 😅 