### PR TITLE
[NFC] small touchups before LLVM bump

### DIFF
--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_ESI_ESIPASSES_H
 #define CIRCT_DIALECT_ESI_ESIPASSES_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "llvm/ADT/Optional.h"

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_PASSES_H
 #define CIRCT_DIALECT_FIRRTL_PASSES_H
 
+#include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "llvm/ADT/Optional.h"
 #include <memory>
@@ -142,7 +143,7 @@ std::unique_ptr<mlir::Pass> createRandomizeRegisterInitPass();
 std::unique_ptr<mlir::Pass> createLowerXMRPass();
 
 std::unique_ptr<mlir::Pass>
-createResolveTracesPass(StringRef outputAnnotationFilename = "");
+createResolveTracesPass(mlir::StringRef outputAnnotationFilename = "");
 
 std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
 

--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -280,7 +280,7 @@ def LLHD_RegOp : LLHD_Op<"reg", [
     static RegMode getRegModeByName(StringRef name) {
       std::optional<RegMode> optional =  symbolizeRegMode(name);
       assert(optional && "Invalid RegMode string.");
-      return optional.value();
+      return *optional;
     }
 
     bool hasGate(unsigned index) {

--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -23,6 +23,7 @@
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 #include <cstdint>

--- a/tools/circt-reduce/Tester.h
+++ b/tools/circt-reduce/Tester.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <vector>
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -71,14 +71,14 @@ void debugArg(const std::string &head, mlir::Value op, const APFloat &value,
 
 void debugArg(const std::string &head, mlir::Value op, const Any &value,
               double time) {
-  if (any_isa<APInt>(value)) {
-    debugArg(head, op, any_cast<APInt>(value), time);
-  } else if (any_isa<APFloat>(value)) {
-    debugArg(head, op, any_cast<APFloat>(value), time);
-  } else if (any_isa<unsigned>(value)) {
+  if (auto *val = any_cast<APInt>(&value)) {
+    debugArg(head, op, *val, time);
+  } else if (auto *val = any_cast<APFloat>(&value)) {
+    debugArg(head, op, val, time);
+  } else if (auto *val = any_cast<unsigned>(&value)) {
     // Represents an allocated buffer.
-    LLVM_DEBUG(dbgs() << "  " << head << ":  " << op << " = Buffer "
-                      << any_cast<unsigned>(value) << "\n");
+    LLVM_DEBUG(dbgs() << "  " << head << ":  " << op << " = Buffer " << *val
+                      << "\n");
   } else {
     llvm_unreachable("unknown type");
   }


### PR DESCRIPTION
Add some headers and scope some variables.

Drop a use of `.value()` was done for llvm::Optional when it was deprecated, but also remove an instance hidden in tablegen on `std::optional` following upstream changes doing similar due to availability and exception semantics.
For example, see: https://github.com/llvm/llvm-project/commit/30199d11d27460e8c96a81c493526c32dbea428d .

Commits are normally the sort to just be pushed and touch different parts of the code, so I plan to merge via "rebase/merge", once CI confirms all is well.