### PR TITLE
[PyCDE] Wire construct improvements

### DIFF
--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -13,7 +13,7 @@ import mlir.ir as ir
 
 from contextvars import ContextVar
 from functools import singledispatchmethod
-from typing import Optional, Union
+from typing import List, Optional, Union
 import re
 import numpy as np
 
@@ -246,6 +246,12 @@ class BitVectorValue(PyCDEValue):
   def __get_item__value(self, idx: BitVectorValue) -> BitVectorValue:
     """Get the single bit at `idx`."""
     return self.slice(idx, 1)
+
+  @staticmethod
+  def concat(items: List[BitVectorValue]):
+    """Concatenate a list of bitvectors into one larger bitvector."""
+    from .dialects import comb
+    return comb.ConcatOp(*items)
 
   def slice(self, low_bit: BitVectorValue, num_bits: int):
     """Get a constant-width slice starting at `low_bit` and ending at `low_bit +

--- a/frontends/PyCDE/test/test_constructs.py
+++ b/frontends/PyCDE/test/test_constructs.py
@@ -7,14 +7,14 @@ from pycde.dialects import comb
 from pycde.testing import unittestmodule
 
 # CHECK-LABEL: msft.module @WireAndRegTest {} (%In: i8, %clk: i1) -> (Out: i8, OutReg: i8)
-# CHECK:         %w1 = sv.wire sym @w1 : !hw.inout<i8>
-# CHECK:         [[r0:%.+]] = sv.read_inout %w1 : !hw.inout<i8>
-# CHECK:         sv.assign %w1, %In : i8
+# CHECK:         [[r0:%.+]] = comb.extract %In from 0 {sv.namehint = "In_0upto7"} : (i8) -> i7
+# CHECK:         [[r1:%.+]] = comb.extract %In from 7 {sv.namehint = "In_7upto8"} : (i8) -> i1
+# CHECK:         [[r2:%.+]] = comb.concat [[r1]], [[r0]] {sv.namehint = "w1"} : i1, i7
 # CHECK:         %in = sv.wire sym @in : !hw.inout<i8>
-# CHECK:         {{%.+}} = sv.read_inout %in : !hw.inout<i8>
+# CHECK:         {{%.+}} = sv.read_inout %in {sv.namehint = "in"} : !hw.inout<i8>
 # CHECK:         sv.assign %in, %In : i8
 # CHECK:         [[r1:%.+]] = seq.compreg %In, %clk : i8
-# CHECK:         msft.output [[r0]], [[r1]] : i8, i8
+# CHECK:         msft.output [[r2]], [[r1]] : i8, i8
 
 
 @unittestmodule()
@@ -28,7 +28,8 @@ class WireAndRegTest:
   def create(ports):
     w1 = Wire(types.i8, "w1")
     ports.Out = w1
-    w1.assign(ports.In)
+    w1[0:7] = ports.In[0:7]
+    w1[7] = ports.In[7]
 
     NamedWire(ports.In, "in")
 


### PR DESCRIPTION
- Wires with names no longer automatically construct NamedWires.
- Respect the given name in backedges and after assignment.
- Assign to slices and indexes.