### PR TITLE
[HW][FIRRTL] Add functions to FieldIDTypeInteface

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -129,11 +129,12 @@ public:
   /// Get the sub-type of a type for a field ID, and the subfield's ID. Strip
   /// off a single layer of this type and return the sub-type and a field ID
   /// targeting the same field, but rebased on the sub-type.
-  std::pair<FIRRTLBaseType, unsigned> getSubTypeByFieldID(unsigned fieldID);
+  std::pair<circt::hw::FieldIDTypeInterface, unsigned>
+  getSubTypeByFieldID(unsigned fieldID);
 
   /// Return the final type targeted by this field ID by recursively walking all
   /// nested aggregate types. This is the identity function for ground types.
-  FIRRTLBaseType getFinalTypeByFieldID(unsigned fieldID);
+  circt::hw::FieldIDTypeInterface getFinalTypeByFieldID(unsigned fieldID);
 
   /// Returns the effective field id when treating the index field as the
   /// root of the type.  Essentially maps a fieldID to a fieldID after a
@@ -356,7 +357,8 @@ public:
 
   /// Strip off a single layer of this type and return the sub-type and a field
   /// ID targeting the same field, but rebased on the sub-type.
-  std::pair<FIRRTLBaseType, unsigned> getSubTypeByFieldID(unsigned fieldID);
+  std::pair<circt::hw::FieldIDTypeInterface, unsigned>
+  getSubTypeByFieldID(unsigned fieldID);
 
   /// Get the maximum field ID in this bundle.  This is helpful for constructing
   /// field IDs when this BundleType is nested in another aggregate type.
@@ -407,7 +409,8 @@ public:
 
   /// Strip off a single layer of this type and return the sub-type and a field
   /// ID targeting the same field, but rebased on the sub-type.
-  std::pair<FIRRTLBaseType, size_t> getSubTypeByFieldID(size_t fieldID);
+  std::pair<circt::hw::FieldIDTypeInterface, size_t>
+  getSubTypeByFieldID(size_t fieldID);
 
   /// Get the maximum field ID in this vector.  This is helpful for constructing
   /// field IDs when this VectorType is nested in another aggregate type.

--- a/include/circt/Dialect/HW/HWTypeInterfaces.td
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.td
@@ -23,7 +23,36 @@ def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
 
   let methods = [
     InterfaceMethod<"Get the maximum field ID for this type",
-      "uint64_t", "getMaxFieldID">
+      "uint64_t", "getMaxFieldID">,
+
+    InterfaceMethod<[{
+      Get the sub-type of a type for a field ID, and the subfield's ID. Strip
+      off a single layer of this type and return the sub-type and a field ID
+      targeting the same field, but rebased on the sub-type.
+    }], "std::pair<circt::hw::FieldIDTypeInterface, unsigned>",
+    "getSubTypeByFieldID", (ins "unsigned":$fieldID)>,
+
+    InterfaceMethod<[{
+      Return the final type targeted by this field ID by recursively walking all
+      nested aggregate types. This is the identity function for ground types.
+    }], "circt::hw::FieldIDTypeInterface", "getFinalTypeByFieldID",
+    (ins "unsigned":$fieldID)>,
+
+    InterfaceMethod<[{
+      Returns the effective field id when treating the index field as the
+      root of the type.  Essentially maps a fieldID to a fieldID after a
+      subfield op. Returns the new id and whether the id is in the given
+      child.
+    }], "std::pair<unsigned, bool>", "rootChildFieldID",
+    (ins "unsigned":$fieldID, "unsigned":$index)>,
+
+    InterfaceMethod<[{
+      Returns the effective field id when treating the index field as the
+      root of the type.  Essentially maps a fieldID to a fieldID after a
+      subfield op. Returns the new id and whether the id is in the given
+      child.
+    }], "unsigned", "getGroundFields">
+
   ];
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -690,7 +690,8 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
       AnnoPathValue internalPathSrc;
       auto targetType = wireTarget->ref.getType().cast<FIRRTLBaseType>();
       if (wireTarget->fieldIdx)
