### PR TITLE
[FIRRTL][LowerXMR] Ignore 0-width RefType values

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -59,6 +59,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // Get a reference to the actual signal to which the XMR will be
             // generated.
             Value xmrDef = send.getBase();
+            if (send.getType().getType().getBitWidthOrSentinel() == 0) {
+              markForRemoval(send);
+              return success();
+            }
             // Get an InnerRefAttr to the xmrDef op. If the operation does not
             // take any InnerSym (like firrtl.add, firrtl.or etc) then create a
             // NodeOp to add the InnerSym.
@@ -130,6 +134,12 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             if (!connect.getSrc().getType().isa<RefType>())
               return success();
             markForRemoval(connect);
+            if (connect.getSrc()
+                    .getType()
+                    .cast<RefType>()
+                    .getType()
+                    .getBitWidthOrSentinel() == 0)
+              return success();
             // Merge the dataflow classes of destination into the source of the
             // Connect. This handles two cases:
             // 1. If the dataflow at the source is known, then the
@@ -147,6 +157,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
           })
           .Case<RefSubOp>([&](RefSubOp op) {
             markForRemoval(op);
+            if (op.getType().getType().getBitWidthOrSentinel() == 0)
+              return success();
             auto defMem = dyn_cast<MemOp>(op.getInput().getDefiningOp());
             if (!defMem) {
               defMem.emitOpError("can only lower RefSubOp of Memory");
@@ -169,9 +181,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // XMRs. That is, RefResolveOp can be visited before the
             // corresponding RefSendOp is recorded.
 
-            dataFlowClasses.unionSets(resolve.getRef(), resolve.getResult());
-            resolveOps.push_back(resolve);
             markForRemoval(resolve);
+            if (resolve.getType().getBitWidthOrSentinel() != 0)
+              dataFlowClasses.unionSets(resolve.getRef(), resolve.getResult());
+            resolveOps.push_back(resolve);
             return success();
           })
           .Default([&](auto) { return success(); });
@@ -343,7 +356,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       // Reference ports must be removed.
       setPortToRemove(inst, portNum, numPorts);
       // Drop the dead-instance-ports.
-      if (instanceResult.use_empty())
+      if (instanceResult.use_empty() || instanceResult.getType()
+                                                .cast<RefType>()
+                                                .getType()
+                                                .getBitWidthOrSentinel() == 0)
         continue;
       auto refModuleArg = refMod.getArgument(portNum);
       if (inst.getPortDirection(portNum) == Direction::Out) {


### PR DESCRIPTION
This commit ensures that zero-width RefType values are ignored and symbols are not added for 0-width ports.
Without this commit, zero-width RefType values were being replaced with a constant, but it was still adding an unused symbol on zero-width ports.