### PR TITLE
Bump LLVM

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -174,8 +174,8 @@ class System:
   def graph(self, short_names=True):
     import mlir.all_passes_registration
     pm = mlir.passmanager.PassManager.parse(
-      "builtin.module(view-op-graph{short-names=" +
-      ("1" if short_names else "0") + "})")
+        "builtin.module(view-op-graph{short-names=" +
+        ("1" if short_names else "0") + "})")
     pm.run(self.mod)
 
   def cleanup(self):
@@ -198,7 +198,7 @@ class System:
     if gen_left == 0:
       self._op_cache.release_ops()
       pm = mlir.passmanager.PassManager.parse(
-        "builtin.module(msft-discover-appids)")
+          "builtin.module(msft-discover-appids)")
       pm.run(self.mod)
     return
 

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -49,14 +49,13 @@ class System:
   ]
 
   PASSES = """
-    lower-hwarith-to-hw, msft-lower-constructs, msft-lower-instances,
-    {partition}
-    esi-connect-services,
+    builtin.module(lower-hwarith-to-hw, msft-lower-constructs,
+    msft-lower-instances, {partition} esi-connect-services,
     esi-emit-collateral{{tops={tops} schema-file=schema.capnp}},
     lower-msft-to-hw{{verilog-file={verilog_file}}},
     lower-esi-to-physical, lower-esi-ports, lower-esi-to-hw, convert-fsm-to-sv,
     lower-seq-to-sv, hw.module(prettify-verilog), hw.module(hw-cleanup),
-    msft-export-tcl{{tops={tops} tcl-file={tcl_file}}}
+    msft-export-tcl{{tops={tops} tcl-file={tcl_file}}})
   """
 
   def __init__(self,
@@ -174,12 +173,13 @@ class System:
 
   def graph(self, short_names=True):
     import mlir.all_passes_registration
-    pm = mlir.passmanager.PassManager.parse("view-op-graph{short-names=" +
-                                            ("1" if short_names else "0") + "}")
+    pm = mlir.passmanager.PassManager.parse(
+      "builtin.module(view-op-graph{short-names=" +
+      ("1" if short_names else "0") + "})")
     pm.run(self.mod)
 
   def cleanup(self):
-    pm = mlir.passmanager.PassManager.parse("canonicalize")
+    pm = mlir.passmanager.PassManager.parse("builtin.module(canonicalize)")
     pm.run(self.mod)
 
   def generate(self, generator_names=[], iters=None):
@@ -197,7 +197,8 @@ class System:
     gen_left = len(self._generate_queue)
     if gen_left == 0:
       self._op_cache.release_ops()
-      pm = mlir.passmanager.PassManager.parse("msft-discover-appids")
+      pm = mlir.passmanager.PassManager.parse(
+        "builtin.module(msft-discover-appids)")
       pm.run(self.mod)
     return
 

--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -13,8 +13,7 @@
 #ifndef CIRCT_DIALECT_HW_HWATTRIBUTESNAMING
 #define CIRCT_DIALECT_HW_HWATTRIBUTESNAMING
 
-def InnerRefAttr : AttrDef<HWDialect, "InnerRef", [
-    DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
+def InnerRefAttr : AttrDef<HWDialect, "InnerRef", [SubElementAttrInterface]> {
   let summary = "Refer to a name inside a module";
   let description = [{
     This works like a symbol reference, but to a name inside a module.

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -49,5 +49,5 @@ msft.module @MsLoopback {} (%clk: i1) -> () {
   msft.output
 }
 """)
-  pm = passmanager.PassManager.parse("esi-connect-services")
+  pm = passmanager.PassManager.parse("builtin.module(esi-connect-services)")
   pm.run(mod)

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -256,7 +256,8 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK:   set_location_assignment M20K_X2_Y6_N1 -to $parent|inst1|ext1|foo_subpath
   print(mod)
   pm = mlir.passmanager.PassManager.parse(
-      "builtin.module(msft-lower-instances,lower-msft-to-hw,msft-export-tcl{tops=top})")
+      "builtin.module(msft-lower-instances,lower-msft-to-hw,msft-export-tcl{tops=top})"
+  )
   pm.run(mod)
   circt.export_verilog(mod, sys.stdout)
 

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -256,7 +256,7 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK:   set_location_assignment M20K_X2_Y6_N1 -to $parent|inst1|ext1|foo_subpath
   print(mod)
   pm = mlir.passmanager.PassManager.parse(
-      "msft-lower-instances,lower-msft-to-hw,msft-export-tcl{tops=top}")
+      "builtin.module(msft-lower-instances,lower-msft-to-hw,msft-export-tcl{tops=top})")
   pm.run(mod)
   circt.export_verilog(mod, sys.stdout)
 

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -113,7 +113,7 @@ with Context() as ctx, Location.unknown():
   # CHECK-LABEL: === Verilog ===
   print("=== Verilog ===")
 
-  pm = PassManager.parse("hw.module(hw-cleanup)")
+  pm = PassManager.parse("builtin.module(hw.module(hw-cleanup))")
   pm.run(m)
   # CHECK: module MyWidget
   # CHECK: external module FancyThing

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -77,7 +77,7 @@ with Context() as ctx, Location.unknown():
   # CHECK-LABEL: === Verilog ===
   print("=== Verilog ===")
 
-  pm = PassManager.parse("lower-seq-to-sv")
+  pm = PassManager.parse("builtin.module(lower-seq-to-sv)")
   pm.run(m)
   # CHECK: always_ff @(posedge clk)
   # CHECK: my_reg <= {{.+}}

--- a/integration_test/Bindings/Python/import.py
+++ b/integration_test/Bindings/Python/import.py
@@ -8,4 +8,4 @@ from mlir.passmanager import PassManager
 from mlir.ir import Context
 
 with Context():
-  pm = PassManager.parse("cse")
+  pm = PassManager.parse("builtin.module(cse)")

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -238,14 +238,6 @@ void InnerRefAttr::print(AsmPrinter &p) const {
   p << ">";
 }
 
-Attribute
-InnerRefAttr::replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
-                                          ArrayRef<Type> replTypes) const {
-  assert(replAttrs.size() == 2);
-  return get(getContext(), replAttrs[0].cast<FlatSymbolRefAttr>(),
-             replAttrs[1].cast<StringAttr>());
-}
-
 //===----------------------------------------------------------------------===//
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/CalyxToFSM/lower-if.mlir
+++ b/test/Conversion/CalyxToFSM/lower-if.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --split-input-file -pass-pipeline='calyx.component(lower-calyx-to-fsm)' %s | FileCheck %s
+// RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
 // CHECK:      fsm.machine @control() attributes {compiledGroups = [@true, @false, @cond], initialState = "fsm_entry"} {
 // CHECK-NEXT:   fsm.state @fsm_entry output {

--- a/test/Conversion/CalyxToFSM/lower-seq.mlir
+++ b/test/Conversion/CalyxToFSM/lower-seq.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --split-input-file -pass-pipeline='calyx.component(lower-calyx-to-fsm)' %s | FileCheck %s
+// RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
 // CHECK:      fsm.machine @control() attributes {compiledGroups = [@C, @B, @A], initialState = "fsm_entry"} {
 // CHECK-NEXT:   fsm.state @fsm_entry output {

--- a/test/Conversion/CalyxToFSM/lower-while.mlir
+++ b/test/Conversion/CalyxToFSM/lower-while.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --split-input-file -pass-pipeline='calyx.component(lower-calyx-to-fsm)' %s | FileCheck %s
+// RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
 // CHECK:      fsm.machine @control() attributes {compiledGroups = [@do_add, @do_add, @do_add, @cond], initialState = "fsm_entry"} {
 // CHECK-NEXT:   fsm.state @fsm_entry output {

--- a/test/Conversion/CalyxToFSM/materialize-errors.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(materialize-calyx-to-fsm)' -split-input-file -verify-diagnostics %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(materialize-calyx-to-fsm))' -split-input-file -verify-diagnostics %s
 
 calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
   calyx.wires {

--- a/test/Conversion/CalyxToFSM/materialize-fsm.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-fsm.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(materialize-calyx-to-fsm)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(materialize-calyx-to-fsm))' %s | FileCheck %s
 
 // CHECK: fsm.machine @control(%[[A_DONE:.*]]: i1, %[[B_DONE:.*]]: i1, %[[COND_DONE:.*]]: i1, %[[TOP_LEVEL_GO:.*]]: i1) -> (i1, i1, i1, i1) attributes {compiledGroups = [@A, @B, @cond], initialState = "[[FSM_ENTRY:.*]]"} {
 // CHECK-NEXT:   %[[C1:.*]] = hw.constant true

--- a/test/Conversion/CombToLLVM/convert_bitwise.mlir
+++ b/test/Conversion/CombToLLVM/convert_bitwise.mlir
@@ -59,7 +59,7 @@ func.func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
   // CHECK: %[[R2:.*]] = llvm.ashr %[[R1]], %arg1 : i32
   %2 = comb.shrs %1, %arg1 : i32
 
-  // CHECK: %[[CNT:.*]] = "llvm.intr.ctpop"(%arg0) : (i32) -> i32
+  // CHECK: %[[CNT:.*]] = llvm.intr.ctpop(%arg0) : (i32) -> i32
   // CHECK: llvm.trunc %[[CNT]] : i32 to i1
   %3 = comb.parity %arg0 : i32
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1,7 +1,7 @@
-// RUN: circt-opt -lower-firrtl-to-hw -verify-diagnostics %s | FileCheck %s
-// RUN: circt-opt -pass-pipeline="lower-firrtl-to-hw{disable-mem-randomization}" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM
-// RUN: circt-opt -pass-pipeline="lower-firrtl-to-hw{disable-reg-randomization}" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_REG
-// RUN: circt-opt -pass-pipeline="lower-firrtl-to-hw{disable-mem-randomization disable-reg-randomization}" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
+// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw)" -verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM
+// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_REG
+// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
 
 // DISABLE_RANDOM-LABEL: module @Simple
 firrtl.circuit "Simple"   attributes {annotations = [{class =

--- a/test/Dialect/Calyx/clk-insertion.mlir
+++ b/test/Dialect/Calyx/clk-insertion.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(calyx-clk-insertion,calyx-reset-insertion)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(calyx-clk-insertion,calyx-reset-insertion))' %s | FileCheck %s
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @A(%in: i8, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i8, %done: i1 {done}) {

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(calyx-compile-control)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(calyx-compile-control))' %s | FileCheck %s
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @Z(%go : i1 {go}, %reset : i1 {reset}, %clk : i1 {clk}) -> (%flag :i1, %done : i1 {done}) {

--- a/test/Dialect/Calyx/gicm.mlir
+++ b/test/Dialect/Calyx/gicm.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(calyx-gicm)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(calyx-gicm))' %s | FileCheck %s
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(calyx-go-insertion)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(calyx-go-insertion))' %s | FileCheck %s
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @A(%in: i8, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i8, %done: i1 {done}) {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='calyx.component(calyx-remove-groups)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(calyx-remove-groups))' %s | FileCheck %s
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @Z(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%flag: i1, %out :i2, %done: i1 {done}) {

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imconstprop)' -canonicalize='top-down=true region-simplify=true' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imconstprop), canonicalize{top-down region-simplify})'  %s | FileCheck %s
 // github.com/chipsalliance/firrtl: test/scala/firrtlTests/ConstantPropagationTests.scala
 
 //propagate constant inputs  

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-annotations)' -split-input-file %s -verify-diagnostics
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations))' -split-input-file %s -verify-diagnostics
 
 // An unknown annotation should error.
 //

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-annotations)' --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations))' --split-input-file %s | FileCheck %s
 
 // circt.test copies the annotation to the target
 // circt.testNT puts the targetless annotation on the circuit

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,7 +1,7 @@
 // RUN: split-file %s %t
 // RUN: cd %t
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' Foo.mlir | FileCheck Foo.mlir
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' NoDUT.mlir | FileCheck NoDUT.mlir
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-blackbox-reader))' Foo.mlir | FileCheck Foo.mlir
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-blackbox-reader))' NoDUT.mlir | FileCheck NoDUT.mlir
 
 //--- Baz.sv
 /* Baz */

--- a/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-comb-cycles)' --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-comb-cycles))' --split-input-file --verify-diagnostics %s | FileCheck %s
 
 module  {
   // Simple combinational loop

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-comb-cycles{print-simple-cycle=false})' --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-comb-cycles{print-simple-cycle=false}))' --split-input-file --verify-diagnostics %s | FileCheck %s
 
 module  {
   // Loop-free circuit

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --allow-unregistered-dialect -verify-diagnostics -split-input-file -pass-pipeline='firrtl.circuit(firrtl-dedup)' %s
+// RUN: circt-opt --allow-unregistered-dialect -verify-diagnostics -split-input-file -pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s
 
 // expected-error@below {{MustDeduplicateAnnotation missing "modules" member}}
 firrtl.circuit "MustDedup" attributes {annotations = [{

--- a/test/Dialect/FIRRTL/dedup-locations.mlir
+++ b/test/Dialect/FIRRTL/dedup-locations.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='firrtl.circuit(firrtl-dedup)' %s | FileCheck %s
+// RUN: circt-opt -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s | FileCheck %s
 
 firrtl.circuit "Test" {
 // CHECK-LABEL: @Dedup0()

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-dedup)' %s -mlir-print-debuginfo | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s -mlir-print-debuginfo | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Empty"
 firrtl.circuit "Empty" {

--- a/test/Dialect/FIRRTL/drop-name.mlir
+++ b/test/Dialect/FIRRTL/drop-name.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=all}))' %s   | FileCheck %s --check-prefix=ALL
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=named}))' %s | FileCheck %s --check-prefix=NAMED
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=none}))' %s  | FileCheck %s --check-prefix=NONE
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=all})))' %s   | FileCheck %s --check-prefix=ALL
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=named})))' %s | FileCheck %s --check-prefix=NAMED
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=none})))' %s  | FileCheck %s --check-prefix=NONE
 
 firrtl.circuit "Foo" {
   firrtl.module @Foo() {

--- a/test/Dialect/FIRRTL/emit-metadata-errors.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata)' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-metadata))' --verify-diagnostics --split-input-file %s
 
 //===----------------------------------------------------------------------===//
 // RetimeModules

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="dut.conf"})' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="dut.conf"}))' %s | FileCheck %s
 
 firrtl.circuit "empty" {
   firrtl.module @empty() {

--- a/test/Dialect/FIRRTL/emit-omir-errors.mlir
+++ b/test/Dialect/FIRRTL/emit-omir-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-omir{file=omir.json})' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-omir{file=omir.json}))' --verify-diagnostics --split-input-file %s
 
 #loc = loc(unknown)
 firrtl.circuit "Top" attributes {annotations = [{

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-omir{file=omir.json})' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-omir{file=omir.json}))' %s | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // Absence of any OMIR

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' -verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-expand-whens)))' -verify-diagnostics --split-input-file %s
 
 // This test is checking each kind of declaration to ensure that it is caught
 // by the initialization coverage check. This is also testing that we can emit

--- a/test/Dialect/FIRRTL/expand-whens-locations.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-locations.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' --mlir-print-local-scope  --mlir-print-debuginfo %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-expand-whens)))' --mlir-print-local-scope  --mlir-print-debuginfo %s | FileCheck %s
 
 firrtl.circuit "Basic"  {
 // CHECK-LABEL: @Basic

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-expand-whens)))' %s | FileCheck %s
 firrtl.circuit "ExpandWhens" {
 firrtl.module @ExpandWhens () {}
 

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-flatten-memory))' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-flatten-memory)))' %s | FileCheck  %s
 
 
 firrtl.circuit "Mem" {

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central)' -split-input-file -verify-diagnostics %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-grand-central))' -split-input-file -verify-diagnostics %s
 
 // expected-error @+1 {{more than one 'ExtractGrandCentralAnnotation' was found, but exactly one must be provided}}
 firrtl.circuit "MoreThanOneExtractGrandCentralAnnotation" attributes {

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-grand-central-signal-mappings)' --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-grand-central-signal-mappings))' --split-input-file %s | FileCheck %s
 
 firrtl.circuit "SubCircuit" attributes {
   annotations = [

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central,symbol-dce)' -split-input-file %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-grand-central,symbol-dce))' -split-input-file %s | FileCheck %s
 
 // This is the main test that includes different interfaces of different
 // types. All the interfaces share a common, simple circuit that provides two

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imconstprop)' --split-input-file  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imconstprop))' --split-input-file  %s | FileCheck %s
 
 // This contains a lot of tests which should be caught by IMCP.
 // For now, we are checking that the aggregates don't cause the pass to error out.

--- a/test/Dialect/FIRRTL/imconstprop-crashers.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-crashers.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imconstprop)' -verify-diagnostics --split-input-file %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imconstprop))' -verify-diagnostics --split-input-file %s
 
 
 // https://github.com/llvm/circt/issues/1187

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imconstprop)' --split-input-file  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imconstprop))' --split-input-file  %s | FileCheck %s
 
 firrtl.circuit "Test" {
 

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-imdeadcodeelim)' --split-input-file  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imdeadcodeelim))' --split-input-file  %s | FileCheck %s
 firrtl.circuit "top" {
   // In `dead_module`, %source is connected to %dest through several dead operations such as
   // node, wire, reg or rgereset. %dest is also dead at any instantiation, so check that

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-resets)' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets))' --verify-diagnostics --split-input-file %s
 
 // Tests extracted from:
 // - github.com/chipsalliance/firrtl:

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-resets)' --verify-diagnostics --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets))' --verify-diagnostics --split-input-file %s | FileCheck %s
 
 // Tests extracted from:
 // - github.com/chipsalliance/firrtl:

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-widths)' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths))' --verify-diagnostics --split-input-file %s
 
 firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.clock) {

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-widths)' --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths))' --verify-diagnostics %s | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferConstant

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-rw))' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-infer-rw)))' %s | FileCheck %s
 
 firrtl.circuit "TLRAM" {
 // Test the case when the enable is a simple not of write enable.

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy-errors.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl-inject-dut-hier)' --split-input-file %s
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='builtin.module(firrtl.circuit(firrtl-inject-dut-hier))' --split-input-file %s
 
 // expected-error @+1 {{contained multiple 'sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation' annotations when at most one is allowed}}
 firrtl.circuit "MultipleHierarchyAnnotations" attributes {

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-inject-dut-hier)' -split-input-file %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-inject-dut-hier))' -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" attributes {

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-inliner)' -allow-unregistered-dialect %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-inliner))' -allow-unregistered-dialect %s | FileCheck %s
 
 // Test that an external module as the main module works.
 firrtl.circuit "main_extmodule" {

--- a/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-chirrtl))'  %s
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-chirrtl)))'  %s
 
 firrtl.circuit "NoInferredEnables" {
 firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %v: !firrtl.uint<32>) {

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-chirrtl))'  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-chirrtl)))'  %s | FileCheck %s
 
 firrtl.circuit "Empty" {
 

--- a/test/Dialect/FIRRTL/lower-types-aggregate.mlir
+++ b/test/Dialect/FIRRTL/lower-types-aggregate.mlir
@@ -1,7 +1,7 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=all})' %s | FileCheck %s
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=all preserve-public-types=false})' %s | FileCheck --check-prefix=NOT_PRESERVE_PUBLIC_TYPES %s
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=vec})' %s | FileCheck --check-prefix=VEC %s
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=1d-vec})' %s | FileCheck --check-prefix=1D_VEC %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all}))' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all preserve-public-types=false}))' %s | FileCheck --check-prefix=NOT_PRESERVE_PUBLIC_TYPES %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=vec}))' %s | FileCheck --check-prefix=VEC %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=1d-vec}))' %s | FileCheck --check-prefix=1D_VEC %s
 
 firrtl.circuit "TopLevel" {
   // CHECK-LABEL: firrtl.extmodule @External(in source_valid: !firrtl.uint<1>)

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1,5 +1,5 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types)' %s | FileCheck --check-prefixes=CHECK,COMMON %s
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=all})' %s | FileCheck --check-prefixes=AGGREGATE,COMMON %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types))' %s | FileCheck --check-prefixes=CHECK,COMMON %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all}))' %s | FileCheck --check-prefixes=AGGREGATE,COMMON %s
 
 
 firrtl.circuit "TopLevel" {

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-mem-to-reg-of-vec)' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec))' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @Mem(out %d : !firrtl.ref<vector<uint<8>, 8>>, out %d2 : !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [

--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -1,5 +1,5 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(merge-connections))' %s | FileCheck %s --check-prefixes=CHECK,COMMON
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(merge-connections{aggressive-merging=true}))' %s | FileCheck %s --check-prefixes=AGGRESSIVE,COMMON
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(merge-connections)))' %s | FileCheck %s --check-prefixes=CHECK,COMMON
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(merge-connections{aggressive-merging=true})))' %s | FileCheck %s --check-prefixes=AGGRESSIVE,COMMON
 
 firrtl.circuit "Test"   {
   // circuit Test :

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline="firrtl.circuit(firrtl-prefix-modules)" %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline="builtin.module(firrtl.circuit(firrtl-prefix-modules))" %s | FileCheck %s
 
 // Check that the circuit is updated when the main module is updated.
 // CHECK: firrtl.circuit "T_Top"

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-remove-unused-ports)' %s -split-input-file | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-remove-unused-ports))' %s -split-input-file | FileCheck %s
 firrtl.circuit "Top"   {
   // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
   // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-sfc-compat))' --verify-diagnostics --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-sfc-compat)))' --verify-diagnostics --split-input-file %s | FileCheck %s
 
 firrtl.circuit "SFCCompatTests" {
 

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -pass-pipeline='hw.module(pipeline.pipeline(pipeline-explicit-regs))' | FileCheck %s
+// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.pipeline(pipeline-explicit-regs)))' | FileCheck %s
 
 // CHECK:      %[[PIPELINE_RES:.*]] = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> i32 {
 // CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i1):

--- a/test/Dialect/SV/hw-export-module-hierarchy.mlir
+++ b/test/Dialect/SV/hw-export-module-hierarchy.mlir
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: circt-opt -pass-pipeline='hw-export-module-hierarchy{dir-name=%t}' %s
+// RUN: circt-opt -pass-pipeline='builtin.module(hw-export-module-hierarchy{dir-name=%t})' %s
 // RUN: FileCheck %s < %t/testharness_hier.json
 
 // CHECK:      {

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt -hw-memory-sim %s | FileCheck %s --check-prefixes=CHECK,COMMON
-// RUN: circt-opt -pass-pipeline="hw-memory-sim{strip-mux-pragmas}" %s | FileCheck %s --check-prefix COMMON --implicit-check-not sv.attributes
-// RUN: circt-opt -pass-pipeline="hw-memory-sim{disable-mem-randomization}" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
-// RUN: circt-opt -pass-pipeline="hw-memory-sim{disable-reg-randomization}" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
-// RUN: circt-opt -pass-pipeline="hw-memory-sim{disable-mem-randomization disable-reg-randomization}" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG --implicit-check-not RANDOMIZE_MEM
+// RUN: circt-opt -pass-pipeline="builtin.module(hw-memory-sim{strip-mux-pragmas})" %s | FileCheck %s --check-prefix COMMON --implicit-check-not sv.attributes
+// RUN: circt-opt -pass-pipeline="builtin.module(hw-memory-sim{disable-mem-randomization})" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
+// RUN: circt-opt -pass-pipeline="builtin.module(hw-memory-sim{disable-reg-randomization})" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
+// RUN: circt-opt -pass-pipeline="builtin.module(hw-memory-sim{disable-mem-randomization disable-reg-randomization})" %s | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG --implicit-check-not RANDOMIZE_MEM
 
 hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "readUnderWrite", "writeUnderWrite", "writeClockIDs"]
 

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt %s -verify-diagnostics --lower-seq-firrtl-to-sv | FileCheck %s --check-prefixes=CHECK,COMMON
-// RUN: circt-opt %s -verify-diagnostics --pass-pipeline="hw.module(lower-seq-firrtl-to-sv{disable-reg-randomization})" | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
+// RUN: circt-opt %s -verify-diagnostics --pass-pipeline="builtin.module(hw.module(lower-seq-firrtl-to-sv{disable-reg-randomization}))" | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
 
 // COMMON-LABEL: hw.module @lowering
 hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {

--- a/test/Transforms/strip-debuginfo-pred.mlir
+++ b/test/Transforms/strip-debuginfo-pred.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -allow-unregistered-dialect %s -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='strip-debuginfo-with-pred{drop-suffix=txt}' | FileCheck %s
+// RUN: circt-opt -allow-unregistered-dialect %s -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='builtin.module(strip-debuginfo-with-pred{drop-suffix=txt})' | FileCheck %s
 // This test verifies that debug locations are stripped.
 
 // CHECK-LABEL: func @inline_notation


### PR DESCRIPTION
The following changes were required to bump LLVM:
- SubElementAttrInterface now defines the implementation of `replaceImmediateSubElements`.
- Update tests to use an explicit anchor op in the pass pipeline