### PR TITLE
[FIRRTL] Update subfield format

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -880,7 +880,7 @@ This is parsed into the following MLIR.  Here, only `a.a` is invalidated:
 
 ``` mlir
 firrtl.module @Foo(out %a: !firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) {
-  %0 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) -> !firrtl.uint<1>
+  %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>, b: flip<uint<1>>>
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   firrtl.connect %0, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }

--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -178,7 +178,7 @@ Registers expect the logic assignment to them to be in SSA form.
 For example, a strict connect to a field of a structure:
 
 ```firrtl
-%field = firrtl.subfield %a(0)
+%field = firrtl.subfield %a[field]
 firrtl.strictconnect %field, %value
 ```
 Is converted into a `hw.struct_inject` operation:

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -211,7 +211,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     The subfield expression refers to a subelement of an expression with a
     bundle type.
     ```
-      %result = firrtl.subfield %input "fieldIndex" : t1, t2
+      %result = firrtl.subfield %input[field-name] : !input-type
     ```
     }];
 
@@ -220,10 +220,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
   let hasFolder = 1;
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
-
-  // TODO: Could drop the result type, inferring it from the source.
-  let assemblyFormat =
-    "$input `(` $fieldIndex `)` attr-dict `:` functional-type($input, $result)";
+  let hasCustomAssemblyFormat = 1;
 
   let builders = [
     OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
@@ -242,6 +239,12 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     FieldRef getAccessedField() {
       return FieldRef(getInput(), getInput().getType().cast<BundleType>()
                                             .getFieldID(getFieldIndex()));
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getInput().getType().cast<BundleType>()
+        .getElementName(getFieldIndex());
     }
   }];
 }

--- a/test/Conversion/FIRRTLToHW/errors.mlir
+++ b/test/Conversion/FIRRTLToHW/errors.mlir
@@ -59,20 +59,20 @@ firrtl.circuit "zero_width_mem" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c0_ui25 = firrtl.constant 0 : !firrtl.uint<25>
     %tmp41_r0, %tmp41_w0 = firrtl.mem Undefined {depth = 10 : i64, name = "tmp41", portNames = ["r0", "w0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
-    %0 = firrtl.subfield %tmp41_r0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>) -> !firrtl.clock
+    %0 = firrtl.subfield %tmp41_r0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %1 = firrtl.subfield %tmp41_r0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %tmp41_r0[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>
     firrtl.connect %1, %r0en : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %tmp41_r0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>) -> !firrtl.uint<4>
+    %2 = firrtl.subfield %tmp41_r0[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<0>>
     firrtl.connect %2, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-    %3 = firrtl.subfield %tmp41_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>) -> !firrtl.clock
+    %3 = firrtl.subfield %tmp41_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     firrtl.connect %3, %clock : !firrtl.clock, !firrtl.clock
-    %4 = firrtl.subfield %tmp41_w0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %tmp41_w0[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     firrtl.connect %4, %r0en : !firrtl.uint<1>, !firrtl.uint<1>
-    %5 = firrtl.subfield %tmp41_w0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>) -> !firrtl.uint<4>
+    %5 = firrtl.subfield %tmp41_w0[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     firrtl.connect %5, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-    %6 = firrtl.subfield %tmp41_w0(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %tmp41_w0[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     firrtl.connect %6, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %7 = firrtl.subfield %tmp41_w0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>) -> !firrtl.uint<0>
+    %7 = firrtl.subfield %tmp41_w0[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -692,37 +692,37 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @_M_combMem_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %[[v1]]: i1, RW0_wdata: %1: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK: hw.output %_M_ext.R0_data, %_M_ext.RW0_rdata : i42, i42
 
-      %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.sint<42>
+      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
       firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
-      %1 = firrtl.subfield %_M_rw(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.sint<42>
+      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %result2, %1 : !firrtl.sint<42>, !firrtl.sint<42>
-      %2 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
+      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
       firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %3 = firrtl.subfield %_M_read(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<1>
+      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
       firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.clock
+      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
       firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
 
-      %5 = firrtl.subfield %_M_rw(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %5, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %6 = firrtl.subfield %_M_rw(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.clock
+      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %8, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %9 = firrtl.subfield %_M_rw(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
       firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-      %10 = firrtl.subfield %_M_write(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+      %10 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
       firrtl.connect %10, %c0_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
-      %11 = firrtl.subfield %_M_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+      %11 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
       firrtl.connect %11, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %12 = firrtl.subfield %_M_write(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.clock
+      %12 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
       firrtl.connect %12, %clock2 : !firrtl.clock, !firrtl.clock
-      %13 = firrtl.subfield %_M_write(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.sint<42>
+      %13 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
       firrtl.connect %13, %indata : !firrtl.sint<42>, !firrtl.sint<42>
-      %14 = firrtl.subfield %_M_write(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+      %14 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
       firrtl.connect %14, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -741,38 +741,37 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata = hw.instance "_M_mask_ext" @_M_mask_combMem(R0_addr: %c0_i10: i10, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i10: i10, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %0: i40, RW0_wmask: %c0_i4: i4, W0_addr: %c0_i10: i10, W0_en: %inpred: i1, W0_clk: %clock2: i1, W0_data: %indata: i40, W0_mask: %c0_i4: i4) -> (R0_data: i40, RW0_rdata: i40)
     // CHECK: hw.output %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata : i40, i40
 
-      %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>) -> !firrtl.sint<40>
+      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
       firrtl.connect %result, %0 : !firrtl.sint<40>, !firrtl.sint<40>
-      %1 = firrtl.subfield %_M_rw(3) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.sint<40>
+      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %result2, %1 : !firrtl.sint<40>, !firrtl.sint<40>
-      %2 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>)      -> !firrtl.uint<10>
+      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
       firrtl.connect %2, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %3 = firrtl.subfield %_M_read(1) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>) -> !firrtl.uint<1>
+      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
       firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read(2) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>) -> !firrtl.clock
+      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
       firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
 
-      %5 = firrtl.subfield %_M_rw(0) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>,  wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.uint<10>
+      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>,  wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %5, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %6 = firrtl.subfield %_M_rw(1) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.uint<1>
+      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw(2) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.clock
+      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw(6) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.uint<4>
+      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %8, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-      %9 = firrtl.subfield %_M_rw(4) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>) -> !firrtl.uint<1>
+      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
       firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-      %10 = firrtl.subfield %_M_write(0) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>,
-      mask: uint<4>>) -> !firrtl.uint<10>
+      %10 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
       firrtl.connect %10, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %11 = firrtl.subfield %_M_write(1) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>) -> !firrtl.uint<1>
+      %11 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
       firrtl.connect %11, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %12 = firrtl.subfield %_M_write(2) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>) -> !firrtl.clock
+      %12 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
       firrtl.connect %12, %clock2 : !firrtl.clock, !firrtl.clock
-      %13 = firrtl.subfield %_M_write(3) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>) -> !firrtl.sint<40>
+      %13 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
       firrtl.connect %13, %indata : !firrtl.sint<40>, !firrtl.sint<40>
-      %14 = firrtl.subfield %_M_write(4) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>) -> !firrtl.uint<4>
+      %14 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
       firrtl.connect %14, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   }
   // CHECK-LABEL: hw.module private @IncompleteRead(
@@ -784,11 +783,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:  %_M_ext.R0_data = hw.instance "_M_ext" @_M_combMem(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1) -> (R0_data: i42)
     %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     // Read port.
-    %6 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
+    %6 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     firrtl.connect %6, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-    %7 = firrtl.subfield %_M_read(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %8 = firrtl.subfield %_M_read(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.clock
+    %8 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     firrtl.connect %8, %clock1 : !firrtl.clock, !firrtl.clock
   }
 
@@ -813,7 +812,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:  }
   firrtl.module private @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
                               out %fldout: !firrtl.uint<64>) {
-    %2 = firrtl.subfield %source (2) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+    %2 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     firrtl.connect %fldout, %2 : !firrtl.uint<64>, !firrtl.uint<64>
   }
 
@@ -858,7 +857,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:    hw.output
   // CHECK-NEXT:  }
   firrtl.module private @Struct0bits(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
-    %2 = firrtl.subfield %source (2) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) -> !firrtl.uint<0>
+    %2 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>
   }
 
   // CHECK-LABEL: hw.module private @MemDepth1
@@ -867,13 +866,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %mem0_ext.R0_data = hw.instance "mem0_ext" @mem0_combMem(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
     // CHECK: hw.output %mem0_ext.R0_data : i32
     %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %0 = firrtl.subfield %mem0_load0(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %0 = firrtl.subfield %mem0_load0[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %1 = firrtl.subfield %mem0_load0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %mem0_load0[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %mem0_load0(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %2 = firrtl.subfield %mem0_load0[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %data, %2 : !firrtl.uint<32>, !firrtl.uint<32>
-    %3 = firrtl.subfield %mem0_load0(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %mem0_load0[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -939,8 +938,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     //
     // CHECK: hw.instance "aa_ext" @aa_combMem
     %memory_aa_w0, %memory_aa_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "aa", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_aa_w0 = firrtl.subfield %memory_aa_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %clk_aa_w1 = firrtl.subfield %memory_aa_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+    %clk_aa_w0 = firrtl.subfield %memory_aa_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %clk_aa_w1 = firrtl.subfield %memory_aa_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %cwire1 = firrtl.wire : !firrtl.clock
     %cwire2 = firrtl.wire : !firrtl.clock
     firrtl.connect %cwire1, %clock1 : !firrtl.clock, !firrtl.clock
@@ -953,8 +952,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     //
     // CHECK: hw.instance "ab_ext" @ab_combMem
     %memory_ab_w0, %memory_ab_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_w0 = firrtl.subfield %memory_ab_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %clk_ab_w1 = firrtl.subfield %memory_ab_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+    %clk_ab_w0 = firrtl.subfield %memory_ab_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %clk_ab_w1 = firrtl.subfield %memory_ab_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     firrtl.connect %clk_ab_w0, %clock1 : !firrtl.clock, !firrtl.clock
     firrtl.connect %clk_ab_w1, %clock2 : !firrtl.clock, !firrtl.clock
 
@@ -965,8 +964,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     //
     // CHECK: hw.instance "ab_node_ext" @aa_combMem
     %memory_ab_node_w0, %memory_ab_node_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab_node", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_node_w0 = firrtl.subfield %memory_ab_node_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %clk_ab_node_w1 = firrtl.subfield %memory_ab_node_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+    %clk_ab_node_w0 = firrtl.subfield %memory_ab_node_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %clk_ab_node_w1 = firrtl.subfield %memory_ab_node_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     firrtl.connect %clk_ab_node_w0, %clock1 : !firrtl.clock, !firrtl.clock
     %tmp = firrtl.node %clock1 : !firrtl.clock
     firrtl.connect %clk_ab_node_w1, %tmp : !firrtl.clock, !firrtl.clock
@@ -1161,7 +1160,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: @subfield_write1(
   firrtl.module private @subfield_write1(out %a: !firrtl.bundle<a: uint<1>>) {
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>>
     %c0_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:      %true = hw.constant true
@@ -1174,9 +1173,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: @subfield_write2(
   firrtl.module private @subfield_write2(in %in: !firrtl.uint<1>, out %sink: !firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>) {
-    %0 = firrtl.subfield %sink(0) : (!firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>) -> !firrtl.bundle<b: bundle<c: uint<1>>>
-    %1 = firrtl.subfield %0(0) : (!firrtl.bundle<b: bundle<c: uint<1>>>) -> !firrtl.bundle<c: uint<1>>
-    %2 = firrtl.subfield %1(0) : (!firrtl.bundle<c: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %sink[a] : !firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>
+    %1 = firrtl.subfield %0[b] : !firrtl.bundle<b: bundle<c: uint<1>>>
+    %2 = firrtl.subfield %1[c] : !firrtl.bundle<c: uint<1>>
     firrtl.connect %2, %in : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:      %.sink.output = sv.wire
     // CHECK-NEXT: %0 = sv.read_inout %.sink.output : !hw.inout<struct<a: !hw.struct<b: !hw.struct<c: i1>>>>
@@ -1199,8 +1198,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @BundleConnection
   firrtl.module private @BundleConnection(in %source: !firrtl.bundle<a: bundle<b: uint<1>>>, out %sink: !firrtl.bundle<a: bundle<b: uint<1>>>) {
-    %0 = firrtl.subfield %sink(0) : (!firrtl.bundle<a: bundle<b: uint<1>>>) -> !firrtl.bundle<b: uint<1>>
-    %1 = firrtl.subfield %source(0) : (!firrtl.bundle<a: bundle<b: uint<1>>>) -> !firrtl.bundle<b: uint<1>>
+    %0 = firrtl.subfield %sink[a] : !firrtl.bundle<a: bundle<b: uint<1>>>
+    %1 = firrtl.subfield %source[a] : !firrtl.bundle<a: bundle<b: uint<1>>>
     firrtl.connect %0, %1 : !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>
     // CHECK:      %.sink.output = sv.wire
     // CHECK-NEXT: %0 = sv.read_inout %.sink.output : !hw.inout<struct<a: !hw.struct<b: i1>>>
@@ -1294,15 +1293,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
     %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %0 = firrtl.subfield %tbMemoryKind1_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
-    %1 = firrtl.subfield %tbMemoryKind1_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %tbMemoryKind1_w(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<4>
-    %3 = firrtl.subfield %tbMemoryKind1_w(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %tbMemoryKind1_w(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %5 = firrtl.subfield %tbMemoryKind1_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
-    %6 = firrtl.subfield %tbMemoryKind1_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
-    %7 = firrtl.subfield %tbMemoryKind1_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
-    %8 = firrtl.subfield %tbMemoryKind1_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+    %0 = firrtl.subfield %tbMemoryKind1_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %1 = firrtl.subfield %tbMemoryKind1_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %2 = firrtl.subfield %tbMemoryKind1_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %3 = firrtl.subfield %tbMemoryKind1_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %4 = firrtl.subfield %tbMemoryKind1_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %5 = firrtl.subfield %tbMemoryKind1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %6 = firrtl.subfield %tbMemoryKind1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %7 = firrtl.subfield %tbMemoryKind1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %8 = firrtl.subfield %tbMemoryKind1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
     firrtl.connect %8, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %7, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -1414,7 +1413,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %count = seq.firreg %0 clock %clock : !hw.struct<a: i2>
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>>
-    %field = firrtl.subfield %count(0) : (!firrtl.bundle<a: uint<2>>) -> !firrtl.uint<2>
+    %field = firrtl.subfield %count[a] : !firrtl.bundle<a: uint<2>>
     firrtl.strictconnect %field, %value : !firrtl.uint<2>
 
     // CHECK: %a = hw.struct_extract %count["a"] : !hw.struct<a: i2>
@@ -1434,9 +1433,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>, b: uint<3>>
 
-    %fieldA = firrtl.subfield %count(0) : (!firrtl.bundle<a: uint<2>, b: uint<3>>) -> !firrtl.uint<2>
+    %fieldA = firrtl.subfield %count[a] : !firrtl.bundle<a: uint<2>, b: uint<3>>
     firrtl.strictconnect %fieldA, %value2 : !firrtl.uint<2>
-    %fieldB = firrtl.subfield %count(1) : (!firrtl.bundle<a: uint<2>, b: uint<3>>) -> !firrtl.uint<3>
+    %fieldB = firrtl.subfield %count[b] : !firrtl.bundle<a: uint<2>, b: uint<3>>
     firrtl.strictconnect %fieldB, %value3 : !firrtl.uint<3>
 
     // CHECK: [[AFTER_A:%.+]] = hw.struct_inject %count["a"], %value2 : !hw.struct<a: i2, b: i3>
@@ -1454,8 +1453,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %count = seq.firreg %1 clock %clock : !hw.struct<a: !hw.struct<b: i2>>
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: bundle<b: uint<2>>>
-    %field0 = firrtl.subfield %count(0) : (!firrtl.bundle<a: bundle<b: uint<2>>>) -> !firrtl.bundle<b: uint<2>>
-    %field1 = firrtl.subfield %field0(0) : (!firrtl.bundle<b: uint<2>>) -> !firrtl.uint<2>
+    %field0 = firrtl.subfield %count[a] : !firrtl.bundle<a: bundle<b: uint<2>>>
+    %field1 = firrtl.subfield %field0[b] : !firrtl.bundle<b: uint<2>>
     firrtl.strictconnect %field1, %value : !firrtl.uint<2>
 
     // CHECK: %a = hw.struct_extract %count["a"] : !hw.struct<a: !hw.struct<b: i2>>
@@ -1474,9 +1473,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  out %result: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>) {
     %count = firrtl.reg %clock: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
     %field1 = firrtl.subindex %count[1] : !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
-    %field2 = firrtl.subfield %field1(0) : (!firrtl.bundle<a: vector<bundle<b: uint<2>>, 3>>) -> !firrtl.vector<bundle<b: uint<2>>, 3>
+    %field2 = firrtl.subfield %field1[a] : !firrtl.bundle<a: vector<bundle<b: uint<2>>, 3>>
     %field3 = firrtl.subindex %field2[1] : !firrtl.vector<bundle<b: uint<2>>, 3>
-    %field4 = firrtl.subfield %field3(0) : (!firrtl.bundle<b: uint<2>>) -> !firrtl.uint<2>
+    %field4 = firrtl.subfield %field3[b] : !firrtl.bundle<b: uint<2>>
     firrtl.strictconnect %field4, %value : !firrtl.uint<2>
 
     // CHECK:           %[[VAL_10:.*]] = seq.firreg %[[VAL_11:.*]] clock %clock : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -1,15 +1,15 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK: firrtl.module @arith_addi_in_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:   %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   %[[VAL_12:.*]] = firrtl.add %[[VAL_5]], %[[VAL_8]] : (!firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<65>
 // CHECK:   %[[VAL_13:.*]] = firrtl.bits %[[VAL_12]] 63 to 0 : (!firrtl.uint<65>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %[[VAL_11]], %[[VAL_13]] : !firrtl.uint<64>, !firrtl.uint<64>

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK: firrtl.module @handshake_br_in_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:   %[[VAL_2:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[VAL_2:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   firrtl.connect %[[VAL_5]], %[[VAL_2]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[VAL_3]], %[[VAL_6]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[VAL_7]], %[[VAL_4]] : !firrtl.uint<64>, !firrtl.uint<64>

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -2,10 +2,10 @@
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_3slots_seq_1ins_1outs_ctrl(
 // CHECK-SAME:  in %[[arg0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[arg1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-// CHECK:   %[[IN_VALID:.+]] = firrtl.subfield %[[arg0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[IN_READY:.+]] = firrtl.subfield %[[arg0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[OUT_VALID:.+]] = firrtl.subfield %[[arg1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[OUT_READY:.+]] = firrtl.subfield %[[arg1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:   %[[IN_VALID:.+]] = firrtl.subfield %[[arg0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[IN_READY:.+]] = firrtl.subfield %[[arg0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[OUT_VALID:.+]] = firrtl.subfield %[[arg1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[OUT_READY:.+]] = firrtl.subfield %[[arg1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 
 // Stage 0 ready wire and valid register.
@@ -91,8 +91,8 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_in_ui64_out_ui64_2slots_seq(
 // CHECK-SAME:  in %[[arg0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[arg1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-// CHECK:   %[[IN_DATA:.+]] = firrtl.subfield %[[arg0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %[[arg1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[IN_DATA:.+]] = firrtl.subfield %[[arg0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %[[arg1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   %c0_ui64 = firrtl.constant 0 : !firrtl.uint<64>
 
 // CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -3,15 +3,15 @@
 // Test a control merge that is control only.
 
 // CHECK:           firrtl.module @handshake_control_merge_out_ui64_2ins_2outs_ctrl(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[CLOCK:.*]]: !firrtl.clock, in %[[RESET:.*]]: !firrtl.uint<1>) {
-// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant 0 : !firrtl.uint<2>
@@ -98,9 +98,9 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // Test a control merge that also outputs the selected input's data.
 
 // CHECK:           firrtl.module @handshake_control_merge_in_ui64_ui64_out_ui64_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_4:.*]]: !firrtl.clock, in %[[VAL_5:.*]]: !firrtl.uint<1>) {
-// CHECK: %[[ARG0_DATA:.+]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK: %[[ARG1_DATA:.+]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK: %[[ARG0_DATA:.+]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %[[ARG1_DATA:.+]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // ...
 // CHECK:   %win = firrtl.wire : !firrtl.uint<2>
 // ...

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -2,18 +2,18 @@
 
 // CHECK-LABEL: firrtl.module @handshake_cond_br_in_ui1_ui64_out_ui64_ui64(
 // CHECK-SAME:  in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG2:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG3:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:   %0 = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %2 = firrtl.subfield %[[ARG0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %3 = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %[[ARG2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %7 = firrtl.subfield %[[ARG2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %[[ARG2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %9 = firrtl.subfield %[[ARG3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %10 = firrtl.subfield %[[ARG3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.subfield %[[ARG3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %0 = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:   %1 = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:   %2 = firrtl.subfield %[[ARG0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:   %3 = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %4 = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %5 = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %6 = firrtl.subfield %[[ARG2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %7 = firrtl.subfield %[[ARG2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %8 = firrtl.subfield %[[ARG2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %9 = firrtl.subfield %[[ARG3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %10 = firrtl.subfield %[[ARG3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %11 = firrtl.subfield %[[ARG3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   %12 = firrtl.and %0, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.not %2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %14 = firrtl.and %2, %12 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -3,11 +3,11 @@
 // Submodule for the index and i64 ConstantOps as they have the same value and converted type.
 // CHECK-LABEL: firrtl.module @handshake_constant_c42_out_ui64(
 // CHECK-SAME: in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   firrtl.connect %[[ARG1_VALID:.+]], %[[ARG0_VALID:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[ARG0_READY:.+]], %[[ARG1_READY:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %c42_ui64 = firrtl.constant 42 : !firrtl.uint<64>

--- a/test/Conversion/HandshakeToFIRRTL/test_extmemory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_extmemory.mlir
@@ -1,59 +1,59 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK:           firrtl.module @handshake_extmemory_in_ui32_ui64_ui64_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_6:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) {
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_0]](3) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_0]](4) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_0]](5) : (!firrtl.bundle<[[ARG1:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3:.+]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4:.+]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6:.+]]: bundle<valid: uint<1>, ready flip: uint<1>>>) -> !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_19:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_20:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_21:.*]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_22:.*]] = firrtl.subfield %[[VAL_4]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_23:.*]] = firrtl.subfield %[[VAL_4]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_24:.*]] = firrtl.subfield %[[VAL_4]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_25:.*]] = firrtl.subfield %[[VAL_5]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_26:.*]] = firrtl.subfield %[[VAL_5]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_27:.*]] = firrtl.subfield %[[VAL_6]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_28:.*]] = firrtl.subfield %[[VAL_6]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_29:.*]] = firrtl.subfield %[[VAL_7]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_0]][[[ARG1]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_0]][[[ARG2]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_0]][[[ARG3]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_0]][[[ARG4]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_0]][[[ARG5]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_0]][[[ARG6]]] : !firrtl.bundle<[[ARG1]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG2]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG3]] flip: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, [[ARG4]]: bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, [[ARG5]]: bundle<valid: uint<1>, ready flip: uint<1>>, [[ARG6]]: bundle<valid: uint<1>, ready flip: uint<1>>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_19:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_20:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_21:.*]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_22:.*]] = firrtl.subfield %[[VAL_4]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_23:.*]] = firrtl.subfield %[[VAL_4]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_24:.*]] = firrtl.subfield %[[VAL_4]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_25:.*]] = firrtl.subfield %[[VAL_5]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_26:.*]] = firrtl.subfield %[[VAL_5]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_27:.*]] = firrtl.subfield %[[VAL_6]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_28:.*]] = firrtl.subfield %[[VAL_6]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_29:.*]] = firrtl.subfield %[[VAL_7]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_29]], %[[VAL_13]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_30:.*]] = firrtl.subfield %[[VAL_7]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_30:.*]] = firrtl.subfield %[[VAL_7]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_14]], %[[VAL_30]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_31:.*]] = firrtl.subfield %[[VAL_7]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_31:.*]] = firrtl.subfield %[[VAL_7]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_31]], %[[VAL_15]] : !firrtl.uint<32>, !firrtl.uint<32>
-// CHECK:             %[[VAL_32:.*]] = firrtl.subfield %[[VAL_8]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_32:.*]] = firrtl.subfield %[[VAL_8]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_32]], %[[VAL_16]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_33:.*]] = firrtl.subfield %[[VAL_8]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_33:.*]] = firrtl.subfield %[[VAL_8]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_17]], %[[VAL_33]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_34:.*]] = firrtl.subfield %[[VAL_8]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_34:.*]] = firrtl.subfield %[[VAL_8]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_34]], %[[VAL_18]] : !firrtl.uint<64>, !firrtl.uint<64>
-// CHECK:             %[[VAL_35:.*]] = firrtl.subfield %[[VAL_9]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_35:.*]] = firrtl.subfield %[[VAL_9]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_35]], %[[VAL_19]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_36:.*]] = firrtl.subfield %[[VAL_9]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_36:.*]] = firrtl.subfield %[[VAL_9]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_20]], %[[VAL_36]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_37:.*]] = firrtl.subfield %[[VAL_9]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_37:.*]] = firrtl.subfield %[[VAL_9]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_37]], %[[VAL_21]] : !firrtl.uint<64>, !firrtl.uint<64>
-// CHECK:             %[[VAL_38:.*]] = firrtl.subfield %[[VAL_10]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_38:.*]] = firrtl.subfield %[[VAL_10]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_22]], %[[VAL_38]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_39:.*]] = firrtl.subfield %[[VAL_10]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_39:.*]] = firrtl.subfield %[[VAL_10]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_39]], %[[VAL_23]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_40:.*]] = firrtl.subfield %[[VAL_10]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_40:.*]] = firrtl.subfield %[[VAL_10]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_24]], %[[VAL_40]] : !firrtl.uint<32>, !firrtl.uint<32>
-// CHECK:             %[[VAL_41:.*]] = firrtl.subfield %[[VAL_11]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_41:.*]] = firrtl.subfield %[[VAL_11]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_25]], %[[VAL_41]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_42:.*]] = firrtl.subfield %[[VAL_11]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_42:.*]] = firrtl.subfield %[[VAL_11]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_42]], %[[VAL_26]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_43:.*]] = firrtl.subfield %[[VAL_12]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_43:.*]] = firrtl.subfield %[[VAL_12]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_27]], %[[VAL_43]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_44:.*]] = firrtl.subfield %[[VAL_12]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_44:.*]] = firrtl.subfield %[[VAL_12]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_44]], %[[VAL_28]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:           }
 

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -2,12 +2,12 @@
 
 // CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ctrl(
 // CHECK-SAME:  in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[ARG2:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>
-// CHECK:   %[[ARG_VALID:.+]] = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %[[ARG2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %[[ARG2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG_VALID:.+]] = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %[[ARG2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %[[ARG2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 
 // Done logic.
 // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -71,9 +71,9 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
 // CHECK-LABEL: firrtl.module @handshake_fork_in_ui64_out_ui64_ui64(
 // CHECK-SAME: in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG2:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-// CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %[[ARG0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %[[ARG2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %[[ARG0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %[[ARG2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 
 // CHECK:   firrtl.connect %[[RES0_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:   firrtl.connect %[[RES1_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>

--- a/test/Conversion/HandshakeToFIRRTL/test_index_cast.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_index_cast.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s --split-input-file | FileCheck %s
   
 // CHECK:      firrtl.module @arith_index_cast_in_ui64_out_ui8(in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) {
-// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
+// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
 // CHECK-NEXT:   %6 = firrtl.bits %2 7 to 0 : (!firrtl.uint<64>) -> !firrtl.uint<8>
 // CHECK-NEXT:   firrtl.connect %5, %6 : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:   firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -28,12 +28,12 @@ handshake.func @test_index_cast(%arg0: index, %arg1: none, ...) -> (i8, none) {
 // -----
 
 // CHECK:      firrtl.module @arith_index_cast_in_ui8_out_ui64(in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
-// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK-NEXT:   %6 = firrtl.pad %2, 64 : (!firrtl.uint<8>) -> !firrtl.uint<64>
 // CHECK-NEXT:   firrtl.connect %5, %6 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK-NEXT:   firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -41,12 +41,12 @@ handshake.func @test_index_cast(%arg0: index, %arg1: none, ...) -> (i8, none) {
 // CHECK-NEXT:   firrtl.connect %1, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT: }
 // CHECK-NEXT: firrtl.module @arith_index_cast_in_ui9_out_ui64(in %[[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>, out %[[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>) -> !firrtl.uint<9>
-// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK-NEXT:   %0 = firrtl.subfield %[[ARG0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>
+// CHECK-NEXT:   %1 = firrtl.subfield %[[ARG0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>
+// CHECK-NEXT:   %2 = firrtl.subfield %[[ARG0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>
+// CHECK-NEXT:   %3 = firrtl.subfield %[[ARG1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %4 = firrtl.subfield %[[ARG1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK-NEXT:   %5 = firrtl.subfield %[[ARG1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK-NEXT:   %6 = firrtl.pad %2, 64 : (!firrtl.uint<9>) -> !firrtl.uint<64>
 // CHECK-NEXT:   firrtl.connect %5, %6 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK-NEXT:   firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_join.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_join.mlir
@@ -2,12 +2,12 @@
 
 // CHECK-LABEL:   firrtl.circuit "test_join"   {
 // CHECK:           firrtl.module @handshake_join_2ins_1outs_ctrl(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) {
-// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             %[[VAL_9:.*]] = firrtl.and %[[VAL_5]], %[[VAL_3]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_7]], %[[VAL_9]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_10:.*]] = firrtl.and %[[VAL_8]], %[[VAL_9]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -28,16 +28,16 @@ handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, 
 // CHECK-SAME:      in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>,
 // CHECK-SAME:      in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>,
 // CHECK-SAME:      out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) {
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             %[[VAL_14:.*]] = firrtl.and %[[VAL_7]], %[[VAL_4]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             %[[VAL_15:.*]] = firrtl.and %[[VAL_10]], %[[VAL_14]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_12]], %[[VAL_15]] : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -2,15 +2,15 @@
 
 // CHECK-LABEL:   firrtl.circuit "test_lazy_fork"   {
 // CHECK:           firrtl.module @handshake_lazy_fork_in_ui64_out_ui64_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             %[[VAL_12:.*]] = firrtl.and %[[VAL_10]], %[[VAL_7]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_4]], %[[VAL_12]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_13:.*]] = firrtl.and %[[VAL_3]], %[[VAL_12]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_load.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_load.mlir
@@ -1,20 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file -verify-diagnostics %s
 
 // CHECK:           firrtl.module @handshake_load_in_ui64_ui8_out_ui8_ui64(in %[[VAL_87:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_88:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %[[VAL_89:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_90:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[VAL_91:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:             %[[VAL_92:.*]] = firrtl.subfield %[[VAL_87]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_93:.*]] = firrtl.subfield %[[VAL_87]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_94:.*]] = firrtl.subfield %[[VAL_87]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_95:.*]] = firrtl.subfield %[[VAL_88]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_96:.*]] = firrtl.subfield %[[VAL_88]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_97:.*]] = firrtl.subfield %[[VAL_88]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
-// CHECK:             %[[VAL_98:.*]] = firrtl.subfield %[[VAL_89]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_99:.*]] = firrtl.subfield %[[VAL_89]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_100:.*]] = firrtl.subfield %[[VAL_90]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_101:.*]] = firrtl.subfield %[[VAL_90]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_102:.*]] = firrtl.subfield %[[VAL_90]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
-// CHECK:             %[[VAL_103:.*]] = firrtl.subfield %[[VAL_91]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_104:.*]] = firrtl.subfield %[[VAL_91]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_105:.*]] = firrtl.subfield %[[VAL_91]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_92:.*]] = firrtl.subfield %[[VAL_87]][0] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_93:.*]] = firrtl.subfield %[[VAL_87]][1] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_94:.*]] = firrtl.subfield %[[VAL_87]][2] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_95:.*]] = firrtl.subfield %[[VAL_88]][0] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_96:.*]] = firrtl.subfield %[[VAL_88]][1] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_97:.*]] = firrtl.subfield %[[VAL_88]][2] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_98:.*]] = firrtl.subfield %[[VAL_89]][0] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_99:.*]] = firrtl.subfield %[[VAL_89]][1] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_100:.*]] = firrtl.subfield %[[VAL_90]][0] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_101:.*]] = firrtl.subfield %[[VAL_90]][1] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_102:.*]] = firrtl.subfield %[[VAL_90]][2] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_103:.*]] = firrtl.subfield %[[VAL_91]][0] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_104:.*]] = firrtl.subfield %[[VAL_91]][1] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_105:.*]] = firrtl.subfield %[[VAL_91]][2] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             firrtl.connect %[[VAL_105]], %[[VAL_94]] : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:             firrtl.connect %[[VAL_102]], %[[VAL_97]] : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK:             %[[VAL_106:.*]] = firrtl.and %[[VAL_92]], %[[VAL_98]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -1,42 +1,42 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK:  firrtl.module @handshake_memory_out_ui8_id0(in %[[ARG0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %[[ARG1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[ARG2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[ARG3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[ARG4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[ARG5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[ARG6:.*]]: !firrtl.clock, in %[[ARG7:.*]]: !firrtl.uint<1>) {
-// CHECK: %[[ST_DATA_VALID:.+]] = firrtl.subfield %[[ARG0]](0)
-// CHECK: %[[ST_DATA_READY:.+]] = firrtl.subfield %[[ARG0]](1)
-// CHECK: %[[ST_DATA_DATA:.+]] = firrtl.subfield %[[ARG0]](2)
-// CHECK: %[[ST_ADDR_VALID:.+]] = firrtl.subfield %[[ARG1]](0)
-// CHECK: %[[ST_ADDR_READY:.+]] = firrtl.subfield %[[ARG1]](1)
-// CHECK: %[[ST_ADDR_DATA:.+]] = firrtl.subfield %[[ARG1]](2)
-// CHECK: %[[LD_ADDR_VALID:.+]] = firrtl.subfield %[[ARG2]](0)
-// CHECK: %[[LD_ADDR_READY:.+]] = firrtl.subfield %[[ARG2]](1)
-// CHECK: %[[LD_ADDR_DATA:.+]] = firrtl.subfield %[[ARG2]](2)
-// CHECK: %[[LD_DATA_VALID:.+]] = firrtl.subfield %[[ARG3]](0)
-// CHECK: %[[LD_DATA_READY:.+]] = firrtl.subfield %[[ARG3]](1)
-// CHECK: %[[LD_DATA_DATA:.+]] = firrtl.subfield %[[ARG3]](2)
-// CHECK: %[[ST_CONTROL_VALID:.+]] = firrtl.subfield %[[ARG4]](0)
-// CHECK: %[[ST_CONTROL_READY:.+]] = firrtl.subfield %[[ARG4]](1)
-// CHECK: %[[LD_CONTROL_VALID:.+]] = firrtl.subfield %[[ARG5]](0)
-// CHECK: %[[LD_CONTROL_READY:.+]] = firrtl.subfield %[[ARG5]](1)
+// CHECK: %[[ST_DATA_VALID:.+]] = firrtl.subfield %[[ARG0]][valid]
+// CHECK: %[[ST_DATA_READY:.+]] = firrtl.subfield %[[ARG0]][ready]
+// CHECK: %[[ST_DATA_DATA:.+]] = firrtl.subfield %[[ARG0]][data]
+// CHECK: %[[ST_ADDR_VALID:.+]] = firrtl.subfield %[[ARG1]][valid]
+// CHECK: %[[ST_ADDR_READY:.+]] = firrtl.subfield %[[ARG1]][ready]
+// CHECK: %[[ST_ADDR_DATA:.+]] = firrtl.subfield %[[ARG1]][data]
+// CHECK: %[[LD_ADDR_VALID:.+]] = firrtl.subfield %[[ARG2]][valid]
+// CHECK: %[[LD_ADDR_READY:.+]] = firrtl.subfield %[[ARG2]][ready]
+// CHECK: %[[LD_ADDR_DATA:.+]] = firrtl.subfield %[[ARG2]][data]
+// CHECK: %[[LD_DATA_VALID:.+]] = firrtl.subfield %[[ARG3]][valid]
+// CHECK: %[[LD_DATA_READY:.+]] = firrtl.subfield %[[ARG3]][ready]
+// CHECK: %[[LD_DATA_DATA:.+]] = firrtl.subfield %[[ARG3]][data]
+// CHECK: %[[ST_CONTROL_VALID:.+]] = firrtl.subfield %[[ARG4]][valid]
+// CHECK: %[[ST_CONTROL_READY:.+]] = firrtl.subfield %[[ARG4]][ready]
+// CHECK: %[[LD_CONTROL_VALID:.+]] = firrtl.subfield %[[ARG5]][valid]
+// CHECK: %[[LD_CONTROL_READY:.+]] = firrtl.subfield %[[ARG5]][ready]
 
 // Construct the memory.
 // CHECK: %[[MEM_LOAD:.+]], %[[MEM_STORE:.+]] = firrtl.mem Old {depth = 10 : i64, name = "mem0", portNames = ["load0", "store0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
 
 
 // Connect the store clock.
-// CHECK: %[[MEM_LOAD_CLK:.+]] = firrtl.subfield %[[MEM_LOAD]](2) : {{.*}} -> !firrtl.clock
+// CHECK: %[[MEM_LOAD_CLK:.+]] = firrtl.subfield %[[MEM_LOAD]][clk]
 // CHECK: firrtl.connect %[[MEM_LOAD_CLK]], %clock
 
 // Connect the load address, truncating if necessary.
-// CHECK: %[[MEM_LOAD_ADDR:.+]] = firrtl.subfield %[[MEM_LOAD]](0) : {{.*}} -> !firrtl.uint<4>
+// CHECK: %[[MEM_LOAD_ADDR:.+]] = firrtl.subfield %[[MEM_LOAD]][addr]
 // CHECK: %[[LD_ADDR_DATA_TAIL:.+]] = firrtl.tail %[[LD_ADDR_DATA]], 60 : (!firrtl.uint<64>) -> !firrtl.uint<4>
 // CHECK: firrtl.connect %[[MEM_LOAD_ADDR]], %[[LD_ADDR_DATA_TAIL]]
 
 // Connect the load data.
-// CHECK: %[[MEM_LOAD_DATA:.+]] = firrtl.subfield %[[MEM_LOAD]](3) : {{.*}} -> !firrtl.uint<8>
+// CHECK: %[[MEM_LOAD_DATA:.+]] = firrtl.subfield %[[MEM_LOAD]][data]
 // CHECK: firrtl.connect %[[LD_DATA_DATA]], %[[MEM_LOAD_DATA]]
 
 // Connect the load address valid to the load enable.
-// CHECK: %[[MEM_LOAD_EN:.+]] = firrtl.subfield %[[MEM_LOAD]](1) : {{.*}} -> !firrtl.uint<1>
+// CHECK: %[[MEM_LOAD_EN:.+]] = firrtl.subfield %[[MEM_LOAD]][en]
 // CHECK: firrtl.connect %[[MEM_LOAD_EN]], %[[LD_ADDR_VALID]]
 
 // Create control-only fork for the load address valid and ready signal to the
@@ -50,16 +50,16 @@
 // CHECK-DAG: firrtl.{{.+}} %[[LD_CONTROL_READY]]
 
 // Connect the store clock.
-// CHECK: %[[MEM_STORE_CLK:.+]] = firrtl.subfield %[[MEM_STORE]](2) : {{.*}} -> !firrtl.clock
+// CHECK: %[[MEM_STORE_CLK:.+]] = firrtl.subfield %[[MEM_STORE]][clk]
 // CHECK: firrtl.connect %[[MEM_STORE_CLK]], %clock
 
 // Connect the store address, truncating if necessary.
-// CHECK: %[[MEM_STORE_ADDR:.+]] = firrtl.subfield %[[MEM_STORE]](0) : {{.*}} -> !firrtl.uint<4>
+// CHECK: %[[MEM_STORE_ADDR:.+]] = firrtl.subfield %[[MEM_STORE]][addr]
 // CHECK: %[[ST_ADDR_DATA_TAIL:.+]] = firrtl.tail %[[ST_ADDR_DATA]], 60 : (!firrtl.uint<64>) -> !firrtl.uint<4>
 // CHECK: firrtl.connect %[[MEM_STORE_ADDR]], %[[ST_ADDR_DATA_TAIL]]
 
 // Connect the store data.
-// CHECK: %[[MEM_STORE_DATA:.+]] = firrtl.subfield %[[MEM_STORE]](3) : {{.*}} -> !firrtl.uint<8>
+// CHECK: %[[MEM_STORE_DATA:.+]] = firrtl.subfield %[[MEM_STORE]][data]
 // CHECK: firrtl.connect %[[MEM_STORE_DATA]], %[[ST_DATA_DATA]]
 
 // Create the write valid buffer.
@@ -88,11 +88,11 @@
 // CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID_BUFFER_MUX]]
 
 // Connect the write valid signal to the memory enable
-// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]](1) : {{.*}} -> !firrtl.uint<1>
+// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]][en]
 // CHECK: firrtl.connect %[[MEM_STORE_EN]], %[[WRITE_VALID]]
 
 // Connect the write valid signal to the memory mask.
-// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]](4) : {{.*}} -> !firrtl.uint<1>
+// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]][mask]
 // CHECK: firrtl.connect %[[MEM_STORE_MASK]], %[[WRITE_VALID]]
 
 // CHECK: firrtl.module @main(in %[[VAL_69:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %[[VAL_70:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_71:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_72:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[VAL_73:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_74:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_75:.*]]: !firrtl.clock, in %[[VAL_76:.*]]: !firrtl.uint<1>) {

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -1,15 +1,15 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK: firrtl.module @handshake_merge_in_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant 0 : !firrtl.uint<2>

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -1,18 +1,18 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK:           firrtl.module @handshake_mux_in_ui64_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             %[[VAL_16:.*]] = firrtl.bits %[[VAL_6]] 0 to 0 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:             %[[VAL_17:.*]] = firrtl.mux(%[[VAL_16]], %[[VAL_12]], %[[VAL_9]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
 // CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_17]] : !firrtl.uint<64>, !firrtl.uint<64>
@@ -45,10 +45,10 @@ handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, 
 // Test a mux tree with an odd number of inputs.
 
 // CHECK:           firrtl.module @handshake_mux_in_ui64_ui64_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]](2)
-// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]](2)
-// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]](2)
-// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_4]](2)
+// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]][data]
+// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]][data]
+// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]][data]
+// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_4]][data]
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA3]], %[[MUX1]])
 // CHECK: firrtl.connect %[[RESULT]], %[[MUX2]]
@@ -62,15 +62,15 @@ handshake.func @test_mux_3way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 // Test a mux tree with multiple full layers.
 
 // CHECK:           firrtl.module @handshake_mux_in_ui64_ui64_ui64_ui64_ui64_ui64_ui64_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_6:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_7:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_8:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_9:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]](2)
-// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]](2)
-// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]](2)
-// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]](2)
-// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]](2)
-// CHECK: %[[DATA6:.+]] = firrtl.subfield %[[VAL_6]](2)
-// CHECK: %[[DATA7:.+]] = firrtl.subfield %[[VAL_7]](2)
-// CHECK: %[[DATA8:.+]] = firrtl.subfield %[[VAL_8]](2)
-// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_9]](2)
+// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]][data]
+// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]][data]
+// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]][data]
+// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]][data]
+// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]][data]
+// CHECK: %[[DATA6:.+]] = firrtl.subfield %[[VAL_6]][data]
+// CHECK: %[[DATA7:.+]] = firrtl.subfield %[[VAL_7]][data]
+// CHECK: %[[DATA8:.+]] = firrtl.subfield %[[VAL_8]][data]
+// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_9]][data]
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA4]], %[[DATA3]])
 // CHECK: %[[MUX5:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
@@ -89,12 +89,12 @@ handshake.func @test_mux_8way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 // Test a mux tree with multiple layers and a partial first layer (odd).
 
 // CHECK:           firrtl.module @handshake_mux_in_ui64_ui64_ui64_ui64_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_6:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]](2)
-// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]](2)
-// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]](2)
-// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]](2)
-// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]](2)
-// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_6]](2)
+// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]][data]
+// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]][data]
+// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]][data]
+// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]][data]
+// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]][data]
+// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_6]][data]
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA4]], %[[DATA3]])
 // CHECK: %[[MUX3:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
@@ -111,13 +111,13 @@ handshake.func @test_mux_5way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 // Test a mux tree with multiple layers and a partial first layer (even).
 
 // CHECK:           firrtl.module @handshake_mux_in_ui64_ui64_ui64_ui64_ui64_ui64_ui64_out_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_6:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_7:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]](2)
-// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]](2)
-// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]](2)
-// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]](2)
-// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]](2)
-// CHECK: %[[DATA6:.+]] = firrtl.subfield %[[VAL_6]](2)
-// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_7]](2)
+// CHECK: %[[DATA1:.+]] = firrtl.subfield %[[VAL_1]][data]
+// CHECK: %[[DATA2:.+]] = firrtl.subfield %[[VAL_2]][data]
+// CHECK: %[[DATA3:.+]] = firrtl.subfield %[[VAL_3]][data]
+// CHECK: %[[DATA4:.+]] = firrtl.subfield %[[VAL_4]][data]
+// CHECK: %[[DATA5:.+]] = firrtl.subfield %[[VAL_5]][data]
+// CHECK: %[[DATA6:.+]] = firrtl.subfield %[[VAL_6]][data]
+// CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_7]][data]
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA4]], %[[DATA3]])
 // CHECK: %[[MUX3:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])

--- a/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
@@ -4,17 +4,17 @@
 // CHECK-SAME:    in %[[IN0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
 // CHECK-SAME:    in %[[IN1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>,
 // CHECK-SAME:    out %[[OUT:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) {
-// CHECK:    %[[IN0_VALID:.*]] = firrtl.subfield %[[IN0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:    %[[IN0_READY:.*]] = firrtl.subfield %[[IN0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:    %[[IN0_DATA:.*]] = firrtl.subfield %[[IN0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:    %[[IN1_VALID:.*]] = firrtl.subfield %[[IN1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:    %[[IN1_READY:.*]] = firrtl.subfield %[[IN1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:    %[[IN1_DATA:.*]] = firrtl.subfield %[[IN1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:    %[[OUT_VALID:.*]] = firrtl.subfield %[[OUT]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.uint<1>
-// CHECK:    %[[OUT_READY:.*]] = firrtl.subfield %[[OUT]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.uint<1>
-// CHECK:    %[[OUT_DATA:.*]] = firrtl.subfield %[[OUT]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.bundle<field0: uint<64>, field1: uint<32>>
-// CHECK:    %[[VAL_9:.*]] = firrtl.subfield %[[OUT_DATA]](0) : (!firrtl.bundle<field0: uint<64>, field1: uint<32>>) -> !firrtl.uint<64>
-// CHECK:    %[[VAL_10:.*]] = firrtl.subfield %[[OUT_DATA]](1) : (!firrtl.bundle<field0: uint<64>, field1: uint<32>>) -> !firrtl.uint<32>
+// CHECK:    %[[IN0_VALID:.*]] = firrtl.subfield %[[IN0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:    %[[IN0_READY:.*]] = firrtl.subfield %[[IN0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:    %[[IN0_DATA:.*]] = firrtl.subfield %[[IN0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:    %[[IN1_VALID:.*]] = firrtl.subfield %[[IN1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:    %[[IN1_READY:.*]] = firrtl.subfield %[[IN1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:    %[[IN1_DATA:.*]] = firrtl.subfield %[[IN1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:    %[[OUT_VALID:.*]] = firrtl.subfield %[[OUT]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:    %[[OUT_READY:.*]] = firrtl.subfield %[[OUT]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:    %[[OUT_DATA:.*]] = firrtl.subfield %[[OUT]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:    %[[VAL_9:.*]] = firrtl.subfield %[[OUT_DATA]][field0] : !firrtl.bundle<field0: uint<64>, field1: uint<32>>
+// CHECK:    %[[VAL_10:.*]] = firrtl.subfield %[[OUT_DATA]][field1] : !firrtl.bundle<field0: uint<64>, field1: uint<32>>
 // CHECK:    firrtl.connect %[[VAL_9]], %[[IN0_DATA]] : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:    firrtl.connect %[[VAL_10]], %[[IN1_DATA]] : !firrtl.uint<32>, !firrtl.uint<32>
 // CHECK:    %[[VAL_11:.*]] = firrtl.and %[[IN1_VALID]], %[[IN0_VALID]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -39,17 +39,17 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK-SAME:    out %[[OUT1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>,
 // CHECK-SAME:    in %[[CLOCK:.*]]: !firrtl.clock,
 // CHECK-SAME:    in %[[RESET:.*]]: !firrtl.uint<1>) {
-// CHECK:  %[[IN_VALID:.*]] = firrtl.subfield %[[IN]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.uint<1>
-// CHECK:  %[[IN_READY:.*]] = firrtl.subfield %[[IN]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.uint<1>
-// CHECK:  %[[IN_DATA:.*]] = firrtl.subfield %[[IN]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>) -> !firrtl.bundle<field0: uint<64>, field1: uint<32>>
-// CHECK:  %[[OUT0_VALID:.*]] = firrtl.subfield %[[OUT0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:  %[[OUT0_READY:.*]] = firrtl.subfield %[[OUT0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:  %[[OUT0_DATA:.*]] = firrtl.subfield %[[OUT0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:  %[[OUT1_VALID:.*]] = firrtl.subfield %[[OUT1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:  %[[OUT1_READY:.*]] = firrtl.subfield %[[OUT1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:  %[[OUT1_DATA:.*]] = firrtl.subfield %[[OUT1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:  %[[VAL_9:.*]] = firrtl.subfield %[[IN_DATA]](0) : (!firrtl.bundle<field0: uint<64>, field1: uint<32>>) -> !firrtl.uint<64>
-// CHECK:  %[[VAL_10:.*]] = firrtl.subfield %[[IN_DATA]](1) : (!firrtl.bundle<field0: uint<64>, field1: uint<32>>) -> !firrtl.uint<32>
+// CHECK:  %[[IN_VALID:.*]] = firrtl.subfield %[[IN]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:  %[[IN_READY:.*]] = firrtl.subfield %[[IN]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:  %[[IN_DATA:.*]] = firrtl.subfield %[[IN]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:  %[[OUT0_VALID:.*]] = firrtl.subfield %[[OUT0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:  %[[OUT0_READY:.*]] = firrtl.subfield %[[OUT0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:  %[[OUT0_DATA:.*]] = firrtl.subfield %[[OUT0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:  %[[OUT1_VALID:.*]] = firrtl.subfield %[[OUT1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:  %[[OUT1_READY:.*]] = firrtl.subfield %[[OUT1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:  %[[OUT1_DATA:.*]] = firrtl.subfield %[[OUT1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:  %[[VAL_9:.*]] = firrtl.subfield %[[IN_DATA]][field0] : !firrtl.bundle<field0: uint<64>, field1: uint<32>>
+// CHECK:  %[[VAL_10:.*]] = firrtl.subfield %[[IN_DATA]][field1] : !firrtl.bundle<field0: uint<64>, field1: uint<32>>
 // CHECK:  firrtl.connect %[[OUT0_DATA]], %[[VAL_9]] : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:  firrtl.connect %[[OUT1_DATA]], %[[VAL_10]] : !firrtl.uint<32>, !firrtl.uint<32>
 

--- a/test/Conversion/HandshakeToFIRRTL/test_select.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_select.mlir
@@ -2,18 +2,18 @@
 
 // CHECK-LABEL:   firrtl.circuit "test_select"   {
 // CHECK:           firrtl.module @handshake_select_in_ui1_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             %[[VAL_16:.*]] = firrtl.bits %[[VAL_6]] 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             %[[VAL_17:.*]] = firrtl.mux(%[[VAL_16]], %[[VAL_9]], %[[VAL_12]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
 // CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_17]] : !firrtl.uint<32>, !firrtl.uint<32>

--- a/test/Conversion/HandshakeToFIRRTL/test_signed_ops.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_signed_ops.mlir
@@ -3,15 +3,15 @@
 
 // CHECK:  firrtl.circuit "test_cmpi"  {
 // CHECK:    firrtl.module @arith_cmpi_in_ui32_ui32_out_ui1_sgt(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) {
-// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
 // CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_14:.*]] = firrtl.gt %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.uint<1>
@@ -33,15 +33,15 @@ handshake.func @test_cmpi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i1, none
 
 // CHECK:  firrtl.circuit "test_divsi"  {
 // CHECK:    firrtl.module @arith_divsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
-// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_14:.*]] = firrtl.div %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.sint<33>
@@ -63,15 +63,15 @@ handshake.func @test_divsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, no
 
 // CHECK:  firrtl.circuit "test_remsi"  {
 // CHECK:    firrtl.module @arith_remsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
-// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_14:.*]] = firrtl.rem %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.sint<32>
@@ -93,12 +93,12 @@ handshake.func @test_remsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, no
 
 // CHECK:  firrtl.circuit "test_extsi"  {
 // CHECK:    firrtl.module @arith_extsi_in_ui16_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
-// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<16>
-// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:      %[[VAL_9:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<16>) -> !firrtl.sint<16>
 // CHECK:      %[[VAL_10:.*]] = firrtl.pad %[[VAL_9]], 16 : (!firrtl.sint<16>) -> !firrtl.sint<16>
 // CHECK:      %[[VAL_11:.*]] = firrtl.asUInt %[[VAL_10]] : (!firrtl.sint<16>) -> !firrtl.uint<16>
@@ -117,15 +117,15 @@ handshake.func @test_extsi(%arg0: i16, %arg1: none, ...) -> (i32, none) {
 
 // CHECK:  firrtl.circuit "test_shrsi"  {
 // CHECK:    firrtl.module @arith_shrsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
-// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_14:.*]] = firrtl.dshr %[[VAL_12]], %[[VAL_8]] : (!firrtl.sint<32>, !firrtl.uint<32>) -> !firrtl.sint<32>
 // CHECK:      %[[VAL_15:.*]] = firrtl.asUInt %[[VAL_14]] : (!firrtl.sint<32>) -> !firrtl.uint<32>

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL:   firrtl.circuit "test_sink"   {
 // CHECK:           firrtl.module @handshake_sink_in_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:             %[[VAL_1:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_1:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             %[[VAL_2:.*]] = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_1]], %[[VAL_2]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:           }

--- a/test/Conversion/HandshakeToFIRRTL/test_source.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_source.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK:           firrtl.module @handshake_source_0ins_1outs_ctrl(out %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) {
-// CHECK:             %[[VAL_1:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_1:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             %[[VAL_2:.*]] = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_1]], %[[VAL_2]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:           }

--- a/test/Conversion/HandshakeToFIRRTL/test_store.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_store.mlir
@@ -1,20 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK:           firrtl.module @handshake_store_in_ui64_ui8_out_ui8_ui64(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
-// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_4]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_4]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_4]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_4]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_4]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_4]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:             %[[VAL_19:.*]] = firrtl.wire  : !firrtl.uint<1>
 // CHECK:             %[[VAL_20:.*]] = firrtl.and %[[VAL_14]], %[[VAL_17]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             %[[VAL_21:.*]] = firrtl.and %[[VAL_5]], %[[VAL_8]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
@@ -2,22 +2,22 @@
 
 // CHECK-LABEL:   firrtl.circuit "multi_in"  {
 // CHECK:           firrtl.module @handshake_sync_in_ui32_ui512_out_ui32_ui512(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_5:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>, in %[[VAL_6:.*]]: !firrtl.clock, in %[[VAL_7:.*]]: !firrtl.uint<1>) {
-// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<512>
-// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_4]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_19:.*]] = firrtl.subfield %[[VAL_4]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_20:.*]] = firrtl.subfield %[[VAL_4]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_21:.*]] = firrtl.subfield %[[VAL_5]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_22:.*]] = firrtl.subfield %[[VAL_5]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_23:.*]] = firrtl.subfield %[[VAL_5]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>) -> !firrtl.uint<512>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_2]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_2]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_2]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
+// CHECK:             %[[VAL_16:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_17:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             %[[VAL_18:.*]] = firrtl.subfield %[[VAL_4]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_19:.*]] = firrtl.subfield %[[VAL_4]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_20:.*]] = firrtl.subfield %[[VAL_4]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_21:.*]] = firrtl.subfield %[[VAL_5]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
+// CHECK:             %[[VAL_22:.*]] = firrtl.subfield %[[VAL_5]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
+// CHECK:             %[[VAL_23:.*]] = firrtl.subfield %[[VAL_5]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<512>>
 // CHECK:             %[[VAL_24:.*]] = firrtl.wire   : !firrtl.uint<1>
 // CHECK:             %[[VAL_25:.*]] = firrtl.wire   : !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_20]], %[[VAL_12]] : !firrtl.uint<32>, !firrtl.uint<32>

--- a/test/Conversion/HandshakeToFIRRTL/test_trunci.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_trunci.mlir
@@ -3,12 +3,12 @@
 // CHECK-LABEL:     firrtl.module @arith_trunci_in_ui32_out_ui8(
 // CHECK-SAME:          in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>,
 // CHECK-SAME:          out %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) {
-// CHECK:             %[[VAL_2:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
-// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>) -> !firrtl.uint<8>
+// CHECK:             %[[VAL_2:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_1]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
 // CHECK:             %[[VAL_8:.*]] = firrtl.bits %[[VAL_4]] 7 to 0 : (!firrtl.uint<32>) -> !firrtl.uint<8>
 // CHECK:             firrtl.connect %[[VAL_7]], %[[VAL_8]] : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK:             firrtl.connect %[[VAL_5]], %[[VAL_2]] : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through subfield connects.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
-    %bundle0.a = firrtl.subfield %bundle0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    %bundle0.a = firrtl.subfield %bundle0[0] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
@@ -24,7 +24,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through multiple connect hops.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
-    %bundle0.a = firrtl.subfield %bundle0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    %bundle0.a = firrtl.subfield %bundle0[0] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     %bundle1 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
@@ -25,7 +25,7 @@ firrtl.circuit "AsyncResetConst" {
 
     // Constant check should see through subfield connects.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
-    %bundle0.a = firrtl.subfield %bundle0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    %bundle0.a = firrtl.subfield %bundle0[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
     %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -860,14 +860,14 @@ firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}]
 // CHECK-SAME: %a: !firrtl.uint<1>
 // CHECK:      %r = firrtl.reg  %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %[[view_companion_view__2refPort:.+]], %[[view_companion_view__2refPort_1:.+]], %[[view_companion_view__1refPort:.+]], %[[view_companion_view__0refPort:.+]], %[[view_companion_view_portrefPort:.+]] = firrtl.instance view_companion  @view_companion(in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>, in {{.*}}: !firrtl.ref<uint<1>>)
-// CHECK:      %0 = firrtl.subfield %r(1) : (!firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>) -> !firrtl.vector<uint<1>, 2>
+// CHECK:      %0 = firrtl.subfield %r[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<1>, 2>
-// CHECK:      %2 = firrtl.subfield %r(1) : (!firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>) -> !firrtl.vector<uint<1>, 2>
+// CHECK:      %2 = firrtl.subfield %r[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %3 = firrtl.subindex %2[1] : !firrtl.vector<uint<1>, 2>
-// CHECK:      %4 = firrtl.subfield %r(0) : (!firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>) -> !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      %5 = firrtl.subfield %4(1) : (!firrtl.bundle<_0: uint<1>, _1: uint<1>>) -> !firrtl.uint<1>
-// CHECK:      %6 = firrtl.subfield %r(0) : (!firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>) -> !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      %7 = firrtl.subfield %6(0) : (!firrtl.bundle<_0: uint<1>, _1: uint<1>>) -> !firrtl.uint<1>
+// CHECK:      %4 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
+// CHECK:      %5 = firrtl.subfield %4[_1] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
+// CHECK:      %6 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
+// CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %8 = firrtl.ref.send %1 : !firrtl.uint<1>
 // CHECK:      firrtl.connect %view_companion__1_0, %8 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
 // CHECK:      %9 = firrtl.ref.send %3 : !firrtl.uint<1>
@@ -1352,8 +1352,8 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
   // CHECK-SAME:   out %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<2>>
   firrtl.module @Bar() {
     %a = firrtl.wire interesting_name  : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    // CHECK:      %[[a_0:[a-zA-Z0-9_]+]] = firrtl.subfield %a(0)
-    // CHECK-NEXT: %[[a_1:[a-zA-Z0-9_]+]] = firrtl.subfield %a(1)
+    // CHECK:      %[[a_0:[a-zA-Z0-9_]+]] = firrtl.subfield %a[a]
+    // CHECK-NEXT: %[[a_1:[a-zA-Z0-9_]+]] = firrtl.subfield %a[b]
     // CHECK-NEXT: %[[a_0_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %[[a_0]]
     // CHECK-NEXT: firrtl.connect %[[refPort_0]], %[[a_0_ref]]
     // CHECK-NEXT: %[[a_1_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %[[a_1]]

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -698,7 +698,7 @@ firrtl.module @subfield(out %out : !firrtl.uint<8>) {
   // CHECK: %c8_ui8 = firrtl.constant 8 : !firrtl.uint<8>
   // CHECK: firrtl.strictconnect %out, %c8_ui8 : !firrtl.uint<8>
   %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
-  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+  %1 = firrtl.subfield %0[a] : !firrtl.bundle<a: uint<8>>
   firrtl.strictconnect %out, %1 : !firrtl.uint<8>
 }
 
@@ -707,7 +707,7 @@ firrtl.module @subfield_agg(out %out : !firrtl.vector<uint<8>, 1>) {
   // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
   // CHECK: firrtl.strictconnect %out, %0 : !firrtl.vector<uint<8>, 1>
   %0 = firrtl.aggregateconstant [[8 : ui8]] : !firrtl.bundle<a: vector<uint<8>, 1>>
-  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a: vector<uint<8>, 1>>) -> !firrtl.vector<uint<8>, 1>
+  %1 = firrtl.subfield %0[a] : !firrtl.bundle<a: vector<uint<8>, 1>>
   firrtl.strictconnect %out, %1 : !firrtl.vector<uint<8>, 1>
 }
 
@@ -2174,8 +2174,8 @@ firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, dat
 // CHECK-LABEL: firrtl.module @MergeBundle
 firrtl.module @MergeBundle(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i:!firrtl.uint<1> ) {
   %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-  %a0 = firrtl.subfield %a(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a1 = firrtl.subfield %a(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a0 = firrtl.subfield %a[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a1 = firrtl.subfield %a[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   firrtl.strictconnect %a0, %i : !firrtl.uint<1>
   firrtl.strictconnect %a1, %i : !firrtl.uint<1>
   firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
@@ -2206,12 +2206,12 @@ firrtl.module @MergeAgg(out %o: !firrtl.vector<bundle<valid: uint<1>, ready: uin
   %a0 = firrtl.subindex %a[0] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
   %a1 = firrtl.subindex %a[1] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
   %a2 = firrtl.subindex %a[2] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
-  %a00 = firrtl.subfield %a0(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a01 = firrtl.subfield %a0(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a10 = firrtl.subfield %a1(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a11 = firrtl.subfield %a1(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a20 = firrtl.subfield %a2(0) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
-  %a21 = firrtl.subfield %a2(1) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>>) -> !firrtl.uint<1>
+  %a00 = firrtl.subfield %a0[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a01 = firrtl.subfield %a0[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a10 = firrtl.subfield %a1[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a11 = firrtl.subfield %a1[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a20 = firrtl.subfield %a2[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  %a21 = firrtl.subfield %a2[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   firrtl.strictconnect %a00, %c : !firrtl.uint<1>
   firrtl.strictconnect %a01, %c : !firrtl.uint<1>
   firrtl.strictconnect %a10, %c : !firrtl.uint<1>
@@ -2535,7 +2535,7 @@ firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out 
 firrtl.module @CrashAllUnusedPorts() {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %foo, %bar = firrtl.mem  Undefined  {depth = 3 : i64, groupID = 4 : ui32, name = "whatever", portNames = ["MPORT_1", "MPORT_5"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<1>>, !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<2>>
-  %26 = firrtl.subfield %foo(1) : (!firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<1>>) -> !firrtl.uint<1>
+  %26 = firrtl.subfield %foo[en] : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<1>>
   firrtl.strictconnect %26, %c0_ui1 : !firrtl.uint<1>
 }
 

--- a/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
@@ -32,16 +32,16 @@ module  {
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-      %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
+      %0 = firrtl.subfield %m_r[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
       // expected-note @+1 {{hasloops.m.r.addr}}
-      %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %m_r[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %m_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       %c1_ui = firrtl.constant 1 : !firrtl.uint
       firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
       // expected-note @+1 {{hasloops.m.r.data}}
-      %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %3 = firrtl.subfield %m_r[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -90,15 +90,15 @@ module  {
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-      %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
+      %0 = firrtl.subfield %m_r[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
       // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %m_r[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %m_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       %c1_ui = firrtl.constant 1 : !firrtl.uint
       firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-      %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %3 = firrtl.subfield %m_r[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -192,7 +192,7 @@ firrtl.circuit "vectorRegInit"   {
 firrtl.circuit "bundleRegInit"   {
   firrtl.module @bundleRegInit(in %clk: !firrtl.clock) {
     %reg = firrtl.reg %clk : !firrtl.bundle<a: uint<1>>
-    %0 = firrtl.subfield %reg(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %reg[a] : !firrtl.bundle<a: uint<1>>
     firrtl.connect %0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -264,8 +264,8 @@ firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, in %b : !firrtl.bundle<
 firrtl.circuit "test" {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, out %b : !firrtl.bundle<f1: uint<1>>) {
-  %0 = firrtl.subfield %a(0) : (!firrtl.bundle<f1: uint<1>>) -> !firrtl.uint<1>
-  %1 = firrtl.subfield %b(0) : (!firrtl.bundle<f1: uint<1>>) -> !firrtl.uint<1>
+  %0 = firrtl.subfield %a[f1] : !firrtl.bundle<f1: uint<1>>
+  %1 = firrtl.subfield %b[f1] : !firrtl.bundle<f1: uint<1>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.f1" has source flow, expected sink or duplex flow}}
   firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -305,10 +305,10 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a: bundle<a flip: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: bundle<a flip: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %a_a_a = firrtl.subfield %a_a(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %ax_a_a = firrtl.subfield %ax_a(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+  %a_a_a = firrtl.subfield %a_a[a] : !firrtl.bundle<a flip: uint<1>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+  %ax_a_a = firrtl.subfield %ax_a[a] : !firrtl.bundle<a flip: uint<1>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.a.a" has source flow}}
   firrtl.connect %a_a_a, %ax_a_a : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -326,8 +326,8 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
   // expected-error @+1 {{the destination expression "a.a" has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
 }
@@ -345,10 +345,10 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %a_a_a = firrtl.subfield %a_a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %ax_a_a = firrtl.subfield %ax_a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %a_a_a = firrtl.subfield %a_a[a] : !firrtl.bundle<a: uint<1>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %ax_a_a = firrtl.subfield %ax_a[a] : !firrtl.bundle<a: uint<1>>
   // expected-error @+1 {{connect has invalid flow: the destination expression "a.a.a" has source flow}}
   firrtl.connect %a_a_a, %ax_a_a : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -366,8 +366,8 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a flip: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.a" has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
 }
@@ -395,7 +395,7 @@ firrtl.circuit "test" {
 firrtl.module @test(out %a: !firrtl.uint<1>) {
   // expected-note @below {{the source was defined here}}
   %memory_r = firrtl.mem Undefined  {depth = 2 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  %memory_r_en = firrtl.subfield %memory_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+  %memory_r_en = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
   // expected-error @below {{connect has invalid flow: the source expression "memory.r.en" has sink flow}}
   firrtl.connect %a, %memory_r_en : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -413,10 +413,10 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a: bundle<a flip: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: bundle<a flip: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %a_a_a = firrtl.subfield %a_a(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %ax_a_a = firrtl.subfield %ax_a(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+  %a_a_a = firrtl.subfield %a_a[a] : !firrtl.bundle<a flip: uint<1>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+  %ax_a_a = firrtl.subfield %ax_a[a] : !firrtl.bundle<a flip: uint<1>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.a.a" has source flow}}
   firrtl.connect %a_a_a, %ax_a_a : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -434,8 +434,8 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
   // expected-error @+1 {{connect has invalid flow: the destination expression "a.a" has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
 }
@@ -453,10 +453,10 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %a_a_a = firrtl.subfield %a_a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-  %ax_a_a = firrtl.subfield %ax_a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %a_a_a = firrtl.subfield %a_a[a] : !firrtl.bundle<a: uint<1>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+  %ax_a_a = firrtl.subfield %ax_a[a] : !firrtl.bundle<a: uint<1>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.a.a" has source flow}}
   firrtl.connect %a_a_a, %ax_a_a : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -474,8 +474,8 @@ firrtl.circuit "test"  {
 // expected-note @below {{the destination was defined here}}
 firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a flip: uint<1>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
-  %a_a = firrtl.subfield %a(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-  %ax_a = firrtl.subfield %ax(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
+  %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
+  %ax_a = firrtl.subfield %ax[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
   // expected-error @below {{connect has invalid flow: the destination expression "a.a" has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
 }
@@ -503,7 +503,7 @@ firrtl.circuit "test" {
 firrtl.module @test(out %a: !firrtl.uint<1>) {
   // expected-note @below {{the source was defined here}}
   %memory_r = firrtl.mem Undefined  {depth = 2 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  %memory_r_en = firrtl.subfield %memory_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+  %memory_r_en = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
   // expected-error @below {{connect has invalid flow: the source expression "memory.r.en" has sink flow}}
   firrtl.connect %a, %memory_r_en : !firrtl.uint<1>, !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -119,7 +119,7 @@ firrtl.module @wires3(out %out : !firrtl.uint<1>) {
 
 firrtl.module @wires4(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
-  %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -41,17 +41,17 @@ firrtl.circuit "Simple" {
 firrtl.circuit "PrimOps" {
   // CHECK: firrtl.module @PrimOps0
   firrtl.module @PrimOps0(in %a: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) {
-    %a_a = firrtl.subfield %a(0): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
-    %a_b = firrtl.subfield %a(1): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
-    %a_c = firrtl.subfield %a(2): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
+    %a_b = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
+    %a_c = firrtl.subfield %a[c] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %0 = firrtl.xor %a_a, %a_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
     firrtl.connect %a_c, %a_b: !firrtl.uint<2>, !firrtl.uint<2>
   }
   // CHECK-NOT: firrtl.module @PrimOps1
   firrtl.module @PrimOps1(in %b: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) {
-    %b_a = firrtl.subfield %b(0): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
-    %b_b = firrtl.subfield %b(1): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
-    %b_c = firrtl.subfield %b(2): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %b_a = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
+    %b_b = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
+    %b_c = firrtl.subfield %b[c] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %0 = firrtl.xor %b_a, %b_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
     firrtl.connect %b_c, %b_b: !firrtl.uint<2>, !firrtl.uint<2>
   }
@@ -485,15 +485,15 @@ firrtl.circuit "Bundle" {
     // CHECK: firrtl.instance bundle1  @Bundle0
     %e = firrtl.instance bundle1 @Bundle1(out e: !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>)
 
-    // CHECK: [[B:%.+]] = firrtl.subfield %bundle0_a(0)
-    %b = firrtl.subfield %a(0) : (!firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>) -> !firrtl.bundle<c flip: uint<1>, d: uint<1>>
-    // CHECK: [[F:%.+]] = firrtl.subfield %bundle1_a(0)
-    %f = firrtl.subfield %e(0) : (!firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>) -> !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+    // CHECK: [[B:%.+]] = firrtl.subfield %bundle0_a[b]
+    %b = firrtl.subfield %a[b] : !firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>
+    // CHECK: [[F:%.+]] = firrtl.subfield %bundle1_a[b]
+    %f = firrtl.subfield %e[f] : !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>
 
     // Check that we properly fixup connects when the field names change.
     %w0 = firrtl.wire : !firrtl.bundle<g flip: uint<1>, h: uint<1>>
-    // CHECK: [[W0_G:%.+]] = firrtl.subfield %w0(0)
-    // CHECK: [[F_G:%.+]] = firrtl.subfield [[F]](0)
+    // CHECK: [[W0_G:%.+]] = firrtl.subfield %w0[g]
+    // CHECK: [[F_G:%.+]] = firrtl.subfield [[F]][c]
     // CHECK: firrtl.connect [[F_G]], [[W0_G]]
     firrtl.connect %w0, %f : !firrtl.bundle<g flip: uint<1>, h: uint<1>>, !firrtl.bundle<g flip: uint<1>, h: uint<1>>
   }
@@ -504,18 +504,18 @@ firrtl.circuit "Bundle" {
 // CHECK-LABEL: firrtl.circuit "Flip"
 firrtl.circuit "Flip" {
   firrtl.module @Flip0(out %io: !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) {
-    %0 = firrtl.subfield %io(0) : (!firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %io(1) : (!firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %io[foo] : !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
+    %1 = firrtl.subfield %io[fuzz] : !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
     firrtl.connect %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @Flip1(out %io: !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) {
-    %0 = firrtl.subfield %io(0) : (!firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %io(1) : (!firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %io[bar] : !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>
+    %1 = firrtl.subfield %io[buzz] : !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>
     firrtl.connect %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @Flip(out %io: !firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) {
-    %0 = firrtl.subfield %io(1) : (!firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) -> !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>
-    %1 = firrtl.subfield %io(0) : (!firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) -> !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
+    %0 = firrtl.subfield %io[bar] : !firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>
+    %1 = firrtl.subfield %io[foo] : !firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>
     %foo_io = firrtl.instance foo  @Flip0(out io: !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>)
     %bar_io = firrtl.instance bar  @Flip1(out io: !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>)
     firrtl.connect %1, %foo_io : !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>, !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
@@ -559,13 +559,13 @@ firrtl.circuit "NoEmptyAnnos" {
   // CHECK-LABEL: @NoEmptyAnnos0()
   firrtl.module @NoEmptyAnnos0() {
     // CHECK: %w = firrtl.wire  : !firrtl.bundle<a: uint<1>>
-    // CHECK: %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>>
     %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
-    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module @NoEmptyAnnos1() {
     %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
-    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module @NoEmptyAnnos() {
     firrtl.instance empty0 @NoEmptyAnnos0()

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -141,7 +141,7 @@ firrtl.circuit "Foo" {
     // CHECK: node subaccess = vector[ui1]
     %bundle = firrtl.wire : !firrtl.bundle<a: uint, b flip: uint>
     %vector = firrtl.wire : !firrtl.vector<uint, 42>
-    %subfield_tmp = firrtl.subfield %bundle(0) : (!firrtl.bundle<a: uint, b flip: uint>) -> !firrtl.uint
+    %subfield_tmp = firrtl.subfield %bundle[a] : !firrtl.bundle<a: uint, b flip: uint>
     %subindex_tmp = firrtl.subindex %vector[19] : !firrtl.vector<uint, 42>
     %subaccess_tmp = firrtl.subaccess %vector[%ui1] : !firrtl.vector<uint, 42>, !firrtl.uint<1>
     %subfield = firrtl.node %subfield_tmp : !firrtl.uint
@@ -260,9 +260,9 @@ firrtl.circuit "Foo" {
     %shrPrimOp = firrtl.node %shrPrimOp_tmp : !firrtl.uint
 
     %MyMem_a, %MyMem_b, %MyMem_c = firrtl.mem Undefined {depth = 8, name = "MyMem", portNames = ["a", "b", "c"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<4>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint<4>, wmode: uint<1>, wdata: uint<4>, wmask: uint<1>>
-    %MyMem_a_clk = firrtl.subfield %MyMem_a(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<4>>) -> !firrtl.clock
-    %MyMem_b_clk = firrtl.subfield %MyMem_b(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>>) -> !firrtl.clock
-    %MyMem_c_clk = firrtl.subfield %MyMem_c(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint<4>, wmode: uint<1>, wdata: uint<4>, wmask: uint<1>>) -> !firrtl.clock
+    %MyMem_a_clk = firrtl.subfield %MyMem_a[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<4>>
+    %MyMem_b_clk = firrtl.subfield %MyMem_b[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>>
+    %MyMem_c_clk = firrtl.subfield %MyMem_c[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint<4>, wmode: uint<1>, wdata: uint<4>, wmask: uint<1>>
     firrtl.connect %MyMem_a_clk, %someClock : !firrtl.clock, !firrtl.clock
     firrtl.connect %MyMem_b_clk, %someClock : !firrtl.clock, !firrtl.clock
     firrtl.connect %MyMem_c_clk, %someClock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -329,15 +329,15 @@ firrtl.circuit "Top"  attributes {annotations = [{
   firrtl.hierpath private @nla [@Top::@a, @A]
   firrtl.module @Top(in %in0_0: !firrtl.uint<4>, in %in0_1: !firrtl.uint<4>, in %in1_f0: !firrtl.uint<4>, in %in1_f1: !firrtl.uint<4>, out %out0_0: !firrtl.uint<4>, out %out0_1: !firrtl.uint<4>, out %out1_f0: !firrtl.uint<4>, out %out1_f1: !firrtl.uint<4>) {
     %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance a sym @a  @A(in in0: !firrtl.bundle<io: vector<uint<4>, 2>>, in in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>, out out0: !firrtl.vector<uint<4>, 2>, out out1: !firrtl.bundle<f0: uint<4>, f1: uint<4>>)
-    %0 = firrtl.subfield %a_in1(0) : (!firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    %1 = firrtl.subfield %a_in0(0) : (!firrtl.bundle<io: vector<uint<4>, 2>>) -> !firrtl.vector<uint<4>, 2>
+    %0 = firrtl.subfield %a_in1[io] : !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>
+    %1 = firrtl.subfield %a_in0[io]: !firrtl.bundle<io: vector<uint<4>, 2>>
     %2 = firrtl.subindex %a_out0[0] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %out0_0, %2 : !firrtl.uint<4>
     %3 = firrtl.subindex %a_out0[1] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %out0_1, %3 : !firrtl.uint<4>
-    %4 = firrtl.subfield %a_out1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %4 = firrtl.subfield %a_out1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     firrtl.strictconnect %out1_f0, %4 : !firrtl.uint<4>
-    %5 = firrtl.subfield %a_out1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %5 = firrtl.subfield %a_out1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     firrtl.strictconnect %out1_f1, %5 : !firrtl.uint<4>
     %6 = firrtl.bundlecreate %in1_f0, %in1_f1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     firrtl.strictconnect %0, %6 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
@@ -348,27 +348,27 @@ firrtl.circuit "Top"  attributes {annotations = [{
   // CHECK-SAME:    %in0: !firrtl.bundle<io: vector<uint<4>, 2>> sym @[[in0_sym:[^ ]+]],
   // CHECK-SAME:    %in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>> sym @[[in1_sym:[^ ]+]],
   firrtl.module private @A(in %in0: !firrtl.bundle<io: vector<uint<4>, 2>> [{circt.fieldID = 3 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}, {circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}], in %in1: !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>> [{circt.fieldID = 3 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 5 : i64}, {circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 4 : i64}], out %out0: !firrtl.vector<uint<4>, 2>, out %out1: !firrtl.bundle<f0: uint<4>, f1: uint<4>>) {
-    %0 = firrtl.subfield %in1(0) : (!firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    %1 = firrtl.subfield %in0(0) : (!firrtl.bundle<io: vector<uint<4>, 2>>) -> !firrtl.vector<uint<4>, 2>
+    %0 = firrtl.subfield %in1[io] : !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>
+    %1 = firrtl.subfield %in0[io] : !firrtl.bundle<io: vector<uint<4>, 2>>
     // CHECK: %w0 = firrtl.wire sym @[[w0_sym:[^ ]+]]
     %w0 = firrtl.wire   {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 3 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 2 : i64}]} : !firrtl.vector<uint<4>, 2>
     %2 = firrtl.subindex %1[0] : !firrtl.vector<uint<4>, 2>
     %3 = firrtl.subindex %1[1] : !firrtl.vector<uint<4>, 2>
     // CHECK: %w1 = firrtl.wire sym @[[w1_sym:[^ ]+]]
     %w1 = firrtl.wire   {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 7 : i64}, {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 6 : i64}]} : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    %4 = firrtl.subfield %0(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
-    %5 = firrtl.subfield %0(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %4 = firrtl.subfield %0[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %5 = firrtl.subfield %0[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     %6 = firrtl.subindex %w0[0] : !firrtl.vector<uint<4>, 2>
     %7 = firrtl.subindex %out0[0] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %7, %6 : !firrtl.uint<4>
     %8 = firrtl.subindex %w0[1] : !firrtl.vector<uint<4>, 2>
     %9 = firrtl.subindex %out0[1] : !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %9, %8 : !firrtl.uint<4>
-    %10 = firrtl.subfield %w1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
-    %11 = firrtl.subfield %out1(0) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %10 = firrtl.subfield %w1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %11 = firrtl.subfield %out1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     firrtl.strictconnect %11, %10 : !firrtl.uint<4>
-    %12 = firrtl.subfield %w1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
-    %13 = firrtl.subfield %out1(1) : (!firrtl.bundle<f0: uint<4>, f1: uint<4>>) -> !firrtl.uint<4>
+    %12 = firrtl.subfield %w1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    %13 = firrtl.subfield %out1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     firrtl.strictconnect %13, %12 : !firrtl.uint<4>
     %14 = firrtl.vectorcreate %2, %3 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
     firrtl.strictconnect %w0, %14 : !firrtl.vector<uint<4>, 2>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -612,11 +612,42 @@ firrtl.circuit "MemoryPortsWithDifferentTypes" {
 
 // -----
 
-firrtl.circuit "SubfieldOpFieldError" {
+firrtl.circuit "SubfieldOpWithIntegerFieldIndex" {
   firrtl.module @SubfieldOpFieldError() {
     %w = firrtl.wire  : !firrtl.bundle<a: uint<2>, b: uint<2>>
-    // expected-error @+1 {{}}
+    // expected-error @+1 {{'firrtl.subfield' expected valid keyword or string}}
     %w_a = firrtl.subfield %w[2] : !firrtl.bundle<a : uint<2>, b : uint<2>>
+  }
+}
+
+// -----
+
+firrtl.circuit "SubfieldOpFieldUnknown" {
+  firrtl.module @SubfieldOpFieldError() {
+    %w = firrtl.wire  : !firrtl.bundle<a: uint<2>, b: uint<2>>
+    // expected-error @+1 {{'firrtl.subfield' unknown field c in bundle type '!firrtl.bundle<a: uint<2>, b: uint<2>>'}}
+    %w_a = firrtl.subfield %w[c] : !firrtl.bundle<a : uint<2>, b : uint<2>>
+  }
+}
+
+// -----
+
+firrtl.circuit "SubfieldOpInputTypeMismatch" {
+  firrtl.module @SubfieldOpFieldError() {
+    %w = firrtl.wire : !firrtl.bundle<a: uint<2>, b: uint<2>>
+    // expected-error @+2 {{use of value '%w' expects different type than prior uses}}
+    // expected-note  @-2 {{prior use here}}
+    %w_a = firrtl.subfield %w[a] : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "SubfieldOpNonBundleInputType" {
+  firrtl.module @SubfieldOpFieldError() {
+    %w = firrtl.wire : !firrtl.uint<1>
+    // expected-error @+1 {{'firrtl.subfield' input must be bundle type, got '!firrtl.uint<1>'}}
+    %w_a = firrtl.subfield %w[a] : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -616,7 +616,7 @@ firrtl.circuit "SubfieldOpFieldError" {
   firrtl.module @SubfieldOpFieldError() {
     %w = firrtl.wire  : !firrtl.bundle<a: uint<2>, b: uint<2>>
     // expected-error @+1 {{}}
-    %w_a = firrtl.subfield %w(2) : (!firrtl.bundle<a : uint<2>, b : uint<2>>) -> !firrtl.uint<2>
+    %w_a = firrtl.subfield %w[2] : !firrtl.bundle<a : uint<2>, b : uint<2>>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -389,25 +389,25 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %w = firrtl.wire  : !firrtl.bundle<a: uint<2>, b flip: uint<2>>
 
-  // CHECK: [[W_A:%.*]] = firrtl.subfield %w(0)
+  // CHECK: [[W_A:%.*]] = firrtl.subfield %w[a]
   // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2)
   // CHECK: firrtl.connect [[W_A]], [[MUX]]
   firrtl.when %p {
-    %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a : uint<2>, b flip: uint<2>>) -> !firrtl.uint<2>
+    %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
     firrtl.connect %w_a, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
-    %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a : uint<2>, b flip: uint<2>>) -> !firrtl.uint<2>
+    %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
     firrtl.connect %w_a, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 
-  // CHECK: [[W_B:%.*]] = firrtl.subfield %w(1)
+  // CHECK: [[W_B:%.*]] = firrtl.subfield %w[b]
   // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2)
   // CHECK: firrtl.connect [[W_B]], [[MUX]]
-  %w_b0 = firrtl.subfield %w(1) : (!firrtl.bundle<a : uint<2>, b flip: uint<2>>) -> !firrtl.uint<2>
+  %w_b0 = firrtl.subfield %w[b] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
   firrtl.connect %w_b0, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.when %p {
   } else {
-    %w_b1 = firrtl.subfield %w(1) : (!firrtl.bundle<a : uint<2>, b flip: uint<2>>) -> !firrtl.uint<2>
+    %w_b1 = firrtl.subfield %w[b] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
     firrtl.connect %w_b1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
@@ -419,7 +419,7 @@ firrtl.module @simple(in %in : !firrtl.bundle<a: uint<1>>) { }
 firrtl.module @bundle_ports() {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %simple_in = firrtl.instance test0 @simple(in in : !firrtl.bundle<a: uint<1>>)
-  %0 = firrtl.subfield %simple_in(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  %0 = firrtl.subfield %simple_in[a] : !firrtl.bundle<a: uint<1>>
   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -450,7 +450,7 @@ firrtl.module @analog(out %analog : !firrtl.analog<1>) {
   // Should not complain about the embeded analog.
   %c1 = firrtl.constant 0 : !firrtl.uint<1>
   %w = firrtl.wire : !firrtl.bundle<a: uint<1>, b: analog<1>>
-  %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a : uint<1>, b : analog<1>>) -> !firrtl.uint<1>
+  %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a : uint<1>, b : analog<1>>
   firrtl.connect %w_a, %c1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -504,7 +504,7 @@ firrtl.module @multi_dim_vector(in %p : !firrtl.uint<1>) {
 // CHECK-LABEL: @vector_of_bundle
 firrtl.module @vector_of_bundle(in %p : !firrtl.uint<1>, out %ret: !firrtl.vector<bundle<a:uint<1>>, 1>) {
   %0 = firrtl.subindex %ret[0] : !firrtl.vector<bundle<a:uint<1>>, 1>
-  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a:uint<1>>) -> !firrtl.uint<1>
+  %1 = firrtl.subfield %0[a] : !firrtl.bundle<a:uint<1>>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -516,9 +516,9 @@ firrtl.module @vector_of_bundle(in %p : !firrtl.uint<1>, out %ret: !firrtl.vecto
 // CHECK-LABEL: @aggregate_register
 firrtl.module @aggregate_register(in %clock: !firrtl.clock) {
   %0 = firrtl.reg %clock : !firrtl.bundle<a : uint<1>, b : uint<1>>
-  // CHECK:      %1 = firrtl.subfield %0(0)
+  // CHECK:      %1 = firrtl.subfield %0[a]
   // CHECK-NEXT: firrtl.connect %1, %1
-  // CHECK-NEXT: %2 = firrtl.subfield %0(1)
+  // CHECK-NEXT: %2 = firrtl.subfield %0[b]
   // CHECK-NEXT: firrtl.connect %2, %2
 }
 

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -4,36 +4,36 @@
 firrtl.circuit "Mem" {
   firrtl.module public  @Mem(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    %0 = firrtl.subfield %memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.clock
+    %0 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.strictconnect %0, %clock : !firrtl.clock
-    %1 = firrtl.subfield %memory_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.strictconnect %1, %rEn : !firrtl.uint<1>
-    %2 = firrtl.subfield %memory_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<4>
+    %2 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.strictconnect %2, %rAddr : !firrtl.uint<4>
-    %3 = firrtl.subfield %memory_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %3 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.strictconnect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>
-    %4 = firrtl.subfield %memory_w(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.clock
+    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %4, %clock : !firrtl.clock
-    %5 = firrtl.subfield %memory_w(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %5, %wEn : !firrtl.uint<1>
-    %6 = firrtl.subfield %memory_w(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<4>
+    %6 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %6, %wAddr : !firrtl.uint<4>
-    %7 = firrtl.subfield %memory_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    %7 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    %8 = firrtl.subfield %memory_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %8 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
     // ---------------------------------------------------------------------------------
     // After flattenning the memory data
     // CHECK: %[[memory_r:.+]], %[[memory_w:.+]] = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32}
     // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<16>, mask: uint<2>>
     // CHECK: %[[memory_r_0:.+]] = firrtl.wire  {name = "memory_r"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK: %[[v0:.+]] = firrtl.subfield %[[memory_r]](0)
+    // CHECK: %[[v0:.+]] = firrtl.subfield %[[memory_r]][addr]
     // CHECK: firrtl.strictconnect %[[v0]], %[[memory_r_addr:.+]] :
-    // CHECK: %[[v1:.+]] = firrtl.subfield %[[memory_r]](1)
+    // CHECK: %[[v1:.+]] = firrtl.subfield %[[memory_r]][en]
     // CHECK: firrtl.strictconnect %[[v1]], %[[memory_r_en:.+]] :
-    // CHECK: %[[v2:.+]] = firrtl.subfield %[[memory_r]](2)
+    // CHECK: %[[v2:.+]] = firrtl.subfield %[[memory_r]][clk]
     // CHECK: firrtl.strictconnect %[[v2]], %[[memory_r_clk:.+]] :
-    // CHECK: %[[v3:.+]] = firrtl.subfield %[[memory_r]](3)
+    // CHECK: %[[v3:.+]] = firrtl.subfield %[[memory_r]][data]
     //
     // ---------------------------------------------------------------------------------
     // Read ports
@@ -42,34 +42,34 @@ firrtl.circuit "Mem" {
     // --------------------------------------------------------------------------------
     // Write Ports
     // CHECK:  %[[memory_w_1:.+]] = firrtl.wire  {name = "memory_w"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_w]](3)
+    // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_w]][data]
     // CHECK:  %[[v17:.+]] = firrtl.bitcast %[[v15:.+]] : (!firrtl.bundle<a: uint<8>, b: uint<8>>) -> !firrtl.uint<16>
     // CHECK:  firrtl.strictconnect %[[v9]], %[[v17]]
     //
     // --------------------------------------------------------------------------------
     // Mask Ports
-    //  CHECK: %[[v11:.+]] = firrtl.subfield %[[memory_w]](4)
+    //  CHECK: %[[v11:.+]] = firrtl.subfield %[[memory_w]][mask]
     //  CHECK: %[[v12:.+]] = firrtl.bitcast %[[v18:.+]] : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
     //  CHECK: firrtl.strictconnect %[[v11]], %[[v12]]
     // --------------------------------------------------------------------------------
     // Connections to module ports
-    // CHECK:  %[[v21:.+]] = firrtl.subfield %[[memory_r_0]](2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.clock
+    // CHECK:  %[[v21:.+]] = firrtl.subfield %[[memory_r_0]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     // CHECK:  firrtl.strictconnect %[[v21]], %clock :
-    // CHECK:  %[[v22:.+]]  = firrtl.subfield %[[memory_r_0]](1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<1>
+    // CHECK:  %[[v22:.+]]  = firrtl.subfield %[[memory_r_0]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     // CHECK:  firrtl.strictconnect %[[v22]], %rEn : !firrtl.uint<1>
-    // CHECK:  %[[v23:.+]]  = firrtl.subfield %[[memory_r_0]](0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<4>
+    // CHECK:  %[[v23:.+]]  = firrtl.subfield %[[memory_r_0]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     // CHECK:  firrtl.strictconnect %[[v23]], %rAddr : !firrtl.uint<4>
-    // CHECK:  %[[v24:.+]]  = firrtl.subfield %[[memory_r_0]](3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  %[[v24:.+]]  = firrtl.subfield %[[memory_r_0]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     // CHECK:  firrtl.strictconnect %rData, %[[v24]] : !firrtl.bundle<a: uint<8>, b: uint<8>>
-    // CHECK:  %[[v25:.+]]  = firrtl.subfield %[[memory_w_1]](2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.clock
+    // CHECK:  %[[v25:.+]]  = firrtl.subfield %[[memory_w_1]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v25]], %clock : !firrtl.clock
-    // CHECK:  %[[v26:.+]]  = firrtl.subfield %[[memory_w_1]](1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
+    // CHECK:  %[[v26:.+]]  = firrtl.subfield %[[memory_w_1]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v26]], %wEn : !firrtl.uint<1>
-    // CHECK:  %[[v27:.+]]  = firrtl.subfield %[[memory_w_1]](0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<4>
+    // CHECK:  %[[v27:.+]]  = firrtl.subfield %[[memory_w_1]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v27]], %wAddr : !firrtl.uint<4>
-    // CHECK:  %[[v28:.+]]  = firrtl.subfield %[[memory_w_1]](4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    // CHECK:  %[[v28:.+]]  = firrtl.subfield %[[memory_w_1]][mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v28]], %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    // CHECK:  %[[v29:.+]]  = firrtl.subfield %[[memory_w_1]](3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  %[[v29:.+]]  = firrtl.subfield %[[memory_w_1]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v29]], %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
   }
 
@@ -77,13 +77,13 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   %memory_rw = firrtl.mem Undefined  {depth = 16 : i64, groupID = 1 : ui32, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
   // CHECK:  %memory_rw = firrtl.mem Undefined  {depth = 16 : i64, groupID = 1 : ui32, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<17>, wmode: uint<1>, wdata: uint<17>, wmask: uint<17>>
   // CHECK:  %[[memory_rw_0:.+]] = firrtl.wire  {name = "memory_rw"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
-  %0 = firrtl.subfield %memory_rw(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<8>, b: uint<9>>
-  %1 = firrtl.subfield %memory_rw(5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<8>, b: uint<9>>
-  %2 = firrtl.subfield %memory_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  %3 = firrtl.subfield %memory_rw(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
-  %4 = firrtl.subfield %memory_rw(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<4>
-  %5 = firrtl.subfield %memory_rw(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
-  %6 = firrtl.subfield %memory_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.clock
+  %0 = firrtl.subfield %memory_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %1 = firrtl.subfield %memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %2 = firrtl.subfield %memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %3 = firrtl.subfield %memory_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %4 = firrtl.subfield %memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %5 = firrtl.subfield %memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
+  %6 = firrtl.subfield %memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<8>, b: uint<9>>, wmode: uint<1>, wdata: bundle<a: uint<8>, b: uint<9>>, wmask: bundle<a: uint<1>, b: uint<1>>>
   firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %5, %rwEn : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %4, %rwAddr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -91,19 +91,19 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   firrtl.connect %2, %rwMask : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
   firrtl.connect %1, %rwDataIn : !firrtl.bundle<a: uint<8>, b: uint<9>>, !firrtl.bundle<a: uint<8>, b: uint<9>>
   firrtl.connect %rwDataOut, %0 : !firrtl.bundle<a: uint<8>, b: uint<9>>, !firrtl.bundle<a: uint<8>, b: uint<9>>
-  // CHECK:  %[[v6:.+]] = firrtl.subfield %[[memory_rw_0]](3) :
-  // CHECK:  %[[v7:.+]] = firrtl.subfield %memory_rw(3) :
+  // CHECK:  %[[v6:.+]] = firrtl.subfield %[[memory_rw_0]][rdata] :
+  // CHECK:  %[[v7:.+]] = firrtl.subfield %memory_rw[rdata] :
   // CHECK:  %[[v8:.+]] = firrtl.bitcast %[[v7]] :
   // CHECK:  firrtl.strictconnect %[[v6]], %[[v8]] :
-  // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_rw_0]](4) :
-  // CHECK:  %[[v10:.+]] = firrtl.subfield %memory_rw(4) :
+  // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_rw_0]][wmode] :
+  // CHECK:  %[[v10:.+]] = firrtl.subfield %memory_rw[wmode] :
   // CHECK:  firrtl.strictconnect %[[v10]], %[[v9]] : !firrtl.uint<1>
-  // CHECK:  %[[v11:.+]] = firrtl.subfield %[[memory_rw_0]](5) :
-  // CHECK:  %[[v12:.+]] = firrtl.subfield %memory_rw(5) :
+  // CHECK:  %[[v11:.+]] = firrtl.subfield %[[memory_rw_0]][wdata] :
+  // CHECK:  %[[v12:.+]] = firrtl.subfield %memory_rw[wdata] :
   // CHECK:  %[[v13:.+]] = firrtl.bitcast %[[v11]] : (!firrtl.bundle<a: uint<8>, b: uint<9>>) -> !firrtl.uint<17>
   // CHECK:  firrtl.strictconnect %[[v12]], %[[v13]] :
-  // CHECK:  %[[v14:.+]] = firrtl.subfield %[[memory_rw_0]](6) :
-  // CHECK:  %[[v15:.+]] = firrtl.subfield %memory_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<17>, wmode: uint<1>, wdata: uint<17>, wmask: uint<17>>) -> !firrtl.uint<17>
+  // CHECK:  %[[v14:.+]] = firrtl.subfield %[[memory_rw_0]][wmask] :
+  // CHECK:  %[[v15:.+]] = firrtl.subfield %memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<17>, wmode: uint<1>, wdata: uint<17>, wmask: uint<17>>
   // CHECK:  %[[v16:.+]] = firrtl.bitcast %14 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
   // CHECK:  %[[v17:.+]] = firrtl.bits %16 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   // CHECK:  %[[v18:.+]] = firrtl.cat %[[v17]], %[[v17]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
@@ -126,25 +126,25 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %invalid_0 = firrtl.invalidvalue : !firrtl.bundle<a: uint<0>, b: uint<20>>
     %ram_MPORT = firrtl.mem Undefined  {depth = 1 : i64, groupID = 1 : ui32, name = "ram", portNames = ["MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    %3 = firrtl.subfield %ram_MPORT(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<0>, b: uint<20>>
+    %3 = firrtl.subfield %ram_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %3, %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
-    %4 = firrtl.subfield %ram_MPORT(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    %4 = firrtl.subfield %ram_MPORT[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.strictconnect %4, %invalid : !firrtl.bundle<a: uint<1>, b: uint<1>>
     // CHECK:  %ram_MPORT = firrtl.mem Undefined  {depth = 1 : i64, groupID = 1 : ui32, name = "ram", portNames = ["MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %ram_MPORT_1 = firrtl.wire  {name = "ram_MPORT"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  %[[v6:.+]] = firrtl.subfield %ram_MPORT_1(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<0>, b: uint<20>>
-    // CHECK:  %[[v7:.+]] = firrtl.subfield %ram_MPORT(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>) -> !firrtl.uint<20>
+    // CHECK:  %[[v6:.+]] = firrtl.subfield %ram_MPORT_1[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v7:.+]] = firrtl.subfield %ram_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %[[v8:.+]] = firrtl.bitcast %6 : (!firrtl.bundle<a: uint<0>, b: uint<20>>) -> !firrtl.uint<20>
     // CHECK:  firrtl.strictconnect %7, %8 : !firrtl.uint<20>
-    // CHECK:  %[[v9:.+]] = firrtl.subfield %ram_MPORT_1(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-    // CHECK:  %[[v10:.+]] = firrtl.subfield %ram_MPORT(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK:  %[[v9:.+]] = firrtl.subfield %ram_MPORT_1[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v10:.+]] = firrtl.subfield %ram_MPORT[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %[[v11:.+]] = firrtl.bitcast %9 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
     // CHECK:  %[[v12:.+]] = firrtl.bits %11 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     // CHECK:  %[[v13:.+]] = firrtl.bits %11 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %[[v10]], %[[v13]] : !firrtl.uint<1>
-    // CHECK:  %[[v14:.+]] = firrtl.subfield %ram_MPORT_1(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<0>, b: uint<20>>
+    // CHECK:  %[[v14:.+]] = firrtl.subfield %ram_MPORT_1[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.strictconnect %[[v14]], %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
-    // CHECK:  %[[v15:.+]] = firrtl.subfield %ram_MPORT_1(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    // CHECK:  %[[v15:.+]] = firrtl.subfield %ram_MPORT_1[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %3, %io : !firrtl.bundle<a: uint<0>, b: uint<20>>, !firrtl.bundle<a: uint<0>, b: uint<20>>
   }
 

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -93,9 +93,9 @@ firrtl.circuit "TestHarness" attributes {
       writeLatency = 1 : i32
     } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
     // CHECK: firrtl.mem sym @[[gct_sym_7:.+]] Undefined
-    %mem_addr = firrtl.subfield %mem(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-    %mem_en = firrtl.subfield %mem(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-    %mem_clk = firrtl.subfield %mem(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
+    %mem_addr = firrtl.subfield %mem[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+    %mem_en = firrtl.subfield %mem[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+    %mem_clk = firrtl.subfield %mem[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
     firrtl.connect %mem_addr, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %mem_en, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %mem_clk, %clock : !firrtl.clock, !firrtl.clock
@@ -501,10 +501,10 @@ firrtl.circuit "Top" {
     %bar_0 = firrtl.reg sym @bar_0 %clock  {annotations = [{circt.nonlocal = @nla, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 1 : i64, portID = 0 : i64}, {circt.nonlocal = @nla_0, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 0 : i64, portID = 0 : i64}]} : !firrtl.uint<1>
     // CHECK:  %bar_0 = firrtl.reg sym @[[bar_0:.+]] %clock  : !firrtl.uint<1>
     %bar_out_MPORT = firrtl.mem sym @bar Undefined  {depth = 1 : i64, modName = "bar_ext", name = "bar", portNames = ["out_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-    %0 = firrtl.subfield %bar_out_MPORT(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %bar_out_MPORT(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %bar_out_MPORT(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
-    %3 = firrtl.subfield %bar_out_MPORT(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %bar_out_MPORT[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+    %1 = firrtl.subfield %bar_out_MPORT[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+    %2 = firrtl.subfield %bar_out_MPORT[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+    %3 = firrtl.subfield %bar_out_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
     firrtl.strictconnect %0, %c0_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %2, %clock : !firrtl.clock

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -74,9 +74,9 @@ firrtl.circuit "BundlePropagation1"   {
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
-    %0 = firrtl.subfield %tmp(0) : (!firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>) -> !firrtl.uint<3>
-    %1 = firrtl.subfield %tmp(1) : (!firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>) -> !firrtl.uint<3>
-    %2 = firrtl.subfield %tmp(2) : (!firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>) -> !firrtl.uint<3>
+    %0 = firrtl.subfield %tmp[a] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
+    %1 = firrtl.subfield %tmp[b] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
+    %2 = firrtl.subfield %tmp[c] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
     firrtl.strictconnect %0, %c1_ui3 : !firrtl.uint<3>
     firrtl.strictconnect %1, %c2_ui3 : !firrtl.uint<3>
     firrtl.strictconnect %2, %c4_ui3 : !firrtl.uint<3>
@@ -186,9 +186,9 @@ firrtl.circuit "OutPortTop" {
 firrtl.circuit "InputPortTop"  {
   // CHECK-LABEL: firrtl.module @InputPortChild2
   firrtl.module @InputPortChild2(in %in0: !firrtl.bundle<v: uint<1>>, in %in1: !firrtl.bundle<v: uint<1>>, out %out: !firrtl.bundle<v: uint<1>>) {
-    %0 = firrtl.subfield %in1(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %in0(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %out(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %in1[v] : !firrtl.bundle<v: uint<1>>
+    %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
+    %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %2, %3 : !firrtl.uint<1>
   }
@@ -197,9 +197,9 @@ firrtl.circuit "InputPortTop"  {
     in %in1: !firrtl.bundle<v: uint<1>> sym @dntSym,
     out %out: !firrtl.bundle<v: uint<1>>)
   {
-    %0 = firrtl.subfield %in1(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %in0(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %out(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %in1[v] : !firrtl.bundle<v: uint<1>>
+    %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
+    %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %2, %3 : !firrtl.uint<1>
   }
@@ -207,17 +207,17 @@ firrtl.circuit "InputPortTop"  {
   // CHECK-LABEL: firrtl.module @InputPortTop
   firrtl.module @InputPortTop(in %x: !firrtl.bundle<v: uint<1>>, out %z: !firrtl.bundle<v: uint<1>>, out %z2: !firrtl.bundle<v: uint<1>>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %0 = firrtl.subfield %z2(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %x(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %z(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %z2[v] : !firrtl.bundle<v: uint<1>>
+    %1 = firrtl.subfield %x[v] : !firrtl.bundle<v: uint<1>>
+    %2 = firrtl.subfield %z[v] : !firrtl.bundle<v: uint<1>>
     %c_in0, %c_in1, %c_out = firrtl.instance c  @InputPortChild(in in0: !firrtl.bundle<v: uint<1>>, in in1: !firrtl.bundle<v: uint<1>>, out out: !firrtl.bundle<v: uint<1>>)
-    %3 = firrtl.subfield %c_in1(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %c_in0(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %c_out(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %c_in1[v] : !firrtl.bundle<v: uint<1>>
+    %4 = firrtl.subfield %c_in0[v] : !firrtl.bundle<v: uint<1>>
+    %5 = firrtl.subfield %c_out[v] : !firrtl.bundle<v: uint<1>>
     %c2_in0, %c2_in1, %c2_out = firrtl.instance c2  @InputPortChild2(in in0: !firrtl.bundle<v: uint<1>>, in in1: !firrtl.bundle<v: uint<1>>, out out: !firrtl.bundle<v: uint<1>>)
-    %6 = firrtl.subfield %c2_in1(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %c2_in0(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %8 = firrtl.subfield %c2_out(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %c2_in1[v] : !firrtl.bundle<v: uint<1>>
+    %7 = firrtl.subfield %c2_in0[v] : !firrtl.bundle<v: uint<1>>
+    %8 = firrtl.subfield %c2_out[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %2, %5 : !firrtl.uint<1>
     firrtl.strictconnect %4, %1 : !firrtl.uint<1>
     firrtl.strictconnect %3, %c1_ui1 : !firrtl.uint<1>
@@ -233,30 +233,30 @@ firrtl.circuit "InputPortTop"  {
 firrtl.circuit "rhs_sink_output_used_as_wire" {
   // CHECK: firrtl.module @Bar
   firrtl.module @Bar(in %a: !firrtl.bundle<v: uint<1>>, in %b: !firrtl.bundle<v: uint<1>>, out %c: !firrtl.bundle<v: uint<1>>, out %d: !firrtl.bundle<v: uint<1>>) {
-    %0 = firrtl.subfield %d(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %b(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %3 = firrtl.subfield %c(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %d[v] : !firrtl.bundle<v: uint<1>>
+    %1 = firrtl.subfield %a[v] : !firrtl.bundle<v: uint<1>>
+    %2 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<1>>
+    %3 = firrtl.subfield %c[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %3, %2 : !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.bundle<v: uint<1>>
-    %4 = firrtl.subfield %_c(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %_c[v] : !firrtl.bundle<v: uint<1>>
     %5 = firrtl.xor %1, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %4, %5 : !firrtl.uint<1>
     firrtl.strictconnect %0, %4 : !firrtl.uint<1>
   }
   firrtl.module @rhs_sink_output_used_as_wire(in %a: !firrtl.bundle<v: uint<1>>, in %b: !firrtl.bundle<v: uint<1>>, out %c: !firrtl.bundle<v: uint<1>>, out %d: !firrtl.bundle<v: uint<1>>) {
     %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance bar  @Bar(in a: !firrtl.bundle<v: uint<1>>, in b: !firrtl.bundle<v: uint<1>>, out c: !firrtl.bundle<v: uint<1>>, out d: !firrtl.bundle<v: uint<1>>)
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %bar_a(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[v] : !firrtl.bundle<v: uint<1>>
+    %1 = firrtl.subfield %bar_a[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %1, %0 : !firrtl.uint<1>
-    %2 = firrtl.subfield %b(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %3 = firrtl.subfield %bar_b(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<1>>
+    %3 = firrtl.subfield %bar_b[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %3, %2 : !firrtl.uint<1>
-    %4 = firrtl.subfield %bar_c(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %c(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %bar_c[v] : !firrtl.bundle<v: uint<1>>
+    %5 = firrtl.subfield %c[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %5, %4 : !firrtl.uint<1>
-    %6 = firrtl.subfield %bar_d(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %d(0) : (!firrtl.bundle<v: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %bar_d[v] : !firrtl.bundle<v: uint<1>>
+    %7 = firrtl.subfield %d[v] : !firrtl.bundle<v: uint<1>>
     firrtl.strictconnect %7, %6 : !firrtl.uint<1>
   }
 }
@@ -267,8 +267,8 @@ firrtl.circuit "Oscillators"  {
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %1 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -284,8 +284,8 @@ firrtl.circuit "Oscillators"  {
   firrtl.module @Bar(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %1 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.xor %1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -299,8 +299,8 @@ firrtl.circuit "Oscillators"  {
   // CHECK: firrtl.module @Baz
   firrtl.module @Baz(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %1 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -315,11 +315,11 @@ firrtl.circuit "Oscillators"  {
   // CHECK: firrtl.module @Qux
   firrtl.module @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %1 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %ext_a = firrtl.instance ext  @Ext(in a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
-    %2 = firrtl.subfield %ext_a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %3 = firrtl.subfield %ext_a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %ext_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %3 = firrtl.subfield %ext_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %4 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -333,38 +333,38 @@ firrtl.circuit "Oscillators"  {
   }
   // CHECK: firrtl.module @Oscillators
   firrtl.module @Oscillators(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %foo_a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>, out %bar_a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>, out %baz_a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>, out %qux_a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>) {
-    %0 = firrtl.subfield %qux_a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %qux_a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %baz_a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %3 = firrtl.subfield %baz_a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %bar_a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %bar_a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %6 = firrtl.subfield %foo_a(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %foo_a(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %qux_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %1 = firrtl.subfield %qux_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %2 = firrtl.subfield %baz_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %3 = firrtl.subfield %baz_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %4 = firrtl.subfield %bar_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %5 = firrtl.subfield %bar_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %6 = firrtl.subfield %foo_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %7 = firrtl.subfield %foo_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance foo  @Foo(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
-    %8 = firrtl.subfield %foo_a_0(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %9 = firrtl.subfield %foo_a_0(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %8 = firrtl.subfield %foo_a_0[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %9 = firrtl.subfield %foo_a_0[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     firrtl.strictconnect %foo_clock, %clock : !firrtl.clock
     firrtl.strictconnect %foo_reset, %reset : !firrtl.asyncreset
     firrtl.strictconnect %7, %9 : !firrtl.uint<1>
     firrtl.strictconnect %6, %8 : !firrtl.uint<1>
     %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance bar  @Bar(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
-    %10 = firrtl.subfield %bar_a_1(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %11 = firrtl.subfield %bar_a_1(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %10 = firrtl.subfield %bar_a_1[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %11 = firrtl.subfield %bar_a_1[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     firrtl.strictconnect %bar_clock, %clock : !firrtl.clock
     firrtl.strictconnect %bar_reset, %reset : !firrtl.asyncreset
     firrtl.strictconnect %5, %11 : !firrtl.uint<1>
     firrtl.strictconnect %4, %10 : !firrtl.uint<1>
     %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance baz  @Baz(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
-    %12 = firrtl.subfield %baz_a_2(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %13 = firrtl.subfield %baz_a_2(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %12 = firrtl.subfield %baz_a_2[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %13 = firrtl.subfield %baz_a_2[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     firrtl.strictconnect %baz_clock, %clock : !firrtl.clock
     firrtl.strictconnect %baz_reset, %reset : !firrtl.asyncreset
     firrtl.strictconnect %3, %13 : !firrtl.uint<1>
     firrtl.strictconnect %2, %12 : !firrtl.uint<1>
     %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance qux  @Qux(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
-    %14 = firrtl.subfield %qux_a_3(1) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
-    %15 = firrtl.subfield %qux_a_3(0) : (!firrtl.bundle<v1: uint<1>, v2: uint<1>>) -> !firrtl.uint<1>
+    %14 = firrtl.subfield %qux_a_3[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
+    %15 = firrtl.subfield %qux_a_3[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     firrtl.strictconnect %qux_clock, %clock : !firrtl.clock
     firrtl.strictconnect %qux_reset, %reset : !firrtl.asyncreset
     firrtl.strictconnect %1, %15 : !firrtl.uint<1>
@@ -376,15 +376,15 @@ firrtl.circuit "Oscillators"  {
 firrtl.circuit "dntOutput"  {
   firrtl.module @dntOutput(out %b: !firrtl.bundle<v: uint<3>>, in %c: !firrtl.uint<1>) {
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
-    %0 = firrtl.subfield %b(0) : (!firrtl.bundle<v: uint<3>>) -> !firrtl.uint<3>
+    %0 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<3>>
     %int_b = firrtl.instance int  @foo(out b: !firrtl.bundle<v: uint<3>>)
-    %1 = firrtl.subfield %int_b(0) : (!firrtl.bundle<v: uint<3>>) -> !firrtl.uint<3>
+    %1 = firrtl.subfield %int_b[v] : !firrtl.bundle<v: uint<3>>
     %2 = firrtl.mux(%c, %1, %c2_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.strictconnect %0, %2 : !firrtl.uint<3>
   }
   firrtl.module @foo(out %b: !firrtl.bundle<v: uint<3>> sym @dntSym1){
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
-    %0 = firrtl.subfield %b(0) : (!firrtl.bundle<v: uint<3>>) -> !firrtl.uint<3>
+    %0 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<3>>
     firrtl.strictconnect %0, %c1_ui3 : !firrtl.uint<3>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -129,12 +129,12 @@ firrtl.circuit "Test" {
 
     %0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 
-    %1 = firrtl.subfield %0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
-    %2 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
+    %1 = firrtl.subfield %0[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+    %2 = firrtl.subfield %0[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-    %3 = firrtl.subfield %0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %0[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %4 = firrtl.subfield %0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.clock
+    %4 = firrtl.subfield %0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
   }
 }
 

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -37,10 +37,10 @@ firrtl.circuit "top" {
   firrtl.module private @mem(in %source: !firrtl.uint<1>) {
     // CHECK-NEXT: %ReadMemory_read0 = firrtl.mem Undefined {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     %mem = firrtl.mem Undefined {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-    // CHECK-NEXT: %0 = firrtl.subfield %ReadMemory_read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
+    // CHECK-NEXT: %0 = firrtl.subfield %ReadMemory_read0[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     // CHECK-NEXT: firrtl.connect %0, %source : !firrtl.uint<4>, !firrtl.uint<1>
     // CHECK-NEXT: }
-    %0 = firrtl.subfield %mem(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
+    %0 = firrtl.subfield %mem[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     firrtl.connect %0, %source : !firrtl.uint<4>, !firrtl.uint<1>
   }
 
@@ -269,11 +269,11 @@ firrtl.circuit "MemoryInDeadCycle" {
         writeLatency = 1 : i32
       } : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
 
-    %r_addr = firrtl.subfield %Memory_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<4>
+    %r_addr = firrtl.subfield %Memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %r_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %r_en = firrtl.subfield %Memory_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<1>
+    %r_en = firrtl.subfield %Memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %r_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r_clk = firrtl.subfield %Memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.clock
+    %r_clk = firrtl.subfield %Memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %r_clk, %clock : !firrtl.clock, !firrtl.clock
 
     // CHECK-NOT: firrtl.mem
@@ -286,17 +286,17 @@ firrtl.circuit "MemoryInDeadCycle" {
         writeLatency = 1 : i32
       } : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
-    %w_addr = firrtl.subfield %Memory_w(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+    %w_addr = firrtl.subfield %Memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %w_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %w_en = firrtl.subfield %Memory_w(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %w_en = firrtl.subfield %Memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %w_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %w_clk = firrtl.subfield %Memory_w(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.clock
+    %w_clk = firrtl.subfield %Memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %w_clk, %clock : !firrtl.clock, !firrtl.clock
-    %w_mask = firrtl.subfield %Memory_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %w_mask = firrtl.subfield %Memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %w_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    %w_data = firrtl.subfield %Memory_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<42>
-    %r_data = firrtl.subfield %Memory_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<42>
+    %w_data = firrtl.subfield %Memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    %r_data = firrtl.subfield %Memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %w_data, %r_data : !firrtl.uint<42>, !firrtl.uint<42>
   }
 }

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -98,7 +98,7 @@ firrtl.circuit "top"   {
 firrtl.circuit "top" {
   // expected-error @+1 {{reset network never driven with concrete type}}
   firrtl.module @top(in %in: !firrtl.bundle<foo: reset>, out %out: !firrtl.reset) {
-    %0 = firrtl.subfield %in(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
+    %0 = firrtl.subfield %in[foo] : !firrtl.bundle<foo: reset>
     firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
   }
 }
@@ -110,7 +110,7 @@ firrtl.circuit "top" {
   firrtl.module @top(out %out: !firrtl.reset) {
     // expected-error @+1 {{reset network never driven with concrete type}}
     %e_out = firrtl.instance e @ext(out out: !firrtl.bundle<foo: reset>)
-    %0 = firrtl.subfield %e_out(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
+    %0 = firrtl.subfield %e_out[foo] : !firrtl.bundle<foo: reset>
     firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
   }
 }

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -101,16 +101,16 @@ firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: 
 // CHECK-LABEL: firrtl.module @NestedAggregates
 // CHECK-SAME: out %buzz: !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: asyncreset, c: uint<1>>, 2>, bar: vector<bundle<a: asyncreset, b flip: asyncreset, c: uint<8>>, 2>>
 firrtl.module @NestedAggregates(out %buzz: !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) {
-  %0 = firrtl.subfield %buzz(1) : (!firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) -> !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>
-  %1 = firrtl.subfield %buzz(0) : (!firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) -> !firrtl.vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>
+  %0 = firrtl.subfield %buzz[bar] : !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>
+  %1 = firrtl.subfield %buzz[foo] : !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>
   firrtl.connect %0, %1 : !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>, !firrtl.vector<bundle<a: asyncreset, b flip: reset, c: uint<1>>, 2>
 }
 
 // Should work with deeply nested aggregates.
 // CHECK-LABEL: firrtl.module @DeeplyNestedAggregates(in %reset: !firrtl.uint<1>, out %buzz: !firrtl.bundle<a: bundle<b: uint<1>>>) {
 firrtl.module @DeeplyNestedAggregates(in %reset: !firrtl.uint<1>, out %buzz: !firrtl.bundle<a: bundle<b: reset>>) {
-  %0 = firrtl.subfield %buzz(0) : (!firrtl.bundle<a: bundle<b : reset>>) -> !firrtl.bundle<b: reset>
-  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<b: reset>) -> !firrtl.reset
+  %0 = firrtl.subfield %buzz[a] : !firrtl.bundle<a: bundle<b : reset>>
+  %1 = firrtl.subfield %0[b] : !firrtl.bundle<b: reset>
   // CHECK: firrtl.connect %1, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %1, %reset : !firrtl.reset, !firrtl.uint<1>
 }
@@ -391,13 +391,13 @@ firrtl.circuit "Top" {
     // Factoring of sync reset into mux works through subfield op.
     // CHECK: %reg4 = firrtl.regreset %clock, %extraReset, %2
     // CHECK: %4 = firrtl.mux(%init, %reset4, %reg4)
-    // CHECK: %5 = firrtl.subfield %reset4(0)
-    // CHECK: %6 = firrtl.subfield %reg4(0)
+    // CHECK: %5 = firrtl.subfield %reset4[a]
+    // CHECK: %6 = firrtl.subfield %reg4[a]
     // CHECK: %7 = firrtl.mux(%init, %5, %in)
     // CHECK: firrtl.connect %6, %7
     %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
-    %0 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    %0 = firrtl.subfield %reg4[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %0, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subindex op.
@@ -428,9 +428,9 @@ firrtl.circuit "Top" {
 
     // Subfields that are never assigned to should not leave unused reset
     // subfields behind.
-    // CHECK-NOT: firrtl.subfield %reset4(0)
-    // CHECK: %20 = firrtl.subfield %reg4(0)
-    %3 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    // CHECK-NOT: firrtl.subfield %reset4[a]
+    // CHECK: %20 = firrtl.subfield %reg4[a]
+    %3 = firrtl.subfield %reg4[a] : !firrtl.bundle<a: uint<8>>
   }
 }
 
@@ -449,14 +449,14 @@ firrtl.circuit "Top" {
     %reg_sint = firrtl.reg %clock : !firrtl.sint
     // CHECK: %0 = firrtl.wire : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
     // CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
-    // CHECK: %1 = firrtl.subfield %0(0)
+    // CHECK: %1 = firrtl.subfield %0[a]
     // CHECK: firrtl.strictconnect %1, %c0_ui8
     // CHECK: %2 = firrtl.wire : !firrtl.bundle<x: uint<8>, y: uint<8>>
-    // CHECK: %3 = firrtl.subfield %2(0)
+    // CHECK: %3 = firrtl.subfield %2[x]
     // CHECK: firrtl.strictconnect %3, %c0_ui8
-    // CHECK: %4 = firrtl.subfield %2(1)
+    // CHECK: %4 = firrtl.subfield %2[y]
     // CHECK: firrtl.strictconnect %4, %c0_ui8
-    // CHECK: %5 = firrtl.subfield %0(1)
+    // CHECK: %5 = firrtl.subfield %0[b]
     // CHECK: firrtl.strictconnect %5, %2
     // CHECK: %reg_bundle = firrtl.regreset %clock, %reset, %0
     %reg_bundle = firrtl.reg %clock : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
@@ -763,10 +763,10 @@ firrtl.circuit "ZeroWidthRegister" {
 // CHECK-LABEL: firrtl.module @ZeroLengthVectorInBundle1
 firrtl.circuit "ZeroLengthVectorInBundle1"  {
   firrtl.module @ZeroLengthVectorInBundle1(out %out: !firrtl.bundle<resets: vector<reset, 0>, data flip: uint<3>>) {
-    %0 = firrtl.subfield %out(0) : (!firrtl.bundle<resets: vector<reset, 0>, data flip: uint<3>>) -> !firrtl.vector<reset, 0>
+    %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<reset, 0>, data flip: uint<3>>
     %invalid = firrtl.invalidvalue : !firrtl.vector<reset, 0>
     firrtl.strictconnect %0, %invalid : !firrtl.vector<reset, 0>
-    // CHECK-NEXT: %0 = firrtl.subfield %out(0) : (!firrtl.bundle<resets: vector<uint<1>, 0>, data flip: uint<3>>) -> !firrtl.vector<uint<1>, 0>
+    // CHECK-NEXT: %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<uint<1>, 0>, data flip: uint<3>>
     // CHECK-NEXT: %invalid = firrtl.invalidvalue : !firrtl.vector<uint<1>, 0>
     // CHECK-NEXT: firrtl.strictconnect %0, %invalid : !firrtl.vector<uint<1>, 0>
   }
@@ -777,10 +777,10 @@ firrtl.circuit "ZeroLengthVectorInBundle1"  {
 // CHECK-LABEL: firrtl.module @ZeroLengthVectorInBundle2
 firrtl.circuit "ZeroLengthVectorInBundle2"  {
   firrtl.module @ZeroLengthVectorInBundle2(out %out: !firrtl.bundle<resets: vector<bundle<a: reset>, 0>, data flip: uint<3>>) {
-    %0 = firrtl.subfield %out(0) : (!firrtl.bundle<resets: vector<bundle<a: reset>, 0>, data flip: uint<3>>) -> !firrtl.vector<bundle<a: reset>, 0>
+    %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<bundle<a: reset>, 0>, data flip: uint<3>>
     %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: reset>, 0>
     firrtl.strictconnect %0, %invalid : !firrtl.vector<bundle<a: reset>, 0>
-    // CHECK-NEXT: %0 = firrtl.subfield %out(0) : (!firrtl.bundle<resets: vector<bundle<a: uint<1>>, 0>, data flip: uint<3>>) -> !firrtl.vector<bundle<a: uint<1>>, 0>
+    // CHECK-NEXT: %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<bundle<a: uint<1>>, 0>, data flip: uint<3>>
     // CHECK-NEXT: %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 0>
     // CHECK-NEXT: firrtl.strictconnect %0, %invalid : !firrtl.vector<bundle<a: uint<1>>, 0>
   }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -359,8 +359,8 @@ firrtl.circuit "Foo" {
   firrtl.module @MuxBundleOperands(in %a: !firrtl.bundle<a: uint<8>>, in %p: !firrtl.uint<1>, out %c: !firrtl.bundle<a: uint>) {
     // CHECK: %w = firrtl.wire  : !firrtl.bundle<a: uint<8>>
     %w = firrtl.wire  : !firrtl.bundle<a: uint>
-    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
-    %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint>
+    %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %0, %1 : !firrtl.uint, !firrtl.uint<8>
     // CHECK: %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
     %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint>) -> !firrtl.bundle<a: uint>
@@ -585,8 +585,8 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.reg %clk : !firrtl.bundle<a: uint<3>>
     %w = firrtl.wire : !firrtl.bundle<a: uint>
     %r = firrtl.reg %clk : !firrtl.bundle<a: uint>
-    %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
-    %r_a = firrtl.subfield %r(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+    %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a: uint>
+    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: uint>
     firrtl.connect %w_a, %in : !firrtl.uint, !firrtl.uint<3>
     firrtl.connect %r_a, %in : !firrtl.uint, !firrtl.uint<3>
   }
@@ -595,8 +595,8 @@ firrtl.circuit "Foo" {
   firrtl.module @InferEmptyBundle(in %in : !firrtl.uint<3>) {
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: bundle<>, b: uint<3>>
     %w = firrtl.wire : !firrtl.bundle<a: bundle<>, b: uint>
-    %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a: bundle<>, b: uint>) -> !firrtl.bundle<>
-    %w_b = firrtl.subfield %w(1) : (!firrtl.bundle<a: bundle<>, b: uint>) -> !firrtl.uint
+    %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a: bundle<>, b: uint>
+    %w_b = firrtl.subfield %w[b] : !firrtl.bundle<a: bundle<>, b: uint>
     firrtl.connect %w_b, %in : !firrtl.uint, !firrtl.uint<3>
   }
 
@@ -645,7 +645,7 @@ firrtl.circuit "Foo" {
 
     // CHECK: firrtl.wire : !firrtl.bundle<a: uint<4>>
     %wb = firrtl.wire : !firrtl.bundle<a: uint>
-    %wb_a = firrtl.subfield %wb(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+    %wb_a = firrtl.subfield %wb[a] : !firrtl.bundle<a: uint>
 
     %wv_2 = firrtl.subindex %wv[2] : !firrtl.vector<uint, 10>
     firrtl.connect %wb_a, %wv_2 : !firrtl.uint, !firrtl.uint
@@ -655,7 +655,7 @@ firrtl.circuit "Foo" {
   firrtl.module @InferElementAfterVector() {
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: vector<uint<10>, 10>, b: uint<3>>
     %w = firrtl.wire : !firrtl.bundle<a: vector<uint<10>, 10>, b :uint>
-    %w_a = firrtl.subfield %w(1) : (!firrtl.bundle<a: vector<uint<10>, 10>, b: uint>) -> !firrtl.uint
+    %w_a = firrtl.subfield %w[b] : !firrtl.bundle<a: vector<uint<10>, 10>, b: uint>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %w_a, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
   }
@@ -664,10 +664,10 @@ firrtl.circuit "Foo" {
   firrtl.module @InferComplexBundles() {
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: bundle<v: vector<uint<3>, 10>>, b: bundle<v: vector<uint<3>, 10>>>
     %w = firrtl.wire : !firrtl.bundle<a: bundle<v: vector<uint, 10>>, b: bundle <v: vector<uint, 10>>>
-    %w_a = firrtl.subfield %w(0) : (!firrtl.bundle<a: bundle<v: vector<uint, 10>>, b: bundle <v: vector<uint, 10>>>) -> !firrtl.bundle<v : vector<uint, 10>>
-    %w_a_v = firrtl.subfield %w_a(0) : (!firrtl.bundle<v : vector<uint, 10>>) -> !firrtl.vector<uint, 10>
-    %w_b = firrtl.subfield %w(1) : (!firrtl.bundle<a: bundle<v: vector<uint, 10>>, b: bundle <v: vector<uint, 10>>>) -> !firrtl.bundle<v : vector<uint, 10>>
-    %w_b_v = firrtl.subfield %w_b(0) : (!firrtl.bundle<v : vector<uint, 10>>) -> !firrtl.vector<uint, 10>
+    %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a: bundle<v: vector<uint, 10>>, b: bundle <v: vector<uint, 10>>>
+    %w_a_v = firrtl.subfield %w_a[v] : !firrtl.bundle<v : vector<uint, 10>>
+    %w_b = firrtl.subfield %w[b] : !firrtl.bundle<a: bundle<v: vector<uint, 10>>, b: bundle <v: vector<uint, 10>>>
+    %w_b_v = firrtl.subfield %w_b[v] : !firrtl.bundle<v : vector<uint, 10>>
     firrtl.connect %w_a_v, %w_b_v : !firrtl.vector<uint, 10>, !firrtl.vector<uint, 10>
     %w_b_v_2 = firrtl.subindex %w_b_v[2] : !firrtl.vector<uint, 10>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
@@ -679,9 +679,9 @@ firrtl.circuit "Foo" {
     // CHECK: %w = firrtl.wire : !firrtl.vector<bundle<a: uint<3>, b: uint<3>>, 10>
     %w = firrtl.wire : !firrtl.vector<bundle<a: uint, b:uint>, 10>
     %w_2 = firrtl.subindex %w[2] : !firrtl.vector<bundle<a: uint, b:uint>, 10>
-    %w_2_a = firrtl.subfield %w_2(0) : (!firrtl.bundle<a: uint, b: uint>) -> !firrtl.uint
+    %w_2_a = firrtl.subfield %w_2[a] : !firrtl.bundle<a: uint, b: uint>
     %w_4 = firrtl.subindex %w[4] : !firrtl.vector<bundle<a: uint, b:uint>, 10>
-    %w_4_b = firrtl.subfield %w_4(1) : (!firrtl.bundle<a: uint, b: uint>) -> !firrtl.uint
+    %w_4_b = firrtl.subfield %w_4[b] : !firrtl.bundle<a: uint, b: uint>
     firrtl.connect %w_4_b, %w_2_a : !firrtl.uint, !firrtl.uint
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %w_2_a, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
@@ -732,9 +732,9 @@ firrtl.circuit "Foo" {
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint, mask: uint<1>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint, wmode: uint<1>, wdata: uint, wmask: uint<1>>
-    %m_p0_data = firrtl.subfield %m_p0(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint>) -> !firrtl.uint
-    %m_p1_data = firrtl.subfield %m_p1(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint, mask: uint<1>>) -> !firrtl.uint
-    %m_p2_wdata = firrtl.subfield %m_p2(5) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint, wmode: uint<1>, wdata: uint, wmask: uint<1>>) -> !firrtl.uint
+    %m_p0_data = firrtl.subfield %m_p0[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint>
+    %m_p1_data = firrtl.subfield %m_p1[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint, mask: uint<1>>
+    %m_p2_wdata = firrtl.subfield %m_p2[wdata] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint, wmode: uint<1>, wdata: uint, wmask: uint<1>>
     %c0_ui5 = firrtl.constant 0 : !firrtl.uint<5>
     %c0_ui7 = firrtl.constant 0 : !firrtl.uint<7>
     firrtl.connect %m_p1_data, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
@@ -760,11 +760,11 @@ firrtl.circuit "Foo" {
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: bundle<a: uint>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<a: uint>, mask: bundle<a: uint<1>>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint>, wmode: uint<1>, wdata: bundle<a: uint>, wmask: bundle<a: uint<1>>>
-    %m_p0_data = firrtl.subfield %m_p0(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: bundle<a: uint>>) -> !firrtl.bundle<a: uint>
-    %m_p1_data = firrtl.subfield %m_p1(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<a: uint>, mask: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint>
-    %m_p2_wdata = firrtl.subfield %m_p2(5) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint>, wmode: uint<1>, wdata: bundle<a: uint>, wmask: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint>
-    %m_p1_data_a = firrtl.subfield %m_p1_data(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
-    %m_p2_wdata_a = firrtl.subfield %m_p2_wdata(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+    %m_p0_data = firrtl.subfield %m_p0[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: bundle<a: uint>>
+    %m_p1_data = firrtl.subfield %m_p1[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<a: uint>, mask: bundle<a: uint<1>>>
+    %m_p2_wdata = firrtl.subfield %m_p2[wdata] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint>, wmode: uint<1>, wdata: bundle<a: uint>, wmask: bundle<a: uint<1>>>
+    %m_p1_data_a = firrtl.subfield %m_p1_data[a] : !firrtl.bundle<a: uint>
+    %m_p2_wdata_a = firrtl.subfield %m_p2_wdata[a] : !firrtl.bundle<a: uint>
     %c0_ui5 = firrtl.constant 0 : !firrtl.uint<5>
     %c0_ui7 = firrtl.constant 0 : !firrtl.uint<7>
     firrtl.connect %m_p1_data_a, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -8,23 +8,23 @@ firrtl.circuit "TLRAM" {
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
       %debug, %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.ref<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.strictconnect %dbg_0, %debug : !firrtl.ref<vector<uint<8>, 16>>
-      %0 = firrtl.subfield %mem_0_MPORT(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
+      %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
-      %1 = firrtl.subfield %mem_0_MPORT(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %1, %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %mem_0_MPORT(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+      %2 = firrtl.subfield %mem_0_MPORT[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
-      %3 = firrtl.subfield %mem_0_MPORT(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
+      %3 = firrtl.subfield %mem_0_MPORT[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %mem_MPORT_data_0, %3 : !firrtl.uint<8>, !firrtl.uint<8>
-      %4 = firrtl.subfield %mem_0_MPORT_1(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<4>
+      %4 = firrtl.subfield %mem_0_MPORT_1[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %4, %index : !firrtl.uint<4>, !firrtl.uint<4>
-      %5 = firrtl.subfield %mem_0_MPORT_1(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+      %5 = firrtl.subfield %mem_0_MPORT_1[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %5, %wen : !firrtl.uint<1>, !firrtl.uint<1>
-      %6 = firrtl.subfield %mem_0_MPORT_1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+      %6 = firrtl.subfield %mem_0_MPORT_1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
-      %7 = firrtl.subfield %mem_0_MPORT_1(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
+      %7 = firrtl.subfield %mem_0_MPORT_1[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %7, %data_0 : !firrtl.uint<8>, !firrtl.uint<8>
-      %8 = firrtl.subfield %mem_0_MPORT_1(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+      %8 = firrtl.subfield %mem_0_MPORT_1[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %8, %_T_29 : !firrtl.uint<1>, !firrtl.uint<1>
       %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -58,15 +58,15 @@ firrtl.circuit "TLRAM" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %2 = firrtl.subfield %mem__T_14[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %3 = firrtl.subfield %mem__T_14[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %4 = firrtl.subfield %mem__T_14[mask] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem__T_22[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
@@ -91,15 +91,15 @@ firrtl.circuit "TLRAM" {
 // CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
 // CHECK:   firrtl.strictconnect %[[v0:.+]], %[[v7]]
 // CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %2 = firrtl.subfield %mem__T_14[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %3 = firrtl.subfield %mem__T_14[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %4 = firrtl.subfield %mem__T_14[mask] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem__T_22[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
     %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -124,15 +124,15 @@ firrtl.circuit "TLRAM" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK: %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %2 = firrtl.subfield %mem__T_14[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %3 = firrtl.subfield %mem__T_14[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %4 = firrtl.subfield %mem__T_14[mask] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem__T_22[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
     %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -155,15 +155,15 @@ firrtl.circuit "TLRAM" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     // CHECK:    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-    %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
-    %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
-    %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %mem_T_3[addr] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %1 = firrtl.subfield %mem_T_3[en] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %2 = firrtl.subfield %mem_T_3[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %3 = firrtl.subfield %mem_T_3[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %4 = firrtl.subfield %mem_T_5[addr] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem_T_5[en] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %6 = firrtl.subfield %mem_T_5[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %7 = firrtl.subfield %mem_T_5[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %8 = firrtl.subfield %mem_T_5[mask] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
     %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -186,15 +186,15 @@ firrtl.circuit "TLRAM" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %dbg0, %mem_T_3, %mem_T_5, %dbg = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "T_3", "T_5", "dbg"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.ref<vector<uint<32>,128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.ref<vector<uint<32>,128>>
 // CHECK: %mem_dbg0, %mem_dbg, %mem_rw = firrtl.mem  Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "dbg", "rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<32>, 128>>, !firrtl.ref<vector<uint<32>, 128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-    %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
-    %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
-    %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %mem_T_3[addr] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %1 = firrtl.subfield %mem_T_3[en] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %2 = firrtl.subfield %mem_T_3[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %3 = firrtl.subfield %mem_T_3[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %4 = firrtl.subfield %mem_T_5[addr] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem_T_5[en] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %6 = firrtl.subfield %mem_T_5[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %7 = firrtl.subfield %mem_T_5[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %8 = firrtl.subfield %mem_T_5[mask] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
     %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -219,15 +219,15 @@ firrtl.circuit "TLRAM" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %2 = firrtl.subfield %mem__T_14[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %3 = firrtl.subfield %mem__T_14[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %4 = firrtl.subfield %mem__T_14[mask] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %5 = firrtl.subfield %mem__T_22[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
     %xc = firrtl.wire : !firrtl.clock
@@ -249,26 +249,26 @@ firrtl.circuit "TLRAM" {
       %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
 
       // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
-      // CHECK: %[[v6:.+]] = firrtl.subfield %mem_0_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>) -> !firrtl.uint<1>
+      // CHECK: %[[v6:.+]] = firrtl.subfield %mem_0_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[c1_ui1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
       // CHECK: firrtl.strictconnect %[[v6]], %[[c1_ui1]]
-      %0 = firrtl.subfield %mem_0_MPORT(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
+      %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
-      %1 = firrtl.subfield %mem_0_MPORT(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %1, %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %mem_0_MPORT(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+      %2 = firrtl.subfield %mem_0_MPORT[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
-      %3 = firrtl.subfield %mem_0_MPORT(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
+      %3 = firrtl.subfield %mem_0_MPORT[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %mem_MPORT_data_0, %3 : !firrtl.uint<8>, !firrtl.uint<8>
-      %4 = firrtl.subfield %mem_0_MPORT_1(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>) -> !firrtl.uint<4>
+      %4 = firrtl.subfield %mem_0_MPORT_1[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       firrtl.connect %4, %index : !firrtl.uint<4>, !firrtl.uint<4>
-      %5 = firrtl.subfield %mem_0_MPORT_1(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>) -> !firrtl.uint<1>
+      %5 = firrtl.subfield %mem_0_MPORT_1[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       firrtl.connect %5, %wen : !firrtl.uint<1>, !firrtl.uint<1>
-      %6 = firrtl.subfield %mem_0_MPORT_1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>) -> !firrtl.clock
+      %6 = firrtl.subfield %mem_0_MPORT_1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
-      %7 = firrtl.subfield %mem_0_MPORT_1(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>) -> !firrtl.uint<8>
+      %7 = firrtl.subfield %mem_0_MPORT_1[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       firrtl.connect %7, %data_0 : !firrtl.uint<8>, !firrtl.uint<8>
-      %8 = firrtl.subfield %mem_0_MPORT_1(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>) -> !firrtl.uint<2>
+      %8 = firrtl.subfield %mem_0_MPORT_1[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       %c1 = firrtl.constant 3 : !firrtl.uint<2>
       firrtl.connect %8, %c1 : !firrtl.uint<2>, !firrtl.uint<2>
       %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -25,13 +25,13 @@ firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1
 
 firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
   // CHECK: %ram_ramport = firrtl.mem sym @s1 Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data flip: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
   // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
   // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport[data]
   %ram = chirrtl.combmem  sym @s1 : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
@@ -57,15 +57,15 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
 
 firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
   // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
   // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport[data]
   // CHECK: firrtl.strictconnect [[DATA]], %invalid_ui1
-  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport[mask]
   // CHECK: firrtl.strictconnect [[MASK]], %invalid_ui1
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
@@ -91,18 +91,18 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
 
 firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
   // CHECK: firrtl.strictconnect [[ADDR]], %invalid
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
   // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
-  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport[rdata]
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport[wmode]
   // CHECK: firrtl.strictconnect [[WMODE]], %c0_ui1
-  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport[wdata]
   // CHECK: firrtl.strictconnect [[WDATA]], %invalid_ui1
-  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
   // CHECK: firrtl.strictconnect [[WMASK]], %invalid
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
 
@@ -127,12 +127,12 @@ firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  %ramport_b = firrtl.subfield %ramport_data(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %ramport_b = firrtl.subfield %ramport_data[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   // Check that only the subfield of the mask is written to.
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]](1)
-  // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]](1)
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport[data]
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport[mask]
+  // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]][b]
+  // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]][b]
   // CHECK: firrtl.strictconnect [[MASK_B]], %c1_ui1
   // CHECK: firrtl.connect [[DATA_B]], %value
   firrtl.connect %ramport_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
@@ -145,21 +145,21 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
-  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
-  // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]](0)
-  // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]](0)
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport[rdata]
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport[wmode]
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport[wdata]
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
+  // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]][a]
+  // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]][a]
   // CHECK: firrtl.strictconnect [[WMASK_A]], %c1_ui1
   // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA_A]], %in
-  %port_a = firrtl.subfield %ramport_data(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_a = firrtl.subfield %ramport_data[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: [[RDATA_B:%.*]] = firrtl.subfield [[RDATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: [[RDATA_B:%.*]] = firrtl.subfield [[RDATA]][b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   // CHECK: firrtl.connect %out, [[RDATA_B]] : !firrtl.uint<1>, !firrtl.uint<1>
-  %port_b = firrtl.subfield %ramport_data(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_b = firrtl.subfield %ramport_data[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   firrtl.connect %out, %port_b : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -170,10 +170,10 @@ firrtl.module @ReadAndWriteToSubindex(in %clock: !firrtl.clock, in %addr: !firrt
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<vector<uint<1>, 10>, 256>) -> (!firrtl.vector<uint<1>, 10>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
-  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport[rdata]
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport[wmode]
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport[wdata]
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
   // CHECK: [[WDATA_0:%.*]] = firrtl.subindex [[WDATA]][0]
   // CHECK: [[WMASK_0:%.*]] = firrtl.subindex [[WMASK]][0]
   // CHECK: firrtl.strictconnect [[WMASK_0]], %c1_ui1 : !firrtl.uint<1>
@@ -226,8 +226,8 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   firrtl.connect %w, %invalid_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   %ram = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<32>, 16>
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram  {name = "ramport"}: (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%w], %clock : !chirrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
@@ -246,8 +246,8 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   %ram = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<32>, 16>
   %invalid_ui32 = firrtl.invalidvalue : !firrtl.uint<32>
   firrtl.connect %v, %invalid_ui32 : !firrtl.uint<32>, !firrtl.uint<32>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   // CHECK: firrtl.when %p
   firrtl.when %p  {
    // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
@@ -266,12 +266,12 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
 // aggregate, we do not perform regular enable inference.
 // CHECK-LABEL: firrtl.module @EnableInference2
 firrtl.module @EnableInference2(in %clock: !firrtl.clock, in %io: !firrtl.bundle<addr: uint<3>>, out %out: !firrtl.uint<8>) {
-  %0 = firrtl.subfield %io(0) : (!firrtl.bundle<addr: uint<3>>) -> !firrtl.uint<3>
+  %0 = firrtl.subfield %io[addr] : !firrtl.bundle<addr: uint<3>>
   %mem = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<8>, 8>
   %read_data, %read_port = chirrtl.memoryport Infer %mem  {name = "read"} : (!chirrtl.cmemory<uint<8>, 8>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %read_port[%0], %clock : !chirrtl.cmemoryport, !firrtl.uint<3>, !firrtl.clock
   firrtl.connect %out, %read_data : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK: [[EN:%.*]] = firrtl.subfield %mem_read(1)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %mem_read[en]
   // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
   // CHECK: firrtl.strictconnect [[EN]], %c1_ui1
 }
@@ -282,7 +282,7 @@ firrtl.module @AddressLargerThanPort(in %clock: !firrtl.clock, in %addr: !firrtl
   // CHECK-LABEL: @AddressLargerThanPort
   %mem = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<1>, 4>
   %r_data, %r_port = chirrtl.memoryport Infer %mem  {name = "r"} : (!chirrtl.cmemory<uint<1>, 4>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
-  // CHECK: [[ADDR:%.+]] = firrtl.subfield %mem_r(0)
+  // CHECK: [[ADDR:%.+]] = firrtl.subfield %mem_r[addr]
   %addr_node = firrtl.node %addr  : !firrtl.uint<3>
   // CHECK: [[TRUNC:%.+]] = firrtl.tail %addr_node, 1
   // CHECK: firrtl.strictconnect [[ADDR]], [[TRUNC]]

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -135,11 +135,11 @@ firrtl.circuit "NoMask" {
     %MemSimple_read, %MemSimple_write = firrtl.mem Undefined {depth = 12 : i64, name = "MemSimple", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
     // Enable:
-    %0 = firrtl.subfield %MemSimple_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %MemSimple_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %0, %en : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Mask:
-    %1 = firrtl.subfield %MemSimple_write(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %MemSimple_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %1, %mask : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: [[AND:%.+]] = firrtl.and %mask, %en
@@ -154,11 +154,11 @@ firrtl.circuit "YesMask" {
     %MemSimple_read, %MemSimple_write = firrtl.mem Undefined {depth = 1022 : i64, name = "MemSimple", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: uint<40>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<4>>
 
     // Enable:
-    %0 = firrtl.subfield %MemSimple_write(1) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<4>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %MemSimple_write[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<4>>
     firrtl.connect %0, %en : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Mask:
-    %1 = firrtl.subfield %MemSimple_write(4) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<4>>) -> !firrtl.uint<4>
+    %1 = firrtl.subfield %MemSimple_write[mask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<4>>
     firrtl.connect %1, %mask : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: firrtl.connect %MemSimple_W0_en, %en
@@ -173,13 +173,13 @@ firrtl.circuit "MemDepth1" {
     // CHECK: firrtl.instance mem0  @mem0(in W0_addr: !firrtl.uint<1>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<32>, in W0_mask: !firrtl.uint<4>)
     // CHECK: firrtl.connect %mem0_W0_data, %data : !firrtl.uint<32>, !firrtl.uint<32>
     %mem0_write = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
-    %1 = firrtl.subfield %mem0_write(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %mem0_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
     firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
-    %3 = firrtl.subfield %mem0_write(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %mem0_write[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
     firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.subfield %mem0_write(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>) -> !firrtl.clock
+    %0 = firrtl.subfield %mem0_write[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %2 = firrtl.subfield %mem0_write(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>) -> !firrtl.uint<32>
+    %2 = firrtl.subfield %mem0_write[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
     firrtl.connect %2, %data : !firrtl.uint<32>, !firrtl.uint<32>
 }
 // CHECK: firrtl.memmodule private @mem0_ext
@@ -190,15 +190,15 @@ firrtl.circuit "MemDepth1" {
 firrtl.circuit "inferUnmaskedMemory" {
   firrtl.module @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMode: !firrtl.uint<1>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
     %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %0 = firrtl.subfield %tbMemoryKind1_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
-    %1 = firrtl.subfield %tbMemoryKind1_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %tbMemoryKind1_w(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<4>
-    %3 = firrtl.subfield %tbMemoryKind1_w(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %tbMemoryKind1_w(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %5 = firrtl.subfield %tbMemoryKind1_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
-    %6 = firrtl.subfield %tbMemoryKind1_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
-    %7 = firrtl.subfield %tbMemoryKind1_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
-    %8 = firrtl.subfield %tbMemoryKind1_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+    %0 = firrtl.subfield %tbMemoryKind1_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %1 = firrtl.subfield %tbMemoryKind1_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %2 = firrtl.subfield %tbMemoryKind1_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %3 = firrtl.subfield %tbMemoryKind1_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %4 = firrtl.subfield %tbMemoryKind1_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %5 = firrtl.subfield %tbMemoryKind1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %6 = firrtl.subfield %tbMemoryKind1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %7 = firrtl.subfield %tbMemoryKind1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %8 = firrtl.subfield %tbMemoryKind1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
     firrtl.connect %8, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %7, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -211,9 +211,9 @@ firrtl.circuit "inferUnmaskedMemory" {
     // CHECK: [[AND:%.+]] = firrtl.and %wMask, %rEn
     // CHECK: firrtl.connect %tbMemoryKind1_W0_en, %0
     %MReadWrite_readwrite = firrtl.mem Undefined {depth = 12 : i64, name = "MReadWrite", portNames = ["readwrite"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
-    %rw_en = firrtl.subfield %MReadWrite_readwrite(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
-    %rw_wmode = firrtl.subfield %MReadWrite_readwrite(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
-    %rw_mask = firrtl.subfield %MReadWrite_readwrite(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_en = firrtl.subfield %MReadWrite_readwrite[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %rw_wmode = firrtl.subfield %MReadWrite_readwrite[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %rw_mask = firrtl.subfield %MReadWrite_readwrite[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_en, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %rw_wmode, %wMode : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %rw_mask, %wMask : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -19,12 +19,12 @@ firrtl.circuit "TopLevel" {
     // COMMON-NEXT:   firrtl.connect %[[SINK_VALID_NAME]], %[[SOURCE_VALID_NAME]] : [[SINK_VALID_TYPE]], [[SOURCE_VALID_TYPE]]
     // COMMON-NEXT:   firrtl.connect %[[SOURCE_READY_NAME]], %[[SINK_READY_NAME]] : [[SOURCE_READY_TYPE]], [[SINK_READY_TYPE]]
 
-    %0 = firrtl.subfield %source(0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %source(1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %source(2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-    %3 = firrtl.subfield %sink(0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %sink(1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %sink(2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
+    %0 = firrtl.subfield %source[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    %1 = firrtl.subfield %source[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    %2 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    %3 = firrtl.subfield %sink[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    %4 = firrtl.subfield %sink[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    %5 = firrtl.subfield %sink[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
     firrtl.when %0 {
       firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
       firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -72,17 +72,17 @@ firrtl.circuit "TopLevel" {
 
     // CHECK-NEXT: firrtl.connect %[[OUT_1_NAME]], %[[FLAT_ARG_1_NAME]] : [[OUT_1_TYPE]], [[FLAT_ARG_1_TYPE]]
     // CHECK-NEXT: firrtl.connect %[[OUT_2_NAME]], %[[FLAT_ARG_2_NAME]] : [[OUT_2_TYPE]], [[FLAT_ARG_2_TYPE]]
-    // AGGREGATE-NEXT:  %0 = firrtl.subfield %[[ARG_NAME]](0)
-    // AGGREGATE-NEXT:  %1 = firrtl.subfield %0(0)
-    // AGGREGATE-NEXT:  %2 = firrtl.subfield %1(0)
-    // AGGREGATE-NEXT:  %3 = firrtl.subfield %0(1)
+    // AGGREGATE-NEXT:  %0 = firrtl.subfield %[[ARG_NAME]][foo]
+    // AGGREGATE-NEXT:  %1 = firrtl.subfield %0[bar]
+    // AGGREGATE-NEXT:  %2 = firrtl.subfield %1[baz]
+    // AGGREGATE-NEXT:  %3 = firrtl.subfield %0[qux]
     // AGGREGATE-NEXT:  firrtl.connect %[[OUT_1_NAME]], %2
     // AGGREGATE-NEXT:  firrtl.connect %[[OUT_2_NAME]], %3
 
-    %0 = firrtl.subfield %arg(0) : (!firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>) -> !firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>
-    %1 = firrtl.subfield %0(0) : (!firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>) -> !firrtl.bundle<baz: uint<1>>
-    %2 = firrtl.subfield %1(0) : (!firrtl.bundle<baz: uint<1>>) -> !firrtl.uint<1>
-    %3 = firrtl.subfield %0(1) : (!firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>) -> !firrtl.sint<64>
+    %0 = firrtl.subfield %arg[foo] : !firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>
+    %1 = firrtl.subfield %0[bar] : !firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>
+    %2 = firrtl.subfield %1[baz] : !firrtl.bundle<baz: uint<1>>
+    %3 = firrtl.subfield %0[qux] : !firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>
     firrtl.connect %out1, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out2, %3 : !firrtl.sint<64>, !firrtl.sint<64>
   }
@@ -147,23 +147,23 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL: firrtl.module private @Mem2
   firrtl.module private @Mem2(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    %0 = firrtl.subfield %memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.clock
+    %0 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %1 = firrtl.subfield %memory_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.connect %1, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %memory_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.uint<4>
+    %2 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.connect %2, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    %3 = firrtl.subfield %memory_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %3 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     firrtl.connect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
-    %4 = firrtl.subfield %memory_w(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.clock
+    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
-    %5 = firrtl.subfield %memory_w(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %5, %wEn : !firrtl.uint<1>, !firrtl.uint<1>
-    %6 = firrtl.subfield %memory_w(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<4>
+    %6 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %6, %wAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    %7 = firrtl.subfield %memory_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    %7 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
-    %8 = firrtl.subfield %memory_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %8 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
 
     // ---------------------------------------------------------------------------------
@@ -174,43 +174,43 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT: %[[MEMORY_B_R:.+]], %[[MEMORY_B_W:.+]] = firrtl.mem {{.+}} data: uint<8>, mask: uint<1>
     // ---------------------------------------------------------------------------------
     // Read ports
-    // CHECK-NEXT: %[[MEMORY_A_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_R]](0)
+    // CHECK-NEXT: %[[MEMORY_A_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_R]][addr]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_ADDR]], %[[MEMORY_R_ADDR:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_R]](0)
+    // CHECK-NEXT: %[[MEMORY_B_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_R]][addr]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_ADDR]], %[[MEMORY_R_ADDR]]
-    // CHECK-NEXT: %[[MEMORY_A_R_EN:.+]] = firrtl.subfield %[[MEMORY_A_R]](1)
+    // CHECK-NEXT: %[[MEMORY_A_R_EN:.+]] = firrtl.subfield %[[MEMORY_A_R]][en]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_EN]], %[[MEMORY_R_EN:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_R_EN:.+]] = firrtl.subfield %[[MEMORY_B_R]](1)
+    // CHECK-NEXT: %[[MEMORY_B_R_EN:.+]] = firrtl.subfield %[[MEMORY_B_R]][en]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_EN]], %[[MEMORY_R_EN]]
-    // CHECK-NEXT: %[[MEMORY_A_R_CLK:.+]] = firrtl.subfield %[[MEMORY_A_R]](2)
+    // CHECK-NEXT: %[[MEMORY_A_R_CLK:.+]] = firrtl.subfield %[[MEMORY_A_R]][clk]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_CLK]], %[[MEMORY_R_CLK:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_R_CLK:.+]] = firrtl.subfield %[[MEMORY_B_R]](2)
+    // CHECK-NEXT: %[[MEMORY_B_R_CLK:.+]] = firrtl.subfield %[[MEMORY_B_R]][clk]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_CLK]], %[[MEMORY_R_CLK]]
-    // CHECK-NEXT: %[[MEMORY_A_R_DATA:.+]] = firrtl.subfield %[[MEMORY_A_R]](3)
+    // CHECK-NEXT: %[[MEMORY_A_R_DATA:.+]] = firrtl.subfield %[[MEMORY_A_R]][data]
     // CHECK-NEXT: firrtl.strictconnect %[[WIRE_A_R_DATA:.+]], %[[MEMORY_A_R_DATA]] :
-    // CHECK-NEXT: %[[MEMORY_B_R_DATA:.+]] = firrtl.subfield %[[MEMORY_B_R]](3)
+    // CHECK-NEXT: %[[MEMORY_B_R_DATA:.+]] = firrtl.subfield %[[MEMORY_B_R]][data]
     // CHECK-NEXT: firrtl.strictconnect %[[WIRE_B_R_DATA:.+]], %[[MEMORY_B_R_DATA]] :
     // ---------------------------------------------------------------------------------
     // Write Ports
-    // CHECK-NEXT: %[[MEMORY_A_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_W]](0)
+    // CHECK-NEXT: %[[MEMORY_A_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_W]][addr]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_ADDR]], %[[MEMORY_W_ADDR:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_W]](0)
+    // CHECK-NEXT: %[[MEMORY_B_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_W]][addr]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_ADDR]], %[[MEMORY_W_ADDR]] :
-    // CHECK-NEXT: %[[MEMORY_A_W_EN:.+]] = firrtl.subfield %[[MEMORY_A_W]](1)
+    // CHECK-NEXT: %[[MEMORY_A_W_EN:.+]] = firrtl.subfield %[[MEMORY_A_W]][en]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_EN]], %[[MEMORY_W_EN:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_W_EN:.+]] = firrtl.subfield %[[MEMORY_B_W]](1)
+    // CHECK-NEXT: %[[MEMORY_B_W_EN:.+]] = firrtl.subfield %[[MEMORY_B_W]][en]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_EN]], %[[MEMORY_W_EN]] :
-    // CHECK-NEXT: %[[MEMORY_A_W_CLK:.+]] = firrtl.subfield %[[MEMORY_A_W]](2)
+    // CHECK-NEXT: %[[MEMORY_A_W_CLK:.+]] = firrtl.subfield %[[MEMORY_A_W]][clk]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_CLK]], %[[MEMORY_W_CLK:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_W_CLK:.+]] = firrtl.subfield %[[MEMORY_B_W]](2)
+    // CHECK-NEXT: %[[MEMORY_B_W_CLK:.+]] = firrtl.subfield %[[MEMORY_B_W]][clk]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_CLK]], %[[MEMORY_W_CLK]] :
-    // CHECK-NEXT: %[[MEMORY_A_W_DATA:.+]] = firrtl.subfield %[[MEMORY_A_W]](3)
+    // CHECK-NEXT: %[[MEMORY_A_W_DATA:.+]] = firrtl.subfield %[[MEMORY_A_W]][data]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_DATA]], %[[WIRE_A_W_DATA:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_W_DATA:.+]] = firrtl.subfield %[[MEMORY_B_W]](3)
+    // CHECK-NEXT: %[[MEMORY_B_W_DATA:.+]] = firrtl.subfield %[[MEMORY_B_W]][data]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_DATA]], %[[WIRE_B_W_DATA:.+]] :
-    // CHECK-NEXT: %[[MEMORY_A_W_MASK:.+]] = firrtl.subfield %[[MEMORY_A_W]](4)
+    // CHECK-NEXT: %[[MEMORY_A_W_MASK:.+]] = firrtl.subfield %[[MEMORY_A_W]][mask]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_MASK]], %[[WIRE_A_W_MASK:.+]] :
-    // CHECK-NEXT: %[[MEMORY_B_W_MASK:.+]] = firrtl.subfield %[[MEMORY_B_W]](4)
+    // CHECK-NEXT: %[[MEMORY_B_W_MASK:.+]] = firrtl.subfield %[[MEMORY_B_W]][mask]
     // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_MASK]], %[[WIRE_B_W_MASK:.+]] :
     //
     // Connections to module ports
@@ -257,8 +257,8 @@ firrtl.circuit "TopLevel" {
 //AGGREGATE-NEXT:  %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //AGGREGATE-NEXT:  firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
 //AGGREGATE-NEXT:  %invalid = firrtl.invalidvalue : !firrtl.bundle<inp_d: uint<14>>
-//AGGREGATE-NEXT:  %0 = firrtl.subfield %invalid(0) : (!firrtl.bundle<inp_d: uint<14>>) -> !firrtl.uint<14>
-//AGGREGATE-NEXT:  %1 = firrtl.subfield %U0_inp_a(0) : (!firrtl.bundle<inp_d: uint<14>>) -> !firrtl.uint<14>
+//AGGREGATE-NEXT:  %0 = firrtl.subfield %invalid[inp_d] : !firrtl.bundle<inp_d: uint<14>>
+//AGGREGATE-NEXT:  %1 = firrtl.subfield %U0_inp_a[inp_d] : !firrtl.bundle<inp_d: uint<14>>
 //AGGREGATE-NEXT:  firrtl.strictconnect %1, %0 : !firrtl.uint<14>
 // https://github.com/llvm/circt/issues/661
 
@@ -268,7 +268,7 @@ firrtl.circuit "TopLevel" {
       %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32}
       : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>,
         !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
-      %127 = firrtl.subfield %head_MPORT_6(2) : (!firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>) -> !firrtl.clock
+      %127 = firrtl.subfield %head_MPORT_6[clk] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
     }
 
 // Check that a non-bundled mux ops are untouched.
@@ -292,7 +292,7 @@ firrtl.circuit "TopLevel" {
       // CHECK-NEXT: %n_a = firrtl.node %a_a  : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b, %n_a : !firrtl.uint<1>, !firrtl.uint<1>
       %n = firrtl.node %a : !firrtl.bundle<a: uint<1>>
-      %n_a = firrtl.subfield %n(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %n_a = firrtl.subfield %n[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %b, %n_a : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
@@ -302,11 +302,11 @@ firrtl.circuit "TopLevel" {
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : !firrtl.bundle<a: uint<1>>
-      %0 = firrtl.subfield %x(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %0 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>>
+      %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      %3 = firrtl.subfield %x(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<1>>
+      %3 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
@@ -326,11 +326,11 @@ firrtl.circuit "TopLevel" {
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
       %x = firrtl.wire : !firrtl.bundle<a: uint<1>>
-      %0 = firrtl.subfield %x(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %0 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>>
+      %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      %3 = firrtl.subfield %x(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<1>>
+      %3 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
@@ -646,15 +646,15 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %a, %ax : !firrtl.bundle<a: bundle<a: uint<1>>>, !firrtl.bundle<a: bundle<a: uint<1>>>
     // a <= ax
     // CHECK-NEXT: firrtl.strictconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %1 = firrtl.subfield %ax(0) : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
+    %1 = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
     firrtl.connect %0, %1 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     // a.a <= ax.a
     // CHECK: firrtl.strictconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
-    %2 = firrtl.subfield %a(0) : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %3 = firrtl.subfield %2(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %ax(0) : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %5 = firrtl.subfield %4(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
+    %3 = firrtl.subfield %2[a] : !firrtl.bundle<a: uint<1>>
+    %4 = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
+    %5 = firrtl.subfield %4[a] : !firrtl.bundle<a: uint<1>>
     firrtl.connect %3, %5 : !firrtl.uint<1>, !firrtl.uint<1>
     // a.a.a <= ax.a.a
     // CHECK: firrtl.connect %a_a_a, %ax_a_a
@@ -665,15 +665,15 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %b, %bx : !firrtl.bundle<a: bundle<a flip: uint<1>>>, !firrtl.bundle<a: bundle<a flip: uint<1>>>
     // b <= bx
     // CHECK: firrtl.strictconnect %bx_a_a, %b_a_a
-    %6 = firrtl.subfield %b(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %7 = firrtl.subfield %bx(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
+    %6 = firrtl.subfield %b[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+    %7 = firrtl.subfield %bx[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
     firrtl.connect %6, %7 : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
     // b.a <= bx.a
     // CHECK: firrtl.strictconnect %bx_a_a, %b_a_a
-    %8 = firrtl.subfield %b(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %9 = firrtl.subfield %8(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
-    %10 = firrtl.subfield %bx(0) : (!firrtl.bundle<a: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %11 = firrtl.subfield %10(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
+    %8 = firrtl.subfield %b[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+    %9 = firrtl.subfield %8[a] : !firrtl.bundle<a flip: uint<1>>
+    %10 = firrtl.subfield %bx[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
+    %11 = firrtl.subfield %10[a] : !firrtl.bundle<a flip: uint<1>>
     firrtl.connect %9, %11 : !firrtl.uint<1>, !firrtl.uint<1>
     // b.a.a <= bx.a.a
     // CHECK: firrtl.connect %b_a_a, %bx_a_a
@@ -684,15 +684,15 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %c, %cx : !firrtl.bundle<a flip: bundle<a: uint<1>>>, !firrtl.bundle<a flip: bundle<a: uint<1>>>
     // c <= cx
     // CHECK: firrtl.strictconnect %cx_a_a, %c_a_a
-    %12 = firrtl.subfield %c(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %13 = firrtl.subfield %cx(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    %12 = firrtl.subfield %c[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+    %13 = firrtl.subfield %cx[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
     firrtl.connect %12, %13 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     // c.a <= cx.a
     // CHECK: firrtl.strictconnect %c_a_a, %cx_a_a
-    %14 = firrtl.subfield %c(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %15 = firrtl.subfield %14(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-    %16 = firrtl.subfield %cx(0) : (!firrtl.bundle<a flip: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
-    %17 = firrtl.subfield %16(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %14 = firrtl.subfield %c[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+    %15 = firrtl.subfield %14[a] : !firrtl.bundle<a: uint<1>>
+    %16 = firrtl.subfield %cx[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
+    %17 = firrtl.subfield %16[a] : !firrtl.bundle<a: uint<1>>
     firrtl.connect %15, %17 : !firrtl.uint<1>, !firrtl.uint<1>
     // c.a.a <= cx.a.a
     // CHECK: firrtl.connect %c_a_a, %cx_a_a
@@ -703,15 +703,15 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %d, %dx : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>, !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     // d <= dx
     // CHECK: firrtl.strictconnect %d_a_a, %dx_a_a
-    %18 = firrtl.subfield %d(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %19 = firrtl.subfield %dx(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
+    %18 = firrtl.subfield %d[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
+    %19 = firrtl.subfield %dx[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     firrtl.connect %18, %19 : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
     // d.a <= dx.a
     // CHECK: firrtl.strictconnect %dx_a_a, %d_a_a
-    %20 = firrtl.subfield %d(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %21 = firrtl.subfield %20(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
-    %22 = firrtl.subfield %dx(0) : (!firrtl.bundle<a flip: bundle<a flip: uint<1>>>) -> !firrtl.bundle<a flip: uint<1>>
-    %23 = firrtl.subfield %22(0) : (!firrtl.bundle<a flip: uint<1>>) -> !firrtl.uint<1>
+    %20 = firrtl.subfield %d[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
+    %21 = firrtl.subfield %20[a] : !firrtl.bundle<a flip: uint<1>>
+    %22 = firrtl.subfield %dx[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
+    %23 = firrtl.subfield %22[a] : !firrtl.bundle<a flip: uint<1>>
     firrtl.connect %21, %23 : !firrtl.uint<1>, !firrtl.uint<1>
     // d.a.a <= dx.a.a
     // CHECK: firrtl.connect %d_a_a, %dx_a_a
@@ -721,23 +721,23 @@ firrtl.circuit "TopLevel" {
  // CHECK-LABEL: firrtl.module private @aofs
     firrtl.module private @aofs(in %a: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>>, 4>) {
       %0 = firrtl.subindex %b[0] : !firrtl.vector<bundle<wo: uint<1>>, 4>
-      %1 = firrtl.subfield %0(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>>
       %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
       firrtl.connect %1, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
       %2 = firrtl.subindex %b[1] : !firrtl.vector<bundle<wo: uint<1>>, 4>
-      %3 = firrtl.subfield %2(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
+      %3 = firrtl.subfield %2[wo] : !firrtl.bundle<wo: uint<1>>
       %invalid_ui1_0 = firrtl.invalidvalue : !firrtl.uint<1>
       firrtl.connect %3, %invalid_ui1_0 : !firrtl.uint<1>, !firrtl.uint<1>
       %4 = firrtl.subindex %b[2] : !firrtl.vector<bundle<wo: uint<1>>, 4>
-      %5 = firrtl.subfield %4(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
+      %5 = firrtl.subfield %4[wo] : !firrtl.bundle<wo: uint<1>>
       %invalid_ui1_1 = firrtl.invalidvalue : !firrtl.uint<1>
       firrtl.connect %5, %invalid_ui1_1 : !firrtl.uint<1>, !firrtl.uint<1>
       %6 = firrtl.subindex %b[3] : !firrtl.vector<bundle<wo: uint<1>>, 4>
-      %7 = firrtl.subfield %6(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
+      %7 = firrtl.subfield %6[wo] : !firrtl.bundle<wo: uint<1>>
       %invalid_ui1_2 = firrtl.invalidvalue : !firrtl.uint<1>
       firrtl.connect %7, %invalid_ui1_2 : !firrtl.uint<1>, !firrtl.uint<1>
       %8 = firrtl.subaccess %b[%sel] : !firrtl.vector<bundle<wo: uint<1>>, 4>, !firrtl.uint<2>
-      %9 = firrtl.subfield %8(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
+      %9 = firrtl.subfield %8[wo] : !firrtl.bundle<wo: uint<1>>
       firrtl.connect %9, %a : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
@@ -867,8 +867,8 @@ firrtl.circuit "TopLevel" {
   firrtl.module private @writeVectorOfBundle1D(in %a: !firrtl.bundle<wo: uint<1>, valid: uint<2>>, in %def: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>) {
     firrtl.connect %b, %def : !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>
     %0 = firrtl.subaccess %b[%sel] : !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, !firrtl.uint<2>
-    %1 = firrtl.subfield %0(0) : (!firrtl.bundle<wo: uint<1>, valid: uint<2>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %a(0) : (!firrtl.bundle<wo: uint<1>, valid: uint<2>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, valid: uint<2>>
+    %2 = firrtl.subfield %a[wo] : !firrtl.bundle<wo: uint<1>, valid: uint<2>>
     firrtl.connect %1, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -927,7 +927,7 @@ firrtl.circuit "TopLevel" {
     %0 = firrtl.subaccess %foo[%c0_ui1] : !firrtl.vector<uint<1>, 0>, !firrtl.uint<1>
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subaccess %i[%sel] : !firrtl.vector<bundle<a: uint<8>, b: uint<4>>, 0>, !firrtl.uint<1>
-    %2 = firrtl.subfield %1(0) : (!firrtl.bundle<a: uint<8>, b: uint<4>>) -> !firrtl.uint<8>
+    %2 = firrtl.subfield %1[a] : !firrtl.bundle<a: uint<8>, b: uint<4>>
     firrtl.connect %o, %2 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: firrtl.connect %o, %invalid_ui8
   }
@@ -991,7 +991,7 @@ firrtl.extmodule @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1
 // CHECK-LABEL: firrtl.module private @is1436_FOO
 firrtl.module private @is1436_FOO() {
   %thing_io = firrtl.instance thing @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
-  %0 = firrtl.subfield %thing_io(0) : (!firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>) -> !firrtl.vector<uint<1>, 1>
+  %0 = firrtl.subfield %thing_io[llWakeup] : !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %1 = firrtl.subaccess %0[%c0_ui2] : !firrtl.vector<uint<1>, 1>, !firrtl.uint<2>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -1021,7 +1021,7 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %d_data, %[[v6]] : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
     // CHECK-NEXT:  %[[v8:.+]] = firrtl.bits %[[v7]] 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
     // CHECK-NEXT:  %[[v9:.+]] = firrtl.bits %[[v7]] 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  %o1 = firrtl.subfield %e(1) : (!firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>) -> !firrtl.vector<uint<1>,2>
+  %o1 = firrtl.subfield %e[data] : !firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>
    %c2 = firrtl.bitcast %a1 : (!firrtl.uint<4>) -> (!firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data: uint<1>>)
     %d2 = firrtl.wire : !firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data: uint<1>>
     firrtl.connect %d2 , %c2: !firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data:

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -370,15 +370,15 @@ firrtl.circuit "Top"  {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %0 = firrtl.subfield %rf_read(0) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<3>
-    %1 = firrtl.subfield %rf_read(1) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
-    %2 = firrtl.subfield %rf_read(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
-    %3 = firrtl.subfield %rf_read(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
-    %4 = firrtl.subfield %rf_write(0) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<3>
-    %5 = firrtl.subfield %rf_write(1) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-    %6 = firrtl.subfield %rf_write(2) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
-    %7 = firrtl.subfield %rf_write(3) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
-    %8 = firrtl.subfield %rf_write(4) : (!firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %rf_read[addr] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %1 = firrtl.subfield %rf_read[en] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %2 = firrtl.subfield %rf_read[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %3 = firrtl.subfield %rf_read[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %4 = firrtl.subfield %rf_write[addr] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %5 = firrtl.subfield %rf_write[en] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %6 = firrtl.subfield %rf_write[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %7 = firrtl.subfield %rf_write[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %8 = firrtl.subfield %rf_write[mask] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     firrtl.strictconnect %0, %io_addr : !firrtl.uint<3>
     firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %2, %clock : !firrtl.clock

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -19,10 +19,10 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK-LABEL: firrtl.circuit "Mem" {
     // CHECK:         firrtl.module public @Mem(
     // CHECK:           %mem_read = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
-    // CHECK:           %[[v0:.+]] = firrtl.subfield %mem_read(0)
-    // CHECK:           %[[v1:.+]] = firrtl.subfield %mem_read(1)
-    // CHECK:           %[[v2:.+]] = firrtl.subfield %mem_read(2)
-    // CHECK:           %[[v3:.+]] = firrtl.subfield %mem_read(3)
+    // CHECK:           %[[v0:.+]] = firrtl.subfield %mem_read[addr]
+    // CHECK:           %[[v1:.+]] = firrtl.subfield %mem_read[en]
+    // CHECK:           %[[v2:.+]] = firrtl.subfield %mem_read[clk]
+    // CHECK:           %[[v3:.+]] = firrtl.subfield %mem_read[data]
     // CHECK:           %mem = firrtl.reg %[[v6:.+]]  : !firrtl.vector<uint<8>, 8>
     // CHECK:           %[[v23:.+]] = firrtl.subaccess %mem[%[[v4:.+]]]
     // CHECK:           %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
@@ -31,11 +31,11 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:             firrtl.strictconnect %[[v3]], %[[v23]]
     // CHECK:           }
     // CHECK:           %mem_write = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    // CHECK:           %[[v5:.+]] = firrtl.subfield %mem_write(0)
-    // CHECK:           %[[v6:.+]] = firrtl.subfield %mem_write(1)
-    // CHECK:           %[[v7:.+]] = firrtl.subfield %mem_write(2)
-    // CHECK:           %[[v8:.+]] = firrtl.subfield %mem_write(3)
-    // CHECK:           %[[v9:.+]] = firrtl.subfield %mem_write(4)
+    // CHECK:           %[[v5:.+]] = firrtl.subfield %mem_write[addr]
+    // CHECK:           %[[v6:.+]] = firrtl.subfield %mem_write[en]
+    // CHECK:           %[[v7:.+]] = firrtl.subfield %mem_write[clk]
+    // CHECK:           %[[v8:.+]] = firrtl.subfield %mem_write[data]
+    // CHECK:           %[[v9:.+]] = firrtl.subfield %mem_write[mask]
     // CHECK:           %[[v10:.+]] = firrtl.subaccess %mem[%[[v5]]]
     // CHECK:           firrtl.when %[[v6]] {
     // CHECK:             firrtl.when %[[v9]] {
@@ -172,11 +172,11 @@ firrtl.circuit "WriteMask" attributes {annotations = [
     // CHECK-LABEL: firrtl.module public @WriteMask()
     // CHECK:         %mem = firrtl.reg %2  : !firrtl.vector<vector<uint<8>, 2>, 8>
     // CHECK:         %mem_write = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
-    // CHECK:         %[[v5:.+]] = firrtl.subfield %mem_write(0)
-    // CHECK:         %[[v6:.+]] = firrtl.subfield %mem_write(1)
-    // CHECK:         %[[v7:.+]] = firrtl.subfield %mem_write(2)
-    // CHECK:         %[[v8:.+]] = firrtl.subfield %mem_write(3)
-    // CHECK:         %[[v9:.+]] = firrtl.subfield %mem_write(4)
+    // CHECK:         %[[v5:.+]] = firrtl.subfield %mem_write[addr]
+    // CHECK:         %[[v6:.+]] = firrtl.subfield %mem_write[en]
+    // CHECK:         %[[v7:.+]] = firrtl.subfield %mem_write[clk]
+    // CHECK:         %[[v8:.+]] = firrtl.subfield %mem_write[data]
+    // CHECK:         %[[v9:.+]] = firrtl.subfield %mem_write[mask]
     // CHECK:         %[[v10:.+]] = firrtl.subaccess %mem[%5] : !firrtl.vector<vector<uint<8>, 2>, 8>, !firrtl.uint<3>
     // CHECK:         %[[v11:.+]] = firrtl.subindex
     // CHECK:         %[[v12:.+]] = firrtl.subindex

--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -13,19 +13,19 @@ firrtl.circuit "Test"   {
   firrtl.module @Test(in %a: !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>, out %b: !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>) {
      %0 = firrtl.subindex %a[0] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %1 = firrtl.subindex %b[0] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
-     %2 = firrtl.subfield %0(0) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.clock
-     %3 = firrtl.subfield %1(0) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.clock
+     %2 = firrtl.subfield %0[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
+     %3 = firrtl.subfield %1[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
      firrtl.strictconnect %3, %2 : !firrtl.clock
-     %4 = firrtl.subfield %0(1) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.uint<1>
-     %5 = firrtl.subfield %1(1) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.uint<1>
+     %4 = firrtl.subfield %0[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
+     %5 = firrtl.subfield %1[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
      firrtl.strictconnect %5, %4 : !firrtl.uint<1>
      %6 = firrtl.subindex %a[1] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %7 = firrtl.subindex %b[1] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
-     %8 = firrtl.subfield %6(0) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.clock
-     %9 = firrtl.subfield %7(0) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.clock
+     %8 = firrtl.subfield %6[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
+     %9 = firrtl.subfield %7[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
      firrtl.strictconnect %9, %8 : !firrtl.clock
-     %10 = firrtl.subfield %6(1) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.uint<1>
-     %11 = firrtl.subfield %7(1) : (!firrtl.bundle<clock: clock, valid: uint<1>>) -> !firrtl.uint<1>
+     %10 = firrtl.subfield %6[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
+     %11 = firrtl.subfield %7[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
      firrtl.strictconnect %11, %10 : !firrtl.uint<1>
   }
 
@@ -41,8 +41,8 @@ firrtl.circuit "Test"   {
   firrtl.module @Constant(out %a: !firrtl.bundle<b: uint<1>, c: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %0 = firrtl.subfield %a(0) : (!firrtl.bundle<b: uint<1>, c: uint<1>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %a(1) : (!firrtl.bundle<b: uint<1>, c: uint<1>>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %a[b] : !firrtl.bundle<b: uint<1>, c: uint<1>>
+    %1 = firrtl.subfield %a[c] : !firrtl.bundle<b: uint<1>, c: uint<1>>
     firrtl.strictconnect %0, %c0_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -99,8 +99,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.strictconnect %_t, %_t_2
     _t <- _t_2
     
-    ; CHECK: [[a0:%.+]] = firrtl.subfield %bundleWithAnalog(0)
-    ; CHECK: [[a1:%.+]] = firrtl.subfield %bundleWithAnalog(0)
+    ; CHECK: [[a0:%.+]] = firrtl.subfield %bundleWithAnalog[a]
+    ; CHECK: [[a1:%.+]] = firrtl.subfield %bundleWithAnalog[a]
     ; CHECK: firrtl.attach [[a1]], [[a0]]
     wire bundleWithAnalog : {a: Analog<1>}
     bundleWithAnalog <- bundleWithAnalog
@@ -129,9 +129,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %out_0 = firrtl.wire interesting_name : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
 
-    ; CHECK: [[A:%.+]] = firrtl.subfield %out_0(0) : (!firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>) -> !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
-    ; CHECK: [[B:%.+]] = firrtl.subfield [[A]](0) : (!firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>) -> !firrtl.bundle<clock: clock, reset: uint<1>>
-    ; CHECK: [[C:%.+]] = firrtl.subfield [[B]](1) : (!firrtl.bundle<clock: clock, reset: uint<1>>) -> !firrtl.uint<1>
+    ; CHECK: [[A:%.+]] = firrtl.subfield %out_0[member] : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
+    ; CHECK: [[B:%.+]] = firrtl.subfield [[A]]["0"] : !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
+    ; CHECK: [[C:%.+]] = firrtl.subfield [[B]][reset] : !firrtl.bundle<clock: clock, reset: uint<1>>
     ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
@@ -455,7 +455,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %write = firrtl.wire
     wire write : { id : UInt<4>, resp : UInt<2>}
 
-    ; CHECK: firrtl.subfield %write(0)
+    ; CHECK: firrtl.subfield %write[id]
     write.id <= UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity2(
@@ -557,7 +557,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output o: UInt<1>
 
     ; Subfields always get emitted by their declarations.
-    ; CHECK: [[SUB:%.+]] = firrtl.subfield %i(0)
+    ; CHECK: [[SUB:%.+]] = firrtl.subfield %i[x]
 
     ; CHECK: %n3 = firrtl.node interesting_name [[SUB]]
     node n3 = i.x
@@ -580,7 +580,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module private @flip_one
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
-    ; CHECK: %0 = firrtl.subfield %bf(0)
+    ; CHECK: %0 = firrtl.subfield %bf[int_1]
     ; CHECK: %_T = firrtl.node interesting_name %0
     node _T = bf.int_1
     ; CHECK: firrtl.when %_T {
@@ -714,15 +714,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   module CheckInvalids_in2 :
     input in2 : { a : UInt<1>, flip b : UInt<1>}
-    ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2(1)
+    ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2[b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[IN2_B]], [[INV]]
     in2 is invalid
 
   module CheckInvalids_in3 :
     input in3 : {a : { b : UInt<1>, flip c : UInt<1>}}
-    ; CHECK: [[IN3_A:%.+]] = firrtl.subfield %in3(0)
-    ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]](1)
+    ; CHECK: [[IN3_A:%.+]] = firrtl.subfield %in3[a]
+    ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]][c]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[IN3_A_C]], [[INV]]
     in3 is invalid
@@ -741,15 +741,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   module CheckInvalids_out2 :
     output out2 : { a : UInt<1>, flip b : UInt<1>}
-    ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2(0)
+    ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2[a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[OUT2_A]], [[INV]]
     out2 is invalid
 
   module CheckInvalids_out3 :
     output out3 : {a : { b : UInt<1>, flip c : UInt<1>}}
-    ; CHECK: [[OUT3_A:%.+]] = firrtl.subfield %out3(0)
-    ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]](0)
+    ; CHECK: [[OUT3_A:%.+]] = firrtl.subfield %out3[a]
+    ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]][b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[OUT3_A_B]], [[INV]]
     out3 is invalid
@@ -762,8 +762,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire0 is invalid
 
     ; CHECK: %wire1 = firrtl.wire
-    ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1(1)
-    ; CHECK: [[WIRE1_A:%.+]] = firrtl.subfield %wire1(0)
+    ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1[b]
+    ; CHECK: [[WIRE1_A:%.+]] = firrtl.subfield %wire1[a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[WIRE1_A]], [[INV]]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
@@ -773,9 +773,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; An analog in the leaf of a wire should be attached not connected.
     ; CHECK: %wire2 = firrtl.wire
-    ; CHECK: [[WIRE2_X:%.+]] = firrtl.subfield %wire2(0)
-    ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]](1)
-    ; CHECK: [[WIRE2_X_A:%.+]] = firrtl.subfield [[WIRE2_X]](0)
+    ; CHECK: [[WIRE2_X:%.+]] = firrtl.subfield %wire2[x]
+    ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]][b]
+    ; CHECK: [[WIRE2_X_A:%.+]] = firrtl.subfield [[WIRE2_X]][a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.strictconnect [[WIRE2_X_A]], [[INV]]
     ; CHECK-NOT: firrtl.attach [[WIRE2_X_B]], [[INV]]
@@ -924,10 +924,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output b: {a: Reset, b: Reset}
 
     b <= a
-    ; CHECK: %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>, b: asyncreset>) -> !firrtl.uint<1>
+    ; CHECK: %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>, b: asyncreset>
     ; CHECK: firrtl.connect %0, %1 : !firrtl.reset, !firrtl.uint<1>
-    ; CHECK: %2 = firrtl.subfield %b(1) : (!firrtl.bundle<a: reset, b: reset>) -> !firrtl.reset
-    ; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<1>, b: asyncreset>) -> !firrtl.asyncreset
+    ; CHECK: %2 = firrtl.subfield %b[b] : !firrtl.bundle<a: reset, b: reset>
+    ; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<1>, b: asyncreset>
     ; CHECK: firrtl.connect %2, %3 : !firrtl.reset, !firrtl.asyncreset
 
   ; CHECK-LABEL: @WhenEncodedVerification

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -34,14 +34,14 @@ circuit MyModule :  @[CIRCUIT.scala 127]
   module Subexpressions :
     input in: UInt
     output auto : { out_0 : UInt<1> }
-    ; CHECK: %0 = firrtl.subfield %auto(0) {{.*}} loc("Field":173:49)
+    ; CHECK: %0 = firrtl.subfield %auto[out_0] {{.*}} loc("Field":173:49)
 
     ; CHECK: %out_0 = firrtl.wire
     wire out_0 : { member : { 0 : { reset : UInt<1>}}}
 
-    ; CHECK: %1 = firrtl.subfield %out_0(0) {{.*}} loc("Field":173:49)
-    ; CHECK: %2 = firrtl.subfield %1(0) {{.*}} loc("Field":173:49)
-    ; CHECK: %3 = firrtl.subfield %2(0) : {{.*}} loc("Field":173:49)
+    ; CHECK: %1 = firrtl.subfield %out_0[member] {{.*}} loc("Field":173:49)
+    ; CHECK: %2 = firrtl.subfield %1["0"] {{.*}} loc("Field":173:49)
+    ; CHECK: %3 = firrtl.subfield %2[reset] : {{.*}} loc("Field":173:49)
     ; CHECK: firrtl.strictconnect %0, %3 : {{.*}} loc("Field":173:49)
     auto.out_0 <- out_0.member.0.reset @[Field 173:49]
 

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -36,7 +36,7 @@ firrtl.circuit "SFCCompatTests" {
   // CHECK-LABEL: firrtl.module @AggregateInvalidThroughWire
   firrtl.module @AggregateInvalidThroughWire(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %d: !firrtl.vector<bundle<a: uint<1>>, 2>, out %q: !firrtl.vector<bundle<a: uint<1>>, 2>) {
     %inv = firrtl.wire : !firrtl.bundle<a: uint<1>>
-    %inv_a = firrtl.subfield %inv(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %inv_a = firrtl.subfield %inv[a] : !firrtl.bundle<a: uint<1>>
     %invalid = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.strictconnect %inv_a, %invalid : !firrtl.uint<1>
 
@@ -206,7 +206,7 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate1" {
     // Connect a complex chain of operations leading to the port to value[1].
     %subindex = firrtl.subindex %x[0] : !firrtl.vector<bundle<y : uint<1>>, 1>
     %node = firrtl.node %subindex : !firrtl.bundle<y : uint<1>>
-    %subfield = firrtl.subfield %node(0) : (!firrtl.bundle<y : uint<1>>) -> !firrtl.uint<1>
+    %subfield = firrtl.subfield %node[y] : !firrtl.bundle<y : uint<1>>
     %value_1 = firrtl.subindex %value[1] : !firrtl.vector<uint<1>, 2>
     firrtl.strictconnect %value_1, %subfield : !firrtl.uint<1>
 

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -17,11 +17,11 @@ firrtl.circuit "ReadOnlyMemory" {
 
 
     // CHECK-NOT: firrtl.mem
-    %2 = firrtl.subfield %Memory_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<4>
+    %2 = firrtl.subfield %Memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %2, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %3 = firrtl.subfield %Memory_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %Memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %4 = firrtl.subfield %Memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.clock
+    %4 = firrtl.subfield %Memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
   }
 }
@@ -41,15 +41,15 @@ firrtl.circuit "WriteOnlyMemory" {
       } : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
     // CHECK-NOT: firrtl.mem
-    %10 = firrtl.subfield %Memory_write(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+    %10 = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %10, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %11 = firrtl.subfield %Memory_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %11 = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %11, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %12 = firrtl.subfield %Memory_write(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.clock
+    %12 = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %12, %clock : !firrtl.clock, !firrtl.clock
-    %13 = firrtl.subfield %Memory_write(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<42>
+    %13 = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %13, %indata : !firrtl.uint<42>, !firrtl.uint<42>
-    %14 = firrtl.subfield %Memory_write(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %14 = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %14, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -76,54 +76,54 @@ firrtl.circuit "ReadWriteToWrite" {
 
 
     // CHECK: [[WIRE:%.+]] = firrtl.wire   : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
-    // CHECK: [[PORT_ADDR:%.+]] = firrtl.subfield %Memory_rw(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
-    // CHECK: [[GET_ADDR:%.+]] = firrtl.subfield [[WIRE]](0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+    // CHECK: [[PORT_ADDR:%.+]] = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    // CHECK: [[GET_ADDR:%.+]] = firrtl.subfield [[WIRE]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[PORT_ADDR]], [[GET_ADDR]] : !firrtl.uint<4>
-    // CHECK: [[PORT_EN:%.+]] = firrtl.subfield %Memory_rw(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
-    // CHECK: [[GET_EN:%.+]] = firrtl.subfield [[WIRE]](1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: [[PORT_EN:%.+]] = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    // CHECK: [[GET_EN:%.+]] = firrtl.subfield [[WIRE]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[PORT_EN]], [[GET_EN]] : !firrtl.uint<1>
-    // CHECK: [[PORT_CLK:%.+]] = firrtl.subfield %Memory_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.clock
-    // CHECK: [[GET_CLK:%.+]] = firrtl.subfield [[WIRE]](2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.clock
+    // CHECK: [[PORT_CLK:%.+]] = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    // CHECK: [[GET_CLK:%.+]] = firrtl.subfield [[WIRE]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[PORT_CLK]], [[GET_CLK]] : !firrtl.clock
-    // CHECK: [[PORT_DATA:%.+]] = firrtl.subfield %Memory_rw(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<42>
-    // CHECK: [[GET_DATA:%.+]] = firrtl.subfield [[WIRE]](5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    // CHECK: [[PORT_DATA:%.+]] = firrtl.subfield %Memory_rw[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    // CHECK: [[GET_DATA:%.+]] = firrtl.subfield [[WIRE]][wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[PORT_DATA]], [[GET_DATA]] : !firrtl.uint<42>
-    // CHECK: [[PORT_MASK:%.+]] = firrtl.subfield %Memory_rw(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
-    // CHECK: [[GET_MASK:%.+]] = firrtl.subfield [[WIRE]](6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: [[PORT_MASK:%.+]] = firrtl.subfield %Memory_rw[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    // CHECK: [[GET_MASK:%.+]] = firrtl.subfield [[WIRE]][wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[PORT_MASK]], [[GET_MASK]] : !firrtl.uint<1>
-    // CHECK: [[SET_ADDR:%.+]] = firrtl.subfield [[WIRE]](0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+    // CHECK: [[SET_ADDR:%.+]] = firrtl.subfield [[WIRE]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_ADDR]], %addr : !firrtl.uint<4>
-    // CHECK: [[SET_EN:%.+]] = firrtl.subfield [[WIRE]](1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: [[SET_EN:%.+]] = firrtl.subfield [[WIRE]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_EN]], %c1_ui1 : !firrtl.uint<1>
-    // CHECK: [[SET_CLK:%.+]] = firrtl.subfield [[WIRE]](2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.clock
+    // CHECK: [[SET_CLK:%.+]] = firrtl.subfield [[WIRE]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_CLK]], %clock : !firrtl.clock
-    // CHECK: [[SET_WMODE:%.+]] = firrtl.subfield [[WIRE]](4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: [[SET_WMODE:%.+]] = firrtl.subfield [[WIRE]][wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_WMODE]], %c1_ui1 : !firrtl.uint<1>
-    // CHECK: [[SET_WDATA:%.+]] = firrtl.subfield [[WIRE]](5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    // CHECK: [[SET_WDATA:%.+]] = firrtl.subfield [[WIRE]][wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_WDATA]], %indata : !firrtl.uint<42>
-    // CHECK: [[SET_WMASK:%.+]] = firrtl.subfield [[WIRE]](6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: [[SET_WMASK:%.+]] = firrtl.subfield [[WIRE]][wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     // CHECK: firrtl.strictconnect [[SET_WMASK]], %c1_ui1 : !firrtl.uint<1>
 
-    %0 = firrtl.subfield %Memory_rw(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+    %0 = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %0, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %1 = firrtl.subfield %Memory_rw(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %Memory_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.clock
+    %2 = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
-    %3 = firrtl.subfield %Memory_rw(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %3 = firrtl.subfield %Memory_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %4 = firrtl.subfield %Memory_rw(5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    %4 = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %4, %indata : !firrtl.uint<42>, !firrtl.uint<42>
-    %5 = firrtl.subfield %Memory_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %Memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %5, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    %6 = firrtl.subfield %Memory_r(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<4>
+    %6 = firrtl.subfield %Memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %6, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %7 = firrtl.subfield %Memory_r(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %Memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %8 = firrtl.subfield %Memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.clock
+    %8 = firrtl.subfield %Memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %8, %clock : !firrtl.clock, !firrtl.clock
-    %9 = firrtl.subfield %Memory_r(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<42>
+    %9 = firrtl.subfield %Memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %result, %9 : !firrtl.uint<42>, !firrtl.uint<42>
   }
 }
@@ -160,55 +160,55 @@ firrtl.circuit "UnusedPorts" {
     // CHECK: [[REG1:%.+]] = firrtl.reg %c0_clock : !firrtl.uint<42>
     // CHECK: [[REG2:%.+]] = firrtl.reg %c0_clock : !firrtl.uint<42>
     // CHECK: firrtl.strictconnect %result_read, [[REG1]] : !firrtl.uint<42>
-    %read_addr = firrtl.subfield %Memory_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<4>
+    %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %read_en = firrtl.subfield %Memory_read(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<1>
+    %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_en, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %read_clk = firrtl.subfield %Memory_read(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.clock
+    %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
-    %read_data = firrtl.subfield %Memory_read(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>) -> !firrtl.uint<42>
+    %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %result_read, %read_data : !firrtl.uint<42>, !firrtl.uint<42>
 
     // CHECK: firrtl.strictconnect %result_rw, [[REG2]] : !firrtl.uint<42>
-    %rw_addr = firrtl.subfield %Memory_rw(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+    %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %rw_en = firrtl.subfield %Memory_rw(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_en, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %rw_clk = firrtl.subfield %Memory_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.clock
+    %rw_clk = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_clk, %clock : !firrtl.clock, !firrtl.clock
-    %rw_rdata = firrtl.subfield %Memory_rw(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    %rw_rdata = firrtl.subfield %Memory_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %result_rw, %rw_rdata : !firrtl.uint<42>, !firrtl.uint<42>
-    %rw_wmode = firrtl.subfield %Memory_rw(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_wmode = firrtl.subfield %Memory_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_wmode, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
-    %rw_wdata = firrtl.subfield %Memory_rw(5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    %rw_wdata = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_wdata, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
-    %rw_wmask = firrtl.subfield %Memory_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_wmask = firrtl.subfield %Memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    %write_addr = firrtl.subfield %Memory_write(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+    %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %write_en = firrtl.subfield %Memory_write(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_en, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %write_clk = firrtl.subfield %Memory_write(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.clock
+    %write_clk = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
-    %write_data = firrtl.subfield %Memory_write(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<42>
+    %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_data, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
-    %write_mask = firrtl.subfield %Memory_write(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+    %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    %pinned_addr = firrtl.subfield %Memory_pinned(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<4>
+    %pinned_addr = firrtl.subfield %Memory_pinned[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
-    %pinned_en = firrtl.subfield %Memory_pinned(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %pinned_en = firrtl.subfield %Memory_pinned[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %pinned_clk = firrtl.subfield %Memory_pinned(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.clock
+    %pinned_clk = firrtl.subfield %Memory_pinned[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_clk, %clock : !firrtl.clock, !firrtl.clock
-    %pinned_rdata = firrtl.subfield %Memory_pinned(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    %pinned_rdata = firrtl.subfield %Memory_pinned[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %result_pinned, %pinned_rdata : !firrtl.uint<42>, !firrtl.uint<42>
-    %pinned_wmode = firrtl.subfield %Memory_pinned(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %pinned_wmode = firrtl.subfield %Memory_pinned[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_wmode, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
-    %pinned_wdata = firrtl.subfield %Memory_pinned(5) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<42>
+    %pinned_wdata = firrtl.subfield %Memory_pinned[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_wdata, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
-    %pinned_wmask = firrtl.subfield %Memory_pinned(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %pinned_wmask = firrtl.subfield %Memory_pinned[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %pinned_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/wire-dft.mlir
+++ b/test/Dialect/FIRRTL/wire-dft.mlir
@@ -75,7 +75,7 @@ firrtl.circuit "TestHarness" {
     // A bundle type should be work for the enable signal using annotations with fieldIDs.
     %test_en = firrtl.wire {annotations = [{circt.fieldID = 3 : i32, class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
     // CHECK: %0 = firrtl.subindex %test_en_0[0] : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
-    // CHECK: %1 = firrtl.subfield %0(1) : (!firrtl.bundle<baz: uint<1>, qux: uint<1>>) -> !firrtl.uint<1>
+    // CHECK: %1 = firrtl.subfield %0[qux] : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
     // CHECK: firrtl.connect %test_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.instance b @B()
 

--- a/test/circt-reduce/test/memory-stubber.mlir
+++ b/test/circt-reduce/test/memory-stubber.mlir
@@ -7,8 +7,8 @@ firrtl.circuit "Basic"   {
   firrtl.module @Basic() {
     %memory_r = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
     // CHECK: %memory_r = firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    // CHECK: [[MEM_ADDR:%.+]] = firrtl.subfield %memory_r(0)
-    // CHECK: [[MEM_EN:%.+]] = firrtl.subfield %memory_r(1)
+    // CHECK: [[MEM_ADDR:%.+]] = firrtl.subfield %memory_r[addr]
+    // CHECK: [[MEM_EN:%.+]] = firrtl.subfield %memory_r[en]
     // CHECK: [[XOR:%.+]] = firrtl.xor [[MEM_ADDR]], [[MEM_EN]]
     // CHECK: firrtl.connect {{%.+}}, [[XOR]]
   }

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -21,12 +21,12 @@ circuit truncatingIntegerConnect :
    a <= b
 
 ; CHECK-LABEL: @regularBundleConnect
-; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
-; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<3>
+; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
+; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<3>, b: uint<2>>
 ; CHECK: %2 = firrtl.pad %1, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
 ; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
-; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
-; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<2>
+; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
+; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<3>, b: uint<2>>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
 ; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
 circuit regularBundleConnect :
@@ -36,12 +36,12 @@ circuit regularBundleConnect :
    a <= b
 
 ; CHECK-LABEL: @truncatingBundleConnect
-; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
-; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<6>
+; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
+; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<6>, b: uint<1>>
 ; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
-; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
-; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<1>
+; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
+; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<6>, b: uint<1>>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
 ; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
 circuit truncatingBundleConnect :


### PR DESCRIPTION
Changes to format:
- Only print the input type, not the result type. This is concise, and bring the subfield syntax in-line with with firrtl.subindex.
- Print the name of the field, not it's index. Internally, the field is still represented as an integer. This required implementing a custom printer (although, not a very complex one).

Old:
```
%0 = firrtl.subfield %input(2) : (!firrtl.bundle<a: uint<1>, b: uint<2>, c: uint<3>>) -> !uint<3>
```

New:
```
%0 = firrtl.subfield %input[c] : !firrtl.bundle<a: uint<1>, b: uint<2>, c: uint<3>>
```

Other changes:
- update lit tests to the new format
- add some new error tests related to new format

Fixes: https://github.com/llvm/circt/issues/4424
Fixes: https://github.com/llvm/circt/issues/4423