### PR TITLE
[ESI] Introduce ESI pure module op

### DIFF
--- a/include/circt/Dialect/ESI/ESI.td
+++ b/include/circt/Dialect/ESI/ESI.td
@@ -55,5 +55,6 @@ include "circt/Dialect/ESI/ESIOps.td"
 include "circt/Dialect/ESI/ESIServices.td"
 include "circt/Dialect/ESI/ESIStdServices.td"
 include "circt/Dialect/ESI/ESIPasses.td"
+include "circt/Dialect/ESI/ESIStructure.td"
 
 #endif // ESI_TD

--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -12,7 +12,7 @@
 
 include "mlir/IR/OpBase.td"
 
-def ESIPureModule : ESI_Op<"pure_module",
+def ESIPureModuleOp : ESI_Op<"pure_module",
       [Symbol, NoTerminator, RegionKindInterface, NoRegionArguments,
        SingleBlock, HasParent<"mlir::ModuleOp">]> {
   let summary = "ESI pure module";

--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -1,0 +1,38 @@
+//===- ESIStructure.td - ESI modules ---------------------*- tablegen -*---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ESI system and other ESI structural components.
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/OpBase.td"
+
+def ESIPureModule : ESI_Op<"pure_module",
+      [Symbol, NoTerminator, RegionKindInterface, NoRegionArguments,
+       SingleBlock, HasParent<"mlir::ModuleOp">]> {
+  let summary = "ESI pure module";
+  let description = [{
+    A module containing only ESI channels and modules with only ESI ports. All
+    non-local connectivity is done through ESI services. If this module is the
+    top level in the design, then the design's actual top level ports are
+    defined by a BSP.
+
+    Useful on its own for simulation and BSPs which don't define a top-level.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let results = (outs); 
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{ $sym_name attr-dict-with-keyword $body }];
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
+  }];
+}

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -10,7 +10,6 @@ include "circt/Dialect/HW/HWOpInterfaces.td"
 
 def InstanceOp : MSFTOp<"instance", [
         Symbol,
-        ParentOneOf<["MSFTModuleOp"]>,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
         DeclareOpInterfaceMethods<HWInstanceLike>

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVTypes.h"
 #include "circt/Support/LLVM.h"
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/SymbolTable.h"
@@ -420,6 +422,33 @@ void ServiceImplementReqOp::gatherPairedReqs(
     else if (auto req = dyn_cast<RequestToServerConnectionOp>(op))
       reqPairs.push_back(std::make_pair(req, nullptr));
   }
+}
+
+//===----------------------------------------------------------------------===//
+// Structural ops.
+//===----------------------------------------------------------------------===//
+
+LogicalResult ESIPureModule::verify() {
+  ESIDialect *esiDialect = getContext()->getLoadedDialect<ESIDialect>();
+
+  Block &body = getBody().front();
+  for (Operation &op : body.getOperations()) {
+    if (hw::HWInstanceLike inst = dyn_cast<hw::HWInstanceLike>(op)) {
+      for (auto operand : op.getOperands())
+        if (!operand.getType().isa<ChannelType>())
+          return inst.emitOpError(
+              "instances in ESI pure modules can only contain channel ports");
+      for (auto resType : op.getResultTypes())
+        if (!resType.isa<ChannelType>())
+          return inst.emitOpError(
+              "instances in ESI pure modules can only contain channel ports");
+    } else {
+      // Pure modules can only contain instance ops and ESI ops.
+      if (op.getDialect() != esiDialect)
+        return op.emitOpError("operation not allowed in ESI pure modules");
+    }
+  }
+  return success();
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -428,7 +428,7 @@ void ServiceImplementReqOp::gatherPairedReqs(
 // Structural ops.
 //===----------------------------------------------------------------------===//
 
-LogicalResult ESIPureModule::verify() {
+LogicalResult ESIPureModuleOp::verify() {
   ESIDialect *esiDialect = getContext()->getLoadedDialect<ESIDialect>();
 
   Block &body = getBody().front();

--- a/test/Dialect/ESI/structure.mlir
+++ b/test/Dialect/ESI/structure.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s  | circt-opt | FileCheck %s
+
+msft.module @Foo {} (%in0 : !esi.channel<i1>) -> (out: !esi.channel<i1>)
+
+// CHECK-LABEL:  esi.pure_module @top {
+// CHECK-NEXT:     %foo.out = msft.instance @foo @Foo(%foo.out)  : (!esi.channel<i1>) -> !esi.channel<i1>
+esi.pure_module @top {
+  %loopback = msft.instance @foo @Foo(%loopback) : (!esi.channel<i1>) -> (!esi.channel<i1>)
+}

--- a/test/Dialect/ESI/structure_errors.mlir
+++ b/test/Dialect/ESI/structure_errors.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt %s -split-input-file --verify-diagnostics
+
+msft.module @Foo {} (%in0: i1) -> (out: i1)
+esi.pure_module @top {
+  // expected-error @+1 {{'msft.instance' op instances in ESI pure modules can only contain channel ports}}
+  %loopback = msft.instance @foo @Foo(%loopback) : (i1) -> (i1)
+}
+
+// -----
+
+msft.module @Foo{} () -> (out: i1)
+
+esi.pure_module @top {
+  // expected-error @+1 {{'msft.instance' op instances in ESI pure modules can only contain channel ports}}
+  msft.instance @foo @Foo() : () -> (i1)
+}
+
+// -----
+
+msft.module @Foo {} (%in0 : !esi.channel<i1>) -> (out: !esi.channel<i1>)
+
+esi.pure_module @top {
+  %loopback = msft.instance @foo @Foo(%loopbackDouble) : (!esi.channel<i1>) -> (!esi.channel<i1>)
+  %data, %valid = esi.unwrap.vr %loopback, %ready : i1
+  // expected-error @+1 {{'comb.add' op operation not allowed in ESI pure modules}}
+  %double = comb.add %data, %data : i1
+  %loopbackDouble, %ready = esi.wrap.vr %double, %valid : i1
+}


### PR DESCRIPTION
A module containing only ESI channels and modules with only ESI ports. All non-local connectivity is done through ESI services. If this module is the top level in the design, then the design's actual top level ports are defined by a BSP.

Useful on its own for simulation and BSPs which don't define a top-level.