### PR TITLE
Bump LLVM to 53406427cdf4290986d1a48ea0d582ad195bff15.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -67,6 +67,9 @@ def ComponentOp : CalyxOp<"component", [
   }];
 
   let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
     ArrayAttr:$portNames,
     ArrayAttr:$portAttributes,
     APIntAttr:$portDirections
@@ -82,11 +85,6 @@ def ComponentOp : CalyxOp<"component", [
       using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::front;
       using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::getFunctionBody;
 
-      /// Returns the type of this function.
-      FunctionType getFunctionType() {
-        return getFunctionTypeAttr().getValue().cast<FunctionType>();
-      }
-
       /// Returns the argument types of this function.
       ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -98,7 +96,8 @@ def ComponentOp : CalyxOp<"component", [
       LogicalResult verifyType() {
         auto type = getFunctionTypeAttr().getValue();
         if (!type.isa<FunctionType>())
-          return emitOpError("requires '" + getTypeAttrName() +
+          return emitOpError("requires '" +
+	                     getFunctionTypeAttrName().getValue() +
                              "' attribute of function type");
         return success();
       }
@@ -174,6 +173,9 @@ def CombComponentOp : CalyxOp<"comb_component", [
   }];
 
   let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
     ArrayAttr:$portNames,
     ArrayAttr:$portAttributes,
     APIntAttr:$portDirections
@@ -189,11 +191,6 @@ def CombComponentOp : CalyxOp<"comb_component", [
       using mlir::detail::FunctionOpInterfaceTrait<CombComponentOp>::front;
       using mlir::detail::FunctionOpInterfaceTrait<CombComponentOp>::getFunctionBody;
 
-      /// Returns the type of this function.
-      FunctionType getFunctionType() {
-        return getFunctionTypeAttr().getValue().cast<FunctionType>();
-      }
-
       /// Returns the argument types of this function.
       ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -205,7 +202,8 @@ def CombComponentOp : CalyxOp<"comb_component", [
       LogicalResult verifyType() {
         auto type = getFunctionTypeAttr().getValue();
         if (!type.isa<FunctionType>())
-          return emitOpError("requires '" + getTypeAttrName() +
+          return emitOpError("requires '" +
+	                     getFunctionTypeAttrName().getValue() +
                              "' attribute of function type");
         return success();
       }

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -29,6 +29,8 @@ def MachineOp : FSMOp<"machine", [
 
   let arguments = (ins StrAttr:$sym_name, StrAttr:$initialState,
                        TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
                        OptionalAttr<StrArrayAttr>:$argNames,
                        OptionalAttr<StrArrayAttr>:$resNames);
   let regions = (region SizedRegion<1>:$body);
@@ -64,7 +66,7 @@ def MachineOp : FSMOp<"machine", [
     LogicalResult verifyType() {
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getTypeAttrName() +
+        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                            "' attribute of function type");
       return success();
     }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -46,7 +46,10 @@ def HWModuleOp : HWModuleOpBase<"module",
     name, a list of ports, a list of parameters, and a body that represents the
     connections within the module.
   }];
-  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
+  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        StrAttr:$comment);
   let results = (outs);
@@ -178,11 +181,6 @@ def HWModuleOp : HWModuleOpBase<"module",
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -194,7 +192,7 @@ def HWModuleOp : HWModuleOpBase<"module",
     LogicalResult verifyType() {
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getTypeAttrName() +
+        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                            "' attribute of function type");
       return success();
     }
@@ -218,7 +216,10 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern"> {
     have proper parameterization in the hw.dialect.  We need a way to represent
     parameterized types instead of just concrete types.
   }];
-  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
+  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
@@ -283,11 +284,6 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern"> {
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -299,7 +295,7 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern"> {
     LogicalResult verifyType() {
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getTypeAttrName() +
+        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                            "' attribute of function type");
       return success();
     }
@@ -345,6 +341,9 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
     module name in Verilog we can use.  See hw.module for an explanation.
   }];
   let arguments = (ins FlatSymbolRefAttr:$generatorKind,
+                       TypeAttrOf<FunctionType>:$function_type,
+		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$verilogName);
@@ -395,11 +394,6 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -411,7 +405,7 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
     LogicalResult verifyType() {
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getTypeAttrName() +
+        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                            "' attribute of function type");
       return success();
     }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -47,7 +47,7 @@ def HWModuleOp : HWModuleOpBase<"module",
     connections within the module.
   }];
   let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
-		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -35,7 +35,11 @@ def FuncOp : Op<Handshake_Dialect, "func", [
     only have a single use.
   }];
 
