### PR TITLE
Fix error in reducer test for annotation-remover

### DIFF
--- a/test/circt-reduce/test/annotation-remover.mlir
+++ b/test/circt-reduce/test/annotation-remover.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test %S.sh --test-arg cat --test-arg "%anotherWire = firrtl.wire  :" --keep-best=0 --include annotation-remover | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg "%anotherWire = firrtl.wire" --keep-best=0 --include annotation-remover | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK: firrtl.module @Foo


### PR DESCRIPTION
The reducer will keep reducing as long as the interesting behaviour is present, using a test script that will tells us that a reduction was valid (ie behaviour is still present).

The  test script for annotation-remover will grep for an expected pattern, returning true (continue reducing) as long as the expected pattern is missing. Once the expected pattern is detected, the script returns false, indicating that the interesting behaviour is missing.  We want circt-reduce to dump the IR with the expected pattern, but we actually cause circt-reduce to discard that version of the IR and backtrack.

This is obviously not correct behaviour, but it was masked by the fact that the target pattern had a typo, so it was never detected. This allowed circt-reduce to continue until all reduction strategies were exhausted, which is actually the behaviour we want. This PR replaces the test script with "true".