### PR TITLE
unittests: Squelch -Wsuggest-override errors in LLVM's gtest.

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_custom_target(CIRCTUnitTests)
 set_target_properties(CIRCTUnitTests PROPERTIES FOLDER "CIRCT Tests")
 
+if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
+  add_compile_options("-Wno-suggest-override")
+endif()
+
 function(add_circt_unittest test_dirname)
   add_unittest(CIRCTUnitTests ${test_dirname} ${ARGN})
 endfunction()


### PR DESCRIPTION
These warnings are verbose and we can't fix them, so don't generate warnings about them.