### PR TITLE
[FIRRTL] Require MultibitMuxOp Index is Unsigned

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -313,7 +313,7 @@ def MultibitMuxOp : FIRRTLExprOp<"multibit_mux"> {
     For the example above, if `%index` is 0, then the value is `%v_0`.
     }];
 
-  let arguments = (ins FIRRTLBaseType:$index, Variadic<FIRRTLBaseType>:$inputs);
+  let arguments = (ins UIntType:$index, Variadic<FIRRTLBaseType>:$inputs);
   let results = (outs FIRRTLBaseType:$result);
   let hasCustomAssemblyFormat = 1;
   let hasFolder = true;


### PR DESCRIPTION
Fix a bug in the MultibitMuxOp ODS specification where it would accept something of any type.  This should only accept something of UIntType.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>