### PR TITLE
[SV][ExportVerilog] Add XMRRefOp, Add ExportVerilog Emissions

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -101,6 +101,28 @@ def XMROp : SVOp<"xmr", []> {
   let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` qualified(type($result))";
 }
 
+def XMRRefOp : SVOp<"xmr.ref", []> {
+  let summary = "Encode a reference to something with a hw.globalRef.";
+  let description = [{
+    This represents a hierarchical path, but using something which the compiler
+    can understand.  In contrast to the XMROp (which models pure Verilog
+    hierarchical paths which may not map to anything knowable in the circuit),
+    this op uses a `hw.globalRef` to refer to something which exists in the
+    circuit.
+
+    Generally, this operation is always preferred for situations where
+    hierarchical paths cannot be known statically and may change.
+  }];
+  let arguments = (
+    ins SymbolNameAttr:$ref,
+        DefaultValuedAttr<StrAttr, "{}">:$stringLeaf
+  );
+  let results = (outs InOutType:$result);
+  let assemblyFormat = [{
+    $ref ( $stringLeaf^ )? attr-dict `:` qualified(type($result))
+  }];
+}
+
 def ReadInOutOp
  : SVOp<"read_inout",
         [Pure, InOutElementConstraint<"result", "input">]> {

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -32,7 +32,7 @@ public:
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, MacroRefExprOp, MacroRefExprSEOp,
             // Declarations.
-            RegOp, WireOp, LogicOp, LocalParamOp, XMROp,
+            RegOp, WireOp, LogicOp, LocalParamOp, XMROp, XMRRefOp,
             // Control flow.
             OrderedOutputOp, IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp,
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
@@ -88,6 +88,7 @@ public:
   HANDLE(LogicOp, Unhandled);
   HANDLE(LocalParamOp, Unhandled);
   HANDLE(XMROp, Unhandled);
+  HANDLE(XMRRefOp, Unhandled);
 
   // Expressions
   HANDLE(ReadInOutOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -292,7 +292,7 @@ static inline bool isExpressionAlwaysInline(Operation *op) {
 
   // XMRs can't be spilled if they are on the lhs.  Conservatively never spill
   // them.
-  if (isa<sv::XMROp>(op))
+  if (isa<sv::XMROp, sv::XMRRefOp>(op))
     return true;
 
   if (isa<sv::SampledOp>(op))

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -49,7 +49,7 @@ bool ExportVerilog::isSimpleReadOrPort(Value v) {
   auto readSrc = read.getInput().getDefiningOp();
   if (!readSrc)
     return false;
-  return isa<WireOp, RegOp, LogicOp, XMROp>(readSrc);
+  return isa<WireOp, RegOp, LogicOp, XMROp, XMRRefOp>(readSrc);
 }
 
 // Check if the value is deemed worth spilling into a wire.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -516,8 +516,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   /// nextNodeOnPath. Only the node representing the final XMR defining op has
   /// no nextNodeOnPath, which denotes a leaf node on the path.
   using nextNodeOnPath = Optional<size_t>;
-  using innerRefToVal = Attribute;
-  using node = std::pair<innerRefToVal, nextNodeOnPath>;
+  using node = std::pair<Attribute, nextNodeOnPath>;
   SmallVector<node> refSendPathList;
 
   /// llvm::EquivalenceClasses wants comparable elements. This comparator uses


### PR DESCRIPTION
Add a new hierarchical reference op that uses a symbol to refer to a
hw::GlobalRefOp that encodes the path to something in the circuit.  This
exists to complement the more restrictive XMROp which is a very direct
translation of a Verilog hierarchical reference that only uses strings.

The XMRRefOp may include an optional string that can be used to append some string to the resolved XMR.  This is a mechanism to got inside an external module boundary.

Add XMRRefOp emission to ExportVerilog.  Test that this works when
inlined into instances and bound instances.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>