### PR TITLE
[PyCDE] Separate BitVectors into Integers vs. Bits

### DIFF
--- a/frontends/PyCDE/integration_test/esi_test.py
+++ b/frontends/PyCDE/integration_test/esi_test.py
@@ -52,12 +52,9 @@ class LoopbackInOutAdd7:
     loopback = Wire(types.channel(types.i16))
     from_host = HostComms.req_resp(loopback, "loopback_inout")
     ready = Wire(types.i1)
-    wide_data, valid = from_host.unwrap(ready)
-    data = wide_data[0:16]
-    # TODO: clean this up with PyCDE overloads (they're currently a little bit
-    # broken for this use-case).
-    data = comb.AddOp(data, types.i16(7))
-    data_chan, data_ready = loopback.type.wrap(data, valid)
+    data, valid = from_host.unwrap(ready)
+    plus7 = data.as_uint(15) + types.ui8(7)
+    data_chan, data_ready = loopback.type.wrap(plus7.as_bits(), valid)
     ready.assign(data_ready)
     loopback.assign(data_chan)
 

--- a/frontends/PyCDE/src/pycde/constructs.py
+++ b/frontends/PyCDE/src/pycde/constructs.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from .pycde_types import PyCDEType, dim
-from .value import BitVectorValue, ListValue, Value, PyCDEValue
+from .value import BitsValue, BitVectorValue, ListValue, Value, PyCDEValue
 from .value import get_slice_bounds
 from circt.support import get_value, BackedgeBuilder
 from circt.dialects import msft, hw, sv
@@ -107,7 +107,7 @@ def Wire(type: PyCDEType, name: str = None):
           last = p
           concat_operands.append(p)
         concat_operands.reverse()
-        self.assign(BitVectorValue.concat(concat_operands))
+        self.assign(BitsValue.concat(concat_operands))
 
   return WireValue()
 

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -4,9 +4,8 @@
 
 from collections import OrderedDict
 
-from .value import (BitVectorValue, ChannelValue, ClockValue, ListValue,
-                    SignedBitVectorValue, UnsignedBitVectorValue, StructValue,
-                    RegularValue, InOutValue, Value)
+from .value import (BitsValue, ChannelValue, ClockValue, ListValue, SIntValue,
+                    UIntValue, StructValue, RegularValue, InOutValue, Value)
 
 import mlir.ir
 from circt.dialects import esi, hw, sv
@@ -160,11 +159,11 @@ def Type(type: Union[mlir.ir.Type, PyCDEType]):
     return InOutType(type)
   if isinstance(type, mlir.ir.IntegerType):
     if type.is_signed:
-      return SignedBitVectorType(type)
+      return SIntType(type)
     elif type.is_unsigned:
-      return UnsignedBitVectorType(type)
+      return UIntType(type)
     else:
-      return BitVectorType(type)
+      return SignlessBitVectorType(type)
   if isinstance(type, esi.ChannelType):
     return ChannelType(type)
   return PyCDEType(type)
@@ -271,20 +270,23 @@ class BitVectorType(PyCDEType):
   def width(self):
     return self._type.width
 
-  def _get_value_class(self):
-    return BitVectorValue
 
-
-class SignedBitVectorType(BitVectorType):
+class SignlessBitVectorType(BitVectorType):
 
   def _get_value_class(self):
-    return SignedBitVectorValue
+    return BitsValue
 
 
-class UnsignedBitVectorType(BitVectorType):
+class SIntType(BitVectorType):
 
   def _get_value_class(self):
-    return UnsignedBitVectorValue
+    return SIntValue
+
+
+class UIntType(BitVectorType):
+
+  def _get_value_class(self):
+    return UIntValue
 
 
 class ClockType(PyCDEType):
@@ -321,7 +323,7 @@ class ChannelType(PyCDEType):
     valid = _obj_to_value(valid, types.i1)
     wrap_op = esi.WrapValidReadyOp(self._type, types.i1, value.value,
                                    valid.value)
