### PR TITLE
[HW][ExportVerilog] Use HierPathOp in XMRRefOp

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -87,7 +87,11 @@ def HWInnerRefAttr : Attr<
 /// A flat symbol reference or a reference to a name within a module.
 def NameRefAttr : Attr<
   CPred<"$_self.isa<::mlir::FlatSymbolRefAttr, ::circt::hw::InnerRefAttr>()">,
-  "name reference attribute">;
+  "name reference attribute">{
+  let returnType = "::mlir::Attribute";
+  let convertFromStorage = "$_self";
+  let valueType = NoneType;
+}
 
 // Like a FlatSymbolRefArrayAttr, but can also refer to names inside modules.
 def NameRefArrayAttr : TypedArrayAttrBase<NameRefAttr,

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -114,7 +114,7 @@ def XMRRefOp : SVOp<"xmr.ref", []> {
     hierarchical paths cannot be known statically and may change.
   }];
   let arguments = (
-    ins SymbolNameAttr:$ref,
+    ins NameRefAttr:$ref,
         DefaultValuedAttr<StrAttr, "{}">:$stringLeaf
   );
   let results = (outs InOutType:$result);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2347,7 +2347,7 @@ SubExprInfo ExprEmitter::visitSV(XMRRefOp op) {
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   auto globalRef =
-      cast<hw::GlobalRefOp>(state.symbolCache.getDefinition(op.getRefAttr()));
+      cast<hw::HierPathOp>(state.symbolCache.getDefinition(op.getRefAttr()));
   auto namepath = globalRef.getNamepathAttr().getValue();
   auto *module = state.symbolCache.getDefinition(
       cast<InnerRefAttr>(namepath.front()).getModule());
@@ -4700,7 +4700,7 @@ StringRef ModuleEmitter::getNameRemotely(Value value,
     // to share logic.
     if (auto xmrRef = dyn_cast<XMRRefOp>(wireInput)) {
       SmallString<32> xmrString;
-      auto globalRef = cast<hw::GlobalRefOp>(
+      auto globalRef = cast<hw::HierPathOp>(
           state.symbolCache.getDefinition(xmrRef.getRefAttr()));
       auto namepath = globalRef.getNamepathAttr().getValue();
       auto *module = state.symbolCache.getDefinition(
@@ -5168,6 +5168,9 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
         })
         .Case<GlobalRefOp>([&](GlobalRefOp globalRefOp) {
           symbolCache.addDefinition(globalRefOp.getSymNameAttr(), globalRefOp);
+        })
+        .Case<HierPathOp>([&](HierPathOp hierPathOp) {
+          symbolCache.addDefinition(hierPathOp.getSymNameAttr(), hierPathOp);
         })
         .Case<TypeScopeOp>([&](TypeScopeOp op) {
           symbolCache.addDefinition(op.getNameAttr(), op);

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1321,25 +1321,16 @@ hw.module @XMR_src(%a : i23) -> (aa: i3) {
 // Additionally, test that XMRs use properly legalized Verilog names.  The XMR
 // target is "new" and the root of the reference is "wait_order".
 
-hw.globalRef @ref [
-  #hw.innerNameRef<@wait_order::@bar>,
-  #hw.innerNameRef<@XMRRef_Bar::@new>
-]
-hw.globalRef @ref2 [
-  #hw.innerNameRef<@wait_order::@baz>
-]
+hw.hierpath private @ref [@wait_order::@bar, @XMRRef_Bar::@new]
+hw.hierpath private @ref2 [@wait_order::@baz]
 hw.module @XMRRef_Bar() {
-  %new = sv.wire sym @new {
-    circt.globalRef = [#hw.globalNameRef<@ref>]
-  } : !hw.inout<i2>
+  %new = sv.wire sym @new : !hw.inout<i2>
 }
 hw.module.extern @XMRRef_Baz(%a: i2, %b: i1)
 hw.module.extern @XMRRef_Qux(%a: i2, %b: i1)
 // CHECK-LABEL: module wait_order
 hw.module @wait_order() {
-  hw.instance "bar" sym @bar @XMRRef_Bar() -> () {
-    circt.globalRef = [#hw.globalNameRef<@ref>]
-  }
+  hw.instance "bar" sym @bar @XMRRef_Bar() -> ()
   %xmr = sv.xmr.ref @ref : !hw.inout<i2>
   %xmrRead = sv.read_inout %xmr : !hw.inout<i2>
   %xmr2 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i1>
@@ -1351,8 +1342,7 @@ hw.module @wait_order() {
   // CHECK-NEXT: );
   // CHECK-NEXT: */
   hw.instance "baz" sym @baz @XMRRef_Baz(a: %xmrRead: i2, b: %xmr2Read: i1) -> () {
-    doNotPrint = true,
-    circt.globalRef = [#hw.globalNameRef<@ref2>]
+    doNotPrint = true
   }
   // CHECK-NEXT: XMRRef_Qux qux (
   // CHECK-NEXT:   .a (wait_order_0.bar.new_0),

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -366,26 +366,15 @@ hw.module @ordered_region(%a: i1) {
 }
 
 // CHECK-LABEL: hw.module @XMRRefOp
-hw.globalRef @ref [
-  #hw.innerNameRef<@XMRRefOp::@foo>,
-  #hw.innerNameRef<@XMRRefFoo::@a>
-]
-hw.globalRef @ref2 [
-  #hw.innerNameRef<@XMRRefOp::@bar>
-]
+hw.hierpath private @ref [@XMRRefOp::@foo, @XMRRefFoo::@a]
+hw.hierpath @ref2 [@XMRRefOp::@bar]
 hw.module.extern @XMRRefBar()
 hw.module @XMRRefFoo() {
-  %a = sv.wire sym @a {
-    circt.globalRef = [#hw.globalNameRef<@ref>]
-  } : !hw.inout<i2>
+  %a = sv.wire sym @a : !hw.inout<i2>
 }
 hw.module @XMRRefOp() {
-  hw.instance "foo" sym @foo @XMRRefFoo() -> () {
-    circt.globalRef = [#hw.globalNameRef<@ref>]
-  }
-  hw.instance "bar" sym @bar @XMRRefBar() -> () {
-    circt.globalRef = [#hw.globalNameRef<@ref2>]
-  }
+  hw.instance "foo" sym @foo @XMRRefFoo() -> ()
+  hw.instance "bar" sym @bar @XMRRefBar() -> ()
   // CHECK: %0 = sv.xmr.ref @ref : !hw.inout<i2>
   %0 = sv.xmr.ref @ref : !hw.inout<i2>
   // CHECK: %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i8>


### PR DESCRIPTION
Change the XMRRefOp to use a HierPathOp instead of a GlobalRefOp.  This is done as the latter is intended to replace the former (and has a lot of benefits like not having to use "breadcrumbs" everywhere).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Depends on:

- https://github.com/llvm/circt/pull/4394
- https://github.com/llvm/circt/pull/4384
- https://github.com/llvm/circt/pull/4413
- https://github.com/llvm/circt/pull/4417