### PR TITLE
[FIRRTL][GC] Always generate the scope yaml file

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1549,7 +1549,14 @@ void GrandCentralPass::runOnOperation() {
   bool removalError = false;
   AnnotationSet::removeAnnotations(circuitOp, [&](Annotation anno) {
     if (anno.isClass(augmentedBundleTypeClass)) {
-      worklist.push_back(anno);
+      // If we are in "instantiateCompanionOnly" mode, then we don't need to
+      // create the interface, so we can skip adding it to the worklist.  This
+      // is a janky hack for situations where you want to synthesize assertion
+      // logic included in the companion, but don't want to have a dead
+      // interface hanging around (or have problems with tools understanding
+      // interfaces).
+      if (!instantiateCompanionOnly)
+        worklist.push_back(anno);
       ++numAnnosRemoved;
       return true;
     }
@@ -2032,14 +2039,6 @@ void GrandCentralPass::runOnOperation() {
       }
     }
   });
-
-  // If we are in "instantiateCompanionOnly" mode, then just exit here.  We
-  // don't need to create the interface.  This is a janky hack for situations
-  // where you want to synthesize assertion logic included in the companion, but
-  // don't want to have a dead interface hanging around (or have problems with
-  // tools understanding interfaces).
-  if (instantiateCompanionOnly)
-    return;
 
   // Now, iterate over the worklist of interface-encoding annotations to create
   // the interface and all its sub-interfaces (interfaces that it instantiates),

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/InstantiateCompanionOnly.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/InstantiateCompanionOnly.fir
@@ -34,6 +34,10 @@ circuit Foo : %[[
     "class": "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
     "directory": "Wire/firrtl/gct",
     "filename": "Wire/firrtl/bindings.sv"
+  },
+  {
+    "class": "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
+    "filename": "gct.yaml"
   }
 ]]
   module Companion :
@@ -57,3 +61,7 @@ circuit Foo : %[[
     ; CHECK-NOT:   emitted as a bind statement
     ; CHECK:       Companion companion
     ; CHECK:     endmodule
+
+; Verify that an empty yaml file is created.
+; CHECK: FILE "gct.yaml"
+; CHECK: []  


### PR DESCRIPTION
When we added the flag to directly instantiate companions, we also stopped generating interfaces.  This flag skipped generating the interface metadata file, which caused issues for flows which still expected it to be generated.  This commit changes the logic to skip adding interfaces to the worklist instead of an early break, which causes us to still generate the metadata, but with no entries.