### PR TITLE
[LowerTypes] Force type lowering of ref type operations to fix memtap type mismatch

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -874,8 +874,6 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
         "cannot generate the MemTap, wiretap Type does not match the memory "
         "type");
   auto sink = wireTarget->ref.getOp()->getResult(0);
-  wireTarget->ref.getOp()->setAttr("firrtl.must_lower_types",
-                                   UnitAttr::get(sink.getContext()));
   state.wiringProblems.push_back({sendVal, sink, "memTap"});
   return success();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -874,6 +874,8 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
         "cannot generate the MemTap, wiretap Type does not match the memory "
         "type");
   auto sink = wireTarget->ref.getOp()->getResult(0);
+  wireTarget->ref.getOp()->setAttr("firrtl.must_lower_types",
+                                   UnitAttr::get(sink.getContext()));
   state.wiringProblems.push_back({sendVal, sink, "memTap"});
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -131,8 +131,12 @@ static bool isPreservableAggregateType(Type type,
   if (mode == PreserveAggregate::None)
     return false;
 
-  auto firrtlType = type.isa<RefType>() ? type.cast<RefType>().getType()
-                                        : type.dyn_cast<FIRRTLBaseType>();
+  // FIXME: Don't presereve RefType for now. This is workaround for MemTap which
+  // causes type mismatches (issue 4479).
+  if (type.isa<RefType>())
+    return false;
+
+  auto firrtlType = type.dyn_cast<FIRRTLBaseType>();
   if (!firrtlType)
     return false;
 
@@ -563,14 +567,12 @@ bool TypeLoweringVisitor::lowerProducer(
     return false;
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
 
-  circt::firrtl::PreserveAggregate::PreserveMode mode =
-      aggregatePreservationMode;
-  if (op->hasAttrOfType<UnitAttr>("firrtl.must_lower_types")) {
-    op->removeAttr("firrtl.must_lower_types");
-    mode = PreserveAggregate::None;
-  }
-
-  if (!peelType(srcType, fieldTypes, mode))
+  // FIXME: Don't presereve aggregates on RefType operations for now. This is
+  // workaround for MemTap which causes type mismatches (issue 4479).
+  if (!peelType(srcType, fieldTypes,
+                isa<RefResolveOp, RefSendOp, RefSubOp>(op)
+                    ? PreserveAggregate::None
+                    : aggregatePreservationMode))
     return false;
 
   // If an aggregate value has a symbol, emit errors.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -563,7 +563,14 @@ bool TypeLoweringVisitor::lowerProducer(
     return false;
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
 
-  if (!peelType(srcType, fieldTypes, aggregatePreservationMode))
+  circt::firrtl::PreserveAggregate::PreserveMode mode =
+      aggregatePreservationMode;
+  if (op->hasAttrOfType<UnitAttr>("firrtl.must_lower_types")) {
+    op->removeAttr("firrtl.must_lower_types");
+    mode = PreserveAggregate::None;
+  }
+
+  if (!peelType(srcType, fieldTypes, mode))
     return false;
 
   // If an aggregate value has a symbol, emit errors.

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,5 +1,5 @@
 ; RUN: firtool --verilog %s | FileCheck %s
-; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGREGATE
+; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
 
 circuit Top : %[[
   {
@@ -62,12 +62,14 @@ circuit Top : %[[
 ; CHECK:  assign memTap_5 = Top.dut.rf_ext.Memory[5];
 ; CHECK:  assign memTap_6 = Top.dut.rf_ext.Memory[6];
 ; CHECK:  assign memTap_7 = Top.dut.rf_ext.Memory[7];
-; AGGREGATE:  assign memTap_0 = Top.dut.rf_ext.Memory[3'h0];
-; AGGREGATE:  assign memTap_1 = Top.dut.rf_ext.Memory[3'h1];
-; AGGREGATE:  assign memTap_2 = Top.dut.rf_ext.Memory[3'h2];
-; AGGREGATE:  assign memTap_3 = Top.dut.rf_ext.Memory[3'h3];
-; AGGREGATE:  assign memTap_4 = Top.dut.rf_ext.Memory[3'h4];
-; AGGREGATE:  assign memTap_5 = Top.dut.rf_ext.Memory[3'h5];
-; AGGREGATE:  assign memTap_6 = Top.dut.rf_ext.Memory[3'h6];
-; AGGREGATE:  assign memTap_7 = Top.dut.rf_ext.Memory[3'h7];
+; AGGGREGATE:       wire [7:0][7:0] memTap;
+; AGGGREGATE-NEXT:  assign memTap =
+; AGGGREGATE-NEXT{LITERAL}: {{Top.dut.rf_ext.Memory[7]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[6]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[5]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[4]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[3]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[2]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[1]},
+; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[0]}};
 ; CHECK:      endmodule

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,4 +1,5 @@
 ; RUN: firtool --verilog %s | FileCheck %s
+; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGREGATE
 
 circuit Top : %[[
   {
@@ -61,4 +62,12 @@ circuit Top : %[[
 ; CHECK:  assign memTap_5 = Top.dut.rf_ext.Memory[5];
 ; CHECK:  assign memTap_6 = Top.dut.rf_ext.Memory[6];
 ; CHECK:  assign memTap_7 = Top.dut.rf_ext.Memory[7];
+; AGGREGATE:  assign memTap_0 = Top.dut.rf_ext.Memory[3'h0];
+; AGGREGATE:  assign memTap_1 = Top.dut.rf_ext.Memory[3'h1];
+; AGGREGATE:  assign memTap_2 = Top.dut.rf_ext.Memory[3'h2];
+; AGGREGATE:  assign memTap_3 = Top.dut.rf_ext.Memory[3'h3];
+; AGGREGATE:  assign memTap_4 = Top.dut.rf_ext.Memory[3'h4];
+; AGGREGATE:  assign memTap_5 = Top.dut.rf_ext.Memory[3'h5];
+; AGGREGATE:  assign memTap_6 = Top.dut.rf_ext.Memory[3'h6];
+; AGGREGATE:  assign memTap_7 = Top.dut.rf_ext.Memory[3'h7];
 ; CHECK:      endmodule


### PR DESCRIPTION
HWMemSimImpl creates unpacked array registers for memory storage. However with aggregate preservation mode, FIRRTL vector is lowered into packed arrays so there is a type mismatch. This PR adds a workaround to force type lowering of reftype operations. 
w/o PR:
```verilog
  reg  [7:0] Memory[0:7];
  ...
  wire [7:0][7:0] memTap;
  assign memTap = Top.dut.rf_ext.Memory;
```
w/ PR:
```verilog
  wire [7:0][7:0] memTap;
  assign memTap =
          {{Top.dut.rf_ext.Memory[7]},
           {Top.dut.rf_ext.Memory[6]},
           {Top.dut.rf_ext.Memory[5]},
           {Top.dut.rf_ext.Memory[4]},
           {Top.dut.rf_ext.Memory[3]},
           {Top.dut.rf_ext.Memory[2]},
           {Top.dut.rf_ext.Memory[1]},
           {Top.dut.rf_ext.Memory[0]}};
```
