### PR TITLE
[FIRRTL] Don't insert same-width pad for connect -> strictconnect.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -120,7 +120,7 @@ def ConnectExtension : Pat<
   (ConnectOp $dst, $src),
   (StrictConnectOp $dst, (PadPrimOp $src, 
     (NativeCodeCall<"$0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel()"> $dst))),
-  [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src)]>;
+  [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src), (mismatchTypes $src, $dst)]>;
 
 def LimitConstant32 : NativeCodeCall<
   "$_builder.getI32IntegerAttr($0.getValue().getLimitedValue(1ULL << 31))">;


### PR DESCRIPTION
Don't "extend" if types are the same, pad inserted is spurious and will be dropped immediately anyway.

Let ConnectSameType handle these, no need to cleanup the pad.

This pattern (ConnectExtension) runs first, and reordering these avoids the pad but tightening the pattern seems better.