### PR TITLE
Revert "[FIRRTL] Convert Wires To Nodes when dominance allows (#4253)"

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1764,41 +1764,11 @@ struct SubfieldAggOneShot : public AggOneShot {
   SubfieldAggOneShot(MLIRContext *context)
       : AggOneShot(SubfieldOp::getOperationName(), 0, context) {}
 };
-
-struct WireToNode : public mlir::RewritePattern {
-  WireToNode(MLIRContext *context)
-      : RewritePattern(WireOp::getOperationName(), 0, context) {}
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    WireOp wire = cast<WireOp>(op);
-    StrictConnectOp writer = getSingleConnectUserOf(wire.getResult());
-    if (!writer)
-      return failure();
-
-    // Check that the write dominates all reads
-    for (auto *user : wire.getResult().getUsers())
-      if (user != writer)
-        if (user->isBeforeInBlock(writer))
-          return failure();
-
-    rewriter.setInsertionPointAfter(writer);
-    auto srcValue = writer.getSrc();
-    rewriter.eraseOp(writer);
-    auto node = rewriter.createOrFold<NodeOp>(
-        wire.getLoc(), srcValue, wire.getName(), wire.getNameKind(),
-        wire.getAnnotations(),
-        wire.getInnerSym() ? *wire.getInnerSym() : InnerSymAttr());
-    rewriter.replaceOp(wire, node);
-    return success();
-  }
-};
-
 } // namespace
 
 void WireOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                          MLIRContext *context) {
-  results.insert<WireAggOneShot, WireToNode>(context);
+  results.insert<WireAggOneShot>(context);
 }
 
 void SubindexOp::getCanonicalizationPatterns(RewritePatternSet &results,

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -458,10 +458,9 @@ void ModuleSignalMappings::instantiateMappingsModule(FModuleOp mappingsModule) {
   LLVM_DEBUG(llvm::dbgs() << "- Instantiating `" << mappingsModuleName
                           << "`\n");
   // Create the actual module.
-  auto builder = ImplicitLocOpBuilder::atBlockBegin(module.getLoc(),
-                                                    module.getBodyBlock());
+  auto builder =
+      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBodyBlock());
   auto inst = builder.create<InstanceOp>(mappingsModule, "signal_mappings");
-  builder.setInsertionPointToEnd(module.getBodyBlock());
 
   // Generate the connections to and from the instance.
   unsigned portIdx = 0;
@@ -472,10 +471,7 @@ void ModuleSignalMappings::instantiateMappingsModule(FModuleOp mappingsModule) {
     Value src = mapping.localValue;
     if (mapping.dir == MappingDirection::ProbeRemote)
       std::swap(src, dst);
-    if (auto node = dst.getDefiningOp<NodeOp>())
-      node.setOperand(src);
-    else
-      builder.create<ConnectOp>(dst, src);
+    builder.create<ConnectOp>(dst, src);
   }
 }
 

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
@@ -234,25 +234,25 @@ circuit Top : %[[
     tap is invalid
 
     ; CHECK:      module Submodule
-    ; CHECK:      wire tap_0 = Submodule.wire_Submodule
-    ; CHECK-NEXT: wire tap_1 = DUT.wire_DUT
-    ; CHECK-NEXT: wire tap_2 = Top.wire_Top
     ; CHECK:      wire tap_3 = 1'h0
     ; CHECK-NEXT: wire tap_4 = 1'h0
-    ; CHECK-NEXT: wire tap_5 = Top.port_Top
+    ; CHECK:      assign tap_0 = Submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
 
     ; CHECK: module DUT
-    ; CHECK:      wire tap_0 = DUT.submodule.wire_Submodule
-    ; CHECK-NEXT: wire tap_1 = DUT.wire_DUT
-    ; CHECK-NEXT: wire tap_2 = Top.wire_Top
     ; CHECK:      wire tap_3 = 1'h0
     ; CHECK-NEXT: wire tap_4 = 1'h0
-    ; CHECK-NEXT: wire tap_5 = Top.port_Top
+    ; CHECK:      assign tap_0 = DUT.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = DUT.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top
 
     ; CHECK: module Top
-    ; CHECK:      wire tap_0 = Top.dut.submodule.wire_Submodule
-    ; CHECK-NEXT: wire tap_1 = Top.dut.wire_DUT
-    ; CHECK-NEXT: wire tap_2 = Top.wire_Top
     ; CHECK:      wire tap_3 = 1'h0
     ; CHECK-NEXT: wire tap_4 = 1'h0
-    ; CHECK-NEXT: wire tap_5 = Top.port_Top
+    ; CHECK:      assign tap_0 = Top.dut.submodule.wire_Submodule
+    ; CHECK-NEXT: assign tap_1 = Top.dut.wire_DUT
+    ; CHECK-NEXT: assign tap_2 = Top.wire_Top
+    ; CHECK-NEXT: assign tap_5 = Top.port_Top

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -117,6 +117,6 @@ circuit Top : %[[
 ; CHECK: module Top(
 ; CHECK-NOT: module
 ; CHECK:   tap = Top.foo.b.inv;
-; CHECK:   wire tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
+; CHECK:   assign tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
 ; CHECK:   InternalPathChild int_0 (
 ; CHECK: endmodule

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -54,12 +54,12 @@ circuit Top : %[[
 
 ; CHECK:      module Top(
 ; CHECK-NOT:  module
-; CHECK:  wire [7:0] memTap_0 = Top.dut.rf_0;
-; CHECK:  wire [7:0] memTap_1 = Top.dut.rf_1;
-; CHECK:  wire [7:0] memTap_2 = Top.dut.rf_2;
-; CHECK:  wire [7:0] memTap_3 = Top.dut.rf_3;
-; CHECK:  wire [7:0] memTap_4 = Top.dut.rf_4;
-; CHECK:  wire [7:0] memTap_5 = Top.dut.rf_5;
-; CHECK:  wire [7:0] memTap_6 = Top.dut.rf_6;
-; CHECK:  wire [7:0] memTap_7 = Top.dut.rf_7;
+; CHECK:  assign memTap_0 = Top.dut.rf_0;
+; CHECK:  assign memTap_1 = Top.dut.rf_1;
+; CHECK:  assign memTap_2 = Top.dut.rf_2;
+; CHECK:  assign memTap_3 = Top.dut.rf_3;
+; CHECK:  assign memTap_4 = Top.dut.rf_4;
+; CHECK:  assign memTap_5 = Top.dut.rf_5;
+; CHECK:  assign memTap_6 = Top.dut.rf_6;
+; CHECK:  assign memTap_7 = Top.dut.rf_7;
 ; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -53,12 +53,12 @@ circuit Top : %[[
 
 ; CHECK:      module Top(
 ; CHECK-NOT:  module
-; CHECK:  wire [7:0] memTap_0 = Top.dut.rf_ext.Memory[0];
-; CHECK:  wire [7:0] memTap_1 = Top.dut.rf_ext.Memory[1];
-; CHECK:  wire [7:0] memTap_2 = Top.dut.rf_ext.Memory[2];
-; CHECK:  wire [7:0] memTap_3 = Top.dut.rf_ext.Memory[3];
-; CHECK:  wire [7:0] memTap_4 = Top.dut.rf_ext.Memory[4];
-; CHECK:  wire [7:0] memTap_5 = Top.dut.rf_ext.Memory[5];
-; CHECK:  wire [7:0] memTap_6 = Top.dut.rf_ext.Memory[6];
-; CHECK:  wire [7:0] memTap_7 = Top.dut.rf_ext.Memory[7];
+; CHECK:  assign memTap_0 = Top.dut.rf_ext.Memory[0];
+; CHECK:  assign memTap_1 = Top.dut.rf_ext.Memory[1];
+; CHECK:  assign memTap_2 = Top.dut.rf_ext.Memory[2];
+; CHECK:  assign memTap_3 = Top.dut.rf_ext.Memory[3];
+; CHECK:  assign memTap_4 = Top.dut.rf_ext.Memory[4];
+; CHECK:  assign memTap_5 = Top.dut.rf_ext.Memory[5];
+; CHECK:  assign memTap_6 = Top.dut.rf_ext.Memory[6];
+; CHECK:  assign memTap_7 = Top.dut.rf_ext.Memory[7];
 ; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2432,11 +2432,11 @@ firrtl.module @Foo3319(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   firrtl.strictconnect %o, %n : !firrtl.uint<1>
 }
 
-// CHECK-LABEL: @WireToNode
-firrtl.module @WireToNode(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
+// CHECK-LABEL: @WireByPass
+firrtl.module @WireByPass(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %n = firrtl.wire interesting_name : !firrtl.uint<1>
-  // %n = firrtl.node interesting_name %c0_ui1
+  // CHECK: firrtl.strictconnect %n, %c0_ui1
   firrtl.strictconnect %n, %c0_ui1 : !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %o, %n
   firrtl.strictconnect %o, %n : !firrtl.uint<1>
@@ -2450,7 +2450,7 @@ firrtl.module @AnnotationsBlockRemoval(
   in %a: !firrtl.uint<1>,
   out %b: !firrtl.uint<1>
 ) {
-  // CHECK: %w = firrtl.node %a {annotations = [{class = "Foo"}]}
+  // CHECK: %w = firrtl.wire
   %w = firrtl.wire droppable_name {annotations = [{class = "Foo"}]} : !firrtl.uint<1>
   firrtl.strictconnect %w, %a : !firrtl.uint<1>
   firrtl.strictconnect %b, %w : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -42,6 +42,7 @@ firrtl.circuit "WriteOnlyMemory" {
       } : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
     // CHECK-NOT: firrtl.mem
+    // CHECK: firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     %10 = firrtl.subfield %Memory_write(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
     firrtl.connect %10, %addr : !firrtl.uint<4>, !firrtl.uint<4>
     %11 = firrtl.subfield %Memory_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -146,6 +147,7 @@ firrtl.circuit "UnusedPorts" {
     // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.wire   : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: firrtl.wire   : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    // CHECK: firrtl.wire   : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
     %Memory_read, %Memory_rw, %Memory_write, %Memory_pinned = firrtl.mem Undefined
       {

--- a/test/firtool/name-preservation.fir
+++ b/test/firtool/name-preservation.fir
@@ -14,8 +14,8 @@ circuit Foo:
     _x <= a
 
     ; Default behavior is to preserve named wires.
-    ; CHECK:        wire x_b
     ; CHECK:        wire x_a
+    ; CHECK:        wire x_b
     wire x: {a: UInt<1>, flip b: UInt<1>}
     x <= _x
 


### PR DESCRIPTION
This reverts commit 5ef429e31b015dca88b1c1e6c3058a9d10e0e0c3. Test failures should be fixed by  https://github.com/llvm/circt/pull/4312