### PR TITLE
[Seq] Use a new pass generation mechanism

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -19,9 +19,13 @@
 namespace circt {
 namespace seq {
 
+#define GEN_PASS_DECL
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+#undef GEN_PASS_DECL
+
 std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
 std::unique_ptr<mlir::Pass>
-createSeqFIRRTLLowerToSVPass(bool disableRegRandomization = false);
+createSeqFIRRTLLowerToSVPass(const LowerSeqFIRRTLToSVOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
 
 /// Generate the code for registering passes.

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -148,7 +148,8 @@ public:
   }
 };
 
-struct LowerSeqHLMemPass : public LowerSeqHLMemBase<LowerSeqHLMemPass> {
+struct LowerSeqHLMemPass
+    : public circt::seq::impl::LowerSeqHLMemBase<LowerSeqHLMemPass> {
   void runOnOperation() override;
 };
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -31,12 +31,14 @@ using namespace circt;
 using namespace seq;
 
 namespace {
-struct SeqToSVPass : public LowerSeqToSVBase<SeqToSVPass> {
+struct SeqToSVPass : public circt::seq::impl::LowerSeqToSVBase<SeqToSVPass> {
   void runOnOperation() override;
 };
-struct SeqFIRRTLToSVPass : public LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
+struct SeqFIRRTLToSVPass
+    : public circt::seq::impl::LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
   void runOnOperation() override;
   using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::disableRegRandomization;
+  using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::LowerSeqFIRRTLToSVBase;
 };
 } // anonymous namespace
 
@@ -520,10 +522,7 @@ std::unique_ptr<Pass> circt::seq::createSeqLowerToSVPass() {
   return std::make_unique<SeqToSVPass>();
 }
 
-std::unique_ptr<Pass>
-circt::seq::createSeqFIRRTLLowerToSVPass(bool disableRegRandomization) {
-  auto pass = std::make_unique<SeqFIRRTLToSVPass>();
-  if (disableRegRandomization)
-    pass->disableRegRandomization = disableRegRandomization;
-  return pass;
+std::unique_ptr<Pass> circt::seq::createSeqFIRRTLLowerToSVPass(
+    const circt::seq::LowerSeqFIRRTLToSVOptions &options) {
+  return std::make_unique<SeqFIRRTLToSVPass>(options);
 }

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -31,11 +31,11 @@ using namespace circt;
 using namespace seq;
 
 namespace {
-struct SeqToSVPass : public circt::seq::impl::LowerSeqToSVBase<SeqToSVPass> {
+struct SeqToSVPass : public impl::LowerSeqToSVBase<SeqToSVPass> {
   void runOnOperation() override;
 };
 struct SeqFIRRTLToSVPass
-    : public circt::seq::impl::LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
+    : public impl::LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
   void runOnOperation() override;
   using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::disableRegRandomization;
   using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::LowerSeqFIRRTLToSVBase;
@@ -523,6 +523,6 @@ std::unique_ptr<Pass> circt::seq::createSeqLowerToSVPass() {
 }
 
 std::unique_ptr<Pass> circt::seq::createSeqFIRRTLLowerToSVPass(
-    const circt::seq::LowerSeqFIRRTLToSVOptions &options) {
+    const LowerSeqFIRRTLToSVOptions &options) {
   return std::make_unique<SeqFIRRTLToSVPass>(options);
 }

--- a/lib/Dialect/Seq/Transforms/PassDetails.h
+++ b/lib/Dialect/Seq/Transforms/PassDetails.h
@@ -17,12 +17,15 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
 namespace seq {
 
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_LOWERSEQFIRRTLTOSV
+#define GEN_PASS_DEF_LOWERSEQHLMEM
+#define GEN_PASS_DEF_LOWERSEQTOSV
 #include "circt/Dialect/Seq/SeqPasses.h.inc"
 
 } // namespace seq

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -792,8 +792,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createCSEPass());
       }
 
-      pm.nest<hw::HWModuleOp>().addPass(
-          seq::createSeqFIRRTLLowerToSVPass(!isRandomEnabled(RandomKind::Reg)));
+      pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass(
+          {/*disableRandomization=*/!isRandomEnabled(RandomKind::Reg)}));
       pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem,
                                             stripMuxPragmas,
                                             !isRandomEnabled(RandomKind::Mem),


### PR DESCRIPTION
This applies a new pass generation method(ref:https://github.com/llvm/circt/issues/3962) to seq dialect passes, that automatically defines a struct of options (e.g. `LowerSeqFIRRTLToSVOptions`) and creates a pass constructor to take the option.
