### PR TITLE
[FIRRTL] Use circuit location for annotation file parse errors.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -168,6 +168,7 @@ FIRLexer::FIRLexer(const llvm::SourceMgr &sourceMgr, MLIRContext *context)
 /// Encode the specified source location information into a Location object
 /// for attachment to the IR or error reporting.
 Location FIRLexer::translateLocation(llvm::SMLoc loc) {
+  assert(loc.isValid());
   unsigned mainFileID = sourceMgr.getMainFileID();
   auto lineAndColumn = sourceMgr.getLineAndColumn(loc, mainFileID);
   return FileLineColLoc::get(bufferNameIdentifier, lineAndColumn.first,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3172,7 +3172,7 @@ ParseResult FIRCircuitParser::parseCircuit(
 
   // Deal with the annotation file if one was specified
   for (auto *annotationsBuf : annotationsBufs)
-    if (importAnnotationsRaw(inlineAnnotationsLoc, circuitTarget,
+    if (importAnnotationsRaw(info.getFIRLoc(), circuitTarget,
                              annotationsBuf->getBuffer(), annos))
       return failure();
 

--- a/test/firtool/annotation-error.fir
+++ b/test/firtool/annotation-error.fir
@@ -1,0 +1,14 @@
+; Test annotation parse error.
+
+; Setup:
+; RUN: echo 'invalid' > %t.json
+
+; RUN: firtool %s --parse-only --annotation-file %t.json --verify-diagnostics
+
+; expected-error @below {{Failed to parse JSON}}
+; expected-note @below {{}}
+circuit Test:
+  module Test:
+    output o : UInt<1>
+    o <= UInt<1>(0)
+    


### PR DESCRIPTION
The inline annotation location is invalid if none are specified, and since the error isn't in inline annotations just point to circuit.

Would be nice to point into the file itself, or mention it, but that will require reworking how these files are loaded/passed around.

For now, let's not crash.
This is the same as we do for OMIR annotation files and their error reporting.

Fixes #4538.