### PR TITLE
Bump LLVM to afb2ed80cb1639236a3aa15f2c9ff96dbb45c3d0.

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -231,7 +231,7 @@ def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  let builders = [ OpBuilder<(ins), "build($_builder, $_state, llvm::None);"> ];
+  let builders = [ OpBuilder<(ins), "build($_builder, $_state, std::nullopt);"> ];
 
   let assemblyFormat = [{ attr-dict ($operands^ `:` qualified(type($operands)))? }];
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -526,7 +526,7 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let arguments = (ins Variadic<AnyType>:$outputs);
 
   let builders = [
-    OpBuilder<(ins), "build($_builder, $_state, llvm::None);">
+    OpBuilder<(ins), "build($_builder, $_state, std::nullopt);">
   ];
 
   let assemblyFormat = "attr-dict ($outputs^ `:` qualified(type($outputs)))?";

--- a/include/circt/Dialect/Interop/Interop.td
+++ b/include/circt/Dialect/Interop/Interop.td
@@ -204,7 +204,7 @@ def ReturnOp : InteropOp<"return", [
   let arguments = (ins Variadic<AnyType>:$returnValues);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, llvm::None);
+    build($_builder, $_state, std::nullopt);
   }]>];
 
   let assemblyFormat = "attr-dict ($returnValues^ `:` type($returnValues))?";

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -469,7 +469,7 @@ def ReturnOp : SystemCOp<"cpp.return", [
   let arguments = (ins Variadic<AnyType>:$returnValues);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, llvm::None);
+    build($_builder, $_state, std::nullopt);
   }]>];
 
   let assemblyFormat = "attr-dict ($returnValues^ `:` type($returnValues))?";

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -658,12 +658,12 @@ circt::firrtl::maybeStringToLocation(StringRef spelling, bool skipParsing,
   unsigned lineNo = 0, columnNo = 0;
   StringRef filename = decodeLocator(spelling, lineNo, columnNo);
   if (filename.empty())
-    return {false, llvm::None};
+    return {false, std::nullopt};
 
   // If info locators are ignored, don't actually apply them.  We still do all
   // the verification above though.
   if (skipParsing)
-    return {true, llvm::None};
+    return {true, std::nullopt};
 
   /// Return an FileLineColLoc for the specified location, but use a bit of
   /// caching to reduce thrasing the MLIRContext.

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -379,7 +379,8 @@ void PlacementDB::walkPlacements(
   // X loop.
   SmallVector<std::pair<size_t, DimYMap>> cols(placements.begin(),
                                                placements.end());
-  maybeSort(cols, walkOrder.transform([](auto wo) { return wo.columns; }));
+  maybeSort(cols, llvm::transformOptional(walkOrder,
+                                          [](auto wo) { return wo.columns; }));
   for (auto colF : cols) {
     size_t x = colF.first;
     if (x < xmin || x > xmax)
@@ -388,7 +389,8 @@ void PlacementDB::walkPlacements(
 
     // Y loop.
     SmallVector<std::pair<size_t, DimNumMap>> rows(yMap.begin(), yMap.end());
-    maybeSort(rows, walkOrder.transform([](auto wo) { return wo.rows; }));
+    maybeSort(rows, llvm::transformOptional(walkOrder,
+                                            [](auto wo) { return wo.rows; }));
     for (auto rowF : rows) {
       size_t y = rowF.first;
       if (y < ymin || y > ymax)

--- a/lib/Dialect/Moore/MooreTypes.cpp
+++ b/lib/Dialect/Moore/MooreTypes.cpp
@@ -770,7 +770,7 @@ Optional<Range> PackedDim::getRange() const {
 }
 
 Optional<unsigned> PackedDim::getSize() const {
-  return getRange().transform([](auto r) { return r.size; });
+  return llvm::transformOptional(getRange(), [](auto r) { return r.size; });
 }
 
 const detail::DimStorage *PackedDim::getImpl() const {

--- a/tools/circt-reduce/Tester.cpp
+++ b/tools/circt-reduce/Tester.cpp
@@ -46,7 +46,7 @@ bool Tester::isInteresting(StringRef testCase) const {
   // Run the tester.
   std::string errMsg;
   int result = llvm::sys::ExecuteAndWait(
-      testScript, testerArgs, /*Env=*/None, /*Redirects=*/None,
+      testScript, testerArgs, /*Env=*/std::nullopt, /*Redirects=*/std::nullopt,
       /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errMsg);
   if (result < 0)
     llvm::report_fatal_error(


### PR DESCRIPTION
This is NFC. The only change is related to the transition from llvm::None to std::nullopt, so I cleaned up the warnings that I saw.

This LLVM commit includes a few additions to the MLIR Python API that will be good to build on top of.