### PR TITLE
[SV] Mark SampledOp Pure

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -240,7 +240,7 @@ def IndexedPartSelectOp
                         " attr-dict `:` qualified(type($input)) `,` qualified(type($base))";
 }
 
-def SampledOp : SVOp<"system.sampled", [SameOperandsAndResultType]> {
+def SampledOp : SVOp<"system.sampled", [Pure, SameOperandsAndResultType]> {
   let summary = "`$sampled` system function to sample a value";
   let description = [{
     Sample a value using System Verilog sampling semantics (see Section 16.5.1

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -311,3 +311,10 @@ hw.module @MergeAssignments(%a: !hw.array<4xi1>, %clock: i1) -> (d: !hw.array<4x
   }
   hw.output %read : !hw.array<4xi1>
 }
+
+// CHECK-LABEL: @Sampled
+// CHECK-NEXT: hw.output
+hw.module @Sampled(%in: i1) {
+  %2 = sv.system.sampled %in : i1
+  hw.output
+}


### PR DESCRIPTION
SampledOp has read-only semantics and therefore it has to have Pure trait to align with ReadInoutOp.