### PR TITLE
[SSP] Rename DOT printer pass, NFC.

### DIFF
--- a/include/circt/Dialect/SSP/SSPPasses.h
+++ b/include/circt/Dialect/SSP/SSPPasses.h
@@ -20,7 +20,7 @@
 namespace circt {
 namespace ssp {
 
-std::unique_ptr<mlir::Pass> createPrintInstancePass();
+std::unique_ptr<mlir::Pass> createPrintPass();
 std::unique_ptr<mlir::Pass> createSchedulePass();
 
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/SSP/SSPPasses.td
+++ b/include/circt/Dialect/SSP/SSPPasses.td
@@ -15,9 +15,9 @@
 
 include "mlir/Pass/PassBase.td"
 
-def PrintInstance : Pass<"ssp-print-instance", "mlir::ModuleOp"> {
+def Print : Pass<"ssp-print", "mlir::ModuleOp"> {
   let summary = "Prints all SSP instances as DOT graphs.";
-  let constructor = "circt::ssp::createPrintInstancePass()";
+  let constructor = "circt::ssp::createPrintPass()";
 }
 
 def Schedule : Pass<"ssp-schedule", "mlir::ModuleOp"> {

--- a/lib/Dialect/SSP/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SSP/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect_library(CIRCTSSPTransforms
-  PrintInstance.cpp
+  Print.cpp
   Schedule.cpp
 
   DEPENDS

--- a/lib/Dialect/SSP/Transforms/Print.cpp
+++ b/lib/Dialect/SSP/Transforms/Print.cpp
@@ -1,4 +1,4 @@
-//===- PrintInstance.cpp - Print instance pass ------------------*- C++ -*-===//
+//===- Print.cpp - Print pass -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Implements the PrintInstance (as a DOT graph) pass.
+// Implements the Print (as a DOT graph) pass.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,8 +19,8 @@ using namespace scheduling;
 using namespace ssp;
 
 namespace {
-struct PrintInstancePass : public PrintInstanceBase<PrintInstancePass> {
-  explicit PrintInstancePass(raw_ostream &os) : os(os) {}
+struct PrintPass : public PrintBase<PrintPass> {
+  explicit PrintPass(raw_ostream &os) : os(os) {}
   void runOnOperation() override;
   raw_ostream &os;
 };
@@ -32,7 +32,7 @@ static void printInstance(InstanceOp instOp, raw_ostream &os) {
   dumpAsDOT(prob, os);
 }
 
-void PrintInstancePass::runOnOperation() {
+void PrintPass::runOnOperation() {
   auto moduleOp = getOperation();
   for (auto instOp : moduleOp.getOps<InstanceOp>()) {
     StringRef probName = instOp.getProblemName();
@@ -55,6 +55,6 @@ void PrintInstancePass::runOnOperation() {
   }
 }
 
-std::unique_ptr<mlir::Pass> circt::ssp::createPrintInstancePass() {
-  return std::make_unique<PrintInstancePass>(llvm::errs());
+std::unique_ptr<mlir::Pass> circt::ssp::createPrintPass() {
+  return std::make_unique<PrintPass>(llvm::errs());
 }

--- a/test/Dialect/SSP/Transforms/print.mlir
+++ b/test/Dialect/SSP/Transforms/print.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -ssp-print-instance %s 2>&1 | FileCheck %s
+// RUN: circt-opt -ssp-print %s 2>&1 | FileCheck %s
 
 // CHECK: digraph G {
 ssp.instance @Foo of "Problem" {


### PR DESCRIPTION
All passes on the SSP dialect will operate on instances, so drop that distinction from the printer pass' name.