### PR TITLE
[FIRRTL] Bore real input ports in WiringProblems

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -204,7 +204,7 @@ struct WiringProblem {
 
   /// A base name to use when generating new signals associated with this wiring
   /// problem.
-  StringRef newNameHint;
+  std::string newNameHint;
 };
 
 /// A store of pending modifications to a FIRRTL module associated with solving

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -323,7 +323,7 @@ InstanceOp firrtl::addPortsToModule(
   // Get a new port name from the Namespace.
   auto portName = [&](FModuleLike nameForMod) {
     return StringAttr::get(nameForMod.getContext(),
-                           getNamespace(nameForMod).newName("_gen_" + newName));
+                           getNamespace(nameForMod).newName(newName));
   };
   // The port number for the new port.
   unsigned portNo = getNumPorts(mod);

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -690,21 +690,18 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     moduleModifications[sinkModule].connectionMap[index] = sink;
 
     // Record ports that should be added to each module along the LCA path.
-    // Wire using RefType based on the source-- the RefSend will be of this
-    // type, and we cannot connect RefType's of non-identical types. The final
-    // connect of the resolved ref to the sink will handle any differences.
-    RefType tpe = TypeSwitch<Type, RefType>(problem.source.getType())
-                      .Case<FIRRTLBaseType>([](FIRRTLBaseType base) {
-                        return RefType::get(base);
-                      })
-                      .Case<RefType>([](RefType ref) { return ref; });
+    RefType refType = TypeSwitch<Type, RefType>(problem.source.getType())
+                          .Case<FIRRTLBaseType>([](FIRRTLBaseType base) {
+                            return RefType::get(base);
+                          })
+                          .Case<RefType>([](RefType ref) { return ref; });
     for (auto sourceInst : sources) {
       auto mod = cast<FModuleOp>(instanceGraph.getReferencedModule(sourceInst));
       moduleModifications[mod].portsToAdd.push_back(
           {index,
            {StringAttr::get(
                 context, state.getNamespace(mod).newName(problem.newNameHint)),
-            tpe, Direction::Out}});
+            refType, Direction::Out}});
     }
     for (auto sinkInst : sinks) {
       auto mod = cast<FModuleOp>(instanceGraph.getReferencedModule(sinkInst));
@@ -712,7 +709,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
           {index,
            {StringAttr::get(
                 context, state.getNamespace(mod).newName(problem.newNameHint)),
-            tpe, Direction::In}});
+            refType.getType(), Direction::In}});
     }
   }
 

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -26,15 +26,18 @@ circuit Top:
     signed.a <= a
     b <= signed.b
 
-    ; CHECK:      module Companion();
-    ; CHECK-NEXT:   MyInterface MyView();
-    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = DUT.a;
+    ; CHECK:      module Companion(
+    ; CHECK:        input [[port:[a-zA-Z0-9_]+]]);
+    ; CHECK:        MyInterface MyView();
+    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = [[port]];
     ; CHECK-NEXT: endmodule
 
     ; CHECK:      module DUT
     ; CHECK:        input a
     ; CHECK:        output b
-    ; CHECK:          Companion companion ();
+    ; CHECK:          Companion companion (
+    ; CHECK-NEXT:       .[[port]] (a)
+    ; CHECK-NEXT:     );
     ; Wire got optimized away!!
     ; CHECK:          assign b = a;
     ; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -188,34 +188,35 @@ circuit Top :
     out.multivec[1][2] <= dut.out.multivec[1][2]
     out.uint <= dut.out.uint
 
