### PR TITLE
[firtool] Add --include-dir option, -I as alias.

### DIFF
--- a/test/firtool/include-dirs.fir
+++ b/test/firtool/include-dirs.fir
@@ -11,6 +11,8 @@
 
 ; Check referenced file is found when its directory is specified.
 ; RUN: not firtool %s -I %t -I %t/subdir 2>&1 | FileCheck %s --check-prefixes=COMMON,FOUND
+; Same check, but checking -Idir works (no space) and that `--include-dir` works.
+; RUN: not firtool %s --include-dir %t -I%t/subdir 2>&1 | FileCheck %s --check-prefixes=COMMON,FOUND
 
 ; Check search order.
 ; RUN: not firtool %s -I %t/alt -I %t 2>&1 | FileCheck %s --check-prefixes=COMMON,ALTERNATE

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -86,8 +86,13 @@ static cl::opt<bool>
                    cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
 static cl::list<std::string> includeDirs(
-    "I", cl::desc("Directory to search in when resolving source references"),
-    cl::value_desc("directory"), cl::Prefix, cl::cat(mainCategory));
+    "include-dir",
+    cl::desc("Directory to search in when resolving source references"),
+    cl::value_desc("directory"), cl::cat(mainCategory));
+static cl::alias includeDirsShort(
+    "I", cl::desc("Alias for --include-dir.  Example: -I<directory>"),
+    cl::aliasopt(includeDirs), cl::Prefix, cl::NotHidden,
+    cl::cat(mainCategory));
 
 static cl::opt<bool>
     verifyDiagnostics("verify-diagnostics",


### PR DESCRIPTION
Support long-form version of option for readability.

Include usage in description to workaround `cl::value_desc` not seeming to work for the alias.