### PR TITLE
[FIRRTL] Allow aggregate in MemTaps and DataTaps

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -837,7 +837,8 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
             "exist and unique instance cannot be resolved");
       srcTarget->instances.append(path.back().begin(), path.back().end());
     }
-    if (tapsAttr.size() != combMem.getType().getNumElements())
+    if (tapsAttr.size() != 1 &&
+        tapsAttr.size() != combMem.getType().getNumElements())
       return mlir::emitError(
           loc, "sink cannot specify more taps than the depth of the memory");
   } else

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -72,7 +72,7 @@ circuit Top : %[[
 
   module Bar :
 
-    wire inv : UInt<1>
+    wire inv : {a : UInt<1>, b : UInt<2>}
     inv is invalid
 
   module Foo :
@@ -83,7 +83,7 @@ circuit Top : %[[
 
     inst foo of Foo
 
-    wire tap : UInt<1>
+    wire tap : {a : UInt<1>, b : UInt<2>}
     tap is invalid
 
     wire tap2 : UInt<1>
@@ -109,9 +109,14 @@ circuit Top : %[[
 ; CHECK-NEXT:      .[[Child_boredPort]] ([[ChildWrapper_boredPort]])
 ; CHECK:       endmodule
 
+; CHECK: module Bar();
+; CHECK:   wire       [[inv_a:[a-zA-Z0-9_]+]]
+; CHECK:   wire [1:0] [[inv_b:[a-zA-Z0-9_]+]]
+
 ; CHECK-LABEL: module Top(
 ; CHECK-NOT:   endmodule
-; CHECK:         assign tap = Top.foo.b.inv;
+; CHECK:         assign tap_a = Top.foo.b.[[inv_a]];
+; CHECK:         assign tap_b = Top.foo.b.[[inv_b]];
 ; CHECK-NEXT:    assign tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
 ; CHECK-NEXT:    assign tap3 = Top.unsigned_0.signed_0.localparam_0.random.something_else;
 ; CHECK:         ChildWrapper unsigned_0 (

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -13,14 +13,7 @@ circuit Top : %[[
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
     "source":"~Top|DUTModule>rf",
     "sink":[
-      "~Top|Top>memTap[0]",
-      "~Top|Top>memTap[1]",
-      "~Top|Top>memTap[2]",
-      "~Top|Top>memTap[3]",
-      "~Top|Top>memTap[4]",
-      "~Top|Top>memTap[5]",
-      "~Top|Top>memTap[6]",
-      "~Top|Top>memTap[7]"
+      "~Top|Top>memTap"
     ]
   }
 ]]

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1106,6 +1106,12 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>
   }
 
+  firrtl.module private @RecursiveRef(in %arg: !firrtl.ref<bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>>) {
+    %0 = firrtl.ref.resolve %arg : !firrtl.ref<bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>>
+    // CHECK:  firrtl.ref.resolve %arg_foo_bar_baz : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.ref.resolve %arg_foo_qux : !firrtl.ref<sint<64>>
+  }
+
   // CHECK-LABEL: firrtl.module private @ForeignTypes
   firrtl.module private @ForeignTypes() {
     // CHECK-NEXT: firrtl.wire : index


### PR DESCRIPTION
Make sure GrandCentral Taps can handle aggregate types. Added a few tests to check RefType of bundles and vectors are lowered correctly. 