### PR TITLE
[PyCDE] Value -> Signal

### DIFF
--- a/frontends/PyCDE/src/behavioral.py
+++ b/frontends/PyCDE/src/behavioral.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .value import BitVectorValue, PyCDEValue, Value
+from .value import BitVectorSignal, Signal, Value
 from .dialects import comb
 
 import ctypes
@@ -45,7 +45,7 @@ class If:
       ports.out = v
   ```"""
 
-  def __init__(self, cond: BitVectorValue):
+  def __init__(self, cond: BitVectorSignal):
     if (cond.type.width != 1):
       raise TypeError("'Cond' bit width must be 1")
     self._cond = cond
@@ -115,7 +115,7 @@ class _IfBlock:
     new_lcls: Dict[str, Value] = {}
     for (varname, value) in s.f_locals.items():
       # Only operate on Values.
-      if not isinstance(value, PyCDEValue):
+      if not isinstance(value, Signal):
         continue
       # If the value was in the original scope and it hasn't changed, don't
       # touch it.

--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -5,7 +5,7 @@
 from pycde.system import System
 from .module import (Generator, _module_base, _BlockContext,
                      _GeneratorPortAccess, _SpecializedModule)
-from pycde.value import ChannelValue, ClockValue, PyCDEValue, Value
+from pycde.value import ChannelValue, ClockSignal, Signal, Value
 from .common import AppID, Input, Output, InputChannel, OutputChannel, _PyProxy
 from .circt.dialects import esi as raw_esi, hw, msft
 from .circt.support import BackedgeBuilder
@@ -92,7 +92,7 @@ class ServiceDecl(_PyProxy):
   def instantiate_builtin(self,
                           builtin: str,
                           result_types: List[PyCDEType] = [],
-                          inputs: List[PyCDEValue] = []):
+                          inputs: List[Signal] = []):
     """Implement a service using an implementation builtin to CIRCT. Needs the
     input ports which the implementation expects and returns the outputs."""
 
@@ -331,7 +331,7 @@ def ServiceImplementation(decl: Optional[ServiceDecl]):
         clk = None
         if len(spec_mod.clock_ports) == 1:
           clk_port = list(spec_mod.clock_ports.values())[0]
-          clk = ClockValue(arguments[clk_port], ClockType())
+          clk = ClockSignal(arguments[clk_port], ClockType())
           clk.__enter__()
 
         # Run the generator.

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -11,7 +11,7 @@ from pycde.support import _obj_to_value
 from .common import (AppID, Clock, Input, Output, _PyProxy)
 from .support import (get_user_loc, _obj_to_attribute, OpOperandConnect,
                       create_type_string, create_const_zero)
-from .value import ClockValue, PyCDEValue, Value
+from .value import ClockSignal, Signal, Value
 
 from .circt import ir, support
 from .circt.dialects import hw, msft
@@ -93,7 +93,7 @@ def generate_msft_module_op(generator: Generator, spec_mod: _SpecializedModule,
     if len(spec_mod.clock_ports) == 1:
       clk_port = list(spec_mod.clock_ports.values())[0]
       val = entry_block.arguments[clk_port]
-      clk = ClockValue(val, ClockType())
+      clk = ClockSignal(val, ClockType())
       clk.__enter__()
 
     outputs = generator.gen_func(args, **kwargs)
@@ -598,7 +598,7 @@ class _GeneratorPortAccess:
       idx = self._mod.input_port_lookup[name]
       val = self._block_args[idx]
       if name in self._mod.clock_ports:
-        return ClockValue(val, ClockType())
+        return ClockSignal(val, ClockType())
       return Value(val)
     if name in self._mod.output_port_lookup:
       if name not in self._output_values:
@@ -623,7 +623,7 @@ class _GeneratorPortAccess:
 
     output_port = self._mod.output_ports[self._mod.output_port_lookup[name]]
     output_port_type = output_port[1]
-    if not isinstance(value, PyCDEValue):
+    if not isinstance(value, Signal):
       value = _obj_to_value(value, output_port_type)
     if value.type != output_port_type:
       if value.type == output_port_type.strip:

--- a/frontends/PyCDE/src/ndarray.py
+++ b/frontends/PyCDE/src/ndarray.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .value import BitVectorValue, ListValue
+from .value import BitVectorSignal, ListValue
 from .pycde_types import BitVectorType, dim
 from pycde.dialects import hw, sv
 import numpy as np
@@ -132,13 +132,13 @@ class NDArray(np.ndarray):
     return hw.ConstantOp(ir.IntegerType.get_signless(width), value)
 
   @staticmethod
-  def _circt_to_arr(value: Union[BitVectorValue, ListValue],
+  def _circt_to_arr(value: Union[BitVectorSignal, ListValue],
                     target_shape: _TargetShape):
     """Converts a CIRCT value into a numpy array."""
-    from .value import (BitVectorValue, ListValue)
+    from .value import (BitVectorSignal, ListValue)
 
-    if isinstance(value, BitVectorValue) and isinstance(target_shape.dtype,
-                                                        BitVectorType):
+    if isinstance(value, BitVectorSignal) and isinstance(
+        target_shape.dtype, BitVectorType):
       # Direct match on the target shape?
       if value.type == target_shape.type:
         return value
@@ -271,10 +271,10 @@ class NDArray(np.ndarray):
     self.check_is_fully_assigned()
 
     def build_subarray(lstOrVal):
-      from .value import BitVectorValue
+      from .value import BitVectorSignal
       # Recursively converts this matrix into ListValues through hw.array_create
       # operations.
-      if not isinstance(lstOrVal, BitVectorValue):
+      if not isinstance(lstOrVal, BitVectorSignal):
         subarrays = [build_subarray(v) for v in lstOrVal]
         return hw.ArrayCreateOp(subarrays)
       return lstOrVal

--- a/frontends/PyCDE/src/pycde_types.py
+++ b/frontends/PyCDE/src/pycde_types.py
@@ -4,8 +4,8 @@
 
 from collections import OrderedDict
 
-from .value import (BitsValue, ChannelValue, ClockValue, ListValue, SIntValue,
-                    UIntValue, StructValue, RegularValue, InOutValue, Value)
+from .value import (BitsSignal, ChannelValue, ClockSignal, ListValue, SIntValue,
+                    UIntValue, StructValue, UntypedSignal, InOutSignal, Value)
 
 from .circt import ir, support
 from .circt.dialects import esi, hw, sv
@@ -138,7 +138,7 @@ class PyCDEType(ir.Type):
 
   def _get_value_class(self):
     """Return the class which should be instantiated to create a Value."""
-    return RegularValue
+    return UntypedSignal
 
 
 def Type(type: Union[ir.Type, PyCDEType]):
@@ -172,7 +172,7 @@ class InOutType(PyCDEType):
     return Type(self._type.element_type)
 
   def _get_value_class(self):
-    return InOutValue
+    return InOutSignal
 
 
 class TypeAliasType(PyCDEType):
@@ -270,7 +270,7 @@ class BitVectorType(PyCDEType):
 class BitsType(BitVectorType):
 
   def _get_value_class(self):
-    return BitsValue
+    return BitsSignal
 
 
 class SIntType(BitVectorType):
@@ -293,7 +293,7 @@ class ClockType(PyCDEType):
     super().__init__(ir.IntegerType.get_signless(1))
 
   def _get_value_class(self):
-    return ClockValue
+    return ClockSignal
 
 
 class ChannelType(PyCDEType):
@@ -319,7 +319,7 @@ class ChannelType(PyCDEType):
     valid = _obj_to_value(valid, types.i1)
     wrap_op = esi.WrapValidReadyOp(self._type, types.i1, value.value,
                                    valid.value)
-    return Value(wrap_op.chanOutput), BitsValue(wrap_op.ready, types.i1)
+    return Value(wrap_op.chanOutput), BitsSignal(wrap_op.ready, types.i1)
 
 
 def dim(inner_type_or_bitwidth, *size: int, name: str = None) -> ArrayType:

--- a/frontends/PyCDE/src/support.py
+++ b/frontends/PyCDE/src/support.py
@@ -78,12 +78,12 @@ def _obj_to_value(x, type, result_type=None):
   if x is None:
     raise ValueError(
         "Encountered 'None' when trying to build hardware for python value.")
-  from .value import PyCDEValue
+  from .value import Signal
   from .dialects import hw, hwarith
   from .pycde_types import (TypeAliasType, ArrayType, StructType, BitVectorType,
                             BitsType, UIntType, SIntType, Type)
 
-  if isinstance(x, PyCDEValue):
+  if isinstance(x, Signal):
     return x
 
   type = Type(type)
@@ -146,8 +146,8 @@ def _obj_to_value(x, type, result_type=None):
 def _infer_type(x):
   """Infer the CIRCT type from a python object. Only works on lists."""
   from .pycde_types import types
-  from .value import PyCDEValue
-  if isinstance(x, PyCDEValue):
+  from .value import Signal
+  if isinstance(x, Signal):
     return x.type
 
   if isinstance(x, (list, tuple)):

--- a/frontends/PyCDE/test/esi.py
+++ b/frontends/PyCDE/test/esi.py
@@ -8,7 +8,7 @@ from pycde.common import Output
 from pycde.constructs import Wire
 from pycde.pycde_types import ChannelType
 from pycde.testing import unittestmodule
-from pycde.value import BitVectorValue, ChannelValue
+from pycde.value import BitVectorSignal, ChannelValue
 
 
 @esi.ServiceDecl
@@ -138,7 +138,7 @@ class MultiplexerService:
     Unwrap the input channel and pad it to 256 bits.
     """
     (data, valid) = input_channel.unwrap(ports.trunk_out_ready)
-    assert isinstance(data, BitVectorValue)
+    assert isinstance(data, BitVectorSignal)
     assert len(data) <= 256
     ports.trunk_out = data.pad_or_truncate(256)
     ports.trunk_out_valid = valid


### PR DESCRIPTION
Renaming the very generic `Value` class name to `Signal`. It's a bit of a stretch for things like `InOutSignal` and `ChannelSignal`, but I think it's better for consistency's sake to use the same suffix for all `Value`s.