### PR TITLE
[FIRRTL] Block dedup on input RefType ports

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1295,6 +1295,13 @@ class DedupPass : public DedupBase<DedupPass> {
         dedupMap[moduleName] = moduleName;
         continue;
       }
+      // If the module has input RefType ports, also skip it.
+      if (llvm::any_of(module.getPorts(), [&](PortInfo port) {
+            return isa<RefType>(port.type) && port.isInput();
+          })) {
+        dedupMap[moduleName] = moduleName;
+        continue;
+      }
       // Calculate the hash of the module.
       auto h = hasher.hash(module);
       // Check if there a module with the same hash.

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -586,6 +586,18 @@ firrtl.circuit "NoDedup" {
   }
 }
 
+// Don't deduplicate modules with input RefType ports.
+// CHECK-LABEL:   firrtl.circuit "InputRefTypePorts"
+// CHECK-COUNT-3: firrtl.module
+firrtl.circuit "InputRefTypePorts" {
+  firrtl.module @Foo(in %a: !firrtl.ref<uint<1>>) {}
+  firrtl.module @Bar(in %a: !firrtl.ref<uint<1>>) {}
+  firrtl.module @InputRefTypePorts() {
+    %foo_a = firrtl.instance foo @Foo(in a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar @Bar(in a: !firrtl.ref<uint<1>>)
+  }
+}
+
 // Check that modules marked MustDedup have been deduped.
 // CHECK-LABEL: firrtl.circuit "MustDedup"
 firrtl.circuit "MustDedup" attributes {annotations = [{


### PR DESCRIPTION
Change FIRRTL's structural deduplication ("dedup") pass to block dedup if a module has input RefType ports.  This is done because input RefType ports are consumed by a RefResolveOp which will lower to a Verilog hierarchical reference (XMR).  If dedup is allowed, this XMR may not have a valid representation because it refers to two different things in the circuit.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>