### PR TITLE
[StandardToHandshake] Remove intermediate conversion ops

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -59,7 +59,7 @@ public:
 
   using BlockValues = DenseMap<Block *, std::vector<Value>>;
   using BlockOps = DenseMap<Block *, std::vector<MergeOpInfo>>;
-  using blockArgPairs = DenseMap<Value, Operation *>;
+  using ValueMap = DenseMap<Value, Value>;
   using MemRefToMemoryAccessOp =
       llvm::MapVector<Value, std::vector<Operation *>>;
 
@@ -72,18 +72,18 @@ public:
   LogicalResult setControlOnlyPath(ConversionPatternRewriter &rewriter) {
     // Creates start and end points of the control-only path
 
-    // Temporary start node (removed in later steps) in entry block
+    // Add start point of the control-only path to the entry block's arguments
     Block *entryBlock = &r.front();
-    rewriter.setInsertionPointToStart(entryBlock);
-    Operation *startOp = rewriter.create<StartOp>(entryBlock->front().getLoc());
-    setBlockEntryControl(entryBlock, startOp->getResult(0));
+    startCtrl = entryBlock->addArgument(rewriter.getNoneType(),
+                                        rewriter.getUnknownLoc());
+    setBlockEntryControl(entryBlock, startCtrl);
 
     // Replace original return ops with new returns with additional control
     // input
     for (auto retOp : llvm::make_early_inc_range(r.getOps<TTerm>())) {
       rewriter.setInsertionPoint(retOp);
       SmallVector<Value, 8> operands(retOp->getOperands());
-      operands.push_back(startOp->getResult(0));
+      operands.push_back(startCtrl);
       rewriter.replaceOpWithNewOp<handshake::ReturnOp>(retOp, operands);
     }
     return success();
@@ -94,7 +94,7 @@ public:
   LogicalResult feedForwardRewriting(ConversionPatternRewriter &rewriter);
   LogicalResult loopNetworkRewriting(ConversionPatternRewriter &rewriter);
 
-  BlockOps insertMergeOps(BlockValues blockLiveIns, blockArgPairs &mergePairs,
+  BlockOps insertMergeOps(BlockValues blockLiveIns, ValueMap &mergePairs,
                           BackedgeBuilder &edgeBuilder,
                           ConversionPatternRewriter &rewriter);
 
@@ -116,8 +116,6 @@ public:
                              ArrayRef<Operation *> memOps, Operation *memOp,
                              int offset, ArrayRef<int> cntrlInd);
 
-  LogicalResult finalize(ConversionPatternRewriter &rewriter);
-
   // Returns the entry control value for operations contained within this
   // block.
   Value getBlockEntryControl(Block *block) const;
@@ -129,6 +127,9 @@ public:
 
 protected:
   Region &r;
+
+  /// Start point of the control-only network
+  BlockArgument startCtrl;
 
 private:
   DenseMap<Block *, Value> blockEntryControlMap;
@@ -194,11 +195,6 @@ LogicalResult lowerRegion(HandshakeLowering &hl, bool sourceConstants,
                                 lsq)))
     return failure();
 
-  // Add  control argument to entry block, replace references to the
-  // temporary handshake::StartOp operation, and finally remove the start
-  // op.
-  if (failed(runPartialLowering(hl, &HandshakeLowering::finalize)))
-    return failure();
   return success();
 }
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -50,8 +50,6 @@ struct MemStoreInterface {
   mlir::Value doneOut;
 };
 
-class TerminatorOp;
-
 /// Default implementation for checking whether an operation is a control
 /// operation. This function cannot be defined within ControlInterface
 /// because its implementation attempts to cast the operation to an

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -573,52 +573,6 @@ def ConstantOp : Handshake_Op<"constant", [
   let hasVerifier = 1;
 }
 
