### PR TITLE
[FIRRTL] Reject string literals with non-7bit-ASCII or \{u,U}.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -452,6 +452,8 @@ FIRToken FIRLexer::lexString(const char *tokStart, bool isRaw) {
       // Ignore escaped '\'' or '"'
       if (*curPtr == '\'' || *curPtr == '"')
         ++curPtr;
+      else if (*curPtr == 'u' || *curPtr == 'U')
+        return emitError(tokStart, "unicode escape not supported in string");
       break;
     case 0:
       // This could be the end of file in the middle of the string.  If so
@@ -465,6 +467,8 @@ FIRToken FIRLexer::lexString(const char *tokStart, bool isRaw) {
     case '\f':
       return emitError(tokStart, "unterminated string");
     default:
+      if (curPtr[-1] & ~0x7F)
+        return emitError(tokStart, "string characters must be 7-bit ASCII");
       // Skip over other characters.
       break;
     }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -298,3 +298,19 @@ circuit Issue2971: ; expected-error {{no main module}}
 
 circuit NoModules: ; expected-error {{no modules found}}
    ; nothing
+
+;// -----
+
+circuit NonAscii:
+  module NonAscii:
+    input clk: Clock
+    input enable: UInt<1>
+    printf(clk, enable, "’") ; expected-error {{string characters must be 7-bit ASCII}}
+
+;// -----
+
+circuit UnicodeEscape:
+  module UnicodeEscape:
+    input clk: Clock
+    input enable: UInt<1>
+    printf(clk, enable, "\u0065") ; expected-error {{unicode escape not supported in string}}


### PR DESCRIPTION
The latter triggers an assertion failure and is not handled presently, the former may cause failures in CIRCT or later in pipeline.

The character `’` presently becomes "\342\200\231" (which seems like a correct encoding).

With assertions disabled, "\u2019" becomes  "\362019".