### PR TITLE
[FIRRTL][MemOp] Donot create memory with 0 ports

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2111,12 +2111,14 @@ bool foldUnusedPorts(PatternRewriter &rewriter, MemOp op) {
     portAnnotations.push_back(op.getPortAnnotation(i));
   }
 
-  auto newOp = rewriter.create<MemOp>(
-      op.getLoc(), resultTypes, op.getReadLatency(), op.getWriteLatency(),
-      op.getDepth(), op.getRuw(), rewriter.getStrArrayAttr(portNames),
-      op.getName(), op.getNameKind(), op.getAnnotations(),
-      rewriter.getArrayAttr(portAnnotations), op.getInnerSymAttr(),
-      op.getGroupIDAttr());
+  MemOp newOp;
+  if (!resultTypes.empty())
+    newOp = rewriter.create<MemOp>(
+        op.getLoc(), resultTypes, op.getReadLatency(), op.getWriteLatency(),
+        op.getDepth(), op.getRuw(), rewriter.getStrArrayAttr(portNames),
+        op.getName(), op.getNameKind(), op.getAnnotations(),
+        rewriter.getArrayAttr(portAnnotations), op.getInnerSymAttr(),
+        op.getGroupIDAttr());
 
   // Replace the dead ports with dummy wires.
   unsigned nextPort = 0;

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -214,3 +214,38 @@ firrtl.circuit "UnusedPorts" {
     firrtl.connect %pinned_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+
+firrtl.circuit "UnusedMem" {
+  // CHECK-LABEL: firrtl.module public @UnusedMem(
+  firrtl.module public @UnusedMem(
+      in %clock: !firrtl.clock,
+      in %addr: !firrtl.uint<4>,
+      in %in_data: !firrtl.uint<42>) {
+
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+    // CHECK-NOT: firrtl.mem
+    %Memory_write = firrtl.mem Undefined
+      {
+        depth = 12 : i64,
+        name = "Memory",
+        portNames = ["read", "rw", "write", "pinned"],
+        readLatency = 0 : i32,
+        writeLatency = 1 : i32
+      } :
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+
+    %write_addr = firrtl.subfield %Memory_write(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+    firrtl.connect %write_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %write_en = firrtl.subfield %Memory_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %write_en, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_clk = firrtl.subfield %Memory_write(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.clock
+    firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
+    %write_data = firrtl.subfield %Memory_write(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<42>
+    firrtl.connect %write_data, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
+    %write_mask = firrtl.subfield %Memory_write(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
This fixes a bug in `MemOp` canonicalizer that creates an op with zero results.
Donot create a memory if all the ports are unused, because that results in a memory with zero ports.

Fixes the following crash in a design.
```
firtool: ../lib/Dialect/FIRRTL/FIRRTLOps.cpp:1879: circt::firrtl::FIRRTLBaseType circt::firrtl::MemOp::getDataType(): Assertion `getNumResults() != 0 && "Mems with no read/write ports are illegal"' failed.
 #9 0x0000000000dea6c6 circt::firrtl::MemOp::getDataType() /work/pbarua3/plato-circt-tester/bin/circt/build/../lib/Dialect/FIRRTL/FIRRTLOps.cpp:0:3
#10 0x0000000000db04fc foldZeroWidthMemory(mlir::PatternRewriter&, circt::firrtl::MemOp) /work/pbarua3/plato-circt-tester/bin/circt/build/../lib/Dialect/FIRRTL/FIRRTLFolds.cpp:2020:10
```