-def EndOp
-    : Handshake_Op<"end", [DeclareOpInterfaceMethods<ExecutableOpInterface>]> {
-  let summary = "end operation";
-  let description = [{
-    The end propagates the result of the appropriate
-    return operation from one of its inputs to its single output after
-    all memory accesses have completed.  Currently not used(data
-    returned through ReturnOp).
-  }];
-
-  let arguments = (ins AnyType : $control, Variadic<AnyType> : $opOperands);
-  let assemblyFormat = [{ operands attr-dict `:` qualified(type($control)) `,` qualified(type($opOperands))}];
-}
-
-def StartOp : Handshake_Op<"start", [
-  Pure, 
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
-  DeclareOpInterfaceMethods<ExecutableOpInterface>,
-  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>
-]> {
-  let summary = "start operation";
-  let description = [{
-       Triggers execution of the control - only network.  Placed in entry
-    block.  Currently not used( trigger given as function argument)
-  }];
-
-  let results = (outs NoneType : $result);
-  let assemblyFormat = [{ attr-dict `:` qualified(type($result))}];
-}
-
-def TerminatorOp : Handshake_Op<"terminator", [Terminator]> {
-  let summary = "handshake terminator operation";
-  let description = [{
-    This op is used as a terminator in every block of the dataflow
-    netlist (as a replacement for StandardOp branches). It has no
-    functionality and can be removed in some subsequent pass, when the
-    block structure is removed.
-  }];
-
-  let successors = (successor VariadicSuccessor<AnySuccessor>:$dests);
-  let builders = [OpBuilder<(ins "ArrayRef<Block *>":$successors), [{
-      $_state.addSuccessors(successors);
-  }]>];
-}
-
-
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "memref type attribute">;
 def MemoryOp : Handshake_Op<"memory", [
   DeclareOpInterfaceMethods<ExecutableOpInterface>,

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -32,12 +32,12 @@ public:
         .template Case<
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
-            EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
-            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
-            handshake::SelectOp, SourceOp, StartOp, StoreOp, SyncOp,
-            TerminatorOp, PackOp, UnpackOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitHandshake(opNode, args...);
-        })
+            ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp, MemoryOp,
+            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
+            handshake::SelectOp, SourceOp, StoreOp, SyncOp, PackOp, UnpackOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitHandshake(opNode, args...);
+            })
         .Default([&](auto opNode) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
         });
@@ -66,7 +66,6 @@ public:
   HANDLE(ConditionalBranchOp);
   HANDLE(ConstantOp);
   HANDLE(ControlMergeOp);
-  HANDLE(EndOp);
   HANDLE(ForkOp);
   HANDLE(FuncOp);
   HANDLE(InstanceOp);
@@ -81,10 +80,8 @@ public:
   HANDLE(ReturnOp);
   HANDLE(SinkOp);
   HANDLE(SourceOp);
-  HANDLE(StartOp);
   HANDLE(StoreOp);
   HANDLE(SyncOp);
