### PR TITLE
[Seq] Create new clock enabled register op

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -68,6 +68,13 @@ passed to the `sv.reg` during lowering if present.
 
 Upon initialization, the state is defined to be uninitialized.
 
+### Variant: `seq.compreg.ce`
+
+This op is a version of compreg with the addition of a clock enable signal.
+Having the clock enable explicit (instead of a mux feeding it) is convenient for
+mapping to SV behavioral and will be (in the future) easier to map to device
+primitives or standard cells.
+
 ### Rationale
 
 Several design decisions were made in defining this op. Mostly, they were
@@ -82,10 +89,6 @@ optimization) another op could be added.
   (potentially complex) analysis to find the reset mux if required
   - Inclusion of 'resetValue': if we have a 'reset' signal, we need to
   include a value.
-  - Omission of 'enable': enables are easily modeled via a multiplexer on the
-  input with one of the mux inputs as the output of the register. This -- we
-  assume -- property makes 'enables' easier to detect than reset in the
-  common case.
 
 - Timing / clocking:
   - Omission of 'negedge' event on 'clock': this is easily modeled by

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -51,6 +51,40 @@ def CompRegOp : SeqOp<"compreg",
   ];
 }
 
+def CompRegClockEnabledOp : SeqOp<"compreg.ce",
+    [Pure, Clocked, Resettable,
+     AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
+     SameVariadicOperandSize,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
+       // AllTypesMatch doesn't work with Optional types yet.
+
+  let summary = "When enabled, register a value";
+  let description = "See the Seq dialect rationale for a longer description";
+
+  let arguments = (ins AnyType:$input, I1:$clk, I1:$clockEnable, StrAttr:$name,
+    Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+    OptionalAttr<SymbolNameAttr>:$sym_name);
+  let results = (outs AnyType:$data);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$ce,
+                   "StringRef":$sym_name), [{
+      return build($_builder, $_state, input.getType(),
+                   input, clk, ce, sym_name, Value(), Value(),
+                   StringAttr::get($_builder.getContext(), sym_name));
+    }]>,
+    OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$ce,
+                   "Value":$reset, "Value":$rstValue, "StringRef":$sym_name),
+    [{
+      return build($_builder, $_state, input.getType(),
+                   input, clk, ce, sym_name, reset, rstValue,
+                   StringAttr::get($_builder.getContext(), sym_name));
+    }]>,
+  ];
+}
+
 def FirRegOp : SeqOp<"firreg",
     [Pure, Clocked, Resettable,
      AllTypesMatch<["next", "data"/*, "resetValue"*/]>,

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -198,7 +198,8 @@ void HLMemOp::build(OpBuilder &builder, OperationState &result, Value clk,
 //===----------------------------------------------------------------------===//
 // CompRegOp
 
-ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
+template <bool ClockEnabled>
+static ParseResult parseCompReg(OpAsmParser &parser, OperationState &result) {
   llvm::SMLoc loc = parser.getCurrentLocation();
 
   if (succeeded(parser.parseOptionalKeyword("sym"))) {
@@ -207,7 +208,8 @@ ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
       return failure();
   }
 
-  SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
+  constexpr size_t clockEnabledOffset = (size_t)ClockEnabled;
+  SmallVector<OpAsmParser::UnresolvedOperand, 5> operands;
   if (parser.parseOperandList(operands))
     return failure();
   switch (operands.size()) {
@@ -215,15 +217,17 @@ ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(loc, "expected operands");
   case 1:
     return parser.emitError(loc, "expected clock operand");
-  case 2:
+  case 2 + clockEnabledOffset:
     // No reset.
     break;
-  case 3:
+  case 3 + clockEnabledOffset:
     return parser.emitError(loc, "expected resetValue operand");
-  case 4:
+  case 4 + clockEnabledOffset:
     // reset and reset value included.
     break;
   default:
+    if (ClockEnabled && operands.size() == 2)
+      return parser.emitError(loc, "expected clock enable");
     return parser.emitError(loc, "too many operands");
   }
 
@@ -231,36 +235,48 @@ ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
       parser.parseType(ty))
     return failure();
-  Type i1 = IntegerType::get(result.getContext(), 1);
 
   setNameFromResult(parser, result);
 
   result.addTypes({ty});
-  if (operands.size() == 2)
-    return parser.resolveOperands(operands, {ty, i1}, loc, result.operands);
-  else
-    return parser.resolveOperands(operands, {ty, i1, i1, ty}, loc,
-                                  result.operands);
+
+  Type i1 = IntegerType::get(result.getContext(), 1);
+  SmallVector<Type, 5> operandTypes;
+  operandTypes.append({ty, i1});
+  if (ClockEnabled)
+    operandTypes.push_back(i1);
+  if (operands.size() > 2 + clockEnabledOffset)
+    operandTypes.append({i1, ty});
+  return parser.resolveOperands(operands, operandTypes, loc, result.operands);
 }
 
-void CompRegOp::print(::mlir::OpAsmPrinter &p) {
+static void printClockEnable(::mlir::OpAsmPrinter &p, CompRegOp op) {}
+
+static void printClockEnable(::mlir::OpAsmPrinter &p,
+                             CompRegClockEnabledOp op) {
+  p << ", " << op.getClockEnable();
+}
+
+template <class Op>
+static void printCompReg(::mlir::OpAsmPrinter &p, Op op) {
   SmallVector<StringRef> elidedAttrs;
-  if (auto sym = getSymName()) {
+  if (auto sym = op.getSymName()) {
     elidedAttrs.push_back("sym_name");
     p << ' ' << "sym ";
     p.printSymbolName(*sym);
   }
 
-  p << ' ' << getInput() << ", " << getClk();
-  if (getReset())
-    p << ", " << getReset() << ", " << getResetValue() << ' ';
+  p << ' ' << op.getInput() << ", " << op.getClk();
+  printClockEnable(p, op);
+  if (op.getReset())
+    p << ", " << op.getReset() << ", " << op.getResetValue() << ' ';
 
   // Determine if 'name' can be elided.
-  if (canElideName(p, *this))
+  if (canElideName(p, op))
     elidedAttrs.push_back("name");
 
-  p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
-  p << " : " << getInput().getType();
+  p.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
+  p << " : " << op.getInput().getType();
 }
 
 /// Suggest a name for each result value based on the saved result names
@@ -276,6 +292,36 @@ LogicalResult CompRegOp::verify() {
     return emitOpError(
         "either reset and resetValue or neither must be specified");
   return success();
+}
+
+ParseResult CompRegOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseCompReg<false>(parser, result);
+}
+
+void CompRegOp::print(::mlir::OpAsmPrinter &p) { printCompReg(p, *this); }
+
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void CompRegClockEnabledOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // If the wire has an optional 'name' attribute, use it.
+  if (!getName().empty())
+    setNameFn(getResult(), getName());
+}
+
+LogicalResult CompRegClockEnabledOp::verify() {
+  if ((getReset() && !getResetValue()) || (!getReset() && getResetValue()))
+    return emitOpError(
+        "either reset and resetValue or neither must be specified");
+  return success();
+}
+
+ParseResult CompRegClockEnabledOp::parse(OpAsmParser &parser,
+                                         OperationState &result) {
+  return parseCompReg<true>(parser, result);
+}
+
+void CompRegClockEnabledOp::print(::mlir::OpAsmPrinter &p) {
+  printCompReg(p, *this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Seq/compreg-errors.mlir
+++ b/test/Dialect/Seq/compreg-errors.mlir
@@ -1,0 +1,50 @@
+// RUN: circt-opt %s -verify-diagnostics --split-input-file
+
+hw.module @top(%clk: i1, %rst: i1, %i: i32) {
+  // expected-error@+1 {{'seq.compreg' expected resetValue operand}}
+  seq.compreg %i, %clk, %rst : i32
+}
+
+// -----
+
+hw.module @top(%clk: i1, %rst: i1, %i: i32) {
+  // expected-error@+1 {{'seq.compreg' expected clock operand}}
+  seq.compreg %i : i32
+}
+
+// -----
+
+
+hw.module @top(%clk: i1, %rst: i1, %i: i32) {
+  // expected-error@+1 {{'seq.compreg' expected operands}}
+  seq.compreg : i32
+}
+
+// -----
+
+hw.module @top(%clk: i1, %rst: i1, %i: i32) {
+  %rv = hw.constant 0 : i32
+  // expected-error@+1 {{'seq.compreg' too many operands}}
+  seq.compreg %i, %clk, %rst, %rv, %rv : i32
+}
+
+// -----
+hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32) {
+  // expected-error@+1 {{'seq.compreg.ce' expected resetValue operand}}
+  %r0 = seq.compreg.ce %i, %clk, %ce, %rst : i32
+}
+
+// -----
+
+hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32) {
+  // expected-error@+1 {{'seq.compreg.ce' expected clock enable}}
+  %r0 = seq.compreg.ce %i, %clk : i32
+}
+
+// -----
+
+hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32) {
+  %rv = hw.constant 0 : i32
+  // expected-error@+1 {{'seq.compreg.ce' too many operands}}
+  %r0 = seq.compreg.ce %i, %clk, %ce, %rst, %rv, %rv : i32
+}

