### PR TITLE
[FIRRTL][CheckCombLoops] Handle scalar to Aggregate paths

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -186,15 +186,19 @@ public:
                   // Get all the ports that have a comb path from `port`.
                   for (const auto &portNode : portPaths[port])
                     for (auto outputPort : portNode.getSecond()) {
-                      auto instResult = ins.getResult(
+                      Value instResult = ins.getResult(
                           outputPort.val.cast<BlockArgument>().getArgNumber());
-                      assert(instResult.getType()
-                                 .cast<FIRRTLBaseType>()
-                                 .isGround() &&
-                             "only ground type value expected here");
-                      // Note that, in this case the instResult is always of
-                      // Ground Type. FieldRefs are handled as a pre-pass before
-                      // the DFS begins.
+                      if (!instResult.getType()
+                               .cast<FIRRTLBaseType>()
+                               .isGround()) {
+
+                        size_t outPortId;
+                        if (!getStorageLocIdFromVal(instResult, outPortId))
+                          continue;
+                        if (!getValueFromStorageLocId(
+                                outPortId + outputPort.fieldId, instResult))
+                          continue;
+                      }
                       children.push_back({instResult, ins});
                     }
                 }

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -577,3 +577,25 @@ firrtl.circuit "revisitOps2"   {
     firrtl.connect %x, %out_1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+// -----
+
+// Comb path from ground type to aggregate.
+// CHECK-NOT: firrtl.circuit "scalarToVec"
+firrtl.circuit "scalarToVec"   {
+  firrtl.module @thru(in %in1: !firrtl.uint<1>, in %in2: !firrtl.vector<uint<1>,3>, out %out: !firrtl.vector<uint<1>,2>) {
+    %out_1 = firrtl.subindex %out[1] : !firrtl.vector<uint<1>,2>
+    firrtl.connect %out_1, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+  // expected-error @+1 {{scalarToVec.inner2.in1 <- scalarToVec.x <- scalarToVec.inner2.out[1] <- scalarToVec.inner2.in1}}
+  firrtl.module @scalarToVec() {
+    %in1_0, %in2, %out = firrtl.instance inner2 @thru(in in1: !firrtl.uint<1>, in in2: !firrtl.vector<uint<1>,3>, out out: !firrtl.vector<uint<1>,2>)
+    //%in1_0 = firrtl.subindex %in1[0] : !firrtl.vector<uint<1>,2>
+    %out_1 = firrtl.subindex %out[1] : !firrtl.vector<uint<1>,2>
+    %x = firrtl.wire  : !firrtl.uint<1>
+    // expected-remark @+1 {{this operation is part of the combinational cycle}}
+    firrtl.connect %in1_0, %x : !firrtl.uint<1>, !firrtl.uint<1>
+    // expected-remark @+1 {{this operation is part of the combinational cycle}}
+    firrtl.connect %x, %out_1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Fix a bug in `CheckCombLoops` pass, it was not handling paths between ground type and aggregates.