-    ; PREFIX:         module FOO_BAR_MyView_companion();
-    ; PREFIX:           FOO_BAR_BAZ_MyInterface MyView();
+    ; PREFIX:         module FOO_BAR_MyView_companion(
+    ; PREFIX:         FOO_BAR_BAZ_MyInterface MyView(
 
-    ; NOEXTRACT:      module MyView_companion();
+    ; NOEXTRACT:      module MyView_companion(
+    ; NOEXTRACT:      );
     ; NOEXTRACT:        MyInterface MyView();
-    ; NOEXTRACT:        assign MyView.uint = DUT.w_uint;
-    ; NOEXTRACT-NEXT:   assign MyView.vec[0] = DUT.w_vec_0;
-    ; NOEXTRACT-NEXT:   assign MyView.vec[1] = DUT.w_vec_1;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][0] = DUT.w_multivec_0_0;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][1] = DUT.w_multivec_0_1;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][2] = DUT.w_multivec_0_2;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][0] = DUT.w_multivec_1_0;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][1] = DUT.w_multivec_1_1;
-    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][2] = DUT.w_multivec_1_2;
-    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[0].sint = DUT.w_vecOfBundle_0_sint;
-    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[0].uint = DUT.w_vecOfBundle_0_uint;
-    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[1].sint = DUT.w_vecOfBundle_1_sint;
-    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[1].uint = DUT.w_vecOfBundle_1_uint;
-    ; NOEXTRACT-NEXT:   assign MyView.otherOther.other.sint = DUT.w_otherOther_other_sint;
-    ; NOEXTRACT-NEXT:   assign MyView.otherOther.other.uint = DUT.w_otherOther_other_uint;
+    ; NOEXTRACT:        assign MyView.uint = [[DUT_w_uint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vec[0] = [[DUT_w_vec_0:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vec[1] = [[DUT_w_vec_1:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][0] = [[DUT_w_multivec_0_0:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][1] = [[DUT_w_multivec_0_1:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[0][2] = [[DUT_w_multivec_0_2:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][0] = [[DUT_w_multivec_1_0:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][1] = [[DUT_w_multivec_1_1:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.multivec[1][2] = [[DUT_w_multivec_1_2:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[0].sint = [[DUT_w_vecOfBundle_0_sint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[0].uint = [[DUT_w_vecOfBundle_0_uint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[1].sint = [[DUT_w_vecOfBundle_1_sint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.vecOfBundle[1].uint = [[DUT_w_vecOfBundle_1_uint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.otherOther.other.sint = [[DUT_w_otherOther_other_sint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.otherOther.other.uint = [[DUT_w_otherOther_other_uint:[a-zA-Z0-9_]+]];
     ; NOEXTRACT-NEXT:   assign MyView.sub_uint = 1'h1;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vec[0] = DUT.submodule.w_vec_0;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vec[1] = DUT.submodule.w_vec_1;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[0].sint = DUT.submodule.w_vecOfBundle_0_sint;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[0].uint = DUT.submodule.w_vecOfBundle_0_uint;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].sint = DUT.submodule.w_vecOfBundle_1_sint;
-    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].uint = DUT.submodule.w_vecOfBundle_1_uint;
-    ; NOEXTRACT-NEXT:   assign MyView.ext_port_1 = DUT.
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vec[0] = [[DUT_submodule_w_vec_0:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vec[1] = [[DUT_submodule_w_vec_1:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[0].sint = [[DUT_submodule_w_vecOfBundle_0_sint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[0].uint = [[DUT_submodule_w_vecOfBundle_0_uint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].sint = [[DUT_submodule_w_vecOfBundle_1_sint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].uint = [[DUT_submodule_w_vecOfBundle_1_uint:[a-zA-Z0-9_]+]];
+    ; NOEXTRACT-NEXT:   assign MyView.ext_port_1 = [[ExtModuleWithPort_source_1:[a-zA-Z0-9_]+]];
     ; NOEXTRACT:        Tap tap (
     ; NOEXTRACT-NEXT:     .b     (r),
     ; NOEXTRACT-NEXT:     .clock (clock),
@@ -226,9 +227,60 @@ circuit Top :
     ; CHECK:          module DUT
     ; CHECK-NOT:      endmodule
     ; EXTRACT:          /* This instance is elsewhere emitted as a bind statement.
-    ; EXTRACT-NEXT:        MyView_companion MyView_companion
+    ; EXTRACT-NEXT:        MyView_companion MyView_companion (
+    ; EXTRACT-NEXT:          .[[in_uint_port:[a-zA-Z0-9_]+]]                             (in_uint),
+    ; EXTRACT-NEXT:          .[[in_vec_0_port:[a-zA-Z0-9_]+]]                            (in_vec_0),
+    ; EXTRACT-NEXT:          .[[in_vec_1_port:[a-zA-Z0-9_]+]]                            (in_vec_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_0_port:[a-zA-Z0-9_]+]]                     (in_multivec_0_0),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_1_port:[a-zA-Z0-9_]+]]                     (in_multivec_0_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_2_port:[a-zA-Z0-9_]+]]                     (in_multivec_0_2),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_0_port:[a-zA-Z0-9_]+]]                     (in_multivec_1_0),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_1_port:[a-zA-Z0-9_]+]]                     (in_multivec_1_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_2_port:[a-zA-Z0-9_]+]]                     (in_multivec_1_2),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_0_sint_port:[a-zA-Z0-9_]+]]               (in_vecOfBundle_0_sint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_0_uint_port:[a-zA-Z0-9_]+]]               (in_vecOfBundle_0_uint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_sint_port:[a-zA-Z0-9_]+]]               (in_vecOfBundle_1_sint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_uint_port:[a-zA-Z0-9_]+]]               (in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[in_otherOther_other_sint_port:[a-zA-Z0-9_]+]]            (in_otherOther_other_sint),
+    ; EXTRACT-NEXT:          .[[in_otherOther_other_uint_port:[a-zA-Z0-9_]+]]            (in_otherOther_other_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_0),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_1),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_sint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_sint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[ExtModuleWithPort_source_1_port:[a-zA-Z0-9_]+]]          ([[ExtModuleWithPort_source_1_wire:[a-zA-Z0-9_]+]])
+    ; EXTRACT-NEXT:        );
     ; EXTRACT-NEXT:     */
-    ; NOEXTRACT:        {{^ *}}MyView_companion MyView_companion
+    ; NOEXTRACT:        {{^ *}}MyView_companion MyView_companion (
+    ; NOEXTRACT-NEXT:        .[[DUT_w_uint]]                               (w_uint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vec_0]]                              (w_vec_0),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vec_1]]                              (w_vec_1),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_0_0]]                       (w_multivec_0_0),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_0_1]]                       (w_multivec_0_1),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_0_2]]                       (w_multivec_0_2),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_1_0]]                       (w_multivec_1_0),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_1_1]]                       (w_multivec_1_1),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_multivec_1_2]]                       (w_multivec_1_2),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vecOfBundle_0_sint]]                 (w_vecOfBundle_0_sint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vecOfBundle_0_uint]]                 (w_vecOfBundle_0_uint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vecOfBundle_1_sint]]                 (w_vecOfBundle_1_sint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_vecOfBundle_1_uint]]                 (w_vecOfBundle_1_uint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_otherOther_other_sint]]              (w_otherOther_other_sint),
+    ; NOEXTRACT-NEXT:        .[[DUT_w_otherOther_other_uint]]              (w_otherOther_other_uint),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_0]]                    (DUT.submodule.w_vec_0),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_1]]                    (DUT.submodule.w_vec_1),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_sint]]       (DUT.submodule.w_vecOfBundle_0_sint),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_uint]]       (DUT.submodule.w_vecOfBundle_0_uint),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_sint]]       (DUT.submodule.w_vecOfBundle_1_sint),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_uint]]       (DUT.submodule.w_vecOfBundle_1_uint)
+    ; NOEXTRACT-NEXT:        .[[ExtModuleWithPort_source_1:[a-zA-Z0-9_]+]] ([[ExtModuleWithPort_source_1_wire:[a-zA-Z0-9_]+]])
+    ; NOEXTRACT-NEXT:      );
+
+    ; CHECK:              ExtModuleWithPort ext (
+    ; CHECK-NEXT:           .source_0 (
+    ; CHECK-NEXT:           .source_1 ([[ExtModuleWithPort_source_1_wire]])
+    ; CHECK-NEXT:         );
 
     ; EXTRACT:        FILE ".{{[/\]}}BlackBox_DUT.v"
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}BlackBox_GCT.v"
@@ -242,31 +294,31 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}MyView_companion.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}{{[/\]}}MyView_companion.sv
-    ; EXTRACT:        module MyView_companion();
+    ; EXTRACT:        module MyView_companion(
     ; EXTRACT:          MyInterface MyView();
-    ; EXTRACT:          assign MyView.uint = DUT.in_uint;
-    ; EXTRACT-NEXT:     assign MyView.vec[0] = DUT.in_vec_0;
-    ; EXTRACT-NEXT:     assign MyView.vec[1] = DUT.in_vec_1;
-    ; EXTRACT-NEXT:     assign MyView.multivec[0][0] = DUT.in_multivec_0_0;
-    ; EXTRACT-NEXT:     assign MyView.multivec[0][1] = DUT.in_multivec_0_1;
-    ; EXTRACT-NEXT:     assign MyView.multivec[0][2] = DUT.in_multivec_0_2;
-    ; EXTRACT-NEXT:     assign MyView.multivec[1][0] = DUT.in_multivec_1_0;
-    ; EXTRACT-NEXT:     assign MyView.multivec[1][1] = DUT.in_multivec_1_1;
-    ; EXTRACT-NEXT:     assign MyView.multivec[1][2] = DUT.in_multivec_1_2;
-    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[0].sint = DUT.in_vecOfBundle_0_sint;
-    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[0].uint = DUT.in_vecOfBundle_0_uint;
-    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[1].sint = DUT.in_vecOfBundle_1_sint;
-    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[1].uint = DUT.in_vecOfBundle_1_uint;
-    ; EXTRACT-NEXT:     assign MyView.otherOther.other.sint = DUT.in_otherOther_other_sint;
-    ; EXTRACT-NEXT:     assign MyView.otherOther.other.uint = DUT.in_otherOther_other_uint;
+    ; EXTRACT:          assign MyView.uint = [[in_uint_port]];
+    ; EXTRACT-NEXT:     assign MyView.vec[0] = [[in_vec_0_port]];
+    ; EXTRACT-NEXT:     assign MyView.vec[1] = [[in_vec_1_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[0][0] = [[in_multivec_0_0_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[0][1] = [[in_multivec_0_1_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[0][2] = [[in_multivec_0_2_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[1][0] = [[in_multivec_1_0_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[1][1] = [[in_multivec_1_1_port]];
+    ; EXTRACT-NEXT:     assign MyView.multivec[1][2] = [[in_multivec_1_2_port]];
+    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[0].sint = [[in_vecOfBundle_0_sint_port]];
+    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[0].uint = [[in_vecOfBundle_0_uint_port]];
+    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[1].sint = [[in_vecOfBundle_1_sint_port]];
+    ; EXTRACT-NEXT:     assign MyView.vecOfBundle[1].uint = [[in_vecOfBundle_1_uint_port]];
+    ; EXTRACT-NEXT:     assign MyView.otherOther.other.sint = [[in_otherOther_other_sint_port]];
+    ; EXTRACT-NEXT:     assign MyView.otherOther.other.uint = [[in_otherOther_other_uint_port]];
     ; EXTRACT-NEXT:     assign MyView.sub_uint = 1'h1;
-    ; EXTRACT-NEXT:     assign MyView.sub_vec[0] = DUT.submodule.in_vec_0;
-    ; EXTRACT-NEXT:     assign MyView.sub_vec[1] = DUT.submodule.in_vec_1;
-    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[0].sint = DUT.submodule.in_vecOfBundle_0_sint;
-    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[0].uint = DUT.submodule.in_vecOfBundle_0_uint;
-    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].sint = DUT.submodule.in_vecOfBundle_1_sint;
-    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].uint = DUT.submodule.in_vecOfBundle_1_uint;
-    ; EXTRACT-NEXT:     assign MyView.ext_port_1 = DUT.
+    ; EXTRACT-NEXT:     assign MyView.sub_vec[0] = [[DUT_submodule_in_vec_0_port]];
+    ; EXTRACT-NEXT:     assign MyView.sub_vec[1] = [[DUT_submodule_in_vec_1_port]];
+    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[0].sint = [[DUT_submodule_in_vecOfBundle_0_sint_port]];
+    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[0].uint = [[DUT_submodule_in_vecOfBundle_0_uint_port]];
+    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].sint = [[DUT_submodule_in_vecOfBundle_1_sint_port]];
+    ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].uint = [[DUT_submodule_in_vecOfBundle_1_uint_port]];
+    ; EXTRACT-NEXT:     assign MyView.ext_port_1 = [[ExtModuleWithPort_source_1_port]];
     ; EXTRACT:          Tap tap (
     ; EXTRACT-NEXT:       .b     (r),
     ; EXTRACT-NEXT:       .clock (_tap_clock),
@@ -276,7 +328,30 @@ circuit Top :
 
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}bindings.sv"
     ; EXTRACT-NOT:    FILE
-    ; EXTRACT:        bind DUT MyView_companion MyView_companion{{ *}}();
+    ; EXTRACT:        bind DUT MyView_companion MyView_companion{{ *}}(
+    ; EXTRACT-NEXT:          .[[in_uint_port]]                             (in_uint),
+    ; EXTRACT-NEXT:          .[[in_vec_0_port]]                            (in_vec_0),
+    ; EXTRACT-NEXT:          .[[in_vec_1_port]]                            (in_vec_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_0_port]]                     (in_multivec_0_0),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_1_port]]                     (in_multivec_0_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_0_2_port]]                     (in_multivec_0_2),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_0_port]]                     (in_multivec_1_0),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_1_port]]                     (in_multivec_1_1),
+    ; EXTRACT-NEXT:          .[[in_multivec_1_2_port]]                     (in_multivec_1_2),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_0_sint_port]]               (in_vecOfBundle_0_sint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_0_uint_port]]               (in_vecOfBundle_0_uint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_sint_port]]               (in_vecOfBundle_1_sint),
+    ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_uint_port]]               (in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[in_otherOther_other_sint_port]]            (in_otherOther_other_sint),
+    ; EXTRACT-NEXT:          .[[in_otherOther_other_uint_port]]            (in_otherOther_other_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port]]              (DUT.submodule.in_vec_0),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port]]              (DUT.submodule.in_vec_1),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port]] (DUT.submodule.in_vecOfBundle_0_sint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port]] (DUT.submodule.in_vecOfBundle_0_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port]] (DUT.submodule.in_vecOfBundle_1_sint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port]] (DUT.submodule.in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[ExtModuleWithPort_source_1_port]]          ([[ExtModuleWithPort_source_1_wire]])
+    ; );
     ; NOEXTRACT-NOT:  FILE "Wire{{[/\]}}firrtl{{[/\]}}bindings.sv"
 
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}MyInterface.sv"

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-more-xmrs.fir
@@ -42,32 +42,32 @@ circuit Top : %[[
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
-        "sink":"~Top|DUT>tap_0"
+        "sink":"~Top|DUT>tap_6"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>wire_DUT",
-        "sink":"~Top|DUT>tap_1"
+        "sink":"~Top|DUT>tap_7"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
-        "sink":"~Top|DUT>tap_2"
+        "sink":"~Top|DUT>tap_8"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
-        "sink":"~Top|DUT>tap_3"
+        "sink":"~Top|DUT>tap_9"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>port_DUT",
-        "sink":"~Top|DUT>tap_4"
+        "sink":"~Top|DUT>tap_10"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>port_Top",
-        "sink":"~Top|DUT>tap_5"
+        "sink":"~Top|DUT>tap_11"
       }
     ]
   },
