### PR TITLE
[FIRRTL] Change Wires to Nodes in WiringProblems

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -632,9 +632,6 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     });
   }
 
-  for (auto *op : opsToErase)
-    op->erase();
-
   // Iterate over modules from leaves to roots, applying ModuleModifications to
   // each module.
   LLVM_DEBUG({ llvm::dbgs() << "Updating modules:\n"; });
@@ -717,6 +714,10 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
       }
     }
   }
+
+  // Delete unused WireOps created by producers of WiringProblems.
+  for (auto *op : opsToErase)
+    op->erase();
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -490,6 +490,29 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     return value.getDefiningOp()->getParentOfType<FModuleLike>();
   };
 
+  // Utility function to connect a destination to a source.  Always use a
+  // ConnectOp as the widths may be uninferred.
+  auto connect = [&](Value src, Value dest, ImplicitLocOpBuilder &builder) {
+    if (foldFlow(dest) == Flow::Source)
+      std::swap(src, dest);
+    // Create RefSend/RefResolve if necessary.
+    if (dest.getType().isa<RefType>() && !src.getType().isa<RefType>()) {
+      src = builder.create<RefSendOp>(src);
+    } else if (!dest.getType().isa<RefType>() && src.getType().isa<RefType>()) {
+      src = builder.create<RefResolveOp>(src);
+    }
+    // If the sink is a wire with no users, then convert this to a node.
+    auto destOp = dyn_cast_or_null<WireOp>(dest.getDefiningOp());
+    if (destOp && dest.getUses().empty()) {
+      builder.create<NodeOp>(src.getType(), src, destOp.getName())
+          .setAnnotationsAttr(destOp.getAnnotations());
+      destOp->erase();
+      return;
+    }
+    // Otherwise, just connect to the source.
+    builder.create<ConnectOp>(dest, src);
+  };
+
   auto &instanceGraph = state.instancePathCache.instanceGraph;
   auto *context = state.circuit.getContext();
 
@@ -508,7 +531,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     if (sink.getParentBlock() == source.getParentBlock()) {
       auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
                                                       sink.getParentBlock());
-      builder.create<ConnectOp>(sink, source);
+      connect(source, sink, builder);
       continue;
     }
 
@@ -634,28 +657,13 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
                                                     fmodule.getBodyBlock());
 
-    // Utility function to connect a destination to a source.  Always use a
-    // ConnectOp as the widths may be uninferred.
-    auto connect = [&](Value src, Value dest) {
-      if (foldFlow(dest) == Flow::Source)
-        std::swap(src, dest);
-      // Create RefSend/RefResolve if necessary.
-      if (dest.getType().isa<RefType>() && !src.getType().isa<RefType>()) {
-        src = builder.create<RefSendOp>(src);
-      } else if (!dest.getType().isa<RefType>() &&
-                 src.getType().isa<RefType>()) {
-        src = builder.create<RefResolveOp>(src);
-      }
-      builder.create<ConnectOp>(dest, src);
-    };
-
     // Connect each port to the value stored in the connectionMap for this
     // wiring problem index.
     for (auto [problemIdx, portPair] : llvm::zip(problemIndices, newPorts)) {
       Value src = moduleModifications[fmodule].connectionMap[problemIdx];
       assert(src && "there did not exist a driver for the port");
       Value dest = fmodule.getArgument(portIdx++);
-      connect(src, dest);
+      connect(src, dest, builder);
     }
 
     // If a U-turn exists, this is an LCA and we need a U-turn connection.  This
@@ -663,7 +671,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     for (auto [problemIdx, dest] : moduleModifications[fmodule].uturns) {
       Value src = moduleModifications[fmodule].connectionMap[problemIdx];
       assert(src && "there did not exist a connection for the u-turn");
-      connect(src, dest);
+      connect(src, dest, builder);
     }
 
     // Update the connectionMap of all modules for which we created a port.

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -3,6 +3,7 @@
 ; RUN: firtool --annotation-file %s.anno.json --annotation-file %s.Extract.anno.json %s --annotation-file %s.YAML.anno.json | FileCheck %s --check-prefixes YAML
 ; RUN: firtool --split-verilog --annotation-file %s.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
 ; RUN: firtool --annotation-file %s.anno.json --annotation-file %s.Prefix.anno.json %s | FileCheck %s --check-prefixes PREFIX
+; RUN: firtool --annotation-file %s.anno.json %s --disable-opt
 
 circuit Top :
   extmodule BlackBox_DUT :

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -838,27 +838,22 @@ firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}]
 // CHECK-SAME: {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
 // CHECK-SAME:  id = [[ID_ViewName]] : i64,
 // CHECK-SAME:  name = "view"}
-// CHECK:      %[[wire_1:[a-zA-Z0-9_]+]] = firrtl.wire
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}
-// CHECK-NEXT: %[[wire_2:[a-zA-Z0-9_]+]] = firrtl.wire
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}
-// CHECK-NEXT: %[[wire_3:[a-zA-Z0-9_]+]] = firrtl.wire
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3 : i64}
-// CHECK-NEXT: %[[wire_4:[a-zA-Z0-9_]+]] = firrtl.wire
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4 : i64}
-// CHECK-NEXT: %[[wire_5:[a-zA-Z0-9_]+]] = firrtl.wire
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5 : i64}
 //
 // CHECK:      %[[wire_1_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.connect %[[wire_1]], %[[wire_1_ref]]
