### PR TITLE
[FIRRTL] Simple points-to like analysis

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
@@ -37,13 +37,15 @@ public:
     bool isRoot() const { return path.empty(); }
   };
 
-  PathNode *nodeForValue(Value v);
+  const PathNode *nodeForValue(Value v) const;
 
 private:
   void visitOp(Operation *op);
   void visitSubfield(SubfieldOp sf);
   void visitSubindex(SubindexOp si);
   void visitSubaccess(SubaccessOp sa);
+  void visitMem(MemOp mem);
+  void visitInst(InstanceOp inst);
 
   void makeNodeForValue(Value dst, Value src, ArrayRef<int64_t> path);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
@@ -1,0 +1,35 @@
+//===- FIRRTLFieldSource.h - Field Source (points-to) -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FIRRTL Field Source Analysis, which is a points-to
+// analysis which identifies the source field and storage of any value derived
+// from a storage location.  Values derived from reads of storage locations do
+// not appear in this analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLFIELDSOURCE_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLFIELDSOURCE_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+namespace firrtl {
+
+/// To use this class, retrieve a cached copy from the analysis manager:
+///   auto &fieldsource = getAnalysis<FieldSource>(getOperation());
+class FieldSource {
+public:
+  explicit FieldSource(Operation *operation);
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLFIELDSOURCE_H

--- a/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
@@ -25,8 +25,30 @@ namespace firrtl {
 /// To use this class, retrieve a cached copy from the analysis manager:
 ///   auto &fieldsource = getAnalysis<FieldSource>(getOperation());
 class FieldSource {
+
 public:
   explicit FieldSource(Operation *operation);
+
+  struct PathNode {
+    PathNode(Value src, ArrayRef<int64_t> ar) : src(src), path(ar) {}
+    Value src;
+    SmallVector<int64_t, 4> path;
+
+    bool isRoot() const { return path.empty(); }
+  };
+
+  PathNode* nodeForValue(Value v);
+
+  private:
+  void visitOp(Operation* op);
+  void visitSubfield(SubfieldOp sf);
+  void visitSubindex(SubindexOp si);
+  void visitSubaccess(SubaccessOp sa);
+
+
+  void makeNodeForValue(Value dst, Value src, ArrayRef<int64_t> path);
+
+  DenseMap<Value, PathNode> paths;
 };
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLFieldSource.h
@@ -37,14 +37,13 @@ public:
     bool isRoot() const { return path.empty(); }
   };
 
-  PathNode* nodeForValue(Value v);
+  PathNode *nodeForValue(Value v);
 
-  private:
-  void visitOp(Operation* op);
+private:
+  void visitOp(Operation *op);
   void visitSubfield(SubfieldOp sf);
   void visitSubindex(SubindexOp si);
   void visitSubaccess(SubaccessOp sa);
-
 
   void makeNodeForValue(Value dst, Value src, ArrayRef<int64_t> path);
 

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -96,6 +96,8 @@ createMemToRegOfVecPass(bool replSeqMem = false, bool ignoreReadEnable = false);
 
 std::unique_ptr<mlir::Pass> createPrefixModulesPass();
 
+std::unique_ptr<mlir::Pass> createFIRRTLFieldSourcePass();
+
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 
 std::unique_ptr<mlir::Pass> createPrintNLATablePass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -402,6 +402,12 @@ def PrefixModules : Pass<"firrtl-prefix-modules", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createPrefixModulesPass()";
 }
 
