### PR TITLE
[CombFolds] Preserve more twoState flags in canonicalization

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -162,6 +162,13 @@ static bool tryFlatteningOperands(Operation *op, PatternRewriter &rewriter) {
 
     Value result =
         createGenericOp(op->getLoc(), op->getName(), newOperands, rewriter);
+
+    // If the original operation and flatten operand have bin flags, propagte
+    // the flag to new one.
+    if (op->hasAttrOfType<UnitAttr>("twoState") &&
+        flattenOp->hasAttrOfType<UnitAttr>("twoState"))
+      result.getDefiningOp()->setAttr("twoState", rewriter.getUnitAttr());
+
     replaceOpAndCopyName(rewriter, op, result);
     return true;
   }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2860,7 +2860,7 @@ LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
     assert(!matchPattern(op.getRhs(), m_RConstant(rhs)) && "Should be folded");
     replaceOpWithNewOpAndCopyName<ICmpOp>(
         rewriter, op, ICmpOp::getFlippedPredicate(op.getPredicate()),
-        op.getRhs(), op.getLhs(), false);
+        op.getRhs(), op.getLhs(), op.getTwoState());
     return success();
   }
 
@@ -2873,7 +2873,7 @@ LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
     auto replaceWith = [&](ICmpPredicate predicate, Value lhs,
                            Value rhs) -> LogicalResult {
       replaceOpWithNewOpAndCopyName<ICmpOp>(rewriter, op, predicate, lhs, rhs,
-                                            false);
+                                            op.getTwoState());
       return success();
     };
 
@@ -2983,7 +2983,8 @@ LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
         if (rhs.isZero()) {
           // x == 0 -> x ^ 1
           replaceOpWithNewOpAndCopyName<XorOp>(rewriter, op, op.getLhs(),
-                                               getConstant(APInt(1, 1)), false);
+                                               getConstant(APInt(1, 1)),
+                                               op.getTwoState());
           return success();
         }
         if (rhs.isAllOnes()) {
@@ -3003,7 +3004,8 @@ LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
         if (rhs.isAllOnes()) {
           // x != 1 -> x ^ 1
           replaceOpWithNewOpAndCopyName<XorOp>(rewriter, op, op.getLhs(),
-                                               getConstant(APInt(1, 1)), false);
+                                               getConstant(APInt(1, 1)),
+                                               op.getTwoState());
           return success();
         }
       }
@@ -3045,7 +3047,7 @@ LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
                                            : APInt::getZero(width));
           replaceOpWithNewOpAndCopyName<ICmpOp>(rewriter, op, op.getPredicate(),
                                                 replicateOp.getInput(), cst,
-                                                false);
+                                                op.getTwoState());
           return success();
         }
     }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1466,3 +1466,11 @@ hw.module @MuxSimplify(%index: i1, %a: i1, %foo_0: i2, %foo_1: i2) -> (r_0: i2, 
 // CHECK-NEXT:  %15 = comb.or %14, %index : i1
 // CHECK-NEXT:  %16 = comb.mux bin %15, %foo_0, %foo_1 : i2
 // CHECK-NEXT:  hw.output %1, %3, %6, %8, %10, %13, %16
+
+// CHECK-LABEL: @twoStateICmp
+hw.module @twoStateICmp(%arg: i4) -> (cond: i1) {
+  // CHECK: %0 = comb.icmp bin eq %arg, %c-1_i4
+  %c-1_i4 = hw.constant -1 : i4
+  %0 = comb.icmp bin eq %c-1_i4, %arg : i4
+  hw.output %0 : i1
+}

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -84,21 +84,21 @@ circuit Qux: %[[{
 ;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
 ;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]]
 ;CHECK:    %12 = comb.icmp eq %rwAddr, %c0_i2 : i2
-;CHECK:    %13 = comb.and %rwEn, %rwMode, %rwMask, %12 : i1
+;CHECK:    %13 = comb.and bin %rwEn, %rwMode, %rwMask, %12 : i1
 ;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c1_i2 : i2
-;CHECK:    %15 = comb.and %rwEn, %rwMode, %rwMask, %14 : i1
+;CHECK:    %15 = comb.and bin %rwEn, %rwMode, %rwMask, %14 : i1
 ;CHECK:    %16 = comb.icmp bin eq %rwAddr, %c-2_i2 : i2
-;CHECK:    %17 = comb.and %rwEn, %rwMode, %rwMask, %16 : i1
+;CHECK:    %17 = comb.and bin %rwEn, %rwMode, %rwMask, %16 : i1
 ;CHECK:    %18 = comb.icmp bin eq %rwAddr, %c-1_i2 : i2
-;CHECK:    %19 = comb.and %rwEn, %rwMode, %rwMask, %18 : i1
+;CHECK:    %19 = comb.and bin %rwEn, %rwMode, %rwMask, %18 : i1
 ;CHECK:    %20 = comb.icmp eq %wAddr, %c0_i2 : i2
-;CHECK:    %21 = comb.and %wEn, %wMask, %20 : i1
+;CHECK:    %21 = comb.and bin %wEn, %wMask, %20 : i1
 ;CHECK:    %22 = comb.icmp bin eq %wAddr, %c1_i2 : i2
-;CHECK:    %23 = comb.and %wEn, %wMask, %22 : i1
+;CHECK:    %23 = comb.and bin %wEn, %wMask, %22 : i1
 ;CHECK:    %24 = comb.icmp bin eq %wAddr, %c-2_i2 : i2
-;CHECK:    %25 = comb.and %wEn, %wMask, %24 : i1
+;CHECK:    %25 = comb.and bin %wEn, %wMask, %24 : i1
 ;CHECK:    %26 = comb.icmp bin eq %wAddr, %c-1_i2 : i2
-;CHECK:    %27 = comb.and %wEn, %wMask, %26 : i1
+;CHECK:    %27 = comb.and bin %wEn, %wMask, %26 : i1
 ;CHECK:    sv.always posedge %clock {
 ;CHECK:      sv.if %21 {
 ;CHECK:        sv.passign %memory_0, %wData : i8


### PR DESCRIPTION
This PR changes to preserve twoState flags in icmp and flatten operands canonicalizations. The assertion failures should be fixed by https://github.com/llvm/circt/pull/4490.