### PR TITLE
[Handshake] Cleanup Handshake operations builders

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -16,7 +16,9 @@
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/HandshakePasses.h"
+#include "circt/Support/BackedgeBuilder.h"
 #include "mlir/Transforms/DialectConversion.h"
+
 #include <memory>
 
 namespace mlir {
@@ -48,8 +50,14 @@ LogicalResult partiallyLowerRegion(const RegionLoweringFunc &loweringFunc,
 // operation of the encapsulated region.
 class HandshakeLowering {
 public:
+  struct MergeOpInfo {
+    Operation *const op;
+    const Value val;
+    SmallVector<Backedge> edges;
+  };
+
   using BlockValues = DenseMap<Block *, std::vector<Value>>;
-  using BlockOps = DenseMap<Block *, std::vector<Operation *>>;
+  using BlockOps = DenseMap<Block *, std::vector<MergeOpInfo>>;
   using blockArgPairs = DenseMap<Value, Operation *>;
   using MemRefToMemoryAccessOp =
       llvm::MapVector<Value, std::vector<Operation *>>;
@@ -86,12 +94,13 @@ public:
   LogicalResult loopNetworkRewriting(ConversionPatternRewriter &rewriter);
 
   BlockOps insertMergeOps(BlockValues blockLiveIns, blockArgPairs &mergePairs,
+                          BackedgeBuilder &edgeBuilder,
                           ConversionPatternRewriter &rewriter);
 
   // Insert appropriate type of Merge CMerge for control-only path,
   // Merge for single-successor blocks, Mux otherwise
-  Operation *insertMerge(Block *block, Value val,
-                         ConversionPatternRewriter &rewriter);
+  MergeOpInfo insertMerge(Block *block, Value val, BackedgeBuilder &edgeBuilder,
+                          ConversionPatternRewriter &rewriter);
 
   // Replaces standard memory ops with their handshake version (i.e.,
   // ops which connect to memory/LSQ). Returns a map with an ordered

--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -53,7 +53,8 @@ public:
   struct MergeOpInfo {
     Operation *op;
     Value val;
-    SmallVector<Backedge> edges;
+    SmallVector<Backedge> dataEdges;
+    Optional<Backedge> indexEdge{};
   };
 
   using BlockValues = DenseMap<Block *, std::vector<Value>>;

--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -51,8 +51,8 @@ LogicalResult partiallyLowerRegion(const RegionLoweringFunc &loweringFunc,
 class HandshakeLowering {
 public:
   struct MergeOpInfo {
-    Operation *const op;
-    const Value val;
+    Operation *op;
+    Value val;
     SmallVector<Backedge> edges;
   };
 

--- a/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
+++ b/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
@@ -19,23 +19,21 @@ include "circt/Dialect/Handshake/Handshake.td"
 def HasOneOperand : Constraint<CPred<"$_self.size() == 1">, "has one operand">;
 def HasOneResult : Constraint<CPred<"$_self.size() == 1">, "has one result">;
 
-def EliminateSimpleMergesPattern : Pat<(MergeOp $dataType, $size, $arg), (replaceWithValue $arg),
+def EliminateSimpleMergesPattern : Pat<(MergeOp $arg), (replaceWithValue $arg),
                                        [(HasOneOperand:$arg)]>;
 
-def EliminateSimpleBranchesPattern
-    : Pat<(BranchOp $dataType, $a), (replaceWithValue $a)>;
+def EliminateSimpleBranchesPattern: Pat<(BranchOp  $a), (replaceWithValue $a)>;
 
-def EliminateSimpleForksPattern : Pat<(ForkOp
-                                       : $op $dataType, $size, $arg),
+def EliminateSimpleForksPattern : Pat<(ForkOp:$op $arg),
                                       (replaceWithValue $arg), [(HasOneResult
                                                                : $op)]>;
 
 def EliminateSunkConstantsPattern
-    : Pat<(SinkOp:$sink (ConstantOp $control, $value)),
+    : Pat<(SinkOp:$sink (ConstantOp $value, $ctrl)),
           (replaceWithValue $sink)>;
 
 def EliminateSunkBuffersPattern
-    : Pat<(SinkOp:$sink (BufferOp $dataType, $size, $value, $sequential, $initValues)),
-          (SinkOp $value)>;
+    : Pat<(SinkOp (BufferOp $operand, $size, $bufferType, $initValues)),
+          (SinkOp $operand)>;
 
 #endif // CIRCT_DIALECT_HANDSHAKE_HANDSHAKECANONICALIZATION_TD

--- a/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
+++ b/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
@@ -22,7 +22,7 @@ def HasOneResult : Constraint<CPred<"$_self.size() == 1">, "has one result">;
 def EliminateSimpleMergesPattern : Pat<(MergeOp $arg), (replaceWithValue $arg),
                                        [(HasOneOperand:$arg)]>;
 
-def EliminateSimpleBranchesPattern: Pat<(BranchOp  $a), (replaceWithValue $a)>;
+def EliminateSimpleBranchesPattern: Pat<(BranchOp $a), (replaceWithValue $a)>;
 
 def EliminateSimpleForksPattern : Pat<(ForkOp:$op $arg),
                                       (replaceWithValue $arg), [(HasOneResult

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -19,17 +19,16 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
   let description = [{
       Sized Operation with Single Type (SOST).
       
-      These are operations of the format: 
-      opname operands optAttrDict : dataType
-      that have a 'size' and 'dataType' properties.
-      
-      If 'explicitSize' is set, the operation is parsed as follows:
-      opname [$size] operands opAttrDict : dataType
+      These are operations whose operands all have the same type and which have
+      an integer size property, be it the number of operation operands (e.g.,
+      for a merge) or the number of operation results (e.g., for a fork).
   }];
 
   let methods = [
     InterfaceMethod<[{
         Get the data type associated to the operation.
+        The default implementation of this method simply returns the type of
+        the first operation operand.
       }],
       "Type", "getDataType", (ins), "",
       [{
@@ -39,6 +38,8 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
     >,
     InterfaceMethod<[{
         Get the size associated to the operation.
+        The default implementation of this method simply returns the number of
+        operation operands.
       }],
       "unsigned", "getSize", (ins), "",
       [{
@@ -60,7 +61,7 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
       }]
     >,
     InterfaceMethod<[{
-        Default printing format for SOST operations.
+        Print the "SOST characteristics" of an operation. 
       }],
       "void", "sostPrint", (ins 
         "mlir::OpAsmPrinter &": $printer,
@@ -75,8 +76,7 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
         }
         printer << " " << concreteOp->getOperands();
         printer.printOptionalAttrDict(concreteOp->getAttrs());
-        Type type = concreteOp.getDataType();
-        printer << " : " << type;
+        printer << " : " << concreteOp.getDataType();
       }]
     >
   ];

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -229,7 +229,7 @@ def ControlInterface : OpInterface<"ControlInterface"> {
         (ins),
         "",
         [{
-          // Implemented outside of interface due to dependence on
+          // Implemented outside of interface due to dependency on
           // SOSTInterface being declared at the time where this method is
           // defined.
           return isControlOpImpl($_op);

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -15,6 +15,73 @@
 
 include "mlir/IR/OpBase.td"
 
+def SOSTInterface : OpInterface<"SOSTInterface"> {
+  let description = [{
+      Sized Operation with Single Type (SOST).
+      
+      These are operations of the format: 
+      opname operands optAttrDict : dataType
+      that have a 'size' and 'dataType' properties.
+      
+      If 'explicitSize' is set, the operation is parsed as follows:
+      opname [$size] operands opAttrDict : dataType
+  }];
+
+  let methods = [
+    InterfaceMethod<[{
+        Get the data type associated to the operation.
+      }],
+      "Type", "getDataType", (ins), "",
+      [{
+        auto concreteOp = cast<ConcreteOp>($_op);
+        return concreteOp->getOperands().front().getType();
+      }]
+    >,
+    InterfaceMethod<[{
+        Get the size associated to the operation.
+      }],
+      "unsigned", "getSize", (ins), "",
+      [{
+        auto concreteOp = cast<ConcreteOp>($_op);
+        return concreteOp->getOperands().size();
+      }]
+    >,
+    InterfaceMethod<[{
+        Determine whether the operation is a control operation.
+        The default implementation of this method assumes that the operation
+        is a control operation if its data type is a NoneType.
+      }],
+      "bool", "sostIsControl", (ins), "",
+      [{
+        auto concreteOp = cast<ConcreteOp>($_op);
+        // The operation is a control operation if its single data type is a 
+        // NoneType.
+        return concreteOp.getDataType().template isa<NoneType>();
+      }]
+    >,
+    InterfaceMethod<[{
+        Default printing format for SOST operations.
+      }],
+      "void", "sostPrint", (ins 
+        "mlir::OpAsmPrinter &": $printer,
+        "bool": $explicitSize
+      ), "", 
+      [{
+        auto concreteOp = cast<ConcreteOp>($_op);
+
+        if (explicitSize) {
+          int size = concreteOp.getSize();
+          printer << " [" << size << "]";
+        }
+        printer << " " << concreteOp->getOperands();
+        printer.printOptionalAttrDict(concreteOp->getAttrs());
+        Type type = concreteOp.getDataType();
+        printer << " : " << type;
+      }]
+    >
+  ];
+}
+
 def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
   let description = [{
      Some handshake operations can have predecessors in other
@@ -141,10 +208,10 @@ def ControlInterface : OpInterface<"ControlInterface"> {
         (ins),
         "",
         [{
-          auto ctrlAttr = $_op->template getAttrOfType<BoolAttr>("control");
-          if(!ctrlAttr)
-            return false;
-          return ctrlAttr.getValue();
+          // Implemented outside of interface due to dependence on
+          // SOSTInterface being declared at the time where this method is
+          // defined.
+          return isControlOpImpl($_op);
         }]>];
 }
 

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -44,7 +44,7 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
       "unsigned", "getSize", (ins), "",
       [{
         auto concreteOp = cast<ConcreteOp>($_op);
-        return concreteOp->getOperands().size();
+        return concreteOp->getNumOperands();
       }]
     >,
     InterfaceMethod<[{
@@ -62,18 +62,19 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
       }]
     >,
     InterfaceMethod<[{
-        Print the "SOST characteristics" of an operation. 
+        Print the "SOST characteristics" of an operation.
+        If the `explicitSize` parameter is set to true, then the method prints
+        the operation's size (in the SOST sense) between square brackets before
+        printing the operation's operands, attributes, and data type.
       }],
       "void", "sostPrint", (ins 
-        "mlir::OpAsmPrinter &": $printer,
-        "bool": $explicitSize
+        "mlir::OpAsmPrinter &": $printer, "bool": $explicitSize
       ), "", 
       [{
         auto concreteOp = cast<ConcreteOp>($_op);
 
         if (explicitSize) {
-          int size = concreteOp.getSize();
-          printer << " [" << size << "]";
+          printer << " [" << concreteOp.getSize() << "]";
         }
         printer << " " << concreteOp->getOperands();
         printer.printOptionalAttrDict(concreteOp->getAttrs());

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -50,7 +50,8 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
     InterfaceMethod<[{
         Determine whether the operation is a control operation.
         The default implementation of this method assumes that the operation
-        is a control operation if its data type is a NoneType.
+        is a control operation if and only if its associated data type is a
+        NoneType.
       }],
       "bool", "sostIsControl", (ins), "",
       [{
@@ -80,6 +81,26 @@ def SOSTInterface : OpInterface<"SOSTInterface"> {
       }]
     >
   ];
+
+  let verify = [{
+    auto concreteOp = cast<ConcreteOp>($_op);
+
+    // SOST operation's size must be at least one
+    if (concreteOp.getSize() < 1) {
+      return concreteOp.emitOpError(
+        "SOST operation's size must be at least 1, but has size ") 
+        << concreteOp.getSize();
+    }
+
+    // SOST operation's operands must all have the same type
+    auto dataType = concreteOp.getDataType();
+    for (auto operand : concreteOp->getOperands())
+      if (operand.getType() != dataType) 
+        return concreteOp.emitOpError("SOST operation reports having data type ")
+          << dataType << ", but one operand has type " << operand.getType();
+    
+    return success();
+  }];
 }
 
 def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -53,7 +53,7 @@ struct MemStoreInterface {
 class TerminatorOp;
 
 /// Default implementation for checking whether an operation is a control
-/// operation. This function cannot be implemented within ControlInterface
+/// operation. This function cannot be defined within ControlInterface
 /// because its implementation attempts to cast the operation to an
 /// SOSTInterface, which may not be declared at the point where the default
 /// trait's method is defined. Therefore, the default implementation of

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -28,6 +28,7 @@
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/Any.h"

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -51,6 +51,14 @@ struct MemStoreInterface {
 
 class TerminatorOp;
 
+/// Default implementation for checking whether an operation is a control
+/// operation. This function cannot be implemented within ControlInterface
+/// because its implementation attempts to cast the operation to an
+/// SOSTInterface, which may not be declared at the point where the default
+/// trait's method is defined. Therefore, the default implementation of
+/// ControlInterface's isControl method simply calls this function.
+bool isControlOpImpl(Operation *op);
+
 #include "circt/Dialect/Handshake/HandshakeInterfaces.h.inc"
 
 } // end namespace handshake

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -215,7 +215,8 @@ def BufferTypeEnum: I32EnumAttr<
 }
 def BufferTypeEnumAttr: EnumAttr<Handshake_Dialect, BufferTypeEnum, "buffer_type_enum">;
 
-def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
+def BufferOp : Handshake_Op<"buffer", [Pure, HasClock, 
+  SOSTInterface,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>]> {
   let summary = "buffer operation";
@@ -235,15 +236,19 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
   }];
 
   let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
     AnyType:$operand,
+    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
     BufferTypeEnumAttr:$bufferType,
     OptionalAttr<I64ArrayAttr>:$initValues);
   let results = (outs AnyType:$result);
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Type":$dataType, "int":$size,
-    "Value":$operand, "BufferTypeEnum":$bufferType)>];
+
+  let builders = [OpBuilder<
+      (ins "Value":$operand, "int":$size, "BufferTypeEnum":$bufferType), [{
+        $_state.addOperands(operand);
+        $_state.addTypes(operand.getType());
+        $_state.addAttribute("size", IntegerAttr::get(IntegerType::get($_state.getContext(), 32), size));
+        $_state.addAttribute("bufferType", BufferTypeEnumAttr::get($_state.getContext(), bufferType));
+    }]>];
 
   let extraClassDeclaration = [{
     bool isSequential() {
@@ -267,8 +272,10 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
 }
 
 def ForkOp : Handshake_Op<"fork", [
-  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
-  HasClock, DeclareOpInterfaceMethods<GeneralOpInterface>
+  Pure, HasClock,
+  DeclareOpInterfaceMethods<SOSTInterface, ["getSize"]>, 
+  DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<GeneralOpInterface>
 ]> {
   let summary = "fork operation";
 
@@ -283,19 +290,16 @@ def ForkOp : Handshake_Op<"fork", [
     ```
   }];
 
-  let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
-    AnyType : $operand);
+  let arguments = (ins AnyType : $operand);
   let results = (outs Variadic<AnyType> : $result);
-
   let hasCanonicalizer = 1;
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$operand, "int":$outputs)>];
   let hasCustomAssemblyFormat = 1;
 }
 
-def LazyForkOp : Handshake_Op<"lazy_fork", [Pure]> {
+def LazyForkOp : Handshake_Op<"lazy_fork", [
+  Pure, 
+  DeclareOpInterfaceMethods<SOSTInterface, ["getSize", "sostIsControl"]>
+]> {
   let summary = "lazy fork operation";
   let description = [{
     The lazy_fork operation represents a lazy fork operation.
@@ -308,18 +312,13 @@ def LazyForkOp : Handshake_Op<"lazy_fork", [Pure]> {
     ```
   }];
 
-  let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
-    AnyType : $operand);
+  let arguments = (ins AnyType : $operand);
   let results = (outs Variadic<AnyType> : $result);
   let hasCustomAssemblyFormat = 1;
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$operand, "int":$outputs, "bool":$isControl)>];
 }
 
 def MergeOp : Handshake_Op<"merge", [
-  Pure, MergeLikeOpInterface,
+  Pure, MergeLikeOpInterface, SOSTInterface,
   DeclareOpInterfaceMethods<ExecutableOpInterface>
 ]> {
   let summary = "merge operation";
@@ -335,19 +334,15 @@ def MergeOp : Handshake_Op<"merge", [
     ```
   }];
 
-  let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
-    Variadic<AnyType>:$dataOperands);
+  let arguments = (ins Variadic<AnyType>:$dataOperands);
   let results = (outs AnyType:$result);
   let hasCustomAssemblyFormat = 1;
   let hasCanonicalizer = 1;
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ValueRange":$operands)>];
 }
 
 def MuxOp : Handshake_Op<"mux", [
   Pure, MergeLikeOpInterface,
+  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>
 ]> {
@@ -369,21 +364,15 @@ def MuxOp : Handshake_Op<"mux", [
     %0 = mux %select [%data0, %data1, %data2] {attributes}: index, i32
     ```
   }];
-  let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
-    AnyType : $selectOperand,
-    Variadic<AnyType> : $dataOperands);
+  let arguments = (ins AnyType : $selectOperand, Variadic<AnyType> : $dataOperands);
   let results = (outs AnyType : $result);
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$selectOperand, "ValueRange":$inputs)>];
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
 def ControlMergeOp : Handshake_Op<"control_merge", [
-  Pure, MergeLikeOpInterface, HasClock,
+  Pure, MergeLikeOpInterface, HasClock, SOSTInterface,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>
 ]> {
@@ -402,20 +391,15 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
     ```
   }];
 
-  let arguments = (ins
-    TypeAttr:$dataType,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
-    Variadic<AnyType> : $dataOperands);
+  let arguments = (ins Variadic<AnyType> : $dataOperands);
   let results = (outs AnyType : $result, Index : $index);
-
   let hasCanonicalizer = 1;
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ValueRange":$inputs)>];
   let hasCustomAssemblyFormat = 1;
 }
 
 def BranchOp : Handshake_Op<"br", [
-  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, DeclareOpInterfaceMethods<SOSTInterface, ["sostIsControl"]>, 
+  DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>,
   AllTypesMatch<["dataOperand", "dataResult"]>
   ]> {
@@ -431,20 +415,15 @@ def BranchOp : Handshake_Op<"br", [
       %1 = br %0 : i32
       ```
   }];
-  let arguments = (ins
-    TypeAttr:$dataType,
-    AnyType : $dataOperand);
+  let arguments = (ins AnyType : $dataOperand);
   let results = (outs AnyType : $dataResult);
-
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$dataOperand, "bool":$isControl)>];
-
   let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
 }
 
 def ConditionalBranchOp : Handshake_Op<"cond_br", [
   Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>,
   TypesMatchWith<"data operand type matches true branch result type",
@@ -464,13 +443,8 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
      ```
   }];
 
-  let arguments = (ins I1 : $conditionOperand,
-                       AnyType : $dataOperand);
-  let results = (outs AnyType : $trueResult,
-                      AnyType : $falseResult);
-
-  let builders = [OpBuilder<(ins "Value":$condOperand, "Value":$dataOperand, "bool":$isControl)>];
-  let skipDefaultBuilders = 1;
+  let arguments = (ins I1 : $conditionOperand, AnyType : $dataOperand);
+  let results = (outs AnyType : $trueResult, AnyType : $falseResult);
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
     // These are the indices into the dests list.
@@ -480,6 +454,7 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
 
 def SelectOp : Handshake_Op<"select", [
   Pure,
+  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   TypesMatchWith<"data operand type matches true branch result type",
                     "trueOperand", "falseOperand", "$_self">,
@@ -506,15 +481,12 @@ def SelectOp : Handshake_Op<"select", [
   let arguments = (ins I1 : $condOperand,
                        AnyType : $trueOperand, AnyType : $falseOperand);
   let results = (outs AnyType : $result);
-
-  let builders = [OpBuilder<(ins
-    "Value":$condOperand, "Value":$trueOperand, "Value":$falseOperand)>];
-  let skipDefaultBuilders = 1;
   let hasCustomAssemblyFormat = 1;
 }
 
-def SinkOp
-    : Handshake_Op<"sink", [DeclareOpInterfaceMethods<ExecutableOpInterface>]> {
+def SinkOp : Handshake_Op<"sink", [
+  SOSTInterface, DeclareOpInterfaceMethods<ExecutableOpInterface>
+]> {
   let summary = "sink operation";
   let description = [{
     The sink operation discards any data that arrives at its
@@ -525,19 +497,14 @@ def SinkOp
     sink %data : i32
     ```
   }];
