### PR TITLE
Revert "Backport mux canonicalizations into SiFive 1.22"

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2338,47 +2338,6 @@ LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
       return success();
   }
 
-  // mux(c1, mux(c2, a, b), mux(c2, a, c)) -> mux(c2, a, mux(c1, b, c))
-  if (auto trueMux = dyn_cast_or_null<MuxOp>(op.getTrueValue().getDefiningOp()),
-      falseMux = dyn_cast_or_null<MuxOp>(op.getFalseValue().getDefiningOp());
-      trueMux && falseMux && trueMux.getCond() == falseMux.getCond() &&
-      trueMux.getTrueValue() == falseMux.getTrueValue()) {
-    auto subMux = rewriter.create<MuxOp>(
-        rewriter.getFusedLoc(trueMux.getLoc(), falseMux.getLoc()), op.getCond(),
-        trueMux.getFalseValue(), falseMux.getFalseValue());
-    replaceOpWithNewOpAndCopyName<MuxOp>(rewriter, op, trueMux.getCond(),
-                                         trueMux.getTrueValue(), subMux);
-    return success();
-  }
-
-  // mux(c1, mux(c2, a, b), mux(c2, c, b)) -> mux(c2, mux(c1, a, c), b)
-  if (auto trueMux = dyn_cast_or_null<MuxOp>(op.getTrueValue().getDefiningOp()),
-      falseMux = dyn_cast_or_null<MuxOp>(op.getFalseValue().getDefiningOp());
-      trueMux && falseMux && trueMux.getCond() == falseMux.getCond() &&
-      trueMux.getFalseValue() == falseMux.getFalseValue()) {
-    auto subMux = rewriter.create<MuxOp>(
-        rewriter.getFusedLoc(trueMux.getLoc(), falseMux.getLoc()), op.getCond(),
-        trueMux.getTrueValue(), falseMux.getTrueValue());
-    replaceOpWithNewOpAndCopyName<MuxOp>(rewriter, op, trueMux.getCond(),
-                                         subMux, trueMux.getFalseValue());
-    return success();
-  }
-
-  // mux(c1, mux(c2, a, b), mux(c3, a, b)) -> mux(mux(c1, c2, c3), a, b)
-  if (auto trueMux = dyn_cast_or_null<MuxOp>(op.getTrueValue().getDefiningOp()),
-      falseMux = dyn_cast_or_null<MuxOp>(op.getFalseValue().getDefiningOp());
-      trueMux && falseMux &&
-      trueMux.getTrueValue() == falseMux.getTrueValue() &&
-      trueMux.getFalseValue() == falseMux.getFalseValue()) {
-    auto subMux = rewriter.create<MuxOp>(
-        rewriter.getFusedLoc(
-            {op.getLoc(), trueMux.getLoc(), falseMux.getLoc()}),
-        op.getCond(), trueMux.getCond(), falseMux.getCond());
-    replaceOpWithNewOpAndCopyName<MuxOp>(
-        rewriter, op, subMux, trueMux.getTrueValue(), trueMux.getFalseValue());
-    return success();
-  }
-
   // mux(cond, x|y|z|a, a) -> (x|y|z)&replicate(cond) | a
   if (foldCommonMuxValue(op, false, rewriter))
     return success();

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1400,32 +1400,3 @@ hw.module @Issue2546() -> (b: i1) {
   %0 = comb.xor %0, %true : i1
   hw.output %0 : i1
 }
-
-// CHECK-LABEL: hw.module @MuxSimplify
-hw.module @MuxSimplify(%index: i1, %a: i1, %foo_0: i2, %foo_1: i2) -> (r_0: i2, r_1: i2, r_2 : i2) {
-  %true = hw.constant true
-  %c-2_i2 = hw.constant -2 : i2
-  %c1_i2 = hw.constant 1 : i2
-  %0 = comb.xor bin %index, %true : i1
-  %1 = comb.mux bin %0, %c1_i2, %foo_0 : i2
-  %2 = comb.mux bin %index, %c1_i2, %foo_1 : i2
-  %3 = comb.mux bin %0, %c-2_i2, %foo_0 : i2
-  %4 = comb.mux bin %a, %1, %3 : i2
-  %5 = comb.mux bin %index, %c-2_i2, %foo_1 : i2
-  %6 = comb.mux bin %a, %2, %5 : i2
-  
-  %7 = comb.mux bin %a, %foo_0, %foo_1 : i2
-  %8 = comb.mux bin %index, %foo_0, %foo_1 : i2
-  %9 = comb.xor %a, %index : i1
-  %10 = comb.mux bin %9, %7, %8 : i2
-  
-  hw.output %4, %6, %10 : i2, i2, i2
-}
-// CHECK:  %0 = comb.mux %a, %c1_i2, %c-2_i2 : i2
-// CHECK-NEXT:  %1 = comb.mux %index, %foo_0, %0 : i2
-// CHECK-NEXT:  %2 = comb.mux %a, %c1_i2, %c-2_i2 : i2
-// CHECK-NEXT:  %3 = comb.mux %index, %2, %foo_1 : i2
-// CHECK-NEXT:  %4 = comb.xor %a, %index : i1 
-// CHECK-NEXT:  %5 = comb.mux %4, %a, %index : i1 
-// CHECK-NEXT:  %6 = comb.mux %5, %foo_0, %foo_1 : i2 
-// CHECK-NEXT:  hw.output %1, %3, %6


### PR DESCRIPTION
On the second thought, the canonicalizers are too strong as a backport at this time.
Reverts llvm/circt#4492