+def PrintFIRRTLFieldSourcePass
+    : Pass<"firrtl-print-field-source", "firrtl::FModuleOp"> {
+  let summary = "Print field source information.";
+  let constructor =  "circt::firrtl::createFIRRTLFieldSourcePass()";
+}
+
 def PrintInstanceGraph
     : Pass<"firrtl-print-instance-graph", "firrtl::CircuitOp"> {
   let summary = "Print a DOT graph of the module hierarchy.";

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   FIRRTLAnnotations.cpp
   FIRRTLAttributes.cpp
   FIRRTLDialect.cpp
+  FIRRTLFieldSource.cpp
   FIRRTLFolds.cpp
   FIRRTLInstanceGraph.cpp
   FIRRTLOpInterfaces.cpp

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -10,31 +10,64 @@ using namespace firrtl;
 
 FieldSource::FieldSource(Operation* operation) {
     FModuleOp mod = cast<FModuleOp>(operation);
-    for (auto port : mod.getBodyBlock()->getArguments) {
-
-    }   
-    for (auto& op : mod.getBodyBlock())
-        visitOp(op);
+    for (auto port : mod.getBodyBlock()->getArguments())
+        if (auto ft = dyn_cast<FIRRTLBaseType>(port.getType()))
+          if (!ft.isGround())
+            makeNodeForValue(port, port, {});
+    for (auto& op : *mod.getBodyBlock())
+        visitOp(&op);
 }
 
 
 void FieldSource::visitOp(Operation* op) {
     if (auto sf = dyn_cast<SubfieldOp>(op))
-        visitSubfield(sf);
-    else if (auto si = dyn_cast<SubindexOp>)
-        visitSubindex(si);
-else if (auto sa = dyn_cast<SubaccessOp>(op))
-visitSubaccess(sa);
+        return visitSubfield(sf);
+    else if (auto si = dyn_cast<SubindexOp>(op))
+        return visitSubindex(si);
+    else if (auto sa = dyn_cast<SubaccessOp>(op))
+        return visitSubaccess(sa);
+    // recurse in to regions
+    for (auto& r : op->getRegions())
+        for (auto& b : r.getBlocks())
+            for (auto& op : b)
+            visitOp(&op);
 }
 
 void FieldSource::visitSubfield(SubfieldOp sf) {
-
+    auto value = sf.getInput();
+    auto node = nodeForValue(value);
+    assert(node && "node should be in the map");
+    auto sv = node->path;
+    sv.push_back(sf.getFieldIndex());
+    makeNodeForValue(sf.getResult(), node->src, sv);
 }
 
-void FieldSource::visitSubindex(SubfieldOp sf) {
-    
+void FieldSource::visitSubindex(SubindexOp si) {
+    auto value = si.getInput();
+    auto node = nodeForValue(value);
+    assert(node && "node should be in the map");
+    auto sv = node->path;
+    sv.push_back(si.getIndex());
+    makeNodeForValue(si.getResult(), node->src, sv);
 }
 
-void FieldSource::visitSubaccess(SubfieldOp sf) {
-   
+void FieldSource::visitSubaccess(SubaccessOp sa) {
+    auto value = sa.getInput();
+    auto node = nodeForValue(value);
+    assert(node && "node should be in the map");
+    auto sv = node->path;
+    sv.push_back(-1);
+    makeNodeForValue(sa.getResult(), node->src, sv);
+}
+
+FieldSource::PathNode* FieldSource::nodeForValue(Value v) {
+    auto ii = paths.find(v);
+    if (ii == paths.end())
+        return nullptr;
+    return &ii->second;
+}
+
+void FieldSource::makeNodeForValue(Value dst, Value src, ArrayRef<int64_t> path) {
+    auto ii = paths.try_emplace(dst, src, path);
+    assert(ii.second && "Double insert into the map");
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -1,0 +1,40 @@
+
+
+
+#include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"
+
+using namespace circt;
+using namespace firrtl;
+
+
+
+FieldSource::FieldSource(Operation* operation) {
+    FModuleOp mod = cast<FModuleOp>(operation);
+    for (auto port : mod.getBodyBlock()->getArguments) {
+
+    }   
+    for (auto& op : mod.getBodyBlock())
+        visitOp(op);
+}
+
+
+void FieldSource::visitOp(Operation* op) {
+    if (auto sf = dyn_cast<SubfieldOp>(op))
+        visitSubfield(sf);
+    else if (auto si = dyn_cast<SubindexOp>)
+        visitSubindex(si);
+else if (auto sa = dyn_cast<SubaccessOp>(op))
+visitSubaccess(sa);
+}
+
+void FieldSource::visitSubfield(SubfieldOp sf) {
+
+}
+
+void FieldSource::visitSubindex(SubfieldOp sf) {
+    
+}
+
+void FieldSource::visitSubaccess(SubfieldOp sf) {
+   
+}

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -1,73 +1,70 @@
 
 
-
 #include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"
 
 using namespace circt;
 using namespace firrtl;
 
+FieldSource::FieldSource(Operation *operation) {
+  FModuleOp mod = cast<FModuleOp>(operation);
+  for (auto port : mod.getBodyBlock()->getArguments())
+    if (auto ft = dyn_cast<FIRRTLBaseType>(port.getType()))
+      if (!ft.isGround())
+        makeNodeForValue(port, port, {});
+  for (auto &op : *mod.getBodyBlock())
+    visitOp(&op);
+}
 
-
-FieldSource::FieldSource(Operation* operation) {
-    FModuleOp mod = cast<FModuleOp>(operation);
-    for (auto port : mod.getBodyBlock()->getArguments())
-        if (auto ft = dyn_cast<FIRRTLBaseType>(port.getType()))
-          if (!ft.isGround())
-            makeNodeForValue(port, port, {});
-    for (auto& op : *mod.getBodyBlock())
+void FieldSource::visitOp(Operation *op) {
+  if (auto sf = dyn_cast<SubfieldOp>(op))
+    return visitSubfield(sf);
+  else if (auto si = dyn_cast<SubindexOp>(op))
+    return visitSubindex(si);
+  else if (auto sa = dyn_cast<SubaccessOp>(op))
+    return visitSubaccess(sa);
+  // recurse in to regions
+  for (auto &r : op->getRegions())
+    for (auto &b : r.getBlocks())
+      for (auto &op : b)
         visitOp(&op);
 }
 
-
-void FieldSource::visitOp(Operation* op) {
-    if (auto sf = dyn_cast<SubfieldOp>(op))
-        return visitSubfield(sf);
-    else if (auto si = dyn_cast<SubindexOp>(op))
-        return visitSubindex(si);
-    else if (auto sa = dyn_cast<SubaccessOp>(op))
-        return visitSubaccess(sa);
-    // recurse in to regions
-    for (auto& r : op->getRegions())
-        for (auto& b : r.getBlocks())
-            for (auto& op : b)
-            visitOp(&op);
-}
-
 void FieldSource::visitSubfield(SubfieldOp sf) {
-    auto value = sf.getInput();
-    auto node = nodeForValue(value);
-    assert(node && "node should be in the map");
-    auto sv = node->path;
-    sv.push_back(sf.getFieldIndex());
-    makeNodeForValue(sf.getResult(), node->src, sv);
+  auto value = sf.getInput();
+  auto node = nodeForValue(value);
+  assert(node && "node should be in the map");
+  auto sv = node->path;
+  sv.push_back(sf.getFieldIndex());
+  makeNodeForValue(sf.getResult(), node->src, sv);
 }
 
 void FieldSource::visitSubindex(SubindexOp si) {
-    auto value = si.getInput();
-    auto node = nodeForValue(value);
-    assert(node && "node should be in the map");
-    auto sv = node->path;
-    sv.push_back(si.getIndex());
-    makeNodeForValue(si.getResult(), node->src, sv);
+  auto value = si.getInput();
+  auto node = nodeForValue(value);
+  assert(node && "node should be in the map");
+  auto sv = node->path;
+  sv.push_back(si.getIndex());
+  makeNodeForValue(si.getResult(), node->src, sv);
 }
 
 void FieldSource::visitSubaccess(SubaccessOp sa) {
-    auto value = sa.getInput();
-    auto node = nodeForValue(value);
-    assert(node && "node should be in the map");
-    auto sv = node->path;
-    sv.push_back(-1);
-    makeNodeForValue(sa.getResult(), node->src, sv);
+  auto value = sa.getInput();
+  auto node = nodeForValue(value);
+  assert(node && "node should be in the map");
+  auto sv = node->path;
+  sv.push_back(-1);
+  makeNodeForValue(sa.getResult(), node->src, sv);
 }
 
-FieldSource::PathNode* FieldSource::nodeForValue(Value v) {
-    auto ii = paths.find(v);
-    if (ii == paths.end())
-        return nullptr;
-    return &ii->second;
+FieldSource::PathNode *FieldSource::nodeForValue(Value v) {
+  auto ii = paths.find(v);
+  if (ii == paths.end())
+    return nullptr;
+  return &ii->second;
 }
 
-void FieldSource::makeNodeForValue(Value dst, Value src, ArrayRef<int64_t> path) {
-    auto ii = paths.try_emplace(dst, src, path);
-    assert(ii.second && "Double insert into the map");
+void FieldSource::makeNodeForValue(Value dst, Value src,
+                                   ArrayRef<int64_t> path) {
+  auto ii = paths.try_emplace(dst, src, path);
+  assert(ii.second && "Double insert into the map");
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -47,7 +47,7 @@ void FieldSource::visitOp(Operation *op) {
 
 void FieldSource::visitSubfield(SubfieldOp sf) {
   auto value = sf.getInput();
-  const auto* node = nodeForValue(value);
+  const auto *node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(sf.getFieldIndex());
@@ -56,7 +56,7 @@ void FieldSource::visitSubfield(SubfieldOp sf) {
 
 void FieldSource::visitSubindex(SubindexOp si) {
   auto value = si.getInput();
-  const auto* node = nodeForValue(value);
+  const auto *node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(si.getIndex());
@@ -65,7 +65,7 @@ void FieldSource::visitSubindex(SubindexOp si) {
 
 void FieldSource::visitSubaccess(SubaccessOp sa) {
   auto value = sa.getInput();
-  const auto* node = nodeForValue(value);
+  const auto *node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(-1);

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"
 
 using namespace circt;

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -28,15 +28,15 @@ FieldSource::FieldSource(Operation *operation) {
 void FieldSource::visitOp(Operation *op) {
   if (auto sf = dyn_cast<SubfieldOp>(op))
     return visitSubfield(sf);
-  else if (auto si = dyn_cast<SubindexOp>(op))
+  if (auto si = dyn_cast<SubindexOp>(op))
     return visitSubindex(si);
-  else if (auto sa = dyn_cast<SubaccessOp>(op))
+  if (auto sa = dyn_cast<SubaccessOp>(op))
     return visitSubaccess(sa);
-  else if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp>(op))
+  if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp>(op))
     return makeNodeForValue(op->getResult(0), op->getResult(0), {});
-  else if (auto mem = dyn_cast<MemOp>(op))
+  if (auto mem = dyn_cast<MemOp>(op))
     return visitMem(mem);
-  else if (auto inst = dyn_cast<InstanceOp>(op))
+  if (auto inst = dyn_cast<InstanceOp>(op))
     return visitInst(inst);
   // recurse in to regions
   for (auto &r : op->getRegions())
@@ -47,7 +47,7 @@ void FieldSource::visitOp(Operation *op) {
 
 void FieldSource::visitSubfield(SubfieldOp sf) {
   auto value = sf.getInput();
-  auto node = nodeForValue(value);
+  const auto* node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(sf.getFieldIndex());
@@ -56,7 +56,7 @@ void FieldSource::visitSubfield(SubfieldOp sf) {
 
 void FieldSource::visitSubindex(SubindexOp si) {
   auto value = si.getInput();
-  auto node = nodeForValue(value);
+  const auto* node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(si.getIndex());
@@ -65,7 +65,7 @@ void FieldSource::visitSubindex(SubindexOp si) {
 
 void FieldSource::visitSubaccess(SubaccessOp sa) {
   auto value = sa.getInput();
-  auto node = nodeForValue(value);
+  const auto* node = nodeForValue(value);
   assert(node && "node should be in the map");
   auto sv = node->path;
   sv.push_back(-1);

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -1,3 +1,14 @@
+//===- FIRRTLFieldSource.cpp - Field Source Analysis ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a basic points-to like analysis.
+//
+//===----------------------------------------------------------------------===//
 
 
 #include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -28,6 +28,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   MemToRegOfVec.cpp
   ModuleInliner.cpp
   PrefixModules.cpp
+  PrintFIRRTLFieldSource.cpp
   PrintInstanceGraph.cpp
   PrintNLATable.cpp
   RandomizeRegisterInit.cpp

--- a/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
@@ -1,0 +1,60 @@
+//===- PrintFIRRTLFieldSource.cpp - Print the Field Source ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Print the FieldSource analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct PrintFIRRTLFieldSourcePass
+    : public PrintFIRRTLFieldSourcePassBase<PrintFIRRTLFieldSourcePass> {
+  PrintFIRRTLFieldSourcePass(raw_ostream &os) : os(os) {}
+
+    void visitValue(const FieldSource& fieldRefs, Value v) {
+      auto* p = fieldRefs.nodeForValue(v);
+      if (p) {
+        os << v << " : " << p->src << " : {";
+        llvm::interleaveComma(p->path, os);
+        os << "}\n";
+      }
+    }
+
+    void visitOp(const FieldSource& fieldRefs, Operation* op) {
+      for (auto r : op->getResults())
+        visitValue(fieldRefs, r);
+    // recurse in to regions
+    for (auto& r : op->getRegions())
+        for (auto& b : r.getBlocks())
+            for (auto& op : b)
+            visitOp(fieldRefs, &op);
+    }
+
+  void runOnOperation() override {
+    auto modOp = getOperation();
+    auto &fieldRefs = getAnalysis<FieldSource>();
+    for (auto port : modOp.getBodyBlock()->getArguments())
+        visitValue(fieldRefs, port);
+        for (auto& op : *modOp.getBodyBlock())
+            visitOp(fieldRefs, op);
+
+    markAllAnalysesPreserved();
+  }
+  raw_ostream &os;
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createFIRRTLFieldSourcePass() {
+  return std::make_unique<PrintFIRRTLFieldSourcePass>(llvm::errs());
+}

--- a/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
@@ -22,32 +22,32 @@ struct PrintFIRRTLFieldSourcePass
     : public PrintFIRRTLFieldSourcePassBase<PrintFIRRTLFieldSourcePass> {
   PrintFIRRTLFieldSourcePass(raw_ostream &os) : os(os) {}
 
-    void visitValue(const FieldSource& fieldRefs, Value v) {
-      auto* p = fieldRefs.nodeForValue(v);
-      if (p) {
-        os << v << " : " << p->src << " : {";
-        llvm::interleaveComma(p->path, os);
-        os << "}\n";
-      }
+  void visitValue(const FieldSource &fieldRefs, Value v) {
+    auto *p = fieldRefs.nodeForValue(v);
+    if (p) {
+      os << v << " : " << p->src << " : {";
+      llvm::interleaveComma(p->path, os);
+      os << "}\n";
     }
+  }
 
-    void visitOp(const FieldSource& fieldRefs, Operation* op) {
-      for (auto r : op->getResults())
-        visitValue(fieldRefs, r);
+  void visitOp(const FieldSource &fieldRefs, Operation *op) {
+    for (auto r : op->getResults())
+      visitValue(fieldRefs, r);
     // recurse in to regions
-    for (auto& r : op->getRegions())
-        for (auto& b : r.getBlocks())
-            for (auto& op : b)
-            visitOp(fieldRefs, &op);
-    }
+    for (auto &r : op->getRegions())
+      for (auto &b : r.getBlocks())
+        for (auto &op : b)
+          visitOp(fieldRefs, &op);
+  }
 
   void runOnOperation() override {
     auto modOp = getOperation();
     auto &fieldRefs = getAnalysis<FieldSource>();
     for (auto port : modOp.getBodyBlock()->getArguments())
-        visitValue(fieldRefs, port);
-        for (auto& op : *modOp.getBodyBlock())
-            visitOp(fieldRefs, op);
+      visitValue(fieldRefs, port);
+    for (auto &op : *modOp.getBodyBlock())
+      visitOp(fieldRefs, op);
 
     markAllAnalysesPreserved();
   }

--- a/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrintFIRRTLFieldSource.cpp
@@ -25,7 +25,11 @@ struct PrintFIRRTLFieldSourcePass
   void visitValue(const FieldSource &fieldRefs, Value v) {
     auto *p = fieldRefs.nodeForValue(v);
     if (p) {
-      os << v << " : " << p->src << " : {";
+      if (p->isRoot())
+        os << "ROOT: ";
+      else
+        os << "SUB:  " << v;
+      os << " : " << p->src << " : {";
       llvm::interleaveComma(p->path, os);
       os << "}\n";
     }
@@ -43,11 +47,12 @@ struct PrintFIRRTLFieldSourcePass
 
   void runOnOperation() override {
     auto modOp = getOperation();
+    os << "** " << modOp.getName() << "\n";
     auto &fieldRefs = getAnalysis<FieldSource>();
     for (auto port : modOp.getBodyBlock()->getArguments())
       visitValue(fieldRefs, port);
     for (auto &op : *modOp.getBodyBlock())
-      visitOp(fieldRefs, op);
+      visitOp(fieldRefs, &op);
 
     markAllAnalysesPreserved();
   }


### PR DESCRIPTION
This analysis maps values back to their definitions (operations which produce a new value) and provides an indexing path in the original definition to produce the current value.
Subaccesses produce a -1 (wildcard) in the path.
The analysis provides the user with a stable summary node for each value which is suitable to use in other data-structures.

```
wire a : firrtl.vector<bundle<f1: uint, f2: uint>, 4> => definition, is a root (empty path)
v = subindex(a, 2) => derived from a with path {2}
w = subfield(v, f2) => derived from a with path {2, 1}
```