### PR TITLE
[FIRRTL] Handle Nodes in getDeclName. NFC.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -479,7 +479,7 @@ static void getDeclName(Value value, SmallString<64> &string, bool nameSafe) {
                         .getValue();
           value = nullptr;
         })
-        .Case<WireOp, RegOp, RegResetOp>([&](auto op) {
+        .Case<FNamableOp>([&](auto op) {
           string += op.getName();
           value = nullptr;
         })


### PR DESCRIPTION
Use `FNamableOp` to handle `NodeOp` and get their name in `getDeclName`.