### PR TITLE
handshake instance and external_instance

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -116,8 +116,9 @@ def FuncOp : Op<Handshake_Dialect, "func", [
 
 // InstanceOp
 def InstanceOp : Handshake_Op<"instance", [
-    CallOpInterface,
-    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+    CallOpInterface, HasClock,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+
 ]> {
   let summary = "module instantiate operation";
   let description = [{
@@ -185,7 +186,7 @@ def InstanceOp : Handshake_Op<"instance", [
 }
 
 // ExternalInstanceOp
-def ExternalInstanceOp : Handshake_Op<"external_instance", []> {
+def ExternalInstanceOp : Handshake_Op<"external_instance", [HasClock]> {
   let summary = "external module instantiate operation";
   let description = [{
     The `external_instance` operation represents the instantiation of an external module.  This

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -184,6 +184,35 @@ def InstanceOp : Handshake_Op<"instance", [
   }];
 }
 
+// ExternalInstanceOp
+def ExternalInstanceOp : Handshake_Op<"external_instance", []> {
+  let summary = "external module instantiate operation";
+  let description = [{
+    The `external_instance` operation represents the instantiation of an external module.  This
+    is similar to a function call, except that different instances of the
+    same module are guaranteed to have their own distinct state.
+    The instantiated module is encoded as a symbol reference attribute named
+    "module". Compared to the instance operation this operation references an external function
+    from a different dialect than the Handshake dialect.
+
+    Example:
+    ```mlir
+    %2 = handshake.external_instance @ext1(%0, %1) : (f32, f32) -> (f32)
+    ```
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$module, Variadic<AnyType>:$opOperands);
+  let results = (outs Variadic<AnyType>);
+
+  let extraClassDeclaration = [{
+    FunctionType getModuleType();
+  }];
+
+  let assemblyFormat = [{
+    $module `(` $opOperands `)` attr-dict `:` functional-type($opOperands, results)
+  }];
+}
+
 // This is almost exactly like a standard FuncOp, except that it has some
 // extra verification conditions.  In particular, each Value must
 // only have a single use.

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -33,7 +33,7 @@ public:
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
             ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp, MemoryOp,
-            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
+            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, ExternalInstanceOp,
             handshake::SelectOp, SourceOp, StoreOp, SyncOp, PackOp, UnpackOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitHandshake(opNode, args...);
@@ -69,6 +69,7 @@ public:
   HANDLE(ForkOp);
   HANDLE(FuncOp);
   HANDLE(InstanceOp);
+  HANDLE(ExternalInstanceOp);
   HANDLE(JoinOp);
   HANDLE(LazyForkOp);
   HANDLE(LoadOp);

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1419,6 +1419,10 @@ FunctionType InstanceOp::getModuleType() {
   return FunctionType::get(getContext(), getOperandTypes(), getResultTypes());
 }
 
+FunctionType ExternalInstanceOp::getModuleType() {
+  return FunctionType::get(getContext(), getOperandTypes(), getResultTypes());
+}
+
 ParseResult UnpackOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand tuple;
   TupleType type;


### PR DESCRIPTION
The lowering from Handshake to Hw is now working for the instructions "handshake.instance" and "handshake.external_instance". In the "handshake.external_instance" the ESIWrap Attribute is still missing