### PR TITLE
[FIRRTL] Support for cover statements

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -164,6 +164,7 @@ ParseResult parseJson(Location loc, const JsonType &jsonValue, FnType fn) {
 enum class VerifFlavor {
   VerifLibAssert, // contains "[verif-library-assert]"
   VerifLibAssume, // contains "[verif-library-assume]"
+  VerifLibCover,  // contains "[verif-library-cover]"
   Assert,         // begins with "assert:"
   Assume,         // begins with "assume:"
   Cover,          // begins with "cover:"
@@ -263,6 +264,8 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
     flavor = VerifFlavor::VerifLibAssert;
   else if (fmt.contains("[verif-library-assume]"))
     flavor = VerifFlavor::VerifLibAssume;
+  else if (fmt.contains("[verif-library-cover]"))
+    flavor = VerifFlavor::VerifLibCover;
   else if (fmt.consume_front("assert:"))
     flavor = VerifFlavor::Assert;
   else if (fmt.consume_front("assume:"))
@@ -454,7 +457,8 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
     // to JSON and embedded in the print message within `<extraction-summary>`
     // XML tags.
   case VerifFlavor::VerifLibAssert:
-  case VerifFlavor::VerifLibAssume: {
+  case VerifFlavor::VerifLibAssume:
+  case VerifFlavor::VerifLibCover: {
     // Isolate the JSON text in the `<extraction-summary>` XML tag.
     StringRef prefix, exStr, suffix;
     std::tie(prefix, exStr) = fmt.split("<extraction-summary>");
@@ -467,7 +471,7 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
           "printf-encoded assert/assume requires extraction summary");
       diag.attachNote(printOp.getLoc())
           << "because printf message contains "
-             "`[verif-library-{assert,assume}]` tag";
+             "`[verif-library-{assert,assume,cover}]` tag";
       diag.attachNote(printOp.getLoc())
           << "expected JSON-encoded extraction summary in "
              "`<extraction-summary>` XML tag";
@@ -590,8 +594,12 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
       op = builder.create<AssertOp>(printOp.getClock(), predicate,
                                     printOp.getCond(), message,
                                     printOp.getSubstitutions(), label, true);
-    else // VerifFlavor::VerifLibAssume
+    else if (flavor == VerifFlavor::VerifLibAssume)
       op = builder.create<AssumeOp>(printOp.getClock(), predicate,
+                                    printOp.getCond(), message,
+                                    printOp.getSubstitutions(), label, true);
+    else // VerifFlavor::VerifLibCover
+      op = builder.create<CoverOp>(printOp.getClock(), predicate,
                                     printOp.getCond(), message,
                                     printOp.getSubstitutions(), label, true);
     printOp.erase();

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -600,8 +600,8 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
                                     printOp.getSubstitutions(), label, true);
     else // VerifFlavor::VerifLibCover
       op = builder.create<CoverOp>(printOp.getClock(), predicate,
-                                    printOp.getCond(), message,
-                                    printOp.getSubstitutions(), label, true);
+                                   printOp.getCond(), message,
+                                   printOp.getSubstitutions(), label, true);
     printOp.erase();
 
     // Attach additional attributes extracted from the JSON object.

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1111,6 +1111,17 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]]
 
+    ; Verification Library Covers
+
+    ; Predicate modifier `noMod`
+    when cond:
+      printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}", value)
+      stop(clock, enable, 1)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
+    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
+    ; CHECK-SAME: name = "verif_library_cover_label"
+
   module LargeMem :
     input clock : Clock
     input reset : Reset

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1114,10 +1114,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Verification Library Covers
 
     ; Predicate modifier `noMod`
-    when cond:
+    when not(cond):
       printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
+    ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
     ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_cover_label"

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1119,7 +1119,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
-    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
+    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
+    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_cover_label"
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1116,7 +1116,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Predicate modifier `noMod`
     when not(cond):
       printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}", value)
-      stop(clock, enable, 1)
+    assert(clock, cond, enable, "")
     ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
     ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>


### PR DESCRIPTION
Similar to current `assert` and `assume` parsing; parse `printf`s for magic strings to emit `cover` statements.