### PR TITLE
[Handshake] Fix use-after-free bugs in canonicalization patterns.

### DIFF
--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -240,13 +240,13 @@ struct EliminateForkToForkPattern : mlir::OpRewritePattern<ForkOp> {
       for (auto it :
            llvm::zip(parentForkOp->getResults(), newParentForkOp.getResults()))
         std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
-      rewriter.eraseOp(parentForkOp);
 
       /// Replace the results of the matches fork op with the corresponding
       /// results of the new parent fork op.
       rewriter.replaceOp(op,
                          newParentForkOp.getResults().take_back(op.getSize()));
     });
+    rewriter.eraseOp(parentForkOp);
     return success();
   }
 };
@@ -392,10 +392,10 @@ struct EliminateCBranchIntoMuxPattern : OpRewritePattern<MuxOp> {
     rewriter.updateRootInPlace(firstParentCBranch, [&] {
       // Replace uses of the mux's output with cbranch's data input
       rewriter.replaceOp(op, firstParentCBranch.getDataOperand());
-
-      // Remove the cbranch
-      rewriter.eraseOp(firstParentCBranch);
     });
+
+    // Remove the cbranch
+    rewriter.eraseOp(firstParentCBranch);
 
     return success();
   }


### PR DESCRIPTION
A couple of the Handshake ops had use-after-free bugs in their canonicalization patterns. We were calling `eraseOp()` on the root op within an `updateRootInPlace()` call. This is illegal because `updateRootInPlace()` must only update the root op in-place, not erase the op altogether.

These were fixed by moving the `eraseOp()` call after the `updateRootInPlace()` call.