### PR TITLE
[CI] Bump integration test images.

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v11.2
+      image: ghcr.io/circt/images/circt-integration-test:v11.3
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v11.2
+      image: ghcr.io/circt/images/circt-integration-test:v11.3
     strategy:
       # Keep the 'matrix' strategy with one data point to make it obvious that
       # this is one point in the overall matrix.


### PR DESCRIPTION
Bump to v11.3 = v11.2 + OR-Tools v9.5 (https://github.com/circt/images/pull/26)