### PR TITLE
[PyCDE] Class based struct definitions

### DIFF
--- a/frontends/PyCDE/src/support.py
+++ b/frontends/PyCDE/src/support.py
@@ -80,8 +80,8 @@ def _obj_to_value(x, type, result_type=None):
         "Encountered 'None' when trying to build hardware for python value.")
   from .value import Signal
   from .dialects import hw, hwarith
-  from .types import (TypeAlias, Array, Struct, BitVectorType, Bits, UInt, SInt,
-                      _FromCirctType)
+  from .types import (TypeAlias, Array, StructType, BitVectorType, Bits, UInt,
+                      SInt, _FromCirctType)
 
   if isinstance(x, Signal):
     return x
@@ -127,7 +127,7 @@ def _obj_to_value(x, type, result_type=None):
       return hw.ArrayCreateOp(reversed(list_of_vals))
 
   if isinstance(x, dict):
-    if not isinstance(type, Struct):
+    if not isinstance(type, StructType):
       raise ValueError(f"Dict is only convertable to hw struct, not '{type}'")
     elem_name_values = []
     for (fname, ftype) in type.fields:

--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -88,9 +88,7 @@ class System:
     self.hw_output_dir.mkdir(exist_ok=True)
 
     with self:
-      for m in self.top_modules:
-        assert issubclass(m, Module)
-        m._builder.circt_mod
+      [m._builder.circt_mod for m in self.top_modules]
 
   def add_packaging_step(self, func: Callable):
     self.packaging_funcs.append(func)

--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -88,7 +88,9 @@ class System:
     self.hw_output_dir.mkdir(exist_ok=True)
 
     with self:
-      [m._builder.circt_mod for m in self.top_modules]
+      for m in self.top_modules:
+        assert issubclass(m, Module)
+        m._builder.circt_mod
 
   def add_packaging_step(self, func: Callable):
     self.packaging_funcs.append(func)

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -303,6 +303,8 @@ class StructType(Type):
 
 
 class RegisteredStruct(TypeAlias):
+  """Represents a named struct with a custom signal class. Primarily used by
+  `value.Struct`."""
 
   def __new__(cls, fields: typing.List[typing.Tuple[str, Type]], name: str,
               value_class):

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -4,6 +4,8 @@
 
 from collections import OrderedDict
 
+from .support import _obj_to_value
+
 from .circt import ir, support
 from .circt.dialects import esi, hw, sv
 
@@ -312,6 +314,10 @@ class RegisteredStruct(TypeAlias):
     inst = super().__new__(cls, inner_type, name)
     inst._value_class = value_class
     return inst
+
+  def __call__(self, **kwargs):
+    from .value import Value
+    return Value(kwargs, self._type)
 
   def _get_value_class(self):
     return self._value_class

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -4,10 +4,6 @@
 
 from collections import OrderedDict
 
-from .value import (BitsSignal, ChannelValue, ClockSignal, ArraySignal,
-                    SIntValue, UIntValue, StructValue, UntypedSignal,
-                    InOutSignal, Value)
-
 from .circt import ir, support
 from .circt.dialects import esi, hw, sv
 
@@ -37,7 +33,7 @@ class _Types:
     return self.wrap(Channel(inner))
 
   def struct(self, members, name: str = None) -> hw.StructType:
-    s = Struct(members)
+    s = StructType(members)
     if name is None:
       return s
     return TypeAlias(s, name)
@@ -62,11 +58,15 @@ class Type:
   # Global Type cache.
   _cache: typing.Dict[typing.Tuple[type, ir.Type], "Type"] = {}
 
-  def __new__(cls, circt_type: ir.Type) -> "Type":
+  def __new__(cls, circt_type: ir.Type, incl_cls_in_key: bool = True) -> "Type":
     """Look up a type in the Type cache. If present, return it. If not, create
     it and put it in the cache."""
     assert isinstance(circt_type, ir.Type)
-    cache_key = (cls, circt_type)
+    if incl_cls_in_key:
+      cache_key = (cls, circt_type)
+    else:
+      cache_key = circt_type
+
     if cache_key not in Type._cache:
       t = super(Type, cls).__new__(cls)
       t._type = circt_type
@@ -94,6 +94,7 @@ class Type:
 
   def _get_value_class(self):
     """Return the class which should be instantiated to create a Value."""
