### PR TITLE
[HW][NFC] InnerRef: Remove unused method definition

### DIFF
--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -41,14 +41,6 @@ def InnerRefAttr : AttrDef<HWDialect, "InnerRef"> {
                                          mlir::StringAttr symName,
                                          mlir::StringAttr moduleName);
 
-    /// Recursively traverse the sub-attribute.
-    void walkImmediateSubElements(
-        llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
-        llvm::function_ref<void(mlir::Type)> walkTypesFn) {
-      walkAttrsFn(getModuleRef());
-      walkAttrsFn(getName());
-    }
-
     /// Return the name of the referenced module.
     mlir::StringAttr getModule() const { return getModuleRef().getAttr(); }
   }];


### PR DESCRIPTION
No longer implement the SubElementAttrInterface interface, so this method is no longer used.