### PR TITLE
[ExportVerilog] Inline bitcast op when only used by concat

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1333,3 +1333,17 @@ hw.module @Issue4485(%in: i4) {
   %2 = sv.system.sampled %1 : i1
   hw.output
 }
+
+
+// CHECK-LABEL: module inline_bitcast_in_concat(
+// CHECK-NEXT:    input  [6:0]      in1,
+// CHECK-NEXT:    input  [7:0][3:0] in2,
+// CHECK-NEXT:    output [38:0]     out);
+// CHECK-EMPTY:
+// CHECK-NEXT:    assign out = {in1, /*cast(bit[31:0])*/in2};
+// CHECK-NEXT:  endmodule
+hw.module @inline_bitcast_in_concat(%in1: i7, %in2: !hw.array<8xi4>) -> (out: i39) {
+  %r2 = hw.bitcast %in2 : (!hw.array<8xi4>) -> i32
+  %0 = comb.concat %in1, %r2: i7, i32
+  hw.output %0 : i39
+}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1334,7 +1334,6 @@ hw.module @Issue4485(%in: i4) {
   hw.output
 }
 
-
 // CHECK-LABEL: module inline_bitcast_in_concat(
 // CHECK-NEXT:    input  [6:0]      in1,
 // CHECK-NEXT:    input  [7:0][3:0] in2,


### PR DESCRIPTION
Bitcast is generally not allowed to be inlined but we can inline
if its user is (array)concat since they don't require type information.