### PR TITLE
[ExportVerilog] Sink mux inlining check to isExpressionEmittedInline.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -318,7 +318,7 @@ bool isZeroBitType(Type type);
 
 /// Return true if this expression should be emitted inline into any statement
 /// that uses it.
-bool isExpressionEmittedInline(Operation *op);
+bool isExpressionEmittedInline(Operation *op, const LoweringOptions &options);
 
 /// For each module we emit, do a prepass over the structure, pre-lowering and
 /// otherwise rewriting operations we don't want to emit.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -57,11 +57,8 @@ static bool shouldSpillWire(Operation &op, const LoweringOptions &options) {
   if (!isVerilogExpression(&op))
     return false;
 
-  if (options.disallowMuxInlining && isa<MuxOp>(op))
-    return true;
-
   // Spill temporary wires if it is not possible to inline.
-  return !ExportVerilog::isExpressionEmittedInline(&op);
+  return !ExportVerilog::isExpressionEmittedInline(&op, options);
 }
 
 // Given an instance, make sure all inputs are driven from wires or ports.

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -149,16 +149,19 @@ module attributes {circt.loweringOptions =
 module attributes {circt.loweringOptions =
                   "disallowMuxInlining"} {
   // CHECK-LABEL: mux
-  hw.module @mux(%c: i1, %b: i8, %a: i8) -> (d: i8) {
+  hw.module @mux(%c: i1, %b: i8, %a: i8) -> (d: i8, e: i8) {
     // CHECK:      %use_for_mux = sv.wire
     // CHECK-NEXT: sv.assign %use_for_mux, %0 : i8
     // CHECK-NEXT: %[[read:.+]] = sv.read_inout %use_for_mux : !hw.inout<i8>
-    // CHECK-NEXT: comb.add %[[read]], %a : i8
+    // CHECK-NEXT: %[[add:.+]] = comb.add %[[read]], %a : i8
     %0 = comb.mux %c, %a, %b : i8
     %use_for_mux = sv.wire : !hw.inout<i8>
     sv.assign %use_for_mux, %0 : i8
     %1 = comb.add %0, %a : i8
-    hw.output %1 : i8
+    // CHECK: %[[mux2:.+]] = comb.mux
+    %2 = comb.mux %c, %a, %b : i8
+    // CHECK: hw.output %[[add]], %[[mux2]]
+    hw.output %1, %2 : i8, i8
   }
 }
 


### PR DESCRIPTION
Before, PrepareForEmission would check the disallowMuxInlining option before checking isExpressionEmittedInline. In this case, we might choose to spill muxes into generated wires that are themselves trivially assigned to an output, wire, or reg.

Instead, this change sinks the disallowMuxInlining check into isExpressionEmittedInline, after we check if the expression is part of an output or assignment. This way, muxes are allowed to be inlined directly into an assignment we are going to generate anyway, avoiding unnecessary generated wires. Muxes will still be spilled to wires otherwise, when requested.