### PR TITLE
[FIRRTL] Fold binary ops returning zero-width, replace impossible check.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -205,8 +205,8 @@ constFoldFIRRTLBinaryOp(Operation *op, ArrayRef<Attribute> operands,
   if (resultType.getWidthOrSentinel() < 0)
     return {};
 
-  // Any binary non-cmp op on I<0> is 0.
-  if (resultType.getWidthOrSentinel() == 0 && opKind == BinOpKind::Compare)
+  // Any binary op returning i0 is 0.
+  if (resultType.getWidthOrSentinel() == 0)
     return getIntAttr(resultType, APInt(0, 0, resultType.isSigned()));
 
   // Determine the operand widths. This is either dictated by the operand type,

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1620,7 +1620,7 @@ firrtl.module @ComparisonOfConsts(
   // CHECK-NEXT: firrtl.strictconnect %y19, %c1_ui1
 }
 
-// CHECK-LABEL: @zeroWidth
+// CHECK-LABEL: @zeroWidth(
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.strictconnect %out, %c0_ui2 : !firrtl.uint<2>
 // CHECK-NEXT:  }
@@ -1647,6 +1647,37 @@ firrtl.module @zeroWidth(out %out: !firrtl.uint<2>, in %in1 : !firrtl.uint<0>, i
   %ret9 = firrtl.cat %ret8, %or : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
   %ret10 = firrtl.cat %ret9, %xor : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
   firrtl.strictconnect %out, %ret10 : !firrtl.uint<2>
+}
+
+// CHECK-LABEL: @zeroWidthOperand(
+// CHECK-NEXT:   %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.strictconnect %y6, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.strictconnect %y8, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.strictconnect %y9, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.strictconnect %y12, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.strictconnect %y14, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:  }
+firrtl.module @zeroWidthOperand(
+  in %in0 : !firrtl.uint<0>,
+  in %in1 : !firrtl.uint<1>,
+  out %y6: !firrtl.uint<0>,
+  out %y8: !firrtl.uint<0>,
+  out %y9: !firrtl.uint<0>,
+  out %y12: !firrtl.uint<0>,
+  out %y14: !firrtl.uint<0>
+) {
+  %div1 = firrtl.div %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+  %rem1 = firrtl.rem %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+  %rem2 = firrtl.rem %in1, %in0 : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %dshlw1 = firrtl.dshlw %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+  %dshlw2 = firrtl.dshlw %in1, %in0 : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %dshr1 = firrtl.dshr %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+
+  firrtl.strictconnect %y6, %div1 : !firrtl.uint<0>
+  firrtl.strictconnect %y8, %rem1 : !firrtl.uint<0>
+  firrtl.strictconnect %y9, %rem2 : !firrtl.uint<0>
+  firrtl.strictconnect %y12, %dshlw1 : !firrtl.uint<0>
+  firrtl.strictconnect %y14, %dshr1 : !firrtl.uint<0>
 }
 
 // CHECK-LABEL: @add_cst_prop1

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1670,7 +1670,6 @@ firrtl.module @zeroWidthOperand(
   %rem1 = firrtl.rem %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
   %rem2 = firrtl.rem %in1, %in0 : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<0>
   %dshlw1 = firrtl.dshlw %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
-  %dshlw2 = firrtl.dshlw %in1, %in0 : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %dshr1 = firrtl.dshr %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
 
   firrtl.strictconnect %y6, %div1 : !firrtl.uint<0>


### PR DESCRIPTION
Previous code did not match its comment which is how it was noticed. Upon inspection it also did nothing since comparisons always return i0. (test introduced with it passes without the code change,
 commit: 1a742d10abd0690fb64df89897535c2ff3142bf6)

Zero-width operands will be treated as "constant" zero later in this function, so zero-width+zero-width and zero-width+constant fold presently.

Replace the check with a new one that folds any binary op with zero-width result into zero.

There are folds involving one operand being zero-width that are missing, future work.