### PR TITLE
[ExportVerilog] Emit VerbatimExpr inline in bind

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -77,6 +77,10 @@ static void spillWiresForInstanceInputs(InstanceOp op) {
     auto src = op.getOperand(nextOpNo);
     ++nextOpNo;
 
+    auto *srcOp = src.getDefiningOp();
+    if (isa_and_nonnull<VerbatimExprOp>(srcOp))
+      continue;
+
     if (isSimpleReadOrPort(src))
       continue;
 


### PR DESCRIPTION
Change emission of SystemVerilog (SV) verbatim expressions to always inline into bound instances.  This is specifically done to enable cross-module references (XMRs), encoded as verbatim expressions, to be emitted in the bind.  FIRRTL-originating XMRs use verbatim expressions as they require the ability to use substitutions.

This is part of a broader effort to disallow "upwards XMRs" in FIRRTL. These are represented using input RefType ports.  These are generally problematic because an "upwards XMR" may require duplication of the module in which it is used in order to legalize to an SV XMR.  However, this means that any preexisting upwards XMR now needs to be converted to an input port.  By enabling these XMRs to be emitted in the bind, no modifications are necessary in the module where the bind occurs. Without this commit, a dead wire would have to be placed unconditionally in the bind site.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

One main note: this could be better handled via the `sv::XMROp`. However, that currently doesn't handle string substitutions (and this is necessary for XMRs originating from FIRRTL). That operation could be refactored to support string substitutions. However, it's then unclear if it's any different from `VerbatimExprOp`.