### PR TITLE
[Scheduling] Overhaul simplex-based modulo scheduler.

### DIFF
--- a/lib/Scheduling/SimplexSchedulers.cpp
+++ b/lib/Scheduling/SimplexSchedulers.cpp
@@ -1042,10 +1042,10 @@ void ModuloSimplexScheduler::scheduleOperation(Operation *n) {
 
   for (unsigned ct : candTimes)
     if (succeeded(mrt.enter(n, ct))) {
-      auto fixedN = scheduleAt(stvN, stN);
+      auto fixedN = scheduleAt(stvN, ct);
       assert(succeeded(fixedN));
       (void)fixedN;
-      LLVM_DEBUG(dbgs() << "Success at t=" << stN << " " << *n << '\n');
+      LLVM_DEBUG(dbgs() << "Success at t=" << ct << " " << *n << '\n');
       return;
     }
 

--- a/test/Scheduling/modulo-problems.mlir
+++ b/test/Scheduling/modulo-problems.mlir
@@ -20,7 +20,7 @@ func.func @canis14_fig2() attributes {
 }
 
 // SIMPLEX-LABEL: minII_feasible
-// SIMPLEX-SAME: simplexInitiationInterval = 4
+// SIMPLEX-SAME: simplexInitiationInterval = 3
 func.func @minII_feasible() attributes {
   problemInitiationInterval = 3,
   auxdeps = [ [6,1,5], [5,2,3], [6,7] ],


### PR DESCRIPTION
This PR fixes #4375 and improves the quality of solutions found by the `ModuloSimplexScheduler`.

- e779cc5f162aed257303a719c8e35103c79eb0b6 was just a simple bug that caused wrong solutions with oversubscribed operator types to be returned.
- f09ae330c485afe9562b0b16f169f79e39516dcc is the main fix. This modulo scheduler works by iteratively fixing resource-limited operations to specific time steps, which are baked into the simplex tableau. In the paper, this done as a modulo decomposition, making the value dependent on the II-parameter. I believe the intention was to automatically shift ops to keep them in the same MRT slot whenever the II changes, but I didn't get that to work properly in all cases. Instead, I now just fix operations to absolute time steps (same as for the non-cyclic `SharedOperatorsProblem`), and compensate the start times of already scheduled ops myself.
- While debugging, I saw that the scheduler sometimes produces horribly bad results, because the operations have no mobility (w.r.t. the ASAP/ALAP times). In b8f878a66aec809ffc963f177ee4de9fea5775a4, I changed the behavior to look at the II-1 next time steps instead. This might make the schedule longer, but if the partial solution is still feasible under the current II, we much prefer that over incrementing the II to resolve the resource conflict.
- Lastly, 24c39aebf5e300f8d4e7f79f783442822dff811f fixes an oversight: When considering to move already scheduled operations in order to resolve the resource conflict at hand, we can skip ops that use a different operator type.