### PR TITLE
[FIRRTL] Move SIntType and UIntType to ODS

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -17,16 +17,55 @@ include "FIRRTLDialect.td"
 include "circt/Dialect/HW/HWTypeInterfaces.td"
 
 // Base class for other typedefs. Provides dialact-specific defaults.
-class FIRRTLImplType<string name, list<Trait> traits = []>
-  : TypeDef<FIRRTLDialect, name, traits, "::circt::firrtl::FIRRTLBaseType"> {}
+class FIRRTLImplType<string name,
+                     list<Trait> traits = [],
+                     string baseCppClass = "::circt::firrtl::FIRRTLBaseType">
+    : TypeDef<FIRRTLDialect, name, traits, baseCppClass> {}
 
-def WidthQualifiedTrait : NativeTypeTrait<"WidthQualifiedTrait"> {
+//===----------------------------------------------------------------------===//
+// Type Traits
+//===----------------------------------------------------------------------===//
+
+def WidthQualifiedTypeTrait : NativeTypeTrait<"WidthQualifiedTypeTrait"> {
   let cppNamespace = "::circt::firrtl";
 }
 
 //===----------------------------------------------------------------------===//
-// Type declarations
+// Type Definitions
 //===----------------------------------------------------------------------===//
+
+def SIntImpl : FIRRTLImplType<"SInt",
+                              [WidthQualifiedTypeTrait, FieldIDTypeInterface],
+                              "::circt::firrtl::IntType"> {
+  let summary = "A signed integer type, whose width may not be known.";
+  let parameters = (ins "int32_t":$widthOrSentinel);
+  let builders = [
+    TypeBuilder<(ins "std::optional<int32_t>":$width)>,
+    TypeBuilder<(ins)>,
+  ];
+  let genVerifyDecl = true;
+  let extraClassDeclaration = [{
+    using WidthQualifiedTypeTrait<SIntType>::getWidth;
+    using WidthQualifiedTypeTrait<SIntType>::hasWidth;
+  }];
+}
+
+def UIntImpl : FIRRTLImplType<"UInt",
+                              [WidthQualifiedTypeTrait, FieldIDTypeInterface],
+                              "::circt::firrtl::IntType"> {
+  let summary = "An unsigned integer type, whose width may not be known.";
+  let parameters = (ins "int32_t":$widthOrSentinel);
+  let builders = [
+    TypeBuilder<(ins "std::optional<int32_t>":$width)>,
+    TypeBuilder<(ins)>,
+  ];
+  let genVerifyDecl = true;
+  let extraClassDeclaration = [{
+    using WidthQualifiedTypeTrait<UIntType>::getWidth;
+    using WidthQualifiedTypeTrait<UIntType>::hasWidth;
+  }];
+}
+
 def ClockTypeImpl : FIRRTLImplType<"Clock", [FieldIDTypeInterface]> {
   let summary = "Clock signal";
 }
@@ -40,14 +79,14 @@ def AsyncResetTypeImpl : FIRRTLImplType<"AsyncReset", [FieldIDTypeInterface]> {
 }
 
 def AnalogTypeImpl : FIRRTLImplType<"Analog",
-  [WidthQualifiedTrait, FieldIDTypeInterface]> {
+  [WidthQualifiedTypeTrait, FieldIDTypeInterface]> {
   let summary = "Analog signal";
-  let parameters = (ins "int32_t":$baseWidth);
+  let parameters = (ins "int32_t":$widthOrSentinel);
   let builders = [
-    TypeBuilder<(ins "int32_t":$baseWidth)>,
+    TypeBuilder<(ins "std::optional<int32_t>":$width)>,
     TypeBuilder<(ins)>,
   ];
-
+  let genVerifyDecl = true;
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -701,68 +701,58 @@ Type firrtl::getPassiveType(Type anyBaseFIRRTLType) {
 // IntType
 //===----------------------------------------------------------------------===//
 
-/// Return the bitwidth of this type or None if unknown.
-std::optional<int32_t> IntType::getWidth() {
-  return isSigned() ? this->cast<SIntType>().getWidth()
-                    : this->cast<UIntType>().getWidth();
-}
-
 /// Return a SIntType or UInt type with the specified signedness and width.
-IntType IntType::get(MLIRContext *context, bool isSigned, int32_t width) {
+IntType IntType::get(MLIRContext *context, bool isSigned,
+                     int32_t widthOrSentinel) {
   if (isSigned)
-    return SIntType::get(context, width);
-  return UIntType::get(context, width);
+    return SIntType::get(context, widthOrSentinel);
+  return UIntType::get(context, widthOrSentinel);
+}
+
+int32_t IntType::getWidthOrSentinel() {
+  if (isa<SIntType>())
+    return this->cast<SIntType>().getWidthOrSentinel();
+  if (isa<UIntType>())
+    return this->cast<UIntType>().getWidthOrSentinel();
+  return -1;
 }
 
 //===----------------------------------------------------------------------===//
-// Width Qualified Ground Types
+// SIntType
 //===----------------------------------------------------------------------===//
 
-namespace circt {
-namespace firrtl {
-namespace detail {
-struct WidthTypeStorage : mlir::TypeStorage {
-  WidthTypeStorage(int32_t width) : width(width) {}
-  using KeyTy = int32_t;
+SIntType SIntType::get(MLIRContext *context) { return get(context, -1); }
 
-  bool operator==(const KeyTy &key) const { return key == width; }
-
-  static WidthTypeStorage *construct(TypeStorageAllocator &allocator,
-                                     const KeyTy &key) {
-    return new (allocator.allocate<WidthTypeStorage>()) WidthTypeStorage(key);
-  }
-
-  int32_t width;
-};
-} // namespace detail
-} // namespace firrtl
-} // namespace circt
-
-static std::optional<int32_t>
-getWidthQualifiedTypeWidth(firrtl::detail::WidthTypeStorage *impl) {
-  int width = impl->width;
-  if (width < 0)
-    return std::nullopt;
-  return width;
+SIntType SIntType::get(MLIRContext *context, std::optional<int32_t> width) {
+  if (!width)
+    return get(context);
+  return get(context, *width);
 }
 
-/// Get an with a known width, or -1 for unknown.
-SIntType SIntType::get(MLIRContext *context, int32_t width) {
-  assert(width >= -1 && "unknown width");
-  return Base::get(context, width);
+LogicalResult SIntType::verify(function_ref<InFlightDiagnostic()> emitError,
+                               int32_t widthOrSentinel) {
+  if (widthOrSentinel < -1)
+    return emitError() << "invalid width";
+  return success();
 }
 
-std::optional<int32_t> SIntType::getWidth() {
-  return getWidthQualifiedTypeWidth(this->getImpl());
+//===----------------------------------------------------------------------===//
+// UIntType
+//===----------------------------------------------------------------------===//
+
+UIntType UIntType::get(MLIRContext *context) { return get(context, -1); }
+
+UIntType UIntType::get(MLIRContext *context, std::optional<int32_t> width) {
+  if (!width)
+    return get(context);
+  return get(context, *width);
 }
 
-UIntType UIntType::get(MLIRContext *context, int32_t width) {
-  assert(width >= -1 && "unknown width");
-  return Base::get(context, width);
-}
-
-std::optional<int32_t> UIntType::getWidth() {
-  return getWidthQualifiedTypeWidth(this->getImpl());
+LogicalResult UIntType::verify(function_ref<InFlightDiagnostic()> emitError,
+                               int32_t widthOrSentinel) {
+  if (widthOrSentinel < -1)
+    return emitError() << "invalid width";
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1105,11 +1095,25 @@ auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
 }
 
 //===----------------------------------------------------------------------===//
-// ODS Custom Builders
+// AnalogType
 //===----------------------------------------------------------------------===//
 
 AnalogType AnalogType::get(mlir::MLIRContext *context) {
   return AnalogType::get(context, -1);
+}
+
+AnalogType AnalogType::get(mlir::MLIRContext *context,
+                           std::optional<int32_t> width) {
+  if (!width)
+    return AnalogType::get(context);
+  return AnalogType::get(context, *width);
+}
+
+LogicalResult AnalogType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                 int32_t widthOrSentinel) {
+  if (widthOrSentinel < -1)
+    return emitError() << "invalid width";
+  return success();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
- Make WidthQualifiedTrait a type trait, renaming it to WidthQualifiedTypeTrait.
- Rather than have users implement getWidth(), have users implement getWidthOrSentinel().
  - enshrine the idea that `widthOrSentinel : int32_t` is the most primitive format for widths of types.
  - this means that if a type has an attribute called widthOrSentinel, then it can use this trait for free
- Remove WidthQualifiedType and WidthTypeStorage
- In AnalogType, rename the widthBase attribute to widthOrSentinel
- Make IntType use WidthQualifiedTypeTrait
  - changeWidth(int32_t width) had to be removed from WidthQualifiedTypeTrait to support this
- Verify the widthOrSentinel value in a type verifier, rather than in the builder
- Add a verifier for AnalogType
- Let FIRRTLImplType take a baseCppClass parameter
  - Used to let S/UIntType to inherit from IntType.