### PR TITLE
[FIRRTL] Remove extra whitespace around optional attr dicts

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -173,7 +173,7 @@ operation or port attributes.  As an example of this, the above parses into the
 following MLIR representation:
 
 ```mlir
-firrtl.circuit "Foo"  {
+firrtl.circuit "Foo" {
   firrtl.module @Foo() attributes {annotations = [{hello = "world"}]} {
     firrtl.skip
   }

--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -390,7 +390,7 @@ followed by instance `@baz` in module `@Bar`, followed by the wire named `@w` in
 module `@Baz`.
 
 ``` mlir
-firrtl.circuit "Foo"   {
+firrtl.circuit "Foo" {
   firrtl.hierpath @nla [@Foo::@bar, @Bar::@baz, @Baz::@w]
   firrtl.module @Baz() {
     %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla, class = "ExampleAnno"}]} : !firrtl.uint

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -339,7 +339,7 @@ def PrimitiveOp : CalyxCell<"primitive", [
   let results = (outs Variadic<AnyType>:$results);
 
   let assemblyFormat = [{
-    $sym_name `of` $primitiveName``custom<ParameterList>($parameters) attr-dict (`:` qualified(type($results))^)?
+    $sym_name `of` $primitiveName `` custom<ParameterList>($parameters) attr-dict (`:` qualified(type($results))^)?
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -111,8 +111,8 @@ def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName, FNamableOp]> {
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations, OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs CMemoryType:$result);
-  let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind)
-                         custom<CombMemOp>(attr-dict) `:` qualified(type($result))}];
+  let assemblyFormat = [{(`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+                         `` custom<CombMemOp>(attr-dict) `:` qualified(type($result))}];
   let builders = [
     OpBuilder<(ins "firrtl::FIRRTLBaseType":$elementType, "uint64_t":$numElements,
                    "mlir::StringRef":$name, "firrtl::NameKindEnum":$nameKind,
@@ -130,7 +130,7 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, FNamableOp]> {
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs CMemoryType:$result);
-  let assemblyFormat = [{(`sym` $inner_sym^)? custom<NameKind>($nameKind) $ruw
+  let assemblyFormat = [{(`sym` $inner_sym^)? `` custom<NameKind>($nameKind) $ruw
                          custom<SeqMemOp>(attr-dict) `:` qualified(type($result))}];
   let builders = [
     OpBuilder<(ins "firrtl::FIRRTLBaseType":$elementType, "uint64_t":$numElements,
@@ -161,7 +161,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
   let results = (outs FIRRTLBaseType:$data, CMemoryPortType:$port);
 
   let assemblyFormat = [{
-    $direction $memory custom<MemoryPortOp>(attr-dict) `:`
+    $direction $memory `` custom<MemoryPortOp>(attr-dict) `:`
        functional-type(operands, results)
   }];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -134,8 +134,8 @@ def MemOp : ReferableDeclOp<"mem"> {
   let results = (outs Variadic<FIRRTLType>:$results);
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<NameKind>($nameKind)
-    $ruw custom<MemOp>(attr-dict) `:` qualified(type($results))
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+    $ruw `` custom<MemOp>(attr-dict) `:` qualified(type($results))
   }];
 
   let builders = [
@@ -254,8 +254,8 @@ def NodeOp : ReferableDeclOp<"node",
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<NameKind>($nameKind)
-    $input custom<ImplicitSSAName>(attr-dict) `:` qualified(type($input))
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+    $input `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($input))
   }];
 
   let hasCanonicalizer = true;
