### PR TITLE
[RTL-SIM] Fix trace debug output in Verilator driver

### DIFF
--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -1171,7 +1171,12 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
   // TODO: support cases where the pointer offset is non-zero.
   Slice assertPtr(ptr);
   auto typeAndOffset = assertPtr.slice(0, 32).name("typeAndOffset");
-  asserts.assertEqual(typeAndOffset, 0);
+  if (getType().isInteger(0)) {
+    asserts.assertEqual(typeAndOffset.slice(0, 2), 0);
+    asserts.assertEqual(typeAndOffset.slice(2, 30), 0x3FFFFFFF);
+  } else {
+    asserts.assertEqual(typeAndOffset, 0);
+  }
 
   // We expect the data section to be equal to the computed data section size.
   auto dataSectionSize =

--- a/lib/Dialect/ESI/cosim/cosim_dpi_server/DpiEntryPoints.cpp
+++ b/lib/Dialect/ESI/cosim/cosim_dpi_server/DpiEntryPoints.cpp
@@ -50,6 +50,7 @@ static void log(char *epId, bool toClient, const Endpoint::BlobPtr &msg) {
     fprintf(logFile, " %02x", b);
   }
   fprintf(logFile, "\n");
+  fflush(logFile);
 }
 
 /// Get the TCP port on which to listen. If the port isn't specified via an

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -16,6 +16,7 @@ import argparse
 import os
 import subprocess
 import sys
+from typing import List
 
 ThisFileDir = os.path.dirname(__file__)
 DebugBuild = "@CMAKE_BUILD_TYPE@" == "Debug"
@@ -60,7 +61,7 @@ class Questa(IEEEDriver):
     sources = filter(lambda fn: not (fn.endswith(".so") or fn.endswith(".dll")),
                      sources)
     vlog = os.path.join(self.path, "vlog")
-    args = [vlog, "-sv"] + args.split() + list(sources) 
+    args = [vlog, "-sv"] + args.split() + list(sources)
     if self.args.gui:
       args.append('+acc')
     return subprocess.run(args)
@@ -149,7 +150,8 @@ class Iverilog(IEEEDriver):
 
   def compile(self, sources, args):
     return subprocess.run(
-        [self.iverilog, "-s", self.top, "-g2005-sv", "-o", "obj.vvp"] + args.split() + sources)
+        [self.iverilog, "-s", self.top, "-g2005-sv", "-o", "obj.vvp"] +
+        args.split() + sources)
 
   def run(self, cycles, args):
     print(self.top)
@@ -187,11 +189,13 @@ class Verilator:
                      sources)
     self.ldPaths = ":".join([os.path.dirname(x) for x in dpiLibs])
     debugFlags = []
+    cflags = []
     if DebugBuild:
-      debugFlags = ["--trace", "--trace-params", "--trace-structs", "-DTRACE"]
-    return subprocess.run([
+      debugFlags = ["--trace", "--trace-params", "--trace-structs"]
+      cflags.append("-DTRACE")
+    return call_logged([
         self.verilator, "--cc", "--top-module", self.top, "-sv", "--build",
-        "--exe", "--assert"
+        "--exe", "--assert", "-CFLAGS", " ".join(cflags)
     ] + debugFlags + args.split() + sources)
 
   def run(self, cycles, args):
@@ -205,6 +209,12 @@ class Verilator:
     sys.stdout.flush()
     os.environ["LD_LIBRARY_PATH"] = self.ldPaths
     return subprocess.run(cmd)
+
+
+def call_logged(cmd: List[str]):
+  cmd_str = " ".join(cmd)
+  print(f"Running: {cmd_str}")
+  return subprocess.run(cmd)
 
 
 def __main__(args):

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -193,10 +193,13 @@ class Verilator:
     if DebugBuild:
       debugFlags = ["--trace", "--trace-params", "--trace-structs"]
       cflags.append("-DTRACE")
+    cflagsIfNeeded = []
+    if len(cflags) > 0:
+      cflagsIfNeeded = ["-CFLAGS", " ".join(cflags)]
     return call_logged([
         self.verilator, "--cc", "--top-module", self.top, "-sv", "--build",
-        "--exe", "--assert", "-CFLAGS", " ".join(cflags)
-    ] + debugFlags + args.split() + sources)
+        "--exe", "--assert"
+    ] + cflagsIfNeeded + debugFlags + args.split() + sources)
 
   def run(self, cycles, args):
     exe = os.path.join("obj_dir", "V" + self.top)

--- a/tools/circt-rtl-sim/driver.cpp.in
+++ b/tools/circt-rtl-sim/driver.cpp.in
@@ -60,6 +60,11 @@ int main(int argc, char **argv) {
     Verilated::traceEverOn(true);
     dut.trace(tfp, 99); // Trace 99 levels of hierarchy
     tfp->open(waveformFile);
+    std::cout << "[driver] Writing trace to " << waveformFile << std::endl;
+#else
+    std::cout
+        << "[driver] Warning: waveform file specified, but not a debug build"
+        << std::endl;
 #endif
   }
 


### PR DESCRIPTION
We were passing in CFLAGS improperly. Also add fix some asserts in the ESI capnp decoder modules to support `i0`.