### PR TITLE
[IMDCE] Generate warnings if empty modules are kept

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -501,7 +501,7 @@ void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
                 << "` is empty but cannot be removed because the "
                    "module has ports ";
     llvm::interleaveComma(module.getPortNames(), diag);
-    diag << " are referenced by name";
+    diag << " are referenced by name or dontTouched";
     return;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -475,15 +475,33 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
 }
 
 void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
-  // Public modules cannot be erased.
-  if (module.isPublic())
+  // If the module is not empty, just skip.
+  if (!module.getBodyBlock()->empty())
     return;
 
-  // If the module doesn't have arguments, operations or annotations, we
-  // consider it to be dead.
-  if (!module.getBodyBlock()->args_empty() || !module.getBodyBlock()->empty() ||
-      !module.getAnnotations().empty())
+  // We cannot delete public modules so generate a warning.
+  if (module.isPublic()) {
+    mlir::emitWarning(module.getLoc())
+        << "module `" << module.getName()
+        << "` is empty but cannot be removed because the module is public";
     return;
+  }
+
+  if (!module.getAnnotations().empty()) {
+    module.emitWarning() << "module `" << module.getName()
+                         << "` is empty but cannot be removed "
+                            "because the module has annotations "
+                         << module.getAnnotations();
+    return;
+  }
+
+  if (!module.getBodyBlock()->args_empty()) {
+    module.emitWarning()
+        << "module `" << module.getName()
+        << "` is empty but cannot be removed because the module has ports "
+           "(probably with symbols)";
+    return;
+  }
 
   // Ok, the module is empty. Delete instances unless they have symbols.
   LLVM_DEBUG(llvm::dbgs() << "Erase " << module.getName() << "\n");
@@ -491,11 +509,11 @@ void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
   InstanceGraphNode *instanceGraphNode =
       instanceGraph->lookup(module.moduleNameAttr());
 
-  bool existsInstanceWithSymbol = false;
+  SmallVector<Location> instancesWithSymbols;
   for (auto *use : llvm::make_early_inc_range(instanceGraphNode->uses())) {
     auto instance = cast<InstanceOp>(use->getInstance());
     if (instance.getInnerSym()) {
-      existsInstanceWithSymbol = true;
+      instancesWithSymbols.push_back(instance.getLoc());
       continue;
     }
     use->erase();
@@ -503,8 +521,16 @@ void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
   }
 
   // If there is an instance with a symbol, we don't delete the module itself.
