### PR TITLE
[FIRRTL] No final inst in ExtractInstances output

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -1036,8 +1036,9 @@ void ExtractInstancesPass::createTraceFiles() {
         os << ".";
         addSymbol(sym);
       }
-      os << ".";
-      addSymbol(getInnerRefTo(inst));
+      // The final instance name is excluded as this does not provide useful
+      // additional information and could conflict with a name inside the final
+      // module.
       os << "\n";
     }
 

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -154,8 +154,8 @@ circuit TestHarness : %[[
   ; MEM-NOT: Prefix_mem_ext mem_ext
 
   ; MEMS-CONF: name Prefix_mem_ext depth 8 width 8 ports write,read
-  ; SEQMEMS-TXT: mem_wiring_1 -> Prefix_DUTModule.InjectedSubmodule.inst0.mem.mem_ext
-  ; SEQMEMS-TXT: mem_wiring_0 -> Prefix_DUTModule.InjectedSubmodule.inst1.mem.mem_ext
+  ; SEQMEMS-TXT: mem_wiring_1 -> Prefix_DUTModule.InjectedSubmodule.inst0.mem
+  ; SEQMEMS-TXT: mem_wiring_0 -> Prefix_DUTModule.InjectedSubmodule.inst1.mem
 
   ; OMIR:      "id": "OMID:0"
   ; OMIR:      "name": "finalPath"

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Simple2.fir
@@ -61,4 +61,4 @@ circuit TestHarness : %[[
   ; MEM-NOT: mem_ext mem_ext
 
   ; MEMS-CONF: name mem_ext depth 8 width 8 ports write,read
-  ; SEQMEMS-TXT: mem_wiring_0 -> DUTModule.mem.mem_ext
+  ; SEQMEMS-TXT: mem_wiring_0 -> DUTModule.mem

--- a/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
+++ b/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
@@ -22,8 +22,8 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
   // CHECK: firrtl.instance inst1 sym [[INST1_SYM:@.+]] @SomeModule
 
   // CHECK-LABEL: firrtl.module private @ClockGatesGroup
-  // CHECK: firrtl.instance gate sym [[CKG0_SYM:@.+]] @EICG_wrapper
-  // CHECK: firrtl.instance gate sym [[CKG1_SYM:@.+]] @EICG_wrapper
+  // CHECK: firrtl.instance gate @EICG_wrapper
+  // CHECK: firrtl.instance gate @EICG_wrapper
 
   // CHECK-LABEL: firrtl.module private @DUTModule
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %foo_en: !firrtl.uint<1>, in %bar_en: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
@@ -46,15 +46,13 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
     firrtl.connect %dut_foo_en, %foo_en : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: clock_gate_1 -> {{0}}.{{1}}.{{2}}.{{3}}\0A
-  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}.{{4}}.{{5}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_1 -> {{0}}.{{1}}.{{2}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}.{{3}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: #hw.innerNameRef<@DUTModule::[[INJMOD_SYM]]>
   // CHECK-SAME: #hw.innerNameRef<@InjectedSubmodule::[[INST0_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ClockGatesGroup::[[CKG0_SYM]]>
   // CHECK-SAME: #hw.innerNameRef<@InjectedSubmodule::[[INST1_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ClockGatesGroup::[[CKG1_SYM]]>
   // CHECK-SAME: ]
 }

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -41,7 +41,7 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   // CHECK-LABEL: firrtl.module @ExtractBlackBoxesSimple
   firrtl.module @ExtractBlackBoxesSimple(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
     // CHECK: %dut_in, %dut_out, %dut_bb_0_in, %dut_bb_0_out = firrtl.instance dut sym {{@.+}} @DUTModule
-    // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb sym [[BB_SYM:@.+]] @MyBlackBox
+    // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb @MyBlackBox
     // CHECK-NEXT: firrtl.strictconnect %bb_in, %dut_bb_0_in
     // CHECK-NEXT: firrtl.strictconnect %dut_bb_0_out, %bb_out
     %dut_in, %dut_out = firrtl.instance dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
@@ -49,12 +49,11 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{1}}.{{2}}\0A
+  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"BlackBoxes.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: #hw.innerNameRef<@DUTModule::[[WRAPPER_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractBlackBoxesSimple::[[BB_SYM]]>
   // CHECK-SAME: ]
 }
 
@@ -140,7 +139,7 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
     // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb sym [[BB_SYM:@.+]] {annotations = [{class = "Old1"}, {class = "On1"}, {class = "Old2"}, {class = "On2"}]} @MyBlackBox
     // CHECK-NEXT: firrtl.strictconnect %bb_in, %dut_prefix_1_in
     // CHECK-NEXT: firrtl.strictconnect %dut_prefix_1_out, %bb_out
-    // CHECK-NEXT: %bb2_in, %bb2_out = firrtl.instance bb2 sym [[BB2_SYM:@.+]] @MyBlackBox2
+    // CHECK-NEXT: %bb2_in, %bb2_out = firrtl.instance bb2 @MyBlackBox2
     // CHECK-NEXT: firrtl.strictconnect %bb2_in, %dut_prefix_0_in
     // CHECK-NEXT: firrtl.strictconnect %dut_prefix_0_out, %bb2_out
     %dut_in, %dut_out = firrtl.instance dut sym @dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
@@ -148,14 +147,12 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: prefix_0 -> {{0}}.{{1}}.{{2}}\0A
-  // CHECK-SAME{LITERAL}: prefix_1 -> {{0}}.{{1}}.{{3}}\0A
+  // CHECK-SAME{LITERAL}: prefix_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: prefix_1 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"BlackBoxes.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: @DUTModule::[[WRAPPER_SYM]]
-  // CHECK-SAME: @ExtractBlackBoxesSimple2::[[BB2_SYM]]
-  // CHECK-SAME: @ExtractBlackBoxesSimple2::[[BB_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -254,14 +251,12 @@ firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
     firrtl.connect %tb_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{1}}.{{2}}\0A
-  // CHECK-SAME{LITERAL}: bb_1 -> {{0}}.{{1}}.{{3}}\0A
+  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: bb_1 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"BlackBoxes.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: @DUTModule::[[WRAPPER_SYM]]
-  // CHECK-SAME: @BlackBoxes::[[BB2_SYM]]
-  // CHECK-SAME: @BlackBoxes::[[BB1_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -279,17 +274,16 @@ firrtl.circuit "ExtractClockGatesSimple" attributes {annotations = [{class = "si
   }
   // CHECK-LABEL: firrtl.module @ExtractClockGatesSimple
   firrtl.module @ExtractClockGatesSimple(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
-    // CHECK: firrtl.instance gate sym [[CKG_SYM:@.+]] @EICG_wrapper
+    // CHECK: firrtl.instance gate @EICG_wrapper
     %dut_clock, %dut_en = firrtl.instance dut @DUTModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
     firrtl.connect %dut_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %dut_en, %en : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: @ExtractClockGatesSimple::[[CKG_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -363,14 +357,12 @@ firrtl.circuit "ExtractClockGatesMixed" attributes {annotations = [{class = "sif
     firrtl.connect %dut_in, %intf_in : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}.{{2}}\0A
-  // CHECK-SAME{LITERAL}: clock_gate_1 -> {{0}}.{{3}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_1 -> {{0}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: @DUTModule::@inst
-  // CHECK-SAME: @ExtractClockGatesMixed::@ckg1
-  // CHECK-SAME: @ExtractClockGatesMixed::@ckg2
   // CHECK-SAME: ]
 }
 
@@ -393,25 +385,23 @@ firrtl.circuit "ExtractClockGatesComposed" attributes {annotations = [
   }
   // CHECK-LABEL: firrtl.module @ExtractClockGatesComposed
   firrtl.module @ExtractClockGatesComposed(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
-    // CHECK: firrtl.instance gate sym [[CKG_SYM:@.+]] @EICG_wrapper
-    // CHECK: firrtl.instance mem_ext sym [[MEM_SYM:@.+]] @mem_ext
+    // CHECK: firrtl.instance gate @EICG_wrapper
+    // CHECK: firrtl.instance mem_ext @mem_ext
     %dut_clock, %dut_en = firrtl.instance dut @DUTModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
     firrtl.connect %dut_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %dut_en, %en : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: @ExtractClockGatesComposed::[[CKG_SYM]]
   // CHECK-SAME: ]
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: @ExtractClockGatesComposed::[[MEM_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -436,15 +426,14 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
   firrtl.module @ExtractSeqMemsSimple2() {
     firrtl.instance dut @DUTModule()
     // CHECK-NEXT: firrtl.instance dut sym [[DUT_SYM:@.+]] @DUTModule
-    // CHECK-NEXT: firrtl.instance mem_ext sym [[MEM_EXT_SYM:@.+]] @mem_ext
+    // CHECK-NEXT: firrtl.instance mem_ext @mem_ext
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}.{{1}}.{{2}}\0A
+  // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: @DUTModule::[[MEM_SYM]]
-  // CHECK-SAME: @ExtractSeqMemsSimple2::[[MEM_EXT_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -494,13 +483,11 @@ firrtl.circuit "InstSymConflict" {
     firrtl.strictconnect %out, %dut_out : !firrtl.uint<8>
   }
   // CHECK: sv.verbatim "
-  // CHECK-SAME{LITERAL}: bb_1 -> {{0}}.{{1}}.{{2}}\0A
-  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{3}}.{{4}}\0A
+  // CHECK-SAME{LITERAL}: bb_1 -> {{0}}.{{1}}\0A
+  // CHECK-SAME{LITERAL}: bb_0 -> {{0}}.{{2}}\0A
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
   // CHECK-SAME: #hw.innerNameRef<@DUTModule::@mod1>
-  // CHECK-SAME: #hw.innerNameRef<@InstSymConflict::@bb_0>
   // CHECK-SAME: #hw.innerNameRef<@DUTModule::@mod2>
-  // CHECK-SAME: #hw.innerNameRef<@InstSymConflict::@bb>
   // CHECK-SAME: ]
 }


### PR DESCRIPTION
Change the ExtractInstances pass to no longer include the final extracted instance in the output file it optionally generates.

The new format of this file has the _path to the module_ where the extracted instance used to be located as opposed to the _path to the pre-extracted instance_ with a name that is either the new name of the instance (MFC, previously) or the old instance name (SFC).

Concretely, this changes the output from something like (MFC, previously):

    clock_gate_0 -> Foo.bar.baz.gate_0
    clock_gate_1 -> Foo.bar.gate_1

To:

    clock_gate_0 -> Foo.bar.baz
    clock_gate_1 -> Foo.bar

Here, "clock_gate_<n>" is the name of the ports that a user is supposed to look at and "gate_<n>" is the name of the extracted instance outside of the module that contains these ports.  This is weird because it leaks information that is not supposed to be visible.  Specifically, this leaks that there is an instance called "gate_<n>" that is outside the design and not in "Foo.bar.baz" or "Foo.bar".  This post-extracted instance name is necessarily uniqued within the module where it was extracted ("gate_0" and "gate_1" could be generated if multiple instances with the same name, "gate",are extracted).

The Scala-based FIRRTL Compiler (SFC) does something different, but also wrong.  The SFC will emit the above like:

    clock_gate_0 -> Foo.bar.baz.gate
    clock_gate_1 -> Foo.bar.gate

Here, "gate" is the original name of the instance.  However, "gate", like "gate_<n>", does not match the name of anything in either "Foo.bar.baz" or "Foo.bar" as this instance was extracted.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>