### PR TITLE
[PrepareForEmission] Handle twoState flags in variadic op lowerings

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -285,6 +285,8 @@ static Value lowerFullyAssociativeOp(Operation &op, OperandRange operands,
   newOps.push_back(newOp);
   if (name)
     newOp->setAttr("sv.namehint", name);
+  if (auto twoState = op.getAttr("twoState"))
+    newOp->setAttr("twoState", twoState);
   return newOp->getResult(0);
 }
 
@@ -829,8 +831,10 @@ static void legalizeHWModule(Block &block, const LoweringOptions &options) {
         op.hasTrait<mlir::OpTrait::IsCommutative>() &&
         mlir::isMemoryEffectFree(&op) && op.getNumRegions() == 0 &&
         op.getNumSuccessors() == 0 &&
-        (op.getAttrs().empty() ||
-         (op.getAttrs().size() == 1 && op.hasAttr("sv.namehint")))) {
+        llvm::all_of(op.getAttrs(), [](auto attr) {
+          return attr.getName() == "sv.namehint" ||
+                 attr.getName() == "twoState";
+        })) {
       // Lower this operation to a balanced binary tree of the same operation.
       SmallVector<Operation *> newOps;
       auto result = lowerFullyAssociativeOp(op, op.getOperands(), newOps);

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -25,6 +25,15 @@ hw.module @outOfOrderInoutOperations(%a: i4) -> (c: i4) {
   hw.output %0: i4
 }
 
+// CHECK-LABEL: @twoState_variadic
+hw.module @twoState_variadic(%a: i1, %b: i1, %c: i1) -> (d:i1){
+  // CHECK:      %0 = comb.or bin %b, %c : i1
+  // CHECK-NEXT: %1 = comb.or bin %a, %0 : i1
+  // CHECK-NEXT: hw.output %1 : i1
+  %0 = comb.or bin %a, %b, %c: i1
+  hw.output %0: i1
+}
+
 // -----
 
 module {


### PR DESCRIPTION
PrepareForEmission has to handle `twoState` flags while variadic op lowering. This PR clones `twoState` flags to decomposed operations. Fix https://github.com/llvm/circt/issues/4489