### PR TITLE
[FIRRTL] Change LowerXMR to create XMRRefOps

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -115,7 +115,7 @@ getInnerRefTo(FModuleLike mod, size_t portIdx, StringRef nameHint,
               std::function<ModuleNamespace &(FModuleLike)> getNamespace);
 
 //===----------------------------------------------------------------------===//
-// RefType and BaseType utilities.
+// Type utilities
 //===----------------------------------------------------------------------===//
 
 /// If reftype, return wrapped base type.  Otherwise (if base), return as-is.
@@ -133,6 +133,11 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
       .Case<FIRRTLBaseType>([&](auto base) { return fn(base); })
       .Case<RefType>([&](auto ref) { return RefType::get(fn(ref.getType())); });
 }
+
+/// Given a type, return the corresponding lowered type for the HW dialect.
+/// Non-FIRRTL types are simply passed through. This returns a null type if it
+/// cannot be lowered.
+Type lowerType(Type type);
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -607,6 +607,7 @@ def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
     This pass lowers RefType ops and ports to verbatim encoded XMRs.
   }];
   let constructor = "circt::firrtl::createLowerXMRPass()";
+  let dependentDialects = ["sv::SVDialect"];
 }
 
 def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::CircuitOp"> {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -133,6 +133,10 @@ static bool isDuplicatableNullaryExpression(Operation *op) {
       return true;
   }
 
+  // Always duplicate XMRs into their use site.
+  if (isa<XMRRefOp>(op))
+    return true;
+
   // If this is a macro reference without side effects, allow duplication.
   if (isa<MacroRefExprOp>(op))
     return true;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -539,9 +539,6 @@ void FIRRTLModuleLowering::runOnOperation() {
             return signalPassFailure();
           state.oldToNewModuleMap[&op] = loweredMod;
         })
-        .Case<hw::HierPathOp>([&](auto nla) {
-          // Just drop it.
-        })
         .Default([&](Operation *op) {
           // We don't know what this op is.  If it has no illegal FIRRTL types,
           // we can forward the operation.  Otherwise, we emit an error and drop

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -9,11 +9,12 @@ firrtl.circuit "xmr" {
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
     %x = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
     %x2 = firrtl.ref.resolve %2 : !firrtl.ref<uint<0>>
-    // CHECK-NOT: %x2 = firrtl.ref.resolve %2 : !firrtl.ref<uint<0>>
+    // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
-    // CHECK:  %w = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}" : () -> !firrtl.uint<2> {symbols = [@xmr, #hw.innerNameRef<@xmr::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %o, %0 : !firrtl.uint<2>
+    // CHECK:      %w = firrtl.wire sym @[[wSym:[a-zA-Z0-9_]+]] : !firrtl.uint<2>
+    // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref #hw.innerNameRef<@xmr::@[[wSym]]> : !hw.inout<i2>
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
+    // CHECK:      firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
   }
 }
 
@@ -22,11 +23,13 @@ firrtl.circuit "xmr" {
 // Test the correct xmr path is generated
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK:      hw.hierpath @[[path:[a-zA-Z0-9_]+]]
+  // CHECK-SAME:   [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -40,7 +43,9 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
+    // CHECK-NEXT; firrtl.strictconnect %a, %[[#cast]] : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -70,8 +75,9 @@ firrtl.circuit "Top" {
 // Test the correct xmr path to port is generated
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
-    // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
+    // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @[[xmrSym]]) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -85,8 +91,10 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
   }
 }
 
