### PR TITLE
Add TAGS to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /install*
 /docker_build
 tags
+TAGS
 .vscode
 .idea
 compile_commands.json


### PR DESCRIPTION
I believe "TAGS" is the default output for `etags`