@@ -77,32 +77,32 @@ circuit Top : %[[
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>wire_Submodule",
-        "sink":"~Top|Top>tap[0]"
+        "sink":"~Top|Top>tap_12[0]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>wire_DUT",
-        "sink":"~Top|Top>tap[1]"
+        "sink":"~Top|Top>tap_12[1]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>wire_Top",
-        "sink":"~Top|Top>tap[2]"
+        "sink":"~Top|Top>tap_12[2]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT/submodule:Submodule>port_Submodule",
-        "sink":"~Top|Top>tap[3]"
+        "sink":"~Top|Top>tap_12[3]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top/dut:DUT>port_DUT",
-        "sink":"~Top|Top>tap[4]"
+        "sink":"~Top|Top>tap_12[4]"
       },
       {
         "class":"sifive.enterprise.grandcentral.ReferenceDataTapKey",
         "source":"~Top|Top>port_Top",
-        "sink":"~Top|Top>tap[5]"
+        "sink":"~Top|Top>tap_12[5]"
       }
     ]
   },
@@ -144,31 +144,31 @@ circuit Top : %[[
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_0"
+    "target": "~Top|DUT>tap_6"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_1"
+    "target": "~Top|DUT>tap_7"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_2"
+    "target": "~Top|DUT>tap_8"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_3"
+    "target": "~Top|DUT>tap_9"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_4"
+    "target": "~Top|DUT>tap_10"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|DUT>tap_5"
+    "target": "~Top|DUT>tap_11"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
-    "target": "~Top|Top>tap"
+    "target": "~Top|Top>tap_12"
   }
 ]]
   module Submodule :
