### PR TITLE
Bump LLVM to 95e49f5a74c9e79778a62cc58b15875613cf9e59.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -509,15 +509,9 @@ private:
   PatternApplicationState &patternState;
 };
 
-struct ModuleOpConversion : public OpRewritePattern<mlir::ModuleOp> {
-  ModuleOpConversion(MLIRContext *context, StringRef topLevelFunction);
-
-  LogicalResult matchAndRewrite(mlir::ModuleOp moduleOp,
-                                PatternRewriter &rewriter) const override;
-
-private:
-  StringRef topLevelFunction;
-};
+/// Helper to update the top-level ModuleOp to set the entrypoing function.
+LogicalResult applyModuleOpConversion(mlir::ModuleOp,
+                                      StringRef topLevelFunction);
 
 /// FuncOpPartialLoweringPatterns are patterns which intend to match on FuncOps
 /// and then perform their own walking of the IR.

--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -15,9 +15,8 @@
 
 include "circt/Dialect/HW/HWDialect.td"
 include "mlir/IR/AttrTypeBase.td"
-include "mlir/IR/SubElementInterfaces.td"
 
-def InnerRefAttr : AttrDef<HWDialect, "InnerRef", [SubElementAttrInterface]> {
+def InnerRefAttr : AttrDef<HWDialect, "InnerRef"> {
   let summary = "Refer to a name inside a module";
   let description = [{
     This works like a symbol reference, but to a name inside a module.

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -16,7 +16,6 @@
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
-include "mlir/IR/SubElementInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 

--- a/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
+++ b/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
@@ -1446,11 +1446,7 @@ public:
       return failure();
 
     // Program conversion
-    RewritePatternSet conversionPatterns(&getContext());
-    conversionPatterns.add<calyx::ModuleOpConversion>(&getContext(),
-                                                      topLevelFunction);
-    return applyOpPatternsAndFold(getOperation(),
-                                  std::move(conversionPatterns));
+    return calyx::applyModuleOpConversion(getOperation(), topLevelFunction);
   }
 
   /// 'Once' patterns are expected to take an additional LogicalResult&

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1227,11 +1227,7 @@ public:
       return failure();
 
     // Program conversion
-    RewritePatternSet conversionPatterns(&getContext());
-    conversionPatterns.add<calyx::ModuleOpConversion>(&getContext(),
-                                                      topLevelFunction);
-    return applyOpPatternsAndFold(getOperation(),
-                                  std::move(conversionPatterns));
+    return calyx::applyModuleOpConversion(getOperation(), topLevelFunction);
   }
 
   /// 'Once' patterns are expected to take an additional LogicalResult&

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -347,19 +347,15 @@ std::string CalyxLoweringState::blockName(Block *b) {
 // ModuleOpConversion
 //===----------------------------------------------------------------------===//
 
-ModuleOpConversion::ModuleOpConversion(MLIRContext *context,
-                                       StringRef topLevelFunction)
-    : OpRewritePattern<mlir::ModuleOp>(context),
-      topLevelFunction(topLevelFunction) {}
+/// Helper to update the top-level ModuleOp to set the entrypoing function.
+LogicalResult applyModuleOpConversion(mlir::ModuleOp moduleOp,
+                                      StringRef topLevelFunction) {
 
-LogicalResult
-ModuleOpConversion::matchAndRewrite(mlir::ModuleOp moduleOp,
-                                    PatternRewriter &rewriter) const {
   if (moduleOp->hasAttr("calyx.entrypoint"))
     return failure();
 
   moduleOp->setAttr("calyx.entrypoint",
-                    rewriter.getStringAttr(topLevelFunction));
+                    StringAttr::get(moduleOp.getContext(), topLevelFunction));
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
@@ -13,7 +13,6 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/SubElementInterfaces.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/Support/Debug.h"
 
@@ -37,18 +36,11 @@ private:
 
 /// Find all InnerRefAttrs inside a given Attribute.
 void InnerSymbolDCEPass::findInnerRefs(Attribute attr) {
-  // Check if this Attribute is an InnerRefAttr.
-  if (auto innerRef = dyn_cast<InnerRefAttr>(attr)) {
-    insertInnerRef(innerRef);
-    return;
-  }
-
-  // Check if any sub-Attributes are InnerRefAttrs.
-  if (auto subElementAttr = dyn_cast<SubElementAttrInterface>(attr))
-    subElementAttr.walkSubAttrs([&](Attribute subAttr) {
-      if (auto innerRef = dyn_cast<InnerRefAttr>(subAttr))
-        insertInnerRef(innerRef);
-    });
+  // Check if this Attribute or any sub-Attributes are InnerRefAttrs.
+  attr.walk([&](Attribute subAttr) {
+    if (auto innerRef = dyn_cast<InnerRefAttr>(subAttr))
+      insertInnerRef(innerRef);
+  });
 }
 
 /// Add an InnerRefAttr to the set of all InnerRefAttrs.


### PR DESCRIPTION
This deals with two issues:

SubElementInterfaces went away and became a core construct: https://github.com/llvm/llvm-project/commit/03d136cf5f3f10b618b7e17f897ebf6019518dcc

It seems most of the APIs we used are already supported, and InnerSymbolDCE needed to change. Since the new `walk` API includes the attribute itself, InnerSymbolDCE can be simplified slightly.

I would hope this change is covered by tests. The InnerSymbolDCE change is: https://github.com/llvm/circt/blob/main/test/Dialect/FIRRTL/inner-symbol-dce.mlir

A new assertion was added to GreedyPatternRewriteDriver as part of a refactoring change, which doesn't support our use-case: https://github.com/llvm/llvm-project/commit/977cddb95eac67a6dc6680a7d0fadee81114de11

I just changed the rewrite pattern in question to just do a direct IR manipulation. This pattern was simply updating a ModuleOp in place (although not with updateRootInPlace 😞 ).

This change is covered by tests. 