-        targetType = targetType.getFinalTypeByFieldID(wireTarget->fieldIdx);
+        targetType = cast<FIRRTLBaseType>(
+            targetType.getFinalTypeByFieldID(wireTarget->fieldIdx));
       sendVal = lowerInternalPathAnno(internalPathSrc, *moduleTarget, target,
                                       internalPathAttr, targetType, state);
       if (!sendVal)

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/HW/HWTypeInterfaces.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -486,9 +487,10 @@ unsigned FIRRTLBaseType::getMaxFieldID() {
       });
 }
 
-std::pair<FIRRTLBaseType, unsigned>
+std::pair<circt::hw::FieldIDTypeInterface, unsigned>
 FIRRTLBaseType::getSubTypeByFieldID(unsigned fieldID) {
-  return TypeSwitch<FIRRTLBaseType, std::pair<FIRRTLBaseType, unsigned>>(*this)
+  return TypeSwitch<FIRRTLBaseType,
+                    std::pair<circt::hw::FieldIDTypeInterface, unsigned>>(*this)
       .Case<AnalogType, ClockType, ResetType, AsyncResetType, SIntType,
             UIntType>([&](FIRRTLBaseType t) {
         assert(!fieldID && "non-aggregate types must have a field id of 0");
@@ -502,8 +504,9 @@ FIRRTLBaseType::getSubTypeByFieldID(unsigned fieldID) {
       });
 }
 
-FIRRTLBaseType FIRRTLBaseType::getFinalTypeByFieldID(unsigned fieldID) {
-  std::pair<FIRRTLBaseType, unsigned> pair(*this, fieldID);
+circt::hw::FieldIDTypeInterface
+FIRRTLBaseType::getFinalTypeByFieldID(unsigned fieldID) {
+  std::pair<circt::hw::FieldIDTypeInterface, unsigned> pair(*this, fieldID);
   while (pair.second)
     pair = pair.first.getSubTypeByFieldID(pair.second);
   return pair.first;
@@ -941,7 +944,7 @@ unsigned BundleType::getIndexForFieldID(unsigned fieldID) {
   return std::distance(fieldIDs.begin(), it);
 }
 
-std::pair<FIRRTLBaseType, unsigned>
+std::pair<circt::hw::FieldIDTypeInterface, unsigned>
 BundleType::getSubTypeByFieldID(unsigned fieldID) {
   if (fieldID == 0)
     return {*this, 0};
@@ -1043,7 +1046,7 @@ size_t FVectorType::getIndexForFieldID(size_t fieldID) {
   return (fieldID - 1) / (getElementType().getMaxFieldID() + 1);
 }
 
-std::pair<FIRRTLBaseType, size_t>
+std::pair<circt::hw::FieldIDTypeInterface, size_t>
 FVectorType::getSubTypeByFieldID(size_t fieldID) {
   if (fieldID == 0)
     return {*this, 0};

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1393,9 +1393,10 @@ Optional<TypeSum> GrandCentralPass::computeField(
             FieldRef fieldRef = leafMap.lookup(ground.getID()).field;
             auto value = fieldRef.getValue();
             auto fieldID = fieldRef.getFieldID();
-            auto tpe =
-                value.getType().cast<FIRRTLBaseType>().getFinalTypeByFieldID(
-                    fieldID);
+            auto tpe = cast<FIRRTLBaseType>(
+                value.getType()
+                    .cast<circt::hw::FieldIDTypeInterface>()
+                    .getFinalTypeByFieldID(fieldID));
             if (!tpe.isGround()) {
               value.getDefiningOp()->emitOpError()
                   << "cannot be added to interface with id '"


### PR DESCRIPTION
Move all functions pertaining to Field IDs from being declared only on FIRRTL Types into the pre-existing hw::FieldIDTypeInterface.  This moves the following methods:

  - getSubTypeByFieldID
  - getFinalTypeByFieldID
  - rootChildFieldID
  - getGroundFields

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>