### PR TITLE
[PyCDE][NFC] Create signals from Python objects through Types

### DIFF
--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from typing import List, Optional, Set, Tuple, Dict
 
 from .common import (AppID, Clock, Input, Output, PortError, _PyProxy)
-from .support import (get_user_loc, _obj_to_attribute, _obj_to_value,
-                      create_type_string, create_const_zero)
+from .support import (get_user_loc, _obj_to_attribute, create_type_string,
+                      create_const_zero)
 from .signals import ClockSignal, Signal, _FromCirctValue
 from .types import ClockType
 
@@ -140,7 +140,7 @@ class PortProxyBase:
         raise PortError(
             f"Input port {pname} expected type {ptype}, not {signal.type}")
     else:
-      signal = _obj_to_value(signal, ptype)
+      signal = ptype(signal)
     self._output_values[idx] = signal
 
   def _set_outputs(self, signal_dict: Dict[str, Signal]):
@@ -433,7 +433,7 @@ class ModuleBuilder(ModuleLikeBuilderBase):
       else:
         # If it's not a signal, assume the user wants to specify a constant and
         # try to convert it to a hardware constant.
-        signal = _obj_to_value(signal, ptype)
+        signal = ptype(signal)
       input_values[idx] = signal
       del input_lookup[name]
 

--- a/frontends/PyCDE/src/signals.py
+++ b/frontends/PyCDE/src/signals.py
@@ -668,9 +668,8 @@ class ChannelSignal(Signal):
 
   def unwrap(self, ready):
     from .dialects import esi
-    from .support import _obj_to_value
     from .types import types
-    ready = _obj_to_value(ready, types.i1)
+    ready = types.i1(ready)
     unwrap_op = esi.UnwrapValidReadyOp(self.type.inner_type, types.i1,
                                        self.value, ready.value)
     return unwrap_op[0], unwrap_op[1]

--- a/frontends/PyCDE/src/support.py
+++ b/frontends/PyCDE/src/support.py
@@ -63,92 +63,9 @@ def create_const_zero(type):
     return hw.BitcastOp(type, zero)
 
 
-class OpOperandConnect(support.OpOperand):
-  """An OpOperand pycde extension which adds a connect method."""
-
-  def connect(self, obj, result_type=None):
-    if result_type is None:
-      result_type = self.type
-    val = _obj_to_value(obj, self.type, result_type)
-    support.connect(self, val)
-
-
-def _obj_to_value(x, type: "Type", result_type=None) -> ir.Value:
-  """Convert a python object to a CIRCT value, given the CIRCT type."""
-  if x is None:
-    raise ValueError(
-        "Encountered 'None' when trying to build hardware for python value.")
-  from .signals import Signal
-  from .dialects import hw, hwarith
-  from .types import (Type, TypeAlias, Array, StructType, BitVectorType, Bits,
-                      UInt, SInt, _FromCirctType)
-
-  assert isinstance(type, Type)
-  if isinstance(x, Signal):
-    if x.type != type:
-      raise TypeError(f"expected {x.type}, got {type}")
-    return x
-
-  if isinstance(type, TypeAlias):
-    return _obj_to_value(x, type.inner_type, type)
-
-  if result_type is None:
-    result_type = type
-  else:
-    result_type = _FromCirctType(result_type)
-    assert isinstance(result_type, TypeAlias) or result_type == type
-
-  val = support.get_value(x)
-  # If x is already a valid value, just return it.
-  if val is not None:
-    if val.type != result_type:
-      raise ValueError(f"Expected {result_type}, got {val.type}")
-    return val
-
-  if isinstance(x, int):
-    if not isinstance(type, BitVectorType):
-      raise ValueError(f"Int can only be converted to hw int, not '{type}'")
-    with get_user_loc():
-      if isinstance(type, Bits):
-        return hw.ConstantOp(type, x)
-      elif isinstance(type, (UInt, SInt)):
-        return hwarith.ConstantOp(type, x)
-      else:
-        assert False, "Internal error: bit vector type unknown"
-
-  if isinstance(x, (list, tuple)):
-    if not isinstance(type, Array):
-      raise ValueError(f"List is only convertable to hw array, not '{type}'")
-    elemty = result_type.element_type
-    if len(x) != type.size:
-      raise ValueError("List must have same size as array "
-                       f"{len(x)} vs {type.size}")
-    list_of_vals = list(map(lambda x: _obj_to_value(x, elemty), x))
-    # CIRCT's ArrayCreate op takes the array in reverse order.
-    with get_user_loc():
-      return hw.ArrayCreateOp(reversed(list_of_vals))
-
-  if isinstance(x, dict):
-    if not isinstance(type, StructType):
-      raise ValueError(f"Dict is only convertable to hw struct, not '{type}'")
-    elem_name_values = []
-    for (fname, ftype) in type.fields:
-      if fname not in x:
-        raise ValueError(f"Could not find expected field: {fname}")
-      v = _obj_to_value(x[fname], ftype)
-      elem_name_values.append((fname, v))
-      x.pop(fname)
-    if len(x) > 0:
-      raise ValueError(f"Extra fields specified: {x}")
-    with get_user_loc():
-      return hw.StructCreateOp(elem_name_values, result_type=result_type._type)
-
-  raise ValueError(f"Unable to map object '{x}' to MLIR Value")
-
-
 def _infer_type(x):
   """Infer the CIRCT type from a python object. Only works on lists."""
