### PR TITLE
[FIRRTL][HW] Move getNumPorts to HWModuleLike

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -223,12 +223,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     // All Port Information
     //===------------------------------------------------------------------===//
 
-    InterfaceMethod<"Get the number of ports",
-    "size_t", "getNumPorts", (ins), [{}],
-    /*defaultImplementation=*/[{
-      return $_op.getPortTypesAttr().size();
-    }]>,
-
     InterfaceMethod<"Get information about all ports",
     "SmallVector<PortInfo>", "getPorts">,
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -51,11 +51,26 @@ def CircuitOp : FIRRTLOp<"circuit",
   let hasRegionVerifier = 1;
 }
 
-def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
-                                    NoTerminator, HasParent<"CircuitOp">,
-                                    DeclareOpInterfaceMethods<FModuleLike>,
-                                    DeclareOpInterfaceMethods<HWModuleLike>,
-                                    OpAsmOpInterface, InnerSymbolTable]> {
+class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
+  FIRRTLOp<mnemonic, traits # [
+    IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
+    DeclareOpInterfaceMethods<FModuleLike>,
+    DeclareOpInterfaceMethods<HWModuleLike>,
+    OpAsmOpInterface, InnerSymbolTable]> {
+
+  /// Additional class definitions inside the module op.
+  code extraModuleClassDefinition = [{}];
+
+  let extraClassDefinition = extraModuleClassDefinition # [{
+    size_t $cppClass::getNumPorts() {
+      return getPortTypesAttr().size();
+    }
+  }];
+
+}
+
+
+def FModuleOp : FIRRTLModuleLike<"module", [SingleBlock, NoTerminator]> {
   let summary = "FIRRTL Module";
   let description = [{
     The "firrtl.module" operation represents a Verilog module, including a given
@@ -101,10 +116,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
 
 }
 
-def FExtModuleOp : FIRRTLOp<"extmodule",
-      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, OpAsmOpInterface,
-       DeclareOpInterfaceMethods<FModuleLike>, InnerSymbolTable,
-       DeclareOpInterfaceMethods<HWModuleLike>]> {
+def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
   let summary = "FIRRTL external module";
   let description = [{
     The "firrtl.extmodule" operation represents an external reference to a
@@ -143,10 +155,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let hasVerifier = 1;
 }
 
-def FMemModuleOp : FIRRTLOp<"memmodule",
-      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, OpAsmOpInterface,
-       DeclareOpInterfaceMethods<FModuleLike>, InnerSymbolTable,
-       DeclareOpInterfaceMethods<HWModuleLike>]> {
+def FMemModuleOp : FIRRTLModuleLike<"memmodule"> {
   let summary = "FIRRTL Generated Memory Module";
   let description = [{
     The "firrtl.memmodule" operation represents an external reference to a

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -19,7 +19,7 @@ def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResul
 def MachineOp : FSMOp<"machine", [
       FunctionOpInterface,
       Symbol, SymbolTable, NoTerminator,
-      HWModuleLike]> {
+      DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "Define a finite-state machine";
   let description = [{
     `fsm.machine` represents a finite-state machine, including a machine name,
@@ -76,6 +76,13 @@ def MachineOp : FSMOp<"machine", [
 
     /// Return the name of the i'th result of this machine.
     StringAttr getResName(size_t i);
+  }];
+
+  let extraClassDefinition = [{
+    size_t $cppClass::getNumPorts() {
+      auto machineType = getFunctionType();
+      return machineType.getNumInputs() + machineType.getNumResults();
+    }
   }];
 
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -36,6 +36,9 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     "::mlir::StringAttr", "moduleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
+
+    InterfaceMethod<"Get the number of ports",
+    "size_t", "getNumPorts">,
   ];
 
   let verify = [{

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -35,6 +35,15 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       ArrayRef<unsigned> eraseOutputs
     );
   }];
+
+  /// Additional class definitions inside the module op.
+  code extraModuleClassDefinition = [{}];
+
+  let extraClassDefinition = extraModuleClassDefinition # [{
+    size_t $cppClass::getNumPorts() {
+      return getAllPorts().size();
+    }
+  }];
 }
 
 def HWModuleOp : HWModuleOpBase<"module",

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -175,6 +175,13 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
     Block *getBodyBlock() { return &getFunctionBody().front(); }
   }];
 
+  let extraClassDefinition = [{
+    size_t $cppClass::getNumPorts() {
+      auto ports = getPorts();
+      return ports.inputs.size() + ports.outputs.size();
+    }
+  }];
+
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -13,7 +13,7 @@
 
 def SCModuleOp : SystemCOp<"module", [
     Symbol,
-    HWModuleLike,
+    DeclareOpInterfaceMethods<HWModuleLike>,
     FunctionOpInterface,
     IsolatedFromAbove,
     SingleBlock,
@@ -102,6 +102,12 @@ def SCModuleOp : SystemCOp<"module", [
     // Return the Destructor operation in this module's body or create one if
     // none exists yet.
     systemc::DestructorOp getOrCreateDestructor();
+  }];
+
+  let extraClassDefinition = [{
+    size_t $cppClass::getNumPorts() {
+      return getPortNames().size();
+    }
   }];
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -229,7 +229,7 @@ Optional<AnnoPathValue> firrtl::resolveEntities(TokenAnnoTarget path,
     } else {
       auto field = component.front().name;
       ref = AnnoTarget();
-      for (size_t p = 0, pe = target.getNumPorts(); p < pe; ++p)
+      for (size_t p = 0, pe = getNumPorts(target); p < pe; ++p)
         if (target.getPortName(p) == field) {
           ref = PortAnnoTarget(target, p);
           break;
@@ -326,7 +326,7 @@ InstanceOp firrtl::addPortsToModule(
                            getNamespace(nameForMod).newName("_gen_" + newName));
   };
   // The port number for the new port.
-  unsigned portNo = mod.getNumPorts();
+  unsigned portNo = getNumPorts(mod);
   PortInfo portInfo = {portName(mod), portType, dir, {}, mod.getLoc()};
   mod.insertPorts({{portNo, portInfo}});
   if (targetCaches)

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -109,7 +109,7 @@ static bool applyToPort(AnnotationSet annos, Operation *op, size_t portCount,
 }
 
 bool AnnotationSet::applyToPort(FModuleLike op, size_t portNo) const {
-  return ::applyToPort(*this, op.getOperation(), op.getNumPorts(), portNo);
+  return ::applyToPort(*this, op.getOperation(), getNumPorts(op), portNo);
 }
 
 bool AnnotationSet::applyToPort(MemOp op, size_t portNo) const {

--- a/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
+++ b/lib/Dialect/FIRRTL/InnerSymbolTable.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/FIRRTL/InnerSymbolTable.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/Support/Debug.h"
 
@@ -96,7 +97,7 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
            // Check for ports
            // TODO: Add fields per port, once they work that way (use addSyms)
            if (auto mod = dyn_cast<FModuleLike>(curOp)) {
-             for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i)
+             for (size_t i = 0, e = getNumPorts(mod); i < e; ++i)
                if (auto symAttr = mod.getPortSymbolAttr(i))
                  if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
                    return WalkResult::interrupt();
@@ -143,7 +144,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   auto getBase = [](auto &target) -> hw::InnerSymAttr {
     if (target.isPort()) {
       if (auto mod = dyn_cast<FModuleLike>(target.getOp())) {
-        assert(target.getPort() < mod.getNumPorts());
+        assert(target.getPort() < getNumPorts(mod));
         return mod.getPortSymbolAttr(target.getPort());
       }
     } else {

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -679,7 +679,7 @@ struct Deduper {
     // Record any annotations on the module.
     recordAnnotations(module);
     // Record port annotations.
-    for (unsigned i = 0, e = module.getNumPorts(); i < e; ++i)
+    for (unsigned i = 0, e = getNumPorts(module); i < e; ++i)
       recordAnnotations(PortAnnoTarget(module, i));
     // Record any annotations in the module body.
     module->walk([&](Operation *op) { recordAnnotations(op); });
@@ -992,7 +992,7 @@ private:
     // Merge port annotations.
     if (toModule == to) {
       // Merge module port annotations.
-      for (unsigned i = 0, e = toModule.getNumPorts(); i < e; ++i)
+      for (unsigned i = 0, e = getNumPorts(toModule); i < e; ++i)
         mergeAnnotations(toModule, PortAnnoTarget(toModule, i),
                          AnnotationSet::forPort(toModule, i), fromModule,
                          PortAnnoTarget(fromModule, i),
@@ -1211,7 +1211,7 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
     auto module = cast<FModuleLike>(*node->getModule());
     for (auto *instRec : node->uses()) {
       auto inst = instRec->getInstance();
-      for (unsigned i = 0, e = module.getNumPorts(); i < e; ++i)
+      for (unsigned i = 0, e = getNumPorts(module); i < e; ++i)
         fixupReferences(inst->getResult(i), module.getPortType(i));
     }
   }

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -713,7 +713,7 @@ void Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b,
                               SmallVectorImpl<Value> &wires,
                               SmallVectorImpl<Backedge> &edges) {
   auto portInfo = target.getPorts();
-  for (unsigned i = 0, e = target.getNumPorts(); i < e; ++i) {
+  for (unsigned i = 0, e = getNumPorts(target); i < e; ++i) {
     auto arg = target.getArgument(i);
     // Get the type of the wire.
     auto type = arg.getType().cast<FIRRTLType>();
@@ -1208,7 +1208,7 @@ void Inliner::identifyNLAsTargetingOnlyModules() {
           referencedNLASyms.insert(sym.getAttr());
     };
     // Scan ports
-    for (unsigned i = 0, e = mod.getNumPorts(); i != e; ++i)
+    for (unsigned i = 0, e = getNumPorts(mod); i != e; ++i)
       scanAnnos(AnnotationSet::forPort(mod, i));
 
     // Scan operations (and not the module itself):


### PR DESCRIPTION
Move the getNumPorts function from the FModuleLike op interface to the HWModuleLike op interface.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is one of a series of commits working towards https://github.com/llvm/circt/pull/4384.