-    return Value(wrap_op.chanOutput), BitVectorValue(wrap_op.ready, types.i1)
+    return Value(wrap_op.chanOutput), BitsValue(wrap_op.ready, types.i1)
 
 
 def dim(inner_type_or_bitwidth, *size: int, name: str = None) -> ArrayType:

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -163,7 +163,7 @@ def Type(type: Union[mlir.ir.Type, PyCDEType]):
     elif type.is_unsigned:
       return UIntType(type)
     else:
-      return SignlessBitVectorType(type)
+      return BitsType(type)
   if isinstance(type, esi.ChannelType):
     return ChannelType(type)
   return PyCDEType(type)
@@ -271,7 +271,7 @@ class BitVectorType(PyCDEType):
     return self._type.width
 
 
-class SignlessBitVectorType(BitVectorType):
+class BitsType(BitVectorType):
 
   def _get_value_class(self):
     return BitsValue

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -82,7 +82,7 @@ def _obj_to_value(x, type, result_type=None):
   from .value import PyCDEValue
   from .dialects import hw, hwarith
   from .pycde_types import (TypeAliasType, ArrayType, StructType, BitVectorType,
-                            SignlessBitVectorType, UIntType, SIntType, Type)
+                            BitsType, UIntType, SIntType, Type)
 
   if isinstance(x, PyCDEValue):
     return x
@@ -108,7 +108,7 @@ def _obj_to_value(x, type, result_type=None):
     if not isinstance(type, BitVectorType):
       raise ValueError(f"Int can only be converted to hw int, not '{type}'")
     with get_user_loc():
-      if isinstance(type, SignlessBitVectorType):
+      if isinstance(type, BitsType):
         return hw.ConstantOp(type, x)
       elif isinstance(type, (UIntType, SIntType)):
         return hwarith.ConstantOp(type, x)

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -80,9 +80,9 @@ def _obj_to_value(x, type, result_type=None):
     raise ValueError(
         "Encountered 'None' when trying to build hardware for python value.")
   from .value import PyCDEValue
-  from .dialects import hw
+  from .dialects import hw, hwarith
   from .pycde_types import (TypeAliasType, ArrayType, StructType, BitVectorType,
-                            Type)
+                            SignlessBitVectorType, UIntType, SIntType, Type)
 
   if isinstance(x, PyCDEValue):
     return x
@@ -108,7 +108,12 @@ def _obj_to_value(x, type, result_type=None):
     if not isinstance(type, BitVectorType):
       raise ValueError(f"Int can only be converted to hw int, not '{type}'")
     with get_user_loc():
-      return hw.ConstantOp(type, x)
+      if isinstance(type, SignlessBitVectorType):
+        return hw.ConstantOp(type, x)
+      elif isinstance(type, (UIntType, SIntType)):
+        return hwarith.ConstantOp(type, x)
+      else:
+        assert False, "Internal error: bit vector type unknown"
 
   if isinstance(x, (list, tuple)):
     if not isinstance(type, ArrayType):

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -393,9 +393,6 @@ class BitsValue(BitVectorValue):
 
 
 class IntValue(BitVectorValue):
-  # hwarith icmp predicate constants.
-  _ICMP_PRED_EQ = 0
-  _ICMP_PRED_NE = 1
 
   #  === Infix operators ===
 
@@ -445,10 +442,12 @@ class IntValue(BitVectorValue):
     return ret
 
   def __eq__(self, other):
-    return self.__exec_icmp__(other, IntValue._ICMP_PRED_EQ, "eq")
+    from circt.dialects import hwarith
+    return self.__exec_icmp__(other, hwarith.ICmpOp.PRED_EQ, "eq")
 
   def __ne__(self, other):
