### PR TITLE
[GrandCentral] Ignore deduped Companion views

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -565,7 +565,7 @@ private:
   /// Mapping of ID to companion module.
   DenseMap<Attribute, CompanionInfo> companionIDMap;
 
-  // Records the verbatim ops inserted while creating Interface elements for a
+  // Records the ops inserted while creating Interface elements for a
   // view companion. These are recorded such that they can be erased later, if
   // the interface is found out to be redundant.
   SmallVector<Operation *> insertedOps;
@@ -2098,17 +2098,17 @@ void GrandCentralPass::runOnOperation() {
     verbatim += instanceSymbol;
     // List of interface elements.
     SmallVector<Operation *> interfaceElems;
-    // insertedOps will record all the verbatim ops inserted in the companion
-    // module, which must be erased, if the interface is redundant. The
-    // traverseBundle is a recursive traversal of the AugmentedBundleType, it
-    // will construct the Interface and populate it with the elements and insert
-    // the corresponding verbatim xmr assignments. The interface might be
-    // redundant if it is a nonlocal view and another exactly same interface is
-    // already generated. To compare the interface elements, with an existing
-    // interface, it is necessary to complete the traverseBundle traversal and
-    // gather all the elements of the interface.
+    // insertedOps will record all the interface ops and the verbatim ops
+    // inserted in the companion module, which must be erased, if the interface
+    // is redundant. The traverseBundle is a recursive traversal of the
+    // AugmentedBundleType, it will construct the Interface and populate it with
+    // the elements and insert the corresponding verbatim xmr assignments. The
+    // interface might be redundant if it is a nonlocal view and another exactly
+    // same interface is already generated. To compare the interface elements,
+    // with an existing interface, it is necessary to complete the
+    // traverseBundle traversal and gather all the elements of the interface.
     // TODO: Update the algorithm to build the interface after traversal and not
-    // during the recurdive traversal.
+    // during the recursive traversal.
     insertedOps.clear();
     auto iface = traverseBundle(bundle, bundle.getID(), bundle.getPrefix(),
                                 verbatim, interfaceElems);
@@ -2116,7 +2116,7 @@ void GrandCentralPass::runOnOperation() {
       removalError = true;
       continue;
     }
-    auto compareInterfaceSignal = [&](Operation *&lhs, Operation *&rhs) {
+    auto compareInterfaceSignal = [&](Operation *lhs, Operation *rhs) {
       return (cast<sv::InterfaceSignalOp>(lhs).getSymName() ==
                   cast<sv::InterfaceSignalOp>(rhs).getSymName() &&
               cast<sv::InterfaceSignalOp>(lhs).getType() ==
@@ -2128,7 +2128,7 @@ void GrandCentralPass::runOnOperation() {
       // annotations, then add the interface for only one of them. This happens
       // when the companion is deduped.
       auto viewMapIter = companionToInterfaceMap.find(companionModule);
-      if (viewMapIter != companionToInterfaceMap.end()) {
+      if (viewMapIter != companionToInterfaceMap.end())
         if (std::equal(interfaceElems.begin(), interfaceElems.end(),
                        viewMapIter->getSecond().begin(),
                        compareInterfaceSignal)) {
@@ -2141,7 +2141,7 @@ void GrandCentralPass::runOnOperation() {
           }
           continue;
         }
-      }
+
       companionToInterfaceMap[companionModule] = interfaceElems;
     }
     ++numViews;

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2061,7 +2061,7 @@ void GrandCentralPass::runOnOperation() {
   SmallVector<sv::InterfaceOp, 2> interfaceVec;
   SmallDenseMap<FModuleLike, SmallVector<Operation *>> companionToInterfaceMap;
   auto compareInterfaceSignal = [&](Operation *lhs, Operation *rhs) {
-    // If its a verbatim op, no need to check the string, because the interface
+    // If it's a verbatim op, no need to check the string, because the interface
     // names might not match. As long as the signal ops match that is
     // sufficient.
     if (isa<sv::VerbatimOp>(lhs) && isa<sv::VerbatimOp>(rhs))

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -557,7 +557,7 @@ struct InterfaceElemsBuilder {
     StringAttr description;
     StringAttr elemName;
     TypeSum elemType;
-    Properties(StringAttr des, StringAttr name, TypeSum elemType)
+    Properties(StringAttr des, StringAttr name, TypeSum &elemType)
         : description(des), elemName(name), elemType(elemType) {}
   };
   SmallVector<Properties> elementsList;
@@ -2116,7 +2116,7 @@ void GrandCentralPass::runOnOperation() {
                                      xmrElem.syms);
     }
     sv::InterfaceOp topIface;
-    for (auto ifaceBuilder : interfaceBuilder) {
+    for (const auto &ifaceBuilder : interfaceBuilder) {
       auto builder = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
       auto loc = getOperation().getLoc();
       sv::InterfaceOp iface =

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1064,79 +1064,155 @@ firrtl.circuit "NoInterfaces" attributes {
 // -----
 
 // Check that nonlocal duplicate views are dropped.
-firrtl.circuit "Top"  attributes {
+firrtl.circuit "Top" attributes {
   annotations = [
     {
       class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-      defName = "MyInterface",
+      defName = "VectorOfBundleView",
       elements = [
         {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 1 : i64,
-          name = "signed"
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+              defName = "Bundle2",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "foo",
+                  id = 10 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "bar",
+                  id = 11 : i64
+                }
+              ],
+              name = "bundle2"
+            }
+          ],
+          name = "vector"
         }
       ],
-      id = 2 : i64,
-      name = "MyView"
+      id = 9 : i64,
+      name = "VectorOfBundleView"
     },
     {
       class = "sifive.enterprise.grandcentral.AugmentedBundleType",
-      defName = "MyInterface",
+      defName = "VectorOfBundleView",
       elements = [
         {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 5 : i64,
-          name = "signed"
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          elements = [
+            {
+              class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+              defName = "Bundle2",
+              elements = [
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "foo",
+                  id = 110 : i64
+                },
+                {
+                  class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                  name = "bar",
+                  id = 111 : i64
+                }
+              ],
+              name = "bundle2"
+            }
+          ],
+          name = "vector"
         }
       ],
-      id = 0 : i64,
-      name = "MyView"
+      id = 19 : i64,
+      name = "VectorOfBundleView"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+      directory = "gct-dir",
+      filename = "bindings.sv"
+    },
+    {
+      class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
+      filename = "gct.yaml"
     }
   ]
-  } {
+} {
   firrtl.hierpath private @nla_0 [@Top::@t1, @Dut::@s1]
   firrtl.hierpath private @nla [@Top::@t1, @Dut::@s1]
-  firrtl.module private @NonlocalCompanion(in %MyInterface_1_0: !firrtl.ref<uint<1>>) attributes {
+  firrtl.module @Companion() attributes {
     annotations = [
       {
         circt.nonlocal = @nla,
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-        id = 0 : i64,
-        name = "MyView"
+        defName = "VectorOfBundleView",
+        id = 9 : i64,
+        name = "VectorOfBundleView"
       },
       {
         circt.nonlocal = @nla_0,
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
-        id = 2 : i64,
-        name = "MyView"
+        defName = "VectorOfBundleView",
+        id = 19 : i64,
+        name = "VectorOfBundleView"
       }
-    ]} {
-    %0 = firrtl.ref.resolve %MyInterface_1_0 : !firrtl.ref<uint<1>>
-    %MyInterface_1 = firrtl.node  %0  {
+    ]
+  } {
+
+    // These are dummy references created for the purposes of the test.
+    %_ui1 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<1>
+    %_ui2 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<2>
+    %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
+    %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
+
+    %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
+    %foo = firrtl.node %ui1 {
       annotations = [
-      {
-        circt.nonlocal = @nla,
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 1 : i64
-      },
-      {
-        circt.nonlocal = @nla_0,
-        class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 5 : i64
-      }
-      ]} : !firrtl.uint<1>
+        {
+          circt.nonlocal = @nla,
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 10 : i64
+        },{
+          circt.nonlocal = @nla_0,
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 110 : i64
+        }
+      ]
+    } : !firrtl.uint<1>
+
+    %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
+    %bar = firrtl.node %ui2 {
+      annotations = [
+        {
+          circt.nonlocal = @nla,
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 11 : i64
+        },
+        {
+          circt.nonlocal = @nla_0,
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 111 : i64
+        }
+
+      ]
+    } : !firrtl.uint<2>
+    // CHECK: sv.interface.instance sym @__VectorOfBundleView_VectorOfBundleView
+    // CHECK-SAME: {name = "VectorOfBundleView"} : !sv.interface<@VectorOfBundleView>
+    // CHECK-NOT: sv.interface.instance
   }
   firrtl.module public @Dut() {
-    %1 = firrtl.instance s1 sym @s1 @NonlocalCompanion(in MyInterface_1_0: !firrtl.ref<uint<1>>)
+    firrtl.instance s1 sym @s1 @Companion()
   }
   firrtl.module public @Top() {
     firrtl.instance t1 sym @t1 @Dut()
   }
-  // CHECK:  firrtl.module private @NonlocalCompanion(in %MyInterface_1_0: !firrtl.ref<uint<1>>) {
-  // CHECK:    %0 = sv.interface.instance sym @__MyView_MyInterface__  {name = "MyView"} : !sv.interface<@MyInterface>
-  // CHECK:    %1 = firrtl.ref.resolve %MyInterface_1_0 : !firrtl.ref<uint<1>>
-  // CHECK:    %MyInterface_1 = firrtl.node  %1  : !firrtl.uint<1>
-  // CHECK{LITERAL}:    sv.verbatim "assign {{1}}.signed = {{0}};"(%1) :
-  // CHECK-SAME: !firrtl.uint<1> {symbols = [#hw.innerNameRef<@NonlocalCompanion::@__MyView_MyInterface__>]}
-  // CHECK:  }
+
+  // CHECK-LABEL:  sv.interface @VectorOfBundleView
+  // CHECK-NOT:    sv.interface @VectorOfBundleView_0 
+  // CHECK-LABEL:  sv.interface @Bundle2
+  // CHECK-NEXT:   sv.interface.signal @foo : i1
+  // CHECK-NEXT:   sv.interface.signal @bar : i2
+
+  // CHECK-NOT:    sv.interface @Bundle2_0 
 }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1205,9 +1205,9 @@ firrtl.circuit "Top" attributes {
     firrtl.instance t1 sym @t1 @Dut()
   }
 
-  // CHECK:  sv.interface @[[VectorOfBundleView]] attributes
+  // CHECK:      sv.interface @[[VectorOfBundleView]] attributes
   // CHECK-NOT:    sv.interface @VectorOfBundleView_0 
-  // CHECK:  sv.interface @Bundle2
+  // CHECK:      sv.interface @Bundle2
   // CHECK-NEXT:   sv.interface.signal @foo : i1
   // CHECK-NEXT:   sv.interface.signal @bar : i2
   // CHECK-NOT:    sv.interface @Bundle2_0 

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1159,48 +1159,45 @@ firrtl.circuit "Top" attributes {
       }
     ]
   } {
+      // These are dummy references created for the purposes of the test.
+      %_ui1 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<1>
+      %_ui2 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<2>
+      %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
+      %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
 
-    // These are dummy references created for the purposes of the test.
-    %_ui1 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<1>
-    %_ui2 = firrtl.verbatim.expr "???" : () -> !firrtl.uint<2>
-    %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
-    %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
-
-    %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
-    %foo = firrtl.node %ui1 {
-      annotations = [
-        {
-          circt.nonlocal = @nla,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 10 : i64
-        },{
-          circt.nonlocal = @nla_0,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 110 : i64
-        }
-      ]
-    } : !firrtl.uint<1>
-
-    %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
-    %bar = firrtl.node %ui2 {
-      annotations = [
-        {
-          circt.nonlocal = @nla,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 11 : i64
-        },
-        {
-          circt.nonlocal = @nla_0,
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 111 : i64
-        }
-
-      ]
-    } : !firrtl.uint<2>
-    // CHECK: sv.interface.instance sym @__VectorOfBundleView_VectorOfBundleView
-    // CHECK-SAME: {name = "VectorOfBundleView"} : !sv.interface<@VectorOfBundleView>
-    // CHECK-NOT: sv.interface.instance
-  }
+      %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
+      %foo = firrtl.node %ui1 {
+        annotations = [
+          {
+            circt.nonlocal = @nla,
+            class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+            id = 10 : i64
+          },{
+            circt.nonlocal = @nla_0,
+            class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+            id = 110 : i64
+          }
+        ]
+      } : !firrtl.uint<1>
+      %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
+      %bar = firrtl.node %ui2 {
+        annotations = [
+          {
+            circt.nonlocal = @nla,
+            class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+            id = 11 : i64
+          },
+          {
+            circt.nonlocal = @nla_0,
+            class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+            id = 111 : i64
+          }
+        ]
+      } : !firrtl.uint<2>
+      // CHECK: sv.interface.instance sym 
+      // CHECK-SAME: !sv.interface<@[[VectorOfBundleView:[a-zA-Z0-9_]+]]>
+      // CHECK-NOT: sv.interface.instance
+    }
   firrtl.module public @Dut() {
     firrtl.instance s1 sym @s1 @Companion()
   }
