### PR TITLE
[FIRRTL] Move FVectorType to ODS

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -373,53 +373,6 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-// FVector Type
-//===----------------------------------------------------------------------===//
-
-/// VectorType is a fixed size collection of elements, like an array.
-class FVectorType
-    : public FIRRTLType::TypeBase<FVectorType, FIRRTLBaseType,
-                                  detail::VectorTypeStorage,
-                                  circt::hw::FieldIDTypeInterface::Trait> {
-public:
-  using Base::Base;
-
-  static FVectorType get(FIRRTLBaseType elementType, size_t numElements);
-
-  FIRRTLBaseType getElementType();
-  size_t getNumElements();
-
-  /// Return the recursive properties of the type.
-  RecursiveTypeProperties getRecursiveTypeProperties();
-
-  /// Return this type with any flip types recursively removed from itself.
-  FIRRTLBaseType getPassiveType();
-
-  /// Get an integer ID for the field. Field IDs start at 1, and are assigned
-  /// to each field in a vector in a recursive depth-first walk of all elements.
-  /// A field ID of 0 is used to reference the vector itself.
-  size_t getFieldID(size_t index);
-
-  /// Find the element index corresponding to the desired fieldID.  If the
-  /// fieldID corresponds to a field in nested under an element, it will return
-  /// the index of the parent element.
-  size_t getIndexForFieldID(size_t fieldID);
-
-  /// Strip off a single layer of this type and return the sub-type and a field
-  /// ID targeting the same field, but rebased on the sub-type.
-  std::pair<FIRRTLBaseType, size_t> getSubTypeByFieldID(size_t fieldID);
-
-  /// Get the maximum field ID in this vector.  This is helpful for constructing
-  /// field IDs when this VectorType is nested in another aggregate type.
-  size_t getMaxFieldID();
-
-  /// Returns the effective field id when treating the index field as the root
-  /// of the type.  Essentially maps a fieldID to a fieldID after a subfield op.
-  /// Returns the new id and whether the id is in the given child.
-  std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
-};
-
-//===----------------------------------------------------------------------===//
 // Reference Type
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -50,4 +50,48 @@ def AnalogTypeImpl : FIRRTLImplType<"Analog",
 
 }
 
+def FVectorTypeImpl : FIRRTLImplType<"FVector", [FieldIDTypeInterface]> {
+  let summary = "a fixed size collection of elements, like an array.";
+  let genStorageClass = false;
+  let parameters = (ins "FIRRTLBaseType":$elementType, "size_t":$numElements);
+  let skipDefaultBuilders = true;
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "FIRRTLBaseType":$elementType,
+      "size_t":$numElements)
+    >
+  ];
+  let extraClassDeclaration = [{
+    /// Return the recursive properties of the type.
+    RecursiveTypeProperties getRecursiveTypeProperties();
+
+    /// Return this type with any flip types recursively removed from itself.
+    FIRRTLBaseType getPassiveType();
+
+    /// Get an integer ID for the field. Field IDs start at 1, and are assigned
+    /// to each field in a vector in a recursive depth-first walk of all
+    /// elements. A field ID of 0 is used to reference the vector itself.
+    size_t getFieldID(size_t index);
+
+    /// Find the element index corresponding to the desired fieldID.  If the
+    /// fieldID corresponds to a field in nested under an element, it will
+    /// return the index of the parent element.
+    size_t getIndexForFieldID(size_t fieldID);
+
+    /// Strip off a single layer of this type and return the sub-type and a
+    /// field ID targeting the same field, but rebased on the sub-type.
+    std::pair<FIRRTLBaseType, size_t> getSubTypeByFieldID(size_t fieldID);
+
+    /// Get the maximum field ID in this vector.  This is helpful for
+    /// constructing field IDs when this VectorType is nested in another
+    /// aggregate type.
+    size_t getMaxFieldID();
+
+    /// Returns the effective field id when treating the index field as the root
+    /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
+    /// op. Returns the new id and whether the id is in the given child.
+    std::pair<size_t, bool> rootChildFieldID(size_t fieldID, size_t index);
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -966,25 +966,23 @@ std::pair<unsigned, bool> BundleType::rootChildFieldID(unsigned fieldID,
 }
 
 //===----------------------------------------------------------------------===//
-// Vector Type
+// FVectorType
 //===----------------------------------------------------------------------===//
 
-namespace circt {
-namespace firrtl {
-namespace detail {
-struct VectorTypeStorage : mlir::TypeStorage {
+struct circt::firrtl::detail::FVectorTypeStorage : mlir::TypeStorage {
   using KeyTy = std::pair<FIRRTLBaseType, size_t>;
 
-  VectorTypeStorage(KeyTy value) : value(value) {
+  FVectorTypeStorage(KeyTy value) : value(value) {
     auto properties = value.first.getRecursiveTypeProperties();
     passiveContainsAnalogTypeInfo.setInt(properties.toFlags());
   }
 
   bool operator==(const KeyTy &key) const { return key == value; }
 
-  static VectorTypeStorage *construct(TypeStorageAllocator &allocator,
-                                      KeyTy key) {
-    return new (allocator.allocate<VectorTypeStorage>()) VectorTypeStorage(key);
+  static FVectorTypeStorage *construct(TypeStorageAllocator &allocator,
+                                       KeyTy key) {
+    return new (allocator.allocate<FVectorTypeStorage>())
+        FVectorTypeStorage(key);
   }
 
   KeyTy value;
@@ -995,18 +993,16 @@ struct VectorTypeStorage : mlir::TypeStorage {
       passiveContainsAnalogTypeInfo;
 };
 
-} // namespace detail
-} // namespace firrtl
-} // namespace circt
-
 FVectorType FVectorType::get(FIRRTLBaseType elementType, size_t numElements) {
   return Base::get(elementType.getContext(),
                    std::make_pair(elementType, numElements));
 }
 
-FIRRTLBaseType FVectorType::getElementType() { return getImpl()->value.first; }
+FIRRTLBaseType FVectorType::getElementType() const {
+  return getImpl()->value.first;
+}
 
-size_t FVectorType::getNumElements() { return getImpl()->value.second; }
+size_t FVectorType::getNumElements() const { return getImpl()->value.second; }
 
 /// Return the recursive properties of the type.
 RecursiveTypeProperties FVectorType::getRecursiveTypeProperties() {


### PR DESCRIPTION
Use a flag genStorageClass to let us continue to use a custom storage class.