### PR TITLE
[firtool] Use CIRCT's StripDebInfo pass instead of upstream

### DIFF
--- a/test/firtool/print-before.fir
+++ b/test/firtool/print-before.fir
@@ -1,7 +1,6 @@
 ; Ensure firtool can dump MLIR from various points of the pipeline.
 ; Check passes from different components and registration categories.
 ; RUN: firtool %s -mlir-print-ir-before=cse 2>&1 | FileCheck %s -Dpass=CSE
-; RUN: firtool %s -mlir-print-ir-before=strip-debuginfo -strip-debug-info 2>&1 | FileCheck %s -Dpass=StripDebugInfo
 ; RUN: firtool %s -mlir-print-ir-before=firrtl-inliner 2>&1 | FileCheck %s -Dpass=Inliner
 ; RUN: firtool %s -mlir-print-ir-before=firrtl-lower-annotations 2>&1 | FileCheck %s -Dpass=LowerFIRRTLAnnotations
 ; RUN: firtool %s -mlir-print-ir-before=firrtl-grand-central 2>&1 | FileCheck %s -Dpass=GrandCentral

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -905,7 +905,8 @@ static LogicalResult processBuffer(
           }));
 
     if (stripDebugInfo)
-      exportPm.addPass(mlir::createStripDebugInfoPass());
+      exportPm.addPass(circt::createStripDebugInfoWithPredPass(
+          [](mlir::Location loc) { return true; }));
 
     // Emit a single file or multiple files depending on the output format.
     switch (outputFormat) {


### PR DESCRIPTION
With the recent change to how port location information is handled, the upstream pass StripDebugInfo no longer leaves the IR in a valid state, as it does not update the debug information stored in module ops.  To fix this problem, we just have to use the local version of this pass, StripDebugInfoWithPred and tell it to remove all locations.

Closes #4631.