-  from .types import Array, _FromCirctType
+  from .types import Array
   from .signals import Signal
   if isinstance(x, Signal):
     return x.type
@@ -169,10 +86,10 @@ def _infer_type(x):
 def _obj_to_value_infer_type(value) -> ir.Value:
   """Infer the CIRCT type, then convert the Python object to a CIRCT Value of
   that type."""
-  type = _infer_type(value)
-  if type is None:
+  cde_type = _infer_type(value)
+  if cde_type is None:
     raise ValueError(f"Cannot infer CIRCT type from '{value}")
-  return _obj_to_value(value, type)
+  return cde_type(value)
 
 
 def create_type_string(ty):

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -373,9 +373,10 @@ class BitVectorType(Type):
 
   def _from_obj_check(self, x):
     if not isinstance(x, int):
-      raise ValueError(
-          f"'{type(self)}' can only be created from ints, not {type(x)}")
-    if x.bit_length() > self.width:
+      raise ValueError(f"{type(self).__name__} can only be created from ints, "
+                       f"not {type(x).__name__}")
+    signed_bit = 1 if isinstance(self, SInt) else 0
+    if x.bit_length() + signed_bit > self.width:
       raise ValueError(f"{x} overflows type {self}")
 
 
@@ -442,7 +443,7 @@ class UInt(BitVectorType):
     from .dialects import hwarith
     self._from_obj_check(x)
     if x < 0:
-      raise ValueError(f"'UInt' can only store positive numbers, not {type(x)}")
+      raise ValueError(f"UInt can only store positive numbers, not {x}")
     circt_type = self if alias is None else alias
     return hwarith.ConstantOp(circt_type, x)
 

--- a/frontends/PyCDE/test/test_misc_errors.py
+++ b/frontends/PyCDE/test/test_misc_errors.py
@@ -3,6 +3,7 @@
 from pycde import Input, generator, dim, Module
 from pycde.constructs import Mux
 from pycde.testing import unittestmodule
+from pycde.types import Bits, SInt, UInt
 
 
 @unittestmodule()
@@ -29,3 +30,44 @@ class Mux2(Module):
   def create(ports):
     # CHECK: ValueError: 'Mux' must have 1 or more data input
     Mux(ports.Sel)
+
+
+# -----
+
+
+@unittestmodule(print=False)
+class WrongInts(Module):
+
+  @generator
+  def construct(mod):
+    b4 = Bits(4)
+    si4 = SInt(4)
+    ui4 = UInt(4)
+
+    try:
+      # CHECK: Bits can only be created from ints, not str
+      b4("foo")
+      assert False
+    except ValueError as e:
+      print(e)
+
+    try:
+      # CHECK: 300 overflows type bits4
+      b4(300)
+      assert False
+    except ValueError as e:
+      print(e)
+
+    try:
+      # CHECK: 15 overflows type sint4
+      si4(15)
+      assert False
+    except ValueError as e:
+      print(e)
+
+    try:
+      # CHECK: UInt can only store positive numbers, not -1
+      ui4(-1)
+      assert False
+    except ValueError as e:
+      print(e)


### PR DESCRIPTION
Instead of calling `_obj_to_value` from the support library, use some OOP to leverage the `Type` system to do it. The `_obj_to_value` function dates back to when we were using raw `ir.Types` and not extending them. Now that we have a proper type hierarchy (and can rely on it being used), this change is possible.