### PR TITLE
[DropNames] Reuse a droppable name attribute, nfc

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -432,6 +432,11 @@ def FNamableOp : OpInterface<"FNamableOp"> {
         NameKindEnumAttr::get(this->getOperation()->getContext(),
                               NameKindEnum::DroppableName));
     }]>,
+    InterfaceMethod<"Set a namekind.",
+    "void", "setNameKindAttr", (ins "firrtl::NameKindEnumAttr":$nameKind),
+                                       [{}], /*defaultImplementation=*/[{
+      this->getOperation()->setAttr("nameKind", nameKind);
+    }]>,
     InterfaceMethod<"Return the name.",
     "mlir::StringAttr", "getNameAttr", (ins), [{}],
     /*defaultImplementation=*/[{

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -38,10 +38,12 @@ struct DropNamesPass : public DropNameBase<DropNamesPass> {
 private:
   size_t dropNamesIf(llvm::function_ref<bool(FNamableOp)> pred) {
     size_t changedNames = 0;
+    auto droppableNameAttr =
+        NameKindEnumAttr::get(&getContext(), NameKindEnum::DroppableName);
     getOperation()->walk([&](FNamableOp op) {
       if (pred(op) && !op.hasDroppableName()) {
         ++changedNames;
-        op.dropName();
+        op.setNameKindAttr(droppableNameAttr);
       }
     });
     return changedNames;


### PR DESCRIPTION
Currently DropName pass creates a tremendous number of name kind attributes which require unnecessary interning. This PR changes to reuse a namekind attribute.