### PR TITLE
[PrettyPrinter] Enable maxStartingIndent feature, default to high value. 

### DIFF
--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -172,13 +172,17 @@ public:
   /// - margin: line width.
   /// - baseIndent: always indent at least this much (starting 'indent' value).
   /// - currentColumn: current column, used to calculate space remaining.
+  /// - maxStartingIndent: max column indentation starts at, must be >= margin.
   PrettyPrinter(llvm::raw_ostream &os, uint32_t margin, uint32_t baseIndent = 0,
-                uint32_t currentColumn = 0, Listener *listener = nullptr)
+                uint32_t currentColumn = 0,
+                uint32_t maxStartingIndent = kInfinity / 4,
+                Listener *listener = nullptr)
       : space(margin - std::max(currentColumn, baseIndent)),
         defaultFrame{baseIndent, PrintBreaks::Inconsistent}, indent(baseIndent),
-        margin(margin), maxStartingIndent(margin), os(os), listener(listener) {
-    assert(margin < kInfinity / 2);
-    assert(margin > baseIndent);
+        margin(margin), maxStartingIndent(std::max(maxStartingIndent, margin)),
+        os(os), listener(listener) {
+    assert(maxStartingIndent < kInfinity / 2);
+    assert(maxStartingIndent > baseIndent);
     assert(margin > currentColumn);
     // Ensure first print advances to at least baseIndent.
     pendingIndentation =
@@ -285,9 +289,9 @@ private:
   /// Target line width.
   const uint32_t margin;
 
-  /// Maximum starting indentation level (=margin).
-  /// Currently not configurable, but can be useful to continue indentation past
-  /// margin while still limiting how far is allowed.
+  /// Maximum starting indentation level (default=kInfinity/4).
+  /// Useful to continue indentation past margin while still providing a limit
+  /// to avoid pathological output and for consumption by tools with limits.
   const uint32_t maxStartingIndent;
 
   /// Output stream.

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -67,3 +67,94 @@ hw.module @CoverAssert(
     sv.assert.concurrent posedge %clock, %5 label "assert__label" message "assert failed"
 }
 
+hw.module @MuxChain(%a_0: i1, %a_1: i1, %a_2: i1, %c_0: i1, %c_1: i1, %c_2: i1) -> (out: i1) {
+  %0 = comb.mux bin %a_1, %c_1, %c_0 : i1
+  %1 = comb.mux bin %a_0, %0, %c_2 : i1
+  %2 = comb.mux bin %a_2, %1, %c_1 : i1
+  %3 = comb.mux bin %a_1, %c_0, %2 : i1
+  %4 = comb.mux bin %a_0, %c_2, %3 : i1
+  %5 = comb.mux bin %a_2, %c_1, %4 : i1
+  %6 = comb.mux bin %a_1, %c_0, %5 : i1
+  %7 = comb.mux bin %a_0, %c_2, %6 : i1
+  %8 = comb.mux bin %a_2, %c_1, %7 : i1
+  %9 = comb.mux bin %a_1, %c_0, %8 : i1
+  %10 = comb.mux bin %a_0, %c_2, %9 : i1
+  %11 = comb.mux bin %a_2, %c_1, %10 : i1
+  %12 = comb.mux bin %a_1, %c_0, %11 : i1
+  %13 = comb.mux bin %a_0, %c_2, %12 : i1
+  %14 = comb.mux bin %a_2, %c_1, %13 : i1
+  %15 = comb.mux bin %a_1, %c_0, %14 : i1
+  %16 = comb.mux bin %a_0, %c_2, %15 : i1
+  %17 = comb.mux bin %a_2, %c_1, %16 : i1
+  %18 = comb.mux bin %a_1, %c_0, %17 : i1
+  %19 = comb.mux bin %a_0, %c_2, %18 : i1
+  %20 = comb.mux bin %a_2, %c_1, %19 : i1
+  %21 = comb.mux bin %a_1, %c_0, %20 : i1
+  %22 = comb.mux bin %a_0, %c_2, %21 : i1
+  %23 = comb.mux bin %a_2, %c_1, %22 : i1
+  %24 = comb.mux bin %a_1, %c_0, %23 : i1
+  %25 = comb.mux bin %a_0, %c_2, %24 : i1
+  %26 = comb.mux bin %a_0, %c_1, %25 : i1
+  %27 = comb.mux bin %a_0, %c_0, %26 : i1
+  hw.output %27 : i1
+
+//      CHECK:  assign out =
+// CHECK-NEXT:    a_0
+// CHECK-NEXT:      ? c_0
+// CHECK-NEXT:      : a_0
+// CHECK-NEXT:          ? c_1
+// CHECK-NEXT:          : a_0
+// CHECK-NEXT:              ? c_2
+// CHECK-NEXT:              : a_1
+// CHECK-NEXT:                  ? c_0
+// CHECK-NEXT:                  : a_2
+// CHECK-NEXT:                      ? c_1
+// CHECK-NEXT:                      : a_0
+// CHECK-NEXT:                          ? c_2
+// CHECK-NEXT:                          : a_1
+// CHECK-NEXT:                              ? c_0
+// CHECK-NEXT:                              : a_2
+// CHECK-NEXT:                                  ? c_1
+// CHECK-NEXT:                                  : a_0
+// CHECK-NEXT:                                      ? c_2
+// CHECK-NEXT:                                      : a_1
+// CHECK-NEXT:                                          ? c_0
+// CHECK-NEXT:                                          : a_2
+// CHECK-NEXT:                                              ? c_1
+// CHECK-NEXT:                                              : a_0
+// CHECK-NEXT:                                                  ? c_2
+// CHECK-NEXT:                                                  : a_1
+// CHECK-NEXT:                                                      ? c_0
+// CHECK-NEXT:                                                      : a_2
+// CHECK-NEXT:                                                          ? c_1
+// CHECK-NEXT:                                                          : a_0
+// CHECK-NEXT:                                                              ? c_2
+// CHECK-NEXT:                                                              : a_1
+// CHECK-NEXT:                                                                  ? c_0
+// CHECK-NEXT:                                                                  : a_2
+// CHECK-NEXT:                                                                      ? c_1
+// CHECK-NEXT:                                                                      : a_0
+// CHECK-NEXT:                                                                          ? c_2
+// CHECK-NEXT:                                                                          : a_1
+// CHECK-NEXT:                                                                              ? c_0
+// CHECK-NEXT:                                                                              : a_2
+// CHECK-NEXT:                                                                                  ? c_1
+// CHECK-NEXT:                                                                                  : a_0
+// CHECK-NEXT:                                                                                      ? c_2
+// CHECK-NEXT:                                                                                      : a_1
+//            ------------------------------------------------------------------------------------------v (margin=90)
+// CHECK-NEXT:                                                                                          ? c_0
+// CHECK-NEXT:                                                                                          : a_2
+// CHECK-NEXT:                                                                                              ? c_1
+// CHECK-NEXT:                                                                                              : a_0
+// CHECK-NEXT:                                                                                                  ? c_2
+// CHECK-NEXT:                                                                                                  : a_1
+// CHECK-NEXT:                                                                                                      ? c_0
+// CHECK-NEXT:                                                                                                      : a_2
+// CHECK-NEXT:                                                                                                          ? (a_0
+// CHECK-NEXT:                                                                                                               ? (a_1
+// CHECK-NEXT:                                                                                                                    ? c_1
+// CHECK-NEXT:                                                                                                                    : c_0)
+// CHECK-NEXT:                                                                                                               : c_2)
+// CHECK-NEXT:                                                                                                          : c_1;{{.*}}
+}


### PR DESCRIPTION
Allows lines to have their base indent start past the margin limit, while still targeting that for breaks.

Produces nicer outputs for giant expressions, such as very large mux chains.

Not tied to any user-facing option, but can be set when constructing PrettyPrinter instances.

Current default value is 8191.

Add test for mux chain, demonstrating and checking that base indent can start past margin.

Previously the indent would cap at margin.