### PR TITLE
[Calyx] Add 'remove comb groups' pass

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -23,6 +23,7 @@ namespace calyx {
 
 std::unique_ptr<mlir::Pass> createCompileControlPass();
 std::unique_ptr<mlir::Pass> createGoInsertionPass();
+std::unique_ptr<mlir::Pass> createRemoveCombGroupsPass();
 std::unique_ptr<mlir::Pass> createRemoveGroupsPass();
 std::unique_ptr<mlir::Pass> createClkInsertionPass();
 std::unique_ptr<mlir::Pass> createResetInsertionPass();

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -68,11 +68,69 @@ def GroupInvariantCodeMotion : Pass<"calyx-gicm", "calyx::ComponentOp"> {
 }
 
 def RemoveCombGroups : Pass<"calyx-remove-comb-groups", "calyx::ComponentOp"> {
-  let summary = "";
+  let summary = "Removes combinational groups from a Calyx component.";
   let description = [{
     Transforms combinational groups, which have a constant done condition,
     into proper groups by registering the values read from the ports of cells
     used within the combinational group.
+
+    It also transforms (invoke,if,while)-with into semantically equivalent
+    control programs that first enable a group that calculates and registers the
+    ports defined by the combinational group execute the respective cond group
+    and then execute the control operator.
+
+    ## Example
+    ```
+    group comb_cond<"static"=0> {
+        lt.right = 32'd10;
+        lt.left = 32'd1;
+        eq.right = r.out;
+        eq.left = x.out;
+        comb_cond[done] = 1'd1;
+    }
+    control {
+        invoke comp(left = lt.out, ..)(..) with comb_cond;
+        if lt.out with comb_cond {
+            ...
+        }
+        while eq.out with comb_cond {
+            ...
+        }
+    }
+    ```
+    into:
+    ```
+    group comb_cond<"static"=1> {
+        lt.right = 32'd10;
+        lt.left = 32'd1;
+        eq.right = r.out;
+        eq.left = x.out;
+        lt_reg.in = lt.out
+        lt_reg.write_en = 1'd1;
+        eq_reg.in = eq.out;
+        eq_reg.write_en = 1'd1;
+        comb_cond[done] = lt_reg.done & eq_reg.done ? 1'd1;
+    }
+    control {
+        seq {
+          comb_cond;
+          invoke comp(left = lt_reg.out, ..)(..);
+        }
+        seq {
+          comb_cond;
+          if lt_reg.out {
+              ...
+          }
+        }
+        seq {
+          comb_cond;
+          while eq_reg.out {
+              ...
+              comb_cond;
+          }
+        }
+    }
+    ```
   }];
   let dependentDialects = ["comb::CombDialect"];
   let constructor = "circt::calyx::createRemoveCombGroupsPass()";

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -67,6 +67,17 @@ def GroupInvariantCodeMotion : Pass<"calyx-gicm", "calyx::ComponentOp"> {
   let constructor = "circt::calyx::createGroupInvariantCodeMotionPass()";
 }
 
+def RemoveCombGroups : Pass<"calyx-remove-comb-groups", "calyx::ComponentOp"> {
+  let summary = "";
+  let description = [{
+    Transforms combinational groups, which have a constant done condition,
+    into proper groups by registering the values read from the ports of cells
+    used within the combinational group.
+  }];
+  let dependentDialects = ["comb::CombDialect"];
+  let constructor = "circt::calyx::createRemoveCombGroupsPass()";
+}
+
 def CompileControl : Pass<"calyx-compile-control", "calyx::ComponentOp"> {
   let summary = "Generates latency-insensitive finite state machines to realize control.";
   let description = [{

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   GoInsertion.cpp
   ClkResetInsertion.cpp
   RemoveGroups.cpp
+  RemoveCombGroups.cpp
   CalyxHelpers.cpp
   CalyxLoweringUtils.cpp
 

--- a/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
@@ -163,8 +163,8 @@ struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
               auto reg = createReg(component, rewriter, combRes.getLoc(),
                                    cell.instanceName(),
                                    combRes.getType().getIntOrFloatBitWidth());
-              combResRegMapping->insert({combRes, reg});
-              combResReg = combResRegMapping->find(combRes);
+              auto it = combResRegMapping->insert({combRes, reg});
+              combResReg = it.first;
             }
 
             // Assign the cell result register - a register should only be

--- a/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
@@ -1,0 +1,290 @@
+//===- RemoveCombGroups.cpp - Remove Comb Groups Pass -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the Remove Comb Groups pass.
+//
+//===----------------------------------------------------------------------===//
+
+/// Transforms combinational groups, which have a constant done condition,
+/// into proper groups by registering the values read from the ports of cells
+/// used within the combinational group.
+///
+/// It also transforms (invoke,if,while)-with into semantically equivalent
+/// control programs that first enable a group that calculates and registers the
+/// ports defined by the combinational group execute the respective cond group
+/// and then execute the control operator.
+///
+/// # Example
+/// ```
+/// group comb_cond<"static"=0> {
+///     lt.right = 32'd10;
+///     lt.left = 32'd1;
+///     eq.right = r.out;
+///     eq.left = x.out;
+///     comb_cond[done] = 1'd1;
+/// }
+/// control {
+///     invoke comp(left = lt.out, ..)(..) with comb_cond;
+///     if lt.out with comb_cond {
+///         ...
+///     }
+///     while eq.out with comb_cond {
+///         ...
+///     }
+/// }
+/// ```
+/// into:
+/// ```
+/// group comb_cond<"static"=1> {
+///     lt.right = 32'd10;
+///     lt.left = 32'd1;
+///     eq.right = r.out;
+///     eq.left = x.out;
+///     lt_reg.in = lt.out
+///     lt_reg.write_en = 1'd1;
+///     eq_reg.in = eq.out;
+///     eq_reg.write_en = 1'd1;
+///     comb_cond[done] = lt_reg.done & eq_reg.done ? 1'd1;
+/// }
+/// control {
+///     seq {
+///       comb_cond;
+///       invoke comp(left = lt_reg.out, ..)(..);
+///     }
+///     seq {
+///       comb_cond;
+///       if lt_reg.out {
+///           ...
+///       }
+///     }
+///     seq {
+///       comb_cond;
+///       while eq_reg.out {
+///           ...
+///           comb_cond;
+///       }
+///     }
+/// }
+/// ```
+
+#include "PassDetails.h"
+#include "circt/Dialect/Calyx/CalyxOps.h"
+#include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace circt;
+using namespace calyx;
+using namespace mlir;
+
+namespace {
+
+static calyx::RegisterOp createReg(ComponentOp component,
+                                   PatternRewriter &rewriter, Location loc,
+                                   Twine prefix, size_t width) {
+  IRRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(component.getBodyBlock());
+  return rewriter.create<calyx::RegisterOp>(loc, (prefix + "_reg").str(),
+                                            width);
+}
+
+// Wraps the provided 'op' inside a newly created TOp operation, and
+// returns the TOp operation.
+template <typename TOp>
+static TOp wrapInsideOp(OpBuilder &builder, Operation *op) {
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPoint(op);
+  auto newOp = builder.create<TOp>(op->getLoc());
+  op->moveBefore(newOp.getBodyBlock(), newOp.getBodyBlock()->begin());
+  return newOp;
+}
+
+using CombResRegMapping = DenseMap<Value, RegisterOp>;
+
+struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  RemoveCombGroupsPattern(MLIRContext *ctx, CombResRegMapping *mapping)
+      : OpRewritePattern(ctx), combResRegMapping(mapping) {}
+
+  LogicalResult matchAndRewrite(calyx::CombGroupOp combGroup,
+                                PatternRewriter &rewriter) const override {
+
+    auto component = combGroup->getParentOfType<ComponentOp>();
+    auto group = rewriter.replaceOpWithNewOp<calyx::GroupOp>(
+        combGroup, combGroup.getName());
+    rewriter.mergeBlocks(combGroup.getBodyBlock(), group.getBodyBlock());
+
+    // Determine which cell results are read from the control schedule.
+    SetVector<Operation *> cellsAssigned;
+    for (auto op : group.getOps<calyx::AssignOp>()) {
+      auto defOp = dyn_cast<CellInterface>(op.getDest().getDefiningOp());
+      assert(defOp && "expected some assignment to a cell");
+      cellsAssigned.insert(defOp);
+    }
+
+    rewriter.setInsertionPointToStart(group.getBodyBlock());
+    auto oneConstant = rewriter.create<hw::ConstantOp>(
+        group.getLoc(), APInt(1, 1, /*unsigned=*/true));
+
+    // Maintain the set of cell results which have already been assigned to
+    // its register within this group.
+    SetVector<Value> alreadyAssignedResults;
+
+    // Collect register done signals. These are needed for generating the
+    // GroupDone signal.
+    SetVector<Value> registerDoneSigs;
+
+    // 1. Iterate over the cells assigned within the combinational group.
+    // 2. For any use of a cell result within the controls schedule.
+    // 3.  Ensure that the cell result has a register.
+    // 4.  Ensure that the cell result has been written to its register in this
+    //     group.
+    // We do not replace uses of the combinational results now, since the
+    // following code relies on a checking cell result value use in the
+    // control schedule, which needs to remain even when two combinational
+    // groups assign to the same cell.
+    for (auto cellOp : cellsAssigned) {
+      auto cell = dyn_cast<CellInterface>(cellOp);
+      for (auto combRes : cell.getOutputPorts()) {
+        for (auto &use : llvm::make_early_inc_range(combRes.getUses())) {
+          if (use.getOwner()->getParentOfType<calyx::ControlOp>()) {
+            auto combResReg = combResRegMapping->find(combRes);
+            if (combResReg == combResRegMapping->end()) {
+              // First time a registered variant of this result is needed.
+              auto reg = createReg(component, rewriter, combRes.getLoc(),
+                                   cell.instanceName(),
+                                   combRes.getType().getIntOrFloatBitWidth());
+              combResRegMapping->insert({combRes, reg});
+              combResReg = combResRegMapping->find(combRes);
+            }
+
+            // Assign the cell result register - a register should only be
+            // assigned once within a group.
+            if (!alreadyAssignedResults.contains(combRes)) {
+              rewriter.create<AssignOp>(combRes.getLoc(),
+                                        combResReg->second.getIn(), combRes);
+              rewriter.create<AssignOp>(
+                  combRes.getLoc(), combResReg->second.getWriteEn(), oneConstant);
+              alreadyAssignedResults.insert(combRes);
+            }
+
+            registerDoneSigs.insert(combResReg->second.getDone());
+          }
+        }
+      }
+    }
+
+    // Create a group done op with the complex &[regDone] expression as a
+    // guard.
+    assert(!registerDoneSigs.empty() &&
+           "No registers assigned in the combinational group?");
+    rewriter.setInsertionPointToEnd(group.getBodyBlock());
+    rewriter.create<calyx::GroupDoneOp>(
+        group.getLoc(),
+        rewriter.create<hw::ConstantOp>(group.getLoc(), APInt(1, 1)),
+        rewriter.create<comb::AndOp>(combGroup.getLoc(), rewriter.getI1Type(),
+                                     registerDoneSigs.takeVector()));
+
+    return success();
+  }
+
+  mutable CombResRegMapping *combResRegMapping;
+};
+
+struct RemoveCombGroupsPass
+    : public RemoveCombGroupsBase<RemoveCombGroupsPass> {
+  void runOnOperation() override;
+
+  /// Removes 'with' groups from an operation and instead schedules the group
+  /// right before the oop.
+  void rewriteIfWithCombGroup(OpBuilder &builder) {
+    OpBuilder::InsertionGuard guard(builder);
+    getOperation().walk([&](IfOp ifOp) {
+      if (!ifOp.getGroupName())
+        return;
+      auto groupName = ifOp.getGroupName();
+      // Ensure that we're inside a sequential control composition.
+      wrapInsideOp<SeqOp>(builder, ifOp);
+      builder.setInsertionPoint(ifOp);
+      builder.create<EnableOp>(ifOp.getLoc(), groupName.value());
+      ifOp.removeGroupNameAttr();
+    });
+  }
+
+  void rewriteWhileWithCombGroup(OpBuilder &builder) {
+    OpBuilder::InsertionGuard guard(builder);
+    getOperation().walk([&](WhileOp whileOp) {
+      if (!whileOp.getGroupName())
+        return;
+      auto groupName = whileOp.getGroupName().value();
+      // Ensure that we're inside a sequential control composition.
+      wrapInsideOp<SeqOp>(builder, whileOp);
+      builder.setInsertionPoint(whileOp);
+      builder.create<EnableOp>(whileOp.getLoc(), groupName);
+      whileOp.removeGroupNameAttr();
+
+      // Also schedule the group at the end of the while body.
+      auto &curWhileBodyOp = whileOp.getBodyBlock()->front();
+      builder.setInsertionPointToStart(whileOp.getBodyBlock());
+      auto newSeqBody = builder.create<SeqOp>(curWhileBodyOp.getLoc());
+      builder.setInsertionPointToStart(newSeqBody.getBodyBlock());
+      auto condEnable =
+          builder.create<EnableOp>(curWhileBodyOp.getLoc(), groupName);
+      curWhileBodyOp.moveBefore(condEnable);
+    });
+  }
+
+  void rewriteCellResults() {
+    for (auto &&[res, reg] : combResToReg) {
+      for (auto &use : llvm::make_early_inc_range(res.getUses())) {
+        if (use.getOwner()->getParentOfType<calyx::ControlOp>()) {
+          use.set(reg.getOut());
+        }
+      }
+    }
+  }
+
+  CombResRegMapping combResToReg;
+};
+
+} // end anonymous namespace
+
+void RemoveCombGroupsPass::runOnOperation() {
+  ConversionTarget target(getContext());
+  target.addLegalDialect<calyx::CalyxDialect>();
+  target.addLegalDialect<hw::HWDialect>();
+  target.addLegalDialect<comb::CombDialect>();
+  target.addIllegalOp<calyx::CombGroupOp>();
+
+  RewritePatternSet patterns(&getContext());
+
+  // Maintain a mapping from combinational result SSA values to the registered
+  // version of that combinational unit. This is used to avoid duplicating
+  // registers when cells are used across different groups.
+  patterns.add<RemoveCombGroupsPattern>(&getContext(), &combResToReg);
+
+  if (applyPartialConversion(getOperation(), target, std::move(patterns))
+          .failed())
+    signalPassFailure();
+
+  // Rewrite uses of the cell results to their registered variants.
+  rewriteCellResults();
+
+  // Rewrite 'with' uses of the previously combinational groups.
+  OpBuilder builder(&getContext());
+  rewriteIfWithCombGroup(builder);
+  rewriteWhileWithCombGroup(builder);
+}
+
+std::unique_ptr<mlir::Pass> circt::calyx::createRemoveCombGroupsPass() {
+  return std::make_unique<RemoveCombGroupsPass>();
+}

--- a/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
@@ -133,7 +133,7 @@ struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
 
     rewriter.setInsertionPointToStart(group.getBodyBlock());
     auto oneConstant = rewriter.create<hw::ConstantOp>(
-        group.getLoc(), APInt(1, 1, /*unsigned=*/true));
+        group.getLoc(), APInt(1, 1, /*isSigned=*/true));
 
     // Maintain the set of cell results which have already been assigned to
     // its register within this group.
@@ -152,7 +152,7 @@ struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
     // following code relies on a checking cell result value use in the
     // control schedule, which needs to remain even when two combinational
     // groups assign to the same cell.
-    for (auto cellOp : cellsAssigned) {
+    for (auto *cellOp : cellsAssigned) {
       auto cell = dyn_cast<CellInterface>(cellOp);
       for (auto combRes : cell.getOutputPorts()) {
         for (auto &use : llvm::make_early_inc_range(combRes.getUses())) {

--- a/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
@@ -172,8 +172,9 @@ struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
             if (!alreadyAssignedResults.contains(combRes)) {
               rewriter.create<AssignOp>(combRes.getLoc(),
                                         combResReg->second.getIn(), combRes);
-              rewriter.create<AssignOp>(
-                  combRes.getLoc(), combResReg->second.getWriteEn(), oneConstant);
+              rewriter.create<AssignOp>(combRes.getLoc(),
+                                        combResReg->second.getWriteEn(),
+                                        oneConstant);
               alreadyAssignedResults.insert(combRes);
             }
 

--- a/test/Dialect/Calyx/remove-comb-groups.mlir
+++ b/test/Dialect/Calyx/remove-comb-groups.mlir
@@ -1,0 +1,120 @@
+// RUN: circt-opt --split-input-file --calyx-remove-comb-groups %s --canonicalize | FileCheck %s
+
+// CHECK-LABEL: calyx.component @main
+calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+  %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+  %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+  %c1_1 = hw.constant 1 : i1
+  calyx.wires {
+// CHECK-NOT: calyx.comb_group @Cond
+// CHECK-LABEL: calyx.group @Cond {
+// CHECK:   calyx.assign %eq_reg.in = %eq.out : i1
+// CHECK:   calyx.assign %eq_reg.write_en = %true : i1
+// CHECK:   calyx.assign %eq.left = %true : i1
+// CHECK:   calyx.assign %eq.right = %true : i1
+// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+    calyx.comb_group @Cond {
+      calyx.assign %eq.left =  %c1_1 : i1
+      calyx.assign %eq.right = %c1_1 : i1
+    }
+    calyx.group @A {
+      calyx.assign %r.in = %c1_1 : i1
+      calyx.assign %r.write_en = %c1_1 : i1
+      calyx.group_done %r.done : i1
+    }
+  }
+
+// CHECK: calyx.control {
+// CHECK:   calyx.seq {
+// CHECK:     calyx.enable @Cond
+// CHECK:     calyx.if %eq_reg.out {
+// CHECK:       calyx.seq {
+// CHECK:         calyx.enable @A
+// CHECK:       }
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+  calyx.control {
+    calyx.if %eq.out with @Cond {
+      calyx.seq {
+        calyx.enable @A
+      }
+    }
+  }
+}
+
+// -----
+
+// Test the case where cells are shared across combinational groups.
+
+calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+  %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+  %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+  %c1_1 = hw.constant 1 : i1
+  calyx.wires {
+
+// CHECK-NOT: calyx.comb_group @Cond1
+// CHECK: calyx.group @Cond1 {
+// CHECK:   calyx.assign %eq_reg.in = %eq.out : i1
+// CHECK:   calyx.assign %eq_reg.write_en = %true : i1
+// CHECK:   calyx.assign %eq.left = %true : i1
+// CHECK:   calyx.assign %eq.right = %true : i1
+// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+// CHECK: }
+    calyx.comb_group @Cond1 {
+      calyx.assign %eq.left =  %c1_1 : i1
+      calyx.assign %eq.right = %c1_1 : i1
+    }
+
+// CHECK-NOT: calyx.comb_group @Cond2
+// CHECK: calyx.group @Cond2 {
+// CHECK:   calyx.assign %eq_reg.in = %eq.out : i1
+// CHECK:   calyx.assign %eq_reg.write_en = %true : i1
+// CHECK:   calyx.assign %eq.left = %true : i1
+// CHECK:   calyx.assign %eq.right = %true : i1
+// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+// CHECK: }
+    calyx.comb_group @Cond2 {
+      calyx.assign %eq.left =  %c1_1 : i1
+      calyx.assign %eq.right = %c1_1 : i1
+    }
+    calyx.group @A {
+      calyx.assign %r.in = %c1_1 : i1
+      calyx.assign %r.write_en = %c1_1 : i1
+      calyx.group_done %r.done : i1
+    }
+  }
+
+// CHECK: calyx.control {
+// CHECK:   calyx.par {
+// CHECK:     calyx.enable @Cond1
+// CHECK:     calyx.if %eq_reg.out {
+// CHECK:       calyx.seq {
+// CHECK:         calyx.enable @A
+// CHECK:       }
+// CHECK:     }
+// CHECK:     calyx.enable @Cond2
+// CHECK:     calyx.while %eq_reg.out {
+// CHECK:       calyx.seq {
+// CHECK:         calyx.enable @A
+// CHECK:         calyx.enable @Cond2
+// CHECK:       }
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+  calyx.control {
+    calyx.par {
+      calyx.if %eq.out with @Cond1 {
+        calyx.seq {
+          calyx.enable @A
+        }
+      }
+      calyx.while %eq.out with @Cond2 {
+        calyx.seq {
+          calyx.enable @A
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Committing an old piece of code I had lying around. The pass is modeled after the native calyx compiler implementation.

... as far as i know, this is the only missing piece to actually do Calyx-to-HW in CIRCT, through the FSM flow...