### PR TITLE
[ESI] Support BSPs in service metadata emission

### DIFF
--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1430,6 +1430,8 @@ void ESIEmitCollateralPass::emitServiceJSON() {
   auto *ctxt = &getContext();
   SymbolCache topSyms;
   topSyms.addDefinitions(mod);
+
+  // Check for invalid top names.
   for (StringRef topModName : tops)
     if (topSyms.getDefinition(FlatSymbolRefAttr::get(ctxt, topModName)) ==
         nullptr) {

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1430,6 +1430,13 @@ void ESIEmitCollateralPass::emitServiceJSON() {
   auto *ctxt = &getContext();
   SymbolCache topSyms;
   topSyms.addDefinitions(mod);
+  for (StringRef topModName : tops)
+    if (topSyms.getDefinition(FlatSymbolRefAttr::get(ctxt, topModName)) ==
+        nullptr) {
+      mod.emitError("Could not find module named '") << topModName << "'\n";
+      signalPassFailure();
+      return;
+    }
 
   std::string jsonStrBuffer;
   llvm::raw_string_ostream os(jsonStrBuffer);
@@ -1483,7 +1490,8 @@ void ESIEmitCollateralPass::emitServiceJSON() {
     });
 
     // Get a list of metadata ops which originated in modules (path is empty).
-    DenseMap<hw::HWModuleLike, SmallVector<ServiceHierarchyMetadataOp, 0>>
+    SmallVector<
+        std::pair<hw::HWModuleLike, SmallVector<ServiceHierarchyMetadataOp, 0>>>
         modsWithLocalServices;
     for (auto hwmod : mod.getOps<hw::HWModuleLike>()) {
       SmallVector<ServiceHierarchyMetadataOp, 0> metadataOps;
@@ -1492,16 +1500,18 @@ void ESIEmitCollateralPass::emitServiceJSON() {
           metadataOps.push_back(md);
       });
       if (!metadataOps.empty())
-        modsWithLocalServices[hwmod] = metadataOps;
+        modsWithLocalServices.push_back(std::make_pair(hwmod, metadataOps));
     }
 
     // Then output metadata for those modules exclusively.
     j.attributeArray("modules", [&] {
-      for (auto &modWithSvc : modsWithLocalServices) {
+      for (auto &nameMdPair : modsWithLocalServices) {
+        hw::HWModuleLike hwmod = nameMdPair.first;
+        auto &mdOps = nameMdPair.second;
         j.object([&] {
-          j.attribute("symbol", modWithSvc.first.moduleName());
+          j.attribute("symbol", hwmod.moduleName());
           j.attributeArray("services", [&] {
-            for (ServiceHierarchyMetadataOp metadata : modWithSvc.getSecond()) {
+            for (ServiceHierarchyMetadataOp metadata : mdOps) {
               j.object([&] {
                 j.attribute("service", metadata.getServiceSymbol());
                 j.attribute("impl_type", metadata.getImplType());

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -435,7 +435,7 @@ static void emitServiceMetadata(ServiceImplementReqOp implReqOp) {
   // service -- and create an implicit service declaration for them.
   std::unique_ptr<Block> bspPorts = nullptr;
   if (!implReqOp.getServiceSymbol().has_value()) {
-    bspPorts.reset(new Block());
+    bspPorts = std::make_unique<Block>();
     b.setInsertionPointToStart(bspPorts.get());
   }
 

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -431,6 +431,8 @@ void ESIConnectServicesPass::copyMetadata(hw::HWMutableModuleLike mod) {
 static void emitServiceMetadata(ServiceImplementReqOp implReqOp) {
   ImplicitLocOpBuilder b(implReqOp.getLoc(), implReqOp);
 
+  // Check if there are any "BSP" service providers -- ones which implement any
+  // service -- and create an implicit service declaration for them.
   std::unique_ptr<Block> bspPorts = nullptr;
   if (!implReqOp.getServiceSymbol().has_value()) {
     bspPorts.reset(new Block());
@@ -483,6 +485,7 @@ static void emitServiceMetadata(ServiceImplementReqOp implReqOp) {
   if (bspPorts && !bspPorts->empty()) {
     b.setInsertionPointToEnd(
         implReqOp->getParentOfType<mlir::ModuleOp>().getBody());
+    // TODO: we currently only support one BSP. Should we support more?
     auto decl = b.create<CustomServiceDeclOp>("BSP");
     decl.getPorts().push_back(bspPorts.release());
     implReqOp.setServiceSymbol(decl.getSymNameAttr().getValue());

--- a/test/Dialect/ESI/services_collateral.mlir
+++ b/test/Dialect/ESI/services_collateral.mlir
@@ -1,9 +1,11 @@
 // REQUIRES: capnp
-// RUN: circt-opt --esi-connect-services --esi-emit-collateral=tops=LoopbackCosimTopWrapper --lower-msft-to-hw --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw  --export-verilog %s -o %t1.mlir  | FileCheck %s
+// RUN: circt-opt %s --esi-connect-services --esi-emit-collateral=tops=LoopbackCosimTopWrapper,LoopbackCosimBSP --lower-msft-to-hw --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw  --export-verilog -o %t1.mlir  | FileCheck %s
 
 // CHECK-LABEL: // ----- 8< ----- FILE "services.json" ----- 8< -----
 
 // CHECK-LABEL: "declarations": [ 
+
+
 
 // CHECK-LABEL:    "name": "HostComms",
 // CHECK-NEXT:     "ports": [
@@ -49,35 +51,50 @@
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }
 // CHECK-NEXT:       ]
-esi.service.decl @HostComms {
-  esi.service.to_server @Send : !esi.channel<!esi.any>
-  esi.service.to_client @Recv : !esi.channel<i8>
-  esi.service.inout @ReqResp : !esi.channel<i8> -> !esi.channel<i16>
-}
 
-msft.module @SendStruct {} (%clk: i1) -> () {
-  %c2_i3 = hw.constant 2 : i3
-  %s = hw.struct_create (%c2_i3) : !hw.struct<foo: i3>
-  %c1_i1 = hw.constant 1 : i1
-  %schan, %ready = esi.wrap.vr %s, %c1_i1 : !hw.struct<foo: i3>
-  esi.service.req.to_server %schan -> <@HostComms::@Send> ([]): !esi.channel<!hw.struct<foo: i3>>
-  msft.output
-}
-
-msft.module @InOutLoopback {} (%clk: i1) -> () {
-  %dataIn = esi.service.req.inout %dataTrunc -> <@HostComms::@ReqResp> (["loopback_inout"]) : !esi.channel<i8> -> !esi.channel<i16>
-  %unwrap, %valid = esi.unwrap.vr %dataIn, %rdy: i16
-  %trunc = comb.extract %unwrap from 0 : (i16) -> (i8)
-  %dataTrunc, %rdy = esi.wrap.vr %trunc, %valid : i8
-  msft.output
-}
-
-msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
-  esi.service.instance svc @HostComms impl as "cosim" (%clk, %rst) : (i1, i1) -> ()
-  msft.instance @m1 @InOutLoopback(%clk) : (i1) -> ()
-  msft.instance @m2 @SendStruct(%clk) : (i1) -> ()
-  msft.output
-}
+// CHECK-LABEL:     "name": "BSP",
+// CHECK-NEXT:      "ports": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "name": "Send",
+// CHECK-NEXT:          "to-server-type": {
+// CHECK-NEXT:            "dialect": "esi",
+// CHECK-NEXT:            "inner": {
+// CHECK-NEXT:              "dialect": "hw",
+// CHECK-NEXT:              "fields": [
+// CHECK-NEXT:                {
+// CHECK-NEXT:                  "name": "foo",
+// CHECK-NEXT:                  "type": {
+// CHECK-NEXT:                    "dialect": "builtin",
+// CHECK-NEXT:                    "mnemonic": "i3"
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                }
+// CHECK-NEXT:              ],
+// CHECK-NEXT:              "mnemonic": "struct"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "mnemonic": "channel"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "name": "ReqResp",
+// CHECK-NEXT:          "to-client-type": {
+// CHECK-NEXT:            "dialect": "esi",
+// CHECK-NEXT:            "inner": {
+// CHECK-NEXT:              "dialect": "builtin",
+// CHECK-NEXT:              "mnemonic": "i16"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "mnemonic": "channel"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          "to-server-type": {
+// CHECK-NEXT:            "dialect": "esi",
+// CHECK-NEXT:            "inner": {
+// CHECK-NEXT:              "dialect": "builtin",
+// CHECK-NEXT:              "mnemonic": "i8"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "mnemonic": "channel"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ]
+// CHECK-NEXT:    }
 
 // CHECK-LABEL: "top_levels": [
 
@@ -91,6 +108,14 @@ msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
 // CHECK-NEXT:        "outer_sym": "LoopbackCosimTop"
 // CHECK-NEXT:        }
 // CHECK-NEXT:      ]
+// CHECK-LABEL: "module": "@LoopbackCosimBSP",
+// CHECK-NEXT:   "services": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "service": "BSP",
+// CHECK-NEXT:       "instance_path": []
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }
 
 // CHECK-LABEL:  "modules": [
 // CHECK-NEXT:     {
@@ -169,15 +194,120 @@ msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
 // CHECK-NEXT:                   "mnemonic": "channel"
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               }
+
+// CHECK-LABEL:  "symbol": "LoopbackCosimBSP",
+// CHECK-NEXT:   "services": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "service": "BSP",
+// CHECK-NEXT:       "impl_type": "cosim",
+// CHECK-NEXT:       "clients": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "client_name": [
+// CHECK-NEXT:             "m1",
+// CHECK-NEXT:             "loopback_inout"
+// CHECK-NEXT:           ],
+// CHECK-NEXT:           "port": {
+// CHECK-NEXT:             "inner": "ReqResp",
+// CHECK-NEXT:             "outer_sym": "HostComms"
+// CHECK-NEXT:           },
+// CHECK-NEXT:           "to_client_type": {
+// CHECK-NEXT:             "capnp_name": "I16",
+// CHECK-NEXT:             "capnp_type_id": 15002640976408729367,
+// CHECK-NEXT:             "hw_bitwidth": 16,
+// CHECK-NEXT:             "mlir_name": "!esi.channel<i16>",
+// CHECK-NEXT:             "type_desc": {
+// CHECK-NEXT:               "dialect": "esi",
+// CHECK-NEXT:               "inner": {
+// CHECK-NEXT:                 "dialect": "builtin",
+// CHECK-NEXT:                 "mnemonic": "i16"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "mnemonic": "channel"
 // CHECK-NEXT:             }
-// CHECK-NEXT:           ]
-// CHECK-NEXT:         }
-// CHECK-NEXT:       ]
-// CHECK-NEXT:     }
-// CHECK-NEXT:   ]
+// CHECK-NEXT:           },
+// CHECK-NEXT:           "to_server_type": {
+// CHECK-NEXT:             "capnp_name": "I8",
+// CHECK-NEXT:             "capnp_type_id": 9950424317211852587,
+// CHECK-NEXT:             "hw_bitwidth": 8,
+// CHECK-NEXT:             "mlir_name": "!esi.channel<i8>",
+// CHECK-NEXT:             "type_desc": {
+// CHECK-NEXT:               "dialect": "esi",
+// CHECK-NEXT:               "inner": {
+// CHECK-NEXT:                 "dialect": "builtin",
+// CHECK-NEXT:                 "mnemonic": "i8"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "mnemonic": "channel"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         },
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "client_name": [
+// CHECK-NEXT:             "m2"
+// CHECK-NEXT:           ],
+// CHECK-NEXT:           "port": {
+// CHECK-NEXT:             "inner": "Send",
+// CHECK-NEXT:             "outer_sym": "HostComms"
+// CHECK-NEXT:           },
+// CHECK-NEXT:           "to_server_type": {
+// CHECK-NEXT:             "capnp_name": "Struct12633565592854986228",
+// CHECK-NEXT:             "capnp_type_id": 12633565592854986228,
+// CHECK-NEXT:             "hw_bitwidth": 3,
+// CHECK-NEXT:             "mlir_name": "!esi.channel<!hw.struct<foo: i3>>",
+// CHECK-NEXT:             "type_desc": {
+// CHECK-NEXT:               "dialect": "esi",
+// CHECK-NEXT:               "inner": {
+// CHECK-NEXT:                 "dialect": "hw",
+// CHECK-NEXT:                 "fields": [
+// CHECK-NEXT:                   {
+// CHECK-NEXT:                     "name": "foo",
+// CHECK-NEXT:                     "type": {
+// CHECK-NEXT:                       "dialect": "builtin",
+// CHECK-NEXT:                       "mnemonic": "i3"
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 ],
+// CHECK-NEXT:                 "mnemonic": "struct"
+// CHECK-NEXT:               },
+// CHECK-NEXT:               "mnemonic": "channel"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
 
+esi.service.decl @HostComms {
+  esi.service.to_server @Send : !esi.channel<!esi.any>
+  esi.service.to_client @Recv : !esi.channel<i8>
+  esi.service.inout @ReqResp : !esi.channel<i8> -> !esi.channel<i16>
+}
 
+msft.module @SendStruct {} (%clk: i1) -> () {
+  %c2_i3 = hw.constant 2 : i3
+  %s = hw.struct_create (%c2_i3) : !hw.struct<foo: i3>
+  %c1_i1 = hw.constant 1 : i1
+  %schan, %ready = esi.wrap.vr %s, %c1_i1 : !hw.struct<foo: i3>
+  esi.service.req.to_server %schan -> <@HostComms::@Send> ([]): !esi.channel<!hw.struct<foo: i3>>
+  msft.output
+}
+
+msft.module @InOutLoopback {} (%clk: i1) -> () {
+  %dataIn = esi.service.req.inout %dataTrunc -> <@HostComms::@ReqResp> (["loopback_inout"]) : !esi.channel<i8> -> !esi.channel<i16>
+  %unwrap, %valid = esi.unwrap.vr %dataIn, %rdy: i16
+  %trunc = comb.extract %unwrap from 0 : (i16) -> (i8)
+  %dataTrunc, %rdy = esi.wrap.vr %trunc, %valid : i8
+  msft.output
+}
+
+msft.module @LoopbackCosimTop {} (%clk: i1, %rst: i1) {
+  esi.service.instance svc @HostComms impl as "cosim" (%clk, %rst) : (i1, i1) -> ()
+  msft.instance @m1 @InOutLoopback(%clk) : (i1) -> ()
+  msft.instance @m2 @SendStruct(%clk) : (i1) -> ()
+  msft.output
+}
 msft.module @LoopbackCosimTopWrapper {} (%clk: i1, %rst: i1) {
   msft.instance @top @LoopbackCosimTop(%clk, %rst) : (i1, i1) -> ()
+  msft.output
+}
+
+msft.module @LoopbackCosimBSP {} (%clk: i1, %rst: i1) {
+  esi.service.instance impl as "cosim" (%clk, %rst) : (i1, i1) -> ()
+  msft.instance @m1 @InOutLoopback(%clk) : (i1) -> ()
+  msft.instance @m2 @SendStruct(%clk) : (i1) -> ()
   msft.output
 }

--- a/test/Dialect/ESI/services_collateral.mlir
+++ b/test/Dialect/ESI/services_collateral.mlir
@@ -5,8 +5,6 @@
 
 // CHECK-LABEL: "declarations": [ 
 
-
-
 // CHECK-LABEL:    "name": "HostComms",
 // CHECK-NEXT:     "ports": [
 // CHECK-NEXT:         {


### PR DESCRIPTION
A "BSP" is a service provider which implements any and all service declarations. It is intended to live at the top of a service hierarchy to provide board-level services (e.g. host connectivity). Add support for BSPs in the service metadata output.