+// CHECK:      firrtl.node %[[wire_1_ref]]
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}
 // CHECK:      %[[wire_2_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.connect %[[wire_2]], %[[wire_2_ref]]
+// CHECK:      firrtl.node %[[wire_2_ref]]
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}
 // CHECK:      %[[wire_3_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.connect %[[wire_3]], %[[wire_3_ref]]
+// CHECK:      firrtl.node %[[wire_3_ref]]
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3 : i64}
 // CHECK:      %[[wire_4_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.connect %[[wire_4]], %[[wire_4_ref]]
+// CHECK:      firrtl.node %[[wire_4_ref]]
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4 : i64}
 // CHECK:      %[[wire_5_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.connect %[[wire_5]], %[[wire_5_ref]]
+// CHECK:      firrtl.node %[[wire_5_ref]]
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5 : i64}
 
 // The RefSend must be generated.
 // CHECK: firrtl.module @GCTInterface
@@ -1343,16 +1338,14 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
   // CHECK-SAME:   in %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<2>>
   // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion", id = 0 : i64, name = "View"}
   firrtl.module @Companion() {
-    // CHECK-NEXT: %[[wire_0:[a-zA-Z0-9_]+]] = firrtl.wire
+    // CHECK-NEXT: %[[refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_0]]
+    // CHECK-NEXT: firrtl.node %[[refPort_0_resolve]]
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}]}
     // CHECK-SAME:   !firrtl.uint<1>
-    // CHECK-NEXT: %[[wire_1:[a-zA-Z0-9_]+]] = firrtl.wire
+    // CHECK-NEXT: %[[refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_1]]
+    // CHECK-NEXT: firrtl.node %[[refPort_1_resolve]]
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}]}
     // CHECK-SAME:   !firrtl.uint<2>
-    // CHECK-NEXT: %[[refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_0]]
-    // CHECK-NEXT: firrtl.connect %[[wire_0]], %[[refPort_0_resolve]]
-    // CHECK-NEXT: %[[refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_1]]
-    // CHECK-NEXT: firrtl.connect %[[wire_1]], %[[refPort_1_resolve]]
   }
   // CHECK:      firrtl.module @Bar
   // CHECK-SAME:   out %[[refPort_0:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
@@ -1536,11 +1529,10 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
   firrtl.module @Companion() {
     firrtl.instance bar @Bar()
     // CHECK-NEXT:   %[[bar_a_refPort:[a-zA-Z0-9_]+]] = firrtl.instance bar
-    // CHECK-NEXT:   %[[b:[a-zA-Z0-9_]+]] = firrtl.wire
+    // CHECK-NEXT:   %[[b_refResolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_a_refPort]]
+    // CHECK-NEXT:   firrtl.node %[[b_refResolve]]
     // CHECK-SAME:     {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}
     // CHECK-SAME:     : !firrtl.uint<1>
-    // CHECK-NEXT:   %[[b_refResolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_a_refPort]]
-    // CHECK-NEXT:   firrtl.connect %[[b]], %[[b_refResolve]]
   }
   firrtl.module @GrandCentralParentIsNotLCA() {
     firrtl.instance companion @Companion()
@@ -1631,15 +1623,12 @@ firrtl.circuit "GrandCentralViewInsideCompanion" attributes {
   firrtl.module @Companion(out %b: !firrtl.uint<2>) {
     %clock = firrtl.specialconstant 0 : !firrtl.clock
     %a = firrtl.reg %clock : !firrtl.uint<1>
-    // CHECK:      %[[a_view:[a-zA-Z0-9_]+]] = firrtl.wire
+    // CHECK:      firrtl.node %a
     // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = [[aId]] : i64}
     // CHECK-SAME:   : !firrtl.uint<1>
-    // CHECK-NEXT: %[[b_view:[a-zA-Z0-9_]+]] = firrtl.wire
+    // CHECK-NEXT: firrtl.node %b
     // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = [[bId]] : i64}
     // CHECK-SAME:   : !firrtl.uint<2>
-    //
-    // CHECK-NEXT: firrtl.connect %[[a_view]], %a
-    // CHECK-NEXT: firrtl.connect %[[b_view]], %b
   }
   firrtl.module @GrandCentralViewInsideCompanion() {
     %companion_b = firrtl.instance companion @Companion(out b: !firrtl.uint<2>)


### PR DESCRIPTION
Change the connect utility lambda used during WiringProblem solving to connect sources to sinks to (manually) canonicalize unused wire sinks to nodes.  This cleans up a pattern that is necessarily emitted during Grand Central View Annotation handling where the final sink is created as a wire (as it does not yet have any driver until the WiringProblem it creates is solved).  Later, the Grand Central View pass expects to only see nodes and not wires.  By doing the canonicalization inside the WiringProblem solver, this avoids needing to rely on a wire2node canonicalization which may or may not be run.

Put differently, this gets Grand Central views to work with --disable-opt.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>