### PR TITLE
[FIRRTL] Introduce element-wise operations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -548,6 +548,18 @@ let inferType = "impl::inferBitwiseResult" in {
   }
 }
 
+// Element-wise and/or/xor operations whose result and operands are 1d vectors with
+// a same type. Apply bitwise operation to each element.
+let inferType = "impl::inferElementwiseResult" in
+let hasFolder = 0 in {
+  def ElementwiseAndPrimOp : BinaryPrimOp<"elementwise_and", 1DVecIntType,
+                                1DVecIntType, 1DVecUIntType, [Commutative]>;
+  def ElementwiseOrPrimOp  : BinaryPrimOp<"elementwise_or", 1DVecIntType,
+                                1DVecIntType, 1DVecUIntType, [Commutative]>;
+  def ElementwiseXorPrimOp : BinaryPrimOp<"elementwise_xor", 1DVecUIntType,
+                                1DVecIntType, 1DVecUIntType, [Commutative]>;
+}
+
 // Comparison Operations
 let inferType = "impl::inferComparisonResult" in {
   let hasCanonicalizer = true in {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -149,6 +149,8 @@ FIRRTLType inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
                              std::optional<Location> loc);
 FIRRTLType inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
                               std::optional<Location> loc);
+FIRRTLType inferElementwiseResult(FIRRTLType lhs, FIRRTLType rhs,
+                                  std::optional<Location> loc);
 FIRRTLType inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                  std::optional<Location> loc);
 FIRRTLType inferReductionResult(FIRRTLType arg, std::optional<Location> loc);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -161,6 +161,14 @@ def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock",
                                   "::circt::firrtl::FIRRTLBaseType">;
 
+def 1DVecUIntType : FIRRTLDialectType<
+  CPred<"isa<FVectorType>($_self) && isa<UIntType>(cast<FVectorType>($_self).getElementType())">,
+  "1d vector with UInt element type", "::circt::firrtl::FIRRTLBaseType">;
+
+def 1DVecIntType : FIRRTLDialectType<
+  CPred<"isa<FVectorType>($_self) && isa<IntType>(cast<FVectorType>($_self).getElementType())">,
+  "1d vector with Int element type", "::circt::firrtl::FIRRTLBaseType">;
+
 def OneBitCastableType : AnyTypeOf<
   [OneBitType, AnyResetType, AsyncResetType, ClockType],
   "1-bit uint/sint/analog, reset, asyncreset, or clock",

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -37,6 +37,8 @@ public:
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
+            // Elementwise operations,
+            ElementwiseOrPrimOp, ElementwiseAndPrimOp, ElementwiseXorPrimOp,
             // Comparisons.
             LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp,
             // Misc Binary Primitives.
@@ -141,6 +143,10 @@ public:
   HANDLE(AndRPrimOp, Unary);
   HANDLE(OrRPrimOp, Unary);
   HANDLE(XorRPrimOp, Unary);
+
+  HANDLE(ElementwiseOrPrimOp, Unhandled);
+  HANDLE(ElementwiseAndPrimOp, Unhandled);
+  HANDLE(ElementwiseXorPrimOp, Unhandled);
 
   // Intrinsic Expr.
   HANDLE(IsXIntrinsicOp, Unhandled);

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -121,6 +121,8 @@ std::unique_ptr<mlir::Pass> createSFCCompatPass();
 std::unique_ptr<mlir::Pass>
 createMergeConnectionsPass(bool enableAggressiveMerging = false);
 
+std::unique_ptr<mlir::Pass> createVectorizationPass();
+
 std::unique_ptr<mlir::Pass> createInjectDUTHierarchyPass();
 
 /// Configure which values will be explicitly preserved by the DropNames pass.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -503,6 +503,11 @@ def MergeConnections : Pass<"merge-connections", "firrtl::FModuleOp"> {
   ];
 }
 
+def Vectorization : Pass<"vectorization", "firrtl::FModuleOp"> {
+  let summary = "Transform firrtl primitive operations into vector operations";
+  let constructor = "circt::firrtl::createVectorizationPass()";
+}
+
 def InferReadWrite : Pass<"firrtl-infer-rw", "firrtl::FModuleOp"> {
   let summary = "Infer the read-write memory port";
   let description = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3421,6 +3421,25 @@ FIRRTLType impl::inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
   return UIntType::get(lhs.getContext(), resultWidth);
 }
 
