### PR TITLE
[FIRRTL] Change FIRRTL fieldID fns to use uint64_t

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -124,27 +124,27 @@ public:
   /// types and vector types, each field is assigned a field ID in a depth-first
   /// walk order. This function is used to calculate field IDs when this type is
   /// nested under another type.
-  unsigned getMaxFieldID();
+  uint64_t getMaxFieldID();
 
   /// Get the sub-type of a type for a field ID, and the subfield's ID. Strip
   /// off a single layer of this type and return the sub-type and a field ID
   /// targeting the same field, but rebased on the sub-type.
-  std::pair<FIRRTLBaseType, unsigned> getSubTypeByFieldID(unsigned fieldID);
+  std::pair<FIRRTLBaseType, uint64_t> getSubTypeByFieldID(uint64_t fieldID);
 
   /// Return the final type targeted by this field ID by recursively walking all
   /// nested aggregate types. This is the identity function for ground types.
-  FIRRTLBaseType getFinalTypeByFieldID(unsigned fieldID);
+  FIRRTLBaseType getFinalTypeByFieldID(uint64_t fieldID);
 
   /// Returns the effective field id when treating the index field as the
   /// root of the type.  Essentially maps a fieldID to a fieldID after a
   /// subfield op. Returns the new id and whether the id is in the given
   /// child.
-  std::pair<unsigned, bool> rootChildFieldID(unsigned fieldID, unsigned index);
+  std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
 
   /// Get the number of ground (non-aggregate) fields in the type.  A field
   /// which is a bundle or vector is not counted, but the recursive ground
   /// fields of are.
-  unsigned getGroundFields() const;
+  uint64_t getGroundFields() const;
 
 protected:
   using FIRRTLType::FIRRTLType;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -71,26 +71,26 @@ def FVectorTypeImpl : FIRRTLImplType<"FVector", [FieldIDTypeInterface]> {
     /// Get an integer ID for the field. Field IDs start at 1, and are assigned
     /// to each field in a vector in a recursive depth-first walk of all
     /// elements. A field ID of 0 is used to reference the vector itself.
-    size_t getFieldID(size_t index);
+    uint64_t getFieldID(uint64_t index);
 
     /// Find the element index corresponding to the desired fieldID.  If the
     /// fieldID corresponds to a field in nested under an element, it will
     /// return the index of the parent element.
-    size_t getIndexForFieldID(size_t fieldID);
+    uint64_t getIndexForFieldID(uint64_t fieldID);
 
     /// Strip off a single layer of this type and return the sub-type and a
     /// field ID targeting the same field, but rebased on the sub-type.
-    std::pair<FIRRTLBaseType, size_t> getSubTypeByFieldID(size_t fieldID);
+    std::pair<FIRRTLBaseType, uint64_t> getSubTypeByFieldID(uint64_t fieldID);
 
     /// Get the maximum field ID in this vector.  This is helpful for
     /// constructing field IDs when this VectorType is nested in another
     /// aggregate type.
-    size_t getMaxFieldID();
+    uint64_t getMaxFieldID();
 
     /// Returns the effective field id when treating the index field as the root
     /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
     /// op. Returns the new id and whether the id is in the given child.
-    std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
+    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
   }];
 }
 
@@ -154,27 +154,27 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
     /// visiting all nested bundle fields.  A field ID of 0 is used to reference
     /// the bundle itself. The ID can be used to uniquely identify any specific
     /// field in this bundle.
-    unsigned getFieldID(unsigned index);
+    uint64_t getFieldID(uint64_t index);
 
     /// Find the element index corresponding to the desired fieldID.  If the
     /// fieldID corresponds to a field in a nested bundle, it will return the
     /// index of the parent field.
-    unsigned getIndexForFieldID(unsigned fieldID);
+    uint64_t getIndexForFieldID(uint64_t fieldID);
 
     /// Strip off a single layer of this type and return the sub-type and a
     /// field ID targeting the same field, but rebased on the sub-type.
-    std::pair<FIRRTLBaseType, unsigned> getSubTypeByFieldID(unsigned fieldID);
+    std::pair<FIRRTLBaseType, uint64_t> getSubTypeByFieldID(uint64_t fieldID);
 
     /// Get the maximum field ID in this bundle.  This is helpful for
     /// constructing field IDs when this BundleType is nested in another
     /// aggregate type.
-    unsigned getMaxFieldID();
+    uint64_t getMaxFieldID();
 
     /// Returns the effective field id when treating the index field as the root
     /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
     /// op. Returns the new id and whether the id is in the given child.
-    std::pair<unsigned, bool> rootChildFieldID(unsigned fieldID,
-                                               unsigned index);
+    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID,
+                                               uint64_t index);
 
     using iterator = ArrayRef<BundleElement>::iterator;
     iterator begin() const { return getElements().begin(); }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -514,7 +514,7 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(MLIRContext *ctxt,
   if (!annotations || annotations.empty())
     return ArrayAttr::get(ctxt, retval);
   for (auto opAttr : annotations) {
-    std::optional<int64_t> maybeFieldID;
+    std::optional<uint64_t> maybeFieldID;
     DictionaryAttr annotation;
     annotation = opAttr.dyn_cast<DictionaryAttr>();
     if (annotations)


### PR DESCRIPTION
Convert all fieldID-related functions which are not already in the FieldIDTypeInterface to use uint64_t for its type.  Previously, this was a mix of unsigned for bundles and size_t for vectors (due to reasons that vectors can sometimes be representing very large memories with more than 2^32 elements whereas this is rare for bundles).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>