-    return self.__exec_icmp__(other, IntValue._ICMP_PRED_NE, "neq")
+    from circt.dialects import hwarith
+    return self.__exec_icmp__(other, hwarith.ICmpOp.PRED_NE, "neq")
 
   # TODO: This class will contain comparison operators (<, >, <=, >=)
 

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -241,6 +241,47 @@ def get_slice_bounds(size, idxOrSlice: Union[int, slice]):
 
 class BitVectorValue(PyCDEValue):
 
+  def __len__(self):
+    return self.type.width
+
+  #  === Casting ===
+
+  def _exec_cast(self, targetValueType, type_getter, width: int = None):
+
+    from .dialects import hwarith
+    if width is None:
+      width = self.type.width
+
+    if isinstance(self, targetValueType) and width == self.type.width:
+      return self
+    return hwarith.CastOp(self.value, type_getter(width))
+
+  def as_bits(self, width: int = None):
+    """
+    Returns this value as a signless integer. If 'width' is provided, this value
+    will be truncated to that width.
+    """
+    return self._exec_cast(BitsValue, ir.IntegerType.get_signless, width)
+
+  def as_sint(self, width: int = None):
+    """
+    Returns this value as a a signed integer. If 'width' is provided, this value
+    will be truncated or sign-extended to that width.
+    """
+    return self._exec_cast(SIntValue, ir.IntegerType.get_signed, width)
+
+  def as_uint(self, width: int = None):
+    """
+    Returns this value as an unsigned integer. If 'width' is provided, this value
+    will be truncated or zero-padded to that width.
+    """
+    return self._exec_cast(UIntValue, ir.IntegerType.get_unsigned, width)
+
+
+class BitsValue(BitVectorValue):
+  """Operations on signless ints (bits). These will all return signless values -
+  a user is expected to reapply signedness semantics if needed."""
+
   @singledispatchmethod
   def __getitem__(self, idxOrSlice: Union[int, slice]) -> BitVectorValue:
     lo, hi = get_slice_bounds(len(self), idxOrSlice)
@@ -297,58 +338,7 @@ class BitVectorValue(PyCDEValue):
       v.name = f"{self.name}_padto_{num_bits}"
     return v
 
-  def __len__(self):
-    return self.type.width
-
-  #  === Casting ===
-
-  def _exec_cast(self, targetValueType, type_getter, width: int = None):
-
-    from .dialects import hwarith
-    if width is None:
-      width = self.type.width
-
-    if type(self) is targetValueType and width == self.type.width:
-      return self
-    return hwarith.CastOp(self.value, type_getter(width))
-
-  def as_int(self, width: int = None):
-    """
-    Returns this value as a signless integer. If 'width' is provided, this value
-    will be truncated to that width.
-    """
-    return self._exec_cast(BitVectorValue, ir.IntegerType.get_signless, width)
-
-  def as_sint(self, width: int = None):
-    """
-    Returns this value as a a signed integer. If 'width' is provided, this value
-    will be truncated or sign-extended to that width.
-    """
-    return self._exec_cast(SignedBitVectorValue, ir.IntegerType.get_signed,
-                           width)
-
-  def as_uint(self, width: int = None):
-    """
-    Returns this value as an unsigned integer. If 'width' is provided, this value
-    will be truncated or zero-padded to that width.
-    """
-    return self._exec_cast(UnsignedBitVectorValue, ir.IntegerType.get_unsigned,
-                           width)
-
-  #  === Infix operators ===
-
-  # Signless operations. These will all return signless values - a user is
-  # expected to reapply signedness semantics if needed.
-
-  # Generalized function for executing signless binary operations. Performs
-  # a check to ensure that the operands have signless semantics and are of
-  # identical width, and then calls the provided operator.
-  def __exec_signless_binop__(self, other, op, op_name: str):
-    w = max(self.type.width, other.type.width)
-    ret = op(self.as_int(w), other.as_int(w))
-    if self.name is not None and other.name is not None:
-      ret.name = f"{self.name}_{op_name}_{other.name}"
-    return ret
+  # === Infix operators ===
 
   def __exec_signless_binop_nocast__(self, other, op, op_symbol: str,
                                      op_name: str):
