### PR TITLE
[FIRRTL][LowerXMR] Use InstanceGraph to get referencedModule

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -49,7 +49,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   void runOnOperation() override {
     dataFlowClasses = llvm::EquivalenceClasses<Value, ValueComparator>();
-    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    hw::InstanceGraphBase &instanceGraph = getAnalysis<InstanceGraph>();
     SmallVector<RefResolveOp> resolveOps;
     // The dataflow function, that propagates the reachable RefSendOp across
     // RefType Ops.
@@ -123,7 +123,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
               }
             return success();
           })
-          .Case<InstanceOp>([&](auto inst) { return handleInstanceOp(inst); })
+          .Case<InstanceOp>(
+              [&](auto inst) { return handleInstanceOp(inst, instanceGraph); })
           .Case<FConnectLike>([&](FConnectLike connect) {
             // Ignore BaseType.
             if (!connect.getSrc().getType().isa<RefType>())
@@ -299,8 +300,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   // Propagate the reachable RefSendOp across modules.
-  LogicalResult handleInstanceOp(InstanceOp inst) {
-    auto *mod = inst.getReferencedModule();
+  LogicalResult handleInstanceOp(InstanceOp inst,
+                                 hw::InstanceGraphBase &instanceGraph) {
+    Operation *mod = instanceGraph.getReferencedModule(inst);
     if (auto extRefMod = dyn_cast<FExtModuleOp>(mod)) {
       // Extern modules can generate RefType ports, they have an attached
       // attribute which specifies the internal path into the extern module.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -49,7 +49,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   void runOnOperation() override {
     dataFlowClasses = llvm::EquivalenceClasses<Value, ValueComparator>();
-    hw::InstanceGraphBase &instanceGraph = getAnalysis<InstanceGraph>();
+    InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
     SmallVector<RefResolveOp> resolveOps;
     // The dataflow function, that propagates the reachable RefSendOp across
     // RefType Ops.
@@ -301,7 +301,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
   // Propagate the reachable RefSendOp across modules.
   LogicalResult handleInstanceOp(InstanceOp inst,
-                                 hw::InstanceGraphBase &instanceGraph) {
+                                 InstanceGraph &instanceGraph) {
     Operation *mod = instanceGraph.getReferencedModule(inst);
     if (auto extRefMod = dyn_cast<FExtModuleOp>(mod)) {
       // Extern modules can generate RefType ports, they have an attached


### PR DESCRIPTION
Use `InstanceGraph` to get the `referencedModule`. This is more efficient than querying on the `InstanceOp`.