### PR TITLE
[EmitOMIR] Support fieldID for OMIR targetting fields.

### DIFF
--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -235,6 +235,161 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
 // CHECK-SAME:    #hw.innerNameRef<@A::@[[a_sym]]>
 // CHECK-SAME:  ]
 
+
+//===----------------------------------------------------------------------===//
+// Trackers support fieldID
+//===----------------------------------------------------------------------===//
+
+#loc3 = loc("OM.scala":1:1)
+#loc4 = loc("Foo.scala":1:1)
+firrtl.circuit "Top"  attributes {annotations = [{
+  class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+  nodes = [{
+    fields = {
+      paths = {
+        index = 0 : i64,
+        info = #loc3,
+        value = [{
+          id = 0 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>in0[0]",
+          type = "OMReferenceTarget"
+        }, {
+          id = 1 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>in0[1]",
+          type = "OMReferenceTarget"
+        }]
+      }
+    },
+    id = "OMID:1",
+    info = #loc4
+  }, {
+    fields = {
+      paths = {
+        index = 0 : i64,
+        info = #loc4,
+        value = [{
+          id = 2 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>w0[0]",
+          type = "OMReferenceTarget"
+        }, {
+          id = 3 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>w0[1]",
+          type = "OMReferenceTarget"
+        }]
+      }
+    },
+    id = "OMID:2",
+    info = #loc4
+  }, {
+    fields = {
+      paths = {
+        index = 0 : i64,
+        info = #loc3,
+        value = [{
+          id = 4 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>in1.f0",
+          type = "OMReferenceTarget"
+        }, {
+          id = 5 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>in1.f1",
+          type = "OMReferenceTarget"
+        }]
+      }
+    },
+    id = "OMID:3",
+    info = #loc4
+  }, {
+    fields = {
+      paths = {
+        index = 0 : i64,
+        info = #loc4,
+        value = [{
+          id = 6 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>w1.f0",
+          type = "OMReferenceTarget"
+        }, {
+          id = 7 : i64,
+          omir.tracker,
+          path = "~Top|Top/a:A>w1.f1",
+          type = "OMReferenceTarget"
+        }]
+      }
+    },
+    id = "OMID:4",
+    info = #loc4
+  }]
+}]} {
+  firrtl.hierpath private @nla [@Top::@a, @A]
+  firrtl.module @Top(in %in0_0: !firrtl.uint<4>, in %in0_1: !firrtl.uint<4>, in %in1_f0: !firrtl.uint<4>, in %in1_f1: !firrtl.uint<4>, out %out0_0: !firrtl.uint<4>, out %out0_1: !firrtl.uint<4>, out %out1_f0: !firrtl.uint<4>, out %out1_f1: !firrtl.uint<4>) {
+    %a_in0, %a_in1_f0, %a_in1_f1, %a_out0, %a_out1_f0, %a_out1_f1 = firrtl.instance a sym @a  @A(in in0: !firrtl.vector<uint<4>, 2>, in in1_f0: !firrtl.uint<4>, in in1_f1: !firrtl.uint<4>, out out0: !firrtl.vector<uint<4>, 2>, out out1_f0: !firrtl.uint<4>, out out1_f1: !firrtl.uint<4>)
+    %0 = firrtl.subindex %a_in0[0] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %0, %in0_0 : !firrtl.uint<4>
+    %1 = firrtl.subindex %a_in0[1] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %1, %in0_1 : !firrtl.uint<4>
+    firrtl.strictconnect %a_in1_f0, %in1_f0 : !firrtl.uint<4>
+    firrtl.strictconnect %a_in1_f1, %in1_f1 : !firrtl.uint<4>
+    %2 = firrtl.subindex %a_out0[0] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %out0_0, %2 : !firrtl.uint<4>
+    %3 = firrtl.subindex %a_out0[1] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %out0_1, %3 : !firrtl.uint<4>
+    firrtl.strictconnect %out1_f0, %a_out1_f0 : !firrtl.uint<4>
+    firrtl.strictconnect %out1_f1, %a_out1_f1 : !firrtl.uint<4>
+  }
+  // CHECK-LABEL: firrtl.module private @A
+  // CHECK-SAME:    %in0: !firrtl.vector<uint<4>, 2> sym @[[in0_sym:[^ ]+]],
+  // CHECK-SAME:    %in1_f0: !firrtl.uint<4> sym @[[in1_f0_sym:[^ ]+]],
+  // CHECK-SAME:    %in1_f1: !firrtl.uint<4> sym @[[in1_f1_sym:[^ ]+]],
+  firrtl.module private @A(in %in0: !firrtl.vector<uint<4>, 2> [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}], in %in1_f0: !firrtl.uint<4> [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 4 : i64}], in %in1_f1: !firrtl.uint<4> [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 5 : i64}], out %out0: !firrtl.vector<uint<4>, 2>, out %out1_f0: !firrtl.uint<4>, out %out1_f1: !firrtl.uint<4>) {
+    // CHECK: %w0 = firrtl.wire sym @[[w0_sym:[^ ]+]]
+    %w0 = firrtl.wire   {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 3 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 2 : i64}]} : !firrtl.vector<uint<4>, 2>
+    %0 = firrtl.subindex %in0[0] : !firrtl.vector<uint<4>, 2>
+    %1 = firrtl.subindex %in0[1] : !firrtl.vector<uint<4>, 2>
+    // CHECK: %w1_f0 = firrtl.wire sym @[[w1_f0_sym:[^ ]+]]
+    %w1_f0 = firrtl.wire   {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 6 : i64}]} : !firrtl.uint<4>
+    // CHECK: %w1_f1 = firrtl.wire sym @[[w1_f1_sym:[^ ]+]]
+    %w1_f1 = firrtl.wire   {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 7 : i64}]} : !firrtl.uint<4>
+    firrtl.strictconnect %w1_f0, %in1_f0 : !firrtl.uint<4>
+    firrtl.strictconnect %w1_f1, %in1_f1 : !firrtl.uint<4>
+    %2 = firrtl.subindex %w0[0] : !firrtl.vector<uint<4>, 2>
+    %3 = firrtl.subindex %out0[0] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %3, %2 : !firrtl.uint<4>
+    %4 = firrtl.subindex %w0[1] : !firrtl.vector<uint<4>, 2>
+    %5 = firrtl.subindex %out0[1] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %5, %4 : !firrtl.uint<4>
+    firrtl.strictconnect %out1_f0, %w1_f0 : !firrtl.uint<4>
+    firrtl.strictconnect %out1_f1, %w1_f1 : !firrtl.uint<4>
+    %6 = firrtl.vectorcreate %0, %1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %w0, %6 : !firrtl.vector<uint<4>, 2>
+  }
+}
+
+// CHECK:      sv.verbatim
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}[0]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}[1]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{4}}[0]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{4}}[1]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{5}}
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{6}}
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{7}}
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{8}}
+// CHECK-SAME: symbols = [
+// CHECK-SAME:  @Top,
+// CHECK-SAME:  #hw.innerNameRef<@Top::@a>
+// CHECK-SAME:  @A
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[in0_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[w0_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[in1_f0_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[in1_f1_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[w1_f0_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[w1_f1_sym]]>
+
 //===----------------------------------------------------------------------===//
 // Targets that are allowed to lose their tracker
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -252,12 +252,12 @@ firrtl.circuit "Top"  attributes {annotations = [{
         value = [{
           id = 0 : i64,
           omir.tracker,
-          path = "~Top|Top/a:A>in0[0]",
+          path = "~Top|Top/a:A>in0.io[0]",
           type = "OMReferenceTarget"
         }, {
           id = 1 : i64,
           omir.tracker,
-          path = "~Top|Top/a:A>in0[1]",
+          path = "~Top|Top/a:A>in0.io[1]",
           type = "OMReferenceTarget"
         }]
       }
@@ -292,12 +292,12 @@ firrtl.circuit "Top"  attributes {annotations = [{
         value = [{
           id = 4 : i64,
           omir.tracker,
-          path = "~Top|Top/a:A>in1.f0",
+          path = "~Top|Top/a:A>in1.io.f0",
           type = "OMReferenceTarget"
         }, {
           id = 5 : i64,
           omir.tracker,
-          path = "~Top|Top/a:A>in1.f1",
+          path = "~Top|Top/a:A>in1.io.f1",
           type = "OMReferenceTarget"
         }]
       }
@@ -328,67 +328,72 @@ firrtl.circuit "Top"  attributes {annotations = [{
 }]} {
   firrtl.hierpath private @nla [@Top::@a, @A]
   firrtl.module @Top(in %in0_0: !firrtl.uint<4>, in %in0_1: !firrtl.uint<4>, in %in1_f0: !firrtl.uint<4>, in %in1_f1: !firrtl.uint<4>, out %out0_0: !firrtl.uint<4>, out %out0_1: !firrtl.uint<4>, out %out1_f0: !firrtl.uint<4>, out %out1_f1: !firrtl.uint<4>) {
-    %a_in0, %a_in1_f0, %a_in1_f1, %a_out0, %a_out1_f0, %a_out1_f1 = firrtl.instance a sym @a  @A(in in0: !firrtl.vector<uint<4>, 2>, in in1_f0: !firrtl.uint<4>, in in1_f1: !firrtl.uint<4>, out out0: !firrtl.vector<uint<4>, 2>, out out1_f0: !firrtl.uint<4>, out out1_f1: !firrtl.uint<4>)
-    %0 = firrtl.subindex %a_in0[0] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %0, %in0_0 : !firrtl.uint<4>
-    %1 = firrtl.subindex %a_in0[1] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %1, %in0_1 : !firrtl.uint<4>
-    firrtl.strictconnect %a_in1_f0, %in1_f0 : !firrtl.uint<4>
-    firrtl.strictconnect %a_in1_f1, %in1_f1 : !firrtl.uint<4>
+    %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance a sym @a  @A(in in0: !firrtl.bundle<io: vector<uint<4>, 2>>, in in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>, out out0: !firrtl.vector<uint<4>, 2>, out out1: !firrtl.bundle<f0: uint<4>, f1: uint<4>>)
+    %0 = firrtl.subfield %a_in1(0) : (!firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %1 = firrtl.subfield %a_in0(0) : (!firrtl.bundle<io: vector<uint<4>, 2>>) -> !firrtl.vector<uint<4>, 2>
     %2 = firrtl.subindex %a_out0[0] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %out0_0, %2 : !firrtl.uint<4>
     %3 = firrtl.subindex %a_out0[1] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %out0_1, %3 : !firrtl.uint<4>
-    firrtl.strictconnect %out1_f0, %a_out1_f0 : !firrtl.uint<4>
-    firrtl.strictconnect %out1_f1, %a_out1_f1 : !firrtl.uint<4>
+    %4 = firrtl.subfield %a_out1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    firrtl.strictconnect %out1_f0, %4 : !firrtl.uint<4>
+    %5 = firrtl.subfield %a_out1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    firrtl.strictconnect %out1_f1, %5 : !firrtl.uint<4>
+    %6 = firrtl.bundlecreate %in1_f0, %in1_f1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    firrtl.strictconnect %0, %6 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %7 = firrtl.vectorcreate %in0_0, %in0_1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %1, %7 : !firrtl.vector<uint<4>, 2>
   }
   // CHECK-LABEL: firrtl.module private @A
-  // CHECK-SAME:    %in0: !firrtl.vector<uint<4>, 2> sym @[[in0_sym:[^ ]+]],
-  // CHECK-SAME:    %in1_f0: !firrtl.uint<4> sym @[[in1_f0_sym:[^ ]+]],
-  // CHECK-SAME:    %in1_f1: !firrtl.uint<4> sym @[[in1_f1_sym:[^ ]+]],
-  firrtl.module private @A(in %in0: !firrtl.vector<uint<4>, 2> [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}], in %in1_f0: !firrtl.uint<4> [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 4 : i64}], in %in1_f1: !firrtl.uint<4> [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 5 : i64}], out %out0: !firrtl.vector<uint<4>, 2>, out %out1_f0: !firrtl.uint<4>, out %out1_f1: !firrtl.uint<4>) {
+  // CHECK-SAME:    %in0: !firrtl.bundle<io: vector<uint<4>, 2>> sym @[[in0_sym:[^ ]+]],
+  // CHECK-SAME:    %in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>> sym @[[in1_sym:[^ ]+]],
+  firrtl.module private @A(in %in0: !firrtl.bundle<io: vector<uint<4>, 2>> [{circt.fieldID = 3 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}, {circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}], in %in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>> [{circt.fieldID = 3 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 5 : i64}, {circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 4 : i64}], out %out0: !firrtl.vector<uint<4>, 2>, out %out1: !firrtl.bundle<f0: uint<4>, f1: uint<4>>) {
+    %0 = firrtl.subfield %in1(0) : (!firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %1 = firrtl.subfield %in0(0) : (!firrtl.bundle<io: vector<uint<4>, 2>>) -> !firrtl.vector<uint<4>, 2>
     // CHECK: %w0 = firrtl.wire sym @[[w0_sym:[^ ]+]]
     %w0 = firrtl.wire   {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 3 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 2 : i64}]} : !firrtl.vector<uint<4>, 2>
-    %0 = firrtl.subindex %in0[0] : !firrtl.vector<uint<4>, 2>
-    %1 = firrtl.subindex %in0[1] : !firrtl.vector<uint<4>, 2>
-    // CHECK: %w1_f0 = firrtl.wire sym @[[w1_f0_sym:[^ ]+]]
-    %w1_f0 = firrtl.wire   {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 6 : i64}]} : !firrtl.uint<4>
-    // CHECK: %w1_f1 = firrtl.wire sym @[[w1_f1_sym:[^ ]+]]
-    %w1_f1 = firrtl.wire   {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 7 : i64}]} : !firrtl.uint<4>
-    firrtl.strictconnect %w1_f0, %in1_f0 : !firrtl.uint<4>
-    firrtl.strictconnect %w1_f1, %in1_f1 : !firrtl.uint<4>
-    %2 = firrtl.subindex %w0[0] : !firrtl.vector<uint<4>, 2>
-    %3 = firrtl.subindex %out0[0] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<4>
-    %4 = firrtl.subindex %w0[1] : !firrtl.vector<uint<4>, 2>
-    %5 = firrtl.subindex %out0[1] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %5, %4 : !firrtl.uint<4>
-    firrtl.strictconnect %out1_f0, %w1_f0 : !firrtl.uint<4>
-    firrtl.strictconnect %out1_f1, %w1_f1 : !firrtl.uint<4>
-    %6 = firrtl.vectorcreate %0, %1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %w0, %6 : !firrtl.vector<uint<4>, 2>
+    %2 = firrtl.subindex %1[0] : !firrtl.vector<uint<4>, 2>
+    %3 = firrtl.subindex %1[1] : !firrtl.vector<uint<4>, 2>
+    // CHECK: %w1 = firrtl.wire sym @[[w1_sym:[^ ]+]]
+    %w1 = firrtl.wire   {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 7 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 6 : i64}]} : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %4 = firrtl.subfield %0(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %5 = firrtl.subfield %0(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %6 = firrtl.subindex %w0[0] : !firrtl.vector<uint<4>, 2>
+    %7 = firrtl.subindex %out0[0] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %7, %6 : !firrtl.uint<4>
+    %8 = firrtl.subindex %w0[1] : !firrtl.vector<uint<4>, 2>
+    %9 = firrtl.subindex %out0[1] : !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %9, %8 : !firrtl.uint<4>
+    %10 = firrtl.subfield %w1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %11 = firrtl.subfield %out1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    firrtl.strictconnect %11, %10 : !firrtl.uint<4>
+    %12 = firrtl.subfield %w1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %13 = firrtl.subfield %out1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    firrtl.strictconnect %13, %12 : !firrtl.uint<4>
+    %14 = firrtl.vectorcreate %2, %3 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
+    firrtl.strictconnect %w0, %14 : !firrtl.vector<uint<4>, 2>
+    %15 = firrtl.bundlecreate %4, %5 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    firrtl.strictconnect %w1, %15 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
   }
 }
 
 // CHECK:      sv.verbatim
-// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}[0]
-// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}[1]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}.io[0]
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{3}}.io[1]
 // CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{4}}[0]
 // CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{4}}[1]
-// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{5}}
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{5}}.io.f0
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{5}}.io.f1
 // CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{6}}
-// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{7}}
-// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{8}}
+// CHECK-SAME{LITERAL}: OMReferenceTarget:~Top|{{0}}/{{1}}:{{2}}>{{6}}
 // CHECK-SAME: symbols = [
 // CHECK-SAME:  @Top,
 // CHECK-SAME:  #hw.innerNameRef<@Top::@a>
 // CHECK-SAME:  @A
 // CHECK-SAME:  #hw.innerNameRef<@A::@[[in0_sym]]>
 // CHECK-SAME:  #hw.innerNameRef<@A::@[[w0_sym]]>
-// CHECK-SAME:  #hw.innerNameRef<@A::@[[in1_f0_sym]]>
-// CHECK-SAME:  #hw.innerNameRef<@A::@[[in1_f1_sym]]>
-// CHECK-SAME:  #hw.innerNameRef<@A::@[[w1_f0_sym]]>
-// CHECK-SAME:  #hw.innerNameRef<@A::@[[w1_f1_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[in1_sym]]>
+// CHECK-SAME:  #hw.innerNameRef<@A::@[[w1_sym]]>
 
 //===----------------------------------------------------------------------===//
 // Targets that are allowed to lose their tracker


### PR DESCRIPTION
This adds support for OMIR that targets fields. Tracker is updated to hold a fieldID, which behaves like it does in Annotations: defaults to 0 to mean the whole entity, and greater than zero to index into a field of the entity. When constructing output OMIR, if the tracker has a fieldID, the type of the entity being targeted is used to append the appropritate output field. For vectors, this is an index, and for bundles, this is a named field. If we don't know how to easily extract the type of a targeted entity, an error is raised. The common cases of Wires, Registers, Nodes, and Ports are supported.