### PR TITLE
[HW][MSFT] Fix creating modules with InOut typed ports

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -191,6 +191,7 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
   }];
 
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 }
 
 def MSFTModuleExternOp : MSFTOp<"module.extern",

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -153,6 +153,11 @@ hw.module @signed_arrays(%arg0: si8) -> (out: !hw.array<2xsi8>) {
   hw.output %result : !hw.array<2xsi8>
 }
 
+// Check that we pass the verifier that the module's function type matches
+// the block argument types when using InOutTypes.
+// CHECK: hw.module @InOutPort(%arg0: !hw.inout<i1>)
+hw.module @InOutPort(%arg0: !hw.inout<i1>) -> () { }
+
 /// Port names that aren't valid MLIR identifiers are handled with `argNames`
 /// attribute being explicitly printed.
 // https://github.com/llvm/circt/issues/1822


### PR DESCRIPTION
When we create the PortInfo object for a module, if the port is a HW::InOutType, we strip it and set the isInOut field to true.  When we create a module from a PortInfo object we respect this field while constructing the function type, but were not respecting the isInOut when creating the block arguments.

This change starts respecting the `isInOut` field of port info when constructing the block argument types.  This also adds a verifier that the function type of the module matches the block argument types.