### PR TITLE
[SSP] Add pass to roundtrip via the scheduling infra.

### DIFF
--- a/include/circt/Dialect/SSP/SSPPasses.h
+++ b/include/circt/Dialect/SSP/SSPPasses.h
@@ -21,6 +21,7 @@ namespace circt {
 namespace ssp {
 
 std::unique_ptr<mlir::Pass> createPrintPass();
+std::unique_ptr<mlir::Pass> createRoundtripPass();
 std::unique_ptr<mlir::Pass> createSchedulePass();
 
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/SSP/SSPPasses.td
+++ b/include/circt/Dialect/SSP/SSPPasses.td
@@ -20,6 +20,17 @@ def Print : Pass<"ssp-print", "mlir::ModuleOp"> {
   let constructor = "circt::ssp::createPrintPass()";
 }
 
+def Roundtrip : Pass<"ssp-roundtrip", "mlir::ModuleOp"> {
+  let summary = "Roundtrips all SSP instances via the scheduling infrastructure";
+  let constructor = "circt::ssp::createRoundtripPass()";
+  let options = [
+    Option<"checkInputConstraints", "check", "bool", "false",
+           "Check the problem's input constraints.">,
+    Option<"verifySolutionConstraints", "verify", "bool", "false",
+           "Verify the problem's solution constraints.">,
+  ];
+}
+
 def Schedule : Pass<"ssp-schedule", "mlir::ModuleOp"> {
   let summary = "Schedules all SSP instances.";
   let constructor = "circt::ssp::createSchedulePass()";

--- a/lib/Dialect/SSP/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SSP/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTSSPTransforms
   Print.cpp
+  Roundtrip.cpp
   Schedule.cpp
 
   DEPENDS

--- a/lib/Dialect/SSP/Transforms/Roundtrip.cpp
+++ b/lib/Dialect/SSP/Transforms/Roundtrip.cpp
@@ -1,0 +1,79 @@
+//===- Roundtrip.cpp - Roundtrip pass ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements the Roundtrip pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+using namespace circt;
+using namespace scheduling;
+using namespace ssp;
+
+template <typename ProblemT>
+static InstanceOp roundtripAs(InstanceOp instOp, bool check, bool verify,
+                              OpBuilder &builder) {
+  auto prob = loadProblem<ProblemT>(instOp);
+
+  if (check && failed(prob.check()))
+    return {};
+  if (verify && failed(prob.verify()))
+    return {};
+
+  return saveProblem<ProblemT>(prob, builder);
+}
+
+static InstanceOp roundtrip(InstanceOp instOp, bool check, bool verify,
+                            OpBuilder &builder) {
+  auto problemName = instOp.getProblemName();
+
+  if (problemName.equals("Problem"))
+    return roundtripAs<Problem>(instOp, check, verify, builder);
+  if (problemName.equals("CyclicProblem"))
+    return roundtripAs<CyclicProblem>(instOp, check, verify, builder);
+  if (problemName.equals("SharedOperatorsProblem"))
+    return roundtripAs<SharedOperatorsProblem>(instOp, check, verify, builder);
+  if (problemName.equals("ModuloProblem"))
+    return roundtripAs<ModuloProblem>(instOp, check, verify, builder);
+  if (problemName.equals("ChainingProblem"))
+    return roundtripAs<ChainingProblem>(instOp, check, verify, builder);
+
+  llvm::errs() << "ssp-roundtrip: Unknown problem '" << problemName << "'\n";
+  return {};
+}
+
+namespace {
+struct RoundtripPass : public RoundtripBase<RoundtripPass> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+void RoundtripPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  // Solution constraint verification implies checking the input constraints.
+  bool check = checkInputConstraints | verifySolutionConstraints;
+  bool verify = verifySolutionConstraints;
+
+  SmallVector<InstanceOp> instanceOps;
+  OpBuilder builder(&getContext());
+  for (auto instOp : moduleOp.getOps<InstanceOp>()) {
+    builder.setInsertionPoint(instOp);
+    auto newInstOp = roundtrip(instOp, check, verify, builder);
+    if (!newInstOp)
+      return signalPassFailure();
+    instanceOps.push_back(instOp);
+  }
+
+  llvm::for_each(instanceOps, [](InstanceOp op) { op.erase(); });
+}
+
+std::unique_ptr<mlir::Pass> circt::ssp::createRoundtripPass() {
+  return std::make_unique<RoundtripPass>();
+}

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -44,7 +44,6 @@ add_circt_library(CIRCTSchedulingTestPasses
 
   LINK_LIBS PUBLIC
   CIRCTScheduling
-  CIRCTSSP
   MLIRPass
   )
 

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
-// RUN: circt-opt %s -test-ssp-roundtrip | circt-opt | FileCheck %s
+// RUN: circt-opt %s -ssp-roundtrip | circt-opt | FileCheck %s
 
 // 1) tests the plain parser/printer roundtrip.
 // 2) roundtrips via the scheduling infra (i.e. populates a `Problem` instance and reconstructs the SSP IR from it.)

--- a/test/Dialect/SSP/standalone-lib.mlir
+++ b/test/Dialect/SSP/standalone-lib.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
-// RUN: circt-opt %s -test-ssp-roundtrip | circt-opt | FileCheck %s --check-prefix=INFRA
+// RUN: circt-opt %s -ssp-roundtrip | circt-opt | FileCheck %s --check-prefix=INFRA
 
 // 1) tests the plain parser/printer roundtrip.
 // CHECK: ssp.library @Lib {


### PR DESCRIPTION
This PR adds the `-ssp-roundtrip` pass, which
- loads a problem instance from the SSP IR, 
- optionally checks and verifies the problem, 
- and saves it again as SSP IR.

`-ssp-roundtrip` and `-ssp-schedule` are quite similar at the moment. However, the schedule pass will pivot away from doing a complete roundtrip in the near future, so both passes are needed.

The new pass supersedes the one in the scheduling infra's test passes. In fact, this PR is the first step to remove the `CIRCTSchedulingTestPasses` library, as the scheduler tests will be done via the `-ssp-schedule` pass once the test case migration is complete.