### PR TITLE
[CI] uploadBinaries.yml: Temporarily change 20.04 compiler to 12.

### DIFF
--- a/.github/workflows/uploadBinaries.yml
+++ b/.github/workflows/uploadBinaries.yml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - cc: clang
-            cxx: clang++
-            mode: release
+          - mode: release
             assert: OFF
             shared: OFF
         runner: [ubuntu-20.04, ubuntu-18.04, macos-11]
@@ -20,14 +18,21 @@ jobs:
             os: linux
             cmake-args: ''
             tar: tar
+            # Default clang (11) is broken, see LLVM issue 59622.
+            cc: clang++-12
+            cxx: clang++-12
           - runner: ubuntu-18.04
             os: linux
             cmake-args: ''
             tar: tar
+            cc: clang
+            cxx: clang++
           - runner: macos-11
             os: macos
             cmake-args: ''
             tar: gtar
+            cc: clang
+            cxx: clang++
     runs-on: ${{ matrix.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone


### PR DESCRIPTION
clang-11 on Ubuntu currently produces a very broken LLVM.
(see LLVM issue 59622)