### PR TITLE
[ExportVerilog][PrettifyVerilog] Fix exprInEventControl

### DIFF
--- a/test/Conversion/ExportVerilog/sv-always-wire.mlir
+++ b/test/Conversion/ExportVerilog/sv-always-wire.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-opt %s --export-verilog --verify-diagnostics -o %t | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s -prettify-verilog --export-verilog --verify-diagnostics -o %t | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s -test-apply-lowering-options='options=exprInEventControl' -prettify-verilog -export-verilog | FileCheck %s --check-prefix=INLINE
 
 // CHECK-LABEL: module AlwaysSpill(
 hw.module @AlwaysSpill(%port: i1) {
@@ -23,17 +24,33 @@ hw.module @AlwaysSpill(%port: i1) {
 
   // Constant values should cause a spill.
   // CHECK: always @(posedge [[TMP1]])
+  // INLINE: always @(posedge 1'h0)
   sv.always posedge %false {}
   // CHECK: always_ff @(posedge [[TMP2]])
+  // INLINE: always_ff @(posedge 1'h1)
   sv.alwaysff(posedge %true) {}
 }
 
 // CHECK-LABEL: module Foo
-hw.module @Foo(%clock: i1, %reset0: i1, %reset1: i1) -> () {
+// INLINE-LABEL: module Foo
+hw.module @Foo(%reset0: i1, %reset1: i1) -> () {
   %0 = comb.or %reset0, %reset1 : i1
-// CHECK-NOT: _GEN_0
+  // CHECK:      wire [[TMP0:.*]] = reset0 | reset1;
+  // CHECK-NEXT: always @(posedge [[TMP0]])
+  // CHECK-NEXT:   if ([[TMP0]])
   sv.always posedge %0 {
     sv.if %0 {
+    }
+  }
+  %true = hw.constant true
+  %1 = comb.xor %reset0, %true : i1
+  // CHECK:      wire [[TMP1:.*]] = ~reset0;
+  // CHECK-NEXT: always @(posedge [[TMP1]])
+  // CHECK-NEXT:   if ([[TMP1]])
+  // INLINE:     always @(posedge ~reset0)
+  // INLINE-NEXT:   if (~reset0)
+  sv.always posedge %1 {
+    sv.if %1 {
     }
   }
 }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -test-apply-lowering-options='options=exprInEventControl,explicitBitcast,maximumNumberOfTermsPerExpression=10' -export-verilog -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -test-apply-lowering-options='options=explicitBitcast,maximumNumberOfTermsPerExpression=10' -export-verilog -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (


### PR DESCRIPTION
This commit fixes bugs in spilling logic regarding expressions used in sensitivity list.

* PrettifyVerilog is changed to check lowering options so that CSEd expressions are not cloned into users when `exprInEventControl` is enabled.
* There was a duplicated logic in isExpressionUnableToInline and PrepareForEmission so the logic was unified into isExpressionUnableToInline.

Fix https://github.com/llvm/circt/issues/4620

```verilog
; with --lowering-options=exprInEventControl
  always @(posedge clock or posedge ~rst_n) begin
    if (~rst_n)
      r <= 1'h0;
    else
      r <= d;

; w/o --lowering-options=exprInEventControl
  wire _GEN = ~rst_n;
  always @(posedge clock or posedge _GEN) begin
    if (_GEN)
      r <= 1'h0;
    else
      r <= d;
```