+    from .value import UntypedSignal
     return UntypedSignal
 
   def __repr__(self):
@@ -107,9 +108,9 @@ def _FromCirctType(type: Union[ir.Type, Type]) -> Type:
   if isinstance(type, hw.ArrayType):
     return Type.__new__(Array, type)
   if isinstance(type, hw.StructType):
-    return Type.__new__(Struct, type)
+    return Type.__new__(StructType, type)
   if isinstance(type, hw.TypeAliasType):
-    return Type.__new__(TypeAlias, type)
+    return Type.__new__(TypeAlias, type, incl_cls_in_key=False)
   if isinstance(type, hw.InOutType):
     return Type.__new__(InOut, type)
   if isinstance(type, ir.IntegerType):
@@ -136,6 +137,7 @@ class InOut(Type):
     return _FromCirctType(self._type.element_type)
 
   def _get_value_class(self):
+    from .value import InOutSignal
     return InOutSignal
 
 
@@ -145,20 +147,21 @@ class TypeAlias(Type):
   RegisteredAliases: typing.Optional[OrderedDict] = None
 
   def __new__(cls, inner_type: Type, name: str):
-    if not TypeAlias.RegisteredAliases:
+    if TypeAlias.RegisteredAliases is None:
       TypeAlias.RegisteredAliases = OrderedDict()
-    alias = hw.TypeAliasType.get(TypeAlias.TYPE_SCOPE, name, inner_type._type)
 
     if name in TypeAlias.RegisteredAliases:
-      if alias != TypeAlias.RegisteredAliases[name]:
+      if inner_type._type != TypeAlias.RegisteredAliases[name].inner_type:
         raise RuntimeError(
             f"Re-defining type alias for {name}! "
             f"Given: {inner_type}, "
             f"existing: {TypeAlias.RegisteredAliases[name].inner_type}")
-      return TypeAlias.RegisteredAliases[name]
+      alias = TypeAlias.RegisteredAliases[name]
+    else:
+      alias = hw.TypeAliasType.get(TypeAlias.TYPE_SCOPE, name, inner_type._type)
+      TypeAlias.RegisteredAliases[name] = alias
 
-    TypeAlias.RegisteredAliases[name] = alias
-    return super(TypeAlias, cls).__new__(cls, alias)
+    return super(TypeAlias, cls).__new__(cls, alias, incl_cls_in_key=False)
 
   @staticmethod
   def declare_aliases(mod):
@@ -254,13 +257,14 @@ class Array(Type):
     return self.size
 
   def _get_value_class(self):
+    from .value import ArraySignal
     return ArraySignal
 
   def __str__(self) -> str:
     return f"[{self.size}]{self.element_type}"
 
 
-class Struct(Type):
+class StructType(Type):
 
   def __new__(cls, fields: typing.Union[typing.List[typing.Tuple[str, Type]],
                                         typing.Dict[str, Type]]):
@@ -268,7 +272,7 @@ class Struct(Type):
       fields = list(fields.items())
     if not isinstance(fields, list):
       raise TypeError("Expected either list or dict.")
-    return super(Struct, cls).__new__(
+    return super(StructType, cls).__new__(
         cls, hw.StructType.get([(n, t._type) for (n, t) in fields]))
 
   @property
@@ -282,7 +286,8 @@ class Struct(Type):
     return super().__getattribute__(attrname)
 
   def _get_value_class(self):
-    return StructValue
+    from .value import StructSignal
+    return StructSignal
 
   def __str__(self) -> str:
     ret = "struct { "
@@ -295,6 +300,19 @@ class Struct(Type):
       ret += f"{field[0]}: {_FromCirctType(field[1])}"
     ret += "}"
     return ret
+
+
+class RegisteredStruct(TypeAlias):
+
+  def __new__(cls, fields: typing.List[typing.Tuple[str, Type]], name: str,
+              value_class):
+    inner_type = StructType(fields)
+    inst = super().__new__(cls, inner_type, name)
+    inst._value_class = value_class
+    return inst
+
+  def _get_value_class(self):
+    return self._value_class
 
 
 class BitVectorType(Type):
@@ -313,6 +331,7 @@ class Bits(BitVectorType):
     )
 
   def _get_value_class(self):
+    from .value import BitsSignal
     return BitsSignal
 
   def __repr__(self):
