### PR TITLE
[PrettifyVerilog] Don't sink expressions if their values might be changed in procedural regions

### DIFF
--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -598,3 +598,16 @@ hw.module @Issue4030(%a: i1, %clock: i1, %in1: !hw.array<2xi1>) -> (b: !hw.array
   }
   hw.output %2 : !hw.array<5xi1>
 }
+
+// CHECK-LABEL: @BlockAssignment
+hw.module private @BlockAssignment(%val: i2) -> () {
+  %r = sv.reg : !hw.inout<i2>
+  %0 = sv.read_inout %r : !hw.inout<i2>
+  // Check that %0 is not sank into initial op.
+  // CHECK: %r = sv.reg  : !hw.inout<i2>
+  // CHECK-NEXT: %0 = sv.read_inout %r
+  // CHECK-NEXT: sv.initial
+  sv.initial {
+    sv.bpassign %r, %0 : i2
+  }
+}


### PR DESCRIPTION
It's incorrect to sink an expression if its subexpression is mutated by blocking assignments (or other side-effecting operations). This PR fixes the bug by checking the users of inout operations and preventing Prettify from sinking expressions. Since it's necessary to traverse the IR to analysis users, it might be costly without cache so I introduced a class `SideEffectTracker` to first store unsafe declarations and to provide APIs to answer immutability of expressions. 

Fix https://github.com/llvm/circt/issues/4532 (though we still have a similar issue in Prepare spills expressions without considering blocking assignments).  