@@ -1208,11 +1205,10 @@ firrtl.circuit "Top" attributes {
     firrtl.instance t1 sym @t1 @Dut()
   }
 
-  // CHECK-LABEL:  sv.interface @VectorOfBundleView
+  // CHECK:  sv.interface @[[VectorOfBundleView]] attributes
   // CHECK-NOT:    sv.interface @VectorOfBundleView_0 
-  // CHECK-LABEL:  sv.interface @Bundle2
+  // CHECK:  sv.interface @Bundle2
   // CHECK-NEXT:   sv.interface.signal @foo : i1
   // CHECK-NEXT:   sv.interface.signal @bar : i2
-
   // CHECK-NOT:    sv.interface @Bundle2_0 
 }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1085,7 +1085,7 @@ firrtl.circuit "Top"  attributes {
       elements = [
         {
           class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          id = 1 : i64,
+          id = 5 : i64,
           name = "signed"
         }
       ],
@@ -1122,7 +1122,7 @@ firrtl.circuit "Top"  attributes {
       {
         circt.nonlocal = @nla_0,
         class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-        id = 1 : i64
+        id = 5 : i64
       }
       ]} : !firrtl.uint<1>
   }


### PR DESCRIPTION
This commit ensures that, if a companion module has two exactly same view annotations, then only one interface is generated.
This can occur when companions are deduped, and the corresponding View annotations are added as nonlocal after dedup.
If all the elements of the interface are exactly the same, then the companion must generate only one of the interfaces.
This commit still ensures that only a single instance of the companion exists. If multiple instances of the companion exist then GrandCentral will fail. This only handles the case when the parent module instantiating the companion is also deduped, thus ensuring only a single instance of the companion exists.