-  HANDLE(TerminatorOp);
   HANDLE(PackOp);
   HANDLE(UnpackOp);
 #undef HANDLE

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -222,10 +222,11 @@ void HandshakeLowering::setBlockEntryControl(Block *block, Value v) {
 void handshake::removeBasicBlocks(Region &r) {
   auto &entryBlock = r.front().getOperations();
 
-  // Erase all TerminatorOp, and move ReturnOp to the end of entry block.
+  // Now that basic blocks are going to be removed, we can erase all cf-dialect
+  // branches, and move ReturnOp to the entry block's end
   for (auto &block : r) {
     Operation &termOp = block.back();
-    if (isa<handshake::TerminatorOp>(termOp))
+    if (isa<mlir::cf::CondBranchOp, mlir::cf::BranchOp>(termOp))
       termOp.erase();
     else if (isa<handshake::ReturnOp>(termOp))
       entryBlock.splice(entryBlock.end(), block.getOperations(), termOp);
@@ -394,8 +395,9 @@ HandshakeLowering::insertMerge(Block *block, Value val,
   SmallVector<Backedge> dataEdges;
   SmallVector<Value> operands;
 
-  // Control-only path originates from StartOp
-  if (!val.isa<BlockArgument>() && isa<StartOp>(val.getDefiningOp())) {
+  // Every block (except the entry block) needs a control merge for the
+  // control-only network, which originates from startCtrl
+  if (val == startCtrl && block != &r.front()) {
     for (unsigned i = 0; i < numPredecessors; i++) {
       auto edge = edgeBuilder.get(rewriter.getNoneType());
       dataEdges.push_back(edge);
@@ -407,12 +409,20 @@ HandshakeLowering::insertMerge(Block *block, Value val,
     return MergeOpInfo{cmerge, val, dataEdges};
   }
 
-  // If there is at most one block predecessor
+  // Every live-in value to a block is passed through a merge-like operation,
+  // even when it's not required for circuit correctness (useless merge-like
+  // operations are removed down the line during handshake canonicalization)
+
+  // Insert "dummy" MergeOp's for blocks with less than two predecessors
   if (numPredecessors <= 1) {
-    // Dummy merge used here due to hard-coded logic of reconnectMergeOps
     if (numPredecessors == 0) {
+      // All of the entry block's block arguments get passed through a dummy
+      // MergeOp. There is no need for a backedge here as the unique operand can
+      // be resolved immediately
       operands.push_back(val);
     } else {
+      // The value incoming from the single block predecessor will be resolved
+      // later during merge reconnection
       auto edge = edgeBuilder.get(val.getType());
       dataEdges.push_back(edge);
       operands.push_back(Value(edge));
@@ -422,7 +432,9 @@ HandshakeLowering::insertMerge(Block *block, Value val,
   }
 
   // Create a backedge for the index operand, and another one for each data
-  // operand
+  // operand. The index operand will eventually resolve to the current block's
+  // control merge index output, while data operands will resolve to their
+  // respective values from each block predecessor
   Backedge indexEdge = edgeBuilder.get(rewriter.getIndexType());
   for (unsigned i = 0; i < numPredecessors; i++) {
     auto edge = edgeBuilder.get(val.getType());
@@ -436,7 +448,7 @@ HandshakeLowering::insertMerge(Block *block, Value val,
 
 HandshakeLowering::BlockOps
 HandshakeLowering::insertMergeOps(HandshakeLowering::BlockValues blockLiveIns,
-                                  HandshakeLowering::blockArgPairs &mergePairs,
+                                  HandshakeLowering::ValueMap &mergePairs,
                                   BackedgeBuilder &edgeBuilder,
                                   ConversionPatternRewriter &rewriter) {
   HandshakeLowering::BlockOps blockMerges;
@@ -446,7 +458,7 @@ HandshakeLowering::insertMergeOps(HandshakeLowering::BlockValues blockLiveIns,
     for (auto &val : blockLiveIns[&block]) {
       auto mergeInfo = insertMerge(&block, val, edgeBuilder, rewriter);
       blockMerges[&block].push_back(mergeInfo);
-      mergePairs[val] = mergeInfo.op;
+      mergePairs[val] = mergeInfo.op->getResult(0);
     }
     // Block arguments are not in livein list as they are defined inside the
     // block
@@ -457,7 +469,7 @@ HandshakeLowering::insertMergeOps(HandshakeLowering::BlockValues blockLiveIns,
 
       auto mergeInfo = insertMerge(&block, arg, edgeBuilder, rewriter);
       blockMerges[&block].push_back(mergeInfo);
-      mergePairs[arg] = mergeInfo.op;
+      mergePairs[arg] = mergeInfo.op->getResult(0);
     }
   }
   return blockMerges;
@@ -552,7 +564,7 @@ static ConditionalBranchOp getControlCondBranch(Block *block) {
 
 static void reconnectMergeOps(Region &r,
                               HandshakeLowering::BlockOps blockMerges,
-                              HandshakeLowering::blockArgPairs &mergePairs) {
+                              HandshakeLowering::ValueMap &mergePairs) {
   // At this point all merge-like operations have backedges as operands.
   // We here replace all backedge values with appropriate value from
   // predecessor block. The predecessor can either be a merge, the original
@@ -567,7 +579,7 @@ static void reconnectMergeOps(Region &r,
         assert(mgOperand != nullptr);
         if (!mgOperand.getDefiningOp()) {
           assert(mergePairs.count(mgOperand));
-          mgOperand = mergePairs[mgOperand]->getResult(0);
+          mgOperand = mergePairs[mgOperand];
         }
         mergeInfo.dataEdges[operandIdx].setValue(mgOperand);
         operandIdx++;
@@ -606,7 +618,7 @@ static void reconnectMergeOps(Region &r,
 LogicalResult
 HandshakeLowering::addMergeOps(ConversionPatternRewriter &rewriter) {
 
-  blockArgPairs mergePairs;
+  ValueMap mergePairs;
 
   // blockLiveIns: live in variables of block
   BlockValues liveIns = livenessAnalysis(r);
@@ -618,6 +630,21 @@ HandshakeLowering::addMergeOps(ConversionPatternRewriter &rewriter) {
   // Insert merge operations
   BlockOps mergeOps =
       insertMergeOps(liveIns, mergePairs, edgeBuilder, rewriter);
+
+  // For consistency within the entry block, replace the latter's entry control
+  // with the output of the MergeOp that takes the control-only network's start
+  // point as input. This makes it so that only the MergeOp's output is used as
+  // a control within the entry block, instead of a combination of the MergeOp's
+  // output and the function/block control argument. Taking this step out should
+  // have no impact on functionality but would make the resulting IR less
+  // "regular"
+  auto startCtrlMerge = llvm::find_if(startCtrl.getUses(), [this](auto &use) {
+    auto *owner = use.getOwner();
+    return owner->getBlock() == &r.front() && isa<MergeOp>(owner);
+  });
+  assert(startCtrlMerge != startCtrl.getUses().end() &&
+         "Expected startCtrl to go through MergeOp in entry block");
+  setBlockEntryControl(&r.front(), startCtrlMerge->getOwner()->getResult(0));
 
   // Set merge operands and uses
   reconnectMergeOps(r, mergeOps, mergePairs);
@@ -1272,26 +1299,6 @@ HandshakeLowering::addBranchOps(ConversionPatternRewriter &rewriter) {
     }
   }
 
-  // Remove StandardOp branch terminators and place new terminator
-  // Should be removed in some subsequent pass (we only need it to pass
-  // checks in Verifier.cpp)
-  for (Block &block : r) {
-    Operation *termOp = block.getTerminator();
-    if (!(isa<mlir::cf::CondBranchOp>(termOp) ||
-          isa<mlir::cf::BranchOp>(termOp)))
-      continue;
-
-    SmallVector<mlir::Block *, 8> results(block.getSuccessors());
-    rewriter.setInsertionPointToEnd(&block);
-    rewriter.create<handshake::TerminatorOp>(termOp->getLoc(),
-                                             ArrayRef<mlir::Block *>{results});
-
-    // Remove the Operands to keep the single-use rule.
-    for (int i = 0, e = termOp->getNumOperands(); i < e; ++i)
-      termOp->eraseOperand(0);
-    assert(termOp->getNumOperands() == 0);
-    rewriter.eraseOp(termOp);
-  }
   return success();
 }
 
@@ -1590,8 +1597,8 @@ static LogicalResult setJoinControlInputs(ArrayRef<Operation *> memOps,
     auto *op = memOps[i];
     Value ctrl = getBlockControlTerminator(op->getBlock()).ctrlOperand;
     auto *srcOp = ctrl.getDefiningOp();
-    if (!isa<JoinOp, StartOp>(srcOp)) {
-      return srcOp->emitOpError("Op expected to be a JoinOp or StartOp");
+    if (!isa<JoinOp>(srcOp)) {
+      return srcOp->emitOpError("Op expected to be a JoinOp");
     }
     addValueToOperands(srcOp, memOp->getResult(offset + cntrlInd[i]));
   }
@@ -1750,16 +1757,6 @@ HandshakeLowering::connectToMemory(ConversionPatternRewriter &rewriter,
   return success();
 }
 
-// A handshake::StartOp should have been created in the first block of the
-// enclosing function region
-static Operation *findStartOp(Region &region) {
-  for (Operation &op : region.front())
-    if (isa<handshake::StartOp>(op))
-      return &op;
-
-  llvm::report_fatal_error("No handshake::StartOp in first block");
-}
-
 LogicalResult
 HandshakeLowering::replaceCallOps(ConversionPatternRewriter &rewriter) {
   for (Block &block : r) {
@@ -1782,17 +1779,6 @@ HandshakeLowering::replaceCallOps(ConversionPatternRewriter &rewriter) {
       }
     }
   }
-  return success();
-}
-
-LogicalResult HandshakeLowering::finalize(ConversionPatternRewriter &rewriter) {
-  auto ctrlArg =
-      r.front().addArgument(rewriter.getNoneType(), rewriter.getUnknownLoc());
-
-  Operation *startOp = findStartOp(r);
-  startOp->getResult(0).replaceAllUsesWith(ctrlArg);
-  rewriter.eraseOp(startOp);
-
   return success();
 }
 

--- a/lib/Dialect/Handshake/HandshakeExecutableOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeExecutableOps.cpp
@@ -231,24 +231,6 @@ bool ConditionalBranchOp::tryExecute(
   valueMap.erase(in);
   return true;
 }
-bool StartOp::tryExecute(llvm::DenseMap<mlir::Value, llvm::Any> & /*valueMap*/,
-                         llvm::DenseMap<unsigned, unsigned> & /*memoryMap*/,
-                         llvm::DenseMap<mlir::Value, double> & /*timeMap*/,
-                         std::vector<std::vector<llvm::Any>> & /*store*/,
-                         std::vector<mlir::Value> & /*scheduleList*/) {
-  assert(false && "StartOp's should never exist in a real program due to being "
-                  "purely lowering helper operations.");
-  return true;
-}
-bool EndOp::tryExecute(llvm::DenseMap<mlir::Value, llvm::Any> & /*valueMap*/,
-                       llvm::DenseMap<unsigned, unsigned> & /*memoryMap*/,
-                       llvm::DenseMap<mlir::Value, double> & /*timeMap*/,
-                       std::vector<std::vector<llvm::Any>> & /*store*/,
-                       std::vector<mlir::Value> & /*scheduleList*/) {
-  assert(false && "EndOp's should never exist in a real program due to being "
-                  "purely lowering helper operations.");
-  return true;
-}
 
 bool SinkOp::tryExecute(llvm::DenseMap<mlir::Value, llvm::Any> &valueMap,
                         llvm::DenseMap<unsigned, unsigned> & /*memoryMap*/,

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -87,7 +87,7 @@ static bool isControlCheckTypeAndOperand(Type dataType, Value operand) {
   // Otherwise, the operation is a control operation if the operation's
   // operand originates from the control network
   auto *defOp = operand.getDefiningOp();
-  return isa_and_nonnull<ControlMergeOp, StartOp>(defOp) &&
+  return isa_and_nonnull<ControlMergeOp>(defOp) &&
          operand == defOp->getResult(0);
 }
 
@@ -891,8 +891,6 @@ std::string handshake::SelectOp::getOperandName(unsigned int idx) {
 bool SelectOp::isControl() {
   return getTrueOperand().getType().isa<NoneType>();
 }
-
-bool StartOp::isControl() { return true; }
 
 ParseResult SinkOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand, 4> allOperands;

--- a/test/Conversion/StandardToHandshake/arith-ops.mlir
+++ b/test/Conversion/StandardToHandshake/arith-ops.mlir
@@ -6,6 +6,7 @@
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_1]] : f32
 // CHECK:           %[[VAL_7:.*]] = merge %[[VAL_2]] : i32
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_3]] : i32
+// CHECK:           %[[VAL_4x:.*]] = merge %[[VAL_4]] : none
 // CHECK:           %[[VAL_9:.*]] = arith.subf %[[VAL_5]], %[[VAL_6]] : f32
 // CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_10]] : i32
@@ -19,7 +20,7 @@
 // CHECK:           %[[VAL_19:.*]] = arith.andi %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_20:.*]] = arith.ori %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_21:.*]] = arith.xori %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           return %[[VAL_9]], %[[VAL_12]], %[[VAL_4]] : f32, i32, none
+// CHECK:           return %[[VAL_9]], %[[VAL_12]], %[[VAL_4x]] : f32, i32, none
 // CHECK:         }
 func.func @ops(f32, f32, i32, i32) -> (f32, i32) {
 ^bb0(%arg0: f32, %arg1: f32, %arg2: i32, %arg3: i32):

--- a/test/Conversion/StandardToHandshake/call.mlir
+++ b/test/Conversion/StandardToHandshake/call.mlir
@@ -4,7 +4,8 @@
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none)
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
-// CHECK:           return %[[VAL_2]], %[[VAL_1]] : i32, none
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           return %[[VAL_2]], %[[VAL_1x]] : i32, none
 // CHECK:         }
 func.func @bar(%0 : i32) -> i32 {
   return %0 : i32
@@ -14,8 +15,9 @@ func.func @bar(%0 : i32) -> i32 {
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none)
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
-// CHECK:           %[[VAL_3:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_1]]) : (i32, none) -> (i32, none)
-// CHECK:           return %[[VAL_3]]#0, %[[VAL_1]] : i32, none
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           %[[VAL_3:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_1x]]) : (i32, none) -> (i32, none)
+// CHECK:           return %[[VAL_3]]#0, %[[VAL_1x]] : i32, none
 // CHECK:         }
 func.func @foo(%0 : i32) -> i32 {
   %a1 = call @bar(%0) : (i32) -> i32
@@ -43,9 +45,10 @@ func.func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_2]] : i1
 // CHECK:           %[[VAL_7:.*]] = buffer [2] fifo %[[VAL_6]] : i1
+// CHECK:           %[[VAL_3x:.*]] = merge %[[VAL_3]] : none
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_6]], %[[VAL_4]] : i32
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_6]], %[[VAL_5]] : i32
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_6]], %[[VAL_3]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_6]], %[[VAL_3x]] : none
 // CHECK:           %[[VAL_14:.*]] = merge %[[VAL_8]] : i32
 // CHECK:           %[[VAL_15:.*]] = merge %[[VAL_10]] : i32
 // CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_12]] : none

--- a/test/Conversion/StandardToHandshake/disable-task-pipelining.mlir
+++ b/test/Conversion/StandardToHandshake/disable-task-pipelining.mlir
@@ -3,7 +3,8 @@
 
 // CHECK-LABEL:   handshake.func @simple_loop(
 // CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none
-// CHECK:           %[[VAL_1:.*]] = br %[[VAL_0]] : none
+// CHECK:           %[[VAL_0x:.*]] = merge %[[VAL_0]] : none
+// CHECK:           %[[VAL_1:.*]] = br %[[VAL_0x]] : none
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = control_merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]] = constant %[[VAL_2]] {value = 1 : index} : index
 // CHECK:           %[[VAL_5:.*]] = constant %[[VAL_2]] {value = 42 : index} : index
@@ -54,8 +55,9 @@ func.func @simple_loop() {
 // CHECK-SAME:                                  %[[VAL_2:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_4:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_2x:.*]] = merge %[[VAL_2]] : none
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_3]], %[[VAL_4]] : i64
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = cond_br %[[VAL_3]], %[[VAL_2x]] : none
 // CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = control_merge %[[VAL_7]] : none
 // CHECK:           %[[VAL_11:.*]] = merge %[[VAL_5]] : i64
 // CHECK:           %[[VAL_12:.*]] = br %[[VAL_9]] : none

--- a/test/Conversion/StandardToHandshake/external-memory.mlir
+++ b/test/Conversion/StandardToHandshake/external-memory.mlir
@@ -4,9 +4,10 @@
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<4xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: none, ...) -> (i32, none)
 // CHECK:           %[[VAL_2:.*]]:2 = extmemory[ld = 1, st = 0] (%[[VAL_0]] : memref<4xi32>) (%[[VAL_3:.*]]) {id = 0 : i32} : (index) -> (i32, none)
-// CHECK:           %[[VAL_4:.*]] = join %[[VAL_1]], %[[VAL_2]]#1 : none, none
-// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_1]] {value = 0 : index} : index
-// CHECK:           %[[VAL_6:.*]], %[[VAL_3]] = load {{\[}}%[[VAL_5]]] %[[VAL_2]]#0, %[[VAL_1]] : index, i32
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           %[[VAL_4:.*]] = join %[[VAL_1x]], %[[VAL_2]]#1 : none, none
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_1x]] {value = 0 : index} : index
+// CHECK:           %[[VAL_6:.*]], %[[VAL_3]] = load {{\[}}%[[VAL_5]]] %[[VAL_2]]#0, %[[VAL_1x]] : index, i32
 // CHECK:           return %[[VAL_6]], %[[VAL_4]] : i32, none
 // CHECK:         }
 func.func @main(%mem : memref<4xi32>) -> i32 {
@@ -17,10 +18,13 @@ func.func @main(%mem : memref<4xi32>) -> i32 {
 
 // -----
 
-// CHECK-LABEL: handshake.func @no_use(%arg0: memref<4xi32>, %arg1: none, ...) -> none
-// CHECK:    extmemory[ld = 0, st = 0] (%arg0 : memref<4xi32>) () {id = 0 : i32} : () -> ()
-// CHECK:    return %arg1 : none
-// CHECK:  }
+// CHECK-LABEL:   handshake.func @no_use(
+// CHECK-SAME:                           %[[VAL_0:.*]]: memref<4xi32>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: none, ...) -> none
+// CHECK:           extmemory[ld = 0, st = 0] (%[[VAL_0]] : memref<4xi32>) () {id = 0 : i32} : () -> ()
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           return %[[VAL_1x]] : none
+// CHECK:         }
 func.func @no_use(%mem : memref<4xi32>) {
   return
 }

--- a/test/Conversion/StandardToHandshake/func.mlir
+++ b/test/Conversion/StandardToHandshake/func.mlir
@@ -2,7 +2,8 @@
 
 // CHECK-LABEL: handshake.func @foo(
 // CHECK-SAME:      %[[CTRL:.*]]: none, ...) -> none
-// CHECK:         return %[[CTRL]] : none
+// CHECK:         %[[CTRLX:.*]] = merge %[[CTRL]] : none
+// CHECK:         return %[[CTRLX]] : none
 func.func @foo() {
   return
 }
@@ -13,7 +14,8 @@ func.func @foo() {
 // CHECK-SAME:      %[[ARG:.*]]: i32,
 // CHECK-SAME:      %[[CTRL:.*]]: none, ...) -> (i32, none)
 // CHECK:         %[[VAL:.*]] = merge %[[ARG]] : i32
-// CHECK:         return %[[VAL]], %[[CTRL]] : i32, none
+// CHECK:         %[[CTRLX:.*]] = merge %[[CTRL]] : none
+// CHECK:         return %[[VAL]], %[[CTRLX]] : i32, none
 func.func @args(%a: i32) -> i32 {
   return %a: i32
 }

--- a/test/Conversion/StandardToHandshake/memref.mlir
+++ b/test/Conversion/StandardToHandshake/memref.mlir
@@ -2,7 +2,8 @@
 
 // CHECK-LABEL:   handshake.func @remove_unused_mem(
 // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none
-// CHECK:           return %[[VAL_0]] : none
+// CHECK:           %[[VAL_0x:.*]] = merge %[[VAL_0]] : none
+// CHECK:           return %[[VAL_0x]] : none
 // CHECK:         }
 func.func @remove_unused_mem() {
   %0 = memref.alloc() : memref<100xf32>
@@ -16,10 +17,11 @@ func.func @remove_unused_mem() {
 // CHECK-SAME:                               %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]]:3 = memory[ld = 1, st = 1] (%[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]]) {id = 0 : i32, lsq = false} : memref<4xi32>, (i32, index, index) -> (i32, none, none)
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_0]] : index
-// CHECK:           %[[VAL_7:.*]] = join %[[VAL_1]], %[[VAL_2]]#1, %[[VAL_2]]#2 : none, none, none
-// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_1]] {value = 11 : i32} : i32
-// CHECK:           %[[VAL_3]], %[[VAL_4]] = store {{\[}}%[[VAL_6]]] %[[VAL_8]], %[[VAL_1]] : index, i32
-// CHECK:           %[[VAL_9:.*]] = join %[[VAL_1]], %[[VAL_2]]#1 : none, none
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           %[[VAL_7:.*]] = join %[[VAL_1x]], %[[VAL_2]]#1, %[[VAL_2]]#2 : none, none, none
+// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_1x]] {value = 11 : i32} : i32
+// CHECK:           %[[VAL_3]], %[[VAL_4]] = store {{\[}}%[[VAL_6]]] %[[VAL_8]], %[[VAL_1x]] : index, i32
+// CHECK:           %[[VAL_9:.*]] = join %[[VAL_1x]], %[[VAL_2]]#1 : none, none
 // CHECK:           %[[VAL_10:.*]], %[[VAL_5]] = load {{\[}}%[[VAL_6]]] %[[VAL_2]]#0, %[[VAL_9]] : index, i32
 // CHECK:           return %[[VAL_7]] : none
 // CHECK:         }
@@ -37,14 +39,15 @@ func.func @load_store(%1 : index) {
 // CHECK-SAME:                             %[[VAL_0:.*]]: index,
 // CHECK-SAME:                             %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : index
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<10xf32>
 // CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<10xf32>
 // CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<1xi32>
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1]] {value = 1 : index} : index
-// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_1]] {value = 1 : index} : index
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1x]] {value = 1 : index} : index
+// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_1x]] {value = 1 : index} : index
 // CHECK:           memref.dma_start %[[VAL_3]]{{\[}}%[[VAL_2]]], %[[VAL_4]]{{\[}}%[[VAL_2]]], %[[VAL_7]], %[[VAL_5]]{{\[}}%[[VAL_6]]] : memref<10xf32>, memref<10xf32>, memref<1xi32>
 // CHECK:           memref.dma_wait %[[VAL_5]]{{\[}}%[[VAL_6]]], %[[VAL_7]] : memref<1xi32>