@@ -206,18 +206,18 @@ circuit Top : %[[
 
     inst submodule of Submodule
 
-    wire tap_0 : UInt<1>
-    wire tap_1 : UInt<1>
-    wire tap_2 : UInt<1>
-    wire tap_3 : UInt<1>
-    wire tap_4 : UInt<1>
-    wire tap_5 : UInt<1>
-    tap_0 is invalid
-    tap_1 is invalid
-    tap_2 is invalid
-    tap_3 is invalid
-    tap_4 is invalid
-    tap_5 is invalid
+    wire tap_6 : UInt<1>
+    wire tap_7 : UInt<1>
+    wire tap_8 : UInt<1>
+    wire tap_9 : UInt<1>
+    wire tap_10 : UInt<1>
+    wire tap_11 : UInt<1>
+    tap_6 is invalid
+    tap_7 is invalid
+    tap_8 is invalid
+    tap_9 is invalid
+    tap_10 is invalid
+    tap_11 is invalid
 
   module Top :
     output port_Top : UInt<1>
@@ -230,29 +230,50 @@ circuit Top : %[[
     wire_Top <= inv
 
     inst dut of DUT
-    wire tap : UInt<1>[6]
-    tap is invalid
+    wire tap_12 : UInt<1>[6]
+    tap_12 is invalid
 
     ; CHECK-LABEL: module Submodule
-    ; CHECK:         wire tap_3 = 1'h0
-    ; CHECK-NEXT:    wire tap_4 = 1'h0
-    ; CHECK-DAG:     assign tap_0 = wire_Submodule
-    ; CHECK-DAG:     assign tap_1 = DUT.wire_DUT
-    ; CHECK-DAG:     assign tap_2 = Top.wire_Top
-    ; CHECK-DAG:     assign tap_5 = Top.port_Top
+    ; CHECK-NEXT:    input [[Submodule_tap_1_port:[a-zA-Z0-9_]+]]
+    ; CHECK-NEXT:          [[Submodule_tap_2_port:[a-zA-Z0-9_]+]]
+    ; CHECK-NEXT:          [[Submodule_tap_5_port:[a-zA-Z0-9_]+]]
+    ;
+    ; CHECK-DAG:     tap_0 = wire_Submodule;
+    ; CHECK-DAG:     tap_1 = [[Submodule_tap_1_port]];
+    ; CHECK-DAG:     tap_2 = [[Submodule_tap_2_port]];
+    ; CHECK-DAG:     tap_3 = 1'h0;
+    ; CHECK-DAG:     tap_4 = 1'h0;
+    ; CHECK-DAG:     tap_5 = [[Submodule_tap_5_port]];
 
     ; CHECK-LABEL: module DUT
-    ; CHECK:         wire tap_3 = 1'h0
-    ; CHECK-NEXT:    wire tap_4 = 1'h0
-    ; CHECK-DAG:     assign tap_0 = DUT.submodule.wire_Submodule
-    ; CHECK-DAG:     assign tap_1 = wire_DUT
-    ; CHECK-DAG:     assign tap_2 = Top.wire_Top
-    ; CHECK-DAG:     assign tap_5 = Top.port_Top
+    ; CHECK-NEXT:    input [[DUT_tap_2_port:[a-zA-Z0-9_]+]]
+    ; CHECK-NEXT:          [[DUT_tap_5_port:[a-zA-Z0-9_]+]]
+    ; CHECK-NEXT:          [[DUT_tap_8_port:[a-zA-Z0-9_]+]]
+    ; CHECK-NEXT:          [[DUT_tap_11_port:[a-zA-Z0-9_]+]]
+    ;
+    ; CHECK-DAG:     tap_6 = DUT.submodule.wire_Submodule;
+    ; CHECK-DAG:     tap_7 = wire_DUT;
+    ; CHECK-DAG:     tap_8 = [[DUT_tap_8_port]];
+    ; CHECK-DAG:     tap_9 = 1'h0;
+    ; CHECK-DAG:     tap_10 = 1'h0;
+    ; CHECK-DAG:     tap_11 = [[DUT_tap_11_port]];
+    ;
+    ; CHECK:         Submodule submodule (
+    ; CHECK-DAG:       .[[Submodule_tap_1_port]] (wire_DUT)
+    ; CHECK-DAG:       .[[Submodule_tap_2_port]] ([[DUT_tap_2_port]])
+    ; CHECK-DAG:       .[[Submodule_tap_5_port]] ([[DUT_tap_5_port]])
 
     ; CHECK-LABEL: module Top
-    ; CHECK:         wire tap_3 = 1'h0
-    ; CHECK-NEXT:    wire tap_4 = 1'h0
-    ; CHECK-NEXT:    wire tap_5 = 1'h0
-    ; CHECK-DAG:     assign tap_0 = Top.dut.submodule.wire_Submodule
-    ; CHECK-DAG:     assign tap_1 = Top.dut.wire_DUT
-    ; CHECK-DAG:     assign tap_2 = wire_Top
+    ;
+    ; CHECK-DAG:     tap_12_0 = Top.dut.submodule.wire_Submodule
+    ; CHECK-DAG:     tap_12_1 = Top.dut.wire_DUT
+    ; CHECK-DAG:     tap_12_2 = inv;
+    ; CHECK-DAG:     tap_12_3 = 1'h0
+    ; CHECK-DAG:     tap_12_4 = 1'h0
+    ; CHECK-DAG:     tap_12_5 = 1'h0
+    ;
+    ; CHECK:         DUT dut (
+    ; CHECK-DAG:       .[[DUT_tap_2_port]] (inv)
+    ; CHECK-DAG:       .[[DUT_tap_5_port]] (1'h0)
+    ; CHECK-DAG:       .[[DUT_tap_8_port]] (inv)
+    ; CHECK-DAG:       .[[DUT_tap_11_port]] (1'h0)

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -51,59 +51,37 @@ circuit Top : %[[
   }
 ]]
   module InternalPathChild :
-    output io : { flip in : UInt<8>, out : UInt<8>}
 
-    node sum = tail(add(io.in, UInt<1>(1)), 1)
-
-    io.out <= sum
+    skip
 
   extmodule BlackBox :
-    input in : UInt<1>
-    output out : UInt<1>
+
     defname = BlackBox
 
   module Child :
-    output io : { flip in : UInt<1>, out : UInt<1>}
 
     inst localparam of BlackBox
-    localparam.out is invalid
-    localparam.in is invalid
-    localparam.in <= io.in
-    io.out <= localparam.out
+    localparam is invalid
+
     wire tap : UInt<1>
     tap is invalid
 
   module ChildWrapper :
-    output io : { flip in : UInt<1>, out : UInt<1>}
 
     inst signed of Child
-    signed.io.in <= io.in
-    io.out <= signed.io.out
 
   module Bar :
-    input in : UInt<1>
-    output out : UInt<1>
+
     wire inv : UInt<1>
-    inv <= not(in)
-    out <= inv
+    inv is invalid
 
   module Foo :
-    input in : UInt<1>
-    output out : UInt<1>
 
     inst b of Bar
-    b.in <= in
-    out <= b.out
 
   module Top:
-    input in : UInt<1>
-    output out : UInt<1>
-    output io : { flip in : UInt<1>, out : UInt<1>}
-    output io2 : { flip in : UInt<8>, out : UInt<8>}
 
     inst foo of Foo
-    foo.in <= in
-    out <= foo.out
 
     wire tap : UInt<1>
     tap is invalid
@@ -115,23 +93,27 @@ circuit Top : %[[
     tap3 is invalid
 
     inst unsigned of ChildWrapper
-    node _child_io_in_T = and(io.in, in)
-    unsigned.io.in <= _child_io_in_T
-    node _io_out_T = and(unsigned.io.out, out)
-    io.out <= _io_out_T
 
     inst int of InternalPathChild
-    io2 <= int.io
 
 ; CHECK-LABEL: module Child(
-; CHECK:       wire tap
-; CHECK-NEXT:  assign tap = Top.int_0.io_out;
-; CHECK:       BlackBox localparam_0 (
+; CHECK-NOT:   endmodule
+; CHECK:         input [[Child_boredPort:[a-zA-Z0-9_]+]]
+; CHECK:         wire tap = [[Child_boredPort]];
+; CHECK;       endmodule
 
-; CHECK: module Top(
-; CHECK-NOT: module
-; CHECK:   tap = Top.foo.b.inv;
-; CHECK:   assign tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
-; CHECK:   assign tap3 = Top.unsigned_0.signed_0.localparam_0.random.something_else;
-; CHECK:   InternalPathChild int_0 (
-; CHECK: endmodule
+; CHECK-LABEL: module ChildWrapper(
+; CHECK-NOT:   endmodule
+; CHECK:         input [[ChildWrapper_boredPort:[a-zA-Z0-9_]+]]
+; CHECK:         Child signed_0 (
+; CHECK-NEXT:      .[[Child_boredPort]] ([[ChildWrapper_boredPort]])
+; CHECK:       endmodule
+
+; CHECK-LABEL: module Top(
+; CHECK-NOT:   endmodule
+; CHECK:         assign tap = Top.foo.b.inv;
+; CHECK-NEXT:    assign tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
+; CHECK-NEXT:    assign tap3 = Top.unsigned_0.signed_0.localparam_0.random.something_else;
+; CHECK:         ChildWrapper unsigned_0 (
+; CHECK-NEXT:      .[[ChildWrapper_boredPort]] (Top.int_0.io_out)
+; CHECK:       endmodule

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1006,33 +1006,34 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK-SAME:  name = "view"}
 
 // The companion should be marked.
-// CHECK: firrtl.module private @view_companion
+// CHECK:      firrtl.module private @view_companion(
+// CHECK-SAME:   in %[[port_0:[a-zA-Z0-9_]+]]: !firrtl.uint<1>,
+// CHECK-SAME:   in %[[port_1:[a-zA-Z0-9_]+]]: !firrtl.uint<1>,
+// CHECK-SAME:   in %[[port_2:[a-zA-Z0-9_]+]]: !firrtl.uint<1>,
+// CHECK-SAME:   in %[[port_3:[a-zA-Z0-9_]+]]: !firrtl.uint<1>,
+// CHECK-SAME:   in %[[port_4:[a-zA-Z0-9_]+]]: !firrtl.uint<1>
+// CHECK-SAME: )
 // CHECK-SAME: annotations
 // CHECK-SAME: {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
 // CHECK-SAME:  id = [[ID_ViewName]] : i64,
 // CHECK-SAME:  name = "view"}
 //
-// CHECK:      %[[wire_1_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.node %[[wire_1_ref]]
+// CHECK:      firrtl.node %[[port_0]]
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}
-// CHECK:      %[[wire_2_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.node %[[wire_2_ref]]
+// CHECK:      firrtl.node %[[port_1]]
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}
-// CHECK:      %[[wire_3_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.node %[[wire_3_ref]]
+// CHECK:      firrtl.node %[[port_2]]
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3 : i64}
-// CHECK:      %[[wire_4_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.node %[[wire_4_ref]]
+// CHECK:      firrtl.node %[[port_3]]
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4 : i64}
-// CHECK:      %[[wire_5_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}}
-// CHECK:      firrtl.node %[[wire_5_ref]]
+// CHECK:      firrtl.node %[[port_4]]
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5 : i64}
 
 // The RefSend must be generated.
 // CHECK: firrtl.module @GCTInterface
 // CHECK-SAME: %a: !firrtl.uint<1>
 // CHECK:      %r = firrtl.reg  %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
-// CHECK:      %[[view_companion_view__2refPort:.+]], %[[view_companion_view__2refPort_1:.+]], %[[view_companion_view__1refPort:.+]], %[[view_companion_view__0refPort:.+]], %[[view_companion_view_portrefPort:.+]] = firrtl.instance view_companion  @view_companion(in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>)
+// CHECK:      %[[view_companion_view__2refPort:.+]], %[[view_companion_view__2refPort_1:.+]], %[[view_companion_view__1refPort:.+]], %[[view_companion_view__0refPort:.+]], %[[view_companion_view_portrefPort:.+]] = firrtl.instance view_companion  @view_companion(in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>)
 // CHECK:      %0 = firrtl.subfield %r[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<1>, 2>
 // CHECK:      %2 = firrtl.subfield %r[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
@@ -1041,16 +1042,11 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK:      %5 = firrtl.subfield %4[_1] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %6 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      %8 = firrtl.ref.send %1 : !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__1_0, %8 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
-// CHECK:      %9 = firrtl.ref.send %3 : !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__2_0, %9 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
-// CHECK:      %10 = firrtl.ref.send %5 : !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__0_def_3_0, %10 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
-// CHECK:      %11 = firrtl.ref.send %7 : !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__0_def_4_0, %11 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
-// CHECK:      %12 = firrtl.ref.send %a : !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_ViewName_5_0, %12 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+// CHECK:      firrtl.connect %view_companion__1_0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion__2_0, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion__0_def_3_0, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion__0_def_4_0, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_ViewName_5_0, %a : !firrtl.uint<1>, !firrtl.uint<1>
 
 // -----
 
@@ -1557,16 +1553,14 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
   ]
 } {
   // CHECK:      firrtl.module @Companion
-  // CHECK-SAME:   in %[[refPort_0:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
-  // CHECK-SAME:   in %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<2>>
+  // CHECK-SAME:   in %[[port_0:[a-zA-Z0-9_]+]]: !firrtl.uint<1>
+  // CHECK-SAME:   in %[[port_1:[a-zA-Z0-9_]+]]: !firrtl.uint<2>
   // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion", id = 0 : i64, name = "View"}
   firrtl.module @Companion() {
-    // CHECK-NEXT: %[[refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_0]]
-    // CHECK-NEXT: firrtl.node %[[refPort_0_resolve]]
+    // CHECK-NEXT: firrtl.node %[[port_0]]
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}]}
     // CHECK-SAME:   !firrtl.uint<1>
-    // CHECK-NEXT: %[[refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[refPort_1]]
-    // CHECK-NEXT: firrtl.node %[[refPort_1_resolve]]
+    // CHECK-NEXT: firrtl.node %[[port_1]]
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}]}
     // CHECK-SAME:   !firrtl.uint<2>
   }
@@ -1586,10 +1580,12 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
   firrtl.module @GrandCentralViewsBundle() {
     // CHECK-NEXT: %[[bar_refPort_0:[a-zA-Z0-9_]+]], %[[bar_refPort_1:[a-zA-Z0-9_]+]] = firrtl.instance bar
     firrtl.instance bar @Bar()
-    // CHECK-NEXT: %[[companion_refPort_0:[a-zA-Z0-9_]+]], %[[companion_refPort_1:[a-zA-Z0-9_]+]] = firrtl.instance companion
+    // CHECK-NEXT: %[[companion_port_0:[a-zA-Z0-9_]+]], %[[companion_port_1:[a-zA-Z0-9_]+]] = firrtl.instance companion
     firrtl.instance companion @Companion()
-    // CHECK-NEXT: firrtl.connect %[[companion_refPort_0]], %[[bar_refPort_0]]
-    // CHECK-NEXT: firrtl.connect %[[companion_refPort_1]], %[[bar_refPort_1]]
+    // CHECK-NEXT: %[[bar_refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_0]]
+    // CHECK-NEXT: firrtl.connect %[[companion_port_0]], %[[bar_refPort_0_resolve]]
+    // CHECK-NEXT: %[[bar_refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_1]]
+    // CHECK-NEXT: firrtl.connect %[[companion_port_1]], %[[bar_refPort_1_resolve]]
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1042,11 +1042,11 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK:      %5 = firrtl.subfield %4[_1] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %6 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      firrtl.connect %view_companion__1_0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__2_0, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__0_def_3_0, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion__0_def_4_0, %7 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_ViewName_5_0, %a : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %view_companion_view_port__bore, %a : !firrtl.uint<1>, !firrtl.uint<1>
 
 // -----
 
@@ -1601,24 +1601,24 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   ]}]} {
   // CHECK-LABEL: firrtl.circuit "Top"  {
   // CHECK-NOT:   "sifive.enterprise.grandcentral.DataTapsAnnotation"
-  // CHECK:  firrtl.module private @Bar(out %_gen_tap: !firrtl.ref<uint<1>>)
+  // CHECK:  firrtl.module private @Bar(out %inv__bore: !firrtl.ref<uint<1>>)
   firrtl.module private @Bar() {
     %inv = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %inv : !firrtl.uint<1>
-    // CHECK:  firrtl.connect %_gen_tap, %0 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.connect %inv__bore, %0 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
-  // CHECK-LABEL: firrtl.module private @Foo
+  // CHECK-LABEL: firrtl.module private @Foo(out %b_inv__bore: !firrtl.ref<uint<1>>)
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
-    // CHECK:  %b__gen_tap = firrtl.instance b interesting_name  @Bar(out _gen_tap: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.connect %_gen_tap, %b__gen_tap : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  %[[b_inv:[a-zA-Z0-9_]+]] = firrtl.instance b interesting_name  @Bar(out inv__bore: !firrtl.ref<uint<1>>)
+    // CHECK:  firrtl.connect %b_inv__bore, %[[b_inv]] : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
   // CHECK: firrtl.module @Top()
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
-    // CHECK:  %foo__gen_tap = firrtl.instance foo interesting_name  @Foo(out _gen_tap: !firrtl.ref<uint<1>>)
-    // CHECK:  %0 = firrtl.ref.resolve %foo__gen_tap : !firrtl.ref<uint<1>>
+    // CHECK:  %[[foo_b_inv:[a-zA-Z0-9_]+]] = firrtl.instance foo interesting_name  @Foo(out b_inv__bore: !firrtl.ref<uint<1>>)
+    // CHECK:  %0 = firrtl.ref.resolve %[[foo_b_inv]] : !firrtl.ref<uint<1>>
     // CHECK:  %tap = firrtl.node %0 : !firrtl.uint<1>
   }
 }
@@ -1643,7 +1643,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
       }
     ]}]} {
   firrtl.extmodule private @ExtBar()
-  // CHECK: firrtl.extmodule private @ExtBar(out _gen_ref: !firrtl.ref<uint<1>>)
+  // CHECK: firrtl.extmodule private @ExtBar(out random_something_external: !firrtl.ref<uint<1>>)
   // CHECK-SAME: internalPaths = ["random.something.external"]
   // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.ref<uint<1>>)
   // CHECK:  %[[random:.+]] = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
@@ -1653,13 +1653,13 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
   }
 
   // CHECK-LABEL:  firrtl.module private @Foo(