+  
   let arguments = (ins AnyType:$operand);
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "Value":$operand)>,
-    // Like ODS-generated builder, needed for instantiation through declarative rewrite patterns.
-    OpBuilder<(ins
-      "TypeRange":$resultTypes, "ValueRange":$operands, "ArrayRef<::mlir::NamedAttribute>":$attributes)>
-  ];
   let hasCustomAssemblyFormat = 1;
 }
 
-def SourceOp : Handshake_Op<"source", [Pure]> {
+def SourceOp : Handshake_Op<"source", [
+  Pure, DeclareOpInterfaceMethods<SOSTInterface, ["getDataType", "getSize"]> 
+]> {
   let summary = "source operation";
   let description = [{
     The source operation represents continuous token
@@ -545,10 +512,8 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
     successor can consume at any point in time.
   }];
 
-  let skipDefaultBuilders = 1;
   let results = (outs AnyType:$result);
   let hasCustomAssemblyFormat = 1;
-  let builders = [OpBuilder<(ins)>];
 }
 
 def NeverOp : Handshake_Op<"never", [Pure]> {
@@ -582,10 +547,6 @@ def ConstantOp : Handshake_Op<"constant", [
 
   let arguments = (ins TypedAttrInterface:$value, NoneType:$ctrl);
   let results = (outs AnyType : $result);
-
-  let builders = [OpBuilder<(ins "mlir::TypedAttr":$value, "Value":$ctrl)>];
-  let skipDefaultBuilders = 1;
-
   let hasCanonicalizer = 1;
   let assemblyFormat = [{ $ctrl attr-dict `:` qualified(type($result))}];
   let hasVerifier = 1;
@@ -608,7 +569,8 @@ def EndOp
 }
 
 def StartOp : Handshake_Op<"start", [
-  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>
+  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>
 ]> {
   let summary = "start operation";
   let description = [{
@@ -793,6 +755,7 @@ def StoreOp : Handshake_Op<"store", [
 
 def JoinOp : Handshake_Op<"join", [
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<GeneralOpInterface>
 ]> {
   let summary = "join operation";
@@ -807,9 +770,6 @@ def JoinOp : Handshake_Op<"join", [
   }];
   let arguments = (ins Variadic<AnyType> : $data);
   let results = (outs NoneType : $result);
-
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ValueRange":$operands)>];
   let hasCustomAssemblyFormat = 1;
 }
 
@@ -880,7 +840,7 @@ def UnpackOp : Handshake_Op<"unpack", [
 
 def PackOp : Handshake_Op<"pack", [
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
-  DeclareOpInterfaceMethods<GeneralOpInterface>,
+  DeclareOpInterfaceMethods<GeneralOpInterface>,  
   TypesMatchWith<"input types match element types of 'tuple'",
                    "result", "inputs",
                    "$_self.cast<TupleType>().getTypes()">

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -315,7 +315,7 @@ def LazyForkOp : Handshake_Op<"lazy_fork", [Pure]> {
   let results = (outs Variadic<AnyType> : $result);
   let hasCustomAssemblyFormat = 1;
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$operand, "int":$outputs)>];
+  let builders = [OpBuilder<(ins "Value":$operand, "int":$outputs, "bool":$isControl)>];
 }
 
 def MergeOp : Handshake_Op<"merge", [
@@ -447,7 +447,7 @@ def BranchOp : Handshake_Op<"br", [
   let results = (outs AnyType : $dataResult);
 
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$dataOperand)>];
+  let builders = [OpBuilder<(ins "Value":$dataOperand, "bool":$isControl)>];
 
   let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
@@ -479,7 +479,7 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
   let results = (outs AnyType : $trueResult,
                       AnyType : $falseResult);
 
-  let builders = [OpBuilder<(ins "Value":$condOperand, "Value":$dataOperand)>];
+  let builders = [OpBuilder<(ins "Value":$condOperand, "Value":$dataOperand, "bool":$isControl)>];
   let skipDefaultBuilders = 1;
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -247,7 +247,7 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock, SameOperandsAndResultType
       (ins "Value":$operand, "int":$slots, "BufferTypeEnum":$bufferType), [{
         $_state.addOperands(operand);
         $_state.addTypes(operand.getType());
-        $_state.addAttribute("slots", IntegerAttr::get(IntegerType::get($_state.getContext(), 32), slots));
+        $_state.addAttribute("slots", $_builder.getI32IntegerAttr(slots));
         $_state.addAttribute("bufferType", BufferTypeEnumAttr::get($_state.getContext(), bufferType));
     }]>];
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -216,7 +216,7 @@ def BufferTypeEnum: I32EnumAttr<
 def BufferTypeEnumAttr: EnumAttr<Handshake_Dialect, BufferTypeEnum, "buffer_type_enum">;
 
 def BufferOp : Handshake_Op<"buffer", [Pure, HasClock, 
-  SOSTInterface,
+  DeclareOpInterfaceMethods<SOSTInterface, ["getSize"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>]> {
   let summary = "buffer operation";
@@ -237,16 +237,16 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
 
   let arguments = (ins
     AnyType:$operand,
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$size,
+    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$slots,
     BufferTypeEnumAttr:$bufferType,
     OptionalAttr<I64ArrayAttr>:$initValues);
   let results = (outs AnyType:$result);
 
   let builders = [OpBuilder<
-      (ins "Value":$operand, "int":$size, "BufferTypeEnum":$bufferType), [{
+      (ins "Value":$operand, "int":$slots, "BufferTypeEnum":$bufferType), [{
         $_state.addOperands(operand);
         $_state.addTypes(operand.getType());
-        $_state.addAttribute("size", IntegerAttr::get(IntegerType::get($_state.getContext(), 32), size));
+        $_state.addAttribute("slots", IntegerAttr::get(IntegerType::get($_state.getContext(), 32), slots));
         $_state.addAttribute("bufferType", BufferTypeEnumAttr::get($_state.getContext(), bufferType));
     }]>];
 
@@ -255,7 +255,7 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
       return this->getBufferType() == BufferTypeEnum::seq;
     }
     int getNumSlots() {
-      return (*this)->getAttrOfType<IntegerAttr>("size").getValue().getZExtValue();
+      return (*this)->getAttrOfType<IntegerAttr>("slots").getValue().getZExtValue();
     }
     SmallVector<int64_t> getInitValueArray() {
       assert(getInitValues() && "initValues attribute not set");

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -14,6 +14,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 // This is almost exactly like a standard FuncOp, except that it has some
 // extra verification conditions.  In particular, each Value must
@@ -215,7 +216,7 @@ def BufferTypeEnum: I32EnumAttr<
 }
 def BufferTypeEnumAttr: EnumAttr<Handshake_Dialect, BufferTypeEnum, "buffer_type_enum">;
 
-def BufferOp : Handshake_Op<"buffer", [Pure, HasClock, 
+def BufferOp : Handshake_Op<"buffer", [Pure, HasClock, SameOperandsAndResultType,
   DeclareOpInterfaceMethods<SOSTInterface, ["getSize"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>]> {
@@ -272,7 +273,7 @@ def BufferOp : Handshake_Op<"buffer", [Pure, HasClock,
 }
 
 def ForkOp : Handshake_Op<"fork", [
-  Pure, HasClock,
+  Pure, HasClock, SameOperandsAndResultType,
   DeclareOpInterfaceMethods<SOSTInterface, ["getSize"]>, 
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>
@@ -292,12 +293,20 @@ def ForkOp : Handshake_Op<"fork", [
 
   let arguments = (ins AnyType : $operand);
   let results = (outs Variadic<AnyType> : $result);
+  
+  let builders = [OpBuilder<
+    (ins "Value":$operand, "unsigned":$size), [{
+      $_state.addOperands(operand);
+      SmallVector<Type> resultTypes {size, operand.getType()};
+      $_state.addTypes(resultTypes);
+  }]>];
+
   let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
 }
 
 def LazyForkOp : Handshake_Op<"lazy_fork", [
-  Pure, 
+  Pure, SameOperandsAndResultType,
   DeclareOpInterfaceMethods<SOSTInterface, ["getSize", "sostIsControl"]>
 ]> {
   let summary = "lazy fork operation";
@@ -314,11 +323,19 @@ def LazyForkOp : Handshake_Op<"lazy_fork", [
 
   let arguments = (ins AnyType : $operand);
   let results = (outs Variadic<AnyType> : $result);
+
+  let builders = [OpBuilder<
+    (ins "Value":$operand, "unsigned":$size), [{
+      $_state.addOperands(operand);
+      SmallVector<Type> resultTypes {size, operand.getType()};
+      $_state.addTypes(resultTypes);
+  }]>];
+
   let hasCustomAssemblyFormat = 1;
 }
 
 def MergeOp : Handshake_Op<"merge", [
-  Pure, MergeLikeOpInterface, SOSTInterface,
+  Pure, MergeLikeOpInterface, SOSTInterface, SameOperandsAndResultType,
   DeclareOpInterfaceMethods<ExecutableOpInterface>
 ]> {
   let summary = "merge operation";
@@ -342,6 +359,7 @@ def MergeOp : Handshake_Op<"merge", [
 
 def MuxOp : Handshake_Op<"mux", [
   Pure, MergeLikeOpInterface,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>
@@ -373,6 +391,7 @@ def MuxOp : Handshake_Op<"mux", [
 
 def ControlMergeOp : Handshake_Op<"control_merge", [
   Pure, MergeLikeOpInterface, HasClock, SOSTInterface,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>
 ]> {
@@ -398,7 +417,8 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
 }
 
 def BranchOp : Handshake_Op<"br", [
-  Pure, DeclareOpInterfaceMethods<SOSTInterface, ["sostIsControl"]>, 
+  Pure, SameOperandsAndResultType,
+  DeclareOpInterfaceMethods<SOSTInterface, ["sostIsControl"]>, 
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<GeneralOpInterface>,
   AllTypesMatch<["dataOperand", "dataResult"]>
@@ -423,6 +443,7 @@ def BranchOp : Handshake_Op<"br", [
 
 def ConditionalBranchOp : Handshake_Op<"cond_br", [
   Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>,
@@ -454,6 +475,7 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
 
 def SelectOp : Handshake_Op<"select", [
   Pure,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   TypesMatchWith<"data operand type matches true branch result type",
@@ -754,6 +776,7 @@ def StoreOp : Handshake_Op<"store", [
 }
 
 def JoinOp : Handshake_Op<"join", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<GeneralOpInterface>

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -583,15 +583,15 @@ def EndOp
     all memory accesses have completed.  Currently not used(data
     returned through ReturnOp).
   }];
-  let arguments = (ins AnyType : $control, Variadic<AnyType> : $opOperands);
 
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$operand)>];
+  let arguments = (ins AnyType : $control, Variadic<AnyType> : $opOperands);
   let assemblyFormat = [{ operands attr-dict `:` qualified(type($control)) `,` qualified(type($opOperands))}];
 }
 
 def StartOp : Handshake_Op<"start", [
-  Pure, DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  Pure, 
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+  DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>
 ]> {
   let summary = "start operation";
@@ -600,11 +600,7 @@ def StartOp : Handshake_Op<"start", [
     block.  Currently not used( trigger given as function argument)
   }];
 
-  let arguments = (ins BoolAttr : $control);
   let results = (outs NoneType : $result);
-
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins)>];
   let assemblyFormat = [{ attr-dict `:` qualified(type($result))}];
 }
 
@@ -618,9 +614,11 @@ def TerminatorOp : Handshake_Op<"terminator", [Terminator]> {
   }];
 
   let successors = (successor VariadicSuccessor<AnySuccessor>:$dests);
-  let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ArrayRef<Block *>":$successors)>];
+  let builders = [OpBuilder<(ins "ArrayRef<Block *>":$successors), [{
+      $_state.addSuccessors(successors);
+  }]>];
 }
+
 
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "memref type attribute">;
 def MemoryOp : Handshake_Op<"memory", [
@@ -863,7 +861,7 @@ def UnpackOp : Handshake_Op<"unpack", [
 
 def PackOp : Handshake_Op<"pack", [
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
-  DeclareOpInterfaceMethods<GeneralOpInterface>,  
+  DeclareOpInterfaceMethods<GeneralOpInterface>,
   TypesMatchWith<"input types match element types of 'tuple'",
                    "result", "inputs",
                    "$_self.cast<TupleType>().getTypes()">

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -376,13 +376,7 @@ def MuxOp : Handshake_Op<"mux", [
     Variadic<AnyType> : $dataOperands);
   let results = (outs AnyType : $result);
   let skipDefaultBuilders = 1;
-  let builders = [
-    // Note/warning: This builder should only be used by StandardToHandshake
-    // since it contains some hardcoded assumptions that the conversion pass
-    // will manually adjust its operand later.
-    OpBuilder<(ins "Value":$anyInput, "int":$inputs)>,
-    // Use this builder for any other use case.
-    OpBuilder<(ins "Value":$selectOperand, "ValueRange":$inputs)>];
+  let builders = [OpBuilder<(ins "Value":$selectOperand, "ValueRange":$inputs)>];
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
@@ -416,11 +410,7 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
 
   let hasCanonicalizer = 1;
   let skipDefaultBuilders = 1;
-  let builders = [
-    // @note: Legacy builder used by the std-to-handshake pass. Should be removed once the pass is rewritten.
-    OpBuilder<(ins "Value":$operand, "int":$inputs)>,
-    OpBuilder<(ins "ValueRange":$inputs)>
-  ];
+  let builders = [OpBuilder<(ins "ValueRange":$inputs)>];
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -53,12 +53,13 @@ LogicalResult resolveInstanceGraph(ModuleOp moduleOp,
 // values have exactly one use.
 LogicalResult verifyAllValuesHasOneUse(handshake::FuncOp op);
 
-// Adds sink operations to any unused value in f.
+// Adds sink operations to any unused value in r.
 LogicalResult addSinkOps(Region &r, OpBuilder &rewriter);
 
-// Adds fork operations to any value with multiple uses in f.
+// Adds fork operations to any value with multiple uses in r.
 LogicalResult addForkOps(Region &r, OpBuilder &rewriter);
-void insertFork(Value result, bool isLazy, OpBuilder &rewriter);
+void insertFork(Value result, OpBuilder &rewriter);
+void insertLazyFork(Value result, bool isControl, OpBuilder &rewriter);
 
 // Adds a locking mechanism around the region.
 LogicalResult lockRegion(Region &r, OpBuilder &rewriter);

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -58,8 +58,7 @@ LogicalResult addSinkOps(Region &r, OpBuilder &rewriter);
 
 // Adds fork operations to any value with multiple uses in r.
 LogicalResult addForkOps(Region &r, OpBuilder &rewriter);
-void insertFork(Value result, OpBuilder &rewriter);
-void insertLazyFork(Value result, bool isControl, OpBuilder &rewriter);
+void insertFork(Value result, bool isLazy, OpBuilder &rewriter);
 
 // Adds a locking mechanism around the region.
 LogicalResult lockRegion(Region &r, OpBuilder &rewriter);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -134,8 +134,8 @@ static FIRRTLBaseType getBundleType(Type type) {
 }
 
 static bool isControlOp(Operation *op) {
-  auto control = op->getAttr("control");
-  return control && control.dyn_cast_or_null<BoolAttr>().getValue();
+  auto control = op->getAttrOfType<BoolAttr>("control");
+  return control && control.getValue();
 }
 
 /// A class to be used with getPortInfoForOp. Provides an opaque interface for
@@ -1119,9 +1119,8 @@ bool HandshakeBuilder::visitHandshake(SinkOp op) {
 
   rewriter.eraseOp(argValid.getDefiningOp());
 
-  if (isControlOp(op)) {
+  if (isControlOp(op))
     return true;
-  }
 
   // Non-control sink; must also have a data operand.
   assert(argSubfields.size() >= 3 &&

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -24,7 +24,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MathExtras.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <set>
 
@@ -3087,13 +3086,12 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
     // As handshake operations get lowered to FIRRTL (in particular, as
     // NonType's get lowered), the logic that determines whether an operation
     // is a control operation may no longer give the right answer. We therefore
-    // cache the isControl property of each operation before any modification
-    // to the operation and then refer to that attribute during lowering.
+    // cache the "control-ness" of each operation before any modification to the
+    // operation and then refer to that attribute instead during lowering.
     for (auto &op : funcOp.getOps()) {
       auto ctrl = dyn_cast<handshake::ControlInterface>(op);
-      if (ctrl)
-        op.setAttr("control",
-                   BoolAttr::get(rewriter.getContext(), ctrl.isControl()));
+      op.setAttr("control", BoolAttr::get(rewriter.getContext(),
+                                          ctrl && ctrl.isControl()));
     }
 
     auto maybeTopModuleOp = createTopModuleOp<FModuleOp>(

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1114,9 +1114,9 @@ bool HandshakeBuilder::visitHandshake(SinkOp op) {
 
   rewriter.eraseOp(argValid.getDefiningOp());
 
-  if (auto ctrlAttr = op->getAttrOfType<BoolAttr>("control");
-      ctrlAttr && ctrlAttr.getValue())
+  if (op.sostIsControl()) {
     return true;
+  }
 
   // Non-control sink; must also have a data operand.
   assert(argSubfields.size() >= 3 &&

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1580,8 +1580,8 @@ static void addJoinOps(ConversionPatternRewriter &rewriter,
     // Insert only single join per block
     if (!isa<JoinOp>(srcOp)) {
       rewriter.setInsertionPointAfter(srcOp);
-      Operation *newOp =
-          rewriter.create<JoinOp>(srcOp->getLoc(), SmallVector<Type>{}, val);
+      Operation *newOp = rewriter.create<JoinOp>(
+          srcOp->getLoc(), SmallVector<Type>{rewriter.getNoneType()}, val);
       for (auto &u : val.getUses())
         if (u.getOwner() != newOp)
           u.getOwner()->replaceUsesOfWith(val, newOp->getResult(0));
@@ -1669,7 +1669,8 @@ void HandshakeLowering::setMemOpControlInputs(
     else {
       rewriter.setInsertionPoint(currOp);
       Operation *joinOp = rewriter.create<JoinOp>(
-          currOp->getLoc(), SmallVector<Type>{}, controlOperands);
+          currOp->getLoc(), SmallVector<Type>{rewriter.getNoneType()},
+          controlOperands);
       addValueToOperands(currOp, joinOp->getResult(0));
     }
   }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -40,9 +40,9 @@ namespace handshake {
 #include "circt/Dialect/Handshake/HandshakeCanonicalization.h.inc"
 
 bool isControlOpImpl(Operation *op) {
-  if (auto sostInterface = dyn_cast<SOSTInterface>(op); sostInterface) {
+  if (auto sostInterface = dyn_cast<SOSTInterface>(op); sostInterface)
     return sostInterface.sostIsControl();
-  }
+
   return false;
 }
 
@@ -81,9 +81,8 @@ parseSostOperation(OpAsmParser &parser,
 static bool isControlCheckTypeAndOperand(Type dataType, Value operand) {
   // The operation is a control operation if its operand data type is a
   // NoneType.
-  if (dataType.isa<NoneType>()) {
+  if (dataType.isa<NoneType>())
     return true;
-  }
 
   // Otherwise, the operation is a control operation if the operation's
   // operand originates from the control network

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -28,8 +28,8 @@ using namespace handshake;
 using namespace mlir;
 
 static bool isControlOp(Operation *op) {
-  return op->hasAttr("control") &&
-         op->getAttrOfType<BoolAttr>("control").getValue();
+  auto controlInterface = dyn_cast<handshake::ControlInterface>(op);
+  return controlInterface && controlInterface.isControl();
 }
 
 namespace {

--- a/lib/Dialect/Handshake/Transforms/Buffers.cpp
+++ b/lib/Dialect/Handshake/Transforms/Buffers.cpp
@@ -62,8 +62,8 @@ static void insertBuffer(Location loc, Value operand, OpBuilder &builder,
                          unsigned numSlots, BufferTypeEnum bufferType) {
   auto ip = builder.saveInsertionPoint();
   builder.setInsertionPointAfterValue(operand);
-  auto bufferOp = builder.create<handshake::BufferOp>(
-      loc, operand.getType(), numSlots, operand, bufferType);
+  auto bufferOp =
+      builder.create<handshake::BufferOp>(loc, operand, numSlots, bufferType);
   operand.replaceUsesWithIf(
       bufferOp, function_ref<bool(OpOperand &)>([](OpOperand &operand) -> bool {
         return !isa<handshake::BufferOp>(operand.getOwner());

--- a/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
+++ b/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
@@ -37,9 +37,8 @@ LogicalResult handshake::lockRegion(Region &r, OpBuilder &rewriter) {
   BackedgeBuilder bebuilder(rewriter, loc);
   auto backEdge = bebuilder.get(rewriter.getNoneType());
 
-  auto buff = rewriter.create<handshake::BufferOp>(
-      loc, rewriter.getNoneType(), 1, backEdge,
-      /*bufferType=*/BufferTypeEnum::seq);
+  auto buff = rewriter.create<handshake::BufferOp>(loc, backEdge, 1,
+                                                   BufferTypeEnum::seq);
 
   // Dummy value that causes a buffer initialization, but itself does not have a
   // semantic meaning.
@@ -60,7 +59,8 @@ LogicalResult handshake::lockRegion(Region &r, OpBuilder &rewriter) {
   SmallVector<Value> endJoinOperands = llvm::to_vector(ret->getOperands());
   // Add the axilirary control signal output to the end-join
   endJoinOperands.push_back(sync.getResults().back());
-  auto endJoin = rewriter.create<JoinOp>(loc, endJoinOperands);
+  auto endJoin =
+      rewriter.create<JoinOp>(loc, SmallVector<Type>{}, endJoinOperands);
 
   backEdge.setValue(endJoin);
   return success();

--- a/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
+++ b/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
@@ -59,8 +59,7 @@ LogicalResult handshake::lockRegion(Region &r, OpBuilder &rewriter) {
   SmallVector<Value> endJoinOperands = llvm::to_vector(ret->getOperands());
   // Add the axilirary control signal output to the end-join
   endJoinOperands.push_back(sync.getResults().back());
-  auto endJoin = rewriter.create<JoinOp>(
-      loc, SmallVector<Type>{rewriter.getNoneType()}, endJoinOperands);
+  auto endJoin = rewriter.create<JoinOp>(loc, endJoinOperands);
 
   backEdge.setValue(endJoin);
   return success();

--- a/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
+++ b/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
@@ -59,8 +59,8 @@ LogicalResult handshake::lockRegion(Region &r, OpBuilder &rewriter) {
   SmallVector<Value> endJoinOperands = llvm::to_vector(ret->getOperands());
   // Add the axilirary control signal output to the end-join
   endJoinOperands.push_back(sync.getResults().back());
-  auto endJoin =
-      rewriter.create<JoinOp>(loc, SmallVector<Type>{}, endJoinOperands);
+  auto endJoin = rewriter.create<JoinOp>(
+      loc, SmallVector<Type>{rewriter.getNoneType()}, endJoinOperands);
 
   backEdge.setValue(endJoin);
   return success();

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -294,13 +294,11 @@ static Value plumbLoadPort(Location loc, OpBuilder &b,
   // We need to feed both the load data and the load done outputs.
   // Fork the extracted load data into two, and 'join' the second one to
   // generate a none-typed output to drive the load done.
-  SmallVector<Type, 2> forkResults{2, loadData.getType()};
-  auto dataFork = b.create<ForkOp>(loc, forkResults, loadData);
+  auto dataFork = b.create<ForkOp>(loc, loadData, 2);
 
   auto dataOut = dataFork.getResult()[0];
   llvm::SmallVector<Value> joinArgs = {dataFork.getResult()[1]};
-  auto dataDone =
-      b.create<JoinOp>(loc, SmallVector<Type>{b.getNoneType()}, joinArgs);
+  auto dataDone = b.create<JoinOp>(loc, joinArgs);
 
   ldif.dataOut.replaceAllUsesWith(dataOut);
   ldif.doneOut.replaceAllUsesWith(dataDone);

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -299,7 +299,8 @@ static Value plumbLoadPort(Location loc, OpBuilder &b,
 
   auto dataOut = dataFork.getResult()[0];
   llvm::SmallVector<Value> joinArgs = {dataFork.getResult()[1]};
-  auto dataDone = b.create<JoinOp>(loc, SmallVector<Type>{}, joinArgs);
+  auto dataDone =
+      b.create<JoinOp>(loc, SmallVector<Type>{b.getNoneType()}, joinArgs);
 
   ldif.dataOut.replaceAllUsesWith(dataOut);
   ldif.doneOut.replaceAllUsesWith(dataDone);

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -294,11 +294,12 @@ static Value plumbLoadPort(Location loc, OpBuilder &b,
   // We need to feed both the load data and the load done outputs.
   // Fork the extracted load data into two, and 'join' the second one to
   // generate a none-typed output to drive the load done.
-  auto dataFork = b.create<ForkOp>(loc, loadData, 2);
+  SmallVector<Type, 2> forkResults{2, loadData.getType()};
+  auto dataFork = b.create<ForkOp>(loc, forkResults, loadData);
 
   auto dataOut = dataFork.getResult()[0];
   llvm::SmallVector<Value> joinArgs = {dataFork.getResult()[1]};
-  auto dataDone = b.create<JoinOp>(loc, joinArgs);
+  auto dataDone = b.create<JoinOp>(loc, SmallVector<Type>{}, joinArgs);
 
   ldif.dataOut.replaceAllUsesWith(dataOut);
   ldif.doneOut.replaceAllUsesWith(dataDone);

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -59,13 +59,12 @@ static void insertForkGeneric(Value result, bool isLazy, bool isControl,
 
   // Insert fork after op
   rewriter.setInsertionPointAfterValue(result);
+  SmallVector<Type> forkResults{opsToProcess.size(), result.getType()};
   Operation *newOp;
   if (isLazy)
-    newOp = rewriter.create<LazyForkOp>(result.getLoc(), result,
-                                        opsToProcess.size(), isControl);
+    newOp = rewriter.create<LazyForkOp>(result.getLoc(), forkResults, result);
   else
-    newOp =
-        rewriter.create<ForkOp>(result.getLoc(), result, opsToProcess.size());
+    newOp = rewriter.create<ForkOp>(result.getLoc(), forkResults, result);
 
   // Modify operands of successor
   // opsToProcess may have multiple instances of same operand

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -42,9 +42,7 @@ static void replaceFirstUse(Operation *op, Value oldVal, Value newVal) {
 
 static void insertSink(Value val, OpBuilder &rewriter) {
   rewriter.setInsertionPointAfterValue(val);
-  auto sinkOp = rewriter.create<SinkOp>(val.getLoc(), val);
-  if (val.getType().isa<NoneType>())
-    sinkOp->setAttr("control", rewriter.getBoolAttr(true));
+  rewriter.create<SinkOp>(val.getLoc(), val);
 }
 
 namespace circt {

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -226,3 +226,20 @@ handshake.func @invalid_memref_block_arg(%arg0 : memref<2xi64>, %ctrl : none) ->
   // expected-error @-1 {{'handshake.func' op expected that block argument #0 is used by an 'extmemory' operation}}
   return %ctrl : none
 }
+
+// -----
+
+handshake.func @invalid_sost_op_zero_size(%ctrl : none) -> (none, none) {
+  // expected-error @+1 {{'handshake.merge' op must have at least one data operand}}
+  %0 = merge : none
+  return %0, %ctrl : none, none
+}
+
+// -----
+
+handshake.func @invalid_sost_op_wrong_operands(%arg0 : i64, %arg1 : i32, %ctrl : none) -> (i64, none) { // expected-note {{prior use here}}
+  // expected-error @+1 {{use of value '%arg1' expects different type than prior uses: 'i64' vs 'i32'}}
+  %0, %1 = control_merge %arg0, %arg1 : i64
+  return %0, %ctrl : i64, none
+}
+


### PR DESCRIPTION
This commit overhauls Handshake operations by
- removing the majority of custom builders
- re-enabling default operation builders in most cases,
- deleting redundant operation operands,
- deleting the `sost` namespace, whose functionality is moved to an interface (`SOSTInterface`) instead,
- and refactoring the way `ControlInterface` determines whether an operation is a control operation, without relying on a redundant operation attribute. 
 
In addition, the commit adds verification logic as well as return type inference logic for a number of Handshake operations, improving reliability and reducing redundancy.

The commit also refactors the merge insertion step in `StandardToHandshake` to use backedges instead of initially invalid merge-like operations. Operation builders that were used exclusively in that context were therefore deleted.

Fixes #3687.