### PR TITLE
[FIRRTL] Support zero-width literals.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1721,36 +1721,22 @@ ParseResult FIRStmtParser::parseIntegerLiteralExp(Value &result) {
   // Construct an integer attribute of the right width.
   auto type = IntType::get(builder.getContext(), isSigned, width);
 
-  IntegerType::SignednessSemantics signedness;
-  if (isSigned) {
-    signedness = IntegerType::Signed;
-    if (width != -1) {
-      // Check for overflow if we are truncating bits.
-      if (width == 0) {
-        if (!value.isZero())
-          return emitError(loc, "zero bit constant must be zero");
-      } else if (unsigned(width) < value.getBitWidth() &&
-                 value.getNumSignBits() <= value.getBitWidth() - width) {
-        return emitError(loc, "initializer too wide for declared width"),
-               failure();
-      }
-
+  IntegerType::SignednessSemantics signedness =
+      isSigned ? IntegerType::Signed : IntegerType::Unsigned;
+  if (width == 0) {
+    if (!value.isZero())
+      return emitError(loc, "zero bit constant must be zero");
+    value = value.trunc(0);
+  } else if (width != -1) {
+    // Convert to the type's width, checking value is preserved if truncating.
+    auto willTrunc = unsigned(width) < value.getBitWidth();
+    if (isSigned) {
+      if (willTrunc && value.getNumSignBits() <= value.getBitWidth() - width)
+        return emitError(loc, "initializer too wide for declared width");
       value = value.sextOrTrunc(width);
-    }
-  } else {
-    signedness = IntegerType::Unsigned;
-    if (width != -1) {
-      // Check for overflow if we are truncating bits.
-      if (width == 0) {
-        // The check below already would error on this appropriately,
-        // but check explicitly for symmetry in errors produced.
-        if (!value.isZero())
-          return emitError(loc, "zero bit constant must be zero");
-      } else if (unsigned(width) < value.getBitWidth() &&
-                 value.countLeadingZeros() < value.getBitWidth() - width) {
-        return emitError(loc, "initializer too wide for declared width"),
-               failure();
-      }
+    } else {
+      if (willTrunc && value.countLeadingZeros() < value.getBitWidth() - width)
+        return emitError(loc, "initializer too wide for declared width");
       value = value.zextOrTrunc(width);
     }
   }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -215,10 +215,24 @@ circuit Issue418:
 
 ;// -----
 
-circuit Issue426:
-  module Issue426:
-    ; expected-error @+1 {{zero bit constants are not allowed}}
-    node x = UInt<0>("h0")
+circuit Issue3799:
+  module Issue3799:
+    output a: UInt<0>
+    a <= UInt<0>(0) ; ok
+    a <= UInt<0>(-0) ; ok
+    ; expected-error @below {{zero bit constant must be zero}}
+    a <= UInt<0>(1)
+
+;// -----
+
+circuit Issue3799:
+  module Issue3799:
+    output a: SInt<0>
+    a <= SInt<0>(0) ; ok
+    a <= SInt<0>(-0) ; ok
+    ; expected-error @below {{zero bit constant must be zero}}
+    a <= SInt<0>(1)
+
 
 ;// -----
 


### PR DESCRIPTION
Fixes #3799.

Zero-width constants have already been supported in the IR
since aa1c294e99db3c673b9c0d6e0f49e2869f042f14 .

Error language is preserved with "zero bit", closer to spec text.