+FIRRTLType impl::inferElementwiseResult(FIRRTLType lhs, FIRRTLType rhs,
+                                        std::optional<Location> loc) {
+  if (!lhs.isa<FVectorType>() || !rhs.isa<FVectorType>())
+    return {};
+
+  auto lhsVec = lhs.cast<FVectorType>();
+  auto rhsVec = rhs.cast<FVectorType>();
+
+  if (lhsVec.getNumElements() != rhsVec.getNumElements())
+    return {};
+
+  auto elemType = impl::inferBitwiseResult(lhsVec.getElementType(),
+                                           rhsVec.getElementType(), loc);
+  if (!elemType)
+    return {};
+  return FVectorType::get(elemType.cast<FIRRTLBaseType>(),
+                          lhsVec.getNumElements());
+}
+
 FIRRTLType impl::inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                        std::optional<Location> loc) {
   return UIntType::get(lhs.getContext(), 1);
@@ -4277,6 +4296,18 @@ void UninferredResetCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 void UninferredWidthCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void ElementwiseXorPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void ElementwiseOrPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void ElementwiseAndPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   RemoveUnusedPorts.cpp
   SFCCompat.cpp
   VBToBV.cpp
+  Vectorization.cpp
   WireDFT.cpp
 
   DEPENDS

--- a/lib/Dialect/FIRRTL/Transforms/Vectorization.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Vectorization.cpp
@@ -1,0 +1,98 @@
+//===- Vectorization.cpp -  Vectorize primitive operations ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// This pass performs vectorization for primitive operations, e.g:
+// vector_create (or a[0], b[0]), (or a[1], b[1]), (or a[2], b[2])
+// => elementwise_or a, b
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-vectorization"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+template <typename OpTy, typename ResultOpType>
+class VectorCreateToLogicElementwise : public mlir::RewritePattern {
+public:
+  VectorCreateToLogicElementwise(MLIRContext *context)
+      : RewritePattern(VectorCreateOp::getOperationName(), 0, context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto vectorCreateOp = cast<VectorCreateOp>(op);
+    auto type = vectorCreateOp.getType();
+    if (type.hasUninferredWidth() || !isa<UIntType>(type.getElementType()))
+      return failure();
+
+    SmallVector<Value> lhs, rhs;
+
+    // Vectorize if all operands are `OpTy`. Currently there is no other
+    // condition so it could be too aggressive.
+    if (llvm::all_of(op->getOperands(), [&](Value operand) {
+          auto op = operand.getDefiningOp<OpTy>();
+          if (!op)
+            return false;
+          lhs.push_back(op.getLhs());
+          rhs.push_back(op.getRhs());
+          return true;
+        })) {
+      auto lhsVec = rewriter.createOrFold<VectorCreateOp>(
+          op->getLoc(), vectorCreateOp.getType(), lhs);
+      auto rhsVec = rewriter.createOrFold<VectorCreateOp>(
+          op->getLoc(), vectorCreateOp.getType(), rhs);
+      rewriter.replaceOpWithNewOp<ResultOpType>(op, lhsVec, rhsVec);
+      return success();
+    }
+    return failure();
+  }
+};
+} // namespace
+
+struct VectorizationPass : public VectorizationBase<VectorizationPass> {
+  VectorizationPass() = default;
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void VectorizationPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "===----- Running Vectorization "
+                             "--------------------------------------===\n"
+                          << "Module: '" << getOperation().getName() << "'\n";);
+
+  RewritePatternSet patterns(&getContext());
+  patterns
+      .insert<VectorCreateToLogicElementwise<OrPrimOp, ElementwiseOrPrimOp>,
+              VectorCreateToLogicElementwise<AndPrimOp, ElementwiseAndPrimOp>,
+              VectorCreateToLogicElementwise<XorPrimOp, ElementwiseXorPrimOp>>(
+          &getContext());
+  mlir::FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), frozenPatterns);
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createVectorizationPass() {
+  return std::make_unique<VectorizationPass>();
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1653,4 +1653,31 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.strictconnect %r, %a : !firrtl.uint<1>
     firrtl.strictconnect %b2, %r : !firrtl.uint<1>
   }
+
+  // CHECK-LABEL: Elementwise
+  firrtl.module @Elementwise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
+    %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
+    %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
+    %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
+
+    // CHECK-NEXT: %0 = hw.bitcast %a : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %1 = hw.bitcast %b : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %2 = comb.or %0, %1 : i2
+    // CHECK-NEXT: %[[OR:.+]] = hw.bitcast %2 : (i2) -> !hw.array<2xi1>
+
+    // CHECK-NEXT: %4 = hw.bitcast %a : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %5 = hw.bitcast %b : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %6 = comb.and %4, %5 : i2
+    // CHECK-NEXT: %[[AND:.+]] = hw.bitcast %6 : (i2) -> !hw.array<2xi1>
+
+    // CHECK-NEXT: %8 = hw.bitcast %a : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %9 = hw.bitcast %b : (!hw.array<2xi1>) -> i2
+    // CHECK-NEXT: %10 = comb.xor %8, %9 : i2
+    // CHECK-NEXT: %[[XOR:.+]] = hw.bitcast %10 : (i2) -> !hw.array<2xi1>
+
+    // CHECK-NEXT: hw.output %[[OR]], %[[AND]], %[[XOR]] : !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>
+  }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1247,6 +1247,26 @@ firrtl.module private @is1436_FOO() {
     } @SubmoduleWithAggregate(out a: !firrtl.vector<uint<1>, 1>)
   }
 