-// CHECK:           return %[[VAL_1]] : none
+// CHECK:           return %[[VAL_1x]] : none
 // CHECK:         }
 func.func @dma(%1 : index) {
   %mem0 = memref.alloc() : memref<10xf32>

--- a/test/Conversion/StandardToHandshake/source-constants.mlir
+++ b/test/Conversion/StandardToHandshake/source-constants.mlir
@@ -2,9 +2,10 @@
 
 // CHECK-LABEL:   handshake.func @foo(
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none)
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_2:.*]] = source
 // CHECK:           %[[VAL_3:.*]] = constant %[[VAL_2]] {value = 1 : i32} : i32
-// CHECK:           return %[[VAL_3]], %[[VAL_1]] : i32, none
+// CHECK:           return %[[VAL_3]], %[[VAL_1x]] : i32, none
 // CHECK:         }
 
 func.func @foo() -> i32 {

--- a/test/Conversion/StandardToHandshake/task-pipelining.mlir
+++ b/test/Conversion/StandardToHandshake/task-pipelining.mlir
@@ -9,8 +9,9 @@
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_2x:.*]] = merge %[[VAL_2]] : none
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2x]] : none
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_8]] : none
 // CHECK:           %[[VAL_12:.*]] = merge %[[VAL_6]] : i64
 // CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : none
