### PR TITLE
[IMDCE] Improve liveness propagation of input ports

### DIFF
--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -300,3 +300,21 @@ firrtl.circuit "MemoryInDeadCycle" {
     firrtl.connect %w_data, %r_data : !firrtl.uint<42>, !firrtl.uint<42>
   }
 }
+
+// -----
+// CHECK-LABEL: firrtl.circuit "DeadInputPort"
+firrtl.circuit "DeadInputPort"  {
+  // CHECK-NOT: firrtl.module private @Bar
+  firrtl.module private @Bar(in %a: !firrtl.uint<1>) {
+  }
+
+  // CHECK-LABEL: firrtl.module @DeadInputPort
+  firrtl.module @DeadInputPort(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    // CHECK-NEXT: %0 = firrtl.wire
+    // CHECK-NEXT: firrtl.strictconnect %0, %a
+    // CHECK-NEXT: firrtl.strictconnect %b, %0
+    %bar_a = firrtl.instance bar  @Bar(in a: !firrtl.uint<1>)
+    firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %b, %bar_a : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Previously when an instance result was marked as alive, the liveness was propagate to its module port. This is unnecessary when the port is input port. 

For the example below, it was unable to remove module `Bar` because instance result `Bar.a` is marked as alive.  
```
circuit Foo :
  module Bar: 
    input a: UInt<1>
  module Foo :
    input a : UInt<1>
    output b : UInt<2>
    inst bar of Bar
    bar.a <= a
    b <= bar.a
```

w/ PR:
```verilog
module Foo(
  input  a,
  output b);

  assign b = a;
endmodule
```

w/o PR:
```verilog
module Bar(
  input a);

endmodule

module Foo(
  input  a,
  output b);

  Bar bar (
    .a (a)
  );
  assign b = a;
endmodule
```