### PR TITLE
[Handshake] Fix ValueRange lifetime issue.

### DIFF
--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -391,8 +391,7 @@ struct EliminateCBranchIntoMuxPattern : OpRewritePattern<MuxOp> {
 
     rewriter.updateRootInPlace(firstParentCBranch, [&] {
       // Replace uses of the mux's output with cbranch's data input
-      ValueRange dataInput{firstParentCBranch.getDataOperand()};
-      rewriter.replaceOp(op, dataInput);
+      rewriter.replaceOp(op, firstParentCBranch.getDataOperand());
 
       // Remove the cbranch
       rewriter.eraseOp(firstParentCBranch);


### PR DESCRIPTION
Looks like ValueRange stores address of Value,
so just construct in-place for the replaceOp call.

Fixes #4282.