### PR TITLE
[ExportVerilog] Don't regard input ports as assignment patterns

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -696,8 +696,8 @@ bool ExportVerilog::isExpressionEmittedInline(Operation *op,
   // Never create a temporary which is only going to be assigned to an output
   // port, wire, or reg.
   if (op->hasOneUse() &&
-      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, sv::PAssignOp,
-          hw::InstanceOp>(*op->getUsers().begin()))
+      isa<hw::OutputOp, sv::AssignOp, sv::BPAssignOp, sv::PAssignOp>(
+          *op->getUsers().begin()))
     return true;
 
   // If mux inlining is dissallowed, we cannot inline muxes.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1348,13 +1348,13 @@ hw.module @inline_bitcast_in_concat(%in1: i7, %in2: !hw.array<8xi4>) -> (out: i3
   hw.output %0 : i39
 }
 
-// CHECK-LABEL: module dont_inline_aggregate_constant_into_port(
+// CHECK-LABEL: module DontInlineAggregateConstantIntoPorts(
 // CHECK:         wire [1:0][3:0] _GEN = '{4'h0, 4'h1};
 // CHECK-NEXT:    Array i0 (
 // CHECK-NEXT:     .a (_GEN)
 // CHECK-NEXT:    );
 // CHECK-NEXT:  endmodule
-hw.module @dont_inline_aggregate_constant_into_port() -> () {
+hw.module @DontInlineAggregateConstantIntoPorts() -> () {
   %0 = hw.aggregate_constant [0 : i4, 1 : i4] : !hw.array<2xi4>
   hw.instance "i0" @Array(a: %0: !hw.array<2xi4>) -> ()
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -2,6 +2,7 @@
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)
+hw.module.extern @Array(%a: !hw.array<2xi4>)
 
 hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
                         %array2d: !hw.array<12 x array<10xi4>>,
@@ -1345,4 +1346,15 @@ hw.module @inline_bitcast_in_concat(%in1: i7, %in2: !hw.array<8xi4>) -> (out: i3
   %r2 = hw.bitcast %in2 : (!hw.array<8xi4>) -> i32
   %0 = comb.concat %in1, %r2: i7, i32
   hw.output %0 : i39
+}
+
+// CHECK-LABEL: module dont_inline_aggregate_constant_into_port(
+// CHECK:         wire [1:0][3:0] _GEN = '{4'h0, 4'h1};
+// CHECK-NEXT:    Array i0 (
+// CHECK-NEXT:     .a (_GEN)
+// CHECK-NEXT:    );
+// CHECK-NEXT:  endmodule
+hw.module @dont_inline_aggregate_constant_into_port() -> () {
+  %0 = hw.aggregate_constant [0 : i4, 1 : i4] : !hw.array<2xi4>
+  hw.instance "i0" @Array(a: %0: !hw.array<2xi4>) -> ()
 }


### PR DESCRIPTION
This fixes a bug in `isExpressionEmittedInline` introduced by 1c38d707a3cc4e84631f7218a4a62e450143f0d8. 1c38d707a3cc4e84631f7218a4a62e450143f0d8 allowed single-use expressions to be inlined into instance ports, but some expressions are forbidden to be inlined into input ports. We have to check validity with `isExpressionUnableToInline`. 