### PR TITLE
[ExportVerilog] Inline expressions into bound instances

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -696,8 +696,8 @@ bool ExportVerilog::isExpressionEmittedInline(Operation *op,
   // Never create a temporary which is only going to be assigned to an output
   // port, wire, or reg.
   if (op->hasOneUse() &&
-      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, sv::PAssignOp>(
-          *op->getUsers().begin()))
+      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, sv::PAssignOp,
+          hw::InstanceOp>(*op->getUsers().begin()))
     return true;
 
   // If mux inlining is dissallowed, we cannot inline muxes.
@@ -1171,8 +1171,7 @@ public:
   void emitBind(BindOp op);
   void emitBindInterface(BindInterfaceOp op);
 
-  StringRef getNameRemotely(Value value, const ModulePortInfo &modulePorts,
-                            HWModuleOp remoteModule);
+  StringRef getNameRemotely(Value value);
 
   /// Legalize the given field name if it is an invalid verilog name.
   StringRef getVerilogStructFieldName(StringAttr field) {
@@ -4570,11 +4569,26 @@ void ModuleEmitter::emitBind(BindOp op) {
       ps << "." << PPExtString(elt.getName());
       ps.nbsp(maxNameLength - elt.getName().size());
       ps << " (";
+      llvm::SmallPtrSet<Operation *, 4> ops;
+      if (elt.isOutput()) {
+        assert(portVal.hasOneUse() && "output port must have a single use");
 
-      // Emit the value as an expression.
-      auto name = getNameRemotely(portVal, parentPortInfo, parentMod);
-      assert(!name.empty() && "bind port connection must have a name");
-      ps << PPExtString(name) << ")";
+        if (auto output = dyn_cast_or_null<OutputOp>(
+                portVal.getUses().begin()->getOwner())) {
+          // If this is directly using the output port of the containing
+          // module, just specify that directly.
+          size_t outputPortNo = portVal.getUses().begin()->getOperandNumber();
+          ps << PPExtString(getPortVerilogName(
+              parentMod, parentMod.getOutputPort(outputPortNo)));
+        } else {
+          portVal = portVal.getUsers().begin()->getOperand(0);
+          ExprEmitter(*this, ops).emitExpression(portVal, LowestPrecedence);
+        }
+      } else {
+        ExprEmitter(*this, ops).emitExpression(portVal, LowestPrecedence);
+      }
+
+      ps << ")";
 
       if (isZeroWidth)
         ps << PP::end; // Close never-break group.
@@ -4584,101 +4598,6 @@ void ModuleEmitter::emitBind(BindOp op) {
     ps << PP::newline;
   ps << ");";
   setPendingNewline();
-}
-
-/// Return the name of a value in a remote module to be used in a `bind`
-/// statement. This function examines the remote module `remoteModule` and looks
-/// up the corresponding name. This requires that all names this function may be
-/// asked to lookup have been legalized in pre-pass.
-StringRef ModuleEmitter::getNameRemotely(Value value,
-                                         const ModulePortInfo &modulePorts,
-                                         HWModuleOp remoteModule) {
-  if (auto barg = value.dyn_cast<BlockArgument>())
-    return getPortVerilogName(remoteModule,
-                              modulePorts.inputs[barg.getArgNumber()]);
-
-  Operation *valueOp = value.getDefiningOp();
-
-  // Handle wires/registers/XMR references, likely as instance inputs.
-  if (auto readinout = dyn_cast<ReadInOutOp>(valueOp)) {
-    auto *wireInput = readinout.getInput().getDefiningOp();
-    if (!wireInput)
-      return {};
-    if (isa<WireOp, RegOp, LogicOp>(wireInput))
-      return getSymOpName(wireInput);
-
-    if (auto xmr = dyn_cast<XMROp>(wireInput)) {
-      SmallString<16> xmrString;
-      if (xmr.getIsRooted())
-        xmrString.append("$root.");
-      for (auto s : xmr.getPath()) {
-        xmrString.append(s.cast<StringAttr>().getValue());
-        xmrString.append(".");
-      }
-      xmrString.append(xmr.getTerminal());
-      return StringAttr::get(value.getContext(), xmrString);
-    }
-
-    // TODO: This shares a lot of code with the XMRRefOp visitor. Combine these
-    // to share logic.
-    if (auto xmrRef = dyn_cast<XMRRefOp>(wireInput)) {
-      SmallString<32> xmrString;
-      auto refAttr = xmrRef.getRefAttr();
-
-      if (auto innerRef = dyn_cast<InnerRefAttr>(refAttr)) {
-        auto ref = state.symbolCache.getInnerDefinition(innerRef.getModule(),
-                                                        innerRef.getName());
-        auto *module = state.symbolCache.getDefinition(innerRef.getModule());
-        xmrString.append(getSymOpName(module));
-        xmrString.append(".");
-        if (ref.hasPort())
-          xmrString.append(getPortVerilogName(ref.getOp(), ref.getPort()));
-        else
-          xmrString.append(getSymOpName(ref.getOp()));
-      } else {
-
-        auto globalRef = cast<hw::HierPathOp>(state.symbolCache.getDefinition(
-            cast<FlatSymbolRefAttr>(xmrRef.getRefAttr()).getAttr()));
-        auto namepath = globalRef.getNamepathAttr().getValue();
-        auto *module = state.symbolCache.getDefinition(
-            cast<InnerRefAttr>(namepath.front()).getModule());
-        xmrString.append(getSymOpName(module));
-        for (auto sym : namepath) {
-          xmrString.append(".");
-          auto innerRef = cast<InnerRefAttr>(sym);
-          auto ref = state.symbolCache.getInnerDefinition(innerRef.getModule(),
-                                                          innerRef.getName());
-          if (ref.hasPort()) {
-            xmrString.append(getPortVerilogName(ref.getOp(), ref.getPort()));
-            continue;
-          }
-          xmrString.append(getSymOpName(ref.getOp()));
-        }
-      }
-      auto leaf = xmrRef.getStringLeafAttr();
-      if (leaf && leaf.size())
-        xmrString.append(leaf);
-      return StringAttr::get(xmrRef.getContext(), xmrString);
-    }
-  }
-
-  // Handle values being driven onto wires, likely as instance outputs.
-  if (isa<InstanceOp>(valueOp)) {
-    for (auto &use : value.getUses()) {
-      Operation *user = use.getOwner();
-      if (!isa<AssignOp>(user) || use.getOperandNumber() != 1)
-        continue;
-      Value drivenOnto = user->getOperand(0);
-      Operation *drivenOntoOp = drivenOnto.getDefiningOp();
-      if (isa<WireOp, RegOp, LogicOp>(drivenOntoOp))
-        return getSymOpName(drivenOntoOp);
-    }
-  }
-
-  // Handle local parameters.
-  if (isa<LocalParamOp>(valueOp))
-    return getSymOpName(valueOp);
-  return {};
 }
 
 void ModuleEmitter::emitBindInterface(BindInterfaceOp op) {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1171,8 +1171,6 @@ public:
   void emitBind(BindOp op);
   void emitBindInterface(BindInterfaceOp op);
 
-  StringRef getNameRemotely(Value value);
-
   /// Legalize the given field name if it is an invalid verilog name.
   StringRef getVerilogStructFieldName(StringAttr field) {
     return fieldNameResolver.getRenamedFieldName(field).getValue();

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -615,7 +615,8 @@ bool EmittedExpressionStateManager::shouldSpillWireBasedOnState(Operation &op) {
   // to a wire.
   if (op.hasOneUse()) {
     auto *singleUser = *op.getUsers().begin();
-    if (isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp>(singleUser))
+    if (isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, hw::InstanceOp>(
+            singleUser))
       return false;
 
     // If the single user is bitcast, we check the same property for the bitcast
@@ -705,10 +706,9 @@ static LogicalResult legalizeHWModule(Block &block,
     if (auto instance = dyn_cast<InstanceOp>(op)) {
       // Anchor return values to wires early
       lowerInstanceResults(instance);
-      // Anchor ports of instances when the instance is bound by bind op, or
-      // forced by the option.
-      if (instance->hasAttr("doNotPrint") ||
-          options.disallowExpressionInliningInPorts)
+      // Anchor ports of instances when `disallowExpressionInliningInPorts` is
+      // enabled.
+      if (options.disallowExpressionInliningInPorts)
         spillWiresForInstanceInputs(instance);
     }
 

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -610,7 +610,7 @@ hw.module @SiFive_MulDiv(%clock: i1, %reset: i1) -> (io_req_ready: i1) {
   hw.probe @unused, %false, %reset, %clock: i1,i1,i1
   hw.output %false : i1
   //      CHECK: bind_rename_port InvisibleBind_assert (
-  // CHECK-NEXT:   ._io_req_ready_output (_InvisibleBind_assert__io_req_ready_output),
+  // CHECK-NEXT:   ._io_req_ready_output (1'h0),
   // CHECK-NEXT:   .resetSignalName      (reset),
   // CHECK-NEXT:   .clock                (clock)
   // CHECK-NEXT: );
@@ -654,6 +654,6 @@ hw.module @BindInterface() -> () {
 
 sv.bind #hw.innerNameRef<@SiFive_MulDiv::@__ETC_SiFive_MulDiv_assert>
 // CHECK-LABEL: bind SiFive_MulDiv bind_rename_port InvisibleBind_assert
-// CHECK-NEXT:  ._io_req_ready_output (_InvisibleBind_assert__io_req_ready_output)
+// CHECK-NEXT:  ._io_req_ready_output (1'h0)
 // CHECK-NEXT:  .resetSignalName      (reset),
 // CHECK-NEXT:  .clock                (clock)


### PR DESCRIPTION
Previously expressions feed into bound instances are anchored by wires so that we can remotely get names of wires while bindfile emission.  Since https://github.com/llvm/circt/pull/4573 changes name legalizations and we can get local names by inspecting IR, we can get valid emission by justing using `emitExpression`.