### PR TITLE
[PyCDE][NFC] Cleanups and renames

### DIFF
--- a/frontends/PyCDE/src/CMakeLists.txt
+++ b/frontends/PyCDE/src/CMakeLists.txt
@@ -32,7 +32,7 @@ declare_mlir_python_sources(PyCDESources
   system.py
   devicedb.py
   instance.py
-  value.py
+  signals.py
   ndarray.py
   esi.py
   esi_api.py

--- a/frontends/PyCDE/src/__init__.py
+++ b/frontends/PyCDE/src/__init__.py
@@ -22,7 +22,7 @@ from .common import (AppID, Clock, Input, InputChannel, Output, OutputChannel)
 from .module import (generator, modparams, Module)
 from .system import (System)
 from .types import (dim, types)
-from .value import (Value)
+from .signals import (_FromCirctValue)
 
 # Until we get source location based on Python stack traces, default to unknown
 # locations.

--- a/frontends/PyCDE/src/__init__.py
+++ b/frontends/PyCDE/src/__init__.py
@@ -22,7 +22,7 @@ from .common import (AppID, Clock, Input, InputChannel, Output, OutputChannel)
 from .module import (generator, modparams, Module)
 from .system import (System)
 from .types import (dim, types)
-from .signals import (_FromCirctValue)
+from .signals import (Signal)
 
 # Until we get source location based on Python stack traces, default to unknown
 # locations.

--- a/frontends/PyCDE/src/behavioral.py
+++ b/frontends/PyCDE/src/behavioral.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .value import BitVectorSignal, Signal, Value
+from .signals import BitVectorSignal, Signal, _FromCirctValue
 from .dialects import comb
 
 import ctypes
@@ -49,7 +49,7 @@ class If:
     if (cond.type.width != 1):
       raise TypeError("'Cond' bit width must be 1")
     self._cond = cond
-    self._muxes: Dict[str, Tuple[Value, Value]] = {}
+    self._muxes: Dict[str, Tuple[_FromCirctValue, _FromCirctValue]] = {}
 
   @staticmethod
   def current() -> Optional[If]:
@@ -71,7 +71,7 @@ class If:
     _current_if_stmt.reset(self._old_system_token)
 
     # Create the set of muxes from the 'then' and/or 'else' blocks.
-    new_locals: Dict[str, Value] = {}
+    new_locals: Dict[str, _FromCirctValue] = {}
     for (varname, (else_value, then_value)) in self._muxes.items():
       # New values need to have a value assigned from both the 'then' and 'else'.
       if then_value is None or else_value is None:
@@ -112,7 +112,7 @@ class _IfBlock:
     if_stmt = If.current()
     s = inspect.stack()[stack_level][0]
     lcls_to_del = set()
-    new_lcls: Dict[str, Value] = {}
+    new_lcls: Dict[str, _FromCirctValue] = {}
     for (varname, value) in s.f_locals.items():
       # Only operate on Values.
       if not isinstance(value, Signal):

--- a/frontends/PyCDE/src/behavioral.py
+++ b/frontends/PyCDE/src/behavioral.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-from .signals import BitVectorSignal, Signal, _FromCirctValue
 from .dialects import comb
+from .signals import BitVectorSignal, Signal
 
 import ctypes
 from contextvars import ContextVar
@@ -49,7 +49,7 @@ class If:
     if (cond.type.width != 1):
       raise TypeError("'Cond' bit width must be 1")
     self._cond = cond
-    self._muxes: Dict[str, Tuple[_FromCirctValue, _FromCirctValue]] = {}
+    self._muxes: Dict[str, Tuple[Signal, Signal]] = {}
 
   @staticmethod
   def current() -> Optional[If]:
@@ -71,7 +71,7 @@ class If:
     _current_if_stmt.reset(self._old_system_token)
 
     # Create the set of muxes from the 'then' and/or 'else' blocks.
-    new_locals: Dict[str, _FromCirctValue] = {}
+    new_locals: Dict[str, Signal] = {}
     for (varname, (else_value, then_value)) in self._muxes.items():
       # New values need to have a value assigned from both the 'then' and 'else'.
       if then_value is None or else_value is None:
@@ -112,7 +112,7 @@ class _IfBlock:
     if_stmt = If.current()
     s = inspect.stack()[stack_level][0]
     lcls_to_del = set()
-    new_lcls: Dict[str, _FromCirctValue] = {}
+    new_lcls: Dict[str, Signal] = {}
     for (varname, value) in s.f_locals.items():
       # Only operate on Values.
       if not isinstance(value, Signal):

--- a/frontends/PyCDE/src/common.py
+++ b/frontends/PyCDE/src/common.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .circt.dialects import esi as raw_esi, msft
+from .circt.dialects import msft
 from .circt import ir
 
 from .types import Type, Channel, ClockType

--- a/frontends/PyCDE/src/constructs.py
+++ b/frontends/PyCDE/src/constructs.py
@@ -215,9 +215,11 @@ def SystolicArray(row_inputs: ArraySignal, col_inputs: ArraySignal, pe_builder):
   with ir.InsertionPoint(pe_block):
     result = pe_builder(_FromCirctValue(pe_block.arguments[0]),
                         _FromCirctValue(pe_block.arguments[1]))
-    value = _FromCirctValue(result)
-    pe_output_type = value.type
-    msft.PEOutputOp(value)
+    if not isinstance(result, Signal):
+      raise TypeError(
+          f"pe_builder function must return a `Signal` not {result}")
+    pe_output_type = result.type
+    msft.PEOutputOp(result)
 
   sa_result_type = dim(pe_output_type, col_inputs_type.size,
                        row_inputs_type.size)

--- a/frontends/PyCDE/src/devicedb.py
+++ b/frontends/PyCDE/src/devicedb.py
@@ -5,11 +5,11 @@
 from __future__ import annotations
 from typing import Any, List, Optional, Tuple, Union
 
+from .support import get_user_loc
+
 from .circt.dialects import msft
 from .circt.support import attribute_to_var
-
 from .circt.ir import Attribute, StringAttr, ArrayAttr, FlatSymbolRefAttr
-from .support import get_user_loc
 
 from functools import singledispatchmethod
 

--- a/frontends/PyCDE/src/dialects/comb.py
+++ b/frontends/PyCDE/src/dialects/comb.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import comb
 
 wrap_opviews_with_values(comb, __name__)

--- a/frontends/PyCDE/src/dialects/esi.py
+++ b/frontends/PyCDE/src/dialects/esi.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import esi
 
 wrap_opviews_with_values(esi, __name__)

--- a/frontends/PyCDE/src/dialects/fsm.py
+++ b/frontends/PyCDE/src/dialects/fsm.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import fsm
 
 wrap_opviews_with_values(fsm, __name__,

--- a/frontends/PyCDE/src/dialects/hw.py
+++ b/frontends/PyCDE/src/dialects/hw.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import hw
 
 wrap_opviews_with_values(hw, __name__)

--- a/frontends/PyCDE/src/dialects/hwarith.py
+++ b/frontends/PyCDE/src/dialects/hwarith.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import hwarith
 
 wrap_opviews_with_values(hwarith, __name__)

--- a/frontends/PyCDE/src/dialects/msft.py
+++ b/frontends/PyCDE/src/dialects/msft.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import msft
 
 wrap_opviews_with_values(msft, __name__)

--- a/frontends/PyCDE/src/dialects/seq.py
+++ b/frontends/PyCDE/src/dialects/seq.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import seq
 
 wrap_opviews_with_values(seq, __name__)

--- a/frontends/PyCDE/src/dialects/sv.py
+++ b/frontends/PyCDE/src/dialects/sv.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..value import wrap_opviews_with_values
+from ..signals import wrap_opviews_with_values
 from ..circt.dialects import sv
 
 wrap_opviews_with_values(sv, __name__)

--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -146,7 +146,7 @@ class _RequestToClientConn(_RequestConnection):
     req_op = raw_esi.RequestToClientConnectionOp(
         type._type, self.service_port,
         ir.ArrayAttr.get([ir.StringAttr.get(chan_name)]))
-    return ChannelSignal(req_op)
+    return ChannelSignal(req_op.result, type)
 
 
 class _RequestToFromServerConn(_RequestConnection):
@@ -167,7 +167,7 @@ class _RequestToFromServerConn(_RequestConnection):
     to_client = raw_esi.RequestInOutChannelOp(
         self.to_client_type._type, self.service_port, to_server_channel.value,
         ir.ArrayAttr.get([ir.StringAttr.get(chan_name)]))
-    return ChannelSignal(to_client)
+    return ChannelSignal(to_client.result, type)
 
 
 def Cosim(decl: ServiceDecl, clk, rst):
@@ -223,7 +223,7 @@ class NamedChannelValue(ChannelSignal):
 
   def __init__(self, input_chan: ir.Value, client_name: List[str]):
     self.client_name = client_name
-    super().__init__(input_chan)
+    super().__init__(input_chan, _FromCirctType(input_chan.type))
 
 
 class _OutputChannelSetter:

--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -2,10 +2,10 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .system import System
-from .module import Generator, _BlockContext, Module, ModuleLikeBuilderBase
-from .signals import ChannelSignal, Signal, _FromCirctValue
 from .common import Input, Output, InputChannel, OutputChannel, _PyProxy
+from .module import Generator, Module, ModuleLikeBuilderBase
+from .signals import ChannelSignal, Signal, _FromCirctValue
+from .system import System
 from .types import Channel, Type, types, _FromCirctType
 
 from .circt import ir

--- a/frontends/PyCDE/src/esi_api.py
+++ b/frontends/PyCDE/src/esi_api.py
@@ -5,7 +5,6 @@
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from io import FileIO
-import os
 import json
 import pathlib
 import re

--- a/frontends/PyCDE/src/fsm.py
+++ b/frontends/PyCDE/src/fsm.py
@@ -1,13 +1,13 @@
-from pycde import Input, Output, generator
-from pycde.module import Generator, Module
-from pycde.dialects import fsm
-from pycde.types import types
-from typing import Callable
+from .common import Input, Output
+from .dialects import fsm
+from .module import generator, Generator, Module
+from .support import _obj_to_attribute, attributes_of_type
+from .types import types
 
 from .circt.ir import InsertionPoint
-
-from pycde.support import _obj_to_attribute, attributes_of_type
 from .circt.support import connect
+
+from typing import Callable
 
 
 class State:

--- a/frontends/PyCDE/src/instance.py
+++ b/frontends/PyCDE/src/instance.py
@@ -3,13 +3,14 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from __future__ import annotations
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+
+from .devicedb import LocationVector
+from .module import AppID
 
 from .circt.dialects import msft, seq
 from .circt import ir
 
-from pycde.devicedb import LocationVector
-from pycde.module import AppID
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 
 class Instance:

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -3,15 +3,13 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from __future__ import annotations
-from typing import List, Optional, Set, Tuple, Union, Dict
-from pycde.types import ClockType
-
-from pycde.support import _obj_to_value
+from typing import List, Optional, Set, Tuple, Dict
 
 from .common import (AppID, Clock, Input, Output, PortError, _PyProxy)
-from .support import (get_user_loc, _obj_to_attribute, OpOperandConnect,
+from .support import (get_user_loc, _obj_to_attribute, _obj_to_value,
                       create_type_string, create_const_zero)
 from .signals import ClockSignal, Signal, _FromCirctValue
+from .types import ClockType
 
 from .circt import ir, support
 from .circt.dialects import hw, msft

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -11,7 +11,7 @@ from pycde.support import _obj_to_value
 from .common import (AppID, Clock, Input, Output, PortError, _PyProxy)
 from .support import (get_user_loc, _obj_to_attribute, OpOperandConnect,
                       create_type_string, create_const_zero)
-from .value import ClockSignal, Signal, Value
+from .signals import ClockSignal, Signal, _FromCirctValue
 
 from .circt import ir, support
 from .circt.dialects import hw, msft
@@ -132,7 +132,7 @@ class PortProxyBase:
     val = self._block_args[idx]
     if idx in self._builder.clocks:
       return ClockSignal(val, ClockType())
-    return Value(val)
+    return _FromCirctValue(val)
 
   def _set_output(self, idx, signal):
     assert signal is not None
@@ -281,7 +281,7 @@ class ModuleLikeBuilderBase(_PyProxy):
     for idx, (name, port_type) in enumerate(self.outputs):
 
       def fget(self, idx=idx):
-        return Value(self.inst.results[idx])
+        return _FromCirctValue(self.inst.results[idx])
 
       named_outputs[name] = fget
       setattr(self.modcls, name, property(fget=fget))

--- a/frontends/PyCDE/src/ndarray.py
+++ b/frontends/PyCDE/src/ndarray.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .value import BitVectorSignal, ArraySignal
+from .signals import BitVectorSignal, ArraySignal
 from .types import BitVectorType, dim
 from pycde.dialects import hw, sv
 import numpy as np
@@ -79,7 +79,7 @@ class NDArray(np.ndarray):
         TypeError: _description_
     """
 
-    from pycde.value import ArraySignal
+    from pycde.signals import ArraySignal
 
     if (from_value is not None) and (shape is not None or dtype is not None):
       raise ValueError(
@@ -135,7 +135,7 @@ class NDArray(np.ndarray):
   def _circt_to_arr(value: Union[BitVectorSignal, ArraySignal],
                     target_shape: _TargetShape):
     """Converts a CIRCT value into a numpy array."""
-    from .value import (BitVectorSignal, ArraySignal)
+    from .signals import (BitVectorSignal, ArraySignal)
 
     if isinstance(value, BitVectorSignal) and isinstance(
         target_shape.dtype, BitVectorType):
@@ -271,7 +271,7 @@ class NDArray(np.ndarray):
     self.check_is_fully_assigned()
 
     def build_subarray(lstOrVal):
-      from .value import BitVectorSignal
+      from .signals import BitVectorSignal
       # Recursively converts this matrix into ListValues through hw.array_create
       # operations.
       if not isinstance(lstOrVal, BitVectorSignal):

--- a/frontends/PyCDE/src/ndarray.py
+++ b/frontends/PyCDE/src/ndarray.py
@@ -2,11 +2,13 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from .dialects import hw, sv
 from .signals import BitVectorSignal, ArraySignal
 from .types import BitVectorType, dim
-from pycde.dialects import hw, sv
-import numpy as np
+
 from .circt import ir
+
+import numpy as np
 from functools import lru_cache
 from dataclasses import dataclass
 from typing import Union

--- a/frontends/PyCDE/src/signals.py
+++ b/frontends/PyCDE/src/signals.py
@@ -18,7 +18,7 @@ import re
 import numpy as np
 
 
-def Value(value, type: Type = None):
+def _FromCirctValue(value, type: Type = None) -> Signal:
   from .types import _FromCirctType
 
   if isinstance(value, Signal):
@@ -57,6 +57,13 @@ class Signal:
       self.type = _FromCirctType(self.value.type)
 
   _reg_name = re.compile(r"^(.*)__reg(\d+)$")
+
+  @staticmethod
+  def create(obj) -> Signal:
+    """Create a Signal from any python object from which the hardware type can
+    be inferred. For instance, a list of Signals is inferred as an `Array` of
+    those signal types, assuming the types of all the `Signal` are the same."""
+    return _obj_to_value_infer_type(obj)
 
   def reg(self,
           clk=None,
@@ -209,7 +216,7 @@ class InOutSignal(Signal):
   @property
   def read(self):
     if self.read_value is None:
-      self.read_value = Value(sv.ReadInOutOp.create(self).results[0])
+      self.read_value = _FromCirctValue(sv.ReadInOutOp.create(self).results[0])
     return self.read_value
 
 
@@ -222,8 +229,8 @@ def _validate_idx(size: int, idx: Union[int, BitVectorSignal]):
     idx = support.get_value(idx)
     if idx is None or not isinstance(support.type_to_pytype(idx.type),
                                      ir.IntegerType):
-      raise TypeError("Subscript on array must be either int or MLIR int"
-                      f" Value, not {type(idx)}.")
+      raise TypeError("Subscript on array must be either int or int signal"
+                      f" not {type(idx)}.")
 
 
 def get_slice_bounds(size, idxOrSlice: Union[int, slice]):
@@ -271,14 +278,14 @@ class BitVectorSignal(Signal):
     Returns this value as a a signed integer. If 'width' is provided, this value
     will be truncated or sign-extended to that width.
     """
-    return self._exec_cast(SIntValue, ir.IntegerType.get_signed, width)
+    return self._exec_cast(SIntSignal, ir.IntegerType.get_signed, width)
 
   def as_uint(self, width: int = None):
     """
     Returns this value as an unsigned integer. If 'width' is provided, this value
     will be truncated or zero-padded to that width.
     """
-    return self._exec_cast(UIntValue, ir.IntegerType.get_unsigned, width)
+    return self._exec_cast(UIntSignal, ir.IntegerType.get_unsigned, width)
 
 
 class BitsSignal(BitVectorSignal):
@@ -395,7 +402,7 @@ class BitsSignal(BitVectorSignal):
     return ret
 
 
-class IntValue(BitVectorSignal):
+class IntSignal(BitVectorSignal):
 
   #  === Infix operators ===
 
@@ -413,7 +420,7 @@ class IntValue(BitVectorSignal):
         const_type = ir.IntegerType.get_unsigned(other.bit_length())
       other = hwarith.ConstantOp(const_type, other)
 
-    if not isinstance(other, IntValue):
+    if not isinstance(other, IntSignal):
       raise TypeError(
           f"Operator '{op_symbol}' is not supported on non-int or signless "
           "values. RHS operand should be cast .as_sint()/.as_uint() if possible."
@@ -452,7 +459,7 @@ class IntValue(BitVectorSignal):
         const_type = ir.IntegerType.get_unsigned(other.bit_length())
       other = hwarith.ConstantOp(const_type, other)
 
-    if not isinstance(other, IntValue):
+    if not isinstance(other, IntSignal):
       raise TypeError(
           f"Comparisons of signed/unsigned integers to {other.type} not "
           "supported. RHS operand should be cast .as_sint()/.as_uint() if "
@@ -483,11 +490,11 @@ class IntValue(BitVectorSignal):
     assert False, "Unimplemented"
 
 
-class UIntValue(IntValue):
+class UIntSignal(IntSignal):
   pass
 
 
-class SIntValue(IntValue):
+class SIntSignal(IntSignal):
 
   def __neg__(self):
     from .types import types
@@ -564,12 +571,12 @@ class ArraySignal(Signal):
     return self.type.strip.size
 
   """
-  Add a curated set of Numpy functions through the Matrix class.
-  This allows for directly manipulating the ListValues with numpy functionality.
+  Add a curated set of Numpy functions through the Matrix class. This allows
+  for directly manipulating the ArraySignals with numpy functionality.
   Power-users who use the Matrix directly have access to all numpy functions.
   In reality, it will only be a subset of the numpy array functions which are
   safe to be used in the PyCDE context. Curating access at the level of
-  ListValues seems like a safe starting point.
+  ArraySignals seems like a safe starting point.
   """
 
   def transpose(self, *args, **kwargs):
@@ -624,7 +631,7 @@ class StructSignal(Signal):
         if self.name:
           v.name = f"{self.name}__{attr}"
         return v
-    raise AttributeError(f"'Value' object has no attribute '{attr}'")
+    raise AttributeError(f"{type(self)} object has no attribute '{attr}'")
 
 
 class StructMetaType(type):
@@ -669,7 +676,7 @@ class Struct(StructSignal, metaclass=StructMetaType):
   # All the work is done in the metaclass.
 
 
-class ChannelValue(Signal):
+class ChannelSignal(Signal):
 
   def reg(self, clk, rst=None, name=None):
     raise TypeError("Cannot register a channel")
@@ -681,12 +688,12 @@ class ChannelValue(Signal):
     ready = _obj_to_value(ready, types.i1)
     unwrap_op = esi.UnwrapValidReadyOp(self.type.inner_type, types.i1,
                                        self.value, ready.value)
-    return Value(unwrap_op[0]), Value(unwrap_op[1])
+    return _FromCirctValue(unwrap_op[0]), _FromCirctValue(unwrap_op[1])
 
 
 def wrap_opviews_with_values(dialect, module_name, excluded=[]):
   """Wraps all of a dialect's OpView classes to have their create method return
-     a PyCDE Value instead of an OpView. The wrapped classes are inserted into
+     a Signal instead of an OpView. The wrapped classes are inserted into
      the provided module."""
   import sys
   from .types import Type
@@ -701,7 +708,7 @@ def wrap_opviews_with_values(dialect, module_name, excluded=[]):
       def specialize_create(cls):
 
         def create(*args, **kwargs):
-          # If any of the arguments are Value or Type (which are both PyCDE
+          # If any of the arguments are Signal or Type (which are both PyCDE
           # classes) objects, we need to convert them.
           def to_circt(arg):
             if isinstance(arg, Signal):
@@ -724,7 +731,8 @@ def wrap_opviews_with_values(dialect, module_name, excluded=[]):
               created.twoState = True
 
           # Return the wrapped values, if any.
-          converted_results = tuple(Value(res) for res in created.results)
+          converted_results = tuple(
+              _FromCirctValue(res) for res in created.results)
           return converted_results[0] if len(
               converted_results) == 1 else converted_results
 

--- a/frontends/PyCDE/src/signals.py
+++ b/frontends/PyCDE/src/signals.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-from .types import Type
 from .support import get_user_loc, _obj_to_value_infer_type, _obj_to_value
+from .types import Type
 
 from .circt.dialects import sv
 from .circt import support
@@ -282,8 +282,8 @@ class BitVectorSignal(Signal):
 
   def as_uint(self, width: int = None):
     """
-    Returns this value as an unsigned integer. If 'width' is provided, this value
-    will be truncated or zero-padded to that width.
+    Returns this value as an unsigned integer. If 'width' is provided, this
+    value will be truncated or zero-padded to that width.
     """
     return self._exec_cast(UIntSignal, ir.IntegerType.get_unsigned, width)
 
@@ -423,8 +423,8 @@ class IntSignal(BitVectorSignal):
     if not isinstance(other, IntSignal):
       raise TypeError(
           f"Operator '{op_symbol}' is not supported on non-int or signless "
-          "values. RHS operand should be cast .as_sint()/.as_uint() if possible."
-      )
+          "signals. RHS operand should be cast .as_sint()/.as_uint() if "
+          "possible.")
 
     ret = op(self, other)
     if self.name is not None and other.name is not None:

--- a/frontends/PyCDE/src/support.py
+++ b/frontends/PyCDE/src/support.py
@@ -73,17 +73,17 @@ class OpOperandConnect(support.OpOperand):
     support.connect(self, val)
 
 
-def _obj_to_value(x, type, result_type=None) -> ir.Value:
+def _obj_to_value(x, type: "Type", result_type=None) -> ir.Value:
   """Convert a python object to a CIRCT value, given the CIRCT type."""
   if x is None:
     raise ValueError(
         "Encountered 'None' when trying to build hardware for python value.")
   from .signals import Signal
   from .dialects import hw, hwarith
-  from .types import (TypeAlias, Array, StructType, BitVectorType, Bits, UInt,
-                      SInt, _FromCirctType)
+  from .types import (Type, TypeAlias, Array, StructType, BitVectorType, Bits,
+                      UInt, SInt, _FromCirctType)
 
-  type = _FromCirctType(type)
+  assert isinstance(type, Type)
   if isinstance(x, Signal):
     if x.type != type:
       raise TypeError(f"expected {x.type}, got {type}")
@@ -148,7 +148,7 @@ def _obj_to_value(x, type, result_type=None) -> ir.Value:
 
 def _infer_type(x):
   """Infer the CIRCT type from a python object. Only works on lists."""
-  from .types import types
+  from .types import Array, _FromCirctType
   from .signals import Signal
   if isinstance(x, Signal):
     return x.type
@@ -158,7 +158,7 @@ def _infer_type(x):
     list_type = list_types[0]
     if not all([i == list_type for i in list_types]):
       raise ValueError("CIRCT array must be homogenous, unlike object")
-    return types.array(list_type, len(x))
+    return Array(list_type, len(x))
   if isinstance(x, int):
     raise ValueError(f"Cannot infer width of {x}")
   if isinstance(x, dict):

--- a/frontends/PyCDE/src/support.py
+++ b/frontends/PyCDE/src/support.py
@@ -78,7 +78,7 @@ def _obj_to_value(x, type, result_type=None) -> ir.Value:
   if x is None:
     raise ValueError(
         "Encountered 'None' when trying to build hardware for python value.")
-  from .value import Signal
+  from .signals import Signal
   from .dialects import hw, hwarith
   from .types import (TypeAlias, Array, StructType, BitVectorType, Bits, UInt,
                       SInt, _FromCirctType)
@@ -149,7 +149,7 @@ def _obj_to_value(x, type, result_type=None) -> ir.Value:
 def _infer_type(x):
   """Infer the CIRCT type from a python object. Only works on lists."""
   from .types import types
-  from .value import Signal
+  from .signals import Signal
   if isinstance(x, Signal):
     return x.type
 

--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -8,12 +8,12 @@ from pycde.devicedb import (EntityExtern, PlacementDB, PrimitiveDB,
                             PhysicalRegion)
 
 from .common import _PyProxy
+from .instance import Instance, InstanceHierarchyRoot
 from .module import Module, ModuleLikeType, ModuleLikeBuilderBase
 from .types import TypeAlias
-from .instance import Instance, InstanceHierarchyRoot
 
 from . import circt
-from .circt import ir, passmanager, support
+from .circt import ir, passmanager
 from .circt.dialects import esi, hw, msft
 from .esi_api import PythonApiBuilder
 

--- a/frontends/PyCDE/src/testing.py
+++ b/frontends/PyCDE/src/testing.py
@@ -1,4 +1,5 @@
-from pycde import System, Module
+from .system import System
+from .module import Module
 
 import builtins
 import inspect

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -9,7 +9,6 @@ from .support import _obj_to_value
 from .circt import ir, support
 from .circt.dialects import esi, hw, sv
 
-from typing import Union
 import typing
 
 
@@ -103,7 +102,7 @@ class Type:
     return self._type.__repr__()
 
 
-def _FromCirctType(type: Union[ir.Type, Type]) -> Type:
+def _FromCirctType(type: typing.Union[ir.Type, Type]) -> Type:
   if isinstance(type, Type):
     return type
   type = support.type_to_pytype(type)
@@ -427,7 +426,6 @@ class Channel(Type):
 
   def wrap(self, value, valid):
     from .dialects import esi
-    from .support import _obj_to_value
     from .signals import _FromCirctValue, BitsSignal
     value = _obj_to_value(value, self._type.inner)
     valid = _obj_to_value(valid, types.i1)

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -96,7 +96,7 @@ class Type:
 
   def _get_value_class(self):
     """Return the class which should be instantiated to create a Value."""
-    from .value import UntypedSignal
+    from .signals import UntypedSignal
     return UntypedSignal
 
   def __repr__(self):
@@ -139,7 +139,7 @@ class InOut(Type):
     return _FromCirctType(self._type.element_type)
 
   def _get_value_class(self):
-    from .value import InOutSignal
+    from .signals import InOutSignal
     return InOutSignal
 
 
@@ -259,7 +259,7 @@ class Array(Type):
     return self.size
 
   def _get_value_class(self):
-    from .value import ArraySignal
+    from .signals import ArraySignal
     return ArraySignal
 
   def __str__(self) -> str:
@@ -288,7 +288,7 @@ class StructType(Type):
     return super().__getattribute__(attrname)
 
   def _get_value_class(self):
-    from .value import StructSignal
+    from .signals import StructSignal
     return StructSignal
 
   def __str__(self) -> str:
@@ -316,8 +316,8 @@ class RegisteredStruct(TypeAlias):
     return inst
 
   def __call__(self, **kwargs):
-    from .value import Value
-    return Value(kwargs, self._type)
+    from .signals import _FromCirctValue
+    return _FromCirctValue(kwargs, self._type)
 
   def _get_value_class(self):
     return self._value_class
@@ -339,7 +339,7 @@ class Bits(BitVectorType):
     )
 
   def _get_value_class(self):
-    from .value import BitsSignal
+    from .signals import BitsSignal
     return BitsSignal
 
   def __repr__(self):
@@ -355,8 +355,8 @@ class SInt(BitVectorType):
     )
 
   def _get_value_class(self):
-    from .value import SIntValue
-    return SIntValue
+    from .signals import SIntSignal
+    return SIntSignal
 
   def __repr__(self):
     return f"sint{self.width}"
@@ -371,8 +371,8 @@ class UInt(BitVectorType):
     )
 
   def _get_value_class(self):
-    from .value import UIntValue
-    return UIntValue
+    from .signals import UIntSignal
+    return UIntSignal
 
   def __repr__(self):
     return f"uint{self.width}"
@@ -390,7 +390,7 @@ class ClockType(Bits):
     super(ClockType, cls).__new__(cls, 1)
 
   def _get_value_class(self):
-    from .value import ClockSignal
+    from .signals import ClockSignal
     return ClockSignal
 
   def __repr__(self):
@@ -415,8 +415,8 @@ class Channel(Type):
     return _FromCirctType(self._type.inner)
 
   def _get_value_class(self):
-    from .value import ChannelValue
-    return ChannelValue
+    from .signals import ChannelSignal
+    return ChannelSignal
 
   def __str__(self):
     return f"channel<{self.inner_type}>"
@@ -428,12 +428,12 @@ class Channel(Type):
   def wrap(self, value, valid):
     from .dialects import esi
     from .support import _obj_to_value
-    from .value import Value, BitsSignal
+    from .signals import _FromCirctValue, BitsSignal
     value = _obj_to_value(value, self._type.inner)
     valid = _obj_to_value(valid, types.i1)
     wrap_op = esi.WrapValidReadyOp(self._type, types.i1, value.value,
                                    valid.value)
-    return Value(wrap_op[0]), BitsSignal(wrap_op[1], types.i1)
+    return _FromCirctValue(wrap_op[0]), BitsSignal(wrap_op[1], types.i1)
 
 
 def dim(inner_type_or_bitwidth: typing.Union[Type, int],

--- a/frontends/PyCDE/test/errors.py
+++ b/frontends/PyCDE/test/errors.py
@@ -75,7 +75,7 @@ class OperatorError(Module):
 
   @generator
   def build(ports):
-    # CHECK: Operator '+' is not supported on non-int or signless values. RHS operand should be cast .as_sint()/.as_uint() if possible.
+    # CHECK: Operator '+' is not supported on non-int or signless signals. RHS operand should be cast .as_sint()/.as_uint() if possible.
     ports.b + ports.a
 
 

--- a/frontends/PyCDE/test/esi.py
+++ b/frontends/PyCDE/test/esi.py
@@ -8,7 +8,7 @@ from pycde.common import Output
 from pycde.constructs import Wire
 from pycde.types import Channel
 from pycde.testing import unittestmodule
-from pycde.value import BitVectorSignal, ChannelValue
+from pycde.signals import BitVectorSignal, ChannelSignal
 
 
 @esi.ServiceDecl
@@ -130,7 +130,7 @@ class MultiplexerService(esi.ServiceImplementation):
     return channel_type.wrap(sliced, ports.trunk_in_valid)
 
   @staticmethod
-  def unwrap_and_pad(ports, input_channel: ChannelValue):
+  def unwrap_and_pad(ports, input_channel: ChannelSignal):
     """
     Unwrap the input channel and pad it to 256 bits.
     """

--- a/frontends/PyCDE/test/muxing.py
+++ b/frontends/PyCDE/test/muxing.py
@@ -1,13 +1,9 @@
 # RUN: %PYTHON% py-split-input-file.py %s | FileCheck %s
 
-from pycde import generator, dim, Clock, Input, Output, Module, Value, types
+from pycde import generator, dim, Clock, Input, Output, Module, types
+from pycde.signals import Signal
 from pycde.constructs import Mux
 from pycde.testing import unittestmodule
-
-
-def array_from_tuple(*input):
-  return Value(input)
-
 
 # CHECK-LABEL: msft.module @ComplexMux {} (%Clk: i1, %In: !hw.array<5xarray<4xi3>>, %Sel: i1) -> (Out: !hw.array<4xi3>, OutArr: !hw.array<2xarray<4xi3>>, OutInt: i1, OutSlice: !hw.array<3xarray<4xi3>>)
 # CHECK:         %c3_i3 = hw.constant 3 : i3
@@ -49,7 +45,7 @@ class ComplexMux(Module):
   def create(ports):
     ports.Out = Mux(ports.Sel, ports.In[3].reg().reg(cycles=2), ports.In[1])
 
-    ports.OutArr = array_from_tuple(ports.In[0], ports.In[1])
+    ports.OutArr = Signal.create([ports.In[0], ports.In[1]])
     ports.OutSlice = ports.In[0:3]
 
     ports.OutInt = ports.In[0][0][ports.Sel]

--- a/frontends/PyCDE/test/pycde_types.py
+++ b/frontends/PyCDE/test/pycde_types.py
@@ -3,7 +3,7 @@
 from pycde import dim, types, Input, Output, generator, System, Module
 from pycde.types import Bits, StructType, TypeAlias, UInt
 from pycde.testing import unittestmodule
-from pycde.value import Struct, UIntValue
+from pycde.signals import Struct, UIntSignal
 
 # CHECK: [('foo', bits1), ('bar', bits13)]
 st1 = StructType({"foo": types.i1, "bar": types.i13})
@@ -45,7 +45,7 @@ class ExStruct(Struct):
   a: Bits(4)
   b: UInt(32)
 
-  def get_b_plus1(self) -> UIntValue:
+  def get_b_plus1(self) -> UIntSignal:
     return self.b + 1
 
 
@@ -74,5 +74,4 @@ class TestStruct(Module):
     self.out1 = self.inp1.get_b_plus1()
     s = ExStruct(a=self.inp1.a, b=self.inp1.get_b_plus1().as_uint(32))
     assert type(s) is ExStruct._get_value_class()
-    assert s.a == self.inp1.a
     self.out2 = s

--- a/frontends/PyCDE/test/pycde_values.py
+++ b/frontends/PyCDE/test/pycde_values.py
@@ -2,7 +2,7 @@
 
 from pycde.dialects import comb, hw
 from pycde import dim, generator, types, Input, Output, Module
-from pycde.value import And, Or
+from pycde.signals import And, Or
 from pycde.testing import unittestmodule
 
 


### PR DESCRIPTION
Improve bad code:
- Cleanup imports.
- Complete the `Value` to `Signal` rename.
- Clarify argument and return types. Allows for removal of defensive code.