### PR TITLE
[FIRRTL] Remove Grand Central Parent Annotation

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -99,8 +99,6 @@ constexpr const char *viewAnnoClass =
     "sifive.enterprise.grandcentral.ViewAnnotation";
 constexpr const char *companionAnnoClass =
     "sifive.enterprise.grandcentral.ViewAnnotation.companion"; // not in SFC
-constexpr const char *parentAnnoClass =
-    "sifive.enterprise.grandcentral.ViewAnnotation.parent"; // not in SFC
 constexpr const char *prefixInterfacesAnnoClass =
     "sifive.enterprise.grandcentral.PrefixInterfacesAnnotation";
 constexpr const char *augmentedGroundTypeClass =

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -319,7 +319,6 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
     {serializedViewAnnoClass, {noResolve, applyGCTView}},
     {viewAnnoClass, {noResolve, applyGCTView}},
     {companionAnnoClass, {stdResolve, applyWithoutTarget<>}},
-    {parentAnnoClass, {stdResolve, applyWithoutTarget<>}},
     {augmentedGroundTypeClass, {stdResolve, applyWithoutTarget<true>}},
     // Grand Central Data Tap Annotations
     {dataTapsClass, {noResolve, applyGCTDataTaps}},

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -304,7 +304,7 @@ void PrefixModulesPass::renameModule(FModuleOp module) {
 
   // If this module contains a Grand Central interface, then also apply renames
   // to that, but only if there are prefixes to apply.
-  if (auto anno = AnnotationSet(module).getAnnotation(parentAnnoClass))
+  if (auto anno = AnnotationSet(module).getAnnotation(companionAnnoClass))
     interfacePrefixMap[anno.getMember<IntegerAttr>("id")] = prefixFull;
 }
 

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -50,12 +50,7 @@ firrtl.circuit "NonGroundType" attributes {
       ]
     } : !firrtl.vector<uint<2>, 1>
   }
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
+  firrtl.module private @DUT() {
     firrtl.instance View_companion @View_companion()
   }
   firrtl.module @NonGroundType() {
@@ -95,11 +90,7 @@ firrtl.circuit "Foo" attributes {
        id = 0 : i64,
        name = "View"}]} {}
   firrtl.module private @Bar(in %a: !firrtl.uint<1>) {}
-  firrtl.module private @DUT(in %a: !firrtl.uint<1>) attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "View"}]} {
+  firrtl.module private @DUT(in %a: !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.instance' op is marked as an interface element, but this should be impossible due to how the Chisel Grand Central API works}}
     %bar_a = firrtl.instance bar @Bar(in a: !firrtl.uint<1> [
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
@@ -132,11 +123,7 @@ firrtl.circuit "Foo" attributes {
        defName = "Foo",
        id = 0 : i64,
        name = "View"}]} {}
-  firrtl.module private @DUT(in %a: !firrtl.uint<1>) attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "View"}]} {
+  firrtl.module private @DUT(in %a: !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.mem' op is marked as an interface element, but this does not make sense (is there a scattering bug or do you have a malformed hand-crafted MLIR circuit?)}}
     %memory_b_r = firrtl.mem Undefined {
       annotations = [
@@ -176,50 +163,11 @@ firrtl.circuit "Foo" attributes {
        defName = "Foo",
        id = 0 : i64,
        name = "View"}]} {}
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "View"}]} {
+  firrtl.module private @DUT() {
     firrtl.instance View_companion @View_companion()
   }
   firrtl.module @Foo() {
     firrtl.instance dut @DUT()
-  }
-}
-
-
-// -----
-// expected-error @+1 {{'firrtl.circuit' op contains a 'companion' with id '0', but does not contain a GrandCentral 'parent' with the same id}}
-firrtl.circuit "multiInstance2" attributes {
-  annotations = [
-    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-     defName = "Foo",
-     id = 0 : i64,
-     name = "View"},
-    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-     directory = "gct-dir",
-     filename = "gct-dir/bindings.sv"}]} {
-  firrtl.module private @View_companion() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-       defName = "Foo",
-       id = 0 : i64,
-       name = "View"}]} {}
-  // expected-error @+1 {{'firrtl.module' op is marked as a GrandCentral 'parent', but it is instantiated more than once}}
-  firrtl.module private @DUTE() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
-    %a = firrtl.wire : !firrtl.uint<2>
-    %b = firrtl.wire : !firrtl.uint<4>
-    firrtl.instance View_companion @View_companion()
-  }
-  firrtl.module @multiInstance2() {
-    firrtl.instance dut sym @s1 @DUTE() // expected-note {{parent is instantiated here}}
-    firrtl.instance dut1 sym @s2 @DUTE() // expected-note {{parent is instantiated here}}
   }
 }
 
