### PR TITLE
Remove invalids from canonicalizers. They are always wrong.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -54,6 +54,14 @@ def ZeroConstantOp : Constraint<Or<[
         "$0.getDefiningOp<SpecialConstantOp>().getValue() == false">
 ]>>;
 
+/// Constraint that matches a zero ConstantOp or SpecialConstantOp.
+def OneConstantOp : Constraint<Or<[
+  CPred<"$0.getDefiningOp<ConstantOp>() &&"
+        "$0.getDefiningOp<ConstantOp>().getValue().isOne()">,
+  CPred<"$0.getDefiningOp<SpecialConstantOp>() &&"
+        "$0.getDefiningOp<SpecialConstantOp>().getValue() == true">
+]>>;
+
 def GetEmptyString : NativeCodeCall<
   "StringAttr::get($_builder.getContext(), {}) ">;
 
@@ -95,23 +103,15 @@ def MuxSameCondHigh : Pat<
     (EqualTypes $x, $y), (EqualTypes $x, $z), (KnownWidth $x)
   ]>;
 
-// regreset(clock, invalidvalue, resetValue) -> reg(clock)
-def RegResetWithInvalidReset : Pat<
-  (RegResetOp $clock, (InvalidValueOp), $_, $name, $nameKind , $annotations, $inner_sym),
-  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym),
-  []>;
-
-// regreset(clock, reset, invalidvalue) -> reg(clock)
-// This is handled by the `RemoveReset` pass in the original Scala code.
-def RegResetWithInvalidResetValue : Pat<
-  (RegResetOp $clock, $_, (InvalidValueOp), $name, $nameKind, $annotations, $inner_sym),
-  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym),
-  []>;
-
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegResetWithZeroReset : Pat<
   (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym),
   (RegOp $clock, $name, $nameKind, $annotations, $inner_sym), [(ZeroConstantOp $reset)]>;
+
+// regreset(clock, constant_one, resetValue) -> reg(clock)
+def RegResetWithOneReset : Pat<
+  (RegResetOp $clock, $reset, $resetVal, $name, $nameKind, $annotations, $inner_sym),
+  (NodeOp $resetVal, $name, $nameKind, $annotations, $inner_sym), [(OneConstantOp $reset)]>;
 
 // Return the width of an operation result as an integer attribute.  This is
 // useful to pad another operation up to the width of the original operation.

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -54,7 +54,7 @@ def ZeroConstantOp : Constraint<Or<[
         "$0.getDefiningOp<SpecialConstantOp>().getValue() == false">
 ]>>;
 
