### PR TITLE
Bump llvm 2022-11-22

### DIFF
--- a/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
+++ b/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
@@ -1524,29 +1524,33 @@ void PipelineToCalyxPass::runOnOperation() {
   /// Calyx component.
   DenseMap<FuncOp, calyx::ComponentOp> funcMap;
   SmallVector<LoweringPattern, 8> loweringPatterns;
+  calyx::PatternApplicationState patternState;
 
   /// Creates a new Calyx component for each FuncOp in the inpurt module.
-  addOncePattern<FuncOpConversion>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<FuncOpConversion>(loweringPatterns, patternState, funcMap,
+                                   *loweringState);
 
   /// This pattern converts all index typed values to an i32 integer.
-  addOncePattern<calyx::ConvertIndexTypes>(loweringPatterns, funcMap,
-                                           *loweringState);
+  addOncePattern<calyx::ConvertIndexTypes>(loweringPatterns, patternState,
+                                           funcMap, *loweringState);
 
   /// This pattern creates registers for all basic-block arguments.
-  addOncePattern<calyx::BuildBasicBlockRegs>(loweringPatterns, funcMap,
-                                             *loweringState);
+  addOncePattern<calyx::BuildBasicBlockRegs>(loweringPatterns, patternState,
+                                             funcMap, *loweringState);
 
   /// This pattern creates registers for the function return values.
-  addOncePattern<calyx::BuildReturnRegs>(loweringPatterns, funcMap,
-                                         *loweringState);
+  addOncePattern<calyx::BuildReturnRegs>(loweringPatterns, patternState,
+                                         funcMap, *loweringState);
 
   /// This pattern creates registers for iteration arguments of scf.while
   /// operations. Additionally, creates a group for assigning the initial
   /// value of the iteration argument registers.
-  addOncePattern<BuildWhileGroups>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<BuildWhileGroups>(loweringPatterns, patternState, funcMap,
+                                   *loweringState);
 
   /// This pattern creates registers for all pipeline stages.
-  addOncePattern<BuildPipelineRegs>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<BuildPipelineRegs>(loweringPatterns, patternState, funcMap,
+                                    *loweringState);
 
   /// This pattern converts operations within basic blocks to Calyx library
   /// operators. Combinational operations are assigned inside a
@@ -1555,24 +1559,28 @@ void PipelineToCalyxPass::runOnOperation() {
   /// originated from. This is used during control schedule generation. By
   /// having a distinct group for each operation, groups are analogous to SSA
   /// values in the source program.
-  addOncePattern<BuildOpGroups>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<BuildOpGroups>(loweringPatterns, patternState, funcMap,
+                                *loweringState);
 
   /// This pattern creates groups for all pipeline stages.
-  addOncePattern<BuildPipelineGroups>(loweringPatterns, funcMap,
+  addOncePattern<BuildPipelineGroups>(loweringPatterns, patternState, funcMap,
                                       *loweringState);
 
   /// This pattern traverses the CFG of the program and generates a control
   /// schedule based on the calyx::GroupOp's which were registered for each
   /// basic block in the source function.
-  addOncePattern<BuildControl>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<BuildControl>(loweringPatterns, patternState, funcMap,
+                               *loweringState);
 
   /// This pass recursively inlines use-def chains of combinational logic (from
   /// non-stateful groups) into groups referenced in the control schedule.
-  addOncePattern<calyx::InlineCombGroups>(loweringPatterns, *loweringState);
+  addOncePattern<calyx::InlineCombGroups>(loweringPatterns, patternState,
+                                          *loweringState);
 
   /// This pattern performs various SSA replacements that must be done
   /// after control generation.
-  addOncePattern<LateSSAReplacement>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<LateSSAReplacement>(loweringPatterns, patternState, funcMap,
+                                     *loweringState);
 
   /// Eliminate any unused combinational groups. This is done before
   /// calyx::RewriteMemoryAccesses to avoid inferring slice components for
@@ -1581,12 +1589,13 @@ void PipelineToCalyxPass::runOnOperation() {
 
   /// This pattern rewrites accesses to memories which are too wide due to
   /// index types being converted to a fixed-width integer type.
-  addOncePattern<calyx::RewriteMemoryAccesses>(loweringPatterns,
+  addOncePattern<calyx::RewriteMemoryAccesses>(loweringPatterns, patternState,
                                                *loweringState);
 
   /// This pattern removes the source FuncOp which has now been converted into
   /// a Calyx component.
-  addOncePattern<CleanupFuncOps>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<CleanupFuncOps>(loweringPatterns, patternState, funcMap,
+                                 *loweringState);
 
   /// Sequentially apply each lowering pattern.
   for (auto &pat : loweringPatterns) {

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -369,10 +369,11 @@ ModuleOpConversion::matchAndRewrite(mlir::ModuleOp moduleOp,
 
 FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern(
     MLIRContext *context, LogicalResult &resRef,
+    PatternApplicationState &patternState,
     DenseMap<mlir::func::FuncOp, calyx::ComponentOp> &map,
     calyx::CalyxLoweringState &state)
-    : PartialLoweringPattern(context, resRef), functionMapping(map),
-      calyxLoweringState(state) {}
+    : PartialLoweringPattern(context, resRef, patternState),
+      functionMapping(map), calyxLoweringState(state) {}
 
 LogicalResult
 FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp funcOp,
@@ -500,8 +501,9 @@ EliminateUnusedCombGroups::matchAndRewrite(calyx::CombGroupOp combGroupOp,
 //===----------------------------------------------------------------------===//
 
 InlineCombGroups::InlineCombGroups(MLIRContext *context, LogicalResult &resRef,
+                                   PatternApplicationState &patternState,
                                    calyx::CalyxLoweringState &cls)
-    : PartialLoweringPattern(context, resRef), cls(cls) {}
+    : PartialLoweringPattern(context, resRef, patternState), cls(cls) {}
 
 LogicalResult
 InlineCombGroups::partiallyLower(calyx::GroupInterface originGroup,


### PR DESCRIPTION
Leaving this as a draft since this is a WIP.

@mortbopet, I am encountering an issue with the bump where the SCFToCalyx converter will loop forever. I've done a bit of investigating, and I think I understand the problem, but I believe it's going to require a pretty substantial change to the SCFToCalyx converter's structure.

I git bisected the LLVM changes and identified https://github.com/llvm/llvm-project/commit/2fea658a74196a9c9128be34c5bc306eba7a025e as the commit that causes the SCFToCalyx converter to loop indefinitely. In that commit, the `GreedyPatternRewriter` was changed such that when `updateRootInPlace()` is called on an op, at the very end it will push that op back onto the worklist. The rationale is that the pattern rewriter will modify that root op, and as long as the pattern continues to match the root op, it implies that the root op can be further reduced by executing the rewriter again. Note that the upstream commit message also says:

> Note: If your project goes into an infinite loop because of this change, you likely have one or multiple faulty patterns that modify the same operations in-place (`updateRootInplace`) indefinitely.

I wasn't previously familiar with the SCFToCalyx converter, but after having read through the code, I think the issue is that [FuncOpConversion](https://github.com/llvm/circt/blob/e1bd9e1161a47cadfe3bd26cdc918f2fc3940bc9/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp#L713), which is a RewritePattern, operates on a FuncOp, but instead of modifying the FuncOp, it inserts a ComponentOp after the FuncOp. FuncOpConversion doesn't appear to ever return `failure()`, which means that according to the semantics of a RewritePattern, the pattern "always matches," even if we previously ran the RewritePattern on the FuncOp.

Prior to the upstream MLIR change to `GreedyPatternRewriter`, this didn't cause issues because the FuncOp wasn't getting pushed back onto the worklist, so it would only ever run once. However, after the upstream change, the FuncOp is getting pushed back onto the worklist, and since the pattern "matches," we keep running it over and over again, pushing the FuncOp back into the worklist over and over again (and probably inserting many duplicate ComponentOps in the process).

I've tried thinking of different solutions to this problem, but I think fundamentally we are just misusing RewritePatterns if we are not actually using them to rewrite an Op. I'm not too familiar with the actual conversion logic in the SCFToCalyx file, but I'm wondering if it would be better to just not use the PatternRewriter infrastructure and instead just build up the Calyx ops in a more direct way.

If you have the time, @mortbopet, could you take a look at this and make changes to the SCFToCalyx code such that they work on the latest LLVM tree? Note that this Thursday and Friday are a holiday in the US, so I as well as many of the others in the US probably won't be as available in the next few days, but I would appreciate it if you could take a look.

cc @mikeurbach 