### PR TITLE
LLVM Bump

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -129,7 +129,7 @@ public:
   virtual Value getConditionValue() = 0;
 
   // Returns the number of iterations the loop will conduct if known.
-  virtual Optional<uint64_t> getBound() = 0;
+  virtual std::optional<uint64_t> getBound() = 0;
 
   // Returns the location of the loop interface.
   virtual Location getLoc() = 0;

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -228,7 +228,7 @@ def ConcatOp : CombOp<"concat", [InferTypeOpInterface, Pure]> {
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -181,7 +181,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
 
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,
@@ -237,7 +237,7 @@ def MemoryDebugPortOp : CHIRRTLOp<"debugport", [InferTypeOpInterface,
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -34,7 +34,7 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
     /// Infer the return type of this operation.
     static FIRRTLType inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc);
+                                      std::optional<Location> loc);
   }];
 
   // The operation-specific validator for a parsed list of operands and
@@ -61,7 +61,7 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
     /// `InferTypeOpInterface`. We simply forward to a narrower
     /// operation-specific implementation which is sufficient for FIRRTL ops.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,
@@ -354,13 +354,13 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
   let inferTypeDecl = !if(!empty(inferType), [{
     /// Infer the return type of this binary operation.
     static FIRRTLType inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                            Optional<Location> loc);
+                                            std::optional<Location> loc);
     }], "") # !subst("$_infer", !if(!empty(inferType), "inferBinaryReturnType",
       inferType), [{
     /// Infer the return type of this operation.
     static FIRRTLType inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
       return $_infer(operands[0].getType().cast<FIRRTLType>(),
                      operands[1].getType().cast<FIRRTLType>(),
                      loc);
@@ -459,13 +459,13 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
   let inferTypeDecl = !if(!empty(inferType), [{
     /// Infer the return type of this unary operation.
     static FIRRTLType inferUnaryReturnType(FIRRTLType arg,
-                                           Optional<Location> loc);
+                                           std::optional<Location> loc);
     }], "") # !subst("$_infer", !if(!empty(inferType), "inferUnaryReturnType",
       inferType), [{
     /// Infer the return type of this operation.
     static FIRRTLType inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
       return $_infer(operands[0].getType().cast<FIRRTLType>(), loc);
     }
   }]);

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -133,21 +133,21 @@ LogicalResult verifySameOperandsIntTypeKind(Operation *op);
 
 // Type inference adaptor for FIRRTL operations.
 LogicalResult inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results,
     llvm::function_ref<FIRRTLType(ValueRange, ArrayRef<NamedAttribute>,
-                                  Optional<Location>)>
+                                  std::optional<Location>)>
         callback);
 
 // Common type inference functions.
 FIRRTLType inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
-                             Optional<Location> loc);
+                             std::optional<Location> loc);
 FIRRTLType inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
-                              Optional<Location> loc);
+                              std::optional<Location> loc);
 FIRRTLType inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
-                                 Optional<Location> loc);
-FIRRTLType inferReductionResult(FIRRTLType arg, Optional<Location> loc);
+                                 std::optional<Location> loc);
+FIRRTLType inferReductionResult(FIRRTLType arg, std::optional<Location> loc);
 
 // Common parsed argument validation functions.
 LogicalResult validateBinaryOpArguments(ValueRange operands,

--- a/include/circt/Dialect/HWArith/HWArithOps.td
+++ b/include/circt/Dialect/HWArith/HWArithOps.td
@@ -55,7 +55,7 @@ class BinOp<string mnemonic, list<Trait> traits = []> :
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -278,7 +278,7 @@ def LLHD_RegOp : LLHD_Op<"reg", [
   let extraClassDeclaration = [{
     static StringRef getModeAttrName() { return "modes"; }
     static RegMode getRegModeByName(StringRef name) {
-      llvm::Optional<RegMode> optional =  symbolizeRegMode(name);
+      std::optional<RegMode> optional =  symbolizeRegMode(name);
       assert(optional && "Invalid RegMode string.");
       return optional.value();
     }

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -229,7 +229,7 @@ def IndexedPartSelectOp
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -184,7 +184,7 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,
@@ -214,7 +214,7 @@ def StructFieldInOutOp : SVOp<"struct_field_inout",
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/include/circt/Dialect/Seq/SeqTypes.td
+++ b/include/circt/Dialect/Seq/SeqTypes.td
@@ -55,7 +55,7 @@ def HLMemType : SeqType<"HLMem",[
 
     /// Clone this vector type with the given shape and element type. If the
     /// provided shape is `None`, the current shape of the type is used.
-    HLMemType cloneWith(Optional<ArrayRef<int64_t>> shape,
+    HLMemType cloneWith(std::optional<ArrayRef<int64_t>> shape,
                          Type elementType) const;
   }];
 

--- a/include/circt/Dialect/SystemC/SystemCExpressions.td
+++ b/include/circt/Dialect/SystemC/SystemCExpressions.td
@@ -28,7 +28,7 @@ def SignalReadOp : SystemCOp<"signal.read", [Pure,
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.
     static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
+                                          std::optional<Location> loc,
                                           ValueRange operands,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,

--- a/lib/Conversion/ExportChiselInterface/ExportChiselInterface.cpp
+++ b/lib/Conversion/ExportChiselInterface/ExportChiselInterface.cpp
@@ -89,7 +89,7 @@ static LogicalResult emitPortType(Location location, FIRRTLBaseType type,
           location, "Expected width to be inferred for exported port"));
     }
     return emitTypeWithArguments(name, [&](bool) {
-      os << width.value() << ".W";
+      os << *width << ".W";
       return success();
     });
   };

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3406,10 +3406,10 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
   // do.
   if (auto bitwidth =
           firrtl::getBitWidth(op.getType().cast<FIRRTLBaseType>())) {
-    if (bitwidth.value() == 0) // Let the caller handle zero width values.
+    if (*bitwidth == 0) // Let the caller handle zero width values.
       return failure();
 
-    auto constant = getOrCreateIntConstant(bitwidth.value(), 0);
+    auto constant = getOrCreateIntConstant(*bitwidth, 0);
     // If the result is an aggregate value, we have to bitcast the constant.
     if (!resultTy.isa<IntegerType>())
       constant = builder.create<hw::BitcastOp>(resultTy, constant);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2195,27 +2195,27 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
 
     // Get the clock out of the bundle and connect them.
     auto readClock = builder.create<SubfieldOp>(
-        readBundle, readType.getElementIndex("clk").value());
+        readBundle, *readType.getElementIndex("clk"));
     builder.create<ConnectOp>(readClock, clk);
     auto writeClock = builder.create<SubfieldOp>(
-        writeBundle, writeType.getElementIndex("clk").value());
+        writeBundle, *writeType.getElementIndex("clk"));
     builder.create<ConnectOp>(writeClock, clk);
 
     // Get the addresses out of the bundle
     auto readAddr = builder.create<SubfieldOp>(
-        readBundle, readType.getElementIndex("addr").value());
+        readBundle, *readType.getElementIndex("addr"));
     auto writeAddr = builder.create<SubfieldOp>(
-        writeBundle, readType.getElementIndex("addr").value());
+        writeBundle, *readType.getElementIndex("addr"));
 
     // Connect read and write to head and tail registers.
     builder.create<ConnectOp>(readAddr, head);
     builder.create<ConnectOp>(writeAddr, tail);
 
     // Get the memory enable out of the bundles.
