### PR TITLE
[FIRRTL][GrandCentralTaps] Handle sink subfield for internal path

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -425,10 +425,11 @@ LogicalResult static applyNoBlackBoxStyleDataTaps(const AnnoPathValue &target,
       if (!moduleTarget)
         return failure();
       AnnoPathValue internalPathSrc;
-      sendVal = lowerInternalPathAnno(
-          internalPathSrc, *moduleTarget, target, internalPathAttr,
-          wireTarget->ref.getOp()->getResult(0).getType().cast<FIRRTLType>(),
-          state);
+      auto targetType = wireTarget->ref.getType().cast<FIRRTLBaseType>();
+      if (wireTarget->fieldIdx)
+        targetType = targetType.getFinalTypeByFieldID(wireTarget->fieldIdx);
+      sendVal = lowerInternalPathAnno(internalPathSrc, *moduleTarget, target,
+                                      internalPathAttr, targetType, state);
       if (!sendVal)
         return failure();
       srcTarget = internalPathSrc;

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1938,19 +1938,14 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
     module = "~Top|BlackBox",
     sink = "~Top|Top>tap2.wid"
     }]}]} {
-  firrtl.extmodule private @BlackBox(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {defname = "BlackBox"}
+  firrtl.extmodule private @BlackBox() attributes {defname = "BlackBox"}
   // CHECK:  firrtl.extmodule private @BlackBox
-  // CHECK-SAME: (in in: !firrtl.uint<1>, out out: !firrtl.uint<1>,
   // CHECK-SAME:  out [[gen_ref:.+]]: !firrtl.ref<uint<1>>)
   // CHECK-SAME: attributes {defname = "BlackBox", internalPaths = ["random.something"]}
   firrtl.module @Top(in %in: !firrtl.uint<1>) {
-    %tap2 = firrtl.wire interesting_name  : !firrtl.bundle<wid: uint<1>>
-    %invalid = firrtl.invalidvalue : !firrtl.bundle<wid: uint<1>>
-    firrtl.strictconnect %tap2, %invalid : !firrtl.bundle<wid: uint<1>>
-    %localparam_in, %localparam_out = firrtl.instance localparam interesting_name  @BlackBox(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
-    // CHECK:  %localparam_in, %localparam_out, %[[localparam__gen_ref:.+]] = firrtl.instance localparam interesting_name  @BlackBox(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>, out [[gen_ref]]: !firrtl.ref<uint<1>>)
-    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %localparam_in, %invalid_ui1 : !firrtl.uint<1>
+    %tap2 = firrtl.wire : !firrtl.bundle<wid: uint<1>>
+    firrtl.instance localparam @BlackBox()
+    // CHECK:  %[[localparam__gen_ref:.+]] = firrtl.instance localparam @BlackBox(out [[gen_ref]]: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.ref.resolve %[[localparam__gen_ref]] : !firrtl.ref<uint<1>>
   }
 }


### PR DESCRIPTION
This fixes a bug in the `GrandCentral` `DataTaps`, which was ignoring the `fieldIdx` of a `wireTarget`, while constructing the source internal path. This resulted in a `ref.send` of an aggregate type, and `firtool` crashed with a mismatch in types after `lower-annotations`. 
The internal path is just a verbatim string, and the type of the `ref.source` is the same as the sink type, which must consider the subfield correctly.