@@ -357,19 +347,12 @@ class BitVectorValue(PyCDEValue):
       # with PyCDE value comparison.
       return super().__eq__(other)
 
-    signednessOperand = None
-    if type(self) is not BitVectorValue:
-      signednessOperand = "LHS"
-    elif type(other) is not BitVectorValue:
-      signednessOperand = "RHS"
-
-    if signednessOperand is not None:
+    if not isinstance(other, BitsValue):
       raise TypeError(
-          f"Operator '{op_symbol}' requires {signednessOperand} to be cast .as_int()."
-      )
+          f"Operator '{op_symbol}' requires RHS to be cast .as_bits().")
 
     w = max(self.type.width, other.type.width)
-    ret = op(self.as_int(w), other.as_int(w))
+    ret = op(self.as_bits(w), other.as_bits(w))
     if self.name is not None and other.name is not None:
       ret.name = f"{self.name}_{op_name}_{other.name}"
     return ret
@@ -384,36 +367,39 @@ class BitVectorValue(PyCDEValue):
 
   def __and__(self, other):
     from .dialects import comb
-    return self.__exec_signless_binop__(other, comb.AndOp, "and")
+    return self.__exec_signless_binop_nocast__(other, comb.AndOp, "&", "and")
 
   def __or__(self, other):
     from .dialects import comb
-    return self.__exec_signless_binop__(other, comb.OrOp, "or")
+    return self.__exec_signless_binop_nocast__(other, comb.OrOp, "|", "or")
 
   def __xor__(self, other):
     from .dialects import comb
-    return self.__exec_signless_binop__(other, comb.XorOp, "xor")
+    return self.__exec_signless_binop_nocast__(other, comb.XorOp, "^", "xor")
 
   def __invert__(self):
     from .pycde_types import types
-    ret = self.as_int() ^ types.int(self.type.width)(-1)
+    ret = self ^ types.int(self.type.width)(-1)
     if self.name is not None:
-      ret.name = f"neg_{self.name}"
+      ret.name = f"inv_{self.name}"
     return ret
 
-  # Generalized function for executing sign-aware binary operations. Performs
-  # a check to ensure that the operands have signedness semantics, and then calls
-  # the provided operator.
-  def __exec_signedness_binop__(self, other, op, op_symbol: str, op_name: str):
-    signlessOperand = None
-    if type(self) is BitVectorValue:
-      signlessOperand = "LHS"
-    elif type(other) is BitVectorValue:
-      signlessOperand = "RHS"
 
-    if signlessOperand is not None:
+class IntValue(BitVectorValue):
+  # hwarith icmp predicate constants.
+  _ICMP_PRED_EQ = 0
+  _ICMP_PRED_NE = 1
+
+  #  === Infix operators ===
+
+  # Generalized function for executing sign-aware binary operations. Performs
+  # a check to ensure that the operands have signedness semantics, and then
+  # calls the provided operator.
+  def __exec_signedness_binop__(self, other, op, op_symbol: str, op_name: str):
+    if not isinstance(other, IntValue):
       raise TypeError(
-          f"Operator '{op_symbol}' is not supported on signless values. {signlessOperand} operand should be cast .as_sint()/.as_uint()."
+          f"Operator '{op_symbol}' is not supported on non-int or signless "
+          "values. RHS operand should be cast .as_sint()/.as_uint() if possible."
       )
 
     ret = op(self, other)
@@ -437,10 +423,27 @@ class BitVectorValue(PyCDEValue):
     from .dialects import hwarith
     return self.__exec_signedness_binop__(other, hwarith.DivOp, "/", "div")
 