@@ -95,11 +103,16 @@ firrtl.circuit "Top" {
 // Test for multiple readers and multiple instances
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK-DAG: hw.hierpath @[[path_0:[a-zA-Z0-9_]+]] [@Foo::@fooXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
+  // CHECK-DAG: hw.hierpath @[[path_1:[a-zA-Z0-9_]+]] [@Bar::@barXMR, @XmrSrcMod::@[[xmrSym]]]
+  // CHECK-DAG: hw.hierpath @[[path_2:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym]]]
+  // CHECK-DAG: hw.hierpath @[[path_3:[a-zA-Z0-9_]+]] [@Top::@foo, @Foo::@fooXMR, @XmrSrcMod::@[[xmrSym]]]
+  // CHECK-DAG: hw.hierpath @[[path_4:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0
-    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -108,18 +121,22 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
     firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Foo, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK:      firrtl.strictconnect %a, %[[#cast]]
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
     firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Bar, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK:      firrtl.strictconnect %a, %[[#cast]]
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -132,14 +149,20 @@ firrtl.circuit "Top" {
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_2]]
+    // CHECK-NEXT: %[[#cast_2:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %foo_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_3]]
+    // CHECK-NEXT: %[[#cast_3:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %2 = firrtl.ref.resolve %xmr_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_4]]
+    // CHECK-NEXT: %[[#cast_4:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast_2]]
     firrtl.strictconnect %b, %1 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %b, %[[#cast_3]]
     firrtl.strictconnect %c, %2 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %c, %[[#cast_4]]
   }
 }
 
@@ -148,11 +171,12 @@ firrtl.circuit "Top" {
 // Check for downward reference
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0
-    // CHECK:  %0 = firrtl.node sym @xmr_sym %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
@@ -166,14 +190,17 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
 
 }
@@ -183,6 +210,7 @@ firrtl.circuit "Top" {
 // Check for downward reference to port
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
@@ -198,14 +226,17 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
 }
 
@@ -214,10 +245,13 @@ firrtl.circuit "Top" {
 // Test for multiple paths and downward reference.
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path_0:[a-zA-Z0-9_]+]] [@Top::@foo, @Foo::@fooXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
+  // CHECK: hw.hierpath @[[path_1:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -233,9 +267,11 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2p(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@fooXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
 }
 
@@ -244,10 +280,12 @@ firrtl.circuit "Top" {
 // Test for multiple children paths
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -257,7 +295,8 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -266,15 +305,19 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
 }
 
@@ -283,10 +326,12 @@ firrtl.circuit "Top" {
 // Test for multiple children paths
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -296,7 +341,8 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -305,15 +351,19 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
 }
 
@@ -321,10 +371,12 @@ firrtl.circuit "Top" {
 
 // Multiply instantiated Top works, because the reference port does not flow through it.
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Dut::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     firrtl.instance d1 @Dut()
@@ -340,7 +392,8 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
     firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
@@ -349,23 +402,28 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
     %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}" : () -> !firrtl.uint<1> {symbols = [@Dut, #hw.innerNameRef<@Dut::@xmr>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
   }
 }
 
 // -----
 
 firrtl.circuit "Top"  {
-    // CHECK-LABEL: firrtl.module private @DUTModule
-    // CHECK-SAME: (in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
+  // CHECK-LABEL: firrtl.module private @DUTModule
+  // CHECK-SAME: (in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap: !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
@@ -390,9 +448,12 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %7, %io_dataIn : !firrtl.uint<8>
     firrtl.connect %_gen_memTap, %rf_memTap : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.ref<vector<uint<8>, 8>>
   }
+  // CHECK: firrtl.module @Top
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.ref<vector<uint<8>, 8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.ref<vector<uint<8>, 8>>
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory"
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
@@ -407,43 +468,44 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %dut_io_dataIn, %io_dataIn : !firrtl.uint<8>
     firrtl.strictconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_0:]] = firrtl.subindex %[[#cast]][0]
     firrtl.strictconnect %memTap_0, %1 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[0]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_0, %[[#cast_0]] : !firrtl.uint<8>
     %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_1:]] = firrtl.subindex %[[#cast]][1]
     firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[1]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_1, %[[#cast_1]] : !firrtl.uint<8>
     %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_2:]] = firrtl.subindex %[[#cast]][2]
     firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %2 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[2]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_2, %2 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_2, %[[#cast_2]] : !firrtl.uint<8>
     %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_3:]] = firrtl.subindex %[[#cast]][3]
     firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %3 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[3]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_3, %3 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_3, %[[#cast_3]] : !firrtl.uint<8>
     %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_4:]] = firrtl.subindex %[[#cast]][4]
     firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %4 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[4]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_4, %4 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_4, %[[#cast_4]] : !firrtl.uint<8>
     %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_5:]] = firrtl.subindex %[[#cast]][5]
     firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %5 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[5]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_5, %5 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_5, %[[#cast_5]] : !firrtl.uint<8>
     %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_6:]] = firrtl.subindex %[[#cast]][6]
     firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %6 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[6]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_6, %6 : !firrtl.uint<8>
+    // CHECK:  firrtl.strictconnect %memTap_6, %[[#cast_6]] : !firrtl.uint<8>
     %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
+    // CHECK: %[[#cast_7:]] = firrtl.subindex %[[#cast]][7]
     firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
-    // CHECK{LITERAL}:  %7 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[7]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
-    // CHECK:  firrtl.strictconnect %memTap_7, %7 : !firrtl.uint<8>
-  }
+    // CHECK:  firrtl.strictconnect %memTap_7, %[[#cast_7]] : !firrtl.uint<8>
+    }
 }
 
 // -----
 
 firrtl.circuit "Top"  {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK-LABEL:  firrtl.module private @DUTModule
   // CHECK-SAME: in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap_0: !firrtl.ref<uint<8>>, out %_gen_memTap_1: !firrtl.ref<uint<8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
@@ -457,15 +519,19 @@ firrtl.circuit "Top"  {
   }
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.ref<uint<8>>, out _gen_memTap_1: !firrtl.ref<uint<8>>)
-    // CHECK{LITERAL}:  %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[0]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
     %0 = firrtl.ref.resolve %dut__gen_memTap_0 : !firrtl.ref<uint<8>>
-    // CHECK{LITERAL}:  %1 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.Memory[1]" : () -> !firrtl.uint<8> {symbols = [@Top, #hw.innerNameRef<@Top::@xmr_sym>, #hw.innerNameRef<@DUTModule::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[0]"
+    // CHECK-NEXT: %[[#cast_0:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %1 = firrtl.ref.resolve %dut__gen_memTap_1 : !firrtl.ref<uint<8>>
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[1]"
+    // CHECK-NEXT: %[[#cast_1:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
+    // CHECK:      firrtl.strictconnect %memTap_0, %[[#cast_0]]
     firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
+    // CHECK:      firrtl.strictconnect %memTap_1, %[[#cast_1]]
   }
 }
 
@@ -474,6 +540,7 @@ firrtl.circuit "Top"  {
 // Test lowering of internal path into a module
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     // CHECK-NEXT: }
@@ -491,8 +558,10 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:  firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.internal.path" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".internal.path"
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
   }
 }
 
@@ -501,6 +570,7 @@ firrtl.circuit "Top" {
 // Test lowering of internal path into a module
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
+  // CHECK: hw.hierpath @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     // CHECK{LITERAL}:  firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
@@ -519,8 +589,10 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    // CHECK{LITERAL}:   %0 = firrtl.verbatim.expr "{{0}}.{{1}}.{{2}}.{{3}}" : () -> !firrtl.uint<1> {symbols = [@Top, #hw.innerNameRef<@Top::@bar>, #hw.innerNameRef<@Bar::@barXMR>, #hw.innerNameRef<@XmrSrcMod::@xmr_sym>]}
+    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
   }
 }
 


### PR DESCRIPTION
Change the LowerXMR pass to emit XMRRefOps instead of VerbatimExprOps. This is done to enable later inlining of these operations into their usage sites, e.g., directly into a bind.

As this has to bridge between FIRRTL and SV, this uses an unrealized conversion cast to enable usage of an InOut type from FIRRTL.  This is already correctly handled by LowerToHW.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This depends on:

- https://github.com/llvm/circt/pull/4394
- https://github.com/llvm/circt/pull/4384
- https://github.com/llvm/circt/pull/4413
- https://github.com/llvm/circt/pull/4417
- https://github.com/llvm/circt/pull/4421

This PR needs more work, but this is a demo of this working. 

Input with ref types:

```mlir
firrtl.circuit "Foo" {
  firrtl.module @Bar(out %a_ref_port: !firrtl.ref<uint<2>>) {
    %a = firrtl.wire : !firrtl.uint<2>
    %a_ref = firrtl.ref.send %a : !firrtl.uint<2>
    firrtl.strictconnect %a_ref_port, %a_ref : !firrtl.ref<uint<2>>
  }
  firrtl.module @Baz(in %a_ref_port: !firrtl.ref<uint<2>>) {
    %a = firrtl.wire : !firrtl.uint<2>
    %a_ref_resolve = firrtl.ref.resolve %a_ref_port : !firrtl.ref<uint<2>>
    firrtl.strictconnect %a, %a_ref_resolve : !firrtl.uint<2>
  }
  firrtl.module @Foo() {
    %bar_a_ref_port = firrtl.instance bar @Bar(out a_ref_port: !firrtl.ref<uint<2>>)
    %baz_a_ref_port = firrtl.instance baz @Baz(in a_ref_port: !firrtl.ref<uint<2>>)
    firrtl.strictconnect %baz_a_ref_port, %bar_a_ref_port : !firrtl.ref<uint<2>>
  }
}
```

After `LowerXMR`:

```mlir
firrtl.circuit "Foo"  {
  hw.hierpath @fooSym [@Foo::@xmr_sym, @Bar::@xmr_sym]
  firrtl.module @Bar() {
    %a = firrtl.wire sym @xmr_sym   : !firrtl.uint<2>
  }
  firrtl.module @Baz() {
    %a = firrtl.wire   : !firrtl.uint<2>
    %0 = sv.xmr.ref @fooSym : !hw.inout<i2>
    %1 = builtin.unrealized_conversion_cast %0 : !hw.inout<i2> to !firrtl.uint<2>
    firrtl.strictconnect %a, %1 : !firrtl.uint<2>
  }
  firrtl.module @Foo() {
    firrtl.instance bar sym @xmr_sym  @Bar()
    firrtl.instance baz  @Baz()
  }
}
```

After `LowerFIRRTLToHW`:

```mlir
module {
  hw.hierpath @fooSym [@Foo::@xmr_sym, @Bar::@xmr_sym]
  hw.module @Bar() {
    %a = sv.wire sym @xmr_sym  : !hw.inout<i2>
    hw.output
  }
  hw.module @Baz() {
    %a = sv.wire  : !hw.inout<i2>
    %0 = sv.xmr.ref @fooSym : !hw.inout<i2>
    %1 = sv.read_inout %0 : !hw.inout<i2>
    sv.assign %a, %1 : i2
    hw.output
  }
  hw.module @Foo() {
    hw.instance "bar" sym @xmr_sym @Bar() -> ()
    hw.instance "baz" @Baz() -> ()
    hw.output
  }
}
```

Verilog:

```verilog
// Generated by CIRCT unknown git version
module Bar();   // Bar.mlir:2:3
  wire [1:0] a; // Bar.mlir:3:10
endmodule

module Baz();   // Bar.mlir:7:3
  wire [1:0] a; // Bar.mlir:8:10
  assign a = Foo.bar.a; // Bar.mlir:9:22, :10:5
endmodule

module Foo();   // Bar.mlir:12:3
  Bar bar ();   // Bar.mlir:13:23
  Baz baz ();   // Bar.mlir:14:23
endmodule
```