### PR TITLE
[StandardToHandshake] Take fork/sink materialization out of conversion pass

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -185,18 +185,8 @@ LogicalResult lowerRegion(HandshakeLowering &hl, bool sourceConstants,
       return failure();
   }
 
-  // Fork/sink materialization. @todo: this should be removed and
-  // materialization should be run as a separate pass afterward initial dataflow
-  // conversion! However, connectToMemory has some hard-coded assumptions on the
-  // existence of fork/sink operations...
-  if (failed(partiallyLowerRegion(addSinkOps, hl.getContext(), hl.getRegion())))
-    return failure();
-
   if (failed(runPartialLowering(
           hl, &HandshakeLowering::connectConstantsToControl, sourceConstants)))
-    return failure();
-
-  if (failed(partiallyLowerRegion(addForkOps, hl.getContext(), hl.getRegion())))
     return failure();
 
   bool lsq = false;

--- a/integration_test/handshake-runner/call_bb.mlir
+++ b/integration_test/handshake-runner/call_bb.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 763 2996
 module {
   func.func @muladd(%1:index, %2:index, %3:index) -> (index) {

--- a/integration_test/handshake-runner/call_controlflow.mlir
+++ b/integration_test/handshake-runner/call_controlflow.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s 3 2 1 | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s > handshake.mlir
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s > handshake.mlir
 // RUN  handshake-runner handshake.mlir 3 2 1 | FileCheck %s
 // CHECK: 5
 

--- a/integration_test/handshake-runner/cdiv-old-std.mlir
+++ b/integration_test/handshake-runner/cdiv-old-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 1,0,1,0 | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner - 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 1,0,1,0 | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 1,0,1,0 | FileCheck %s
 // CHECK: 0 2,3,4,5 2,3,4,5 1,1431655763,3,858993455 3,4,5,6 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 0,-1,0,-1
 
 module {

--- a/integration_test/handshake-runner/cdiv-std.mlir
+++ b/integration_test/handshake-runner/cdiv-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 0
 
 module {

--- a/integration_test/handshake-runner/complex_bb.mlir
+++ b/integration_test/handshake-runner/complex_bb.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 763 2996
 module {
   func.func @main() -> (index, index) {

--- a/integration_test/handshake-runner/floydwarshall-std.mlir
+++ b/integration_test/handshake-runner/floydwarshall-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 0
 
 module {

--- a/integration_test/handshake-runner/histogram-std.mlir
+++ b/integration_test/handshake-runner/histogram-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 0
 
 module {

--- a/integration_test/handshake-runner/loadstore.mlir
+++ b/integration_test/handshake-runner/loadstore.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s 2 | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner - 2 | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - 2 | FileCheck %s
 // CHECK: 1
 
 module {

--- a/integration_test/handshake-runner/loop-check-1-std.mlir
+++ b/integration_test/handshake-runner/loop-check-1-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 10
 
 module {

--- a/integration_test/handshake-runner/loop-check-2-std.mlir
+++ b/integration_test/handshake-runner/loop-check-2-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 10
 
 module {

--- a/integration_test/handshake-runner/matmul-check-std.mlir
+++ b/integration_test/handshake-runner/matmul-check-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 200
 
 

--- a/integration_test/handshake-runner/matmul-std.mlir
+++ b/integration_test/handshake-runner/matmul-std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // CHECK: 0
 
 module {

--- a/integration_test/handshake-runner/memory_simple_2_std.mlir
+++ b/integration_test/handshake-runner/memory_simple_2_std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s 2,3,4,5 | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner - 2,3,4,5 | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - 2,3,4,5 | FileCheck %s
 // CHECK: 5 5,3,4,5
 
 module {

--- a/integration_test/handshake-runner/memory_simple_std.mlir
+++ b/integration_test/handshake-runner/memory_simple_std.mlir
@@ -1,5 +1,5 @@
 // RUN: handshake-runner %s 2,3,4,5 | FileCheck %s
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner - 2,3,4,5 | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - 2,3,4,5 | FileCheck %s
 // CHECK: 2 2,3,4,5
 
 module {

--- a/integration_test/handshake-runner/simple_loop.mlir
+++ b/integration_test/handshake-runner/simple_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner | FileCheck %s
 // RUN: handshake-runner %s | FileCheck %s
 // CHECK: 42
 module {

--- a/integration_test/handshake-runner/simple_loop_buffered.mlir
+++ b/integration_test/handshake-runner/simple_loop_buffered.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -lower-std-to-handshake %s \
+// RUN: circt-opt -lower-std-to-handshake -handshake-materialize-forks-sinks %s \
 // RUN: | circt-opt --handshake-insert-buffers="strategy=all" \
 // RUN: | handshake-runner | FileCheck %s
 // CHECK: 42

--- a/test/Conversion/StandardToHandshake/arith-ops.mlir
+++ b/test/Conversion/StandardToHandshake/arith-ops.mlir
@@ -3,36 +3,23 @@
 
 // CHECK:   handshake.func @ops(%[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, ...) -> (f32, i32, none)
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_0]] : f32
-// CHECK:           %[[VAL_6:.*]]:3 = fork [3] %[[VAL_5]] : f32
-// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_1]] : f32
-// CHECK:           %[[VAL_8:.*]]:3 = fork [3] %[[VAL_7]] : f32
-// CHECK:           %[[VAL_9:.*]] = merge %[[VAL_2]] : i32
-// CHECK:           %[[VAL_10:.*]]:10 = fork [10] %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]]:9 = fork [9] %[[VAL_11]] : i32
-// CHECK:           %[[VAL_13:.*]] = arith.subf %[[VAL_6]]#2, %[[VAL_8]]#2 : f32
-// CHECK:           %[[VAL_14:.*]] = arith.subi %[[VAL_10]]#9, %[[VAL_12]]#8 : i32
-// CHECK:           %[[VAL_15:.*]] = arith.cmpi slt, %[[VAL_10]]#8, %[[VAL_14]] : i32
-// CHECK:           %[[VAL_16:.*]] = arith.divsi %[[VAL_10]]#7, %[[VAL_12]]#7 : i32
-// CHECK:           %[[VAL_17:.*]] = arith.divui %[[VAL_10]]#6, %[[VAL_12]]#6 : i32
-// CHECK:           sink %[[VAL_17]] : i32
-// CHECK:           %[[VAL_18:.*]] = arith.remsi %[[VAL_10]]#5, %[[VAL_12]]#5 : i32
-// CHECK:           sink %[[VAL_18]] : i32
-// CHECK:           %[[VAL_19:.*]] = arith.remui %[[VAL_10]]#4, %[[VAL_12]]#4 : i32
-// CHECK:           sink %[[VAL_19]] : i32
-// CHECK:           %[[VAL_20:.*]] = select %[[VAL_15]], %[[VAL_12]]#3, %[[VAL_10]]#3 : i32
-// CHECK:           sink %[[VAL_20]] : i32
-// CHECK:           %[[VAL_21:.*]] = arith.divf %[[VAL_6]]#1, %[[VAL_8]]#1 : f32
-// CHECK:           sink %[[VAL_21]] : f32
-// CHECK:           %[[VAL_22:.*]] = arith.remf %[[VAL_6]]#0, %[[VAL_8]]#0 : f32
-// CHECK:           sink %[[VAL_22]] : f32
-// CHECK:           %[[VAL_23:.*]] = arith.andi %[[VAL_10]]#2, %[[VAL_12]]#2 : i32
-// CHECK:           sink %[[VAL_23]] : i32
-// CHECK:           %[[VAL_24:.*]] = arith.ori %[[VAL_10]]#1, %[[VAL_12]]#1 : i32
-// CHECK:           sink %[[VAL_24]] : i32
-// CHECK:           %[[VAL_25:.*]] = arith.xori %[[VAL_10]]#0, %[[VAL_12]]#0 : i32
-// CHECK:           sink %[[VAL_25]] : i32
-// CHECK:           return %[[VAL_13]], %[[VAL_16]], %[[VAL_4]] : f32, i32, none
+// CHECK:           %[[VAL_6:.*]] = merge %[[VAL_1]] : f32
+// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = arith.subf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_10]] : i32
+// CHECK:           %[[VAL_12:.*]] = arith.divsi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_13:.*]] = arith.divui %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_14:.*]] = arith.remsi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_15:.*]] = arith.remui %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_16:.*]] = select %[[VAL_11]], %[[VAL_8]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_17:.*]] = arith.divf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_18:.*]] = arith.remf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_19:.*]] = arith.andi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_20:.*]] = arith.ori %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_21:.*]] = arith.xori %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           return %[[VAL_9]], %[[VAL_12]], %[[VAL_4]] : f32, i32, none
 // CHECK:         }
 func.func @ops(f32, f32, i32, i32) -> (f32, i32) {
 ^bb0(%arg0: f32, %arg1: f32, %arg2: i32, %arg3: i32):

--- a/test/Conversion/StandardToHandshake/call.mlir
+++ b/test/Conversion/StandardToHandshake/call.mlir
@@ -14,10 +14,8 @@ func.func @bar(%0 : i32) -> i32 {
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none)
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_1]] : none
-// CHECK:           %[[VAL_4:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
-// CHECK:           sink %[[VAL_4]]#1 : none
-// CHECK:           return %[[VAL_4]]#0, %[[VAL_3]]#1 : i32, none
+// CHECK:           %[[VAL_3:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_1]]) : (i32, none) -> (i32, none)
+// CHECK:           return %[[VAL_3]]#0, %[[VAL_1]] : i32, none
 // CHECK:         }
 func.func @foo(%0 : i32) -> i32 {
   %a1 = call @bar(%0) : (i32) -> i32
@@ -44,34 +42,26 @@ func.func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_4:.*]] = merge %[[VAL_0]] : i32
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_2]] : i1
-// CHECK:           %[[VAL_7:.*]]:4 = fork [4] %[[VAL_6]] : i1
-// CHECK:           %[[VAL_8:.*]] = buffer [2] fifo %[[VAL_7]]#0 : i1
-// CHECK:           %[[VAL_9:.*]]:2 = fork [2] %[[VAL_8]] : i1
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_7]]#3, %[[VAL_4]] : i32
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_7]]#2, %[[VAL_5]] : i32
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = cond_br %[[VAL_7]]#1, %[[VAL_3]] : none
-// CHECK:           %[[VAL_16:.*]] = merge %[[VAL_10]] : i32
-// CHECK:           %[[VAL_17:.*]] = merge %[[VAL_12]] : i32
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = control_merge %[[VAL_14]] : none
-// CHECK:           %[[VAL_20:.*]]:2 = fork [2] %[[VAL_18]] : none
-// CHECK:           sink %[[VAL_19]] : index
-// CHECK:           %[[VAL_21:.*]]:2 = instance @add(%[[VAL_16]], %[[VAL_17]], %[[VAL_20]]#1) : (i32, i32, none) -> (i32, none)
-// CHECK:           sink %[[VAL_21]]#1 : none
-// CHECK:           %[[VAL_22:.*]] = br %[[VAL_20]]#0 : none
-// CHECK:           %[[VAL_23:.*]] = br %[[VAL_21]]#0 : i32
-// CHECK:           %[[VAL_24:.*]] = merge %[[VAL_11]] : i32
-// CHECK:           %[[VAL_25:.*]] = merge %[[VAL_13]] : i32
-// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = control_merge %[[VAL_15]] : none
-// CHECK:           %[[VAL_28:.*]]:2 = fork [2] %[[VAL_26]] : none
-// CHECK:           sink %[[VAL_27]] : index
-// CHECK:           %[[VAL_29:.*]]:2 = instance @sub(%[[VAL_24]], %[[VAL_25]], %[[VAL_28]]#1) : (i32, i32, none) -> (i32, none)
-// CHECK:           sink %[[VAL_29]]#1 : none
-// CHECK:           %[[VAL_30:.*]] = br %[[VAL_28]]#0 : none
-// CHECK:           %[[VAL_31:.*]] = br %[[VAL_29]]#0 : i32
-// CHECK:           %[[VAL_32:.*]] = mux %[[VAL_9]]#1 {{\[}}%[[VAL_30]], %[[VAL_22]]] : i1, none
-// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_9]]#0 : i1 to index
-// CHECK:           %[[VAL_34:.*]] = mux %[[VAL_33]] {{\[}}%[[VAL_31]], %[[VAL_23]]] : index, i32
-// CHECK:           return %[[VAL_34]], %[[VAL_32]] : i32, none
+// CHECK:           %[[VAL_7:.*]] = buffer [2] fifo %[[VAL_6]] : i1
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_6]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_6]], %[[VAL_5]] : i32
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_6]], %[[VAL_3]] : none
+// CHECK:           %[[VAL_14:.*]] = merge %[[VAL_8]] : i32
+// CHECK:           %[[VAL_15:.*]] = merge %[[VAL_10]] : i32
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_18:.*]]:2 = instance @add(%[[VAL_14]], %[[VAL_15]], %[[VAL_16]]) : (i32, i32, none) -> (i32, none)
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_16]] : none
+// CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]]#0 : i32
+// CHECK:           %[[VAL_21:.*]] = merge %[[VAL_9]] : i32
+// CHECK:           %[[VAL_22:.*]] = merge %[[VAL_11]] : i32
+// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = control_merge %[[VAL_13]] : none
+// CHECK:           %[[VAL_25:.*]]:2 = instance @sub(%[[VAL_21]], %[[VAL_22]], %[[VAL_23]]) : (i32, i32, none) -> (i32, none)
+// CHECK:           %[[VAL_26:.*]] = br %[[VAL_23]] : none
+// CHECK:           %[[VAL_27:.*]] = br %[[VAL_25]]#0 : i32
+// CHECK:           %[[VAL_28:.*]] = mux %[[VAL_7]] {{\[}}%[[VAL_26]], %[[VAL_19]]] : i1, none
+// CHECK:           %[[VAL_29:.*]] = arith.index_cast %[[VAL_7]] : i1 to index
+// CHECK:           %[[VAL_30:.*]] = mux %[[VAL_29]] {{\[}}%[[VAL_27]], %[[VAL_20]]] : index, i32
+// CHECK:           return %[[VAL_30]], %[[VAL_28]] : i32, none
 // CHECK:         }
 func.func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
   cf.cond_br %cond, ^bb1, ^bb2