--- a/test/Dialect/Seq/compreg.mlir
+++ b/test/Dialect/Seq/compreg.mlir
@@ -46,3 +46,19 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // SV: %bar = sv.reg sym @reg1
   // SV: sv.reg sym @reg2
 }
+
+hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32, %s: !hw.struct<foo: i32>) {
+  %rv = hw.constant 0 : i32
+
+  %r0 = seq.compreg.ce %i, %clk, %ce, %rst, %rv : i32
+  // CHECK: %r0 = seq.compreg.ce %i, %clk, %ce, %rst, %c0_i32  : i32
+  // SV: [[REG_CE0:%.+]] = sv.reg  : !hw.inout<i32>
+  // SV: [[REG_CE5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
+  // SV: sv.alwaysff(posedge %clk)  {
+  // SV:   sv.if %ce {
+  // SV:     sv.passign [[REG_CE0]], %i : i32
+  // SV:   }
+  // SV: }(syncreset : posedge %rst)  {
+  // SV:   sv.passign [[REG_CE0]], %c0_i32 : i32
+  // SV: }
+}

--- a/test/Dialect/Seq/compreg.mlir
+++ b/test/Dialect/Seq/compreg.mlir
@@ -47,7 +47,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // SV: sv.reg sym @reg2
 }
 
-hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32, %s: !hw.struct<foo: i32>) {
+hw.module @top_ce(%clk: i1, %rst: i1, %ce: i1, %i: i32) {
   %rv = hw.constant 0 : i32
 
   %r0 = seq.compreg.ce %i, %clk, %ce, %rst, %rv : i32


### PR DESCRIPTION
Introduces `compreg.ce` which is identical to the existing `compreg` but includes a `clockEnable` signal to enable/disable reading the input. This op makes it easier to create SV with the behavioral syntax rather than the structural mux that we currently construct. Could be lowered into the structural mux if that is desired.