### PR TITLE
[FIRRTL][SV][ExportVerilog] allow message on covers (but no substitutions), emit as comments

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -118,8 +118,16 @@ def AtEdge   : I32EnumAttrCase<"AtEdge", 2, "edge">;
 def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
                                    [AtPosEdge, AtNegEdge, AtEdge]>  {}
 
+/// A constraint checking no substitutions if no message.
+def NoSubstitutionsIfNoMessage : PredOpTrait<"has message if has substitutions",
+  CPred<"!$message.empty() || $substitutions.empty()">>;
+
+/// A constraint forcing `cover` ops to have no substitutions.
+def NoSubstitutionsVerif : PredOpTrait<"has no substitutions",
+  CPred<"$substitutions.empty()">>;
+
 class VerifOp<string mnemonic, list<Trait> traits = []> :
-    FIRRTLOp<mnemonic, traits> {
+    FIRRTLOp<mnemonic, [ NoSubstitutionsIfNoMessage ] # traits> {
   let arguments = (ins
     ClockType:$clock,
     UInt1Type:$predicate,
@@ -148,7 +156,7 @@ def AssumeOp : VerifOp<"assume"> {
   let summary = "Assume Verification Statement";
 }
 
-def CoverOp : VerifOp<"cover"> {
+def CoverOp : VerifOp<"cover", [NoSubstitutionsVerif]> {
   let summary = "Cover Verification Statement";
 }
 

--- a/include/circt/Dialect/SV/SVVerification.td
+++ b/include/circt/Dialect/SV/SVVerification.td
@@ -26,9 +26,9 @@ def DeferAssertAttr : I32EnumAttr<
   let cppNamespace = "circt::sv";
 }
 
-/// A constraint forcing `cover` ops to have no message.
-def NoMessageVerif : PredOpTrait<"has no message",
-  CPred<"!$message && $substitutions.empty()">>;
+/// A constraint forcing `cover` ops to have no substitutions.
+def NoSubstitutionsVerif : PredOpTrait<"has no substitutions",
+  CPred<"$substitutions.empty()">>;
 
 /// Immediate verification operations defined by the SV standard.
 class ImmediateVerifOp<string mnemonic, list<Trait> traits = []> :
@@ -81,7 +81,7 @@ def AssumeOp : ImmediateVerifOp<"assume"> {
   }];
 }
 
