### PR TITLE
[FIRRTL] Fix folding cat(SInt<0>,x), return needs to be unsigned.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1049,10 +1049,14 @@ OpFoldResult XorRPrimOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult CatPrimOp::fold(ArrayRef<Attribute> operands) {
-
-  if (getLhs().getType().getBitWidthOrSentinel() == 0)
+  // cat(x, 0-width) -> x
+  // cat(0-width, x) -> x
+  // Limit to unsigned (result type), as cannot insert cast here.
+  if (getLhs().getType().getBitWidthOrSentinel() == 0 &&
+      getRhs().getType().isUnsigned())
     return getRhs();
-  if (getRhs().getType().getBitWidthOrSentinel() == 0)
+  if (getRhs().getType().getBitWidthOrSentinel() == 0 &&
+      getLhs().getType().isUnsigned())
     return getLhs();
 
   if (!hasKnownWidthIntTypes(*this))

--- a/test/Dialect/FIRRTL/imconstprop-crashers.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-crashers.mlir
@@ -12,3 +12,16 @@ firrtl.circuit "Issue1187"  {
     firrtl.connect %result, %0 : !firrtl.uint<0>, !firrtl.uint<0>
   }
 }
+
+// -----
+
+// https://github.com/llvm/circt/issues/4456
+// This shouldn't crash.
+// The fold is what should be tested but need IMCP to drive it.
+firrtl.circuit "Issue4456"  {
+  firrtl.module @Issue4456(in %i: !firrtl.sint<0>, out %o: !firrtl.uint<4>) {
+    %c0_si4 = firrtl.constant 0 : !firrtl.sint<4>
+    %0 = firrtl.cat %i, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<4>
+    firrtl.strictconnect %o, %0 : !firrtl.uint<4>
+  }
+}


### PR DESCRIPTION
Fixes #4456.

Fix is good AFAIK, but test is incomplete-- does not fail (by folding) before this change which should be addressed before landing this.

Fixes reproducer in linked issue (and test2.fir/test3.fir).