### PR TITLE
[GrandCentral] Fix insertion point for external module source

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1021,7 +1021,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
                 }
               }
               auto lastInst = xmrSrcTarget->instances.pop_back_val();
-              builder.setInsertionPoint(lastInst);
+              builder.setInsertionPointAfter(lastInst);
               return getValueByFieldID(builder, lastInst.getResult(portNo),
                                        xmrSrcTarget->fieldIdx);
             })

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -58,6 +58,8 @@ circuit Top :
     output a: UInt<1>
     input b: UInt<1>
 
+  extmodule ExtModuleWithPort:
+    output source: UInt<1>[2]
 
   ; This checks that macro definitions (e.g. "define RANDOM") are included
   ; in MyView_companion.sv. There was a bug that macro definitions were not
@@ -144,6 +146,8 @@ circuit Top :
     inst bbox2 of BlackBox_DUTAndGCT
     bbox2.a <= in.uint
 
+    inst ext of ExtModuleWithPort
+
   module Top :
     input clock : Clock
     input reset : UInt<1>
@@ -211,6 +215,7 @@ circuit Top :
     ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[0].uint = DUT.submodule.w_vecOfBundle_0_uint;
     ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].sint = DUT.submodule.w_vecOfBundle_1_sint;
     ; NOEXTRACT-NEXT:   assign MyView.sub_vecOfBundle[1].uint = DUT.submodule.w_vecOfBundle_1_uint;
+    ; NOEXTRACT-NEXT:   assign MyView.ext_port_1 = DUT.
     ; NOEXTRACT:        Tap tap (
     ; NOEXTRACT-NEXT:     .b     (r),
     ; NOEXTRACT-NEXT:     .clock (clock),
@@ -261,6 +266,7 @@ circuit Top :
     ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[0].uint = DUT.submodule.in_vecOfBundle_0_uint;
     ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].sint = DUT.submodule.in_vecOfBundle_1_sint;
     ; EXTRACT-NEXT:     assign MyView.sub_vecOfBundle[1].uint = DUT.submodule.in_vecOfBundle_1_uint;
+    ; EXTRACT-NEXT:     assign MyView.ext_port_1 = DUT.
     ; EXTRACT:          Tap tap (
     ; EXTRACT-NEXT:       .b     (r),
     ; EXTRACT-NEXT:       .clock (_tap_clock),
@@ -294,6 +300,8 @@ circuit Top :
     ; CHECK-NEXT:       // a vector of a bundle in the submodule with a
     ; CHECK-NEXT:       // multiline comment
     ; CHECK-NEXT:       Sub_vecOfBundle sub_vecOfBundle[2]();
+    ; CHECK-NEXT:       // The second element of an external port
+    ; CHECK-NEXT:       logic ext_port_1;
     ; CHECK-NEXT:     endinterface
 
     ; EXTRACT:        FILE "Wire{{[/\]}}firrtl{{[/\]}}gct{{[/\]}}VecOfBundle.sv"
@@ -349,6 +357,10 @@ circuit Top :
     ; YAML-NEXT:            - name: sub_vec
     ; YAML-NEXT:              description: 'a vector called ''vec'' in the submodule'
     ; YAML-NEXT:              dimensions: [ 2 ]
+    ; YAML-NEXT:              width: 1
+    ; YAML-NEXT:            - name: ext_port_1
+    ; YAML-NEXT:              description: The second element of an external port
+    ; YAML-NEXT:              dimensions: [ ]
     ; YAML-NEXT:              width: 1
     ; YAML-NEXT:          instances:
     ; YAML-NEXT:            - name: vecOfBundle

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.anno.json
@@ -683,6 +683,28 @@
               }
             ]
           }
+        },
+        {
+          "name": "ext_port_1",
+          "description": "The second element of an external port",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "Top",
+              "module": "ExtModuleWithPort",
+              "path": [],
+              "ref": "source",
+              "component": [
+                {
+                  "class": "firrtl.annotations.TargetToken$Index",
+                  "value": 1
+                }
+              ]
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Small fix for insertion point for ops inserted to index into extmodule port.  Insert after the instance not before.

Add test.