### PR TITLE
[FIRRTL][IMCP] Mark aggregate as overdefined

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -420,6 +420,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
     // Handle each of the special operations in the firrtl dialect.
     if (isWireOrReg(&op))
       markWireOrRegOp(&op);
+    else if (isAggregate(&op))
+      markOverdefined(op.getResult(0));
     else if (auto constant = dyn_cast<ConstantOp>(op))
       markConstantOp(constant);
     else if (auto specialConstant = dyn_cast<SpecialConstantOp>(op))

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -411,3 +411,23 @@ firrtl.circuit "Foo"  {
     // CHECK: firrtl.strictconnect %out, %bar_b
   }
 }
+
+// -----
+
+firrtl.circuit "Issue4369"  {
+  // CHECK-LABEL: firrtl.module private @Bar
+  firrtl.module private @Bar(in %in: !firrtl.vector<uint<1>, 1>, out %out: !firrtl.uint<1>) {
+    %0 = firrtl.subindex %in[0] : !firrtl.vector<uint<1>, 1>
+    %a = firrtl.wire   : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %a, %0
+    // CHECK-NEXT: firrtl.strictconnect %out, %a
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.strictconnect %out, %a : !firrtl.uint<1>
+  }
+  firrtl.module @Issue4369(in %a_0: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    %bar_in, %bar_out = firrtl.instance bar  @Bar(in in: !firrtl.vector<uint<1>, 1>, out out: !firrtl.uint<1>)
+    %0 = firrtl.subindex %bar_in[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.strictconnect %0, %a_0 : !firrtl.uint<1>
+    firrtl.strictconnect %b, %bar_out : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
https://github.com/llvm/circt/commit/fa2adf8109b3128cc8cb10e2b0f52a3f90502802 changed IMCP not to mark aggregate as overdefined in the initialization. That caused incorrect optimization so this PR marks aggregate as overdefined. 

Close #4369