### PR TITLE
Backport "[LowerToHW] Add extra guards to header macros (#4469)" to sifive-1.5

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -787,6 +787,12 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     b.create<sv::VerbatimOp>(verilogString);
   };
 
+  // Helper function to emit #ifndef guard.
+  auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
+    b.create<sv::IfDefOp>(
+        guard, []() {}, body);
+  };
+
   // Helper function to emit a "#ifdef guard" with a `define in the then and
   // optionally in the else branch.
   auto emitGuardedDefine = [&](const char *guard, const char *defineTrue,
@@ -817,15 +823,19 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   bool needRandom = false;
   if (state.used_RANDOMIZE_GARBAGE_ASSIGN) {
-    emitGuardedDefine("RANDOMIZE_GARBAGE_ASSIGN", "RANDOMIZE");
+    emitGuard("RANDOMIZE", [&]() {
+      emitGuardedDefine("RANDOMIZE_GARBAGE_ASSIGN", "RANDOMIZE");
+    });
     needRandom = true;
   }
   if (state.used_RANDOMIZE_REG_INIT) {
-    emitGuardedDefine("RANDOMIZE_REG_INIT", "RANDOMIZE");
+    emitGuard("RANDOMIZE",
+              [&]() { emitGuardedDefine("RANDOMIZE_REG_INIT", "RANDOMIZE"); });
     needRandom = true;
   }
   if (state.used_RANDOMIZE_MEM_INIT) {
-    emitGuardedDefine("RANDOMIZE_MEM_INIT", "RANDOMIZE");
+    emitGuard("RANDOMIZE",
+              [&]() { emitGuardedDefine("RANDOMIZE_MEM_INIT", "RANDOMIZE"); });
     needRandom = true;
   }
 
@@ -838,22 +848,28 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
   if (state.used_PRINTF_COND) {
     emitString("\n// Users can define 'PRINTF_COND' to add an extra gate to "
                "prints.");
-    emitGuardedDefine("PRINTF_COND", "PRINTF_COND_ (`PRINTF_COND)",
-                      "PRINTF_COND_ 1");
+    emitGuard("PRINTF_COND_", [&]() {
+      emitGuardedDefine("PRINTF_COND", "PRINTF_COND_ (`PRINTF_COND)",
+                        "PRINTF_COND_ 1");
+    });
   }
 
   if (state.used_ASSERT_VERBOSE_COND) {
     emitString("\n// Users can define 'ASSERT_VERBOSE_COND' to add an extra "
                "gate to assert error printing.");
-    emitGuardedDefine("ASSERT_VERBOSE_COND",
-                      "ASSERT_VERBOSE_COND_ (`ASSERT_VERBOSE_COND)",
-                      "ASSERT_VERBOSE_COND_ 1");
+    emitGuard("ASSERT_VERBOSE_COND_", [&]() {
+      emitGuardedDefine("ASSERT_VERBOSE_COND",
+                        "ASSERT_VERBOSE_COND_ (`ASSERT_VERBOSE_COND)",
+                        "ASSERT_VERBOSE_COND_ 1");
+    });
   }
 
   if (state.used_STOP_COND) {
     emitString("\n// Users can define 'STOP_COND' to add an extra gate "
                "to stop conditions.");
-    emitGuardedDefine("STOP_COND", "STOP_COND_ (`STOP_COND)", "STOP_COND_ 1");
+    emitGuard("STOP_COND_", [&]() {
+      emitGuardedDefine("STOP_COND", "STOP_COND_ (`STOP_COND)", "STOP_COND_ 1");
+    });
   }
 
   if (needRandom) {
@@ -869,31 +885,35 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     emitGuardedDefine("RANDOMIZE_DELAY", nullptr, "RANDOMIZE_DELAY 0.002");
 
     emitString("\n// Define INIT_RANDOM_PROLOG_ for use in our modules below.");
-    b.create<sv::IfDefOp>(
-        "RANDOMIZE",
-        [&]() {
-          emitGuardedDefine(
-              "VERILATOR", "INIT_RANDOM_PROLOG_ `INIT_RANDOM",
-              "INIT_RANDOM_PROLOG_ `INIT_RANDOM #`RANDOMIZE_DELAY begin end");
-        },
-        [&]() { emitString("`define INIT_RANDOM_PROLOG_"); });
+    emitGuard("INIT_RANDOM_PROLOG_", [&]() {
+      b.create<sv::IfDefOp>(
+          "RANDOMIZE",
+          [&]() {
+            emitGuardedDefine(
+                "VERILATOR", "INIT_RANDOM_PROLOG_ `INIT_RANDOM",
+                "INIT_RANDOM_PROLOG_ `INIT_RANDOM #`RANDOMIZE_DELAY begin end");
+          },
+          [&]() { emitString("`define INIT_RANDOM_PROLOG_"); });
+    });
   }
 
   if (state.used_RANDOMIZE_GARBAGE_ASSIGN) {
     emitString("\n// RANDOMIZE_GARBAGE_ASSIGN enable range checks for mem "
                "assignments.");
-    b.create<sv::IfDefOp>(
-        "RANDOMIZE_GARBAGE_ASSIGN",
-        [&]() {
-          emitString(
-              "`define RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK(INDEX, VALUE, "
-              "SIZE) \\");
-          emitString("  ((INDEX) < (SIZE) ? (VALUE) : {`RANDOM})");
-        },
-        [&]() {
-          emitString("`define RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK(INDEX, "
-                     "VALUE, SIZE) (VALUE)");
-        });
+    emitGuard("RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK", [&]() {
+      b.create<sv::IfDefOp>(
+          "RANDOMIZE_GARBAGE_ASSIGN",
+          [&]() {
+            emitString(
+                "`define RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK(INDEX, VALUE, "
+                "SIZE) \\");
+            emitString("  ((INDEX) < (SIZE) ? (VALUE) : {`RANDOM})");
+          },
+          [&]() {
+            emitString("`define RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK(INDEX, "
+                       "VALUE, SIZE) (VALUE)");
+          });
+    });
   }
 
   // Blank line to separate the header from the modules.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -5,6 +5,43 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 "sifive.enterprise.firrtl.ExtractCoverageAnnotation", directory = "dir2",  filename = "./dir2/filename2" }, {class =
 "sifive.enterprise.firrtl.ExtractAssertionsAnnotation", directory = "dir3",  filename = "./dir3/filename3" }]}
 {
+  // Headers
+  // CHECK:      sv.ifdef  "PRINTF_COND_" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ifdef  "PRINTF_COND" {
+  // CHECK-NEXT:     sv.verbatim "`define PRINTF_COND_ (`PRINTF_COND)"
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT{LITERAL}:     sv.verbatim "`define PRINTF_COND_ 1" {symbols = []}
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK:      sv.ifdef  "ASSERT_VERBOSE_COND_" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ifdef  "ASSERT_VERBOSE_COND" {
+  // CHECK-NEXT:     sv.verbatim "`define ASSERT_VERBOSE_COND_ (`ASSERT_VERBOSE_COND)"
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT{LITERAL}:     sv.verbatim "`define ASSERT_VERBOSE_COND_ 1" {symbols = []}
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK:      sv.ifdef  "STOP_COND_" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ifdef  "STOP_COND" {
+  // CHECK-NEXT:     sv.verbatim "`define STOP_COND_ (`STOP_COND)"
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.verbatim "`define STOP_COND_ 1" {symbols = []}
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK:      sv.ifdef  "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ifdef  "RANDOMIZE" {
+  // CHECK-NEXT:     sv.ifdef  "VERILATOR" {
+  // CHECK-NEXT:       sv.verbatim "`define INIT_RANDOM_PROLOG_ `INIT_RANDOM"
+  // CHECK-NEXT:     } else {
+  // CHECK-NEXT{LITERAL}:       sv.verbatim "`define INIT_RANDOM_PROLOG_ `INIT_RANDOM #`RANDOMIZE_DELAY begin end" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT{LITERAL}:     sv.verbatim "`define INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
 
   //These come from MemSimple, IncompleteRead, and MemDepth1
   // CHECK-LABEL: hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs"]


### PR DESCRIPTION
This backports https://github.com/llvm/circt/pull/4469 to sifive 1.5 branch.