@@ -255,15 +203,7 @@ firrtl.circuit "FieldNotInCompanion" attributes {
     ]
   } {}
   // expected-note @+1 {{the leaf value is inside this module}}
-  firrtl.module @FieldNotInCompanion() attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 0 : i64,
-        name = "Foo"
-      }
-    ]
-  } {
+  firrtl.module @FieldNotInCompanion() {
 
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
@@ -322,15 +262,7 @@ firrtl.circuit "InvalidField" attributes {
       ]
     } : !firrtl.uint<1>
   }
-  firrtl.module @InvalidField() attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 0 : i64,
-        name = "Foo"
-      }
-    ]
-  } {
+  firrtl.module @InvalidField() {
     firrtl.instance companion @Companion()
   }
 }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -450,55 +450,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
     } : !firrtl.sint<2>
 
   }
-  firrtl.module @InterfaceGroundType() attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 0 : i64,
-        name = "GroundView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 3 : i64,
-        name = "VectorView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 6 : i64,
-        name = "BundleView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 9 : i64,
-        name = "VectorOfBundle"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 12 : i64,
-        name = "VectorOfVector"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 19 : i64,
-        name = "ZeroWidthView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 21 : i64,
-        name = "ConstantView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 24 : i64,
-        name = "UnsupportedView"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 25 : i64,
-        name = "VectorOfVerbatimView"
-      }
-    ]
-  } {
+  firrtl.module @InterfaceGroundType() {
     firrtl.instance companion @Companion()
   }
 }
@@ -765,11 +717,7 @@ firrtl.circuit "PrefixInterfacesAnnotation"
       class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
       id = 0 : i64,
       name = "MyView"}]} {}
-  firrtl.module private @DUT()
-    attributes {annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "MyView"}]} {
+  firrtl.module private @DUT() {
     firrtl.instance MyView_companion  @MyView_companion()
   }
   firrtl.module @PrefixInterfacesAnnotation() {
@@ -862,11 +810,9 @@ firrtl.circuit "DirectoryBehaviorWithDUT" attributes {
   // The Design-under-test as indicated by the MarkDUTAnnotation
   firrtl.module private @DUT() attributes {
     annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"},
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
-    ]} {
+    ]
+  } {
     firrtl.instance companion @Companion()
 
     firrtl.instance m_d_ @M_D_()
@@ -969,12 +915,7 @@ firrtl.circuit "DirectoryBehaviorWithoutDUT" attributes {
 
   // This is the DUT in the previous example, but is no longer marked as the
   // DUT.
-  firrtl.module @DirectoryBehaviorWithoutDUT() attributes {
-    annotations = [
-      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-       id = 0 : i64,
-       name = "view"}
-    ]} {
+  firrtl.module @DirectoryBehaviorWithoutDUT() {
     firrtl.instance companion @Companion()
 
     firrtl.instance m_d_ @MT_()
@@ -1092,20 +1033,7 @@ firrtl.circuit "Top" attributes {
       ]
     } : !firrtl.uint<2>
   }
-  firrtl.module private @DUT() attributes {
-    annotations = [
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 0 : i64,
-        name = "View_w1"
-      },
-      {
-        class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-        id = 2 : i64,
-        name = "View_w2"
-      }
-    ]
-  } {
+  firrtl.module private @DUT() {
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %a_w1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>


### PR DESCRIPTION
Get rid of the Grand Central "Parent" Annotation.  This is no longer necessary now that the SV Interface is instantiated inside the companion module.  Keeping track of the parent of this companion is unnecessary.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>