### PR TITLE
[SV][Prepare] Improve a namehint propagation and spilling logic

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -615,8 +615,7 @@ bool EmittedExpressionStateManager::shouldSpillWireBasedOnState(Operation &op) {
   // If the operation is only used by an assignment, the op is already spilled
   // to a wire.
   if (op.hasOneUse() &&
-      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, sv::PAssignOp>(
-          *op.getUsers().begin()))
+      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp>(*op.getUsers().begin()))
     return false;
 
   // If the term size is greater than `maximumNumberOfTermsPerExpression`,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1484,12 +1484,11 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
     return failure();
 
   // If the wire has a name attribute, propagate the name to the expression.
-  if (auto *connectedOp = connected.getDefiningOp()) {
+  if (auto *connectedOp = connected.getDefiningOp())
     if (!wire.getName().empty())
       rewriter.updateRootInPlace(connectedOp, [&] {
         connectedOp->setAttr("sv.namehint", wire.getNameAttr());
       });
-  }
 
   // Ok, we can do this.  Replace all the reads with the connected value.
   for (auto read : reads)

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1483,6 +1483,14 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
     // use-before-def checking to do, so we only handle that for now.
     return failure();
 
+  // If the wire has a name attribute, propagate the name to the expression.
+  if (auto *connectedOp = connected.getDefiningOp()) {
+    if (!wire.getName().empty())
+      rewriter.updateRootInPlace(connectedOp, [&] {
+        connectedOp->setAttr("sv.namehint", wire.getNameAttr());
+      });
+  }
+
   // Ok, we can do this.  Replace all the reads with the connected value.
   for (auto read : reads)
     rewriter.replaceOp(read, connected);

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1094,7 +1094,7 @@ hw.module @enum_constant() -> () {
 // CHECK-NEXT:    %0 = comb.concat %false, %arg0 : i1, i2
 // CHECK-NEXT:    %1 = comb.concat %false, %arg0 : i1, i2
 // CHECK-NEXT:    %2 = comb.add %0, %1 : i3
-// CHECK-NEXT:    %3 = comb.icmp eq %2, %arg2 : i3
+// CHECK-NEXT:    %3 = comb.icmp eq %2, %arg2 {sv.namehint = ".in.wire"} : i3
 // CHECK-NEXT:    hw.output %myext.out : i8
 
 hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
@@ -1113,7 +1113,7 @@ hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
 // CHECK-LABEL: hw.module @TestInstance(%u2: i2, %s8: i8, %clock: i1, %reset: i1) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
 // CHECK-NEXT:   hw.instance "xyz" @Simple(in1: %0: i4, in2: %u2: i2, in3: %s8: i8)
-// CHECK-NEXT:   %0 = comb.concat %c0_i2, %u2 : i2, i2
+// CHECK-NEXT:   %0 = comb.concat %c0_i2, %u2 {sv.namehint = ".in1.wire"} : i2, i2
 // CHECK-NEXT:   %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %reset: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
 // CHECK-NEXT:   hw.output
 hw.module.extern @MyParameterizedExtModule(%in: i1) -> (out: i8) attributes {verilogName = "name_thing"}
@@ -1140,7 +1140,7 @@ hw.module @TestInstance(%u2: i2, %s8: i8, %clock: i1, %reset: i1) {
 
 // CHECK-LABEL:  hw.module @instance_cyclic(%arg0: i2, %arg1: i2) {
 // CHECK-NEXT:    %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %0: i1)
-// CHECK-NEXT:    %0 = comb.extract %myext.out from 2 : (i8) -> i1
+// CHECK-NEXT:    %0 = comb.extract %myext.out from 2
 // CHECK-NEXT:    hw.output
 // CHECK-NEXT:  }
 hw.module @instance_cyclic(%arg0: i2, %arg1: i2) {
@@ -1285,7 +1285,7 @@ hw.module @IncompleteRead(%clock1: i1) {
 // CHECK-LABEL:  hw.module @foo() {
 // CHECK-NEXT:    %io_cpu_flush.wire = sv.wire sym @io_cpu_flush.wire  : !hw.inout<i1>
 // CHECK-NEXT:    hw.instance "fetch" @bar(io_cpu_flush: %0: i1) -> ()
-// CHECK-NEXT:    %0 = sv.read_inout %io_cpu_flush.wire : !hw.inout<i1>
+// CHECK-NEXT:    %0 = sv.read_inout %io_cpu_flush.wire {sv.namehint = ".io_cpu_flush.wire"}
 // CHECK-NEXT:    hw.output
 hw.module.extern @bar(%io_cpu_flush: i1)
 hw.module @foo() {

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -79,10 +79,10 @@ circuit Qux: %[[{
 ;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%[[v4]]]
 ;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
 ;CHECK:    sv.assign %[[multbit_mux_wire]], %[[array_get]]
-;CHECK:    %[[v6:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
+;CHECK:    %[[v6:.+]] = sv.read_inout %[[multbit_mux_wire]]
 ;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%rwAddr]
 ;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
+;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]]
 ;CHECK:    %12 = comb.icmp eq %rwAddr, %c0_i2 : i2
 ;CHECK:    %13 = comb.and %rwEn, %rwMode, %rwMask, %12 : i1
 ;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c1_i2 : i2


### PR DESCRIPTION
This implements a name hint propagation to a wire op canonicalization. 
```
%foo = sv.wire
%0 = comb.add ....
sv.assign %foo, %0
...
```
will be converted into
```
%0 = comb.add {sv.namehint = "foo"}
...
```
This also improves wire spilling logic by allowing expressions used only procedural assignments.  
