### PR TITLE
[ExportVerilog] Avoid inlining unpacked array expressions to declarations for tool compatibility

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -341,6 +341,13 @@ static Type stripUnpackedTypes(Type type) {
       .Default([](Type type) { return type; });
 }
 
+/// Return true if the type has a leading unpacked type.
+static bool hasLeadingUnpackedType(Type type) {
+  assert(isa<hw::InOutType>(type) && "inout type is expected");
+  auto elementType = cast<hw::InOutType>(type).getElementType();
+  return stripUnpackedTypes(elementType) != elementType;
+}
+
 /// Return true if type has a struct type as a subtype.
 static bool hasStructType(Type type) {
   return TypeSwitch<Type, bool>(type)
@@ -5855,8 +5862,11 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     }
 
     // Try inlining an assignment into declarations.
+    // FIXME: Unpacked array is not inlined since several tools doesn't support
+    // that syntax. See Issue 6363.
     if (isa<sv::WireOp, LogicOp>(op) &&
-        !op->getParentOp()->hasTrait<ProceduralRegion>()) {
+        !op->getParentOp()->hasTrait<ProceduralRegion>() &&
+        !hasLeadingUnpackedType(op->getResult(0).getType())) {
       // Get a single assignments if any.
       if (auto singleAssign = getSingleAssignAndCheckUsers<AssignOp>(op)) {
         auto *source = singleAssign.getSrc().getDefiningOp();
@@ -5877,7 +5887,10 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     }
 
     // Try inlining a blocking assignment to logic op declaration.
-    if (isa<LogicOp>(op) && op->getParentOp()->hasTrait<ProceduralRegion>()) {
+    // FIXME: Unpacked array is not inlined since several tools doesn't support
+    // that syntax. See Issue 6363.
+    if (isa<LogicOp>(op) && op->getParentOp()->hasTrait<ProceduralRegion>() &&
+        !hasLeadingUnpackedType(op->getResult(0).getType())) {
       // Get a single assignment which might be possible to inline.
       if (auto singleAssign = getSingleAssignAndCheckUsers<BPAssignOp>(op)) {
         // It is necessary for the assignment to dominate users of the op.

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -489,7 +489,8 @@ hw.module @ArrayParamsInst() {
     uarr: %uarr : !hw.uarray<2 x i8>) -> ()
 }
 // CHECK:       wire [1:0][7:0] [[G0:_.*]] = '{8'h1, 8'h2};
-// CHECK:       wire [7:0]      [[G1:_.*]][0:1] = '{8'h1, 8'h2};
+// CHECK:       wire [7:0]      [[G1:_.*]][0:1];
+// CHECK:       assign [[G1]] = '{8'h1, 8'h2};
 // CHECK:       ArrayParams #(
 // CHECK:         .param(2)
 // CHECK:       ) arrays (

--- a/test/firtool/dpi.fir
+++ b/test/firtool/dpi.fir
@@ -33,7 +33,8 @@ circuit DPI:
 ; CHECK-LABEL: module DPI(
 ; CHECK:        logic [7:0] [[TMP:_.+]];
 ; CHECK-NEXT:   reg   [7:0] [[RESULT1:_.+]];
-; CHECK-NEXT:   wire [7:0] [[OPEN_ARRAY:_.+]][0:1] = '{in_0, in_1};
+; CHECK-NEXT:   wire [7:0] [[OPEN_ARRAY:_.+]][0:1];
+; CHECK-NEXT:   assign [[OPEN_ARRAY]] = '{in_0, in_1};
 ; CHECK-NEXT:   always @(posedge clock) begin
 ; CHECK-NEXT:     if (enable) begin
 ; CHECK-NEXT:       clocked_result(in_0, in_1, [[TMP]]);


### PR DESCRIPTION
This changes emission style for unpacked array declaration. Verilator doesn't support initialization assignments for unpacked arrays.
```verilog
wire w[1:0] = '{0, 0};
```
This PR checks the value type and prevents inlining. Ideally it is more desirable to improve verilator but for now I want to avoid inlining unpacked arrays to declaration since it's just a tiny readability optimization. 

Fix https://github.com/llvm/circt/issues/6363.