-/// Constraint that matches a zero ConstantOp or SpecialConstantOp.
+/// Constraint that matches a one ConstantOp or SpecialConstantOp.
 def OneConstantOp : Constraint<Or<[
   CPred<"$0.getDefiningOp<ConstantOp>() &&"
         "$0.getDefiningOp<ConstantOp>().getValue().isOne()">,

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -148,7 +148,7 @@ def MemOp : ReferableDeclOp<"mem"> {
 
   let hasVerifier = 1;
 
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
 
   let extraClassDeclaration = [{
     enum class PortKind { Read, Write, ReadWrite, Debug };

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1967,7 +1967,8 @@ struct FoldResetMux : public mlir::RewritePattern {
 
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::RegResetWithZeroReset, patterns::RegResetWithOneReset, FoldResetMux>(context);
+  results.insert<patterns::RegResetWithZeroReset,
+                 patterns::RegResetWithOneReset, FoldResetMux>(context);
 }
 
 // Returns true if the enable field of a port is set to false.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1967,10 +1967,7 @@ struct FoldResetMux : public mlir::RewritePattern {
 
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::RegResetWithZeroReset,
-                 patterns::RegResetWithInvalidReset,
-                 patterns::RegResetWithInvalidResetValue, FoldResetMux>(
-      context);
+  results.insert<patterns::RegResetWithZeroReset, patterns::RegResetWithOneReset, FoldResetMux>(context);
 }
 
 // Returns true if the enable field of a port is set to false.
@@ -2015,16 +2012,23 @@ static bool isPortUnused(Value port, StringRef data) {
   return true;
 }
 
+namespace {
 // If memory has known, but zero width, eliminate it.
-bool foldZeroWidthMemory(PatternRewriter &rewriter, MemOp op) {
-  if (op.getDataType().getBitWidthOrSentinel() != 0)
-    return false;
+struct FoldZeroWidthMemory : public mlir::RewritePattern {
+  FoldZeroWidthMemory(MLIRContext * context) : RewritePattern(MemOp::getOperationName(), 0, context) {}
+  LogicalResult matchAndRewrite(Operation* op, PatternRewriter &rewriter) const override {
+    MemOp mem = cast<MemOp>(op);    
+  if (hasDontTouch(mem))
+    return failure();
+
+  if (mem.getDataType().getBitWidthOrSentinel() != 0)
+    return failure();
 
   // Make sure are users are safe to replace
-  for (auto port : op->getResults())
+  for (auto port : mem.getResults())
     for (auto *user : port.getUsers())
       if (!isa<SubfieldOp>(user))
-        return false;
+        return failure();
 
   // Annoyingly, there isn't a good replacement for the port as a whole,
   // since they have an outer flip type.
@@ -2036,52 +2040,64 @@ bool foldZeroWidthMemory(PatternRewriter &rewriter, MemOp op) {
     }
   }
   rewriter.eraseOp(op);
-  return true;
+  return success();
 }
+};
 
 // If memory has no write ports, eliminate it.
-bool foldReadOrWriteOnlyMemory(PatternRewriter &rewriter, MemOp op) {
+struct FoldReadOrWriteOnlyMemory : public mlir::RewritePattern {
+  FoldReadOrWriteOnlyMemory(MLIRContext * context) : RewritePattern(MemOp::getOperationName(), 0, context) {}
+  LogicalResult matchAndRewrite(Operation* op, PatternRewriter &rewriter) const override {
+    MemOp mem = cast<MemOp>(op);    
+      if (hasDontTouch(mem))
+    return failure();
   bool isRead = false, isWritten = false;
-  for (unsigned i = 0; i < op.getNumResults(); ++i) {
-    switch (op.getPortKind(i)) {
+  for (unsigned i = 0; i < mem.getNumResults(); ++i) {
+    switch (mem.getPortKind(i)) {
     case MemOp::PortKind::Read:
       isRead = true;
       if (isWritten)
-        return false;
+        return failure();
       continue;
     case MemOp::PortKind::Write:
       isWritten = true;
       if (isRead)
-        return false;
+        return failure();
       continue;
     case MemOp::PortKind::Debug:
     case MemOp::PortKind::ReadWrite:
-      return false;
+      return failure();
     }
     llvm_unreachable("unknown port kind");
   }
   assert((!isWritten || !isRead) && "memory is in use");
 
-  for (auto port : op.getResults()) {
+  for (auto port : mem.getResults()) {
     auto dummyWire = rewriter.create<WireOp>(port.getLoc(), port.getType());
     port.replaceAllUsesWith(dummyWire);
   }
 
   rewriter.eraseOp(op);
-  return true;
+  return success();;
 }
+};
 
 // Eliminate the dead ports of memories.
-bool foldUnusedPorts(PatternRewriter &rewriter, MemOp op) {
+struct FoldUnusedPorts : public mlir::RewritePattern {
+  FoldUnusedPorts(MLIRContext * context) : RewritePattern(MemOp::getOperationName(), 0, context) {}
+  LogicalResult matchAndRewrite(Operation* op, PatternRewriter &rewriter) const override {
+    MemOp mem = cast<MemOp>(op);    
+      if (hasDontTouch(mem))
+    return failure();
   // Identify the dead and changed ports.
-  llvm::SmallBitVector deadPorts(op.getNumResults());
-  for (auto [i, port] : llvm::enumerate(op.getResults())) {
+  llvm::SmallBitVector deadPorts(mem.getNumResults());
+  for (auto [i, port] : llvm::enumerate(mem.getResults())) {
     // Do not simplify annotated ports.
-    if (!op.getPortAnnotation(i).empty())
+    if (!mem.getPortAnnotation(i).empty())
       continue;
 
     // Skip debug ports.
-    auto kind = op.getPortKind(i);
+    auto kind = mem.getPortKind(i);
     if (kind == MemOp::PortKind::Debug)
       continue;
 
@@ -2097,30 +2113,32 @@ bool foldUnusedPorts(PatternRewriter &rewriter, MemOp op) {
     }
   }
   if (deadPorts.none())
-    return false;
+    return failure();
 
   // Rebuild the new memory with the altered ports.
   SmallVector<Type> resultTypes;
   SmallVector<StringRef> portNames;
   SmallVector<Attribute> portAnnotations;
-  for (auto [i, port] : llvm::enumerate(op.getResults())) {
+  for (auto [i, port] : llvm::enumerate(mem.getResults())) {
     if (deadPorts[i])
       continue;
     resultTypes.push_back(port.getType());
-    portNames.push_back(op.getPortName(i));
-    portAnnotations.push_back(op.getPortAnnotation(i));
+    portNames.push_back(mem.getPortName(i));
+    portAnnotations.push_back(mem.getPortAnnotation(i));
   }
 
-  auto newOp = rewriter.create<MemOp>(
-      op.getLoc(), resultTypes, op.getReadLatency(), op.getWriteLatency(),
-      op.getDepth(), op.getRuw(), rewriter.getStrArrayAttr(portNames),
-      op.getName(), op.getNameKind(), op.getAnnotations(),
-      rewriter.getArrayAttr(portAnnotations), op.getInnerSymAttr(),
-      op.getGroupIDAttr());
+  MemOp newOp;
+  if (resultTypes.size())
+     newOp = rewriter.create<MemOp>(
+      mem.getLoc(), resultTypes, mem.getReadLatency(), mem.getWriteLatency(),
+      mem.getDepth(), mem.getRuw(), rewriter.getStrArrayAttr(portNames),
+      mem.getName(), mem.getNameKind(), mem.getAnnotations(),
+      rewriter.getArrayAttr(portAnnotations), mem.getInnerSymAttr(),
+      mem.getGroupIDAttr());
 
   // Replace the dead ports with dummy wires.
   unsigned nextPort = 0;
-  for (auto [i, port] : llvm::enumerate(op.getResults())) {
+  for (auto [i, port] : llvm::enumerate(mem.getResults())) {
     if (deadPorts[i]) {
       auto dummyWire = rewriter.create<WireOp>(port.getLoc(), port.getType());
       port.replaceAllUsesWith(dummyWire);
@@ -2130,17 +2148,24 @@ bool foldUnusedPorts(PatternRewriter &rewriter, MemOp op) {
   }
 
   rewriter.eraseOp(op);
-  return true;
+  return success();
 }
+};
 
 // Rewrite write-only read-write ports to write ports.
-bool foldReadWritePorts(PatternRewriter &rewriter, MemOp op) {
+struct FoldReadWritePorts : public mlir::RewritePattern {
+  FoldReadWritePorts(MLIRContext * context) : RewritePattern(MemOp::getOperationName(), 0, context) {}
+  LogicalResult matchAndRewrite(Operation* op, PatternRewriter &rewriter) const override {
+    MemOp mem = cast<MemOp>(op);    
+      if (hasDontTouch(mem))
+    return failure();
+
   // Identify read-write ports whose read end is unused.
-  llvm::SmallBitVector deadReads(op.getNumResults());
-  for (auto [i, port] : llvm::enumerate(op.getResults())) {
-    if (op.getPortKind(i) != MemOp::PortKind::ReadWrite)
+  llvm::SmallBitVector deadReads(mem.getNumResults());
+  for (auto [i, port] : llvm::enumerate(mem.getResults())) {
+    if (mem.getPortKind(i) != MemOp::PortKind::ReadWrite)
       continue;
-    if (!op.getPortAnnotation(i).empty())
+    if (!mem.getPortAnnotation(i).empty())
       continue;
     if (isPortUnused(port, "rdata")) {
       deadReads.set(i);
@@ -2148,32 +2173,32 @@ bool foldReadWritePorts(PatternRewriter &rewriter, MemOp op) {
     }
   }
   if (deadReads.none())
-    return false;
+    return failure();
 
   SmallVector<Type> resultTypes;
   SmallVector<StringRef> portNames;
   SmallVector<Attribute> portAnnotations;
-  for (auto [i, port] : llvm::enumerate(op.getResults())) {
+  for (auto [i, port] : llvm::enumerate(mem.getResults())) {
     if (deadReads[i])
       resultTypes.push_back(
-          MemOp::getTypeForPort(op.getDepth(), op.getDataType(),
-                                MemOp::PortKind::Write, op.getMaskBits()));
+          MemOp::getTypeForPort(mem.getDepth(), mem.getDataType(),
+                                MemOp::PortKind::Write, mem.getMaskBits()));
     else
       resultTypes.push_back(port.getType());
 
-    portNames.push_back(op.getPortName(i));
-    portAnnotations.push_back(op.getPortAnnotation(i));
+    portNames.push_back(mem.getPortName(i));
+    portAnnotations.push_back(mem.getPortAnnotation(i));
   }
 
   auto newOp = rewriter.create<MemOp>(
-      op.getLoc(), resultTypes, op.getReadLatency(), op.getWriteLatency(),
-      op.getDepth(), op.getRuw(), rewriter.getStrArrayAttr(portNames),
-      op.getName(), op.getNameKind(), op.getAnnotations(),
-      rewriter.getArrayAttr(portAnnotations), op.getInnerSymAttr(),
-      op.getGroupIDAttr());
+      mem.getLoc(), resultTypes, mem.getReadLatency(), mem.getWriteLatency(),
+      mem.getDepth(), mem.getRuw(), rewriter.getStrArrayAttr(portNames),
+      mem.getName(), mem.getNameKind(), mem.getAnnotations(),
+      rewriter.getArrayAttr(portAnnotations), mem.getInnerSymAttr(),
+      mem.getGroupIDAttr());
 
-  for (unsigned i = 0, n = op.getNumResults(); i < n; ++i) {
-    auto result = op.getResult(i);
+  for (unsigned i = 0, n = mem.getNumResults(); i < n; ++i) {
+    auto result = mem.getResult(i);
     auto newResult = newOp.getResult(i);
     if (deadReads[i]) {
       // Create a wire to replace the old result. Wire the sub-fields of the
@@ -2200,25 +2225,16 @@ bool foldReadWritePorts(PatternRewriter &rewriter, MemOp op) {
   }
 
   rewriter.eraseOp(op);
-  return true;
+  return success();
+}
+};
+} // namespace
+
+void MemOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  results.insert<FoldZeroWidthMemory, FoldReadOrWriteOnlyMemory, FoldReadWritePorts, FoldUnusedPorts>(context);
 }
 
-LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {
-  // Do not touch memories marked as such.
-  if (hasDontTouch(op.getOperation()))
-    return failure();
-
-  if (foldZeroWidthMemory(rewriter, op))
-    return success();
-  if (foldReadOrWriteOnlyMemory(rewriter, op))
-    return success();
-  if (foldReadWritePorts(rewriter, op))
-    return success();
-  if (foldUnusedPorts(rewriter, op))
-    return success();
-
-  return failure();
-}
 
 //===----------------------------------------------------------------------===//
 // Declarations

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1852,17 +1852,15 @@ firrtl.module @MuxCanon(in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, in %d1
 }
 
 // CHECK-LABEL: firrtl.module @RegresetToReg
-firrtl.module @RegresetToReg(in %clock: !firrtl.clock, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>) {
-  %c0_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-
-  %c1_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %zero_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>) {
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+  %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   // CHECK: %bar1 = firrtl.reg %clock : !firrtl.uint<1>
-  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-
-  %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
-  // CHECK: %bar2 = firrtl.reg %clock : !firrtl.uint<1>
-  %bar2 = firrtl.regreset %clock, %invalid_asyncreset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %foo2, %dummy : !firrtl.uint<1>
+  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
   firrtl.connect %foo1, %bar1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %foo2, %bar2 : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
I don't believe this patter is triggering, but these are the remaining firrtl canonicalizers which are picking concrete values for invalid (incorrectly).