-    auto memReadEn = builder.create<SubfieldOp>(
-        readBundle, readType.getElementIndex("en").value());
+    auto memReadEn =
+        builder.create<SubfieldOp>(readBundle, *readType.getElementIndex("en"));
     auto memWriteEn = builder.create<SubfieldOp>(
-        writeBundle, writeType.getElementIndex("en").value());
+        writeBundle, *writeType.getElementIndex("en"));
     // Always read
     builder.create<ConnectOp>(memReadEn, oneConst);
     // Write on writeEn
@@ -2223,15 +2223,15 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
 
     // Connect read and write data.
     auto readData = builder.create<SubfieldOp>(
-        readBundle, readType.getElementIndex("data").value());
+        readBundle, *readType.getElementIndex("data"));
     auto writeData = builder.create<SubfieldOp>(
-        writeBundle, writeType.getElementIndex("data").value());
+        writeBundle, *writeType.getElementIndex("data"));
     builder.create<ConnectOp>(dataOut, readData);
     builder.create<ConnectOp>(writeData, dataIn);
 
     // Get the store mask out of the bundle.
     auto writeMask = builder.create<SubfieldOp>(
-        writeBundle, writeType.getElementIndex("mask").value());
+        writeBundle, *writeType.getElementIndex("mask"));
 
     // We might be storing bundles. Therefore, we have to ensure that writeEn is
     // connected to all elements of the mask.
@@ -2639,12 +2639,12 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Get the clock out of the bundle and connect it.
     auto memClock = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("clk").value());
+        insertLoc, memBundle, *memType.getElementIndex("clk"));
     rewriter.create<ConnectOp>(insertLoc, memClock, clock);
 
     // Get the load address out of the bundle.
     auto memAddr = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("addr").value());
+        insertLoc, memBundle, *memType.getElementIndex("addr"));
 
     // Since addresses coming from Handshake are IndexType and have a hardcoded
     // 64-bit width in this pass, we may need to truncate down to the actual
@@ -2664,14 +2664,14 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Get the load data out of the bundle.
     auto memData = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("data").value());
+        insertLoc, memBundle, *memType.getElementIndex("data"));
 
     // Connect the memory to the load data.
     rewriter.create<ConnectOp>(insertLoc, loadDataData, memData);
 
     // Get the load enable out of the bundle.
     auto memEnable = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("en").value());
+        insertLoc, memBundle, *memType.getElementIndex("en"));
 
     // Connect the address valid signal to the memory enable.
     rewriter.create<ConnectOp>(insertLoc, memEnable, loadAddrValid);
@@ -2707,12 +2707,12 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Get the clock out of the bundle and connect it.
     auto memClock = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("clk").value());
+        insertLoc, memBundle, *memType.getElementIndex("clk"));
     rewriter.create<ConnectOp>(insertLoc, memClock, clock);
 
     // Get the store address out of the bundle.
     auto memAddr = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("addr").value());
+        insertLoc, memBundle, *memType.getElementIndex("addr"));
 
     // Since addresses coming from Handshake are IndexType and have a hardcoded
     // 64-bit width in this pass, we may need to truncate down to the actual
@@ -2732,7 +2732,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Get the store data out of the bundle.
     auto memData = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("data").value());
+        insertLoc, memBundle, *memType.getElementIndex("data"));
 
     // Connect the store data to the memory.
     rewriter.create<ConnectOp>(insertLoc, memData, storeDataData);
@@ -2786,14 +2786,14 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Get the store enable out of the bundle.
     auto memEnable = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("en").value());
+        insertLoc, memBundle, *memType.getElementIndex("en"));
 
     // Connect the write valid signal to the memory enable.
     rewriter.create<ConnectOp>(insertLoc, memEnable, writeValid);
 
     // Get the store mask out of the bundle.
     auto memMask = rewriter.create<SubfieldOp>(
-        insertLoc, memBundle, memType.getElementIndex("mask").value());
+        insertLoc, memBundle, *memType.getElementIndex("mask"));
 
     // Since we are not storing bundles in the memory, we can assume the mask is
     // a single bit.
@@ -3097,7 +3097,7 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
         funcOp, /*numClocks=*/1, rewriter, setFlattenAttr);
     if (failed(maybeTopModuleOp))
       return failure();
