### PR TITLE
[LowerTypes] Fix a race condition

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -451,8 +451,12 @@ TypeLoweringVisitor::getPreservatinoModeForModule(FModuleLike module) {
   // We cannot preserve external module ports.
   if (!isa<FModuleOp>(module))
     return PreserveAggregate::None;
+
+  // If `module` is a top-module, we have to lower ports. Don't read attributes
+  // of `module` since the attributes could be mutated in a different thread.
   if (aggregatePreservationMode != PreserveAggregate::None &&
-      preservePublicTypes && cast<hw::HWModuleLike>(*module).isPublic())
+      preservePublicTypes &&
+      module->getParentOfType<CircuitOp>().getMainModule(&symTbl) == module)
     return PreserveAggregate::None;
   return aggregatePreservationMode;
 }


### PR DESCRIPTION
This PR fixes a race condition in LowerTypes with aggregate preservation mode. In the instance op lowering, linkage of referenced module is checked, however it is not allowed to read attributes from different threads. 