### PR TITLE
[FIRRTL] Always create ExtractSeqMems extract file

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -368,6 +368,18 @@ void ExtractInstancesPass::collectAnnos() {
   // mark them as to be extracted.
   // somewhat configurable.
   if (!memoryFileName.empty()) {
+    // Create an empty verbatim to guarantee that this file will exist even if
+    // no memories are found.  This is done to align with the SFC implementation
+    // of this pass where the file is always created.  This does introduce an
+    // additional leading newline in the file.
+    auto *context = circuit.getContext();
+    auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
+                                                    circuit.getBodyBlock());
+    builder.create<sv::VerbatimOp>("")->setAttr(
+        "output_file",
+        hw::OutputFileAttr::getFromFilename(context, memoryFileName,
+                                            /*excludeFromFilelist=*/true));
+
     for (auto module : circuit.getOps<FMemModuleOp>()) {
       LLVM_DEBUG(llvm::dbgs() << "Memory `" << module.moduleName() << "`\n");
       if (!dutModules.contains(module)) {

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -399,6 +399,7 @@ firrtl.circuit "ExtractClockGatesComposed" attributes {annotations = [
     firrtl.connect %dut_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %dut_en, %en : !firrtl.uint<1>, !firrtl.uint<1>
   }
+  // CHECK: sv.verbatim ""
   // CHECK: sv.verbatim "
   // CHECK-SAME{LITERAL}: clock_gate_0 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
@@ -438,6 +439,7 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
     // CHECK-NEXT: firrtl.instance dut sym [[DUT_SYM:@.+]] @DUTModule
     // CHECK-NEXT: firrtl.instance mem_ext sym [[MEM_EXT_SYM:@.+]] @mem_ext
   }
+  // CHECK: sv.verbatim ""
   // CHECK: sv.verbatim "
   // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}.{{1}}.{{2}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
@@ -446,6 +448,17 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
   // CHECK-SAME: @DUTModule::[[MEM_SYM]]
   // CHECK-SAME: @ExtractSeqMemsSimple2::[[MEM_EXT_SYM]]
   // CHECK-SAME: ]
+}
+
+//===----------------------------------------------------------------------===//
+// ExtractSeqMems NoExtraction
+//===----------------------------------------------------------------------===//
+
+// CHECK: firrtl.circuit "ExtractSeqMemsNoExtraction"
+firrtl.circuit "ExtractSeqMemsNoExtraction"  attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractSeqMemsFileAnnotation", filename = "SeqMems.txt"}]} {
+  firrtl.module @ExtractSeqMemsNoExtraction() {}
+  // CHECK: sv.verbatim ""
+  // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Change the ExtractInstances pass to always create an ExtractSeqMems file if the appropriate annotation is passed in.  This is done to align with the SFC implementation of this pass (and to pass an internal unit test).

This uses the same strategy as for CreateSiFiveMetadata where a dummy verbatim is always created.  This simplifies later logic.  This could be improved in the future to only generate the dummy verbatim when necessary (which would remove a now mandatory 1-newline offset that is added to every ExtractSeqMems file created.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>