### PR TITLE
[LowerToHW] Fix the operand order of VectorCreateOp lowering

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -168,7 +168,8 @@ def VectorCreateOp : FIRRTLOp<"vectorcreate"> {
   let summary = "Produce a vector value";
   let description = [{
     Create a vector from component values.  This is equivalent in terms of
-    flow to creating a node.
+    flow to creating a node. The first operand indicates 0-th element of
+    the result.
     ```
       %result = firrtl.vectorcreate %1, %2, %3 : !firrtl.vector<uint<8>, 3>
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2525,7 +2525,8 @@ LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {
 LogicalResult FIRRTLLowering::visitExpr(VectorCreateOp op) {
   auto resultType = lowerType(op.getResult().getType());
   SmallVector<Value> operands;
-  for (auto oper : op.getOperands()) {
+  // NOTE: The operand order must be inverted.
+  for (auto oper : llvm::reverse(op.getOperands())) {
     auto val = getLoweredValue(oper);
     if (!val)
       return failure();

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1738,14 +1738,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
  
   // CHECK-LABEL: hw.module @MergeVector
-  firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>) {
+  firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>, in %j: !firrtl.uint<1>) {
     %a = firrtl.wire   : !firrtl.vector<uint<1>, 3>
     firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
-    %0 = firrtl.vectorcreate %i, %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
+    %0 = firrtl.vectorcreate %i, %i, %j : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
     firrtl.strictconnect %a, %0 : !firrtl.vector<uint<1>, 3>
     // CHECK:  %a = sv.wire : !hw.inout<array<3xi1>> 
     // CHECK:  %0 = sv.read_inout %a : !hw.inout<array<3xi1>> 
-    // CHECK:  %1 = hw.array_create %i, %i, %i : i1 
+    // CHECK:  %1 = hw.array_create %j, %i, %i : i1
     // CHECK:  sv.assign %a, %1 : !hw.array<3xi1> 
     // CHECK:  hw.output %0 : !hw.array<3xi1> 
   }


### PR DESCRIPTION
The operand order of VectorCreateOp is the opposite to ArrayCreateOp. We have to invert the order while lowering.