### PR TITLE
[firtool] Strip mux pragmas by default, NFC

### DIFF
--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -25,7 +25,7 @@ namespace circt {
 
 std::unique_ptr<mlir::Pass> createLowerFIRRTLToHWPass(
     bool enableAnnotationWarning = false, bool emitChiselAssertsAsSVA = false,
-    bool stripMuxPragmas = false, bool disableMemRandomization = false,
+    bool addMuxPragmas = false, bool disableMemRandomization = false,
     bool disableRegRandomization = false);
 
 } // namespace circt

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -297,8 +297,8 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
     "Emit warnings on unprocessed annotations during lower-to-hw pass">,
     Option<"emitChiselAssertsAsSVA", "emit-chisel-asserts-as-sva",
            "bool", "false","Convert all Chisel asserts to SVA">,
-    Option<"stripMuxPragmas", "strip-mux-pragmas", "bool", "false",
-            "Do not annotate mux pragmas to multibit mux and subacess results">
+    Option<"addMuxPragmas", "add-mux-pragmas", "bool", "false",
+            "Annotate mux pragmas to multibit mux and subacess results">
   ];
 }
 

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -27,7 +27,7 @@ std::unique_ptr<mlir::Pass> createSVTraceIVerilogPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass(
     bool replSeqMem = false, bool ignoreReadEnableMem = false,
-    bool stripMuxPragmas = false, bool disableMemRandomization = false,
+    bool addMuxPragmas = false, bool disableMemRandomization = false,
     bool disableRegRandomization = false,
     bool addVivadoRAMAddressConflictSynthesisBugWorkaround = false);
 std::unique_ptr<mlir::Pass>

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -103,8 +103,8 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
     Option<"ignoreReadEnableMem", "ignore-read-enable-mem", "bool",
                 "false",
     "ignore the read enable signal, instead of assigning X on read disable">,
-    Option<"stripMuxPragmas", "strip-mux-pragmas", "bool", "false",
-            "Do not annotate mux pragmas to memory reads">,
+    Option<"addMuxPragmas", "add-mux-pragmas", "bool", "false",
+            "Add mux pragmas to memory reads">,
     Option<"addVivadoRAMAddressConflictSynthesisBugWorkaround",
            "add-vivado-ram-address-conflict-synthesis-bug-workaround", "bool", "false",
             "Add a vivado attribute to specify a ram style of an array register">

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -335,10 +335,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %[[FILLER:.+]] = hw.array_create %[[GET0]] : i1
     // CHECK-NEXT: %[[EXT:.+]] = hw.array_concat %[[FILLER]], %[[ARRAY]]
     // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[EXT]][%[[ZEXT_INDEX]]]
-    // CHECK-NEXT: %[[WIRE:.+]] = sv.wire
-    // CHECK-NEXT: sv.assign %[[WIRE]], %[[ARRAY_GET]]
-    // CHECK-NEXT: %[[READ_WIRE:.+]] = sv.read_inout %[[WIRE]] : !hw.inout<i1>
-    // CHECK: hw.output %false, %[[READ_WIRE]] : i1, i1
+    // CHECK: hw.output %false, %[[ARRAY_GET]] : i1, i1
     firrtl.connect %out2, %61 : !firrtl.sint<1>, !firrtl.sint<1>
   }
 
@@ -1180,10 +1177,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %[[EXTArray:.+]] = hw.array_create %[[EXTValue]], %[[EXTValue]], %[[EXTValue]]
     // CHECK-NEXT: %[[Array:.+]] = hw.array_concat %[[EXTArray]], %a
     // CHECK-NEXT: %[[READ:.+]] = hw.array_get %[[Array]][%3]
-    // CHECK-NEXT: %[[valWire:.+]] = sv.wire  : !hw.inout<i1>
-    // CHECK-NEXT: sv.assign %[[valWire]], %[[READ]]
-    // CHECK-NEXT: %[[RD:.+]] = sv.read_inout %[[valWire]] : !hw.inout<i1>
-    // CHECK-NEXT: sv.assign %2, %[[RD]] : i1
+    // CHECK-NEXT: sv.assign %2, %[[READ]] : i1
     // CHECK-NEXT: hw.output %0 : !hw.array<5xi1>
   }
 
@@ -1321,11 +1315,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %1 = hw.array_get %0[%c0_i2]
     // CHECK-NEXT: %2 = hw.array_create %1 : i1
     // CHECK-NEXT: %3 = hw.array_concat %2, %0
