### PR TITLE
[MergeConnections] Use vector/bundle create and enable aggressive merging by default

### DIFF
--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -35,8 +35,7 @@ firrtl.circuit "Test"   {
   //     a.b <= UInt<1>(0)
   //     a.c <= UInt<1>(1)
   // COMMON-LABEL: firrtl.module @Constant(
-  // COMMON-NEXT:    %c1_ui2 = firrtl.constant 1
-  // COMMON-NEXT:    %0 = firrtl.bitcast %c1_ui2
+  // COMMON-NEXT:    %0 = firrtl.aggregateconstant [0 : ui1, 1 : ui1]
   // COMMON-NEXT:    firrtl.strictconnect %a, %0
   // COMMON-NEXT:  }
   firrtl.module @Constant(out %a: !firrtl.bundle<b: uint<1>, c: uint<1>>) {
@@ -49,9 +48,8 @@ firrtl.circuit "Test"   {
   }
 
   // AGGRESSIVE-LABEL:  firrtl.module @ConcatToVector(
-  // AGGRESSIVE-NEXT:     %0 = firrtl.cat %s2, %s1
-  // AGGRESSIVE-NEXT:     %1 = firrtl.bitcast %0
-  // AGGRESSIVE-NEXT:     firrtl.strictconnect %sink, %1
+  // AGGRESSIVE-NEXT:     %0 = firrtl.vectorcreate %s1, %s2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
+  // AGGRESSIVE-NEXT:     firrtl.strictconnect %sink, %0
   // AGGRESSIVE-NEXT:   }
   // CHECK-LABEL:       firrtl.module @ConcatToVector(
   // CHECK-NEXT:          %0 = firrtl.subindex %sink[1]
@@ -70,9 +68,8 @@ firrtl.circuit "Test"   {
   // Check that we don't use %s1 as a source value.
   // AGGRESSIVE-LABEL:   firrtl.module @FailedToUseAggregate(
   // AGGRESSIVE-NEXT:    %0 = firrtl.subindex %s1[0]
-  // AGGRESSIVE-NEXT:    %1 = firrtl.cat %s2, %0
-  // AGGRESSIVE-NEXT:    %2 = firrtl.bitcast %1
-  // AGGRESSIVE-NEXT:    firrtl.strictconnect %sink, %2
+  // AGGRESSIVE-NEXT:    %1 = firrtl.vectorcreate %0, %s2
+  // AGGRESSIVE-NEXT:    firrtl.strictconnect %sink, %1
   // AGGRESSIVE-NEXT:   }
   // CHECK-LABEL:       firrtl.module @FailedToUseAggregate(
   // CHECK-NEXT:         %0 = firrtl.subindex %sink[1]

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -307,10 +307,11 @@ static cl::opt<bool>
                             cl::desc("Disable the MergeConnections pass"),
                             cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
-static cl::opt<bool>
-    mergeConnectionsAgggresively("merge-connections-aggressive-merging",
-                                 cl::desc("Merge connections aggressively"),
-                                 cl::init(false), cl::cat(mainCategory));
+static cl::opt<bool> disableAggressiveMergeConnections(
+    "disable-aggressive-merge-connections",
+    cl::desc("Disable aggressive merge connections (i.e. merge all field-level "
+             "connections into bulk connections)"),
+    cl::init(false), cl::cat(mainCategory));
 
 /// Enable the pass to merge the read and write ports of a memory, if their
 /// enable conditions are mutually exclusive.
@@ -767,7 +768,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       preserveAggregate != firrtl::PreserveAggregate::None &&
       !disableMergeConnections)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        firrtl::createMergeConnectionsPass(mergeConnectionsAgggresively));
+        firrtl::createMergeConnectionsPass(
+            !disableAggressiveMergeConnections.getValue()));
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {


### PR DESCRIPTION
This PR improves MergeConnections to use vectorcreate and bundle create op instead of bitcasting to aggregates.