-    auto topModuleOp = maybeTopModuleOp.value();
+    auto topModuleOp = *maybeTopModuleOp;
     inlineFuncRegion(funcOp, topModuleOp, rewriter);
 
     NameUniquer instanceUniquer = [&](Operation *op) {

--- a/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
+++ b/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
@@ -62,7 +62,7 @@ public:
     return getOperation().getCondBlock().getTerminator()->getOperand(0);
   }
 
-  Optional<uint64_t> getBound() override {
+  std::optional<uint64_t> getBound() override {
     return getOperation().getTripCount();
   }
 };

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -64,7 +64,7 @@ public:
     return getOperation().getConditionOp().getOperand(0);
   }
 
-  Optional<uint64_t> getBound() override { return std::nullopt; }
+  std::optional<uint64_t> getBound() override { return std::nullopt; }
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -309,7 +309,7 @@ static void eraseControlWithGroupAndConditional(OpTy op,
 
   // Save information about the operation, and erase it.
   Value cond = op.getCond();
-  Optional<StringRef> groupName = op.getGroupName();
+  std::optional<StringRef> groupName = op.getGroupName();
   auto component = op->template getParentOfType<ComponentOp>();
   rewriter.eraseOp(op);
 
@@ -1895,7 +1895,7 @@ LogicalResult IfOp::verify() {
   if (elseBodyExists() && getElseBody()->empty())
     return emitError() << "empty 'else' region.";
 
-  Optional<StringRef> optGroupName = getGroupName();
+  std::optional<StringRef> optGroupName = getGroupName();
   if (!optGroupName) {
     // No combinational group was provided.
     return success();
@@ -2097,7 +2097,7 @@ LogicalResult WhileOp::verify() {
   auto component = (*this)->getParentOfType<ComponentOp>();
   auto wiresOp = component.getWiresOp();
 
-  Optional<StringRef> optGroupName = getGroupName();
+  std::optional<StringRef> optGroupName = getGroupName();
   if (!optGroupName) {
     /// No combinational group was provided
     return success();

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -261,7 +261,7 @@ void ConcatOp::build(OpBuilder &builder, OperationState &result, Value hd,
 }
 
 LogicalResult ConcatOp::inferReturnTypes(MLIRContext *context,
-                                         Optional<Location> loc,
+                                         std::optional<Location> loc,
                                          ValueRange operands,
                                          DictionaryAttr attrs,
                                          mlir::RegionRange regions,

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -119,7 +119,7 @@ void MemoryPortOp::build(OpBuilder &builder, OperationState &result,
 }
 
 LogicalResult MemoryPortOp::inferReturnTypes(MLIRContext *context,
-                                             Optional<Location> loc,
+                                             std::optional<Location> loc,
                                              ValueRange operands,
                                              DictionaryAttr attrs,
                                              mlir::RegionRange regions,
@@ -193,7 +193,7 @@ void MemoryDebugPortOp::build(OpBuilder &builder, OperationState &result,
 }
 
 LogicalResult MemoryDebugPortOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   auto inType = operands[0].getType();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2181,10 +2181,10 @@ void WhenOp::build(OpBuilder &builder, OperationState &result, Value condition,
 /// result value, so the FIRRTL-specific type inference ops directly return the
 /// inferred type rather than pushing into the `results` vector.
 LogicalResult impl::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, RegionRange regions, SmallVectorImpl<Type> &results,
     llvm::function_ref<FIRRTLType(ValueRange, ArrayRef<NamedAttribute>,
-                                  Optional<Location>)>
+                                  std::optional<Location>)>
         callback) {
   auto type = callback(
       operands, attrs ? attrs.getValue() : ArrayRef<NamedAttribute>{}, loc);
@@ -2590,7 +2590,7 @@ bool firrtl::isConstant(Value value) {
 
 FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   auto inType = operands[0].getType().cast<BundleType>();
   auto fieldIndex =
       getAttr<IntegerAttr>(attrs, "fieldIndex").getValue().getZExtValue();
@@ -2614,7 +2614,7 @@ bool SubfieldOp::isFieldFlipped() {
 
 FIRRTLType SubindexOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   auto inType = operands[0].getType();
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
@@ -2635,7 +2635,7 @@ FIRRTLType SubindexOp::inferReturnType(ValueRange operands,
 
 FIRRTLType SubaccessOp::inferReturnType(ValueRange operands,
                                         ArrayRef<NamedAttribute> attrs,
-                                        Optional<Location> loc) {
+                                        std::optional<Location> loc) {
   auto inType = operands[0].getType();
   auto indexType = operands[1].getType();
 
@@ -2683,7 +2683,7 @@ void MultibitMuxOp::print(OpAsmPrinter &p) {
 
 FIRRTLType MultibitMuxOp::inferReturnType(ValueRange operands,
                                           ArrayRef<NamedAttribute> attrs,
-                                          Optional<Location> loc) {
+                                          std::optional<Location> loc) {
   if (operands.size() < 2) {
     if (loc)
       mlir::emitError(*loc, "at least one input is required");
@@ -2712,7 +2712,7 @@ FIRRTLType MultibitMuxOp::inferReturnType(ValueRange operands,
 /// On failure, this reports and error and returns false.  This function should
 /// not be used if you don't want an error reported.
 static bool isSameIntTypeKind(Type lhs, Type rhs, int32_t &lhsWidth,
-                              int32_t &rhsWidth, Optional<Location> loc) {
+                              int32_t &rhsWidth, std::optional<Location> loc) {
   // Must have two integer types with the same signedness.
   auto lhsi = lhs.dyn_cast<IntType>();
   auto rhsi = rhs.dyn_cast<IntType>();
@@ -2758,7 +2758,7 @@ LogicalResult impl::validateBinaryOpArguments(ValueRange operands,
 }
 
 FIRRTLType impl::inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
-                                   Optional<Location> loc) {
+                                   std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2769,7 +2769,7 @@ FIRRTLType impl::inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType MulPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                            Optional<Location> loc) {
+                                            std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2781,7 +2781,7 @@ FIRRTLType MulPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType DivPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                            Optional<Location> loc) {
+                                            std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2796,7 +2796,7 @@ FIRRTLType DivPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType RemPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                            Optional<Location> loc) {
+                                            std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2807,7 +2807,7 @@ FIRRTLType RemPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType impl::inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
-                                    Optional<Location> loc) {
+                                    std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2818,12 +2818,12 @@ FIRRTLType impl::inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType impl::inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   return UIntType::get(lhs.getContext(), 1);
 }
 
 FIRRTLType CatPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                            Optional<Location> loc) {
+                                            std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
   if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
     return {};
@@ -2834,7 +2834,7 @@ FIRRTLType CatPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType DShlPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                             Optional<Location> loc) {
+                                             std::optional<Location> loc) {
   auto lhsi = lhs.dyn_cast<IntType>();
   auto rhsui = rhs.dyn_cast<UIntType>();
   if (!rhsui || !lhsi) {
@@ -2870,7 +2870,7 @@ FIRRTLType DShlPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType DShlwPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                              Optional<Location> loc) {
+                                              std::optional<Location> loc) {
   if (!lhs.isa<IntType>() || !rhs.isa<UIntType>()) {
     if (loc)
       mlir::emitError(*loc,
@@ -2881,7 +2881,7 @@ FIRRTLType DShlwPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 }
 
 FIRRTLType DShrPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
-                                             Optional<Location> loc) {
+                                             std::optional<Location> loc) {
   if (!lhs.isa<IntType>() || !rhs.isa<UIntType>()) {
     if (loc)
       mlir::emitError(*loc,
@@ -2905,13 +2905,14 @@ LogicalResult impl::validateUnaryOpArguments(ValueRange operands,
   return success();
 }
 
-FIRRTLType SizeOfIntrinsicOp::inferUnaryReturnType(FIRRTLType arg,
-                                                   Optional<Location> loc) {
+FIRRTLType
+SizeOfIntrinsicOp::inferUnaryReturnType(FIRRTLType arg,
+                                        std::optional<Location> loc) {
   return UIntType::get(arg.getContext(), 32);
 }
 
 FIRRTLType AsSIntPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                              Optional<Location> loc) {
+                                              std::optional<Location> loc) {
   auto base = input.dyn_cast<FIRRTLBaseType>();
   if (!base) {
     if (loc)
@@ -2928,7 +2929,7 @@ FIRRTLType AsSIntPrimOp::inferUnaryReturnType(FIRRTLType input,
 }
 
 FIRRTLType AsUIntPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                              Optional<Location> loc) {
+                                              std::optional<Location> loc) {
   auto base = input.dyn_cast<FIRRTLBaseType>();
   if (!base) {
     if (loc)
@@ -2944,8 +2945,9 @@ FIRRTLType AsUIntPrimOp::inferUnaryReturnType(FIRRTLType input,
   return UIntType::get(input.getContext(), width);
 }
 
-FIRRTLType AsAsyncResetPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                                    Optional<Location> loc) {
+FIRRTLType
+AsAsyncResetPrimOp::inferUnaryReturnType(FIRRTLType input,
+                                         std::optional<Location> loc) {
   auto base = input.dyn_cast<FIRRTLBaseType>();
   if (!base) {
     if (loc)
@@ -2962,12 +2964,12 @@ FIRRTLType AsAsyncResetPrimOp::inferUnaryReturnType(FIRRTLType input,
 }
 
 FIRRTLType AsClockPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                               Optional<Location> loc) {
+                                               std::optional<Location> loc) {
   return ClockType::get(input.getContext());
 }
 
 FIRRTLType CvtPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                           Optional<Location> loc) {
+                                           std::optional<Location> loc) {
   if (auto uiType = input.dyn_cast<UIntType>()) {
     auto width = uiType.getWidthOrSentinel();
     if (width != -1)
@@ -2984,7 +2986,7 @@ FIRRTLType CvtPrimOp::inferUnaryReturnType(FIRRTLType input,
 }
 
 FIRRTLType NegPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                           Optional<Location> loc) {
+                                           std::optional<Location> loc) {
   auto inputi = input.dyn_cast<IntType>();
   if (!inputi) {
     if (loc)
@@ -2999,7 +3001,7 @@ FIRRTLType NegPrimOp::inferUnaryReturnType(FIRRTLType input,
 }
 
 FIRRTLType NotPrimOp::inferUnaryReturnType(FIRRTLType input,
-                                           Optional<Location> loc) {
+                                           std::optional<Location> loc) {
   auto inputi = input.dyn_cast<IntType>();
   if (!inputi) {
     if (loc)
@@ -3011,7 +3013,7 @@ FIRRTLType NotPrimOp::inferUnaryReturnType(FIRRTLType input,
 }
 
 FIRRTLType impl::inferReductionResult(FIRRTLType input,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   return UIntType::get(input.getContext(), 1);
 }
 
@@ -3031,7 +3033,7 @@ LogicalResult BitsPrimOp::validateArguments(ValueRange operands,
 
 FIRRTLType BitsPrimOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto high = getAttr<IntegerAttr>(attrs, "hi").getValue().getSExtValue();
   auto low = getAttr<IntegerAttr>(attrs, "lo").getValue().getSExtValue();
@@ -3085,7 +3087,7 @@ LogicalResult impl::validateOneOperandOneConst(ValueRange operands,
 
 FIRRTLType HeadPrimOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto amount = getAttr<IntegerAttr>(attrs, "amount").getValue().getSExtValue();
 
@@ -3129,7 +3131,7 @@ LogicalResult MuxPrimOp::validateArguments(ValueRange operands,
 /// - Bundles inferred in a pairwise fashion based on the field types.
 static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
                                          FIRRTLBaseType low,
-                                         Optional<Location> loc) {
+                                         std::optional<Location> loc) {
   // If the types are identical we're done.
   if (high == low)
     return low;
@@ -3216,7 +3218,7 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
 
 FIRRTLType MuxPrimOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   auto highType = operands[1].getType().dyn_cast<FIRRTLBaseType>();
   auto lowType = operands[2].getType().dyn_cast<FIRRTLBaseType>();
   if (!highType || !lowType) {
@@ -3229,7 +3231,7 @@ FIRRTLType MuxPrimOp::inferReturnType(ValueRange operands,
 
 FIRRTLType PadPrimOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto amount = getAttr<IntegerAttr>(attrs, "amount").getValue().getSExtValue();
 
@@ -3251,7 +3253,7 @@ FIRRTLType PadPrimOp::inferReturnType(ValueRange operands,
 
 FIRRTLType ShlPrimOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto amount = getAttr<IntegerAttr>(attrs, "amount").getValue().getSExtValue();
 
@@ -3272,7 +3274,7 @@ FIRRTLType ShlPrimOp::inferReturnType(ValueRange operands,
 
 FIRRTLType ShrPrimOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto amount = getAttr<IntegerAttr>(attrs, "amount").getValue().getSExtValue();
 
@@ -3293,7 +3295,7 @@ FIRRTLType ShrPrimOp::inferReturnType(ValueRange operands,
 
 FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
-                                       Optional<Location> loc) {
+                                       std::optional<Location> loc) {
   auto input = operands[0].getType();
   auto amount = getAttr<IntegerAttr>(attrs, "amount").getValue().getSExtValue();
 
@@ -3325,14 +3327,14 @@ FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
 
 FIRRTLType IsXIntrinsicOp::inferReturnType(ValueRange operands,
                                            ArrayRef<NamedAttribute> attrs,
-                                           Optional<Location> loc) {
+                                           std::optional<Location> loc) {
   return UIntType::get(operands[0].getContext(), 1);
 }
 
 FIRRTLType
 PlusArgsTestIntrinsicOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
-                                         Optional<Location> loc) {
+                                         std::optional<Location> loc) {
   return UIntType::get(attrs[0].getName().getContext(), 1);
 }
 
@@ -3788,7 +3790,7 @@ void XorRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
-                                         Optional<Location> loc) {
+                                         std::optional<Location> loc) {
   auto inType = operands[0].getType();
   auto inRefType = inType.dyn_cast<RefType>();
   if (!inRefType) {
@@ -3802,7 +3804,7 @@ FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
 
 FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
-                                      Optional<Location> loc) {
+                                      std::optional<Location> loc) {
   auto inType = operands[0].getType();
   auto inBaseType = inType.dyn_cast<FIRRTLBaseType>();
   if (!inBaseType) {
@@ -3828,7 +3830,7 @@ void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                      ArrayRef<NamedAttribute> attrs,
-                                     Optional<Location> loc) {
+                                     std::optional<Location> loc) {
   auto inType = operands[0].getType().cast<RefType>().getType();
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -370,7 +370,7 @@ ParseResult FIRParser::parseOptionalInfoLocator(LocationAttr &result) {
     return success();
 
   // Otherwise, set the location attribute and return.
-  result = locationPair.second.value();
+  result = *locationPair.second;
   return success();
 }
 
@@ -3163,7 +3163,7 @@ ParseResult FIRCircuitParser::parseCircuit(
 
   if (!indent.has_value())
     return emitError("'circuit' must be first token on its line"), failure();
-  unsigned circuitIndent = indent.value();
+  unsigned circuitIndent = *indent;
 
   LocWithInfo info(getToken().getLoc(), this);
   StringAttr name;
@@ -3247,7 +3247,7 @@ ParseResult FIRCircuitParser::parseCircuit(
       auto indent = getIndentation();
       if (!indent.has_value())
         return emitError("'module' must be first token on its line"), failure();
-      unsigned moduleIndent = indent.value();
+      unsigned moduleIndent = *indent;
 
       if (moduleIndent <= circuitIndent)
         return emitError("module should be indented more"), failure();

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -73,7 +73,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       // Get the width of individual aggregate leaf elements.
       for (auto f : flatMemType) {
         LLVM_DEBUG(llvm::dbgs() << "\n field type:" << f);
-        auto w = f.getWidth().value();
+        auto w = *f.getWidth();
         memWidths.push_back(w);
         memFlatWidth += w;
       }
@@ -152,8 +152,8 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
             auto oldFieldBitWidth = getBitWidth(oldField.getType());
             // Following condition is true, if a data field is 0 bits. Then
             // newFieldType is of smaller bits than old.
-            if (getBitWidth(newFieldType) != oldFieldBitWidth.value())
-              newFieldType = UIntType::get(context, oldFieldBitWidth.value());
+            if (getBitWidth(newFieldType) != *oldFieldBitWidth)
+              newFieldType = UIntType::get(context, *oldFieldBitWidth);
             realOldField = builder.create<BitCastOp>(newFieldType, oldField);
             // Mask bits require special handling, since some of the mask bits
             // need to be repeated, direct bitcasting wouldn't work. Depending

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -526,7 +526,7 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(MLIRContext *ctxt,
           updateAnnotationFieldID(ctxt, opAttr, field.fieldID, cache.i64ty));
       continue;
     }
-    auto fieldID = maybeFieldID.value();
+    auto fieldID = *maybeFieldID;
     // Check whether the annotation falls into the range of the current field.
     if (fieldID != 0 &&
         !(fieldID >= field.fieldID &&
@@ -1134,7 +1134,7 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
     // Loop over the leaf aggregates and concat each of them to get a UInt.
     // Bitcast the fields to handle nested aggregate types.
     for (const auto &field : llvm::enumerate(fields)) {
-      auto fieldBitwidth = getBitWidth(field.value().type).value();
+      auto fieldBitwidth = *getBitWidth(field.value().type);
       // Ignore zero width fields, like empty bundles.
       if (fieldBitwidth == 0)
         continue;
@@ -1161,7 +1161,7 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
     auto clone = [&](const FlatBundleFieldEntry &field,
                      ArrayAttr attrs) -> Value {
       // All the fields must have valid bitwidth, a requirement for BitCastOp.
-      auto fieldBits = getBitWidth(field.type).value();
+      auto fieldBits = *getBitWidth(field.type);
       // If empty field, then it doesnot have any use, so replace it with an
       // invalid op, which should be trivially removed.
       if (fieldBits == 0)

--- a/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RandomizeRegisterInit.cpp
@@ -61,7 +61,7 @@ static void createRandomizationAttributes(FModuleOp mod) {
     auto start = builder.getIntegerAttr(ui64Type, currentWidth);
     op->setAttr("firrtl.random_init_start", start);
 
-    currentWidth += regWidth.value();
+    currentWidth += *regWidth;
   });
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -222,7 +222,7 @@ void ResolveTracesPass::runOnOperation() {
     auto getNamespace = [&](FModuleLike module) -> ModuleNamespace & {
       if (!moduleNamespace)
         moduleNamespace = ModuleNamespace(module);
-      return moduleNamespace.value();
+      return *moduleNamespace;
     };
 
     // Visit the module.

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -887,7 +887,7 @@ static Attribute parseParamExprWithOpcode(StringRef opcodeStr,
           }))
     return {};
 
-  Optional<PEO> opcode = symbolizePEO(opcodeStr);
+  std::optional<PEO> opcode = symbolizePEO(opcodeStr);
   if (!opcode.has_value()) {
     p.emitError(p.getNameLoc(), "unknown parameter expr operator name");
     return {};

--- a/lib/Dialect/HWArith/HWArithOps.cpp
+++ b/lib/Dialect/HWArith/HWArithOps.cpp
@@ -89,7 +89,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult AddOp::inferReturnTypes(MLIRContext *context,
-                                      Optional<Location> loc,
+                                      std::optional<Location> loc,
                                       ValueRange operands, DictionaryAttr attrs,
                                       mlir::RegionRange regions,
                                       SmallVectorImpl<Type> &results) {
@@ -107,7 +107,7 @@ LogicalResult AddOp::inferReturnTypes(MLIRContext *context,
 //===----------------------------------------------------------------------===//
 
 LogicalResult SubOp::inferReturnTypes(MLIRContext *context,
-                                      Optional<Location> loc,
+                                      std::optional<Location> loc,
                                       ValueRange operands, DictionaryAttr attrs,
                                       mlir::RegionRange regions,
                                       SmallVectorImpl<Type> &results) {
@@ -140,7 +140,7 @@ getSignedInheritedSignedness(IntegerType lhs, IntegerType rhs) {
 }
 
 LogicalResult MulOp::inferReturnTypes(MLIRContext *context,
-                                      Optional<Location> loc,
+                                      std::optional<Location> loc,
                                       ValueRange operands, DictionaryAttr attrs,
                                       mlir::RegionRange regions,
                                       SmallVectorImpl<Type> &results) {
@@ -160,7 +160,7 @@ LogicalResult MulOp::inferReturnTypes(MLIRContext *context,
 //===----------------------------------------------------------------------===//
 
 LogicalResult DivOp::inferReturnTypes(MLIRContext *context,
-                                      Optional<Location> loc,
+                                      std::optional<Location> loc,
                                       ValueRange operands, DictionaryAttr attrs,
                                       mlir::RegionRange regions,
                                       SmallVectorImpl<Type> &results) {

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -359,7 +359,7 @@ void MuxOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 LogicalResult
-MuxOp::inferReturnTypes(MLIRContext *context, Optional<Location> location,
+MuxOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
                         ValueRange operands, DictionaryAttr attributes,
                         mlir::RegionRange regions,
                         SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
@@ -443,7 +443,7 @@ std::string handshake::ControlMergeOp::getResultName(unsigned int idx) {
 }
 
 LogicalResult ControlMergeOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> location, ValueRange operands,
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, mlir::RegionRange regions,
     SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   // ControlMerge must have at least one data operand
@@ -778,7 +778,7 @@ ParseResult BranchOp::parse(OpAsmParser &parser, OperationState &result) {
 void BranchOp::print(OpAsmPrinter &p) { sostPrint(p, false); }
 
 LogicalResult ConditionalBranchOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> location, ValueRange operands,
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, mlir::RegionRange regions,
     SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   // Return type is type of data operand (second argument), twice
@@ -835,11 +835,10 @@ bool ConditionalBranchOp::isControl() {
                                       getDataOperand());
 }
 
-LogicalResult
-SelectOp::inferReturnTypes(MLIRContext *context, Optional<Location> location,
-                           ValueRange operands, DictionaryAttr attributes,
-                           mlir::RegionRange regions,
-                           SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
+LogicalResult SelectOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, mlir::RegionRange regions,
+    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   // Return type is type of true operand (equivalently, of false operand)
   inferredReturnTypes.push_back(operands[1].getType());
   return success();

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -263,11 +263,10 @@ LogicalResult llhd::PtrArraySliceOp::canonicalize(llhd::PtrArraySliceOp op,
 //===----------------------------------------------------------------------===//
 
 template <class SigPtrType>
-static LogicalResult
-inferReturnTypesOfStructExtractOp(MLIRContext *context, Optional<Location> loc,
-                                  ValueRange operands, DictionaryAttr attrs,
-                                  mlir::RegionRange regions,
-                                  SmallVectorImpl<Type> &results) {
+static LogicalResult inferReturnTypesOfStructExtractOp(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &results) {
   Type type = operands[0]
                   .getType()
                   .cast<SigPtrType>()
@@ -288,7 +287,7 @@ inferReturnTypesOfStructExtractOp(MLIRContext *context, Optional<Location> loc,
 }
 
 LogicalResult llhd::SigStructExtractOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   return inferReturnTypesOfStructExtractOp<llhd::SigType>(
@@ -296,7 +295,7 @@ LogicalResult llhd::SigStructExtractOp::inferReturnTypes(
 }
 
 LogicalResult llhd::PtrStructExtractOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   return inferReturnTypesOfStructExtractOp<llhd::PtrType>(
@@ -909,7 +908,7 @@ ParseResult llhd::RegOp::parse(OpAsmParser &parser, OperationState &result) {
 void llhd::RegOp::print(OpAsmPrinter &printer) {
   printer << " " << getSignal();
   for (size_t i = 0, e = getValues().size(); i < e; ++i) {
-    Optional<llhd::RegMode> mode = llhd::symbolizeRegMode(
+    std::optional<llhd::RegMode> mode = llhd::symbolizeRegMode(
         getModes().getValue()[i].cast<IntegerAttr>().getInt());
     if (!mode) {
       emitError("invalid RegMode");

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -96,14 +96,14 @@ struct TclOutputState {
   void emit(PhysLocationAttr);
   LogicalResult emitLocationAssignment(DynInstDataOpInterface refOp,
                                        PhysLocationAttr,
-                                       Optional<StringRef> subpath);
+                                       std::optional<StringRef> subpath);
 
   LogicalResult emit(PDPhysRegionOp region);
   LogicalResult emit(PDPhysLocationOp loc);
   LogicalResult emit(PDRegPhysLocationOp);
   LogicalResult emit(DynamicInstanceVerbatimAttrOp attr);
 
-  void emitPath(hw::GlobalRefOp ref, Optional<StringRef> subpath);
+  void emitPath(hw::GlobalRefOp ref, std::optional<StringRef> subpath);
   void emitInnerRefPart(hw::InnerRefAttr innerRef);
 
   /// Get the GlobalRefOp to which the given operation is pointing. Add it to
@@ -131,7 +131,7 @@ void TclOutputState::emitInnerRefPart(hw::InnerRefAttr innerRef) {
 }
 
 void TclOutputState::emitPath(hw::GlobalRefOp ref,
-                              Optional<StringRef> subpath) {
+                              std::optional<StringRef> subpath) {
   // Traverse each part of the path.
   auto parts = ref.getNamepathAttr().getAsRange<hw::InnerRefAttr>();
   auto lastPart = std::prev(parts.end());
@@ -177,7 +177,7 @@ void TclOutputState::emit(PhysLocationAttr pla) {
 LogicalResult
 TclOutputState::emitLocationAssignment(DynInstDataOpInterface refOp,
                                        PhysLocationAttr loc,
-                                       Optional<StringRef> subpath) {
+                                       std::optional<StringRef> subpath) {
   indent() << "set_location_assignment ";
   emit(loc);
 

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -34,7 +34,7 @@ Attribute PhysLocationAttr::parse(AsmParser &p, Type type) {
       p.parseComma() || p.parseInteger(num) || p.parseGreater())
     return Attribute();
 
-  Optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
+  std::optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
   if (!devType) {
     p.emitError(loc, "Unknown device type '" + devTypeStr + "'");
     return Attribute();

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -107,7 +107,7 @@ static ParseResult parsePhysLoc(OpAsmParser &p, PhysLocationAttr &attr) {
       p.parseInteger(num))
     return failure();
 
-  Optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
+  std::optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
   if (!devType) {
     p.emitError(loc, "Unknown device type '" + devTypeStr + "'");
     return failure();

--- a/lib/Dialect/Moore/MIROps.cpp
+++ b/lib/Dialect/Moore/MIROps.cpp
@@ -21,7 +21,7 @@ using namespace circt::moore;
 //===----------------------------------------------------------------------===//
 
 LogicalResult ConcatOp::inferReturnTypes(MLIRContext *context,
-                                         Optional<Location> loc,
+                                         std::optional<Location> loc,
                                          ValueRange operands,
                                          DictionaryAttr attrs,
                                          mlir::RegionRange regions,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1550,7 +1550,7 @@ static Type getElementTypeOfWidth(Type type, int32_t width) {
 }
 
 LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   auto width = attrs.get("width");
@@ -1603,7 +1603,7 @@ OpFoldResult IndexedPartSelectInOutOp::fold(ArrayRef<Attribute> constants) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult IndexedPartSelectOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   auto width = attrs.get("width");
@@ -1633,7 +1633,7 @@ LogicalResult IndexedPartSelectOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult StructFieldInOutOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::RegionRange regions,
     SmallVectorImpl<Type> &results) {
   auto field = attrs.get("field");

--- a/lib/Dialect/Seq/SeqTypes.cpp
+++ b/lib/Dialect/Seq/SeqTypes.cpp
@@ -44,7 +44,7 @@ void SeqDialect::registerTypes() {
 // HLMemType
 //===----------------------------------------------------------------------===//
 
-HLMemType HLMemType::cloneWith(Optional<ArrayRef<int64_t>> shape,
+HLMemType HLMemType::cloneWith(std::optional<ArrayRef<int64_t>> shape,
                                Type elementType) const {
   return HLMemType::get(elementType.getContext(), shape.value_or(getShape()),
                         elementType);

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -375,8 +375,7 @@ OpFoldResult ConvertOp::fold(ArrayRef<Attribute> operands) {
     auto intermediateBw = getBitWidth(intermediateType);
 
     if (!inputBw && intermediateBw) {
-      if (inputType.isa<IntBaseType, UIntBaseType>() &&
-          intermediateBw.value() >= 64)
+      if (inputType.isa<IntBaseType, UIntBaseType>() && *intermediateBw >= 64)
         return other.getInput();
       // We cannot support input types of signed, unsigned, and vector types
       // since they have no upper bound for the bit-width.
@@ -390,7 +389,7 @@ OpFoldResult ConvertOp::fold(ArrayRef<Attribute> operands) {
           intermediateType.isa<SignedType, UnsignedType>())
         return other.getInput();
 
-      if (inputBw && inputBw.value() <= 64 &&
+      if (inputBw && *inputBw <= 64 &&
           intermediateType
               .isa<IntBaseType, UIntBaseType, SignedType, UnsignedType>())
         return other.getInput();
@@ -400,7 +399,7 @@ OpFoldResult ConvertOp::fold(ArrayRef<Attribute> operands) {
       // here could change the behavior.
     }
 
-    if (inputBw && intermediateBw && inputBw.value() <= intermediateBw.value())
+    if (inputBw && intermediateBw && *inputBw <= *intermediateBw)
       return other.getInput();
   }
 

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -106,7 +106,7 @@ static uint64_t computeTransitiveModuleSize(
 
     auto allInstancesCovered = [&]() {
       return llvm::all_of(
-          moduleOp.getSymbolUses(moduleOp->getParentOfType<ModuleOp>()).value(),
+          *moduleOp.getSymbolUses(moduleOp->getParentOfType<ModuleOp>()),
           [&](auto symbolUse) {
             return std::binary_search(instances.begin(), instances.end(),
                                       symbolUse.getUser());
@@ -128,12 +128,12 @@ static LogicalResult collectInstantiatedModules(
     return failure();
 
   uint64_t opCount = 0;
-  WalkResult result = fmoduleOp.value().walk([&](Operation *op) {
+  WalkResult result = fmoduleOp->walk([&](Operation *op) {
     if (auto instOp = dyn_cast<firrtl::InstanceOp>(op)) {
       auto moduleOp = findInstantiatedModule(instOp, symbols);
       if (!moduleOp) {
         LLVM_DEBUG(llvm::dbgs()
-                   << "- `" << fmoduleOp.value().moduleName()
+                   << "- `" << fmoduleOp->moduleName()
                    << "` recursively instantiated non-FIRRTL module.\n");
         return WalkResult::interrupt();
       }
@@ -150,7 +150,7 @@ static LogicalResult collectInstantiatedModules(
   if (result.wasInterrupted())
     return failure();
 
-  modules.push_back(std::make_pair(fmoduleOp.value(), opCount));
+  modules.push_back(std::make_pair(*fmoduleOp, opCount));
 
   return success();
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -608,7 +608,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     if (failed(pm.run(module.get())))
       return failure();
     auto outputTimer = ts.nest("Print .mlir output");
-    printOp(*module, outputFile.value()->os());
+    printOp(*module, (*outputFile)->os());
     return success();
   }
 
@@ -875,7 +875,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     default:
       llvm_unreachable("can't reach this");
     case OutputVerilog:
-      exportPm.addPass(createExportVerilogPass(outputFile.value()->os()));
+      exportPm.addPass(createExportVerilogPass((*outputFile)->os()));
       break;
     case OutputSplitVerilog:
       exportPm.addPass(createExportSplitVerilogPass(outputFilename));
@@ -898,7 +898,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (outputFormat == OutputIRFir || outputFormat == OutputIRHW ||
       outputFormat == OutputIRSV || outputFormat == OutputIRVerilog) {
     auto outputTimer = ts.nest("Print .mlir output");
-    printOp(*module, outputFile.value()->os());
+    printOp(*module, (*outputFile)->os());
   }
 
   // If requested, print the final MLIR into mlirOutFile.
@@ -1008,7 +1008,7 @@ static LogicalResult executeFirtool(MLIRContext &context) {
   if (outputFormat != OutputSplitVerilog) {
     // Create an output file.
     outputFile.emplace(openOutputFile(outputFilename, &errorMessage));
-    if (!outputFile.value()) {
+    if (!(*outputFile)) {
       llvm::errs() << errorMessage << "\n";
       return failure();
     }
@@ -1037,7 +1037,7 @@ static LogicalResult executeFirtool(MLIRContext &context) {
 
   // If the result succeeded and we're emitting a file, close it.
   if (outputFile.has_value())
-    outputFile.value()->keep();
+    (*outputFile)->keep();
 
   return success();
 }

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -378,7 +378,7 @@ doHLSFlowDynamic(PassManager &pm, ModuleOp module,
   if (outputFormat == OutputVerilog) {
     if (loweringOptions.getNumOccurrences())
       loweringOptions.setAsAttribute(module);
-    pm.addPass(createExportVerilogPass(outputFile.value()->os()));
+    pm.addPass(createExportVerilogPass((*outputFile)->os()));
   }
 
   // Go execute!
@@ -386,7 +386,7 @@ doHLSFlowDynamic(PassManager &pm, ModuleOp module,
     return failure();
 
   if (outputFormat == OutputIR)
-    module->print(outputFile.value()->os());
+    module->print((*outputFile)->os());
 
   return success();
 }
@@ -491,7 +491,7 @@ static LogicalResult executeHlstool(MLIRContext &context) {
 
   Optional<std::unique_ptr<llvm::ToolOutputFile>> outputFile;
   outputFile.emplace(openOutputFile(outputFilename, &errorMessage));
-  if (!outputFile.value()) {
+  if (!*outputFile) {
     llvm::errs() << errorMessage << "\n";
     return failure();
   }
@@ -502,7 +502,7 @@ static LogicalResult executeHlstool(MLIRContext &context) {
 
   // If the result succeeded and we're emitting a file, close it.
   if (outputFile.has_value())
-    outputFile.value()->keep();
+    (*outputFile)->keep();
 
   return success();
 }


### PR DESCRIPTION
Replaced `llvm::Optional` with `std::optional` where necessary and fixed warnings involving `.value()`.