### PR TITLE
[FIRRTL] Use nested array for aggregate constants

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -130,15 +130,15 @@ def AggregateConstantOp : FIRRTLOp<"aggregateconstant", [Pure, ConstantLike]> {
   let description = [{
     The constant operations produces a constant value of an aggregate type.  The
     type must be passive.  Clock and reset values are supported.
-    For nested aggregates, values are applied in depth-first fassion.
+    For nested aggregates, embedded arrays are used.
     ```
-      %result = firrtl.aggregateconstant 1, 2, 3 : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<4>>
-      %result = firrtl.aggregateconstant 1, 2, 3 : !firrtl.vector<uint<8>, 3>
-
+      %result = firrtl.aggregateconstant [1, 2, 3] : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<4>>
+      %result = firrtl.aggregateconstant [1, 2, 3] : !firrtl.vector<uint<8>, 3>
+      %result = firrtl.aggregateconstant [[1, 2], [3, 5]] : !firrtl.vector<!firrtl.bundle<a: uint<8>, b: uint<5>>, 2>
     ```
   }];
 
-  let arguments = (ins TypedArrayAttrBase<APSIntAttr, "field constants">:$fields);
+  let arguments = (ins ArrayAttr:$fields);
   let results = (outs AggregateType:$result);
 
   let assemblyFormat = "$fields attr-dict `:` type($result)";
@@ -265,7 +265,6 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 
-  // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` qualified(type($input))";
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1798,13 +1798,10 @@ void SubfieldOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 static Attribute collectFields(MLIRContext *context,
                                ArrayRef<Attribute> operands) {
-  SmallVector<Attribute> fields;
-  for (auto operand : operands) {
+  for (auto operand : operands)
     if (!operand)
       return {};
-    fields.push_back(operand);
-  }
-  return ArrayAttr::get(context, fields);
+  return ArrayAttr::get(context, operands);
 }
 
 OpFoldResult BundleCreateOp::fold(ArrayRef<Attribute> operands) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -747,7 +747,7 @@ firrtl.module @subindex(out %out : !firrtl.uint<8>) {
 firrtl.module @subindex_agg(out %out : !firrtl.bundle<a: uint<8>>) {
   // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
   // CHECK: firrtl.strictconnect %out, %0 : !firrtl.bundle<a: uint<8>>
-  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<bundle<a: uint<8>>, 1>
+  %0 = firrtl.aggregateconstant [[8 : ui8]] : !firrtl.vector<bundle<a: uint<8>>, 1>
   %1 = firrtl.subindex %0[0] : !firrtl.vector<bundle<a: uint<8>>, 1>
   firrtl.strictconnect %out, %1 : !firrtl.bundle<a: uint<8>>
 }
@@ -765,7 +765,7 @@ firrtl.module @subfield(out %out : !firrtl.uint<8>) {
 firrtl.module @subfield_agg(out %out : !firrtl.vector<uint<8>, 1>) {
   // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
   // CHECK: firrtl.strictconnect %out, %0 : !firrtl.vector<uint<8>, 1>
-  %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: vector<uint<8>, 1>>
+  %0 = firrtl.aggregateconstant [[8 : ui8]] : !firrtl.bundle<a: vector<uint<8>, 1>>
   %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a: vector<uint<8>, 1>>) -> !firrtl.vector<uint<8>, 1>
   firrtl.strictconnect %out, %1 : !firrtl.vector<uint<8>, 1>
 }
@@ -2195,7 +2195,7 @@ firrtl.module @MergeAgg(out %o: !firrtl.vector<bundle<valid: uint<1>, ready: uin
   firrtl.strictconnect %a20, %c : !firrtl.uint<1>
   firrtl.strictconnect %a21, %c : !firrtl.uint<1>
   firrtl.strictconnect %o, %a :  !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
-// CHECK: %0 = firrtl.aggregateconstant [0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1, 0 : ui1] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK: [0 : ui1, 0 : ui1], [0 : ui1, 0 : ui1], [0 : ui1, 0 : ui1]] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 // CHECK-NEXT: %a = firrtl.wire   : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 // CHECK-NEXT: firrtl.strictconnect %o, %a : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 // CHECK-NEXT: firrtl.strictconnect %a, %0 : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -28,6 +28,11 @@ firrtl.module @Constants() {
   firrtl.specialconstant 1 : !firrtl.asyncreset
   // CHECK: firrtl.constant 4 : !firrtl.uint<8> {name = "test"}
   firrtl.constant 4 : !firrtl.uint<8> {name = "test"}
+
+  firrtl.aggregateconstant [1, 2, 3] : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<4>>
+  firrtl.aggregateconstant [1, 2, 3] : !firrtl.vector<uint<8>, 3>
+  firrtl.aggregateconstant [[1, 2], [3, 4]] : !firrtl.vector<bundle<a: uint<8>, b: uint<5>>, 2>
+
 }
 
 //module MyModule :


### PR DESCRIPTION
Using flattened arrays for nested types in firrtl aggregate constants just makes everything harder.  Using nesting which matches types make IMCP and canonicalization easier.