### PR TITLE
[FIRRTL][GrandCentralTaps] Don't add NoDedup annotation to Tap sinks

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -353,9 +353,6 @@ LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
   auto keyAttr = tryGetAs<ArrayAttr>(anno, anno, "keys", loc, dataTapsClass);
   if (!keyAttr)
     return failure();
-  auto noDedupAnnoClassName = StringAttr::get(context, noDedupAnnoClass);
-  auto noDedupAnno = DictionaryAttr::get(
-      context, {{StringAttr::get(context, "class"), noDedupAnnoClassName}});
   for (size_t i = 0, e = keyAttr.size(); i != e; ++i) {
     auto b = keyAttr[i];
     auto path = ("keys[" + Twine(i) + "]").str();
@@ -486,14 +483,6 @@ LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
       sendVal = getValueByFieldID(sendBuilder, sendVal, srcTarget->fieldIdx);
       // Note: No DontTouch added to sendVal, it can be constantprop'ed or
       // CSE'ed.
-    }
-
-    // Mark sink module "NoDedup".
-    // Unique paths are needed for RefType, deduplication may break that.
-    AnnotationSet annos(wireModule);
-    if (!annos.hasAnnotation(noDedupAnnoClassName)) {
-      annos.addAnnotations(noDedupAnno);
-      annos.applyToOperation(wireModule);
     }
 
     auto *targetOp = wireTarget->ref.getOp();

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1395,7 +1395,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
     // CHECK:  %b__gen_tap = firrtl.instance b interesting_name  @Bar(out _gen_tap: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.connect %_gen_tap, %b__gen_tap : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
-  // CHECK: firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]}
+  // CHECK: firrtl.module @Top()
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>


### PR DESCRIPTION
Remove the `NoDedup` annotation from DataTap sink modules.