--- a/test/Conversion/StandardToHandshake/disable-task-pipelining.mlir
+++ b/test/Conversion/StandardToHandshake/disable-task-pipelining.mlir
@@ -5,39 +5,28 @@
 // CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_1:.*]] = br %[[VAL_0]] : none
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = control_merge %[[VAL_1]] : none
-// CHECK:           %[[VAL_4:.*]]:3 = fork [3] %[[VAL_2]] : none
-// CHECK:           sink %[[VAL_3]] : index
-// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_4]]#1 {value = 1 : index} : index
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_4]]#0 {value = 42 : index} : index
-// CHECK:           %[[VAL_7:.*]] = br %[[VAL_4]]#2 : none
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_2]] {value = 1 : index} : index
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_2]] {value = 42 : index} : index
+// CHECK:           %[[VAL_6:.*]] = br %[[VAL_2]] : none
+// CHECK:           %[[VAL_7:.*]] = br %[[VAL_4]] : index
 // CHECK:           %[[VAL_8:.*]] = br %[[VAL_5]] : index
-// CHECK:           %[[VAL_9:.*]] = br %[[VAL_6]] : index
-// CHECK:           %[[VAL_10:.*]] = mux %[[VAL_11:.*]]#1 {{\[}}%[[VAL_12:.*]], %[[VAL_9]]] : index, index
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_10]] : index
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_16:.*]], %[[VAL_7]] : none
-// CHECK:           %[[VAL_11]]:2 = fork [2] %[[VAL_15]] : index
-// CHECK:           %[[VAL_17:.*]] = mux %[[VAL_11]]#0 {{\[}}%[[VAL_18:.*]], %[[VAL_8]]] : index, index
-// CHECK:           %[[VAL_19:.*]]:2 = fork [2] %[[VAL_17]] : index
-// CHECK:           %[[VAL_20:.*]] = arith.cmpi slt, %[[VAL_19]]#1, %[[VAL_13]]#1 : index
-// CHECK:           %[[VAL_21:.*]]:3 = fork [3] %[[VAL_20]] : i1
-// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = cond_br %[[VAL_21]]#2, %[[VAL_13]]#0 : index
-// CHECK:           sink %[[VAL_23]] : index
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_21]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = cond_br %[[VAL_21]]#0, %[[VAL_19]]#0 : index
-// CHECK:           sink %[[VAL_27]] : index
-// CHECK:           %[[VAL_28:.*]] = merge %[[VAL_26]] : index
-// CHECK:           %[[VAL_29:.*]] = merge %[[VAL_22]] : index
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = control_merge %[[VAL_24]] : none
-// CHECK:           %[[VAL_32:.*]]:2 = fork [2] %[[VAL_30]] : none
-// CHECK:           sink %[[VAL_31]] : index
-// CHECK:           %[[VAL_33:.*]] = constant %[[VAL_32]]#0 {value = 1 : index} : index
-// CHECK:           %[[VAL_34:.*]] = arith.addi %[[VAL_28]], %[[VAL_33]] : index
-// CHECK:           %[[VAL_12]] = br %[[VAL_29]] : index
-// CHECK:           %[[VAL_16]] = br %[[VAL_32]]#1 : none
-// CHECK:           %[[VAL_18]] = br %[[VAL_34]] : index
-// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = control_merge %[[VAL_25]] : none
-// CHECK:           sink %[[VAL_36]] : index
-// CHECK:           return %[[VAL_35]] : none
+// CHECK:           %[[VAL_9:.*]] = mux %[[VAL_10:.*]] {{\[}}%[[VAL_11:.*]], %[[VAL_8]]] : index, index
+// CHECK:           %[[VAL_12:.*]], %[[VAL_10]] = control_merge %[[VAL_13:.*]], %[[VAL_6]] : none
+// CHECK:           %[[VAL_14:.*]] = mux %[[VAL_10]] {{\[}}%[[VAL_15:.*]], %[[VAL_7]]] : index, index
+// CHECK:           %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_14]], %[[VAL_9]] : index
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_16]], %[[VAL_9]] : index
+// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = cond_br %[[VAL_16]], %[[VAL_12]] : none
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_16]], %[[VAL_14]] : index
+// CHECK:           %[[VAL_23:.*]] = merge %[[VAL_21]] : index
+// CHECK:           %[[VAL_24:.*]] = merge %[[VAL_17]] : index
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_19]] : none
+// CHECK:           %[[VAL_27:.*]] = constant %[[VAL_25]] {value = 1 : index} : index
+// CHECK:           %[[VAL_28:.*]] = arith.addi %[[VAL_23]], %[[VAL_27]] : index
+// CHECK:           %[[VAL_11]] = br %[[VAL_24]] : index
+// CHECK:           %[[VAL_13]] = br %[[VAL_25]] : none
+// CHECK:           %[[VAL_15]] = br %[[VAL_28]] : index
+// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = control_merge %[[VAL_20]] : none
+// CHECK:           return %[[VAL_29]] : none
 // CHECK:         }
 func.func @simple_loop() {
 ^bb0:
@@ -64,24 +53,20 @@ func.func @simple_loop() {
 // CHECK-SAME:                                  %[[VAL_1:.*]]: i64,
 // CHECK-SAME:                                  %[[VAL_2:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_4:.*]]:2 = fork [2] %[[VAL_3]] : i1
-// CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_5]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_4]]#0, %[[VAL_2]] : none
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_11]] : index
-// CHECK:           %[[VAL_12:.*]] = merge %[[VAL_6]] : i64
-// CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : none
-// CHECK:           %[[VAL_14:.*]] = br %[[VAL_12]] : i64
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = control_merge %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_16]] : index
-// CHECK:           %[[VAL_17:.*]] = merge %[[VAL_7]] : i64
-// CHECK:           %[[VAL_18:.*]] = br %[[VAL_15]] : none
-// CHECK:           %[[VAL_19:.*]] = br %[[VAL_17]] : i64
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = control_merge %[[VAL_18]], %[[VAL_13]] : none
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_21]] {{\[}}%[[VAL_19]], %[[VAL_14]]] : index, i64
-// CHECK:           sink %[[VAL_22]] : i64
-// CHECK:           return %[[VAL_20]] : none
+// CHECK:           %[[VAL_4:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_3]], %[[VAL_4]] : i64
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = control_merge %[[VAL_7]] : none
+// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_5]] : i64
+// CHECK:           %[[VAL_12:.*]] = br %[[VAL_9]] : none
+// CHECK:           %[[VAL_13:.*]] = br %[[VAL_11]] : i64
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
+// CHECK:           %[[VAL_16:.*]] = merge %[[VAL_6]] : i64
+// CHECK:           %[[VAL_17:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_18:.*]] = br %[[VAL_16]] : i64
+// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = control_merge %[[VAL_17]], %[[VAL_12]] : none
+// CHECK:           %[[VAL_21:.*]] = mux %[[VAL_20]] {{\[}}%[[VAL_18]], %[[VAL_13]]] : index, i64
+// CHECK:           return %[[VAL_19]] : none
 // CHECK:         }
 func.func @simpleDiamond(%arg0: i1, %arg1: i64) {
   cf.cond_br %arg0, ^bb1(%arg1: i64), ^bb2(%arg1: i64)

--- a/test/Conversion/StandardToHandshake/external-memory.mlir
+++ b/test/Conversion/StandardToHandshake/external-memory.mlir
@@ -4,12 +4,10 @@
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<4xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: none, ...) -> (i32, none)
 // CHECK:           %[[VAL_2:.*]]:2 = extmemory[ld = 1, st = 0] (%[[VAL_0]] : memref<4xi32>) (%[[VAL_3:.*]]) {id = 0 : i32} : (index) -> (i32, none)