-  let arguments = (ins);
+  let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
   let results = (outs);
   let regions = (region AnyRegion : $body);
 
@@ -49,11 +53,6 @@ def FuncOp : Op<Handshake_Dialect, "func", [
     // Add an entry block to an empty function, and set up the block arguments
     // to match the signature of the function.
     Block *addEntryBlock();
-
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
 
     /// Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
@@ -97,7 +96,7 @@ def FuncOp : Op<Handshake_Dialect, "func", [
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
         return emitOpError(
-            "requires '" + mlir::function_interface_impl::getTypeAttrName() +
+            "requires '" + getFunctionTypeAttrName().getValue() +
             "' attribute of function type");
       return success();
     }

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -49,17 +49,17 @@ def LLHD_EntityOp : LLHD_Op<"entity", [
     ```
   }];
 
-  let arguments = (ins I64Attr: $ins);
+  let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    I64Attr: $ins,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
   let regions = (region SizedRegion<1>: $body);
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -125,15 +125,15 @@ def LLHD_ProcOp : LLHD_Op<"proc", [
     ```
   }];
 
-  let arguments = (ins I64Attr: $ins);
+  let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    I64Attr:$ins,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
   let regions = (region AnyRegion: $body);
 
   let extraClassDeclaration = [{
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -86,11 +86,6 @@ class MSFTModuleOpBase<string mnemonic, list<Trait> traits = []> :
       return getNameAttr().getValue();
     }
 
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
-
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
@@ -103,7 +98,7 @@ class MSFTModuleOpBase<string mnemonic, list<Trait> traits = []> :
       auto type = getFunctionTypeAttr().getValue();
       if (!type.isa<FunctionType>())
         return emitOpError(
-            "requires '" + mlir::function_interface_impl::getTypeAttrName() +
+            "requires '" + getFunctionTypeAttrName().getValue() +
             "' attribute of function type");
       return success();
     }
@@ -135,6 +130,9 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
       - Provides methods for mutation.
   }];
   let arguments = (ins
+      TypeAttrOf<FunctionType>:$function_type,
+      OptionalAttr<DictArrayAttr>:$arg_attrs,
+      OptionalAttr<DictArrayAttr>:$res_attrs,
       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
       DictionaryAttr:$parameters,
       OptionalAttr<StrAttr>:$fileName,
@@ -188,7 +186,10 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
     exists so that we can use `msft.instance` to refer to both `msft.module` and
     `msft.module.extern`, rather than mixing `hw.instance` with `msft.instance`.
   }];
-  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
+  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$verilogName);
   let regions = (region SizedRegion<0>:$body);
@@ -207,11 +208,6 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
   let extraClassDeclaration = [{
     /// Decode information about the input and output ports on this module.
     hw::ModulePortInfo getPorts();
-
-    /// Returns the type of this function.
-    FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<FunctionType>();
-    }
 
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -351,7 +351,7 @@ def FuncOp : SystemCOp<"cpp.func", [
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
-		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs,
                        StrArrayAttr:$argNames,
                        UnitAttr:$externC,

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -31,7 +31,12 @@ def SCModuleOp : SystemCOp<"module", [
     but are nonetheless emitted as regular struct fields.
   }];
 
-  let arguments = (ins StrArrayAttr:$portNames);
+  let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
+    StrArrayAttr:$portNames
+  );
   let regions = (region SizedRegion<1>: $body);
 
   let hasCustomAssemblyFormat = 1;
@@ -53,11 +58,6 @@ def SCModuleOp : SystemCOp<"module", [
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) {
       return RegionKind::Graph;
-    }
-
-    /// Returns the type of this function.
-    mlir::FunctionType getFunctionType() {
-      return getFunctionTypeAttr().getValue().cast<mlir::FunctionType>();
     }
 
     /// Returns the argument types of this function.
@@ -351,6 +351,8 @@ def FuncOp : SystemCOp<"cpp.func", [
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
+		       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
                        StrArrayAttr:$argNames,
                        UnitAttr:$externC,
                        OptionalAttr<StrAttr>:$sym_visibility);

