### PR TITLE
[FIRRTL] Mark DUT AddSeqMemPorts ports dontTouch

### DIFF
--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -89,7 +89,7 @@ firrtl.circuit "Two" attributes {annotations = [
     // CHECK: firrtl.strictconnect %sram_0_user_output, %MWrite_ext_user_output : !firrtl.uint<4>
     // CHECK: firrtl.strictconnect %MWrite_ext_user_input, %sram_0_user_input : !firrtl.uint<3>
   }
-  // CHECK: firrtl.module @Two(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>, out %sram_1_user_output: !firrtl.uint<4>, in %sram_1_user_input: !firrtl.uint<3>)
+  // CHECK: firrtl.module @Two(out %sram_0_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in %sram_0_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}], out %sram_1_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in %sram_1_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}])
   firrtl.module @Two() {
     firrtl.instance child0 @Child()
     firrtl.instance child1 @Child()
@@ -120,13 +120,13 @@ firrtl.circuit "TestHarness" attributes {annotations = [
     width = 4
   }]} {
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  // CHECK: firrtl.module @DUT(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>)
+  // CHECK: firrtl.module @DUT(out %sram_0_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in %sram_0_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}])
   firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
   firrtl.module @TestHarness() {
     firrtl.instance dut @DUT()
-    // CHECK: %dut_sram_0_user_output, %dut_sram_0_user_input = firrtl.instance dut @DUT(out sram_0_user_output: !firrtl.uint<4>, in sram_0_user_input: !firrtl.uint<3>)
+    // CHECK: %dut_sram_0_user_output, %dut_sram_0_user_input = firrtl.instance dut @DUT(out sram_0_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in sram_0_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}])
     // CHECK: %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
     // CHECK: firrtl.strictconnect %dut_sram_0_user_input, %c0_ui3 : !firrtl.uint<3>
   }


### PR DESCRIPTION
Change the AddSeqMemPorts pass to mark ports created on the DUT (or the
top module) with DontTouchAnnotations.  This is done to avoid having
these ports be deleted.  This is currently a problem for output ports
that the pass creates and bores upwards.  The final instance port of the
DUT does not have a user which causes all the ports (except the one on
the memory) to be deletion candidates.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Example

An end-to-end example showing the problem is the following circuit:

```firrtl
circuit TestHarness : %[[
  {
    "class":"sifive.enterprise.firrtl.MarkDUTAnnotation",
    "target":"TestHarness.DUTModule"
  },
  {
    "class":"sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
    "filename":"SeqMems.txt"
  },
  {
    "class":"sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
    "name":"foo",
    "input":false,
    "width":16
  },
  {
    "class":"sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
    "name":"bar",
    "input":true,
    "width":32
  }
]]
  module DUTModule :
    input clock : Clock
    input reset : Reset
    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}

    smem mem : UInt<8> [8]
    infer mport read = mem[io.addr], clock
    io.dataOut <= read
    when io.wen :
      infer mport write = mem[io.addr], clock
      write <= io.dataIn

  module TestHarness :
    input clock : Clock
    input reset : UInt<1>
    output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}

    inst dut of DUTModule
    dut.clock <= clock
    dut.reset <= reset
    io.dataOut <= dut.io.dataOut
    dut.io.wen <= io.wen
    dut.io.dataIn <= io.dataIn
    dut.io.addr <= io.addr
```

Without this PR, this compiles to:

```verilog
// Generated by CIRCT unknown git version
module DUTModule(
  input         clock,
  input  [2:0]  io_addr,
  input  [7:0]  io_dataIn,
  input         io_wen,
  input  [31:0] sram_0_bar,
  output [7:0]  io_dataOut);

  mem mem (
    .R0_addr    (io_addr),
    .R0_clk     (clock),
    .W0_addr    (io_addr),
    .W0_en      (io_wen),
    .W0_clk     (clock),
    .W0_data    (io_dataIn),
    .sram_0_bar (sram_0_bar),
    .R0_data    (io_dataOut)
  );
endmodule

module TestHarness(
  input        clock,
               reset,
  input  [2:0] io_addr,
  input  [7:0] io_dataIn,
  input        io_wen,
  output [7:0] io_dataOut);

  DUTModule dut (
    .clock      (clock),
    .io_addr    (io_addr),
    .io_dataIn  (io_dataIn),
    .io_wen     (io_wen),
    .sram_0_bar (32'h0),
    .io_dataOut (io_dataOut)
  );
endmodule

module mem(
  input  [2:0]  R0_addr,
  input         R0_clk,
  input  [2:0]  W0_addr,
  input         W0_en,
                W0_clk,
  input  [7:0]  W0_data,
  input  [31:0] sram_0_bar,
  output [7:0]  R0_data);

  wire [15:0] _mem_ext_foo;
  mem_ext mem_ext (
    .R0_addr (R0_addr),
    .R0_en   (1'h1),
    .R0_clk  (R0_clk),
    .W0_addr (W0_addr),
    .W0_en   (W0_en),
    .W0_clk  (W0_clk),
    .W0_data (W0_data),
    .bar     (sram_0_bar),
    .R0_data (R0_data),
    .foo     (_mem_ext_foo)
  );
endmodule

// external module mem_ext
```

With this PR, this compiles to:
```verilog
// Generated by CIRCT unknown git version
module DUTModule(
  input         clock,
  input  [2:0]  io_addr,
  input  [7:0]  io_dataIn,
  input         io_wen,
  input  [31:0] sram_0_bar,
  output [7:0]  io_dataOut,
  output [15:0] sram_0_foo);

  mem mem (
    .R0_addr    (io_addr),
    .R0_clk     (clock),
    .W0_addr    (io_addr),
    .W0_en      (io_wen),
    .W0_clk     (clock),
    .W0_data    (io_dataIn),
    .sram_0_bar (sram_0_bar),
    .R0_data    (io_dataOut),
    .sram_0_foo (sram_0_foo)
  );
endmodule

module TestHarness(
  input        clock,
               reset,
  input  [2:0] io_addr,
  input  [7:0] io_dataIn,
  input        io_wen,
  output [7:0] io_dataOut);

  wire [15:0] _dut_sram_0_foo;
  DUTModule dut (
    .clock      (clock),
    .io_addr    (io_addr),
    .io_dataIn  (io_dataIn),
    .io_wen     (io_wen),
    .sram_0_bar (32'h0),
    .io_dataOut (io_dataOut),
    .sram_0_foo (_dut_sram_0_foo)
  );
endmodule

module mem(
  input  [2:0]  R0_addr,
  input         R0_clk,
  input  [2:0]  W0_addr,
  input         W0_en,
                W0_clk,
  input  [7:0]  W0_data,
  input  [31:0] sram_0_bar,
  output [7:0]  R0_data,
  output [15:0] sram_0_foo);

  mem_ext mem_ext (
    .R0_addr (R0_addr),
    .R0_en   (1'h1),
    .R0_clk  (R0_clk),
    .W0_addr (W0_addr),
    .W0_en   (W0_en),
    .W0_clk  (W0_clk),
    .W0_data (W0_data),
    .bar     (sram_0_bar),
    .R0_data (R0_data),
    .foo     (sram_0_foo)
  );
endmodule

// external module mem_ext
```

Diff:

```diff
diff --git a/Foo.old.sv b/Foo.new.sv
index aab54df64..beb951ea0 100644
--- a/Foo.old.sv
+++ b/Foo.new.sv
@@ -5,7 +5,8 @@ module DUTModule(
   input  [7:0]  io_dataIn,
   input         io_wen,
   input  [31:0] sram_0_bar,
-  output [7:0]  io_dataOut);
+  output [7:0]  io_dataOut,
+  output [15:0] sram_0_foo);
 
   mem mem (
     .R0_addr    (io_addr),
@@ -15,7 +16,8 @@ module DUTModule(
     .W0_clk     (clock),
     .W0_data    (io_dataIn),
     .sram_0_bar (sram_0_bar),
-    .R0_data    (io_dataOut)
+    .R0_data    (io_dataOut),
+    .sram_0_foo (sram_0_foo)
   );
 endmodule
 
@@ -27,13 +29,15 @@ module TestHarness(
   input        io_wen,
   output [7:0] io_dataOut);
 
+  wire [15:0] _dut_sram_0_foo;
   DUTModule dut (
     .clock      (clock),
     .io_addr    (io_addr),
     .io_dataIn  (io_dataIn),
     .io_wen     (io_wen),
     .sram_0_bar (32'h0),
-    .io_dataOut (io_dataOut)
+    .io_dataOut (io_dataOut),
+    .sram_0_foo (_dut_sram_0_foo)
   );
 endmodule
 
@@ -45,9 +49,9 @@ module mem(
                 W0_clk,
   input  [7:0]  W0_data,
   input  [31:0] sram_0_bar,
-  output [7:0]  R0_data);
+  output [7:0]  R0_data,
+  output [15:0] sram_0_foo);
 
-  wire [15:0] _mem_ext_foo;
   mem_ext mem_ext (
     .R0_addr (R0_addr),
     .R0_en   (1'h1),
@@ -58,7 +62,7 @@ module mem(
     .W0_data (W0_data),
     .bar     (sram_0_bar),
     .R0_data (R0_data),
-    .foo     (_mem_ext_foo)
+    .foo     (sram_0_foo)
   );
 endmodule
```