-// CHECK:           %[[VAL_4:.*]]:2 = fork [2] %[[VAL_1]] : none
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]]#1 : none
-// CHECK:           %[[VAL_6:.*]] = join %[[VAL_5]]#1, %[[VAL_2]]#1 : none
-// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_5]]#0 {value = 0 : index} : index
-// CHECK:           %[[VAL_8:.*]], %[[VAL_3]] = load {{\[}}%[[VAL_7]]] %[[VAL_2]]#0, %[[VAL_4]]#0 : index, i32
-// CHECK:           return %[[VAL_8]], %[[VAL_6]] : i32, none
+// CHECK:           %[[VAL_4:.*]] = join %[[VAL_1]], %[[VAL_2]]#1 : none, none
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_1]] {value = 0 : index} : index
+// CHECK:           %[[VAL_6:.*]], %[[VAL_3]] = load {{\[}}%[[VAL_5]]] %[[VAL_2]]#0, %[[VAL_1]] : index, i32
+// CHECK:           return %[[VAL_6]], %[[VAL_4]] : i32, none
 // CHECK:         }
 func.func @main(%mem : memref<4xi32>) -> i32 {
   %idx = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/memref.mlir
+++ b/test/Conversion/StandardToHandshake/memref.mlir
@@ -15,18 +15,13 @@ func.func @remove_unused_mem() {
 // CHECK-SAME:                               %[[VAL_0:.*]]: index,
 // CHECK-SAME:                               %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]]:3 = memory[ld = 1, st = 1] (%[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]]) {id = 0 : i32, lsq = false} : memref<4xi32>, (i32, index, index) -> (i32, none, none)
-// CHECK:           %[[VAL_6:.*]]:2 = fork [2] %[[VAL_2]]#1 : none
-// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_0]] : index
-// CHECK:           %[[VAL_8:.*]]:2 = fork [2] %[[VAL_7]] : index
-// CHECK:           %[[VAL_9:.*]]:3 = fork [3] %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]]:2 = fork [2] %[[VAL_9]]#2 : none
-// CHECK:           %[[VAL_11:.*]] = join %[[VAL_10]]#1, %[[VAL_6]]#1, %[[VAL_2]]#2 : none, none, none
-// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_10]]#0 {value = 11 : i32} : i32
-// CHECK:           %[[VAL_3]], %[[VAL_4]] = store {{\[}}%[[VAL_8]]#1] %[[VAL_12]], %[[VAL_9]]#1 : index, i32
-// CHECK:           %[[VAL_13:.*]] = join %[[VAL_9]]#0, %[[VAL_6]]#0 : none, none
-// CHECK:           %[[VAL_14:.*]], %[[VAL_5]] = load {{\[}}%[[VAL_8]]#0] %[[VAL_2]]#0, %[[VAL_13]] : index, i32
-// CHECK:           sink %[[VAL_14]] : i32
-// CHECK:           return %[[VAL_11]] : none
+// CHECK:           %[[VAL_6:.*]] = merge %[[VAL_0]] : index
+// CHECK:           %[[VAL_7:.*]] = join %[[VAL_1]], %[[VAL_2]]#1, %[[VAL_2]]#2 : none, none, none
+// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_1]] {value = 11 : i32} : i32
+// CHECK:           %[[VAL_3]], %[[VAL_4]] = store {{\[}}%[[VAL_6]]] %[[VAL_8]], %[[VAL_1]] : index, i32
+// CHECK:           %[[VAL_9:.*]] = join %[[VAL_1]], %[[VAL_2]]#1 : none, none
+// CHECK:           %[[VAL_10:.*]], %[[VAL_5]] = load {{\[}}%[[VAL_6]]] %[[VAL_2]]#0, %[[VAL_9]] : index, i32
+// CHECK:           return %[[VAL_7]] : none
 // CHECK:         }
 func.func @load_store(%1 : index) {
   %0 = memref.alloc() : memref<4xi32>
@@ -42,19 +37,14 @@ func.func @load_store(%1 : index) {
 // CHECK-SAME:                             %[[VAL_0:.*]]: index,
 // CHECK-SAME:                             %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : index
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] : index
-// CHECK:           %[[VAL_4:.*]]:3 = fork [3] %[[VAL_1]] : none
-// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<10xf32>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() : memref<10xf32>
-// CHECK:           %[[VAL_7:.*]] = memref.alloc() : memref<1xi32>
-// CHECK:           %[[VAL_8:.*]]:2 = fork [2] %[[VAL_7]] : memref<1xi32>
-// CHECK:           %[[VAL_9:.*]] = constant %[[VAL_4]]#1 {value = 1 : index} : index
-// CHECK:           %[[VAL_10:.*]]:2 = fork [2] %[[VAL_9]] : index
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_4]]#0 {value = 1 : index} : index
-// CHECK:           %[[VAL_12:.*]]:2 = fork [2] %[[VAL_11]] : index
-// CHECK:           memref.dma_start %[[VAL_5]]{{\[}}%[[VAL_3]]#0], %[[VAL_6]]{{\[}}%[[VAL_3]]#1], %[[VAL_12]]#0, %[[VAL_8]]#1{{\[}}%[[VAL_10]]#0] : memref<10xf32>, memref<10xf32>, memref<1xi32>
-// CHECK:           memref.dma_wait %[[VAL_8]]#0{{\[}}%[[VAL_10]]#1], %[[VAL_12]]#1 : memref<1xi32>
-// CHECK:           return %[[VAL_4]]#2 : none
+// CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<10xf32>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<10xf32>
+// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<1xi32>
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1]] {value = 1 : index} : index
+// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_1]] {value = 1 : index} : index
+// CHECK:           memref.dma_start %[[VAL_3]]{{\[}}%[[VAL_2]]], %[[VAL_4]]{{\[}}%[[VAL_2]]], %[[VAL_7]], %[[VAL_5]]{{\[}}%[[VAL_6]]] : memref<10xf32>, memref<10xf32>, memref<1xi32>
+// CHECK:           memref.dma_wait %[[VAL_5]]{{\[}}%[[VAL_6]]], %[[VAL_7]] : memref<1xi32>
+// CHECK:           return %[[VAL_1]] : none
 // CHECK:         }
 func.func @dma(%1 : index) {
   %mem0 = memref.alloc() : memref<10xf32>

--- a/test/Conversion/StandardToHandshake/task-pipelining.mlir
+++ b/test/Conversion/StandardToHandshake/task-pipelining.mlir
@@ -7,27 +7,22 @@
 // CHECK-SAME:                                  %[[VAL_1:.*]]: i64,
 // CHECK-SAME:                                  %[[VAL_2:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_4:.*]]:3 = fork [3] %[[VAL_3]] : i1
-// CHECK:           %[[VAL_5:.*]] = buffer [2] fifo %[[VAL_4]]#0 : i1
-// CHECK:           %[[VAL_6:.*]]:2 = fork [2] %[[VAL_5]] : i1
-// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_1]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_4]]#2, %[[VAL_7]] : i64
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_2]] : none
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = control_merge %[[VAL_10]] : none
-// CHECK:           sink %[[VAL_13]] : index
-// CHECK:           %[[VAL_14:.*]] = merge %[[VAL_8]] : i64
-// CHECK:           %[[VAL_15:.*]] = br %[[VAL_12]] : none
-// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : i64
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = control_merge %[[VAL_11]] : none
-// CHECK:           sink %[[VAL_18]] : index
-// CHECK:           %[[VAL_19:.*]] = merge %[[VAL_9]] : i64
-// CHECK:           %[[VAL_20:.*]] = br %[[VAL_17]] : none
-// CHECK:           %[[VAL_21:.*]] = br %[[VAL_19]] : i64
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_6]]#1 {{\[}}%[[VAL_20]], %[[VAL_15]]] : i1, none
-// CHECK:           %[[VAL_23:.*]] = arith.index_cast %[[VAL_6]]#0 : i1 to index
-// CHECK:           %[[VAL_24:.*]] = mux %[[VAL_23]] {{\[}}%[[VAL_21]], %[[VAL_16]]] : index, i64
-// CHECK:           sink %[[VAL_24]] : i64
-// CHECK:           return %[[VAL_22]] : none
+// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
+// CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_8]] : none
+// CHECK:           %[[VAL_12:.*]] = merge %[[VAL_6]] : i64
+// CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]] = br %[[VAL_12]] : i64
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = control_merge %[[VAL_9]] : none
+// CHECK:           %[[VAL_17:.*]] = merge %[[VAL_7]] : i64
+// CHECK:           %[[VAL_18:.*]] = br %[[VAL_15]] : none
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_17]] : i64
+// CHECK:           %[[VAL_20:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_18]], %[[VAL_13]]] : i1, none
+// CHECK:           %[[VAL_21:.*]] = arith.index_cast %[[VAL_4]] : i1 to index
+// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_21]] {{\[}}%[[VAL_19]], %[[VAL_14]]] : index, i64
+// CHECK:           return %[[VAL_20]] : none
 // CHECK:         }
 func.func @simpleDiamond(%arg0: i1, %arg1: i64) {
   cf.cond_br %arg0, ^bb1(%arg1: i64), ^bb2(%arg1: i64)
@@ -45,39 +40,27 @@ func.func @simpleDiamond(%arg0: i1, %arg1: i64) {
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           sink %[[VAL_7]] : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = buffer [2] fifo %[[VAL_11]]#0 : i1
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_12]] : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_15]] : index
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_11]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = control_merge %[[VAL_16]] : none
-// CHECK:           sink %[[VAL_19]] : index
-// CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]] : none
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_17]] : none
-// CHECK:           sink %[[VAL_22]] : index
-// CHECK:           %[[VAL_23:.*]] = br %[[VAL_21]] : none
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = control_merge %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_25]] : index
-// CHECK:           %[[VAL_26:.*]] = br %[[VAL_24]] : none
-// CHECK:           %[[VAL_27:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_23]], %[[VAL_20]]] : i1, none
-// CHECK:           %[[VAL_28:.*]] = arith.index_cast %[[VAL_13]]#0 : i1 to index
-// CHECK:           sink %[[VAL_28]] : index
-// CHECK:           %[[VAL_29:.*]] = br %[[VAL_27]] : none
-// CHECK:           %[[VAL_30:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_26]], %[[VAL_29]]] : i1, none
-// CHECK:           %[[VAL_31:.*]]:2 = fork [2] %[[VAL_30]] : none
-// CHECK:           %[[VAL_32:.*]] = constant %[[VAL_31]]#0 {value = true} : i1
-// CHECK:           %[[VAL_33:.*]] = arith.xori %[[VAL_5]]#0, %[[VAL_32]] : i1
-// CHECK:           %[[VAL_34:.*]] = arith.index_cast %[[VAL_33]] : i1 to index
-// CHECK:           sink %[[VAL_34]] : index
-// CHECK:           return %[[VAL_31]]#1 : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_8]], %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = control_merge %[[VAL_13]] : none
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_17]] : none
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = control_merge %[[VAL_7]] : none
+// CHECK:           %[[VAL_22:.*]] = br %[[VAL_20]] : none
+// CHECK:           %[[VAL_23:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_19]], %[[VAL_16]]] : i1, none
+// CHECK:           %[[VAL_24:.*]] = arith.index_cast %[[VAL_9]] : i1 to index
+// CHECK:           %[[VAL_25:.*]] = br %[[VAL_23]] : none
+// CHECK:           %[[VAL_26:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_22]], %[[VAL_25]]] : i1, none
+// CHECK:           %[[VAL_27:.*]] = constant %[[VAL_26]] {value = true} : i1
+// CHECK:           %[[VAL_28:.*]] = arith.xori %[[VAL_3]], %[[VAL_27]] : i1
+// CHECK:           %[[VAL_29:.*]] = arith.index_cast %[[VAL_28]] : i1 to index
+// CHECK:           return %[[VAL_26]] : none
 // CHECK:         }
 func.func @nestedDiamond(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb4
@@ -102,25 +85,20 @@ func.func @nestedDiamond(%arg0: i1) {
 // CHECK-SAME:                             %[[VAL_1:.*]]: i64,
 // CHECK-SAME:                             %[[VAL_2:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_4:.*]]:3 = fork [3] %[[VAL_3]] : i1
-// CHECK:           %[[VAL_5:.*]] = buffer [2] fifo %[[VAL_4]]#0 : i1
-// CHECK:           %[[VAL_6:.*]]:2 = fork [2] %[[VAL_5]] : i1
-// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_1]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_4]]#2, %[[VAL_7]] : i64
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_2]] : none
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = control_merge %[[VAL_10]] : none
-// CHECK:           sink %[[VAL_13]] : index
-// CHECK:           %[[VAL_14:.*]] = merge %[[VAL_8]] : i64
-// CHECK:           %[[VAL_15:.*]] = br %[[VAL_12]] : none
-// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : i64
-// CHECK:           %[[VAL_17:.*]] = mux %[[VAL_6]]#1 {{\[}}%[[VAL_11]], %[[VAL_15]]] : i1, none
-// CHECK:           %[[VAL_18:.*]]:2 = fork [2] %[[VAL_17]] : none
-// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_18]]#0 {value = true} : i1
-// CHECK:           %[[VAL_20:.*]] = arith.xori %[[VAL_6]]#0, %[[VAL_19]] : i1
-// CHECK:           %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i1 to index
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_21]] {{\[}}%[[VAL_16]], %[[VAL_9]]] : index, i64
-// CHECK:           sink %[[VAL_22]] : i64
-// CHECK:           return %[[VAL_18]]#1 : none
+// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
+// CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_8]] : none
+// CHECK:           %[[VAL_12:.*]] = merge %[[VAL_6]] : i64
+// CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]] = br %[[VAL_12]] : i64
+// CHECK:           %[[VAL_15:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_9]], %[[VAL_13]]] : i1, none
+// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_15]] {value = true} : i1
+// CHECK:           %[[VAL_17:.*]] = arith.xori %[[VAL_4]], %[[VAL_16]] : i1
+// CHECK:           %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i1 to index
+// CHECK:           %[[VAL_19:.*]] = mux %[[VAL_18]] {{\[}}%[[VAL_14]], %[[VAL_7]]] : index, i64
+// CHECK:           return %[[VAL_15]] : none
 // CHECK:         }
 func.func @triangle(%arg0: i1, %val0: i64) {
   cf.cond_br %arg0, ^bb1(%val0: i64), ^bb2(%val0: i64)
@@ -136,36 +114,25 @@ func.func @triangle(%arg0: i1, %val0: i64) {
 // CHECK-SAME:                                   %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                   %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           sink %[[VAL_7]] : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = buffer [2] fifo %[[VAL_11]]#0 : i1
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_12]] : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_15]] : index
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_11]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = control_merge %[[VAL_16]] : none
-// CHECK:           sink %[[VAL_19]] : index
-// CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]] : none
-// CHECK:           %[[VAL_21:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_17]], %[[VAL_20]]] : i1, none
-// CHECK:           %[[VAL_22:.*]]:2 = fork [2] %[[VAL_21]] : none
-// CHECK:           %[[VAL_23:.*]] = constant %[[VAL_22]]#0 {value = true} : i1
-// CHECK:           %[[VAL_24:.*]] = arith.xori %[[VAL_13]]#0, %[[VAL_23]] : i1
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_8]], %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_17:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_13]], %[[VAL_16]]] : i1, none
+// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_17]] {value = true} : i1
+// CHECK:           %[[VAL_19:.*]] = arith.xori %[[VAL_9]], %[[VAL_18]] : i1
+// CHECK:           %[[VAL_20:.*]] = arith.index_cast %[[VAL_19]] : i1 to index
+// CHECK:           %[[VAL_21:.*]] = br %[[VAL_17]] : none
+// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_7]], %[[VAL_21]]] : i1, none
+// CHECK:           %[[VAL_23:.*]] = constant %[[VAL_22]] {value = true} : i1
+// CHECK:           %[[VAL_24:.*]] = arith.xori %[[VAL_3]], %[[VAL_23]] : i1
 // CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i1 to index
