### PR TITLE
[GCSM] Fix buffer wire preservation, add test.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -757,6 +757,8 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
           NameKindEnum::DroppableName, builder.getArrayAttr({}),
           replacementWireName);
       port.replaceAllUsesWith(replacementWire);
+      AnnotationSet::addDontTouch(replacementWire);
+      AnnotationSet::addDontTouch(bufferWire);
       builder.create<StrictConnectOp>(builder.getUnknownLoc(), port,
                                       bufferWire);
       builder.create<StrictConnectOp>(builder.getUnknownLoc(), bufferWire,

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
@@ -41,6 +41,24 @@
 ; JSONINLINE:           "annotations": []
 ; JSONINLINE:           "circuitPackage": "flowtest"
 
+; Check buffer wires are inserted and preserved
+; RUN: FileCheck %s --input-file=%t/default/Top.sv --check-prefix=TOPDEFAULT
+; RUN: FileCheck %s --input-file=%t/default/Foo.sv --check-prefix=FOODEFAULT
+
+; Forced input ports bound to 'buffer' wire that separates the port from its uses.
+; TOPDEFAULT: Foo_clock_buffer = Foo_clock;
+; TOPDEFAULT: Foo_dataIn_a_b_c_buffer = Foo_dataIn_a_b_c;
+; TOPDEFAULT: Foo_dataIn_d_buffer = Foo_dataIn_d;
+; TOPDEFAULT:  .clock         (Foo_clock_buffer)
+; TOPDEFAULT:  .dataIn_a_b_c  (Foo_dataIn_a_b_c_buffer)
+; TOPDEFAULT:  .dataIn_d      (Foo_dataIn_d_buffer)
+; Forced Bar port has buffer wire in Foo.
+; FOODEFAULT-DAG: Bar_b_buffer = Bar_b;
+; FOODEFAULT-DAG:   .b (Bar_b_buffer)
+
+; Forced output ports bound to 'buffer' wire inside module.
+; FOODEFAULT-DAG: Foo_dataOut_u_buffer = Foo_dataOut_u;
+; FOODEFAULT-DAG: dataOut_u = Foo_dataOut_u_buffer
 
 ; 2) Run on sub circuit, with updated annotation file (sigdrive.json) from (1):
 ; RUN: firtool %S/subcircuit.fir --annotation-file %t/default/sigdrive.json | FileCheck %s --check-prefix=MAPPINGDEFAULT
@@ -52,6 +70,7 @@
 ; MAPPINGDEFAULT-NEXT:   input  [9000:0] data_sink_v,
 ; MAPPINGDEFAULT-NEXT:   input           data_sink_w_0,
 ; MAPPINGDEFAULT-NEXT:                   data_sink_w_1,
+; MAPPINGDEFAULT-NEXT:   input  [41:0]   data_sink_x,
 ; MAPPINGDEFAULT-NEXT:   output          clock_source,
 ; MAPPINGDEFAULT-NEXT:   output [41:0]   data_source_u,
 ; MAPPINGDEFAULT-NEXT:   output [9000:0] data_source_v);
@@ -65,6 +84,7 @@
 ; MAPPINGDEFAULT-NEXT:     force Bar.b = data_sink_w_0;
 ; MAPPINGDEFAULT-NEXT:     force Bar.b = data_sink_w_1;
 ; (cont)
+; MAPPINGDEFAULT-NEXT:     force Foo.dataOut_u = data_sink_x;
 ; MAPPINGDEFAULT-NEXT:   end
 ; MAPPINGDEFAULT-NEXT:   `endif
 ; MAPPINGDEFAULT-NEXT:   assign clock_source = Top.clock;
@@ -78,6 +98,7 @@
 ; MAPPINGINLINE-NEXT:   input  [9000:0] data_sink_v,
 ; MAPPINGINLINE-NEXT:   input           data_sink_w_0,
 ; MAPPINGINLINE-NEXT:                   data_sink_w_1,
+; MAPPINGINLINE-NEXT:   input  [41:0]   data_sink_x,
 ; MAPPINGINLINE-NEXT:   output          clock_source,
 ; MAPPINGINLINE-NEXT:   output [41:0]   data_source_u,
 ; MAPPINGINLINE-NEXT:   output [9000:0] data_source_v);
@@ -90,6 +111,7 @@
 ; MAPPINGINLINE-NEXT:     force Bar.b = data_sink_w_0;
 ; MAPPINGINLINE-NEXT:     force Bar.b = data_sink_w_1;
 ; (cont)
+; MAPPINGINLINE-NEXT:     force Top.foo_dataOut_u = data_sink_x;
 ; MAPPINGINLINE-NEXT:   end
 ; MAPPINGINLINE-NEXT:   `endif
 ; MAPPINGINLINE-NEXT:   assign clock_source = Top.clock;

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subCircuit.json
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subCircuit.json
@@ -17,6 +17,10 @@
       {
         "_1": "~Top|Bar>b",
         "_2": "~Sub|Sub>data_sink.w"
+      },
+      {
+        "_1": "~Top|Foo>dataOut.u",
+        "_2": "~Sub|Sub>data_sink.x"
       }
     ],
     "sourceTargets": [

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subcircuit.fir
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subcircuit.fir
@@ -4,14 +4,14 @@ circuit Sub :
   extmodule SubExtern :
     input clockIn : Clock
     output clockOut : Clock
-    input someInput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
-    output someOutput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+    input someInput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2], x: UInt<42> }
+    output someOutput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2], x: UInt<42> }
 
   module Sub :
     wire clock_source : Clock
     wire clock_sink : Clock
-    wire data_source : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
-    wire data_sink : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+    wire data_source : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2], x: UInt<42> }
+    wire data_sink : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2], x: UInt<42> }
     clock_source is invalid
     data_source is invalid
 


### PR DESCRIPTION
Buffer wires are inserted when ports are forced via signal driving,
and inner symbols were used to ensure they were preserved.

However now that we have InnerSymDCE (#3120), that is insufficient
and the wires were being removed, causing issues due to the forced ports
also driving anything directly bound to the instance ports.

Extend the subcircuit flow test to check for these wires to ensure
they are preserved all the way to verilog.

Buffer wires (second wire anyway) for input ports were added in #3153, output ports in #3431.