### PR TITLE
[FIRRTL] Move DShift to patterns

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -92,6 +92,22 @@ def GTWithConstLHS : Pat<
   (LTPrimOp $rhs, $lhs),
   [(AnyConstantOp $lhs), (NonConstantOp $rhs)]>;
 
+def LimitConstant32 : NativeCodeCall<
+  "$_builder.getI32IntegerAttr($0.getValue().getLimitedValue(1ULL << 31))">;
+
+def TypeWidth32 : NativeCodeCall<
+  "$_builder.getI32IntegerAttr($0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel())">;
+
+def DShlOfConstant : Pat<
+  (DShlPrimOp:$old $x, (ConstantOp $cst)),
+  (PadPrimOp (ShlPrimOp $x, (LimitConstant32 $cst)), (TypeWidth32 $old)),
+  [(KnownWidth $x)]>;
+
+def DShrOfConstant : Pat<
+  (DShrPrimOp:$old $x, (ConstantOp $cst)),
+  (PadPrimOp (ShrPrimOp $x, (LimitConstant32 $cst)), (TypeWidth32 $old)),
+  [(KnownWidth $x)]>;
+
 // mux(cond, x, mux(cond, y, z)) -> mux(cond, x, z)
 def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -423,7 +423,7 @@ def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>  {
     A dynamic shift left operation. The width of `$result` is expanded to
     `width($lhs) + 1 << width($rhs) - 1`.
   }];
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
 }
 def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType> {
   let description = [{
@@ -432,7 +432,7 @@ def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType> {
   }];
 }
 def DShrPrimOp  : BinaryPrimOp<"dshr", IntType, UIntType, IntType> {
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1029,44 +1029,14 @@ OpFoldResult CatPrimOp::fold(ArrayRef<Attribute> operands) {
   return {};
 }
 
-LogicalResult DShlPrimOp::canonicalize(DShlPrimOp op,
-                                       PatternRewriter &rewriter) {
-  if (!hasKnownWidthIntTypes(op))
-    return failure();
-
-  return canonicalizePrimOp(
-      op, rewriter, [&](ArrayRef<Attribute> operands) -> OpFoldResult {
-        // dshl(x, cst) -> shl(x, cst).  The result size is generally much wider
-        // than what is needed for the constant.
-        if (auto rhsCst = getConstant(operands[1])) {
-          // Shift amounts are always unsigned, but shift only takes a 32-bit
-          // amount.
-          uint64_t shiftAmt = rhsCst->getLimitedValue(1ULL << 31);
-          return rewriter.createOrFold<ShlPrimOp>(op.getLoc(), op.getLhs(),
-                                                  shiftAmt);
-        }
-        return {};
-      });
+void DShlPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.insert<patterns::DShlOfConstant>(context);
 }
 
-LogicalResult DShrPrimOp::canonicalize(DShrPrimOp op,
-                                       PatternRewriter &rewriter) {
-  if (!hasKnownWidthIntTypes(op))
-    return failure();
-
-  return canonicalizePrimOp(
-      op, rewriter, [&](ArrayRef<Attribute> operands) -> OpFoldResult {
-        // dshr(x, cst) -> shr(x, cst).  The result size is generally much wider
-        // than what is needed for the constant.
-        if (auto rhsCst = getConstant(operands[1])) {
-          // Shift amounts are always unsigned, but shift only takes a 32-bit
-          // amount.
-          uint64_t shiftAmt = rhsCst->getLimitedValue(1ULL << 31);
-          return rewriter.createOrFold<ShrPrimOp>(op.getLoc(), op.getLhs(),
-                                                  shiftAmt);
-        }
-        return {};
-      });
+void DShrPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.insert<patterns::DShrOfConstant>(context);
 }
 
 namespace {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2063,17 +2063,6 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   %c438_ui10 = firrtl.constant 438 : !firrtl.uint<10>
   %2 = firrtl.dshr %c_in, %c438_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
-
-  // CHECK: firrtl.strictconnect %a_out, %a_in : !firrtl.sint<58>
-  %invalid_ui10 = firrtl.invalidvalue : !firrtl.uint<10>
-  %3 = firrtl.dshr %a_in, %invalid_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
-  firrtl.connect %a_out, %3 : !firrtl.sint<58>, !firrtl.sint<58>
-
-  // CHECK: [[TMP:%.+]] = firrtl.pad %b_in, 23 : (!firrtl.uint<8>) -> !firrtl.uint<23>
-  // CHECK: firrtl.strictconnect %b_out, [[TMP]] : !firrtl.uint<23>
-  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
-  %4 = firrtl.dshl %b_in, %invalid_ui4 : (!firrtl.uint<8>, !firrtl.uint<4>) -> !firrtl.uint<23>
-  firrtl.connect %b_out, %4 : !firrtl.uint<23>, !firrtl.uint<23>
 }
 
 // CHECK-LABEL: firrtl.module @constReg


### PR DESCRIPTION
As a bonus, this was another place canonicalize was choosing values for invalids.