+  # Generalized function for executing sign-aware int comparisons.
+  def __exec_icmp__(self, other, pred: int, op_name: str):
+    from .dialects import hwarith
+    if not isinstance(other, IntValue):
+      raise TypeError(
+          f"Comparisons of signed/unsigned integers to {other.type} not "
+          "supported. RHS operand should be cast .as_sint()/.as_uint() if "
+          "possible.")
 
-class WidthExtendingBitVectorValue(BitVectorValue):
+    ret = hwarith.ICmpOp(pred, self, other)
+    if self.name is not None and other.name is not None:
+      ret.name = f"{self.name}_{op_name}_{other.name}"
+    return ret
+
+  def __eq__(self, other):
+    return self.__exec_icmp__(other, IntValue._ICMP_PRED_EQ, "eq")
+
+  def __ne__(self, other):
+    return self.__exec_icmp__(other, IntValue._ICMP_PRED_NE, "neq")
+
   # TODO: This class will contain comparison operators (<, >, <=, >=)
-  pass
 
   def __lt__(self, other):
     assert False, "Unimplemented"
@@ -452,14 +455,13 @@ class WidthExtendingBitVectorValue(BitVectorValue):
     assert False, "Unimplemented"
 
 
-class UnsignedBitVectorValue(WidthExtendingBitVectorValue):
+class UIntValue(IntValue):
   pass
 
 
-class SignedBitVectorValue(WidthExtendingBitVectorValue):
+class SIntValue(IntValue):
 
   def __neg__(self):
-    from .dialects import comb
     from .pycde_types import types
     return self * types.int(self.type.width)(-1).as_sint()
 

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -76,21 +76,7 @@ class OperatorError:
 
   @generator
   def build(ports):
-    # CHECK: Operator '+' is not supported on signless values. LHS operand should be cast .as_sint()/.as_uint().
-    ports.a + ports.b
-
-
-# -----
-
-
-@unittestmodule()
-class OperatorError2:
-  a = Input(types.i32)
-  b = Input(types.si32)
-
-  @generator
-  def build(ports):
-    # CHECK: Operator '+' is not supported on signless values. RHS operand should be cast .as_sint()/.as_uint().
+    # CHECK: Operator '+' is not supported on non-int or signless values. RHS operand should be cast .as_sint()/.as_uint() if possible.
     ports.b + ports.a
 
 
@@ -104,5 +90,5 @@ class OperatorError2:
 
   @generator
   def build(ports):
-    # CHECK: Operator '==' requires LHS to be cast .as_int().
+    # CHECK: Comparisons of signed/unsigned integers to i32 not supported. RHS operand should be cast .as_sint()/.as_uint() if possible.
     ports.b == ports.a

--- a/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
@@ -49,3 +49,19 @@ class CastOp:
   @classmethod
   def create(cls, value, result_type):
     return cls(result_type, value)
+
+
+class ICmpOp:
+
+  @classmethod
+  def create(cls, pred, a, b):
+    if isinstance(pred, int):
+      pred = IntegerAttr.get(IntegerType.get_signless(64), pred)
+    return cls(pred, a, b)
+
+
+class ConstantOp:
+
+  @classmethod
+  def create(cls, data_type, value):
+    return cls(IntegerAttr.get(data_type, value))

--- a/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hwarith_ops_ext.py
@@ -52,6 +52,17 @@ class CastOp:
 
 
 class ICmpOp:
+  # Predicate constants.
+
+  # `==` and `!=`
+  PRED_EQ = 0b000
+  PRED_NE = 0b001
+  # `<` and `>=`
+  PRED_LT = 0b010
+  PRED_GE = 0b011
+  # `<=` and `>`
+  PRED_LE = 0b100
+  PRED_GT = 0b101
 
   @classmethod
   def create(cls, pred, a, b):


### PR DESCRIPTION
Introduce separate class hierarchies for signless integers (which PyCDE calls 'Bits') and signed/unsigned ints since they are fundamentally different things. Certain operations only make sense on bits and certain others only make sense on ints. Also, there are two different dialects for each (comb vs hwarith) so this change reduces edge cases.