### PR TITLE
[HW] Add support for struct_explodeOp in HWToLLVM

### DIFF
--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -80,7 +80,7 @@ static Value zextByOne(Location loc, ConversionPatternRewriter &rewriter,
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Convert a StructExplodeOp to a LLVM dialect.
+/// Convert a StructExplodeOp to the LLVM dialect.
 /// Pattern: struct_explode(input) =>
 ///          struct_extract(input, structElements_index(index)) ...
 struct StructExplodeOpConversion

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -80,6 +80,38 @@ static Value zextByOne(Location loc, ConversionPatternRewriter &rewriter,
 //===----------------------------------------------------------------------===//
 
 namespace {
+/// Convert a StructExplodeOp to a LLVM dialect.
+/// Pattern: struct_explode(input) =>
+///          struct_extract(input, structElements_index(index)) ...
+struct StructExplodeOpConversion
+    : public ConvertOpToLLVMPattern<hw::StructExplodeOp> {
+  using ConvertOpToLLVMPattern<hw::StructExplodeOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::StructExplodeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    SmallVector<Value> replacements;
+
+    for (size_t i = 0, e = adaptor.getInput()
+                               .getType()
+                               .cast<LLVM::LLVMStructType>()
+                               .getBody()
+                               .size();
+         i < e; ++i)
+
+      replacements.push_back(rewriter.create<LLVM::ExtractValueOp>(
+          op->getLoc(), adaptor.getInput(),
+          HWToLLVMEndianessConverter::convertToLLVMEndianess(
+              op.getInput().getType(), i)));
+
+    rewriter.replaceOp(op, replacements);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 /// Convert a StructExtractOp to LLVM dialect.
 /// Pattern: struct_extract(input, fieldname) =>
 ///   extractvalue(input, fieldname_to_index(fieldname))
@@ -193,42 +225,6 @@ struct ArraySliceOpConversion
 
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, dstTy, cast);
 
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// Explosion operation conversions
-//===----------------------------------------------------------------------===//
-
-namespace {
-/// Convert a StructExplodeOp to a LLVM dialect.
-/// Pattern: struct_explode(input) =>
-///          struct_extract(input, structElements_index(index)) ...
-struct StructExplodeOpConversion
-    : public ConvertOpToLLVMPattern<hw::StructExplodeOp> {
-  using ConvertOpToLLVMPattern<hw::StructExplodeOp>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(hw::StructExplodeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-
-    SmallVector<Value> replacements;
-
-    for (size_t i = 0, e = adaptor.getInput()
-                               .getType()
-                               .cast<LLVM::LLVMStructType>()
-                               .getBody()
-                               .size();
-         i < e; ++i)
-
-      replacements.push_back(rewriter.create<LLVM::ExtractValueOp>(
-          op->getLoc(), adaptor.getInput(),
-          HWToLLVMEndianessConverter::convertToLLVMEndianess(
-              op.getInput().getType(), i)));
-
-    rewriter.replaceOp(op, replacements);
     return success();
   }
 };
@@ -547,11 +543,8 @@ void circt::populateHWToLLVMConversionPatterns(LLVMTypeConverter &converter,
 
   // Extraction operation conversion patterns.
   patterns.add<ArrayGetOpConversion, ArraySliceOpConversion,
-               ArrayConcatOpConversion, StructExtractOpConversion,
-               StructInjectOpConversion>(converter);
-
-  // Explosion operation conversion patterns.
-  patterns.add<StructExplodeOpConversion>(converter);
+               ArrayConcatOpConversion, StructExplodeOpConversion,
+               StructExtractOpConversion, StructInjectOpConversion>(converter);
 }
 
 void circt::populateHWToLLVMTypeConversions(LLVMTypeConverter &converter) {

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -199,6 +199,42 @@ struct ArraySliceOpConversion
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// Explosion operation conversions
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Convert a StructExplodeOp to a LLVM dialect.
+/// Pattern: struct_explode(input) =>
+///          struct_extract(input, structElements_index(index)) ...
+struct StructExplodeOpConversion
+    : public ConvertOpToLLVMPattern<hw::StructExplodeOp> {
+  using ConvertOpToLLVMPattern<hw::StructExplodeOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::StructExplodeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    SmallVector<Value> replacements;
+
+    for (size_t i = 0, e = adaptor.getInput()
+                               .getType()
+                               .cast<LLVM::LLVMStructType>()
+                               .getBody()
+                               .size();
+         i < e; ++i)
+
+      replacements.push_back(rewriter.create<LLVM::ExtractValueOp>(
+          op->getLoc(), adaptor.getInput(),
+          HWToLLVMEndianessConverter::convertToLLVMEndianess(
+              op.getInput().getType(), i)));
+
+    rewriter.replaceOp(op, replacements);
+    return success();
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // Insertion operations conversion
 //===----------------------------------------------------------------------===//
 
@@ -513,6 +549,9 @@ void circt::populateHWToLLVMConversionPatterns(LLVMTypeConverter &converter,
   patterns.add<ArrayGetOpConversion, ArraySliceOpConversion,
                ArrayConcatOpConversion, StructExtractOpConversion,
                StructInjectOpConversion>(converter);
+
+  // Explosion operation conversion patterns.
+  patterns.add<StructExplodeOpConversion>(converter);
 }
 
 void circt::populateHWToLLVMTypeConversions(LLVMTypeConverter &converter) {

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -108,5 +108,8 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
   // CHECK: llvm.insertvalue %arg0, %[[SCAST1]][1] : !llvm.struct<(i8, i32)>
   %1 = hw.struct_inject %arg1["foo"], %arg0 : !hw.struct<foo: i32, bar: i8>
 
+  // CHECK-NEXT: %[[SCAST2:.*]] = llvm.extractvalue %[[SCAST]][1] : !llvm.struct<(i8, i32)>
+  // CHECK-NEXT: %[[SCAST3:.*]] = llvm.extractvalue %[[SCAST]][0] : !llvm.struct<(i8, i32)>
+  %2:2 = hw.struct_explode %arg1 : !hw.struct<foo: i32, bar: i8>
   return
 }

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -108,8 +108,8 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
   // CHECK: llvm.insertvalue %arg0, %[[SCAST1]][1] : !llvm.struct<(i8, i32)>
   %1 = hw.struct_inject %arg1["foo"], %arg0 : !hw.struct<foo: i32, bar: i8>
 
-  // CHECK-NEXT: %[[SCAST2:.*]] = llvm.extractvalue %[[SCAST]][1] : !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: %[[SCAST3:.*]] = llvm.extractvalue %[[SCAST]][0] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %[[SCAST]][1] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %[[SCAST]][0] : !llvm.struct<(i8, i32)>
   %2:2 = hw.struct_explode %arg1 : !hw.struct<foo: i32, bar: i8>
   return
 }

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -97,7 +97,7 @@ func.func @convertConstArray(%arg0 : i1, %arg1: !hw.array<2xi32>) {
 }
 
 // CHECK-LABEL: @convertStruct
-func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
+func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg2: !hw.struct<>) {
   // COM: Produces 2 casts here - first one automatically, second one for use in extractvalue
   // CHECK-NEXT: %[[SCAST:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
   // CHECK-NEXT: %[[SCAST0:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
@@ -111,5 +111,7 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
   // CHECK: llvm.extractvalue %[[SCAST]][1] : !llvm.struct<(i8, i32)>
   // CHECK: llvm.extractvalue %[[SCAST]][0] : !llvm.struct<(i8, i32)>
   %2:2 = hw.struct_explode %arg1 : !hw.struct<foo: i32, bar: i8>
+
+  hw.struct_explode %arg2 : !hw.struct<>
   return
 }


### PR DESCRIPTION
The originally related commits were pushed with zvc framework (**PR#4040** closed), and now split out and push separately.
convert struct_explode op to llvm extractvalue op, to eject every element in the struct.

pattern: struct_extract(input) => struct_extract(input, structElements_index(index))

Fix: move the original single struct_explode test to convert_aggregates.mlir file.