### PR TITLE
[CMake] Fix option `CIRCT_LLHD_SIM_ENABLED`

### DIFF
--- a/lib/Dialect/LLHD/CMakeLists.txt
+++ b/lib/Dialect/LLHD/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(IR)
-add_subdirectory(Simulator)
+if(CIRCT_LLHD_SIM_ENABLED)
+  add_subdirectory(Simulator)
+endif()
 add_subdirectory(Transforms)


### PR DESCRIPTION
Ref: https://github.com/llvm/circt/pull/4547#issuecomment-1387495752

@maerhart Would you mind reviewing this PR?