@@ -298,8 +298,8 @@ def RegOp : ReferableDeclOp<"reg"> {
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<NameKind>($nameKind)
-    operands custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+    operands `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 }
@@ -344,8 +344,8 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<NameKind>($nameKind)
-    operands custom<ImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+    operands `` custom<ImplicitSSAName>(attr-dict)
     `:` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
   }];
 
@@ -388,8 +388,9 @@ def WireOp : ReferableDeclOp<"wire"> {
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<NameKind>($nameKind)
-    custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind) ``
+    custom<ImplicitSSAName>(attr-dict) `:`
+    qualified(type($result))
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -77,7 +77,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
   let results = (outs);
 
   let assemblyFormat = [{
-    $clock `,` $cond `,` $formatString custom<PrintfAttrs>(attr-dict)
+    $clock `,` $cond `,` $formatString `` custom<PrintfAttrs>(attr-dict) ` `
     (`(` $substitutions^ `)` `:` qualified(type($substitutions)))?
   }];
 }
@@ -106,7 +106,7 @@ def StopOp : FIRRTLOp<"stop"> {
                        StrAttr:$name);
   let results = (outs);
 
-  let assemblyFormat = "$clock `,` $cond `,` $exitCode custom<StopAttrs>(attr-dict)";
+  let assemblyFormat = "$clock `,` $cond `,` $exitCode `` custom<StopAttrs>(attr-dict)";
 }
 
 class VerifOp<string mnemonic, list<Trait> traits = []> :

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -56,7 +56,7 @@ def CircuitOp : FIRRTLOp<"circuit",
     FModuleLike getMainModule(mlir::SymbolTable* symtbl = nullptr);
   }];
 
-  let assemblyFormat = "$name custom<CircuitOpAttrs>(attr-dict) $body";
+  let assemblyFormat = "$name `` custom<CircuitOpAttrs>(attr-dict) $body";
   let hasRegionVerifier = 1;
 }
 

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -204,7 +204,7 @@ def LocalParamOp : SVOp<"localparam",
   let results = (outs HWValueType:$result);
 
   let assemblyFormat = [{
-    `:` qualified(type($result)) custom<ImplicitSSAName>(attr-dict)
+    `:` qualified(type($result)) `` custom<ImplicitSSAName>(attr-dict)
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -38,7 +38,7 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 
@@ -68,7 +68,7 @@ def RegOp : SVOp<"reg", [
 
   // We handle the name in a custom way, so we use a customer parser/printer.
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict)
      `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
@@ -236,7 +236,7 @@ def LogicOp : SVOp<"logic", [DeclareOpInterfaceMethods<OpAsmOpInterface,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict) `:`
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict) `:`
                                                 qualified(type($result))
   }];
 

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -223,7 +223,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [HasCustomSSAName]> {
   let results = (outs InterfaceType : $result);
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? custom<ImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict)
     `:` qualified(type($result))
   }];
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -51,7 +51,7 @@ ParseResult ChannelBufferOp::parse(OpAsmParser &parser,
 }
 
 void ChannelBufferOp::print(OpAsmPrinter &p) {
-  p << " " << getClk() << ", " << getRst() << ", " << getInput() << " ";
+  p << " " << getClk() << ", " << getRst() << ", " << getInput();
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }
@@ -86,7 +86,7 @@ ParseResult PipelineStageOp::parse(OpAsmParser &parser,
 }
 
 void PipelineStageOp::print(OpAsmPrinter &p) {
-  p << " " << getClk() << ", " << getRst() << ", " << getInput() << " ";
+  p << " " << getClk() << ", " << getRst() << ", " << getInput();
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : " << innerType();
 }

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -104,7 +104,7 @@ static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
   if (attr.getValue() != NameKindEnum::DroppableName)
-    p << stringifyNameKindEnum(attr.getValue());
+    p << " " << stringifyNameKindEnum(attr.getValue());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1513,7 +1513,6 @@ void InstanceOp::print(OpAsmPrinter &p) {
   }
   if (getNameKindAttr().getValue() != NameKindEnum::DroppableName)
     p << ' ' << stringifyNameKindEnum(getNameKindAttr().getValue());
