### PR TITLE
[FIRRTL] Guarantee NodeOp in GCT View

### DIFF
--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1466,6 +1466,106 @@ firrtl.circuit "Top"  attributes {
 
 // -----
 
+// Check that Grand Central View Annotations are applied properly when they are
+// targeting things inside the companion.  Specifically, this should work for
+// both ports and components, e.g., registers.
+
+// CHECK-LABEL: "GrandCentralViewInsideCompanion"
+// CHECK-SAME:    id = [[aId:[0-9]+]] : i64, name = "a"
+// CHECK-SAME:    id = [[bId:[0-9]+]] : i64, name = "b"
+firrtl.circuit "GrandCentralViewInsideCompanion" attributes {
+  rawAnnotations = [
+    {
+      class = "sifive.enterprise.grandcentral.ViewAnnotation",
+      name = "View",
+      companion = "~GrandCentralViewInsideCompanion|Companion",
+      parent = "~GrandCentralViewInsideCompanion|GrandCentralViewInsideCompanion",
+      view = {
+        class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+        defName = "MyInterface",
+        elements = [
+          {
+            name = "a",
+            tpe = {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              ref = {
+                circuit = "GrandCentralViewInsideCompanion",
+                module = "GrandCentralViewInsideCompanion",
+                path = [
+                  {
+                    _1 = {
+                      class = "firrtl.annotations.TargetToken$Instance",
+                      value = "companion"
+                    },
+                    _2 = {
+                      class = "firrtl.annotations.TargetToken$OfModule",
+                      value = "Companion"
+                    }
+                  }
+                ],
+                ref = "a",
+                component = []
+              },
+              tpe = {
+                class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+              }
+            }
+          },
+          {
+            name = "b",
+            tpe = {
+              class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+              ref = {
+                circuit = "GrandCentralViewInsideCompanion",
+                module = "GrandCentralViewInsideCompanion",
+                path = [
+                  {
+                    _1 = {
+                      class = "firrtl.annotations.TargetToken$Instance",
+                      value = "companion"
+                    },
+                    _2 = {
+                      class = "firrtl.annotations.TargetToken$OfModule",
+                      value = "Companion"
+                    }
+                  }
+                ],
+                ref = "b",
+                component = []
+              },
+              tpe = {
+                class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+} {
+  // CHECK:      firrtl.module @Companion
+  firrtl.module @Companion(out %b: !firrtl.uint<2>) {
+    %clock = firrtl.specialconstant 0 : !firrtl.clock
+    %a = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK:      %[[aRefSend:[a-zA-Z0-9_]+]] = firrtl.ref.send %a
+    // CHECK-NEXT: %[[aRefResolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[aRefSend]]
+    // CHECK-NEXT: %[[aNode:[a-zA-Z0-9_]+]] = firrtl.node %[[aRefResolve]]
+    // CHECK-SAME:   {class = "firrtl.transforms.DontTouchAnnotation"}
+    // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = [[aId]] : i64}
+    //
+    // CHECK-NEXT: %[[bRefSend:[a-zA-Z0-9_]+]] = firrtl.ref.send %b
+    // CHECK-NEXT: %[[bRefResolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bRefSend]]
+    // CHECK-NEXT: %[[bNode:[a-zA-Z0-9_]+]] = firrtl.node %[[bRefResolve]]
+    // CHECK-SAME:   {class = "firrtl.transforms.DontTouchAnnotation"}
+    // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = [[bId]] : i64}
+  }
+  firrtl.module @GrandCentralViewInsideCompanion() {
+    %companion_b = firrtl.instance companion @Companion(out b: !firrtl.uint<2>)
+  }
+}
+
+// -----
+
 // Check that TraceNameAnnotation (which has don't touch semantics) is expanded
 // into a TraceAnnotation (which does not have don't touch semantics) and a
 // DontTouchAnnotation whenever this targets something that can be a legal


### PR DESCRIPTION
Change Grand Central (GCT) Views Annotation application logic to always
create a dummy node to store the value of something that is a field of
an interface.  This makes logic during the actual GCT pass simpler (and
easier to check) as this now guarantees that the pass will always see a
node with a DontTouchAnnotation, even for designs where the view is
composed of things inside the companion module.

Relax an overly aggressive check in the Grand Central (GCT) Views pass
which was incorrectly asserting that the source of a SystemVerilog
Interface's field had to be a node of a RefResolveOp or ConstantOp.
This can actually be anything and it will still work.

Fixes #4277 (introduced in 2d3a040f43053d10d195980626ed321a653a89f4).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Note 1: This always creates a `RefSendOp` and `RefReceiveOp`, though they may be unnecessary. This enables reuse of all the logic that @prithayan put into `borePortsFromViewToCompanion` around doing subfield/subindex to extract the element that is being tapped. I originally tried an alternative solution, but this would require duplicating and refactoring that boring method to use common infrastructure. I am heavily reworking how Grand Central View and Tap Annotation lowering happens in a branch. The work done in this PR will be superseded by the branch. Hence, I'm trying to avoid putting a bunch of work into the current approach only to rip it up.