-  // CHECK-SAME: out %_gen_tap: !firrtl.ref<uint<1>>, out %_gen_tap2: !firrtl.ref<uint<1>>
+  // CHECK-SAME: out %b_random_something__bore: !firrtl.ref<uint<1>>, out %b2_random_something_external__bore: !firrtl.ref<uint<1>>
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
     // CHECK:  %[[gen_refPort:.+]] = firrtl.instance b interesting_name @Bar
     // CHECK-SAME: (out [[_gen_ref2]]: !firrtl.ref<uint<1>>)
     firrtl.instance b2 interesting_name  @ExtBar()
-    // CHECK: %b2__gen_ref = firrtl.instance b2 interesting_name  @ExtBar(out _gen_ref: !firrtl.ref<uint<1>>)
+    // CHECK: %b2_random_something_external = firrtl.instance b2 interesting_name  @ExtBar(out random_something_external: !firrtl.ref<uint<1>>)
   }
   // CHECK-LABEL firrtl.module @Top()
   firrtl.module @Top() {
@@ -1667,7 +1667,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
     %tap2 = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %[[foo__gen_tap:.+]], %[[foo__gen_tap2:.+]] = firrtl.instance foo interesting_name  @Foo
-    // CHECK-SAME: (out _gen_tap: !firrtl.ref<uint<1>>, out _gen_tap2: !firrtl.ref<uint<1>>)
+    // CHECK-SAME: (out b_random_something__bore: !firrtl.ref<uint<1>>, out b2_random_something_external__bore: !firrtl.ref<uint<1>>)
     // CHECK:  %[[v0:.+]] = firrtl.ref.resolve %[[foo__gen_tap]] : !firrtl.ref<uint<1>>
     // CHECK:  %tap = firrtl.node %[[v0]] : !firrtl.uint<1>
   }
@@ -1917,7 +1917,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<8>
-    // CHECK:   %[[v0:.+]] = firrtl.ref.resolve %foo__gen_tap : !firrtl.ref<uint>
+    // CHECK:   %[[v0:.+]] = firrtl.ref.resolve %foo_sum__bore : !firrtl.ref<uint>
     // CHECK:   %tap = firrtl.node %[[v0]] : !firrtl.uint
   }
 }


### PR DESCRIPTION
Change WiringProblem solving to bore _real_ ports (non-RefType ports)
when creating input ports.  With this commit, WiringProblems will be
solved by boring output RefType ports from source to LCA and real input
ports to the sink.  This is done because "upwards" XMRs may have tricky
semantics in that they should necessarily block deduplication (as any
upwards reference may cause a single ref.resolve to refer to more than
one thing).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

CC: @dtzSiFive

Note: the second commit is entirely test churn. This was a surprisingly trivial change to `WiringProblem`s. This works because the `connect` lambda inside `LowerAnnotations::solveWiringProblem` will create `RefResolveOp`/`RefSendOp` when it sees incompatible types.