-// CHECK:           sink %[[VAL_25]] : index
-// CHECK:           %[[VAL_26:.*]] = br %[[VAL_22]]#1 : none
-// CHECK:           %[[VAL_27:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_9]], %[[VAL_26]]] : i1, none
-// CHECK:           %[[VAL_28:.*]]:2 = fork [2] %[[VAL_27]] : none
-// CHECK:           %[[VAL_29:.*]] = constant %[[VAL_28]]#0 {value = true} : i1
-// CHECK:           %[[VAL_30:.*]] = arith.xori %[[VAL_5]]#0, %[[VAL_29]] : i1
-// CHECK:           %[[VAL_31:.*]] = arith.index_cast %[[VAL_30]] : i1 to index
-// CHECK:           sink %[[VAL_31]] : index
-// CHECK:           return %[[VAL_28]]#1 : none
+// CHECK:           return %[[VAL_22]] : none
 // CHECK:         }
 func.func @nestedTriangle(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb4
@@ -185,68 +152,49 @@ func.func @nestedTriangle(%arg0: i1) {
 // CHECK-SAME:                                           %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]]:4 = fork [4] %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = buffer [2] fifo %[[VAL_11]]#0 : i1
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_12]] : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_15]] : index
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_11]]#2, %[[VAL_11]]#3 : i1
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = cond_br %[[VAL_11]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_20:.*]] = merge %[[VAL_16]] : i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_18]] : none
-// CHECK:           sink %[[VAL_22]] : index
-// CHECK:           %[[VAL_23:.*]] = br %[[VAL_20]] : i1
-// CHECK:           %[[VAL_24:.*]] = br %[[VAL_21]] : none
-// CHECK:           %[[VAL_25:.*]] = mux %[[VAL_26:.*]] {{\[}}%[[VAL_23]], %[[VAL_17]]] : index, i1
-// CHECK:           %[[VAL_27:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_19]], %[[VAL_24]]] : i1, none
-// CHECK:           %[[VAL_28:.*]]:2 = fork [2] %[[VAL_27]] : none
-// CHECK:           %[[VAL_29:.*]] = constant %[[VAL_28]]#0 {value = true} : i1
-// CHECK:           %[[VAL_30:.*]] = arith.xori %[[VAL_13]]#0, %[[VAL_29]] : i1
-// CHECK:           %[[VAL_26]] = arith.index_cast %[[VAL_30]] : i1 to index
-// CHECK:           %[[VAL_31:.*]] = br %[[VAL_25]] : i1
-// CHECK:           %[[VAL_32:.*]] = br %[[VAL_28]]#1 : none
-// CHECK:           %[[VAL_33:.*]] = mux %[[VAL_34:.*]] {{\[}}%[[VAL_31]], %[[VAL_7]]] : index, i1
-// CHECK:           %[[VAL_35:.*]]:4 = fork [4] %[[VAL_33]] : i1
-// CHECK:           %[[VAL_36:.*]] = buffer [2] fifo %[[VAL_35]]#0 : i1
-// CHECK:           %[[VAL_37:.*]]:2 = fork [2] %[[VAL_36]] : i1
-// CHECK:           %[[VAL_38:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_9]], %[[VAL_32]]] : i1, none
-// CHECK:           %[[VAL_39:.*]]:2 = fork [2] %[[VAL_38]] : none
-// CHECK:           %[[VAL_40:.*]] = constant %[[VAL_39]]#0 {value = true} : i1
-// CHECK:           %[[VAL_41:.*]] = arith.xori %[[VAL_5]]#0, %[[VAL_40]] : i1
-// CHECK:           %[[VAL_34]] = arith.index_cast %[[VAL_41]] : i1 to index
-// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]] = cond_br %[[VAL_35]]#2, %[[VAL_35]]#3 : i1
-// CHECK:           sink %[[VAL_43]] : i1
-// CHECK:           %[[VAL_44:.*]], %[[VAL_45:.*]] = cond_br %[[VAL_35]]#1, %[[VAL_39]]#1 : none
-// CHECK:           %[[VAL_46:.*]] = merge %[[VAL_42]] : i1
-// CHECK:           %[[VAL_47:.*]]:2 = fork [2] %[[VAL_46]] : i1
-// CHECK:           %[[VAL_48:.*]] = buffer [2] fifo %[[VAL_47]]#0 : i1
-// CHECK:           %[[VAL_49:.*]]:2 = fork [2] %[[VAL_48]] : i1
-// CHECK:           %[[VAL_50:.*]], %[[VAL_51:.*]] = control_merge %[[VAL_44]] : none
-// CHECK:           sink %[[VAL_51]] : index
-// CHECK:           %[[VAL_52:.*]], %[[VAL_53:.*]] = cond_br %[[VAL_47]]#1, %[[VAL_50]] : none
-// CHECK:           %[[VAL_54:.*]], %[[VAL_55:.*]] = control_merge %[[VAL_52]] : none
-// CHECK:           sink %[[VAL_55]] : index
-// CHECK:           %[[VAL_56:.*]] = br %[[VAL_54]] : none
-// CHECK:           %[[VAL_57:.*]] = mux %[[VAL_49]]#1 {{\[}}%[[VAL_53]], %[[VAL_56]]] : i1, none
-// CHECK:           %[[VAL_58:.*]]:2 = fork [2] %[[VAL_57]] : none
-// CHECK:           %[[VAL_59:.*]] = constant %[[VAL_58]]#0 {value = true} : i1
-// CHECK:           %[[VAL_60:.*]] = arith.xori %[[VAL_49]]#0, %[[VAL_59]] : i1
-// CHECK:           %[[VAL_61:.*]] = arith.index_cast %[[VAL_60]] : i1 to index
-// CHECK:           sink %[[VAL_61]] : index
-// CHECK:           %[[VAL_62:.*]] = br %[[VAL_58]]#1 : none
-// CHECK:           %[[VAL_63:.*]] = mux %[[VAL_37]]#1 {{\[}}%[[VAL_45]], %[[VAL_62]]] : i1, none
-// CHECK:           %[[VAL_64:.*]]:2 = fork [2] %[[VAL_63]] : none
-// CHECK:           %[[VAL_65:.*]] = constant %[[VAL_64]]#0 {value = true} : i1
-// CHECK:           %[[VAL_66:.*]] = arith.xori %[[VAL_37]]#0, %[[VAL_65]] : i1
-// CHECK:           %[[VAL_67:.*]] = arith.index_cast %[[VAL_66]] : i1 to index
-// CHECK:           sink %[[VAL_67]] : index
-// CHECK:           return %[[VAL_64]]#1 : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_8]], %[[VAL_8]] : i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = cond_br %[[VAL_8]], %[[VAL_10]] : none
+// CHECK:           %[[VAL_16:.*]] = merge %[[VAL_12]] : i1
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = control_merge %[[VAL_14]] : none
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_16]] : i1
+// CHECK:           %[[VAL_20:.*]] = br %[[VAL_17]] : none
+// CHECK:           %[[VAL_21:.*]] = mux %[[VAL_22:.*]] {{\[}}%[[VAL_19]], %[[VAL_13]]] : index, i1
+// CHECK:           %[[VAL_23:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_15]], %[[VAL_20]]] : i1, none
+// CHECK:           %[[VAL_24:.*]] = constant %[[VAL_23]] {value = true} : i1
+// CHECK:           %[[VAL_25:.*]] = arith.xori %[[VAL_9]], %[[VAL_24]] : i1
+// CHECK:           %[[VAL_22]] = arith.index_cast %[[VAL_25]] : i1 to index
+// CHECK:           %[[VAL_26:.*]] = br %[[VAL_21]] : i1
+// CHECK:           %[[VAL_27:.*]] = br %[[VAL_23]] : none
+// CHECK:           %[[VAL_28:.*]] = mux %[[VAL_29:.*]] {{\[}}%[[VAL_26]], %[[VAL_5]]] : index, i1
+// CHECK:           %[[VAL_30:.*]] = buffer [2] fifo %[[VAL_28]] : i1
+// CHECK:           %[[VAL_31:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_7]], %[[VAL_27]]] : i1, none
+// CHECK:           %[[VAL_32:.*]] = constant %[[VAL_31]] {value = true} : i1
+// CHECK:           %[[VAL_33:.*]] = arith.xori %[[VAL_3]], %[[VAL_32]] : i1
+// CHECK:           %[[VAL_29]] = arith.index_cast %[[VAL_33]] : i1 to index
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = cond_br %[[VAL_28]], %[[VAL_28]] : i1
+// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = cond_br %[[VAL_28]], %[[VAL_31]] : none
+// CHECK:           %[[VAL_38:.*]] = merge %[[VAL_34]] : i1
+// CHECK:           %[[VAL_39:.*]] = buffer [2] fifo %[[VAL_38]] : i1
+// CHECK:           %[[VAL_40:.*]], %[[VAL_41:.*]] = control_merge %[[VAL_36]] : none
+// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]] = cond_br %[[VAL_38]], %[[VAL_40]] : none
+// CHECK:           %[[VAL_44:.*]], %[[VAL_45:.*]] = control_merge %[[VAL_42]] : none
+// CHECK:           %[[VAL_46:.*]] = br %[[VAL_44]] : none
+// CHECK:           %[[VAL_47:.*]] = mux %[[VAL_39]] {{\[}}%[[VAL_43]], %[[VAL_46]]] : i1, none
+// CHECK:           %[[VAL_48:.*]] = constant %[[VAL_47]] {value = true} : i1
+// CHECK:           %[[VAL_49:.*]] = arith.xori %[[VAL_39]], %[[VAL_48]] : i1
+// CHECK:           %[[VAL_50:.*]] = arith.index_cast %[[VAL_49]] : i1 to index
+// CHECK:           %[[VAL_51:.*]] = br %[[VAL_47]] : none
+// CHECK:           %[[VAL_52:.*]] = mux %[[VAL_30]] {{\[}}%[[VAL_37]], %[[VAL_51]]] : i1, none
+// CHECK:           %[[VAL_53:.*]] = constant %[[VAL_52]] {value = true} : i1
+// CHECK:           %[[VAL_54:.*]] = arith.xori %[[VAL_30]], %[[VAL_53]] : i1
+// CHECK:           %[[VAL_55:.*]] = arith.index_cast %[[VAL_54]] : i1 to index
+// CHECK:           return %[[VAL_52]] : none
 // CHECK:         }
 func.func @multiple_blocks_needed(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb4
@@ -274,17 +222,10 @@ func.func @multiple_blocks_needed(%arg0: i1) {
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]]:2 = fork [2] %[[VAL_1]] : none
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_4]]#1 : none
-// CHECK:           %[[VAL_7:.*]]:2 = fork [2] %[[VAL_5]] : none
-// CHECK:           sink %[[VAL_6]] : none
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#0, %[[VAL_4]]#0 : none
-// CHECK:           sink %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_8]] : none
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_7]]#0, %[[VAL_7]]#1 : none
-// CHECK:           sink %[[VAL_11]] : index
-// CHECK:           return %[[VAL_10]] : none
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = control_merge %[[VAL_3]], %[[VAL_3]] : none
+// CHECK:           return %[[VAL_7]] : none
 // CHECK:         }
 func.func @sameSuccessor(%cond: i1) {
   cf.cond_br %cond, ^1, ^1
@@ -298,46 +239,34 @@ func.func @sameSuccessor(%cond: i1) {
 // CHECK-SAME:                                %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                                %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i64
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_1]] : none
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]]#0 {value = 1 : i64} : i64
-// CHECK:           %[[VAL_5:.*]] = br %[[VAL_2]] : i64
-// CHECK:           %[[VAL_6:.*]] = br %[[VAL_3]]#1 : none
-// CHECK:           %[[VAL_7:.*]] = br %[[VAL_4]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_6]] : none
-// CHECK:           %[[VAL_10:.*]]:2 = fork [2] %[[VAL_9]] : index
-// CHECK:           %[[VAL_11:.*]] = buffer [1] seq %[[VAL_12:.*]] {initValues = [0]} : i1
-// CHECK:           %[[VAL_13:.*]]:3 = fork [3] %[[VAL_11]] : i1
-// CHECK:           %[[VAL_14:.*]] = mux %[[VAL_13]]#2 {{\[}}%[[VAL_8]], %[[VAL_15:.*]]] : i1, none
-// CHECK:           %[[VAL_16:.*]]:2 = fork [2] %[[VAL_14]] : none
-// CHECK:           %[[VAL_17:.*]] = mux %[[VAL_10]]#1 {{\[}}%[[VAL_5]]] : index, i64
-// CHECK:           %[[VAL_18:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_17]], %[[VAL_19:.*]]] : i1, i64
-// CHECK:           %[[VAL_20:.*]]:2 = fork [2] %[[VAL_18]] : i64
-// CHECK:           %[[VAL_21:.*]] = mux %[[VAL_10]]#0 {{\[}}%[[VAL_7]]] : index, i64
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_13]]#0 {{\[}}%[[VAL_21]], %[[VAL_23:.*]]] : i1, i64
-// CHECK:           %[[VAL_24:.*]]:2 = fork [2] %[[VAL_22]] : i64
-// CHECK:           %[[VAL_25:.*]] = arith.cmpi eq, %[[VAL_24]]#0, %[[VAL_20]]#0 : i64
-// CHECK:           %[[VAL_26:.*]]:4 = fork [4] %[[VAL_25]] : i1
-// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = cond_br %[[VAL_26]]#3, %[[VAL_20]]#1 : i64
-// CHECK:           sink %[[VAL_27]] : i64
-// CHECK:           %[[VAL_29:.*]] = constant %[[VAL_16]]#0 {value = true} : i1
-// CHECK:           %[[VAL_30:.*]] = arith.xori %[[VAL_26]]#0, %[[VAL_29]] : i1
-// CHECK:           %[[VAL_12]] = merge %[[VAL_30]] : i1
-// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_26]]#2, %[[VAL_16]]#1 : none
-// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = cond_br %[[VAL_26]]#1, %[[VAL_24]]#1 : i64
-// CHECK:           sink %[[VAL_33]] : i64
-// CHECK:           %[[VAL_35:.*]] = merge %[[VAL_34]] : i64
-// CHECK:           %[[VAL_36:.*]] = merge %[[VAL_28]] : i64
-// CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]] = control_merge %[[VAL_32]] : none
-// CHECK:           %[[VAL_39:.*]]:2 = fork [2] %[[VAL_37]] : none
-// CHECK:           sink %[[VAL_38]] : index
-// CHECK:           %[[VAL_40:.*]] = constant %[[VAL_39]]#0 {value = 1 : i64} : i64
-// CHECK:           %[[VAL_41:.*]] = arith.addi %[[VAL_35]], %[[VAL_40]] : i64
-// CHECK:           %[[VAL_19]] = br %[[VAL_36]] : i64
-// CHECK:           %[[VAL_15]] = br %[[VAL_39]]#1 : none
-// CHECK:           %[[VAL_23]] = br %[[VAL_41]] : i64
-// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]] = control_merge %[[VAL_31]] : none
-// CHECK:           sink %[[VAL_43]] : index
-// CHECK:           return %[[VAL_42]] : none
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 1 : i64} : i64
+// CHECK:           %[[VAL_4:.*]] = br %[[VAL_2]] : i64
+// CHECK:           %[[VAL_5:.*]] = br %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]] = br %[[VAL_3]] : i64
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = control_merge %[[VAL_5]] : none
+// CHECK:           %[[VAL_9:.*]] = buffer [1] seq %[[VAL_10:.*]] {initValues = [0]} : i1
+// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_7]], %[[VAL_12:.*]]] : i1, none
+// CHECK:           %[[VAL_13:.*]] = mux %[[VAL_8]] {{\[}}%[[VAL_4]]] : index, i64
+// CHECK:           %[[VAL_14:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_13]], %[[VAL_15:.*]]] : i1, i64
+// CHECK:           %[[VAL_16:.*]] = mux %[[VAL_8]] {{\[}}%[[VAL_6]]] : index, i64
+// CHECK:           %[[VAL_17:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_16]], %[[VAL_18:.*]]] : i1, i64
+// CHECK:           %[[VAL_19:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_14]] : i64
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_19]], %[[VAL_14]] : i64
+// CHECK:           %[[VAL_22:.*]] = constant %[[VAL_11]] {value = true} : i1
+// CHECK:           %[[VAL_23:.*]] = arith.xori %[[VAL_19]], %[[VAL_22]] : i1
+// CHECK:           %[[VAL_10]] = merge %[[VAL_23]] : i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_19]], %[[VAL_11]] : none
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = cond_br %[[VAL_19]], %[[VAL_17]] : i64
+// CHECK:           %[[VAL_28:.*]] = merge %[[VAL_27]] : i64
+// CHECK:           %[[VAL_29:.*]] = merge %[[VAL_21]] : i64
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = control_merge %[[VAL_25]] : none
+// CHECK:           %[[VAL_32:.*]] = constant %[[VAL_30]] {value = 1 : i64} : i64
+// CHECK:           %[[VAL_33:.*]] = arith.addi %[[VAL_28]], %[[VAL_32]] : i64
+// CHECK:           %[[VAL_15]] = br %[[VAL_29]] : i64
+// CHECK:           %[[VAL_12]] = br %[[VAL_30]] : none
+// CHECK:           %[[VAL_18]] = br %[[VAL_33]] : i64
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = control_merge %[[VAL_24]] : none
+// CHECK:           return %[[VAL_34]] : none
 // CHECK:         }
 func.func @simple_loop(%arg0: i64) {
   %c1_i64 = arith.constant 1 : i64
@@ -359,59 +288,43 @@ func.func @simple_loop(%arg0: i64) {
 // CHECK-SAME:                                           %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = buffer [2] fifo %[[VAL_11]]#0 : i1
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_12]] : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_15]] : index
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_11]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = control_merge %[[VAL_16]] : none
-// CHECK:           sink %[[VAL_19]] : index
-// CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]] : none
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_17]] : none
-// CHECK:           sink %[[VAL_22]] : index
-// CHECK:           %[[VAL_23:.*]] = br %[[VAL_21]] : none
-// CHECK:           %[[VAL_24:.*]] = merge %[[VAL_7]] : i1
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_26]] : index
-// CHECK:           %[[VAL_27:.*]] = br %[[VAL_24]] : i1
-// CHECK:           %[[VAL_28:.*]] = br %[[VAL_25]] : none
-// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = control_merge %[[VAL_28]] : none
-// CHECK:           %[[VAL_31:.*]] = buffer [1] seq %[[VAL_32:.*]] {initValues = [0]} : i1
-// CHECK:           %[[VAL_33:.*]]:2 = fork [2] %[[VAL_31]] : i1
-// CHECK:           %[[VAL_34:.*]] = mux %[[VAL_33]]#1 {{\[}}%[[VAL_29]], %[[VAL_35:.*]]] : i1, none
-// CHECK:           %[[VAL_36:.*]]:2 = fork [2] %[[VAL_34]] : none
-// CHECK:           %[[VAL_37:.*]] = mux %[[VAL_30]] {{\[}}%[[VAL_27]]] : index, i1
-// CHECK:           %[[VAL_38:.*]] = mux %[[VAL_33]]#0 {{\[}}%[[VAL_37]], %[[VAL_39:.*]]] : i1, i1
-// CHECK:           %[[VAL_40:.*]]:4 = fork [4] %[[VAL_38]] : i1
-// CHECK:           %[[VAL_41:.*]], %[[VAL_42:.*]] = cond_br %[[VAL_40]]#0, %[[VAL_40]]#1 : i1
-// CHECK:           sink %[[VAL_41]] : i1
-// CHECK:           %[[VAL_43:.*]] = constant %[[VAL_36]]#0 {value = true} : i1
-// CHECK:           %[[VAL_44:.*]] = arith.xori %[[VAL_40]]#3, %[[VAL_43]] : i1
-// CHECK:           %[[VAL_32]] = merge %[[VAL_44]] : i1
-// CHECK:           %[[VAL_45:.*]], %[[VAL_46:.*]] = cond_br %[[VAL_40]]#2, %[[VAL_36]]#1 : none
-// CHECK:           %[[VAL_47:.*]] = merge %[[VAL_42]] : i1
-// CHECK:           %[[VAL_48:.*]], %[[VAL_49:.*]] = control_merge %[[VAL_46]] : none
-// CHECK:           sink %[[VAL_49]] : index
-// CHECK:           %[[VAL_39]] = br %[[VAL_47]] : i1
-// CHECK:           %[[VAL_35]] = br %[[VAL_48]] : none
-// CHECK:           %[[VAL_50:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_23]], %[[VAL_20]]] : i1, none
-// CHECK:           %[[VAL_51:.*]] = arith.index_cast %[[VAL_13]]#0 : i1 to index
-// CHECK:           sink %[[VAL_51]] : index
-// CHECK:           %[[VAL_52:.*]] = br %[[VAL_50]] : none
-// CHECK:           %[[VAL_53:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_45]], %[[VAL_52]]] : i1, none
-// CHECK:           %[[VAL_54:.*]]:2 = fork [2] %[[VAL_53]] : none
-// CHECK:           %[[VAL_55:.*]] = constant %[[VAL_54]]#0 {value = true} : i1
-// CHECK:           %[[VAL_56:.*]] = arith.xori %[[VAL_5]]#0, %[[VAL_55]] : i1
-// CHECK:           %[[VAL_57:.*]] = arith.index_cast %[[VAL_56]] : i1 to index
-// CHECK:           sink %[[VAL_57]] : index
-// CHECK:           return %[[VAL_54]]#1 : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_8]], %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = control_merge %[[VAL_13]] : none
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_17]] : none
+// CHECK:           %[[VAL_20:.*]] = merge %[[VAL_5]] : i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_7]] : none
+// CHECK:           %[[VAL_23:.*]] = br %[[VAL_20]] : i1
+// CHECK:           %[[VAL_24:.*]] = br %[[VAL_21]] : none
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_24]] : none
+// CHECK:           %[[VAL_27:.*]] = buffer [1] seq %[[VAL_28:.*]] {initValues = [0]} : i1
+// CHECK:           %[[VAL_29:.*]] = mux %[[VAL_27]] {{\[}}%[[VAL_25]], %[[VAL_30:.*]]] : i1, none
+// CHECK:           %[[VAL_31:.*]] = mux %[[VAL_26]] {{\[}}%[[VAL_23]]] : index, i1
+// CHECK:           %[[VAL_32:.*]] = mux %[[VAL_27]] {{\[}}%[[VAL_31]], %[[VAL_33:.*]]] : i1, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = cond_br %[[VAL_32]], %[[VAL_32]] : i1
+// CHECK:           %[[VAL_36:.*]] = constant %[[VAL_29]] {value = true} : i1
+// CHECK:           %[[VAL_37:.*]] = arith.xori %[[VAL_32]], %[[VAL_36]] : i1
+// CHECK:           %[[VAL_28]] = merge %[[VAL_37]] : i1
+// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]] = cond_br %[[VAL_32]], %[[VAL_29]] : none
+// CHECK:           %[[VAL_40:.*]] = merge %[[VAL_35]] : i1
+// CHECK:           %[[VAL_41:.*]], %[[VAL_42:.*]] = control_merge %[[VAL_39]] : none
+// CHECK:           %[[VAL_33]] = br %[[VAL_40]] : i1
+// CHECK:           %[[VAL_30]] = br %[[VAL_41]] : none
+// CHECK:           %[[VAL_43:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_19]], %[[VAL_16]]] : i1, none
+// CHECK:           %[[VAL_44:.*]] = arith.index_cast %[[VAL_9]] : i1 to index
+// CHECK:           %[[VAL_45:.*]] = br %[[VAL_43]] : none
+// CHECK:           %[[VAL_46:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_38]], %[[VAL_45]]] : i1, none
+// CHECK:           %[[VAL_47:.*]] = constant %[[VAL_46]] {value = true} : i1
+// CHECK:           %[[VAL_48:.*]] = arith.xori %[[VAL_3]], %[[VAL_47]] : i1
+// CHECK:           %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i1 to index
+// CHECK:           return %[[VAL_46]] : none
 // CHECK:         }
 func.func @blockWith3PredsAndLoop(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb4
@@ -439,59 +352,43 @@ func.func @blockWith3PredsAndLoop(%arg0: i1) {
 // CHECK-SAME:                                    %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                    %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = buffer [2] fifo %[[VAL_11]]#0 : i1
-// CHECK:           %[[VAL_13:.*]]:2 = fork [2] %[[VAL_12]] : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_15]] : index
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_11]]#1, %[[VAL_14]] : none
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = control_merge %[[VAL_16]] : none
-// CHECK:           sink %[[VAL_19]] : index
-// CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]] : none
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_17]] : none
-// CHECK:           sink %[[VAL_22]] : index
-// CHECK:           %[[VAL_23:.*]] = br %[[VAL_21]] : none
-// CHECK:           %[[VAL_24:.*]] = merge %[[VAL_7]] : i1
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_26]] : index
-// CHECK:           %[[VAL_27:.*]] = br %[[VAL_24]] : i1
-// CHECK:           %[[VAL_28:.*]] = br %[[VAL_25]] : none
-// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = control_merge %[[VAL_28]] : none
-// CHECK:           %[[VAL_31:.*]] = buffer [1] seq %[[VAL_32:.*]] {initValues = [0]} : i1
-// CHECK:           %[[VAL_33:.*]]:2 = fork [2] %[[VAL_31]] : i1
-// CHECK:           %[[VAL_34:.*]] = mux %[[VAL_33]]#1 {{\[}}%[[VAL_29]], %[[VAL_35:.*]]] : i1, none
-// CHECK:           %[[VAL_36:.*]] = mux %[[VAL_30]] {{\[}}%[[VAL_27]]] : index, i1
-// CHECK:           %[[VAL_37:.*]] = mux %[[VAL_33]]#0 {{\[}}%[[VAL_36]], %[[VAL_38:.*]]] : i1, i1
-// CHECK:           %[[VAL_39:.*]] = br %[[VAL_37]] : i1
-// CHECK:           %[[VAL_40:.*]] = br %[[VAL_34]] : none
-// CHECK:           %[[VAL_41:.*]] = merge %[[VAL_39]] : i1
-// CHECK:           %[[VAL_42:.*]]:4 = fork [4] %[[VAL_41]] : i1
-// CHECK:           %[[VAL_43:.*]], %[[VAL_44:.*]] = control_merge %[[VAL_40]] : none
-// CHECK:           %[[VAL_45:.*]]:2 = fork [2] %[[VAL_43]] : none
-// CHECK:           sink %[[VAL_44]] : index
-// CHECK:           %[[VAL_46:.*]], %[[VAL_38]] = cond_br %[[VAL_42]]#2, %[[VAL_42]]#3 : i1
-// CHECK:           sink %[[VAL_46]] : i1
-// CHECK:           %[[VAL_47:.*]] = constant %[[VAL_45]]#0 {value = true} : i1
-// CHECK:           %[[VAL_48:.*]] = arith.xori %[[VAL_42]]#0, %[[VAL_47]] : i1
-// CHECK:           %[[VAL_32]] = merge %[[VAL_48]] : i1
-// CHECK:           %[[VAL_49:.*]], %[[VAL_35]] = cond_br %[[VAL_42]]#1, %[[VAL_45]]#1 : none
-// CHECK:           %[[VAL_50:.*]] = mux %[[VAL_13]]#1 {{\[}}%[[VAL_23]], %[[VAL_20]]] : i1, none
-// CHECK:           %[[VAL_51:.*]] = arith.index_cast %[[VAL_13]]#0 : i1 to index
-// CHECK:           sink %[[VAL_51]] : index
-// CHECK:           %[[VAL_52:.*]] = br %[[VAL_50]] : none
-// CHECK:           %[[VAL_53:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_49]], %[[VAL_52]]] : i1, none
-// CHECK:           %[[VAL_54:.*]]:2 = fork [2] %[[VAL_53]] : none
-// CHECK:           %[[VAL_55:.*]] = constant %[[VAL_54]]#0 {value = true} : i1
-// CHECK:           %[[VAL_56:.*]] = arith.xori %[[VAL_5]]#0, %[[VAL_55]] : i1
-// CHECK:           %[[VAL_57:.*]] = arith.index_cast %[[VAL_56]] : i1 to index
-// CHECK:           sink %[[VAL_57]] : index
-// CHECK:           return %[[VAL_54]]#1 : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_8]], %[[VAL_10]] : none
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = control_merge %[[VAL_13]] : none
+// CHECK:           %[[VAL_19:.*]] = br %[[VAL_17]] : none
+// CHECK:           %[[VAL_20:.*]] = merge %[[VAL_5]] : i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_7]] : none
+// CHECK:           %[[VAL_23:.*]] = br %[[VAL_20]] : i1
+// CHECK:           %[[VAL_24:.*]] = br %[[VAL_21]] : none
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_24]] : none
+// CHECK:           %[[VAL_27:.*]] = buffer [1] seq %[[VAL_28:.*]] {initValues = [0]} : i1
+// CHECK:           %[[VAL_29:.*]] = mux %[[VAL_27]] {{\[}}%[[VAL_25]], %[[VAL_30:.*]]] : i1, none
+// CHECK:           %[[VAL_31:.*]] = mux %[[VAL_26]] {{\[}}%[[VAL_23]]] : index, i1
+// CHECK:           %[[VAL_32:.*]] = mux %[[VAL_27]] {{\[}}%[[VAL_31]], %[[VAL_33:.*]]] : i1, i1
+// CHECK:           %[[VAL_34:.*]] = br %[[VAL_32]] : i1
+// CHECK:           %[[VAL_35:.*]] = br %[[VAL_29]] : none
+// CHECK:           %[[VAL_36:.*]] = merge %[[VAL_34]] : i1
+// CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]] = control_merge %[[VAL_35]] : none
+// CHECK:           %[[VAL_39:.*]], %[[VAL_33]] = cond_br %[[VAL_36]], %[[VAL_36]] : i1
+// CHECK:           %[[VAL_40:.*]] = constant %[[VAL_37]] {value = true} : i1
+// CHECK:           %[[VAL_41:.*]] = arith.xori %[[VAL_36]], %[[VAL_40]] : i1
+// CHECK:           %[[VAL_28]] = merge %[[VAL_41]] : i1
+// CHECK:           %[[VAL_42:.*]], %[[VAL_30]] = cond_br %[[VAL_36]], %[[VAL_37]] : none
+// CHECK:           %[[VAL_43:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_19]], %[[VAL_16]]] : i1, none
+// CHECK:           %[[VAL_44:.*]] = arith.index_cast %[[VAL_9]] : i1 to index
+// CHECK:           %[[VAL_45:.*]] = br %[[VAL_43]] : none
+// CHECK:           %[[VAL_46:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_42]], %[[VAL_45]]] : i1, none
+// CHECK:           %[[VAL_47:.*]] = constant %[[VAL_46]] {value = true} : i1
+// CHECK:           %[[VAL_48:.*]] = arith.xori %[[VAL_3]], %[[VAL_47]] : i1
+// CHECK:           %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i1 to index
+// CHECK:           return %[[VAL_46]] : none
 // CHECK:         }
 func.func @otherBlockOrder(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb4
@@ -520,59 +417,38 @@ func.func @otherBlockOrder(%arg0: i1) {
 // CHECK-SAME:                                        %[[VAL_1:.*]]: i64,
 // CHECK-SAME:                                        %[[VAL_2:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_4:.*]]:6 = fork [6] %[[VAL_3]] : i1
-// CHECK:           %[[VAL_5:.*]] = buffer [2] fifo %[[VAL_4]]#0 : i1
-// CHECK:           %[[VAL_6:.*]]:2 = fork [2] %[[VAL_5]] : i1
-// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_1]] : i64
-// CHECK:           %[[VAL_8:.*]]:2 = fork [2] %[[VAL_7]] : i64
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = cond_br %[[VAL_4]]#4, %[[VAL_4]]#5 : i1
-// CHECK:           sink %[[VAL_10]] : i1
-// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = cond_br %[[VAL_4]]#3, %[[VAL_8]]#1 : i64
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = cond_br %[[VAL_4]]#2, %[[VAL_8]]#0 : i64
-// CHECK:           sink %[[VAL_13]] : i64
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_2]] : none
-// CHECK:           %[[VAL_17:.*]] = merge %[[VAL_9]] : i1
-// CHECK:           %[[VAL_18:.*]]:4 = fork [4] %[[VAL_17]] : i1
-// CHECK:           %[[VAL_19:.*]] = buffer [2] fifo %[[VAL_18]]#0 : i1
-// CHECK:           %[[VAL_20:.*]]:2 = fork [2] %[[VAL_19]] : i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = control_merge %[[VAL_15]] : none
-// CHECK:           sink %[[VAL_22]] : index
-// CHECK:           %[[VAL_23:.*]] = merge %[[VAL_11]] : i64
-// CHECK:           %[[VAL_24:.*]]:2 = fork [2] %[[VAL_23]] : i64
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_18]]#3, %[[VAL_21]] : none
-// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = cond_br %[[VAL_18]]#2, %[[VAL_24]]#1 : i64
-// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = cond_br %[[VAL_18]]#1, %[[VAL_24]]#0 : i64
-// CHECK:           sink %[[VAL_29]] : i64
-// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = control_merge %[[VAL_25]] : none
-// CHECK:           sink %[[VAL_32]] : index
-// CHECK:           %[[VAL_33:.*]] = merge %[[VAL_27]] : i64
-// CHECK:           sink %[[VAL_33]] : i64
-// CHECK:           %[[VAL_34:.*]] = br %[[VAL_31]] : none
-// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = control_merge %[[VAL_26]] : none
-// CHECK:           sink %[[VAL_36]] : index
-// CHECK:           %[[VAL_37:.*]] = merge %[[VAL_30]] : i64
-// CHECK:           sink %[[VAL_37]] : i64
-// CHECK:           %[[VAL_38:.*]] = merge %[[VAL_28]] : i64
-// CHECK:           sink %[[VAL_38]] : i64
-// CHECK:           %[[VAL_39:.*]] = br %[[VAL_35]] : none
-// CHECK:           %[[VAL_40:.*]], %[[VAL_41:.*]] = control_merge %[[VAL_16]] : none
-// CHECK:           sink %[[VAL_41]] : index
-// CHECK:           %[[VAL_42:.*]] = merge %[[VAL_14]] : i64
-// CHECK:           sink %[[VAL_42]] : i64
-// CHECK:           %[[VAL_43:.*]] = merge %[[VAL_12]] : i64
-// CHECK:           sink %[[VAL_43]] : i64
-// CHECK:           %[[VAL_44:.*]] = br %[[VAL_40]] : none
-// CHECK:           %[[VAL_45:.*]] = mux %[[VAL_20]]#1 {{\[}}%[[VAL_39]], %[[VAL_34]]] : i1, none
-// CHECK:           %[[VAL_46:.*]] = arith.index_cast %[[VAL_20]]#0 : i1 to index
-// CHECK:           sink %[[VAL_46]] : index
-// CHECK:           %[[VAL_47:.*]] = br %[[VAL_45]] : none
-// CHECK:           %[[VAL_48:.*]] = mux %[[VAL_6]]#1 {{\[}}%[[VAL_44]], %[[VAL_47]]] : i1, none
-// CHECK:           %[[VAL_49:.*]]:2 = fork [2] %[[VAL_48]] : none
-// CHECK:           %[[VAL_50:.*]] = constant %[[VAL_49]]#0 {value = true} : i1
-// CHECK:           %[[VAL_51:.*]] = arith.xori %[[VAL_6]]#0, %[[VAL_50]] : i1
-// CHECK:           %[[VAL_52:.*]] = arith.index_cast %[[VAL_51]] : i1 to index
-// CHECK:           sink %[[VAL_52]] : index
-// CHECK:           return %[[VAL_49]]#1 : none
+// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
+// CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_3]] : i1
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_14:.*]] = merge %[[VAL_6]] : i1
+// CHECK:           %[[VAL_15:.*]] = buffer [2] fifo %[[VAL_14]] : i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_12]] : none
+// CHECK:           %[[VAL_18:.*]] = merge %[[VAL_8]] : i64
+// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = cond_br %[[VAL_14]], %[[VAL_16]] : none
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_14]], %[[VAL_18]] : i64
+// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = cond_br %[[VAL_14]], %[[VAL_18]] : i64
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = control_merge %[[VAL_19]] : none
+// CHECK:           %[[VAL_27:.*]] = merge %[[VAL_21]] : i64
+// CHECK:           %[[VAL_28:.*]] = br %[[VAL_25]] : none
+// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = control_merge %[[VAL_20]] : none
+// CHECK:           %[[VAL_31:.*]] = merge %[[VAL_24]] : i64
+// CHECK:           %[[VAL_32:.*]] = merge %[[VAL_22]] : i64
+// CHECK:           %[[VAL_33:.*]] = br %[[VAL_29]] : none
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = control_merge %[[VAL_13]] : none
+// CHECK:           %[[VAL_36:.*]] = merge %[[VAL_11]] : i64
+// CHECK:           %[[VAL_37:.*]] = merge %[[VAL_9]] : i64
+// CHECK:           %[[VAL_38:.*]] = br %[[VAL_34]] : none
+// CHECK:           %[[VAL_39:.*]] = mux %[[VAL_15]] {{\[}}%[[VAL_33]], %[[VAL_28]]] : i1, none
+// CHECK:           %[[VAL_40:.*]] = arith.index_cast %[[VAL_15]] : i1 to index
+// CHECK:           %[[VAL_41:.*]] = br %[[VAL_39]] : none
+// CHECK:           %[[VAL_42:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_38]], %[[VAL_41]]] : i1, none
+// CHECK:           %[[VAL_43:.*]] = constant %[[VAL_42]] {value = true} : i1
+// CHECK:           %[[VAL_44:.*]] = arith.xori %[[VAL_4]], %[[VAL_43]] : i1
+// CHECK:           %[[VAL_45:.*]] = arith.index_cast %[[VAL_44]] : i1 to index
+// CHECK:           return %[[VAL_42]] : none
 // CHECK:         }
 func.func @multiple_block_args(%arg0: i1, %arg1: i64) {
   cf.cond_br %arg0, ^bb1(%arg1 : i64), ^bb4(%arg1, %arg1 : i64, i64)
@@ -596,44 +472,34 @@ func.func @multiple_block_args(%arg0: i1, %arg1: i64) {
 // CHECK-SAME:                                           %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]]#0 : i1
-// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_4]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]]#2, %[[VAL_3]]#3 : i1
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]]#1, %[[VAL_1]] : none
-// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_6]] : i1
-// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = control_merge %[[VAL_8]] : none
-// CHECK:           sink %[[VAL_12]] : index
-// CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : i1
-// CHECK:           %[[VAL_14:.*]] = br %[[VAL_11]] : none
-// CHECK:           %[[VAL_15:.*]] = merge %[[VAL_7]] : i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_9]] : none
-// CHECK:           sink %[[VAL_17]] : index
-// CHECK:           %[[VAL_18:.*]] = br %[[VAL_15]] : i1
-// CHECK:           %[[VAL_19:.*]] = br %[[VAL_16]] : none
-// CHECK:           %[[VAL_20:.*]] = mux %[[VAL_5]]#1 {{\[}}%[[VAL_19]], %[[VAL_14]]] : i1, none
-// CHECK:           %[[VAL_21:.*]]:2 = fork [2] %[[VAL_20]] : none
-// CHECK:           %[[VAL_22:.*]] = arith.index_cast %[[VAL_5]]#0 : i1 to index
-// CHECK:           %[[VAL_23:.*]] = buffer [1] seq %[[VAL_24:.*]] {initValues = [0]} : i1
-// CHECK:           %[[VAL_25:.*]]:2 = fork [2] %[[VAL_23]] : i1
-// CHECK:           %[[VAL_26:.*]] = mux %[[VAL_25]]#1 {{\[}}%[[VAL_21]]#1, %[[VAL_27:.*]]] : i1, none
-// CHECK:           %[[VAL_28:.*]] = mux %[[VAL_22]] {{\[}}%[[VAL_18]], %[[VAL_13]]] : index, i1
-// CHECK:           %[[VAL_29:.*]] = mux %[[VAL_25]]#0 {{\[}}%[[VAL_28]], %[[VAL_30:.*]]] : i1, i1
-// CHECK:           %[[VAL_31:.*]]:4 = fork [4] %[[VAL_29]] : i1
-// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]] = cond_br %[[VAL_31]]#0, %[[VAL_31]]#1 : i1
-// CHECK:           sink %[[VAL_32]] : i1
-// CHECK:           %[[VAL_34:.*]] = constant %[[VAL_21]]#0 {value = true} : i1
-// CHECK:           %[[VAL_35:.*]] = arith.xori %[[VAL_31]]#3, %[[VAL_34]] : i1
-// CHECK:           %[[VAL_24]] = merge %[[VAL_35]] : i1
-// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = cond_br %[[VAL_31]]#2, %[[VAL_26]] : none
-// CHECK:           %[[VAL_38:.*]] = merge %[[VAL_33]] : i1
-// CHECK:           %[[VAL_39:.*]], %[[VAL_40:.*]] = control_merge %[[VAL_37]] : none
-// CHECK:           sink %[[VAL_40]] : index
-// CHECK:           %[[VAL_30]] = br %[[VAL_38]] : i1
-// CHECK:           %[[VAL_27]] = br %[[VAL_39]] : none
-// CHECK:           %[[VAL_41:.*]], %[[VAL_42:.*]] = control_merge %[[VAL_36]] : none
-// CHECK:           sink %[[VAL_42]] : index
-// CHECK:           return %[[VAL_41]] : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = control_merge %[[VAL_6]] : none
+// CHECK:           %[[VAL_11:.*]] = br %[[VAL_8]] : i1
+// CHECK:           %[[VAL_12:.*]] = br %[[VAL_9]] : none
+// CHECK:           %[[VAL_13:.*]] = merge %[[VAL_5]] : i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_7]] : none
+// CHECK:           %[[VAL_16:.*]] = br %[[VAL_13]] : i1
+// CHECK:           %[[VAL_17:.*]] = br %[[VAL_14]] : none
+// CHECK:           %[[VAL_18:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_17]], %[[VAL_12]]] : i1, none
+// CHECK:           %[[VAL_19:.*]] = arith.index_cast %[[VAL_3]] : i1 to index
+// CHECK:           %[[VAL_20:.*]] = buffer [1] seq %[[VAL_21:.*]] {initValues = [0]} : i1
+// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_20]] {{\[}}%[[VAL_18]], %[[VAL_23:.*]]] : i1, none
+// CHECK:           %[[VAL_24:.*]] = mux %[[VAL_19]] {{\[}}%[[VAL_16]], %[[VAL_11]]] : index, i1
+// CHECK:           %[[VAL_25:.*]] = mux %[[VAL_20]] {{\[}}%[[VAL_24]], %[[VAL_26:.*]]] : i1, i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = cond_br %[[VAL_25]], %[[VAL_25]] : i1
+// CHECK:           %[[VAL_29:.*]] = constant %[[VAL_18]] {value = true} : i1
+// CHECK:           %[[VAL_30:.*]] = arith.xori %[[VAL_25]], %[[VAL_29]] : i1
+// CHECK:           %[[VAL_21]] = merge %[[VAL_30]] : i1
+// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_25]], %[[VAL_22]] : none
+// CHECK:           %[[VAL_33:.*]] = merge %[[VAL_28]] : i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = control_merge %[[VAL_32]] : none
+// CHECK:           %[[VAL_26]] = br %[[VAL_33]] : i1
+// CHECK:           %[[VAL_23]] = br %[[VAL_34]] : none
+// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = control_merge %[[VAL_31]] : none
+// CHECK:           return %[[VAL_36]] : none
 // CHECK:         }
 func.func @mergeBlockAsLoopHeader(%arg0: i1) {
   cf.cond_br %arg0, ^bb1, ^bb2


### PR DESCRIPTION
This commit takes out the fork-sink materialization step out of the `StandardToHandshake` conversion pass. The latter is modified to remove assumptions on the existence of forks and sinks in the [`connectToMemory`](https://github.com/llvm/circt/blob/316421a20bae4a9c03cd15a618ceee2de9f136be/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp#L1658) conversion step. Fork-sink materialization can still be run explicitly after dialect conversion to obtain a functionally identical IR as what was produced by the version of the conversion pass that included fork-sink materialization.

Unit tests for `StandardToHandshake` are modified to reflect the now absent forks and sinks. As expected, all forks and sinks are removed from the expected outputs, whereas the rest of the IR stays unchanged (beside SSA-value name changes). `handshake-runner` integration tests are also modified to explicitly run the `-handshake-materialize-forks-sinks` pass after dialect conversion in order to keep the runner's input unchanged.

Fixes #4362.