### PR TITLE
[SV] Verify that sv.interface.instance ops have a nonempty name

### DIFF
--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -209,7 +209,7 @@ def ModportType : SVType<"Modport"> {
 // Other operations
 //===----------------------------------------------------------------------===//
 
-def InterfaceInstanceOp : SVOp<"interface.instance"> {
+def InterfaceInstanceOp : SVOp<"interface.instance", [HasCustomSSAName]> {
   let summary = "Instantiate an interface";
   let description = [{
     Use this to declare an instance of an interface:

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1278,8 +1278,17 @@ void InterfaceModportOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, name, ArrayAttr::get(ctxt, directions));
 }
 
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void InterfaceInstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(), getName());
+}
+
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
 LogicalResult InterfaceInstanceOp::verify() {
+  if (getName().empty())
+    return emitOpError("requires non-empty name");
+
   auto *symtable = SymbolTable::getNearestSymbolTable(*this);
   if (!symtable)
     return emitError("sv.interface.instance must exist within a region "

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -174,6 +174,6 @@ sv.interface @output {
 // following types.
 // CHECK-LABEL: module InterfaceAsInstance();
 hw.module @InterfaceAsInstance () {
-  // CHECK: output_0 ();
-  %0 = sv.interface.instance : !sv.interface<@output>
+  // CHECK: output_0 myOutput();
+  %myOutput = sv.interface.instance : !sv.interface<@output>
 }

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -64,11 +64,11 @@ hw.module @testIfaceWrap() {
   %idataChanOut = esi.wrap.iface %ifaceOutSink: !sv.modport<@IData::@Sink> -> !esi.channel<i32>
 
   // CHECK-LABEL:  hw.module @testIfaceWrap() {
-  // CHECK-NEXT:     %0 = sv.interface.instance {name = "ifaceOut"} : !sv.interface<@IData>
-  // CHECK-NEXT:     %1 = sv.modport.get %0 @Source : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
-  // CHECK-NEXT:     hw.instance "ifaceSender" @IFaceSender(x: %1: !sv.modport<@IData::@Source>) -> ()
-  // CHECK-NEXT:     %2 = sv.modport.get %0 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
-  // CHECK-NEXT:     %3 = esi.wrap.iface %2 : !sv.modport<@IData::@Sink> -> !esi.channel<i32>
+  // CHECK-NEXT:     %ifaceOut = sv.interface.instance : !sv.interface<@IData>
+  // CHECK-NEXT:     %[[#modport0:]] = sv.modport.get %ifaceOut @Source : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
+  // CHECK-NEXT:     hw.instance "ifaceSender" @IFaceSender(x: %[[#modport0:]]: !sv.modport<@IData::@Source>) -> ()
+  // CHECK-NEXT:     %[[#modport1:]] = sv.modport.get %ifaceOut @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
+  // CHECK-NEXT:     %[[#esiport0:]] = esi.wrap.iface %[[#modport1:]] : !sv.modport<@IData::@Sink> -> !esi.channel<i32>
 
   %ifaceIn = sv.interface.instance : !sv.interface<@IData>
   %ifaceInSink = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
@@ -76,11 +76,11 @@ hw.module @testIfaceWrap() {
   %ifaceInSource = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   esi.unwrap.iface %idataChanOut into %ifaceInSource : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 
-  // CHECK-NEXT:     %4 = sv.interface.instance {name = "ifaceIn"} : !sv.interface<@IData>
-  // CHECK-NEXT:     %5 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
-  // CHECK-NEXT:     hw.instance "ifaceRcvr" @IFaceRcvr(x: %5: !sv.modport<@IData::@Sink>) -> ()
-  // CHECK-NEXT:     %6 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
-  // CHECK-NEXT:     esi.unwrap.iface %3 into %6 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
+  // CHECK-NEXT:     %ifaceIn = sv.interface.instance : !sv.interface<@IData>
+  // CHECK-NEXT:     %[[#modport2:]] = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
+  // CHECK-NEXT:     hw.instance "ifaceRcvr" @IFaceRcvr(x: %[[#modport2]]: !sv.modport<@IData::@Sink>) -> ()
+  // CHECK-NEXT:     %[[#modport3:]] = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
+  // CHECK-NEXT:     esi.unwrap.iface %2 into %4 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 }
 
 // CHECK-LABEL: hw.module @i0Typed(%a: !esi.channel<i0>, %clk: i1, %rst: i1) -> (x: !esi.channel<i0>) {

--- a/test/Dialect/ESI/cosim_structs.mlir
+++ b/test/Dialect/ESI/cosim_structs.mlir
@@ -17,6 +17,6 @@ hw.module @top(%clk:i1, %rst:i1) -> () {
 // CAPNP-NEXT:   compressionLevel @1 :UInt8;
 // CAPNP-NEXT:   blob             @2 :List(UInt8);
 
-// COSIM: hw.instance "encodeStruct{{.+}}Inst" @encodeStruct{{.+}}(clk: %clk: i1, valid: %6: i1, unencodedInput: %7: !hw.struct<encrypted: i1, compressionLevel: ui4, blob: !hw.array<32xi8>>) -> (encoded: !hw.array<448xi1>)
+// COSIM: hw.instance "encodeStruct{{.+}}Inst" @encodeStruct{{.+}}(clk: %clk: i1, valid: %[[#]]: i1, unencodedInput: %[[#]]: !hw.struct<encrypted: i1, compressionLevel: ui4, blob: !hw.array<32xi8>>) -> (encoded: !hw.array<448xi1>)
 // COSIM: hw.instance "Compressor" @Cosim_Endpoint<ENDPOINT_ID_EXT: none = "", SEND_TYPE_ID: ui64 = 11116741711825659895, SEND_TYPE_SIZE_BITS: i32 = 448, RECV_TYPE_ID: ui64 = 17519082812652290511, RECV_TYPE_SIZE_BITS: i32 = 128>(clk: %clk: i1, rst: %rst: i1, {{.+}}, {{.+}}, {{.+}}) -> ({{.+}})
 // COSIM: hw.module @encode{{.+}}(%clk: i1, %valid: i1, %unencodedInput: !hw.struct<encrypted: i1, compressionLevel: ui4, blob: !hw.array<32xi8>>) -> (encoded: !hw.array<448xi1>)

--- a/test/Dialect/ESI/wrapif-lowering.mlir
+++ b/test/Dialect/ESI/wrapif-lowering.mlir
@@ -10,22 +10,22 @@ sv.interface @IValidReady_i4 {
 
 hw.module @test(%clk:i1, %rst:i1) {
 
-  %0 = sv.interface.instance : !sv.interface<@IValidReady_i4>
-  %1 = sv.modport.get %0 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
-  %2 = esi.wrap.iface %1 : !sv.modport<@IValidReady_i4::@source> -> !esi.channel<i4>
+  %validReady1 = sv.interface.instance : !sv.interface<@IValidReady_i4>
+  %0 = sv.modport.get %validReady1 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
+  %1 = esi.wrap.iface %0 : !sv.modport<@IValidReady_i4::@source> -> !esi.channel<i4>
 
-  %5 = sv.interface.instance : !sv.interface<@IValidReady_i4>
-  %6 = sv.modport.get %5 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
-  esi.unwrap.iface %2 into %6 : (!esi.channel<i4>, !sv.modport<@IValidReady_i4::@sink>)
+  %validReady2 = sv.interface.instance : !sv.interface<@IValidReady_i4>
+  %2 = sv.modport.get %validReady2 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
+  esi.unwrap.iface %1 into %2 : (!esi.channel<i4>, !sv.modport<@IValidReady_i4::@sink>)
 
-  // CHECK:         %0 = sv.interface.instance : !sv.interface<@IValidReady_i4>
-  // CHECK-NEXT:    %1 = sv.modport.get %0 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
-  // CHECK-NEXT:    %2 = sv.interface.signal.read %0(@IValidReady_i4::@valid) : i1
-  // CHECK-NEXT:    %3 = sv.interface.signal.read %0(@IValidReady_i4::@data) : i4
-  // CHECK-NEXT:    sv.interface.signal.assign %0(@IValidReady_i4::@ready) = %6 : i1
-  // CHECK-NEXT:    %4 = sv.interface.instance : !sv.interface<@IValidReady_i4>
-  // CHECK-NEXT:    %5 = sv.modport.get %4 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
-  // CHECK-NEXT:    %6 = sv.interface.signal.read %4(@IValidReady_i4::@ready) : i1
-  // CHECK-NEXT:    sv.interface.signal.assign %4(@IValidReady_i4::@valid) = %2 : i1
-  // CHECK-NEXT:    sv.interface.signal.assign %4(@IValidReady_i4::@data) = %3 : i4
+  // CHECK:      %validReady1 = sv.interface.instance  : !sv.interface<@IValidReady_i4>
+  // CHECK-NEXT: %[[#modport1:]] = sv.modport.get %validReady1 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
+  // CHECK-NEXT: %[[#signal1:]] = sv.interface.signal.read %validReady1(@IValidReady_i4::@valid) : i1
+  // CHECK-NEXT: %[[#signal2:]] = sv.interface.signal.read %validReady1(@IValidReady_i4::@data) : i4
+  // CHECK-NEXT: sv.interface.signal.assign %validReady1(@IValidReady_i4::@ready) = %[[#signal3:]] : i1
+  // CHECK-NEXT: %validReady2 = sv.interface.instance  : !sv.interface<@IValidReady_i4>
+  // CHECK-NEXT: %[[#modport2:]] = sv.modport.get %validReady2 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
+  // CHECK-NEXT: %[[#signal3:]] = sv.interface.signal.read %validReady2(@IValidReady_i4::@ready) : i1
+  // CHECK-NEXT: sv.interface.signal.assign %validReady2(@IValidReady_i4::@valid) = %[[#signal1:]] : i1
+  // CHECK-NEXT: sv.interface.signal.assign %validReady2(@IValidReady_i4::@data) = %[[#signal2:]] : i4
 }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -544,39 +544,22 @@ firrtl.circuit "InterfaceGroundType" attributes {
 // CHECK-SAME:     fields: []
 // CHECK-SAME:     instances: []
 
-// The shared companion contains all instantiated interfaaces.
+// The shared companion contains all instantiated interfaces.
 // AugmentedGroundType annotations are removed.  Interface is driven via XMRs
 // directly from ref resolve ops.
 //
 // CHECK:          firrtl.module @Companion
 // CHECK-SAME:       output_file = #hw.output_file<"gct-dir{{/|\\\\}}"
 //
-// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfVerbatim:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "VectorOfVerbatimView"} : !sv.interface<@VectorOfVerbatimView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[unsupportedSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "UnsupportedView"} : !sv.interface<@UnsupportedView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[constantSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "ConstantView"} : !sv.interface<@ConstantView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[zeroWidthSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "ZeroWidthView"} : !sv.interface<@ZeroWidthView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfVectorSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "VectorOfVectorView"} : !sv.interface<@VectorOfVectorView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[vectorOfBundleSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "VectorOfBundleView"} : !sv.interface<@VectorOfBundleView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[bundleSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "BundleView"} : !sv.interface<@BundleView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[vectorSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "VectorView"} : !sv.interface<@VectorView>
-//
-// CHECK-NEXT:       sv.interface.instance sym @[[groundSym:[a-zA-Z0-9_]+]]
-// CHECK-SAME:         {name = "GroundView"} : !sv.interface<@GroundView>
+// CHECK-NEXT:       %VectorOfVerbatimView = sv.interface.instance sym @[[vectorOfVerbatim:[a-zA-Z0-9_]+]] : !sv.interface<@VectorOfVerbatimView>
+// CHECK-NEXT:       %UnsupportedView = sv.interface.instance sym @[[unsupportedSym:[a-zA-Z0-9_]+]] : !sv.interface<@UnsupportedView>
+// CHECK-NEXT:       %ConstantView = sv.interface.instance sym @[[constantSym:[a-zA-Z0-9_]+]] : !sv.interface<@ConstantView>
+// CHECK-NEXT:       %ZeroWidthView = sv.interface.instance sym @[[zeroWidthSym:[a-zA-Z0-9_]+]] : !sv.interface<@ZeroWidthView>
+// CHECK-NEXT:       %VectorOfVectorView = sv.interface.instance sym @[[vectorOfVectorSym:[a-zA-Z0-9_]+]] : !sv.interface<@VectorOfVectorView>
+// CHECK-NEXT:       %VectorOfBundleView = sv.interface.instance sym @[[vectorOfBundleSym:[a-zA-Z0-9_]+]] : !sv.interface<@VectorOfBundleView>
+// CHECK-NEXT:       %BundleView = sv.interface.instance sym @[[bundleSym:[a-zA-Z0-9_]+]] : !sv.interface<@BundleView>
+// CHECK-NEXT:       %VectorView = sv.interface.instance sym @[[vectorSym:[a-zA-Z0-9_]+]] : !sv.interface<@VectorView>
+// CHECK-NEXT:       %GroundView = sv.interface.instance sym @[[groundSym:[a-zA-Z0-9_]+]] : !sv.interface<@GroundView>
 //
 // CHECK:            %[[foo_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.ref<uint<1>>
 // CHECK-NOT:        sifive.enterprise.grandcentral.AugmentedGroundType

--- a/test/Dialect/SV/interfaces.mlir
+++ b/test/Dialect/SV/interfaces.mlir
@@ -56,10 +56,10 @@ module {
     sv.interface.signal.assign %iface(@handshake_example::@data) = %zero32 : i32
   }
   // CHECK-LABEL: hw.module @Top() {
-  // CHECK-NEXT:    %0 = sv.interface.instance {name = "iface"} : !sv.interface<@handshake_example>
-  // CHECK-NEXT:    %1 = sv.modport.get %0 @dataflow_in : !sv.interface<@handshake_example> -> !sv.modport<@handshake_example::@dataflow_in>
-  // CHECK-NEXT:    hw.instance "rcvr" @Rcvr(m: %1: !sv.modport<@handshake_example::@dataflow_in>) -> ()
-  // CHECK-NEXT:    %2 = sv.interface.signal.read %0(@handshake_example::@data) : i32
+  // CHECK-NEXT:    %iface = sv.interface.instance : !sv.interface<@handshake_example>
+  // CHECK-NEXT:    %[[#modport:]] = sv.modport.get %iface @dataflow_in : !sv.interface<@handshake_example> -> !sv.modport<@handshake_example::@dataflow_in>
+  // CHECK-NEXT:    hw.instance "rcvr" @Rcvr(m: %[[#modport:]]: !sv.modport<@handshake_example::@dataflow_in>) -> ()
+  // CHECK-NEXT:    %[[#]] = sv.interface.signal.read %iface(@handshake_example::@data) : i32
   // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-  // CHECK-NEXT:    sv.interface.signal.assign %0(@handshake_example::@data) = %c0_i32 : i32
+  // CHECK-NEXT:    sv.interface.signal.assign %iface(@handshake_example::@data) = %c0_i32 : i32
 }


### PR DESCRIPTION
1. Verify that sv.interface.instance ops have a nonempty name.
2. Implement the HasCustomSSAName op interface for sv.interface.instance, so that the name attribute can be round tripped properly as the result's ssa name (parsing the name worked, printing the name would fall back to the attr-dict format).

Fixes: https://github.com/llvm/circt/issues/4134