### PR TITLE
[ExportVerilog] Regard dead expressions as inlinable

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -681,6 +681,10 @@ static BlockStatementCount countStatements(Block &block) {
 /// that uses it.
 bool ExportVerilog::isExpressionEmittedInline(Operation *op,
                                               const LoweringOptions &options) {
+  // Never create a temporary for a dead expression.
+  if (op->getResult(0).use_empty())
+    return true;
+
   // Never create a temporary which is only going to be assigned to an output
   // port, wire, or reg.
   if (op->hasOneUse() &&

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1294,7 +1294,7 @@ hw.module @ParamConcatInst<name: none = "top">() -> () {
 }
 
 // CHECK-LABEL: module ParamsParensPrecedence
-hw.module @ParamsParensPrecedence<param: i32>() {
+hw.module @ParamsParensPrecedence<param: i32>() -> (a:i32, b:i32, c:i32) {
   // CHECK: = $clog2($unsigned(param));
   %1 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
 
@@ -1303,6 +1303,7 @@ hw.module @ParamsParensPrecedence<param: i32>() {
 
   // CHECK: = $signed(param) >>> $signed(param & 8);
   %4 = hw.param.value i32 = #hw.param.expr.shrs<#hw.param.decl.ref<"param">,#hw.param.expr.and<8,#hw.param.decl.ref<"param">>>
+  hw.output %1, %3, %4: i32, i32, i32
 }
 
 // CHECK-LABEL: module ArrayGetInline
@@ -1320,4 +1321,15 @@ hw.module @UniformArrayCreate() -> (arr: !hw.array<5xi8>) {
   %arr = hw.array_create %c0_i8, %c0_i8, %c0_i8, %c0_i8, %c0_i8 : i8
   // CHECK: assign arr = {5{8'h0}};
   hw.output %arr : !hw.array<5xi8>
+}
+
+// CHECK-LABEL: module Issue4485(
+// CHECK-NEXT:    input [3:0] in);
+// CHECK-EMPTY:
+// CHECK-NEXT:  endmodule
+hw.module @Issue4485(%in: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %1 = comb.icmp eq %in, %c0_i4 : i4
+  %2 = sv.system.sampled %1 : i1
+  hw.output
 }


### PR DESCRIPTION
Previously `isExpressionEmittedInline` could return false for dead expressions which caused assertion failures in ExportVerilog. Dead expressions will not be emitted anyway so it makes sense to regard them as valid syntax. 