### PR TITLE
[circt-reduce] Explicitly nest the passes

### DIFF
--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -256,7 +256,7 @@ PassReduction::PassReduction(MLIRContext *context, std::unique_ptr<Pass> pass,
     pm->nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         std::move(pass));
   else
-    pm->addPass(std::move(pass));
+    pm->nest<mlir::ModuleOp>().addPass(std::move(pass));
 }
 
 uint64_t PassReduction::match(Operation *op) {

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -248,11 +248,15 @@ PassReduction::PassReduction(MLIRContext *context, std::unique_ptr<Pass> pass,
   if (passName.empty())
     passName = pass->getName();
 
-  if (auto opName = pass->getOpName())
-    pm = std::make_unique<PassManager>(context, *opName);
+  pm = std::make_unique<PassManager>(context);
+  auto opName = pass->getOpName();
+  if (opName && opName->equals("firrtl.circuit"))
+    pm->nest<firrtl::CircuitOp>().addPass(std::move(pass));
+  else if (opName && opName->equals("firrtl.module"))
+    pm->nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        std::move(pass));
   else
-    pm = std::make_unique<PassManager>(context);
-  pm->addPass(std::move(pass));
+    pm->addPass(std::move(pass));
 }
 
 uint64_t PassReduction::match(Operation *op) {


### PR DESCRIPTION
Nest the passes explicitly when adding to PassManager. 
Required for the latest LLVM Bump, https://github.com/llvm/circt/pull/4563
Relevant commit https://reviews.llvm.org/D137731