### PR TITLE
[LowerToHW] Support 1d vector aggregate constant

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1505,6 +1505,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(SubfieldOp op);
   LogicalResult visitExpr(VectorCreateOp op);
   LogicalResult visitExpr(BundleCreateOp op);
+  LogicalResult visitExpr(AggregateConstantOp op);
   LogicalResult visitUnhandledOp(Operation *op) { return failure(); }
   LogicalResult visitInvalidOp(Operation *op) { return failure(); }
 
@@ -2545,6 +2546,26 @@ LogicalResult FIRRTLLowering::visitExpr(BundleCreateOp op) {
     operands.push_back(val);
   }
   return setLoweringTo<hw::StructCreateOp>(op, resultType, operands);
+}
+
+LogicalResult FIRRTLLowering::visitExpr(AggregateConstantOp op) {
+  auto resultType = lowerType(op.getResult().getType());
+  auto vec = op.getType().dyn_cast<FVectorType>();
+  // Currently we only support 1d vector types.
+  if (!vec || !vec.getElementType().isa<IntType>()) {
+    op.emitError()
+        << "has an unsupported type; currently we only support 1d vectors";
+    return failure();
+  }
+
+  // TODO: Use hw aggregate constant
+  SmallVector<Value> operands;
+  // Make sure to reverse the operands.
+  for (auto elem : llvm::reverse(op.getFields()))
+    operands.push_back(
+        getOrCreateIntConstant(elem.cast<IntegerAttr>().getValue()));
+
+  return setLoweringTo<hw::ArrayCreateOp>(op, resultType, operands);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1750,4 +1750,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:  hw.output %0 : !hw.array<3xi1> 
   }
 
+  // CHECK-LABEL: hw.module @aggregateconstant
+  firrtl.module @aggregateconstant(out %out : !firrtl.vector<uint<8>, 2>) {
+    %0 = firrtl.aggregateconstant [1 : ui8, 0: ui8] : !firrtl.vector<uint<8>, 2>
+    firrtl.strictconnect %out, %0 : !firrtl.vector<uint<8>, 2>
+    // CHECK:      %0 = hw.array_create %c0_i8, %c1_i8 : i8
+    // CHECK-NEXT: hw.output %0 : !hw.array<2xi8>
+  }
 }


### PR DESCRIPTION
This implements a lowering of aggregate constant op. Currently we only support 1d vector until we have hw constant aggregat. 