### PR TITLE
[Scheduling][SSP] Restore feature parity between infra and dialect.

### DIFF
--- a/include/circt/Dialect/SSP/SSPOps.td
+++ b/include/circt/Dialect/SSP/SSPOps.td
@@ -48,11 +48,11 @@ def InstanceOp : SSPOp<"instance",
     ```
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name, StrAttr:$problemName,
+  let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name, StrAttr:$problemName,
                        OptionalAttr<ArrayAttr>:$properties);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $sym_name `of` $problemName custom<Properties>($properties) $body attr-dict
+    ($sym_name^)? `of` $problemName custom<Properties>($properties) $body attr-dict
   }];
   
   let hasVerifier = true;
@@ -61,13 +61,13 @@ def InstanceOp : SSPOp<"instance",
     // OpAsmOpInterface
     static ::llvm::StringRef getDefaultDialect() { return "ssp"; }
 
+    // SymbolOpInterface
+    static bool isOptionalSymbol() { return true; }
+
     // Convenience
     ::mlir::Block *getBodyBlock() {
       return &getBody().getBlocks().front();
     }
-
-    // The symbol is actually the "instance name"
-    ::mlir::StringAttr getInstanceNameAttr() { return getSymNameAttr(); }
 
     // Access to container ops
     ::circt::ssp::OperatorLibraryOp getOperatorLibrary();
@@ -76,10 +76,8 @@ def InstanceOp : SSPOp<"instance",
 
   let skipDefaultBuilders = true;
   let builders = [
-    OpBuilder<(ins "::mlir::StringAttr":$instanceName,
-                   "::mlir::StringAttr":$problemName,
+    OpBuilder<(ins "::mlir::StringAttr":$problemName,
                    CArg<"::mlir::ArrayAttr", "::mlir::ArrayAttr()">:$properties), [{
-      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), instanceName);
       $_state.addAttribute($_builder.getStringAttr("problemName"), problemName);
       if (properties)
         $_state.addAttribute($_builder.getStringAttr("properties"), properties);

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -584,14 +584,7 @@ void roundtrip(InstanceOp instOp) {
   auto prob = loadProblem<ProblemT>(instOp);
 
   OpBuilder builder(instOp);
-  saveProblem<ProblemT>(
-      prob, instOp.getInstanceNameAttr(), instOp.getProblemNameAttr(),
-      [&](Operation *op) {
-        if (auto opOp = dyn_cast<OperationOp>(op))
-          return opOp.getSymNameAttr();
-        return StringAttr();
-      },
-      builder);
+  saveProblem<ProblemT>(prob, builder);
 }
 
 void TestSSPRoundtripPass::runOnOperation() {

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -4,6 +4,32 @@
 // 1) tests the plain parser/printer roundtrip.
 // 2) roundtrips via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
 
+// CHECK: ssp.instance of "Problem" {
+// CHECK:   library {
+// CHECK:   }
+// CHECK:   graph {
+// CHECK:   }
+// CHECK: }
+ssp.instance of "Problem" {
+  library {
+  }
+  graph {
+  }
+}
+
+// CHECK: ssp.instance @named_library of "Problem" {
+// CHECK:   library @myLib {
+// CHECK:   }
+// CHECK:   graph {
+// CHECK:   }
+// CHECK: }
+ssp.instance @named_library of "Problem" {
+  library @myLib {
+  }
+  graph {
+  }
+}
+
 // CHECK: ssp.instance @"no properties" of "Problem" {
 // CHECK:   library {  
 // CHECK:     operator_type @NoProps

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -24,9 +24,9 @@
 // CHECK: }
 
 // 2) Import/export via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)
-//    Operator types from stand-alone libraries are appended to the instance's internal library, whose name is not preserved.
+//    Operator types from stand-alone libraries are appended to the instance's internal library.
 // INFRA: ssp.instance @SomeInstance of "ModuloProblem" {
-// INFRA:   library {
+// INFRA:   library @InternalLib {
 // INFRA:     operator_type @Opr [latency<3>, limit<3>]
 // INFRA:     operator_type @Opr_1 [latency<1>, limit<1>]
 // INFRA:     operator_type @Opr_2 [latency<2>, limit<2>]


### PR DESCRIPTION
This PR restores the feature parity between the scheduling infra's `Problem` class and the SSP dialect, and is important for roundtripping instances without [weird restrictions](https://github.com/llvm/circt/pull/4222#issuecomment-1310514507).

- On the `Problem` side, I added optional name attributes for the instance, operator library and operations.
- On the `ssp` side, I made the instance name symbol optional.

I plan to extend the DOT export and error messages to use these names in follow-up PRs.