@@ -328,6 +347,7 @@ class SInt(BitVectorType):
     )
 
   def _get_value_class(self):
+    from .value import SIntValue
     return SIntValue
 
   def __repr__(self):
@@ -343,6 +363,7 @@ class UInt(BitVectorType):
     )
 
   def _get_value_class(self):
+    from .value import UIntValue
     return UIntValue
 
   def __repr__(self):
@@ -361,6 +382,7 @@ class ClockType(Bits):
     super(ClockType, cls).__new__(cls, 1)
 
   def _get_value_class(self):
+    from .value import ClockSignal
     return ClockSignal
 
   def __repr__(self):
@@ -385,6 +407,7 @@ class Channel(Type):
     return _FromCirctType(self._type.inner)
 
   def _get_value_class(self):
+    from .value import ChannelValue
     return ChannelValue
 
   def __str__(self):
@@ -397,6 +420,7 @@ class Channel(Type):
   def wrap(self, value, valid):
     from .dialects import esi
     from .support import _obj_to_value
+    from .value import Value, BitsSignal
     value = _obj_to_value(value, self._type.inner)
     valid = _obj_to_value(valid, types.i1)
     wrap_op = esi.WrapValidReadyOp(self._type, types.i1, value.value,

--- a/frontends/PyCDE/src/value.py
+++ b/frontends/PyCDE/src/value.py
@@ -607,6 +607,10 @@ class StructSignal(Signal):
 class StructMetaType(type):
 
   def __new__(self, name, bases, dct):
+    """Scans the class being created for type hints, creates a CIRCT struct
+    object and returns the CIRCT struct object instead of the class. Use the
+    class when a `Signal` of the struct type is instantiated."""
+
     cls = super().__new__(self, name, bases, dct)
     from .types import RegisteredStruct, Type
     if "__annotations__" not in dct:
@@ -620,7 +624,26 @@ class StructMetaType(type):
 
 
 class Struct(StructSignal, metaclass=StructMetaType):
-  pass
+  """Subclassing this class creates a hardware struct which can be used in port
+  definitions and will be instantiated in generators:
+
+  ```
+  class ExStruct(Struct):
+    a: Bits(4)
+    b: UInt(32)
+
+    def get_b(self):
+      return self.b
+
+  class TestStruct(Module):
+    inp1 = Input(ExStruct)
+
+    @generator
+    def build(self):
+      ... = self.inp1.get_b()
+  ```
+  """
+  # All the work is done in the metaclass.
 
 
 class ChannelValue(Signal):

--- a/frontends/PyCDE/src/value.py
+++ b/frontends/PyCDE/src/value.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from .support import get_user_loc, _obj_to_value_infer_type
+from .types import Type
+from .support import get_user_loc, _obj_to_value_infer_type, _obj_to_value
 
 from .circt.dialects import sv
 from .circt import support
@@ -17,7 +18,7 @@ import re
 import numpy as np
 
 
-def Value(value, type=None):
+def Value(value, type: Type = None):
   from .types import _FromCirctType
 
   if isinstance(value, Signal):
@@ -25,7 +26,10 @@ def Value(value, type=None):
 
   resvalue = support.get_value(value)
   if resvalue is None:
-    return _obj_to_value_infer_type(value)
+    if type is None:
+      resvalue = _obj_to_value_infer_type(value)
+    else:
+      resvalue = _obj_to_value(value, type)
 
   if type is None:
     type = resvalue.type

--- a/frontends/PyCDE/test/pycde_types.py
+++ b/frontends/PyCDE/test/pycde_types.py
@@ -74,4 +74,5 @@ class TestStruct(Module):
     self.out1 = self.inp1.get_b_plus1()
     s = ExStruct(a=self.inp1.a, b=self.inp1.get_b_plus1().as_uint(32))
     assert type(s) is ExStruct._get_value_class()
+    assert s.a == self.inp1.a
     self.out2 = s

--- a/frontends/PyCDE/test/pycde_types.py
+++ b/frontends/PyCDE/test/pycde_types.py
@@ -35,7 +35,7 @@ dim_alias = dim(1, 8, name="myname5")
 # CHECK: hw.typedecl @myname5 : !hw.array<8xi1>
 # CHECK-NOT: hw.typedecl @myname1
 # CHECK-NOT: hw.typedecl @myname5
-m = System([]).mod.create()
+m = System([]).mod
 TypeAlias.declare_aliases(m)
 TypeAlias.declare_aliases(m)
 print(m)
@@ -52,6 +52,11 @@ class ExStruct(Struct):
 print(ExStruct)
 
 
+# CHECK-LABEL:  msft.module @TestStruct {} (%inp1: !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>) -> (out1: ui33)
+# CHECK-NEXT:     %b = hw.struct_extract %inp1["b"] {sv.namehint = "inp1__b"} : !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
+# CHECK-NEXT:     [[r0:%.+]] = hwarith.constant 1 : ui1
+# CHECK-NEXT:     [[r1:%.+]] = hwarith.add %b, [[r0]] : (ui32, ui1) -> ui33
+# CHECK-NEXT:     msft.output [[r1]] : ui33
 @unittestmodule()
 class TestStruct(Module):
   inp1 = Input(ExStruct)

--- a/frontends/PyCDE/test/pycde_types.py
+++ b/frontends/PyCDE/test/pycde_types.py
@@ -3,7 +3,7 @@
 from pycde import dim, types, Input, Output, generator, System, Module
 from pycde.types import Bits, StructType, TypeAlias, UInt
 from pycde.testing import unittestmodule
-from pycde.value import Struct
+from pycde.value import Struct, UIntValue
 
 # CHECK: [('foo', bits1), ('bar', bits13)]
 st1 = StructType({"foo": types.i1, "bar": types.i13})
@@ -45,23 +45,33 @@ class ExStruct(Struct):
   a: Bits(4)
   b: UInt(32)
 
-  def get_b_plus1(self):
-    return self.b + UInt(1)(1)
+  def get_b_plus1(self) -> UIntValue:
+    return self.b + 1
 
 
 print(ExStruct)
 
 
-# CHECK-LABEL:  msft.module @TestStruct {} (%inp1: !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>) -> (out1: ui33)
+# CHECK-LABEL:  msft.module @TestStruct {} (%inp1: !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>) -> (out1: ui33, out2: !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>)
 # CHECK-NEXT:     %b = hw.struct_extract %inp1["b"] {sv.namehint = "inp1__b"} : !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
 # CHECK-NEXT:     [[r0:%.+]] = hwarith.constant 1 : ui1
 # CHECK-NEXT:     [[r1:%.+]] = hwarith.add %b, [[r0]] : (ui32, ui1) -> ui33
-# CHECK-NEXT:     msft.output [[r1]] : ui33
+# CHECK-NEXT:     %a = hw.struct_extract %inp1["a"] {sv.namehint = "inp1__a"} : !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
+# CHECK-NEXT:     %b_0 = hw.struct_extract %inp1["b"] {sv.namehint = "inp1__b"} : !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
+# CHECK-NEXT:     [[r2:%.+]] = hwarith.constant 1 : ui1
+# CHECK-NEXT:     [[r3:%.+]] = hwarith.add %b_0, [[r2]] : (ui32, ui1) -> ui33
+# CHECK-NEXT:     [[r4:%.+]] = hwarith.cast [[r3]] : (ui33) -> ui32
+# CHECK-NEXT:     [[r5:%.+]] = hw.struct_create (%a, [[r4]]) : !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
+# CHECK-NEXT:     msft.output [[r1]], [[r5]] : ui33, !hw.typealias<@pycde::@ExStruct, !hw.struct<a: i4, b: ui32>>
 @unittestmodule()
 class TestStruct(Module):
   inp1 = Input(ExStruct)
   out1 = Output(UInt(33))
+  out2 = Output(ExStruct)
 
   @generator
   def build(self):
     self.out1 = self.inp1.get_b_plus1()
+    s = ExStruct(a=self.inp1.a, b=self.inp1.get_b_plus1().as_uint(32))
+    assert type(s) is ExStruct._get_value_class()
+    self.out2 = s


### PR DESCRIPTION
Allows users to define structs as Python classes and use instances of that class in generators:

```py
class ExStruct(Struct):
  a: Bits(4)
  b: UInt(32)

  def get_b(self):
    return self.b

class TestStruct(Module):
  inp1 = Input(ExStruct)
  out2 = Output(ExStruct)

  @generator
  def build(self):
    ... = self.inp1.get_b()
    self.out2 = ExStruct(a=..., b=...)
```