### PR TITLE
Register FIRRTL to CAPI

### DIFF
--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -1,0 +1,26 @@
+//===-- circt-c/Dialect/FIRRTL.h - C API for FIRRTL dialect -------*- C -*-===//
+//
+// This header declares the C interface for registering and accessing the
+// FIRRTL dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_FIRRTL_H
+#define CIRCT_C_DIALECT_FIRRTL_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_FIRRTL_H

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(LLVM_OPTIONAL_SOURCES
   Comb.cpp
   ESI.cpp
+  FIRRTL.cpp
   MSFT.cpp
   HW.cpp
   HWArith.cpp
@@ -27,6 +28,14 @@ add_mlir_public_c_api_library(CIRCTCAPIESI
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTESI
+)
+
+add_mlir_public_c_api_library(CIRCTCAPIFIRRTL
+  FIRRTL.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTFIRRTL
 )
 
 add_mlir_public_c_api_library(CIRCTCAPIMSFT

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -1,0 +1,12 @@
+//===- FIRRTL.cpp - C Interface for the FIRRTL Dialect --------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/FIRRTL.h"
+#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl,
+                                      circt::firrtl::FIRRTLDialect)


### PR DESCRIPTION
This add FIRRTL to CAPI. It is used for JVM Binding which can be used via JNA/JNI/[Panama](https://openjdk.org/projects/panama/)