### PR TITLE
[SystemC] Make func private in lit test. NFC

### DIFF
--- a/test/Dialect/SystemC/func-invalid.mlir
+++ b/test/Dialect/SystemC/func-invalid.mlir
@@ -70,12 +70,12 @@ systemc.cpp.func @$invalid_function_name()
 // -----
 
 // expected-error @+1 {{arguments may only have dialect attributes}}
-systemc.cpp.func @invalid_func_arg_attr(i1 {non_dialect_attr = 10})
+systemc.cpp.func private @invalid_func_arg_attr(i1 {non_dialect_attr = 10})
 
 // -----
 
 // expected-error @+1 {{results may only have dialect attributes}}
-systemc.cpp.func @invalid_func_result_attr() -> (i1 {non_dialect_attr = 10})
+systemc.cpp.func private @invalid_func_result_attr() -> (i1 {non_dialect_attr = 10})
 
 // -----
 


### PR DESCRIPTION
This is required for the upstream change: ("Make FunctionOpInterface inherit SymbolOpInterface" https://reviews.llvm.org/D140199)
The visibility is now inherited from FunctionOpInterface .
Fixes the failure in https://github.com/llvm/circt/pull/4563