### PR TITLE
[WireDFT] harden a bit, check clock gate modules.

### DIFF
--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -90,18 +90,12 @@ firrtl.circuit "InAndOutOfDUT" {
 // -----
 // Not an extmodule.
 
-firrtl.circuit "WrongType" {
-
+firrtl.circuit "NotExtModule" {
   // expected-error @below {{clock gate module must be an extmodule}}
-  firrtl.module @EICG_wrapper_mod(in %in: !firrtl.clock, in %test_en: !firrtl.clock, in %en: !firrtl.uint<1>, out %out: !firrtl.clock) attributes {defname = "EICG_wrapper"} {
-  }
-  
-  firrtl.module @A() {
-    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_mod(in in: !firrtl.clock, in test_en: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-  }
+  firrtl.module @EICG_wrapper_mod(in %in: !firrtl.clock, in %test_en: !firrtl.clock, in %en: !firrtl.uint<1>, out %out: !firrtl.clock) attributes {defname = "EICG_wrapper"} {}
 
-  firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance a @A()
+  firrtl.module @NotExtModule() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper_mod(in in: !firrtl.clock, in test_en: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
   }
 }
@@ -114,12 +108,8 @@ firrtl.circuit "WrongType" {
   // expected-note @below {{Second port ("foo") has type '!firrtl.clock', expected '!firrtl.uint<1>'}}
   firrtl.extmodule @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   
-  firrtl.module @A() {
-    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-  }
-
   firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance a @A()
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
   }
 }
@@ -130,13 +120,9 @@ firrtl.circuit "WrongType" {
 firrtl.circuit "MissingPort" {
   // expected-error @below {{clock gate module must have at least two ports}}
   firrtl.extmodule @EICG_wrapper_noports() attributes {defname = "EICG_wrapper"}
-  
-  firrtl.module @A() {
-    firrtl.instance eicg @EICG_wrapper_noports()
-  }
 
   firrtl.module @MissingPort() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance a @A()
+    firrtl.instance eicg @EICG_wrapper_noports()
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
   }
 }
@@ -148,12 +134,8 @@ firrtl.circuit "WrongDirection" {
   // expected-error @below {{clock gate module must have second port with input direction}}
   firrtl.extmodule @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   
-  firrtl.module @A() {
-    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-  }
-
   firrtl.module @WrongDirection() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance a @A()
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -96,17 +96,13 @@ firrtl.circuit "WrongType" {
   firrtl.module @EICG_wrapper_mod(in %in: !firrtl.clock, in %test_en: !firrtl.clock, in %en: !firrtl.uint<1>, out %out: !firrtl.clock) attributes {defname = "EICG_wrapper"} {
   }
   
-  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
   firrtl.module @A() {
     %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_mod(in in: !firrtl.clock, in test_en: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
     firrtl.instance a @A()
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
-    // CHECK: firrtl.connect %a_test_en, %test_en
   }
 }
 
@@ -118,17 +114,13 @@ firrtl.circuit "WrongType" {
   // expected-note @below {{Second port ("foo") has type '!firrtl.clock', expected '!firrtl.uint<1>'}}
   firrtl.extmodule @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   
-  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
   firrtl.module @A() {
     %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
     firrtl.instance a @A()
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
-    // CHECK: firrtl.connect %a_test_en, %test_en
   }
 }
 
@@ -139,17 +131,13 @@ firrtl.circuit "MissingPort" {
   // expected-error @below {{clock gate module must have at least two ports}}
   firrtl.extmodule @EICG_wrapper_noports() attributes {defname = "EICG_wrapper"}
   
-  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
   firrtl.module @A() {
     firrtl.instance eicg @EICG_wrapper_noports()
-    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   firrtl.module @MissingPort() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
     firrtl.instance a @A()
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
-    // CHECK: firrtl.connect %a_test_en, %test_en
   }
 }
 
@@ -160,16 +148,12 @@ firrtl.circuit "WrongDirection" {
   // expected-error @below {{clock gate module must have second port with input direction}}
   firrtl.extmodule @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   
-  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
   firrtl.module @A() {
     %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   firrtl.module @WrongDirection() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
     firrtl.instance a @A()
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
-    // CHECK: firrtl.connect %a_test_en, %test_en
   }
 }

--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -86,3 +86,90 @@ firrtl.circuit "InAndOutOfDUT" {
     firrtl.instance d @DUT()
   }
 }
+
+// -----
+// Not an extmodule.
+
+firrtl.circuit "WrongType" {
+
+  // expected-error @below {{clock gate module must be an extmodule}}
+  firrtl.module @EICG_wrapper_mod(in %in: !firrtl.clock, in %test_en: !firrtl.clock, in %en: !firrtl.uint<1>, out %out: !firrtl.clock) attributes {defname = "EICG_wrapper"} {
+  }
+  
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_mod(in in: !firrtl.clock, in test_en: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    // CHECK: firrtl.connect %a_test_en, %test_en
+  }
+}
+
+// -----
+// Type mismatch between port and signal, must be UInt<1>.
+
+firrtl.circuit "WrongType" {
+  // expected-error @below {{clock gate module must have second port with type UInt<1>}}
+  // expected-note @below {{Second port ("foo") has type '!firrtl.clock', expected '!firrtl.uint<1>'}}
+  firrtl.extmodule @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+  
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_type(in in: !firrtl.clock, in foo: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  firrtl.module @WrongType() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    // CHECK: firrtl.connect %a_test_en, %test_en
+  }
+}
+
+// -----
+// Port is missing.
+
+firrtl.circuit "MissingPort" {
+  // expected-error @below {{clock gate module must have at least two ports}}
+  firrtl.extmodule @EICG_wrapper_noports() attributes {defname = "EICG_wrapper"}
+  
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() {
+    firrtl.instance eicg @EICG_wrapper_noports()
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  firrtl.module @MissingPort() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    // CHECK: firrtl.connect %a_test_en, %test_en
+  }
+}
+
+// -----
+// Port direction is wrong.
+
+firrtl.circuit "WrongDirection" {
+  // expected-error @below {{clock gate module must have second port with input direction}}
+  firrtl.extmodule @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+  
+  // CHECK: firrtl.module @A(in %test_en: !firrtl.uint<1>)
+  firrtl.module @A() {
+    %in, %test_en, %en, %out = firrtl.instance eicg @EICG_wrapper_direction(in in: !firrtl.clock, out bar: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    // CHECK: firrtl.connect %eicg_test_en, %test_en : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  firrtl.module @WrongDirection() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: %a_test_en = firrtl.instance a  @A(in test_en: !firrtl.uint<1>)
+    firrtl.instance a @A()
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    // CHECK: firrtl.connect %a_test_en, %test_en
+  }
+}


### PR DESCRIPTION
Avoid generating invalid or corrupt IR based on assumptions about the structure of the clock gate modules,
and instead check for required structure.

Port name is not checked presently to avoid rejecting circuits that would previously work.

Fixes #4447.
Fixes #4448.