### PR TITLE
[firtool][FIRRTL] Make Grand Central Collateral Synthesizable

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -27,7 +27,8 @@ namespace firrtl {
 
 std::unique_ptr<mlir::Pass>
 createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations = false,
-                                 bool ignoreClasslessAnnotations = false);
+                                 bool ignoreClasslessAnnotations = false,
+                                 bool noRefTypePorts = false);
 
 /// Configure which aggregate values will be preserved by the LowerTypes pass.
 namespace PreserveAggregate {

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -102,7 +102,8 @@ std::unique_ptr<mlir::Pass> createPrintNLATablePass();
 std::unique_ptr<mlir::Pass>
 createBlackBoxReaderPass(std::optional<mlir::StringRef> inputPrefix = {});
 
-std::unique_ptr<mlir::Pass> createGrandCentralPass();
+std::unique_ptr<mlir::Pass>
+createGrandCentralPass(bool instantiateCompanionOnly = false);
 
 std::unique_ptr<mlir::Pass> createCheckCombCyclesPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -27,7 +27,9 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
     Option<"ignoreAnnotationClassless", "disable-annotation-classless", "bool", "false",
       "Ignore classless annotations.">,
     Option<"ignoreAnnotationUnknown", "disable-annotation-unknown", "bool", "true",
-      "Ignore unknown annotations.">
+      "Ignore unknown annotations.">,
+    Option<"noRefTypePorts", "no-ref-type-ports", "bool", "false",
+      "Create normal ports, not ref type ports.">,
   ];
   let dependentDialects = ["hw::HWDialect"];
   let statistics = [

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -420,6 +420,10 @@ def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {
 
   let constructor = "circt::firrtl::createGrandCentralPass()";
   let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
+  let options = [
+    Option<"instantiateCompanionOnly", "instantiate-companion-only", "bool", "false",
+      "Instantiate the companion without a bind and drop the interface">
+  ];
   let statistics = [
     Statistic<"numViews", "num-views-created",
       "Number of top-level SystemVerilog interfaces that were created">,

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -577,6 +577,10 @@ struct InterfaceElemsBuilder {
 ///    instantiate interfaces and to generate the "mappings" file that produces
 ///    cross-module references (XMRs) to drive the interface.
 struct GrandCentralPass : public GrandCentralBase<GrandCentralPass> {
+  GrandCentralPass(bool instantiateCompanionOnlyFlag) {
+    instantiateCompanionOnly = instantiateCompanionOnlyFlag;
+  }
+
   void runOnOperation() override;
 
 private:
@@ -1116,7 +1120,8 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
     NamedAttrList attrs;
     attrs.append("class", classAttr);
     attrs.append("name", name);
-    auto value = tryGetAs<Attribute>(augmentedType, root, "value", loc, clazz, path);
+    auto value =
+        tryGetAs<Attribute>(augmentedType, root, "value", loc, clazz, path);
     if (!value)
       return std::nullopt;
     attrs.append("value", value);
@@ -1890,7 +1895,11 @@ void GrandCentralPass::runOnOperation() {
                 return true;
               }
 
-              (*instance)->setAttr("lowerToBind", builder.getUnitAttr());
+              // Lower the companion to a bind unless the user told us
+              // explicitly not to.
+              if (!instantiateCompanionOnly)
+                (*instance)->setAttr("lowerToBind", builder.getUnitAttr());
+
               (*instance)->setAttr(
                   "output_file",
                   hw::OutputFileAttr::getFromFilename(
@@ -2023,6 +2032,14 @@ void GrandCentralPass::runOnOperation() {
       }
     }
   });
+
+  // If we are in "instantiateCompanionOnly" mode, then just exit here.  We
+  // don't need to create the interface.  This is a janky hack for situations
+  // where you want to synthesize assertion logic included in the companion, but
+  // don't want to have a dead interface hanging around (or have problems with
+  // tools understanding interfaces).
+  if (instantiateCompanionOnly)
+    return;
 
   // Now, iterate over the worklist of interface-encoding annotations to create
   // the interface and all its sub-interfaces (interfaces that it instantiates),
@@ -2250,6 +2267,7 @@ void GrandCentralPass::runOnOperation() {
 // Pass Creation
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createGrandCentralPass() {
-  return std::make_unique<GrandCentralPass>();
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createGrandCentralPass(bool instantiateCompanionOnly) {
+  return std::make_unique<GrandCentralPass>(instantiateCompanionOnly);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -432,6 +432,7 @@ struct LowerAnnotationsPass
 
   bool ignoreUnhandledAnno = false;
   bool ignoreClasslessAnno = false;
+  bool noRefTypePorts = false;
   SmallVector<DictionaryAttr> worklistAttrs;
 };
 } // end anonymous namespace
@@ -721,7 +722,10 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     };
 
     // Record the addition of ports.
-    addPorts(sources, source, refType, Direction::Out);
+    if (noRefTypePorts)
+      addPorts(sources, source, refType.getType(), Direction::Out);
+    else
+      addPorts(sources, source, refType, Direction::Out);
     addPorts(sinks, sink, refType.getType(), Direction::In);
   }
 
@@ -871,10 +875,13 @@ void LowerAnnotationsPass::runOnOperation() {
 }
 
 /// This is the pass constructor.
-std::unique_ptr<mlir::Pass> circt::firrtl::createLowerFIRRTLAnnotationsPass(
-    bool ignoreUnhandledAnnotations, bool ignoreClasslessAnnotations) {
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations,
+                                                bool ignoreClasslessAnnotations,
+                                                bool noRefTypePorts) {
   auto pass = std::make_unique<LowerAnnotationsPass>();
   pass->ignoreUnhandledAnno = ignoreUnhandledAnnotations;
   pass->ignoreClasslessAnno = ignoreClasslessAnnotations;
+  pass->noRefTypePorts = noRefTypePorts;
   return pass;
 }

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/InstantiateCompanionOnly.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/InstantiateCompanionOnly.fir
@@ -1,0 +1,59 @@
+; RUN: firtool %s --grand-central-instantiate-companion | FileCheck %s --check-prefix CHECK
+
+circuit Foo : %[[
+  {
+    "class": "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
+    "name": "bar_view",
+    "companion": "~Foo|Companion",
+    "parent": "~Foo|Foo",
+    "view": {
+      "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+      "defName": "Bar_View",
+      "elements": [
+        {
+          "name": "bar_in",
+          "description": "bar in",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "Foo",
+              "module": "Foo",
+              "path": [],
+              "ref": "a",
+              "component": []
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "class": "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+    "directory": "Wire/firrtl/gct",
+    "filename": "Wire/firrtl/bindings.sv"
+  }
+]]
+  module Companion :
+    input clock: Clock
+    input a: UInt<1>
+
+    assert(clock, a, UInt<1>(1), "hello")
+
+  module Foo :
+    input clock: Clock
+
+    wire a: UInt<1>
+    a is invalid
+
+    inst companion of Companion
+    companion.clock <= clock
+    companion.a <= a
+
+    ; CHECK:     module Foo
+    ; CHECK-NOT: endmodule
+    ; CHECK-NOT:   emitted as a bind statement
+    ; CHECK:       Companion companion
+    ; CHECK:     endmodule

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-no-ref-type.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-no-ref-type.fir
@@ -1,0 +1,40 @@
+; RUN: firtool -lower-annotations-no-ref-type-ports %s | FileCheck %s
+
+circuit Foo: %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~Foo|Foo/bar:Bar>a",
+        "sink": "~Foo|Foo/baz:Baz>a"
+      }
+    ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Foo|Bar>a"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Foo|Baz>a"
+  }
+]]
+  module Bar:
+    wire a: UInt<1>
+    a is invalid
+
+  module Baz:
+    wire a: UInt<1>
+    a is invalid
+
+  module Foo:
+
+    inst bar of Bar
+    inst baz of Baz
+
+    ; CHECK:      module Bar
+    ; CHECK-NEXT:   output
+
+    ; CHECK:      module Baz
+    ; CHECK-NEXT:   input

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -140,6 +140,12 @@ static cl::opt<bool> disableAnnotationsUnknown(
     cl::desc("Ignore unknown annotations when parsing"), cl::init(false),
     cl::cat(mainCategory));
 
+static cl::opt<bool> lowerAnnotationsNoRefTypePorts(
+    "lower-annotations-no-ref-type-ports",
+    cl::desc("Create real ports instead of ref type ports when resolving "
+             "wiring problems inside the LowerAnnotations pass"),
+    cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
 static cl::opt<bool>
     emitMetadata("emit-metadata",
                  cl::desc("Emit metadata for metadata annotations"),
@@ -631,7 +637,8 @@ static LogicalResult processBuffer(
   applyPassManagerCLOptions(pm);
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
-      disableAnnotationsUnknown, disableAnnotationsClassless));
+      disableAnnotationsUnknown, disableAnnotationsClassless,
+      lowerAnnotationsNoRefTypePorts));
 
   // If the user asked for --parse-only, stop after running LowerAnnotations.
   if (outputFormat == OutputParseOnly) {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -303,6 +303,15 @@ static cl::opt<bool>
                         cl::desc("Disable the Grand Central passes"),
                         cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
+static cl::opt<bool> grandCentralInstantiateCompanionOnly(
+    "grand-central-instantiate-companion",
+    cl::desc(
+        "Run Grand Central in a mode where the companion module is "
+        "instantiated and not bound in and the interface is dropped.  This is "
+        "intended for situations where there is useful assertion logic inside "
+        "the companion, but you don't care about the actual interface."),
+    cl::init(false), cl::Hidden, cl::cat(mainCategory));
+
 static cl::opt<bool> exportModuleHierarchy(
     "export-module-hierarchy",
     cl::desc("Export module and instance hierarchy as JSON"), cl::init(false),
@@ -753,7 +762,8 @@ static LogicalResult processBuffer(
   // certain black boxes should be placed.  Note: all Grand Central Taps related
   // collateral is resolved entirely by LowerAnnotations.
   if (!disableGrandCentral)
-    pm.addNestedPass<firrtl::CircuitOp>(firrtl::createGrandCentralPass());
+    pm.addNestedPass<firrtl::CircuitOp>(
+        firrtl::createGrandCentralPass(grandCentralInstantiateCompanionOnly));
 
   // Read black box source files into the IR.
   StringRef blackBoxRoot = blackBoxRootPath.empty()


### PR DESCRIPTION
This includes two hack options to help make Grand Central collateral (Views and Taps) more synthesizable. The options to `firtool` are:

1. `-grand-central-instantiate-companion`
2. `-lower-annotations-no-ref-type-ports`

(1) will change the Grand Central pass to never instantiate the companion module under a bind. (Previously this would only happen if the user didn't request extraction via an annotation.) Additionally, this will _not print any SystemVerilog interface_. From the perspective of a synthesis tool, the interface is a dead wire and should be dropped. This avoids problems where a tool may not accept interfaces.

(2) changes how the `LowerAnnotations` pass resolves wiring problems to always create real ports. Previously, this would create real ports along the LCA to sink path, but not on the the source to LCA path. The effect of this is that no XMRs will be created for Grand Central views or taps features.