### PR TITLE
[tools] Change tools to use CIRCT-specific bug msg

### DIFF
--- a/include/circt/Support/Version.h
+++ b/include/circt/Support/Version.h
@@ -6,6 +6,11 @@
 namespace circt {
 const char *getCirctVersion();
 const char *getCirctVersionComment();
+
+/// A generic bug report message for CIRCT-related projects
+constexpr const char *circtBugReportMsg =
+    "PLEASE submit a bug report to https://github.com/llvm/circt and include "
+    "the crash backtrace.\n";
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_VERSION_H

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -119,6 +119,11 @@ static LogicalResult execute(MLIRContext &context) {
 
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
+
   mlir::DialectRegistry registry;
 
   circt::registerAllDialects(registry);

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -98,6 +98,11 @@ static LogicalResult execute(MLIRContext &context) {
 
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
+
   mlir::DialectRegistry registry;
 
   circt::registerAllDialects(registry);

--- a/tools/circt-lsp-server/circt-lsp-server.cpp
+++ b/tools/circt-lsp-server/circt-lsp-server.cpp
@@ -7,15 +7,22 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/InitAllDialects.h"
+#include "circt/Support/Version.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 using namespace mlir;
 
 int main(int argc, char **argv) {
   DialectRegistry registry;
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
   registerAllDialects(registry);
   circt::registerAllDialects(registry);
   return failed(MlirLspServerMain(argc, argv, registry));

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -14,6 +14,7 @@
 #include "circt/InitAllDialects.h"
 #include "circt/InitAllPasses.h"
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/Version.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -25,6 +26,7 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 // Defined in the test directory, no public header.
 namespace circt {
@@ -35,6 +37,10 @@ void registerSchedulingTestPasses();
 } // namespace circt
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
   mlir::DialectRegistry registry;
 
   // Register MLIR stuff

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -14,6 +14,7 @@
 #include "Reduction.h"
 #include "Tester.h"
 #include "circt/InitAllDialects.h"
+#include "circt/Support/Version.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
@@ -387,6 +388,10 @@ static LogicalResult execute(MLIRContext &context) {
 /// `execute` function to do the actual work.
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
 
   // Register and hide default LLVM options, other than for this tool.
   registerMLIRContextCLOptions();

--- a/tools/circt-translate/circt-translate.cpp
+++ b/tools/circt-translate/circt-translate.cpp
@@ -13,10 +13,16 @@
 
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/InitAllTranslations.h"
+#include "circt/Support/Version.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
   circt::registerAllTranslations();
   return mlir::failed(
       mlir::mlirTranslateMain(argc, argv, "CIRCT Translation Testing Tool"));

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
@@ -1029,6 +1030,10 @@ static LogicalResult executeFirtool(MLIRContext &context) {
 /// MLIRContext and modules inside of it (reducing compile time).
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
 
   // Hide default LLVM options, other than for this tool.
   // MLIR options are added below.

--- a/tools/handshake-runner/handshake-runner.cpp
+++ b/tools/handshake-runner/handshake-runner.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Support/Version.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -43,6 +44,11 @@ static cl::opt<std::string>
 
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
+
   cl::ParseCommandLineOptions(
       argc, argv,
       "MLIR Standard dialect runner\n\n"

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -51,6 +51,7 @@
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/LoweringOptionsParser.h"
+#include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
 
 #include "circt/InitAllDialects.h"
@@ -513,6 +514,10 @@ static LogicalResult executeHlstool(MLIRContext &context) {
 /// MLIRContext and modules inside of it (reducing compile time).
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
 
   // Hide default LLVM options, other than for this tool.
   // MLIR options are added below.

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/LLHD/Simulator/Engine.h"
 #include "circt/Dialect/LLHD/Simulator/Trace.h"
+#include "circt/Support/Version.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -159,6 +160,10 @@ static LogicalResult applyMLIRPasses(ModuleOp module) {
 
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
 
   // Hide default LLVM options, other than for this tool.
   cl::HideUnrelatedOptions(mainCategory);


### PR DESCRIPTION
Change all existing CIRCT tools to use a CIRCT-specific bug report message.  Previously a crash would tell people to file a bug on LLVM which isn't correct.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Example new output:

```
# firtool Foo.fir
Assertion failed: (false), function main, file firtool.cpp, line 1075.
PLEASE submit a bug report to https://github.com/llvm/circt and include the crash backtrace.
Stack dump:
0.      Program arguments: firtool Foo.fir
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  firtool                  0x000000011014bd2d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  firtool                  0x000000011014c2ab PrintStackTraceSignalHandler(void*) + 27
2  firtool                  0x000000011014a0a6 llvm::sys::RunSignalHandlers() + 134
3  firtool                  0x000000011014de6f SignalHandler(int) + 223
4  libsystem_platform.dylib 0x00007ff8040a7dfd _sigtramp + 29
5  firtool                  0x000000011097ed85 llvm::offsetToAlignedAddr(void const*, llvm::Align) + 37
6  libsystem_c.dylib        0x00007ff803fddd24 abort + 123
7  libsystem_c.dylib        0x00007ff803fdd0cb err + 0
8  firtool                  0x000000010ff02842 main + 338
9  dyld                     0x0000000117a9b52e start + 462
zsh: abort      firtool Foo.fir
```

h/t @youngar for finding `setBugReportMsg`, cc @jackkoenig 