### PR TITLE
[ExportVerilog] Tweak braced list formatting, less whitespace.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1841,27 +1841,23 @@ private:
   /// Use callbacks to emit open tokens, closing tokens, and handle each value.
   /// If it fits, will be emitted on a single line with no space between
   /// list and surrounding open and close.
-  /// Otherwise, list is indented and each item is placed on its own line.
+  /// Otherwise, each item is placed on its own line.
   /// This has property that if any element requires breaking, all elements
-  /// are emitted on separate lines.
+  /// are emitted on separate lines (with open/close attached to first/last).
   /// `{a + b, x + y, c}`
   /// OR
   /// ```
-  /// {
-  ///   a + b,
-  ///   x + y,
-  ///   c
-  /// }
+  /// {a + b,
+  ///  x + y,
+  ///  c}
   /// ```
   template <typename Container, typename OpenFunc, typename CloseFunc,
             typename EachFunc>
   void emitBracedList(const Container &c, OpenFunc openFn, EachFunc eachFn,
                       CloseFunc closeFn) {
-    ps.scopedBox(PP::cbox2, [&]() {
-      openFn();
-      ps << PP::zerobreak;
+    openFn();
+    ps.scopedBox(PP::cbox0, [&]() {
       interleaveComma(c, eachFn);
-      ps << BreakToken(0, -2);
       closeFn();
     });
   }

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -6,27 +6,23 @@ sv.interface @IValidReady_Struct  {
 
 // CHECK-LABEL:module structs({{.*}}
 //      CHECK:  assign _GEN =
-// CHECK-NEXT:    '{
-// CHECK-NEXT:      foo: ({_GEN_1, _GEN_0}),
+// CHECK-NEXT:    '{foo: ({_GEN_1, _GEN_0}),
 // CHECK-NEXT:      bar: ({_GEN_0, _GEN_0}),
 // CHECK-NEXT:      baz:
-// CHECK-NEXT:        ({
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_1,
-// CHECK-NEXT:           _GEN_0,
-// CHECK-NEXT:           _GEN_0
-// CHECK-NEXT:         })
-// CHECK-NEXT:    };{{.*}}
+// CHECK-NEXT:        ({_GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_1,
+// CHECK-NEXT:          _GEN_0,
+// CHECK-NEXT:          _GEN_0})};{{.*}}
 hw.module @structs(%clk: i1, %rstn: i1) {
   %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>
   sv.interface.signal.assign %0(@IValidReady_Struct::@data) = %s : !hw.struct<foo: !hw.array<72xi1>, bar: !hw.array<128xi1>, baz: !hw.array<224xi1>>


### PR DESCRIPTION
Tighten up output a bit.

(and don't indent the contents)