### PR TITLE
[CI] uploadBinaries: allow workflow_dispatch, test what we publish, drop cache

### DIFF
--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -39,41 +39,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      # --------
-      # Restore LLVM from cache and build if it's not in there.
-      # --------
-
-      # Extract the LLVM submodule hash for use in the cache key.
-      - name: Get LLVM Hash
-        id: get-llvm-hash
-        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
-
-      - name: Get workflow spec hash
-        id: get-workflow-hash
-        run: echo "::set-output name=hash::$(shasum $GITHUB_WORKSPACE/.github/workflows/uploadBinaries.yml | awk '{print $1}')"
-
-      # Try to fetch LLVM from the cache.
-      - name: Cache LLVM
-        id: cache-llvm
-        uses: actions/cache@v2
-        with:
-          path: |
-            llvm/build
-          key: ${{ matrix.runner }}-llvm-${{ steps.get-llvm-hash.outputs.hash }}-${{ steps.get-workflow-hash.outputs.hash }}-${{ matrix.compiler.cc }}
-
-      - name: Setup Ninja Linux
-        if: matrix.os == 'linux'
-        run: sudo apt-get install ninja-build
-
-      - name: Setup Ninja and GNU Tar Mac
-        if: matrix.os == 'macos'
-        run: brew install ninja gnu-tar
-
-      # Build LLVM if we didn't hit in the cache. Even though we build it in
-      # the previous job, there is a low chance that it'll have been evicted by
-      # the time we get here.
-      - name: Rebuild LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+      - name: Build LLVM
         run: |
           mkdir -p llvm/build
           cd llvm/build

--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -3,6 +3,7 @@ name: Upload Binaries
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -93,6 +94,7 @@ jobs:
               -DLLVM_PARALLEL_LINK_JOBS=1 \
               -DLLVM_TARGETS_TO_BUILD="host"
           ninja
+          ninja check-llvm check-mlir
 
       # --------
       # Build and test CIRCT
@@ -133,6 +135,7 @@ jobs:
           shasum -a 256 circt-bin-${{ matrix.runner }}.tar.gz
       - name: Upload Binaries
         uses: AButler/upload-release-assets@v2.0
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: build/circt-bin-${{ matrix.runner }}.tar.gz
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enable the binary workflow to be run manually, but only upload binaries if it's a tag.  I am not sure what happens if they're already present, so probably best to use this wisely.

While visiting, run the basic lit tests for LLVM/MLIR before bundling them for others (and sometimes ourselves) to use.

Partly to avoid increased pressure on the cache from binaries/components built to run the tests that we don't presently, but also because I'm not sure the cached LLVM will likely ever be a cache hit since we release and update LLVM at about the same frequency.  Maybe if we did do more frequent releases, or ever promoted a pre-release to a an actual one, that would be useful?

cc #4473.