-def CoverOp : ImmediateVerifOp<"cover", [NoMessageVerif]> {
+def CoverOp : ImmediateVerifOp<"cover", [NoSubstitutionsVerif]> {
   let summary = "immediate cover statement";
   let description = [{
     Specify that a Boolean expression should be monitored for coverage, i.e., a
@@ -147,7 +147,7 @@ def AssumeConcurrentOp : ConcurrentVerifOp<"assume.concurrent"> {
 }
 
 def CoverConcurrentOp : ConcurrentVerifOp<"cover.concurrent",
-                                          [NoMessageVerif]> {
+                                          [NoSubstitutionsVerif]> {
   let summary = "concurrent cover statement, i.e., cover property";
   let description = [{
     Specify that a specific property should be monitored for coverage, i.e., a

--- a/include/circt/Dialect/SV/SVVerification.td
+++ b/include/circt/Dialect/SV/SVVerification.td
@@ -26,13 +26,17 @@ def DeferAssertAttr : I32EnumAttr<
   let cppNamespace = "circt::sv";
 }
 
+/// A constraint checking no substitutions if no message.
+def NoSubstitutionsIfNoMessage : PredOpTrait<"has message if has substitutions",
+  CPred<"($message && !$message->empty()) || $substitutions.empty()">>;
+
 /// A constraint forcing `cover` ops to have no substitutions.
 def NoSubstitutionsVerif : PredOpTrait<"has no substitutions",
   CPred<"$substitutions.empty()">>;
 
 /// Immediate verification operations defined by the SV standard.
 class ImmediateVerifOp<string mnemonic, list<Trait> traits = []> :
-    SVOp<mnemonic, [ProceduralOp] # traits> {
+    SVOp<mnemonic, [ProceduralOp, NoSubstitutionsIfNoMessage] # traits> {
   let arguments = (ins
     I1:$expression,
     DeferAssertAttr:$defer,
@@ -92,7 +96,7 @@ def CoverOp : ImmediateVerifOp<"cover", [NoSubstitutionsVerif]> {
 
 /// Concurrent verification operations defined by the SV standard.
 class ConcurrentVerifOp<string mnemonic, list<Trait> traits = []> :
-    SVOp<mnemonic, traits> {
+    SVOp<mnemonic, [NoSubstitutionsIfNoMessage] # traits> {
   let arguments = (ins
     EventControlAttr:$event, I1:$clock, I1:$property,
     OptionalAttr<StrAttr>:$label,

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3042,17 +3042,20 @@ private:
   LogicalResult visitSV(GenerateCaseOp op);
 
   std::optional<PPExtString> getAssertionLabel(Operation *op, StringRef opName);
-  void emitWithOptionalLabel(std::optional<PPExtString> label, llvm::function_ref<void(void)> emitFn);
+  void emitWithOptionalLabel(std::optional<PPExtString> label,
+                             llvm::function_ref<void(void)> emitFn);
   void emitAssertionMessage(StringAttr message, ValueRange args,
                             SmallPtrSetImpl<Operation *> &ops,
                             bool isConcurrent);
   template <typename Op>
-  LogicalResult emitImmediateAssertion(Op op, PPExtString opName, bool messageAsComment = false);
+  LogicalResult emitImmediateAssertion(Op op, PPExtString opName,
+                                       bool messageAsComment = false);
   LogicalResult visitSV(AssertOp op);
   LogicalResult visitSV(AssumeOp op);
   LogicalResult visitSV(CoverOp op);
   template <typename Op>
-  LogicalResult emitConcurrentAssertion(Op op, PPExtString opName, bool messageAsComment = false);
+  LogicalResult emitConcurrentAssertion(Op op, PPExtString opName,
+                                        bool messageAsComment = false);
   LogicalResult visitSV(AssertConcurrentOp op);
   LogicalResult visitSV(AssumeConcurrentOp op);
   LogicalResult visitSV(CoverConcurrentOp op);
@@ -3604,15 +3607,16 @@ LogicalResult StmtEmitter::visitSV(GenerateCaseOp op) {
   return success();
 }
 
-/// Get the `<label>` (no colon) portion of an immediate or concurrent verification
-/// operation. If a label has been stored for the operation through
+/// Get the `<label>` (no colon) portion of an immediate or concurrent
+/// verification operation. If a label has been stored for the operation through
 /// `addLegalName` in the pre-pass, that label is used. Otherwise, if the
 /// `enforceVerifLabels` option is set, a temporary name for the operation is
 /// picked and uniquified through `addName`.
-std::optional<PPExtString> StmtEmitter::getAssertionLabel(Operation *op, StringRef opName) {
+std::optional<PPExtString> StmtEmitter::getAssertionLabel(Operation *op,
+                                                          StringRef opName) {
   if (op->getAttrOfType<StringAttr>("label"))
     return PPExtString(names.getName(op));
-   if (state.options.enforceVerifLabels)
+  if (state.options.enforceVerifLabels)
     return PPExtString(names.addName(op, opName));
   return std::nullopt;
 }
@@ -3636,8 +3640,10 @@ void StmtEmitter::emitAssertionMessage(StringAttr message, ValueRange args,
   });
 }
 
-/// Print a label if specified, then invoke emitFn in an appropriate printing box.
-void StmtEmitter::emitWithOptionalLabel(std::optional<PPExtString> label, llvm::function_ref<void(void)> emitFn) {
+/// Print a label if specified, then invoke emitFn in an appropriate printing
+/// box.
+void StmtEmitter::emitWithOptionalLabel(std::optional<PPExtString> label,
+                                        llvm::function_ref<void(void)> emitFn) {
   // Emit label if specified, indent if break after label.
   startStatement();
   if (label)
@@ -3650,7 +3656,8 @@ void StmtEmitter::emitWithOptionalLabel(std::optional<PPExtString> label, llvm::
 }
 
 template <typename Op>
-LogicalResult StmtEmitter::emitImmediateAssertion(Op op, PPExtString opName, bool messageAsComment) {
+LogicalResult StmtEmitter::emitImmediateAssertion(Op op, PPExtString opName,
+                                                  bool messageAsComment) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
@@ -3702,7 +3709,8 @@ LogicalResult StmtEmitter::visitSV(CoverOp op) {
 }
 
 template <typename Op>
-LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, PPExtString opName, bool messageAsComment) {
+LogicalResult StmtEmitter::emitConcurrentAssertion(Op op, PPExtString opName,
+                                                   bool messageAsComment) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3927,8 +3927,9 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
 
   StringAttr message;
   SmallVector<Value> messageOps;
-  if (!isCover && opMessageAttr && !opMessageAttr.getValue().empty()) {
+  if (opMessageAttr && !opMessageAttr.getValue().empty()) {
     message = opMessageAttr;
+    assert(!isCover || opOperands.empty());
     for (auto operand : opOperands) {
       auto loweredValue = getLoweredValue(operand);
       if (!loweredValue) {

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -47,24 +47,45 @@ hw.module @CoverAssert(
 
     %0 = comb.icmp eq %eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0, %c0_i4 : i4
     %1 = comb.icmp eq %eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0, %c0_i4 : i4
+    %2 = comb.icmp eq %eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0, %c0_i4 : i4
+    %3 = comb.icmp eq %eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0, %c0_i4 : i4
 
-    %2 = comb.xor bin %reset, %true : i1
-    %3 = comb.xor bin %reset, %true : i1
-    %4 = comb.and bin %0, %2 : i1
-    %5 = comb.and bin %1, %3 : i1
+    %4 = comb.xor bin %reset, %true : i1
+    %5 = comb.xor bin %reset, %true : i1
+    %6 = comb.xor bin %reset, %true : i1
+    %7 = comb.xor bin %reset, %true : i1
 
-//      CHECK:  cover__information_label:
+    %8 = comb.and bin %0, %4 : i1
+    %9 = comb.and bin %1, %5 : i1
+    %10 = comb.and bin %2, %6 : i1
+    %11 = comb.and bin %3, %7 : i1
+
+//      CHECK:  cover__information_label: // test message
 // CHECK-NEXT:    cover property (@(posedge clock)
 // CHECK-NEXT:                    eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
 // CHECK-NEXT:                    & ~reset);{{.*}}
-    sv.cover.concurrent posedge %clock, %4 label "cover__information_label"
+    sv.cover.concurrent posedge %clock, %8 label "cover__information_label" message "test message"
+
+//      CHECK:  cover__information_label_2:
+// CHECK-NEXT:    // cover message very long text goes here it never ends it goes on and on and hits the
+// CHECK-NEXT:    // wrapping limit
+// CHECK-NEXT:    cover property (@(posedge clock)
+// CHECK-NEXT:                    eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
+// CHECK-NEXT:                    & ~reset);{{.*}}
+    sv.cover.concurrent posedge %clock, %9 label "cover__information_label_2" message "cover message very long text goes here it never ends it goes on and on and hits the wrapping limit"
 
 //      CHECK:  assert__label:
 // CHECK-NEXT:    assert property (@(posedge clock)
 // CHECK-NEXT:                     eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
 // CHECK-NEXT:                     & ~reset)
 // CHECK-NEXT:    else $error("assert failed");	{{.*}}
-    sv.assert.concurrent posedge %clock, %5 label "assert__label" message "assert failed"
+    sv.assert.concurrent posedge %clock, %10 label "assert__label" message "assert failed"
+
+     // CHECK:  assert property (@(posedge clock)
+// CHECK-NEXT:                   eeeeee_fffff_gggggg_hhh_i_jjjjj_kkkkkkkkk_lllllll_mmmmmmmmm_nnnnnnnn_0 == 4'h0
+// CHECK-NEXT:                   & ~reset)
+// CHECK-NEXT:  else $error("assert failed");	{{.*}}
+    sv.assert.concurrent posedge %clock, %11 message "assert failed"
 }
 
 hw.module @MuxChain(%a_0: i1, %a_1: i1, %a_2: i1, %c_0: i1, %c_1: i1, %c_2: i1) -> (out: i1) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -193,10 +193,14 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.cover %cond, final
       // CHECK-NEXT:     cover_0: cover(cond);
       sv.cover %cond, immediate label "cover_0"
-      // CHECK-NEXT:     // cover message
+      // CHECK-NEXT:     // cover cond message text
       // CHECK-NEXT:     cover(cond);
       // CHECK-NOT: else
-      sv.cover %cond, immediate message "cover message"
+      sv.cover %cond, immediate message "cover cond message text"
+      // CHECK-NEXT:     cover_message: // cover cond message text
+      // CHECK-NEXT:     cover(cond);
+      // CHECK-NOT: else
+      sv.cover %cond, immediate label "cover_message" message "cover cond message text"
 
       // Simulator Control Tasks
       // CHECK-NEXT: $stop;
@@ -280,8 +284,8 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   sv.cover.concurrent posedge %clock, %cond
   // CHECK-NEXT: cover_1: cover property (@(posedge clock) cond);
   sv.cover.concurrent posedge %clock, %cond label "cover_1"
-  // CHECK-NEXT: // cover_2 message
-  // CHECK-NEXT: cover_2: cover property (@(posedge clock) cond);
+  // CHECK-NEXT: cover_2: // cover_2 message
+  // CHECK-NEXT:   cover property (@(posedge clock) cond);
   // CHECK-NOT: else
   sv.cover.concurrent posedge %clock, %cond label "cover_2" message "cover_2 message"
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -193,6 +193,10 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.cover %cond, final
       // CHECK-NEXT:     cover_0: cover(cond);
       sv.cover %cond, immediate label "cover_0"
+      // CHECK-NEXT:     // cover message
+      // CHECK-NEXT:     cover(cond);
+      // CHECK-NOT: else
+      sv.cover %cond, immediate message "cover message"
 
       // Simulator Control Tasks
       // CHECK-NEXT: $stop;
@@ -276,6 +280,10 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   sv.cover.concurrent posedge %clock, %cond
   // CHECK-NEXT: cover_1: cover property (@(posedge clock) cond);
   sv.cover.concurrent posedge %clock, %cond label "cover_1"
+  // CHECK-NEXT: // cover_2 message
+  // CHECK-NEXT: cover_2: cover property (@(posedge clock) cond);
+  // CHECK-NOT: else
+  sv.cover.concurrent posedge %clock, %cond label "cover_2" message "cover_2 message"
 
   // CHECK-NEXT: initial
   // CHECK-NOT: begin

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -477,13 +477,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"([[SAMPLED]]) : i42
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
-    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
     // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover__cover_0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
     firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
     firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
     // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover__cover_1"
@@ -504,8 +501,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     sv.cover %cCond, immediate
     // CHECK-NOT:        label
     // CHECK-NEXT:     sv.cover %cCond, immediate label "cover__cover_0"
-    // CHECK-NEXT:     sv.cover %cCond, immediate
-    // CHECK-NOT:        label
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"
@@ -516,7 +511,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42>
     firrtl.cover %clock, %cCond, %cEn, "cover0"
     firrtl.cover %clock, %cCond, %cEn, "cover0" {name = "cover_0"}
-    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42>
     // CHECK-NEXT: hw.output
   }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1094,3 +1094,13 @@ firrtl.circuit "hi" {
     // expected-error @below {{redefinition of symbol named 'hi'}}
     firrtl.module @hi() {}
 }
+
+// -----
+
+// No substitutions allowed for cover.
+firrtl.circuit "coverSubst" {
+  firrtl.module @coverSubst(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %cond : !firrtl.uint<1>, in %value : !firrtl.uint<4>) {
+    // expected-error @below {{failed to verify that has no substitutions}}
+    firrtl.cover %clock, %cond, %enable, "message"(%value) : !firrtl.uint<4>
+ }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1104,3 +1104,13 @@ firrtl.circuit "coverSubst" {
     firrtl.cover %clock, %cond, %enable, "message"(%value) : !firrtl.uint<4>
  }
 }
+
+// -----
+
+// No substitutions allowed without message.
+firrtl.circuit "noSubstWithoutMessage" {
+  firrtl.module @noSubstWithoutMessage(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %cond : !firrtl.uint<1>, in %value : !firrtl.uint<4>) {
+    // expected-error @below {{failed to verify that has message if has substitutions}}
+    firrtl.assert %clock, %cond, %enable, ""(%value) : !firrtl.uint<4>
+ }
+}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1115,12 +1115,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; Predicate modifier `noMod`
     when not(cond):
-      printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}", value)
+      printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}")
     assert(clock, cond, enable, "")
     ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
-    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
-    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
+    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"
+    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_cover_label"
 

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -229,3 +229,12 @@ hw.module @CaseEnum() {
       sv.fwrite %fd, "x"
     }
 }
+
+// -----
+
+hw.module @NoMessage(%clock: i1, %value : i4) -> () {
+  sv.always posedge %clock {
+    // expected-error @below {{failed to verify that has message if has substitutions}}
+   "sv.assert"(%clock, %value) { defer = 0 : i32 } : (i1, i4) -> ()
+  }
+}


### PR DESCRIPTION
* [FIRRTL][SV] Allow message on cover verif, but not substitutions.

Presently the substitutions are allowed in FIRRTL, but are dropped
during lowering (along with message), and in SV cover was checked
to not have a message.  It'd be nice to preserve these for inclusion in the verilog output.

Change to allow message but no substitutions for cover operations in both dialects.
Add check that no substitutions are present if message is empty (or absent, in SV) for all verif operations.

* [ExportVerilog] emit cover messages as comments after/"within" the label.