@@ -41,8 +42,9 @@ func.func @simpleDiamond(%arg0: i1, %arg1: i64) {
 // CHECK-SAME:                                  %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
@@ -87,8 +89,9 @@ func.func @nestedDiamond(%arg0: i1) {
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_2x:.*]] = merge %[[VAL_2]] : none
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_2x]] : none
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_8]] : none
 // CHECK:           %[[VAL_12:.*]] = merge %[[VAL_6]] : i64
 // CHECK:           %[[VAL_13:.*]] = br %[[VAL_10]] : none
@@ -115,8 +118,9 @@ func.func @triangle(%arg0: i1, %val0: i64) {
 // CHECK-SAME:                                   %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
@@ -153,8 +157,9 @@ func.func @nestedTriangle(%arg0: i1) {
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
@@ -222,8 +227,9 @@ func.func @multiple_blocks_needed(%arg0: i1) {
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = control_merge %[[VAL_3]], %[[VAL_3]] : none
 // CHECK:           return %[[VAL_7]] : none
 // CHECK:         }
@@ -239,9 +245,10 @@ func.func @sameSuccessor(%cond: i1) {
 // CHECK-SAME:                                %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                                %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i64
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 1 : i64} : i64
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1x]] {value = 1 : i64} : i64
 // CHECK:           %[[VAL_4:.*]] = br %[[VAL_2]] : i64
-// CHECK:           %[[VAL_5:.*]] = br %[[VAL_1]] : none
+// CHECK:           %[[VAL_5:.*]] = br %[[VAL_1x]] : none
 // CHECK:           %[[VAL_6:.*]] = br %[[VAL_3]] : i64
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = control_merge %[[VAL_5]] : none
 // CHECK:           %[[VAL_9:.*]] = buffer [1] seq %[[VAL_10:.*]] {initValues = [0]} : i1
@@ -289,8 +296,9 @@ func.func @simple_loop(%arg0: i64) {
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
@@ -353,8 +361,9 @@ func.func @blockWith3PredsAndLoop(%arg0: i1) {
 // CHECK-SAME:                                    %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]] = buffer [2] fifo %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_6]] : none
@@ -419,10 +428,11 @@ func.func @otherBlockOrder(%arg0: i1) {
 // CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_4:.*]] = buffer [2] fifo %[[VAL_3]] : i1
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i64
+// CHECK:           %[[VAL_2x:.*]] = merge %[[VAL_2]] : none
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_3]], %[[VAL_3]] : i1
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_3]], %[[VAL_5]] : i64
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_3]], %[[VAL_2]] : none
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_3]], %[[VAL_2x]] : none
 // CHECK:           %[[VAL_14:.*]] = merge %[[VAL_6]] : i1
 // CHECK:           %[[VAL_15:.*]] = buffer [2] fifo %[[VAL_14]] : i1
 // CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_12]] : none
