### PR TITLE
[GCT][LowerAnnos] Use no-op cast to avoid erasing sources.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -311,9 +311,15 @@ Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
         return state.getNamespace(mod);
       },
       &state.targetCaches);
-  // Since the intance op genenerates the RefType output, no need of another
-  // RefSendOp.
+  // Since the instance op generates the RefType output, no need of another
+  // RefSendOp.  Store into an op to ensure we have stable reference,
+  // so future tapping won't invalidate this Value.
   sendVal = modInstance.getResults().back();
+  sendVal =
+      builder
+          .create<mlir::UnrealizedConversionCastOp>(sendVal.getType(), sendVal)
+          ->getResult(0);
+
   // Now set the instance as the source for the final datatap xmr.
   srcTarget = AnnoPathValue(modInstance);
   if (auto extMod = dyn_cast<FExtModuleOp>((Operation *)mod)) {

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -17,6 +17,12 @@ circuit Top : %[[
       },
       {
         "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|BlackBox",
+        "internalPath":"random.something_else",
+        "sink": "~Top|Top>tap3"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
         "module":"~Top|InternalPathChild",
         "internalPath":"io_out",
         "sink": "~Top|Top/unsigned:ChildWrapper/signed:Child>tap"
@@ -30,6 +36,10 @@ circuit Top : %[[
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
     "target": "~Top|Top>tap2"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Top|Top>tap3"
   },
   {
     "class": "firrtl.transforms.DontTouchAnnotation",
@@ -101,6 +111,9 @@ circuit Top : %[[
     wire tap2 : UInt<1>
     tap2 is invalid
 
+    wire tap3 : UInt<1>
+    tap3 is invalid
+
     inst unsigned of ChildWrapper
     node _child_io_in_T = and(io.in, in)
     unsigned.io.in <= _child_io_in_T
@@ -119,5 +132,6 @@ circuit Top : %[[
 ; CHECK-NOT: module
 ; CHECK:   tap = Top.foo.b.inv;
 ; CHECK:   assign tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
+; CHECK:   assign tap3 = Top.unsigned_0.signed_0.localparam_0.random.something_else;
 ; CHECK:   InternalPathChild int_0 (
 ; CHECK: endmodule


### PR DESCRIPTION
These are dummy ops acting as in-IR users so updates via RAUW maintain the real reference, their operand.

NodeOp is not suited for this use, as it requires
passive and base (non-ref) type operands.

Wiring problem solver now strips these when found
while connecting values.

Included test crashes without this change.

--

Issue occurs with multiple internalPath's taps that target the same instance, as each tap erases the instance causing stale source values (instance port) in the accumulated WiringProblem's.