### PR TITLE
[hlstool] Remove header to fix flaky build

### DIFF
--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -48,14 +48,12 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/LoweringOptionsParser.h"
 #include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
-
-#include "circt/InitAllDialects.h"
-#include "circt/InitAllPasses.h"
 
 #include <iostream>
 


### PR DESCRIPTION
The `InitAllPasses.h` header file includes all the generated pass header files, e.g. `"circt/Dialect/SystemC/Passes.h.inc"`.  To make sure this header file is generated properly before we try to include it, we have to depend on the associated transform library.  Since hlstool does not depend on every single transform library, this causes the build to occasionally fail.  To fix this, we need to only include header files belonging to the dialects we are actually depending on.

This error can be seen in the following build:
https://github.com/llvm/circt/actions/runs/3657570236/jobs/6181309548