### PR TITLE
[FIRRTL] Fix RegResetWithOneReset Canonicalizer

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -62,6 +62,9 @@ def OneConstantOp : Constraint<Or<[
         "$0.getDefiningOp<SpecialConstantOp>().getValue() == true">
 ]>>;
 
+/// Constraint that a component is undriven.
+def Undriven : Constraint<CPred<"!getDriverFromConnect($0)">>;
+
 def GetEmptyString : NativeCodeCall<
   "StringAttr::get($_builder.getContext(), {}) ">;
 
@@ -110,8 +113,9 @@ def RegResetWithZeroReset : Pat<
 
 // regreset(clock, constant_one, resetValue) -> reg(clock)
 def RegResetWithOneReset : Pat<
-  (RegResetOp $clock, $reset, $resetVal, $name, $nameKind, $annotations, $inner_sym),
-  (NodeOp $resetVal, $name, $nameKind, $annotations, $inner_sym), [(OneConstantOp $reset)]>;
+  (RegResetOp:$reg $clock, $reset, $resetVal, $name, $nameKind, $annotations, $inner_sym),
+  (NodeOp $resetVal, $name, $nameKind, $annotations, $inner_sym),
+  [(OneConstantOp $reset), (Undriven $reg)]>;
 
 // Return the width of an operation result as an integer attribute.  This is
 // useful to pad another operation up to the width of the original operation.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2552,4 +2552,14 @@ firrtl.module @CrashAllUnusedPorts() {
   firrtl.strictconnect %26, %c0_ui1 : !firrtl.uint<1>
 }
 
+// CHECK-LABEL: firrtl.module @CrashRegResetWithOneReset
+firrtl.module @CrashRegResetWithOneReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_d: !firrtl.uint<1>, out %io_q: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>) {
+  %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %0 = firrtl.mux(%io_en, %io_d, %reg) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %reg, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %io_q, %reg : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
 }


### PR DESCRIPTION
Fix a bug introduced in cc220a1e where a register canonicalizer would erroneously RAUW to its assignments.  Change this to only do the rewrite if the register is undriven.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>