### PR TITLE
[FIRRTL] Remove ScalaClassAnnotation after consuming it.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -412,6 +412,13 @@ LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
 
   createOutput(testModules, testFilename);
   createOutput(dutModules, dutFilename);
+
+  // Clean up all ScalaClassAnnotations, which are no longer needed.
+  for (auto op : circuitOp.getOps<FModuleLike>()) {
+    AnnotationSet annos(op);
+    annos.removeAnnotations(op, scalaClassAnnoClass);
+  }
+
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -414,10 +414,8 @@ LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
   createOutput(dutModules, dutFilename);
 
   // Clean up all ScalaClassAnnotations, which are no longer needed.
-  for (auto op : circuitOp.getOps<FModuleLike>()) {
-    AnnotationSet annos(op);
-    annos.removeAnnotations(op, scalaClassAnnoClass);
-  }
+  for (auto op : circuitOp.getOps<FModuleLike>())
+    AnnotationSet::removeAnnotations(op, scalaClassAnnoClass);
 
   return success();
 }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -92,7 +92,8 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @ignored6() attributes {annotations = [{class = "firrtl.transforms.BlackBox"}], defname = "ignored6"}
 
   // ScalaClassAnnotation should be discarded after this pass.
-  // CHECK: firrtl.extmodule @ignored2() attributes {defname = "ignored2"}
+  // CHECK: firrtl.extmodule @ignored2()
+  // CHECK-NOT: sifive.enterprise.firrtl.ScalaClassAnnotation
 
   // Gracefully handle missing defnames.
   firrtl.extmodule @NoDefName()

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -91,6 +91,9 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @ignored5() attributes {annotations = [{class = "sifive.enterprise.grandcentral.transforms.SignalMappingAnnotation"}], defname = "ignored5"}
   firrtl.extmodule @ignored6() attributes {annotations = [{class = "firrtl.transforms.BlackBox"}], defname = "ignored6"}
 
+  // ScalaClassAnnotation should be discarded after this pass.
+  // CHECK: firrtl.extmodule @ignored2() attributes {defname = "ignored2"}
+
   // Gracefully handle missing defnames.
   firrtl.extmodule @NoDefName()
 


### PR DESCRIPTION
This annotation is only used in CreateSiFiveMetadata. After that pass consumes it, it can and should be dropped. Some downstream passes have to conservatively skip modules with annotations, so removing this annotation as soon as possible enables later transformations.