-    // CHECK-NEXT: %4 = hw.array_get %3[%index] {sv.attributes = #sv.attributes<[#sv.attribute<"cadence map_to_mux">], emitAsComments>}
-    // CHECK-NEXT: %5 = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: sv.assign %5, %4 {sv.attributes = #sv.attributes<[#sv.attribute<"synopsys infer_mux_override">], emitAsComments>}
-    // CHECK-NEXT: %6 = sv.read_inout %5 : !hw.inout<i1>
-    // CHECK-NEXT: hw.output %6 : i1
+    // CHECK-NEXT: %4 = hw.array_get %3[%index]
+    // CHECK-NEXT: hw.output %4 : i1
   }
 
   firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -36,7 +36,5 @@ circuit test: %[[{
   ; CHEC-OLD: assign out0 = 8'h0;
   ; CHEC-OLD: assign out1 = 8'h0;
 
-  ; CHECK: assign [[g1:.*]] = 8'h0;
-  ; CHECK: assign [[g2:.*]] = 8'h0;
-  ; CHECK: assign out0 = [[g1]];
-  ; CHECK: assign out1 = [[g2]];
+  ; CHECK: assign out0 = 8'h0;
+  ; CHECK: assign out1 = 8'h0;

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -268,10 +268,7 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; VERILOG-LABEL: module MultibitMux(
 ; VERILOG:  wire [3:0] [[T2:.*]] =
 ; VERILOG-SAME{LITERAL}: {{a_0}, {a_2}, {a_1}, {a_0}};
-; VERILOG:  wire [[T1:.*]];
-; VERILOG-NEXT:  /* synopsys infer_mux_override */
-; VERILOG-NEXT:  assign [[T1]] = [[T2]][sel] /* cadence map_to_mux */;
-; VERILOG-NEXT:  assign b = [[T1]];
+; VERILOG-NEXT:  assign b = [[T2]][sel];
 
   module UnusedPortsMod :
     input in : UInt<1>

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,5 +1,5 @@
-; RUN: firtool %s --format=fir --ir-sv | FileCheck %s --check-prefixes=CHECK,COMMON
-; RUN: firtool %s --format=fir --ir-sv -strip-mux-pragmas | FileCheck %s --check-prefix COMMON --implicit-check-not sv.attributes
+; RUN: firtool %s --format=fir --ir-sv | FileCheck %s --check-prefixes=CHECK,COMMON --implicit-check-not sv.attributes
+; RUN: firtool %s --format=fir --ir-sv -add-mux-pragmas | FileCheck %s --check-prefix COMMON
 ; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
 ; RUN: firtool %s --format=fir --ir-sv -disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
 ; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization --disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
@@ -76,58 +76,53 @@ circuit Qux: %[[{
 ;CHECK:    %[[addr:.+]] = sv.reg
 ;CHECK:    %[[v4:.+]] = sv.read_inout %[[addr]]
 ;CHECK:    %[[v5:.+]] = hw.array_create
-;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%[[v4]]]
-;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    sv.assign %[[multbit_mux_wire]], %[[array_get]]
-;CHECK:    %[[v6:.+]] = sv.read_inout %[[multbit_mux_wire]]
-;CHECK:    %[[array_get:.+]] = hw.array_get %[[v5]][%rwAddr]
-;CHECK:    %[[multbit_mux_wire:.+]] = sv.wire  : !hw.inout<i8>
-;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]]
-;CHECK:    %12 = comb.icmp eq %rwAddr, %c0_i2 : i2
+;CHECK:    %[[v6:.+]] = hw.array_get %[[v5]][%[[v4]]]
+;CHECK:    %[[v7:.+]] = hw.array_get %[[v5]][%rwAddr]
+;CHECK:    %8 = comb.icmp eq %rwAddr, %c0_i2 : i2
+;CHECK:    %9 = comb.and %rwEn, %rwMode, %rwMask, %8 : i1
+;CHECK:    %10 = comb.icmp bin eq %rwAddr, %c1_i2 : i2
+;CHECK:    %11 = comb.and %rwEn, %rwMode, %rwMask, %10 : i1
+;CHECK:    %12 = comb.icmp bin eq %rwAddr, %c-2_i2 : i2
 ;CHECK:    %13 = comb.and %rwEn, %rwMode, %rwMask, %12 : i1
-;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c1_i2 : i2
+;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c-1_i2 : i2
 ;CHECK:    %15 = comb.and %rwEn, %rwMode, %rwMask, %14 : i1
-;CHECK:    %16 = comb.icmp bin eq %rwAddr, %c-2_i2 : i2
-;CHECK:    %17 = comb.and %rwEn, %rwMode, %rwMask, %16 : i1
-;CHECK:    %18 = comb.icmp bin eq %rwAddr, %c-1_i2 : i2
-;CHECK:    %19 = comb.and %rwEn, %rwMode, %rwMask, %18 : i1
-;CHECK:    %20 = comb.icmp eq %wAddr, %c0_i2 : i2
+;CHECK:    %16 = comb.icmp eq %wAddr, %c0_i2 : i2
+;CHECK:    %17 = comb.and %wEn, %wMask, %16 : i1
+;CHECK:    %18 = comb.icmp bin eq %wAddr, %c1_i2 : i2
+;CHECK:    %19 = comb.and %wEn, %wMask, %18 : i1
+;CHECK:    %20 = comb.icmp bin eq %wAddr, %c-2_i2 : i2
 ;CHECK:    %21 = comb.and %wEn, %wMask, %20 : i1
-;CHECK:    %22 = comb.icmp bin eq %wAddr, %c1_i2 : i2
+;CHECK:    %22 = comb.icmp bin eq %wAddr, %c-1_i2 : i2
 ;CHECK:    %23 = comb.and %wEn, %wMask, %22 : i1
-;CHECK:    %24 = comb.icmp bin eq %wAddr, %c-2_i2 : i2
-;CHECK:    %25 = comb.and %wEn, %wMask, %24 : i1
-;CHECK:    %26 = comb.icmp bin eq %wAddr, %c-1_i2 : i2
-;CHECK:    %27 = comb.and %wEn, %wMask, %26 : i1
 ;CHECK:    sv.always posedge %clock {
-;CHECK:      sv.if %21 {
+;CHECK:      sv.if %17 {
 ;CHECK:        sv.passign %memory_0, %wData : i8
 ;CHECK:      } else {
-;CHECK:        sv.if %13 {
+;CHECK:        sv.if %9 {
 ;CHECK:          sv.passign %memory_0, %rwDataIn : i8
 ;CHECK:        }
 ;CHECK:      }
-;CHECK:      sv.if %23 {
+;CHECK:      sv.if %19 {
 ;CHECK:        sv.passign %memory_1, %wData : i8
 ;CHECK:      } else {
-;CHECK:        sv.if %15 {
+;CHECK:        sv.if %11 {
 ;CHECK:          sv.passign %memory_1, %rwDataIn : i8
 ;CHECK:        }
 ;CHECK:      }
-;CHECK:      sv.if %25 {
+;CHECK:      sv.if %21 {
 ;CHECK:        sv.passign %memory_2, %wData : i8
 ;CHECK:      } else {
-;CHECK:        sv.if %17 {
+;CHECK:        sv.if %13 {
 ;CHECK:          sv.passign %memory_2, %rwDataIn : i8
 ;CHECK:        }
 ;CHECK:      }
-;CHECK:      sv.if %27 {
+;CHECK:      sv.if %23 {
 ;CHECK:        sv.passign %memory_3, %wData : i8
 ;CHECK:      } else {
-;CHECK:        sv.if %19 {
+;CHECK:        sv.if %15 {
 ;CHECK:          sv.passign %memory_3, %rwDataIn : i8
 ;CHECK:        }
 ;CHECK:      }
 ;CHECK:      sv.passign %addr, %rAddr : i2
 ;CHECK:    }
-;CHECK:    hw.output %[[v6]], %[[v7]]
+;CHECK:    hw.output %6, %7 : i8, i8

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,5 +1,5 @@
 ; RUN: firtool %s --format=fir --ir-sv | FileCheck %s --check-prefixes=CHECK,COMMON --implicit-check-not sv.attributes
-; RUN: firtool %s --format=fir --ir-sv -add-mux-pragmas | FileCheck %s --check-prefix COMMON
+; RUN: firtool %s --format=fir --ir-sv -add-mux-pragmas -strip-mux-pragmas=0 | FileCheck %s --check-prefix COMMON
 ; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
 ; RUN: firtool %s --format=fir --ir-sv -disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
 ; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization --disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -125,4 +125,4 @@ circuit Qux: %[[{
 ;CHECK:      }
 ;CHECK:      sv.passign %addr, %rAddr : i2
 ;CHECK:    }
-;CHECK:    hw.output %6, %7 : i8, i8
+;CHECK:    hw.output %[[v6]], %[[v7]]

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -116,7 +116,7 @@ static cl::opt<bool> addMuxPragmas("add-mux-pragmas",
 
 static cl::opt<bool> stripMuxPragmas(
     "strip-mux-pragmas",
-    cl::desc("Strip mux pragmas. This options was deprecated since annotate "
+    cl::desc("Strip mux pragmas. This option was deprecated since mux pragma annotatations are not...");
              "mux pragmas are not emitted by default"),
     cl::init(false), cl::cat(mainCategory));
 


### PR DESCRIPTION
This PR deprecates `strip-mux-pragmas` flag and add `add-mux-pragmas` flag. Mux pragmas will not be emitted by default. `strip-mux-pragmas` is not deleted for now so that we can deploy a new version of firtool more smoothly. 