### PR TITLE
[NFC] Disable -Wno-suggest-override for llvm_gtest_main as well.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ endif ()
         LINK_COMPONENTS Support # llvm::cl
         BUILDTREE_ONLY
       )
+      if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
+        target_compile_options(llvm_gtest_main INTERFACE "-Wno-suggest-override")
+      endif()
     endif()
     set(CIRCT_GTEST_AVAILABLE 1)
   else()


### PR DESCRIPTION
PR #4409 disabled this for our unittests themselves, but these warnings are still emitted when building llvm_gtest_main in the non-unified build scenario where we have our own build rule.

Would be nice to remove all this.