@@ -473,8 +483,9 @@ func.func @multiple_block_args(%arg0: i1, %arg1: i64) {
 // CHECK-SAME:                                           %[[VAL_1:.*]]: none, ...) -> none
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_3:.*]] = buffer [2] fifo %[[VAL_2]] : i1
+// CHECK:           %[[VAL_1x:.*]] = merge %[[VAL_1]] : none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_2]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1]] : none
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_2]], %[[VAL_1x]] : none
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = control_merge %[[VAL_6]] : none
 // CHECK:           %[[VAL_11:.*]] = br %[[VAL_8]] : i1


### PR DESCRIPTION
This commit removes the `StartOp`, `EndOp`, and `TerminatorOp` from the entire codebase, since they were used exclusively as intermediate operations during `std-to-handshake` conversion and have caused issues in the past. `StartOp`'s purpose is achieved through a new field (`startCtrl`) in the `HandshakeLowering` class, while `TerminatorOp` and `EndOp`'s purpose is obtained by keeping `cf`-level terminators in the IR for longer than before.

Unit tests on the conversion pass are modified manually (as to yield a smaller diff, since rerunning `FileCheck` would change SSA value names and modify almost all lines) to reflect the fact that an additional `MergeOp` is created by the pass for the control-only network in the entry block of each function (this has no impact on circuit behavior, and can be canonicalized away).

The commit also includes some more detailed documentation for the merge-insertion step of the conversion pass.

Fixes #3686.