--- a/lib/Conversion/ExportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ExportVerilog/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_translation_library(CIRCTExportVerilog
   CIRCTHW
   CIRCTSupport
   CIRCTSV
+  MLIRIR
   MLIRPass
   MLIRSideEffectInterfaces
   MLIRTransforms

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1863,7 +1863,7 @@ static LogicalResult lowerFuncOp(func::FuncOp funcOp, MLIRContext *ctx,
   SmallVector<NamedAttribute, 4> attributes;
   for (const auto &attr : funcOp->getAttrs()) {
     if (attr.getName() == SymbolTable::getSymbolAttrName() ||
-        attr.getName() == function_interface_impl::getTypeAttrName())
+        attr.getName() == funcOp.getFunctionTypeAttrName())
       continue;
     attributes.push_back(attr);
   }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -329,6 +329,7 @@ static void eraseControlWithGroupAndConditional(OpTy op,
 // ComponentInterface
 //===----------------------------------------------------------------------===//
 
+template <typename ComponentTy>
 static void printComponentInterface(OpAsmPrinter &p, ComponentInterface comp) {
   auto componentName = comp->template getAttrOfType<StringAttr>(
                                ::mlir::SymbolTable::getSymbolAttrName())
@@ -357,9 +358,14 @@ static void printComponentInterface(OpAsmPrinter &p, ComponentInterface comp) {
                 /*printBlockTerminators=*/false,
                 /*printEmptyBlock=*/false);
 
-  SmallVector<StringRef> elidedAttrs = {"portAttributes", "portNames",
-                                        "portDirections", "sym_name",
-                                        ComponentOp::getTypeAttrName()};
+  SmallVector<StringRef> elidedAttrs = {
+      "portAttributes",
+      "portNames",
+      "portDirections",
+      "sym_name",
+      ComponentTy::getFunctionTypeAttrName(comp->getName()),
+      ComponentTy::getArgAttrsAttrName(comp->getName()),
+      ComponentTy::getResAttrsAttrName(comp->getName())};
   p.printOptionalAttrDict(comp->getAttrs(), elidedAttrs);
 }
 
@@ -439,6 +445,7 @@ parseComponentSignature(OpAsmParser &parser, OperationState &result,
   return success();
 }
 
+template <typename ComponentTy>
 static ParseResult parseComponentInterface(OpAsmParser &parser,
                                            OperationState &result) {
   using namespace mlir::function_interface_impl;
@@ -458,7 +465,8 @@ static ParseResult parseComponentInterface(OpAsmParser &parser,
   // Build the component's type for FunctionLike trait. All ports are listed
   // as arguments so they may be accessed within the component.
   auto type = parser.getBuilder().getFunctionType(portTypes, /*results=*/{});
-  result.addAttribute(ComponentOp::getTypeAttrName(), TypeAttr::get(type));
+  result.addAttribute(ComponentTy::getFunctionTypeAttrName(result.name),
+                      TypeAttr::get(type));
 
   auto *body = result.addRegion();
   if (parser.parseRegion(*body, ports))
@@ -510,7 +518,8 @@ static void buildComponentLike(OpBuilder &builder, OperationState &result,
 
   // Build the function type of the component.
   auto functionType = builder.getFunctionType(portTypes, {});
-  result.addAttribute(getTypeAttrName(), TypeAttr::get(functionType));
+  result.addAttribute(ComponentOp::getFunctionTypeAttrName(result.name),
+                      TypeAttr::get(functionType));
 
   // Record the port names and number of input ports of the component.
   result.addAttribute("portNames", builder.getArrayAttr(portNames));
@@ -625,10 +634,12 @@ SmallVector<PortInfo> ComponentOp::getOutputPortInfo() {
       *this, [](const PortInfo &port) { return port.direction == Input; });
 }
 
-void ComponentOp::print(OpAsmPrinter &p) { printComponentInterface(p, *this); }
+void ComponentOp::print(OpAsmPrinter &p) {
+  printComponentInterface<ComponentOp>(p, *this);
+}
 
 ParseResult ComponentOp::parse(OpAsmParser &parser, OperationState &result) {
-  return parseComponentInterface(parser, result);
+  return parseComponentInterface<ComponentOp>(parser, result);
 }
 
 /// Determines whether the given ComponentOp has all the required ports.
@@ -749,12 +760,12 @@ SmallVector<PortInfo> CombComponentOp::getOutputPortInfo() {
 }
 
 void CombComponentOp::print(OpAsmPrinter &p) {
-  printComponentInterface(p, *this);
+  printComponentInterface<CombComponentOp>(p, *this);
 }
 
 ParseResult CombComponentOp::parse(OpAsmParser &parser,
                                    OperationState &result) {
-  return parseComponentInterface(parser, result);
+  return parseComponentInterface<CombComponentOp>(parser, result);
 }
 
 LogicalResult CombComponentOp::verify() {

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -29,7 +29,8 @@ void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                       ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(mlir::SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
-  state.addAttribute(getTypeAttrName(), TypeAttr::get(type));
+  state.addAttribute(MachineOp::getFunctionTypeAttrName(state.name),
+                     TypeAttr::get(type));
   state.addAttribute("initialState",
                      StringAttr::get(state.getContext(), initialStateName));
   state.attributes.append(attrs.begin(), attrs.end());
@@ -43,8 +44,10 @@ void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (argAttrs.empty())
     return;
   assert(type.getNumInputs() == argAttrs.size());
-  function_interface_impl::addArgAndResultAttrs(builder, state, argAttrs,
-                                                /*resultAttrs=*/std::nullopt);
+  function_interface_impl::addArgAndResultAttrs(
+      builder, state, argAttrs,
+      /*resultAttrs=*/std::nullopt, MachineOp::getArgAttrsAttrName(state.name),
+      MachineOp::getResAttrsAttrName(state.name));
 }
 
 /// Get the initial state of the machine.
@@ -96,11 +99,16 @@ ParseResult MachineOp::parse(OpAsmParser &parser, OperationState &result) {
          std::string &) { return builder.getFunctionType(argTypes, results); };
 
   return function_interface_impl::parseFunctionOp(
-      parser, result, /*allowVariadic=*/false, buildFuncType);
+      parser, result, /*allowVariadic=*/false,
+      MachineOp::getFunctionTypeAttrName(result.name), buildFuncType,
+      MachineOp::getArgAttrsAttrName(result.name),
+      MachineOp::getResAttrsAttrName(result.name));
 }
 
 void MachineOp::print(OpAsmPrinter &p) {
-  function_interface_impl::printFunctionOp(p, *this, /*isVariadic=*/false);
+  function_interface_impl::printFunctionOp(
+      p, *this, /*isVariadic=*/false, getFunctionTypeAttrName(),
+      getArgAttrsAttrName(), getResAttrsAttrName());
 }
 
 static LogicalResult compareTypes(TypeRange rangeA, TypeRange rangeB) {

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -409,8 +409,9 @@ ParseResult llhd::EntityOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
 
   auto type = parser.getBuilder().getFunctionType(argTypes, std::nullopt);
-  result.addAttribute(circt::llhd::EntityOp::getTypeAttrName(),
-                      TypeAttr::get(type));
+  result.addAttribute(
+      circt::llhd::EntityOp::getFunctionTypeAttrName(result.name),
+      TypeAttr::get(type));
 
   auto &body = *result.addRegion();
   if (parser.parseRegion(body, args))
@@ -455,7 +456,7 @@ void llhd::EntityOp::print(OpAsmPrinter &printer) {
   printer.printOptionalAttrDictWithKeyword(
       (*this)->getAttrs(),
       /*elidedAttrs =*/{SymbolTable::getSymbolAttrName(),
-                        llhd::EntityOp::getTypeAttrName(), "ins"});
+                        getFunctionTypeAttrName(), "ins"});
   printer << " ";
   printer.printRegion(getBody(), false, false);
 }
@@ -655,7 +656,7 @@ ParseResult llhd::ProcOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
 
   auto type = builder.getFunctionType(argTypes, std::nullopt);
-  result.addAttribute(circt::llhd::ProcOp::getTypeAttrName(),
+  result.addAttribute(circt::llhd::ProcOp::getFunctionTypeAttrName(result.name),
                       TypeAttr::get(type));
 
   auto *body = result.addRegion();

--- a/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
@@ -126,14 +126,15 @@ void ProcessLoweringPass::runOnOperation() {
 
     // Replace proc with entity
     llhd::EntityOp entity =
-        builder.create<llhd::EntityOp>(op.getLoc(), op.getIns());
+        builder.create<llhd::EntityOp>(op.getLoc(), op.getFunctionType(),
+                                       op.getIns(), /*argAttrs=*/ArrayAttr(),
+                                       /*resAttrs=*/ArrayAttr());
     // Set the symbol name of the entity to the same as the process (as the
     // process gets deleted anyways).
     entity.setName(op.getName());
     // Move all blocks from the process to the entity, the process does not have
     // a region afterwards.
     entity.getBody().takeBody(op.getBody());
-    entity->setAttr("function_type", op->getAttr("function_type"));
     // In the case that wait is used to suspend the process, we need to merge
     // the two blocks as we needed the second block to have a target for wait
     // (the entry block cannot be targeted).


### PR DESCRIPTION
This picks up some major changes to FunctionOpInterface from https://github.com/llvm/llvm-project/commit/53406427cdf4290986d1a48ea0d582ad195bff15.

This generally follows the upstream changes approach to the same:

* Ensure all FunctionOpInterface ops declare function_type, arg_attrs, and res_attrs in ODS.
* Use the ODS-generated methods to get the names of the above attributes, since they were removed from mlir::function_interface_impl.
* Incorporate some minor changes to mlir::function_interface_impl.