-  p << " ";
 
   // Print the attr-dict.
   SmallVector<StringRef, 4> omittedAttrs = {"moduleName",     "name",
@@ -3578,7 +3577,7 @@ static void printNameKind(OpAsmPrinter &p, Operation *op,
                           firrtl::NameKindEnumAttr attr,
                           ArrayRef<StringRef> extraElides = {}) {
   if (attr.getValue() != NameKindEnum::DroppableName)
-    p << stringifyNameKindEnum(attr.getValue());
+    p << " " << stringifyNameKindEnum(attr.getValue());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -280,7 +280,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"}(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"} (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2) : printf_0
 
     ; CHECK: firrtl.stop %clock, %reset, 42

--- a/test/circt-as-dis/basic-firrtl.mlir
+++ b/test/circt-as-dis/basic-firrtl.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-as %s -o - | circt-opt | FileCheck %s
-// RUN: circt-opt %s -emit-bytecode | circt-dis | FileCheck %s
-// RUN: circt-as %s -o - | circt-dis | FileCheck %s
+// RUN: circt-as %s -o - | circt-opt | FileCheck -strict-whitespace %s
+// RUN: circt-opt %s -emit-bytecode | circt-dis | FileCheck -strict-whitespace  %s
+// RUN: circt-as %s -o - | circt-dis | FileCheck -strict-whitespace  %s
 
 firrtl.circuit "Top" {
   firrtl.module @Top(in %in : !firrtl.uint<8>,
@@ -9,6 +9,8 @@ firrtl.circuit "Top" {
   }
 }
 
-// CHECK-LABEL: firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-// CHECK-NEXT:    firrtl.strictconnect %out, %in : !firrtl.uint<8>
+// CHECK-LABEL: firrtl.circuit "Top" {
+// CHECK-NEXT:    firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+// CHECK-NEXT:      firrtl.strictconnect %out, %in : !firrtl.uint<8>
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }


### PR DESCRIPTION
In FIRRTL, we unconditionally print a space before printing optional attribute dictionaries. However, the majority of the time, the attr dict is elided, so that we end up with a double-space in our output. It turns out, the underlying utility in MLIR, `printOptionalAttrDict`, will print a leading space if it has to print the attr dict, so it's pointless for us to be outputting one ourselves. This PR removes the extra whitespace for a number of ops.

A large number of ops use a custom directive to print the attributes. To suppress leading whitespace in this case, we can use an empty literal (``) in the asm format.

Modified Ops:
- `firrtl.circuit`
- `firrtl.module`
- `firrtl.wire`
- `firrtl.mem`
- `firrtl.node`
- `firrtl.printf`
- `firrtl.reg`
- `firrtl.regreset`
- `firrtl.instance`
- `sv.wire`
- `sv.reg`
- `sv.logic`
- `sv.interface.instance`
- `sv.localparam`
- `systemc.cpp.variable`
- `esi.buffer`
- `esi.pipeline`

## Example Changes
### FIRRTL
```mlir
// OLD
module {
  firrtl.circuit "WithAttrs"  attributes {test = "blah"} {
    firrtl.module @WithAttrs() {
    }
  }
  firrtl.circuit "NoAttrs"  {
    firrtl.module @NoAttrs() {
    }
  }
  firrtl.circuit "Example"  {
    firrtl.module @Foo() attributes {test = "blah"} {
    }
    firrtl.module @Example() {
      firrtl.instance name1  {test = "blah"} @Foo()
      firrtl.instance name2  @Foo()
      %w1 = firrtl.wire interesting_name  : !firrtl.uint<1>
      %w2 = firrtl.wire   : !firrtl.uint<1>
      %memory_r, %memory_w = firrtl.mem interesting_name Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: sint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: sint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
      %memory_r_0, %memory_w_1 = firrtl.mem  Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: sint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: sint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
      %n1 = firrtl.node  %w1  : !firrtl.uint<1>
      %n2 = firrtl.node  %w1  {test = "blah"} : !firrtl.uint<1>
      %clk = firrtl.wire   : !firrtl.clock
      %r1 = firrtl.reg  %clk  : !firrtl.uint<1>
      %r2 = firrtl.reg  %clk  {test = "blah"} : !firrtl.uint<1>
    }
  }

// NEW
module {
  firrtl.circuit "WithAttrs" attributes {test = "blah"} {
    firrtl.module @WithAttrs() {
    }
  }
  firrtl.circuit "NoAttrs" {
    firrtl.module @NoAttrs() {
    }
  }
  firrtl.circuit "Example" {
    firrtl.module @Foo() attributes {test = "blah"} {
    }
    firrtl.module @Example() {
      firrtl.instance name1 {test = "blah"} @Foo()
      firrtl.instance name2 @Foo()
      %w1 = firrtl.wire interesting_name : !firrtl.uint<1>
      %w2 = firrtl.wire : !firrtl.uint<1>
      %memory_r, %memory_w = firrtl.mem interesting_name Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: sint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: sint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
      %memory_r_0, %memory_w_1 = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: sint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: sint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
      %n1 = firrtl.node %w1 : !firrtl.uint<1>
      %n2 = firrtl.node %w1 {test = "blah"} : !firrtl.uint<1>
      %clk = firrtl.wire : !firrtl.clock
      %r1 = firrtl.reg %clk : !firrtl.uint<1>
      %r2 = firrtl.reg %clk {test = "blah"} : !firrtl.uint<1>
    }
  }
}
```

### System Verilog
```mlir
// OLD
module {
  sv.interface @A {
  }
  hw.module @Example() {
    %reg1 = sv.reg  : !hw.inout<i1>
    %reg2 = sv.reg  {test = "test"} : !hw.inout<i1>
    %wire1 = sv.wire  : !hw.inout<i1>
    %wire2 = sv.wire  {test = "test"} : !hw.inout<i1>
    %instance1 = sv.interface.instance  : !sv.interface<@A>
    %instance2 = sv.interface.instance  {test = "blah"} : !sv.interface<@A>
    hw.output
  }
}
  
// NEW
module {
  sv.interface @A {
  }
  hw.module @Example() {
    %reg1 = sv.reg : !hw.inout<i1>
    %reg2 = sv.reg {test = "test"} : !hw.inout<i1>
    %wire1 = sv.wire : !hw.inout<i1>
    %wire2 = sv.wire {test = "test"} : !hw.inout<i1>
    %instance1 = sv.interface.instance : !sv.interface<@A>
    %instance2 = sv.interface.instance {test = "blah"} : !sv.interface<@A>
    hw.output
  }
}
```

### SystemC

```mlir
// OLD
module {
  systemc.module @Foo (%x: !systemc.in<!systemc.uint<32>>, %y: !systemc.out<!systemc.uint<32>>) {
    %c42_i32 = hw.constant 42 : i32
    %state1 = systemc.cpp.variable %c42_i32  {test = "apple"}: i32
    %state2 = systemc.cpp.variable %c42_i32 : i32
    %state3 = systemc.cpp.variable  {test = "apple"}: i32
    %state4 = systemc.cpp.variable : i32
  }
}

// NEW
module {
  systemc.module @Foo (%x: !systemc.in<!systemc.uint<32>>, %y: !systemc.out<!systemc.uint<32>>) {
    %c42_i32 = hw.constant 42 : i32
    %state1 = systemc.cpp.variable %c42_i32 {test = "apple"} : i32
    %state2 = systemc.cpp.variable %c42_i32 : i32
    %state3 = systemc.cpp.variable {test = "apple"} : i32
    %state4 = systemc.cpp.variable : i32
  }
}
```

---

Fixes: https://github.com/llvm/circt/issues/3367