-  if (existsInstanceWithSymbol)
+  if (!instancesWithSymbols.empty()) {
+    auto diag =
+        module.emitWarning()
+        << "module  `" << module.getName()
+        << "` is empty but cannot be removed because there is an instance with "
+           "a symbol";
+    diag.attachNote(FusedLoc::get(&getContext(), instancesWithSymbols))
+        << "these are instances with symbols";
     return;
+  }
 
   instanceGraph->erase(instanceGraphNode);
   module.erase();

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -139,7 +139,7 @@ firrtl.circuit "PreserveOutputFile" {
   // CHECK-NEXT: firrtl.module {{.+}}@Sub
   // CHECK-NOT:    %a
   // CHECK-SAME:   output_file
-  // expected-warning @+1{{module `Sub` is empty but cannot be removed because the module has ports (probably with symbols)}}
+  // expected-warning @+1{{module `Sub` is empty but cannot be removed because the module has ports "b" are referenced by name}}
   firrtl.module private @Sub(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1> sym @sym) attributes {output_file = #hw.output_file<"hello">} {}
   // CHECK: firrtl.module @PreserveOutputFile
   firrtl.module @PreserveOutputFile() {
@@ -158,7 +158,7 @@ firrtl.circuit "DeleteEmptyModule" {
   firrtl.module private @empty() attributes {annotations = [{class = "foo"}]}  {}
   // Don't delete @Sub because instance `sub1` has a symbol.
   // CHECK: firrtl.module private @Sub
-  // expected-warning @+1{{module  `Sub` is empty but cannot be removed because there is an instance with a symbol}}
+  // expected-warning @+1{{module  `Sub` is empty but cannot be removed because an instance is referenced by name}}
   firrtl.module private @Sub(in %a: !firrtl.uint<1>)  {}
   // CHECK: firrtl.module @DeleteEmptyModule
   firrtl.module @DeleteEmptyModule() {

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imdeadcodeelim))' --split-input-file  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imdeadcodeelim))' --split-input-file -verify-diagnostics %s | FileCheck %s
 firrtl.circuit "top" {
   // In `dead_module`, %source is connected to %dest through several dead operations such as
   // node, wire, reg or rgereset. %dest is also dead at any instantiation, so check that
@@ -93,6 +93,7 @@ firrtl.circuit "top"  {
 
   // CHECK-LABEL: firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
   // CHECK-NEXT:  }
+  // expected-warning @+1 {{module `top` is empty but cannot be removed because the module is public}}
   firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
     %tile_input, %tile_output = firrtl.instance tile  @Child1(in input: !firrtl.uint<1>, out output: !firrtl.uint<1>)
     firrtl.strictconnect %tile_input, %input : !firrtl.uint<1>
@@ -138,6 +139,7 @@ firrtl.circuit "PreserveOutputFile" {
   // CHECK-NEXT: firrtl.module {{.+}}@Sub
   // CHECK-NOT:    %a
   // CHECK-SAME:   output_file
+  // expected-warning @+1{{module `Sub` is empty but cannot be removed because the module has ports (probably with symbols)}}
   firrtl.module private @Sub(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1> sym @sym) attributes {output_file = #hw.output_file<"hello">} {}
   // CHECK: firrtl.module @PreserveOutputFile
   firrtl.module @PreserveOutputFile() {
@@ -151,15 +153,22 @@ firrtl.circuit "PreserveOutputFile" {
 
 // CHECK-LABEL: "DeleteEmptyModule"
 firrtl.circuit "DeleteEmptyModule" {
+  // CHECK: firrtl.module private @empty
+  // expected-warning @+1{{module `empty` is empty but cannot be removed because the module has annotations [{class = "foo"}]}}
+  firrtl.module private @empty() attributes {annotations = [{class = "foo"}]}  {}
   // Don't delete @Sub because instance `sub1` has a symbol.
   // CHECK: firrtl.module private @Sub
+  // expected-warning @+1{{module  `Sub` is empty but cannot be removed because there is an instance with a symbol}}
   firrtl.module private @Sub(in %a: !firrtl.uint<1>)  {}
   // CHECK: firrtl.module @DeleteEmptyModule
   firrtl.module @DeleteEmptyModule() {
     // CHECK-NEXT: firrtl.instance sub1 sym @Foo @Sub()
+    // expected-note @+1{{these are instances with symbols}}
     firrtl.instance sub1 sym @Foo @Sub(in a: !firrtl.uint<1>)
     // CHECK-NOT: sub2
     firrtl.instance sub2 @Sub(in a: !firrtl.uint<1>)
+    // CHECK: empty
+    firrtl.instance empty @empty()
   }
 }
 
@@ -246,6 +255,7 @@ firrtl.circuit "RefPorts" {
 
 firrtl.circuit "MemoryInDeadCycle" {
   // CHECK-LABEL: firrtl.module public @MemoryInDeadCycle
+  // expected-warning @+1{{module `MemoryInDeadCycle` is empty but cannot be removed because the module is public}}
   firrtl.module public @MemoryInDeadCycle(in %clock: !firrtl.clock, in %addr: !firrtl.uint<4>) {
 
     // CHECK-NOT: firrtl.mem

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -139,7 +139,7 @@ firrtl.circuit "PreserveOutputFile" {
   // CHECK-NEXT: firrtl.module {{.+}}@Sub
   // CHECK-NOT:    %a
   // CHECK-SAME:   output_file
-  // expected-warning @+1{{module `Sub` is empty but cannot be removed because the module has ports "b" are referenced by name}}
+  // expected-warning @+1{{module `Sub` is empty but cannot be removed because the module has ports "b" are referenced by name or dontTouched}}
   firrtl.module private @Sub(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1> sym @sym) attributes {output_file = #hw.output_file<"hello">} {}
   // CHECK: firrtl.module @PreserveOutputFile
   firrtl.module @PreserveOutputFile() {

--- a/test/firtool/firtool-errors.mlir
+++ b/test/firtool/firtool-errors.mlir
@@ -1,6 +1,7 @@
 // RUN: firtool %s -format=mlir -verilog -verify-diagnostics | FileCheck --allow-empty %s
 
 firrtl.circuit "top" {
+  // expected-warning @+3 {{module `top` is empty but cannot be removed because the module is public}}
   // expected-error @+2 {{'firrtl.module' op contains a 'chisel3.util.experimental.ForceNameAnnotation' that is not a non-local annotation}}
   // expected-note @+1 {{the erroneous annotation is '{class = "chisel3.util.experimental.ForceNameAnnotation"}'}}
   firrtl.module @top() attributes {annotations = [{class = "chisel3.util.experimental.ForceNameAnnotation"}]} {


### PR DESCRIPTION
This PR changes IMDCE to generate warnings if empty modules are not erased for several reasons (symbol, annotation, module visibility ..)