+  // COMMON-LABEL: firrtl.module @ElementWise
+  firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 1>, in %b: !firrtl.vector<uint<1>, 1>, out %c_0: !firrtl.vector<uint<1>, 1>, out %c_1: !firrtl.vector<uint<1>, 1>, out %c_2: !firrtl.vector<uint<1>, 1>) {
+    // CHECK-NEXT: %0 = firrtl.or %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %c_0_0, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: %1 = firrtl.and %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %c_1_0, %1 : !firrtl.uint<1>
+    // CHECK-NEXT: %2 = firrtl.xor %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %c_2_0, %2 : !firrtl.uint<1>
+    // Check that elementwise_* are preserved.
+    // AGGREGATE: firrtl.elementwise_or
+    // AGGREGATE: firrtl.elementwise_and
+    // AGGREGATE: firrtl.elementwise_xor
+    %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 1>
+    %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 1>
+    %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 1>
+  }
+
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last

--- a/test/Dialect/FIRRTL/vectorization.mlir
+++ b/test/Dialect/FIRRTL/vectorization.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(vectorization)))' %s | FileCheck %s
+
+firrtl.circuit "ElementWise" {
+// CHECK-LABEL: @ElementWise
+firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
+  // CHECK-NEXT: %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.subindex %b[1] : !firrtl.vector<uint<1>, 2>
+  %1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 2>
+  %2 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
+  %3 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 2>
+  %4 = firrtl.or %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %5 = firrtl.or %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %6 = firrtl.vectorcreate %4, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
+  firrtl.strictconnect %c_0, %6 : !firrtl.vector<uint<1>, 2>
+  %7 = firrtl.and %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %8 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %9 = firrtl.vectorcreate %7, %8 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
+  firrtl.strictconnect %c_1, %9 : !firrtl.vector<uint<1>, 2>
+  %10 = firrtl.xor %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %11 = firrtl.xor %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %12 = firrtl.vectorcreate %10, %11 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
+  firrtl.strictconnect %c_2, %12 : !firrtl.vector<uint<1>, 2>
+}
+}
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -667,6 +667,10 @@ static LogicalResult processBuffer(
       firrtl::createMergeConnectionsPass(
           !disableAggressiveMergeConnections.getValue()));
 
+  if (!disableOptimization)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        firrtl::createVectorizationPass());
+
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
 


### PR DESCRIPTION
This PR introduces element-wise operations, `firrrtl.elementwise_or, firrtl.elementwise_and` and `firrtl.elementwise_xor` to represent logical operations over 1d vector types. 

* FIRRTLOps -- type inference is added.
* Vectorization pass -- canonicalizer `vector_create (a[0] or b[0], a[1] or b[1], a[2] or b[2], ...)` -> `elementwise_or a, b` is added. 
* LowerToHW -- `elementwise_or a, b` -> `bitcast(comb.or (bitcast a), (bitcast b))`

Example:
```scala
circuit Foo:
  module Foo:
    input a: UInt<3>[2]
    input b: UInt<3>[2]
    output c: UInt<3>[2][3]

    c[0][0] <= or(a[0], b[0])
    c[0][1] <= or(a[1], b[1])
    c[1][0] <= and(a[0], b[0])
    c[1][1] <= and(a[1], b[1])
    c[2][0] <= xor(a[0], b[0])
    c[2][1] <= xor(a[1], b[1])
```
```mlir
firrtl.module @Foo(in %a: !firrtl.vector<uint<3>, 2>, in %b: !firrtl.vector<uint<3>, 2>, out %c_0: !firrtl.vector<uint<3>, 2>, out %c_1: !firrtl.vector<uint<3>, 2>, out %c_2: !firrtl.vector<uint<3>, 2>) {
  %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<3>, 2>, !firrtl.vector<uint<3>, 2>) -> !firrtl.vector<uint<3>, 2>
  firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<3>, 2>
  %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<3>, 2>, !firrtl.vector<uint<3>, 2>) -> !firrtl.vector<uint<3>, 2>
  firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<3>, 2>
  %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<3>, 2>, !firrtl.vector<uint<3>, 2>) -> !firrtl.vector<uint<3>, 2>
  firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<3>, 2>
}
```
```verilog
module Foo(
  input  [1:0][2:0] a,
                    b,
  output [1:0][2:0] c_0,
                    c_1,
                    c_2
);

  wire [5:0] _GEN = /*cast(bit[5:0])*/a;
  wire [5:0] _GEN_0 = /*cast(bit[5:0])*/b;
  assign c_0 = /*cast(bit[1:0][2:0])*/_GEN | _GEN_0;
  assign c_1 = /*cast(bit[1:0][2:0])*/_GEN & _GEN_0;
  assign c_2 = /*ca
```

These temporary wires `_GEN` and `_GEN_0` are unnecessary so ExportVerilog needs to be improved but probably we want to introduce vector operations to HW instead of relying on bitcast.