### PR TITLE
[SV][ETC] Name port after instance result name, as well.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -232,26 +232,34 @@ static void addInstancesToCloneSet(
     inputs.insert(v);
 }
 
-static StringRef getNameForPort(Value val, ArrayAttr modulePorts) {
+static StringAttr getNameForPort(Value val, ArrayAttr modulePorts) {
   if (auto bv = val.dyn_cast<BlockArgument>())
-    return modulePorts[bv.getArgNumber()].cast<StringAttr>().getValue();
+    return modulePorts[bv.getArgNumber()].cast<StringAttr>();
 
   if (auto *op = val.getDefiningOp()) {
     if (auto readinout = dyn_cast<ReadInOutOp>(op)) {
       if (auto *readOp = readinout.getInput().getDefiningOp()) {
         if (auto wire = dyn_cast<WireOp>(readOp))
-          return wire.getName();
+          return wire.getNameAttr();
         if (auto reg = dyn_cast<RegOp>(readOp))
-          return reg.getName();
+          return reg.getNameAttr();
       }
     } else if (auto inst = dyn_cast<hw::InstanceOp>(op)) {
       for (auto [index, result] : llvm::enumerate(inst.getResults()))
-        if (result == val)
-          return inst.getResultName(index);
+        if (result == val) {
+          SmallString<64> portName = inst.getInstanceName();
+          portName += ".";
+          auto resultName = inst.getResultName(index);
+          if (resultName && !resultName.getValue().empty())
+            portName += resultName.getValue();
+          else
+            Twine(index).toVector(portName);
+          return StringAttr::get(val.getContext(), portName);
+        }
     }
   }
 
-  return "";
+  return StringAttr::get(val.getContext(), "");
 }
 
 // Given a set of values, construct a module and bind instance of that module
@@ -289,8 +297,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
     auto srcPorts = op.getArgNames();
     for (auto &port : llvm::enumerate(realInputs)) {
       auto name = getNameForPort(port.value(), srcPorts);
-      ports.push_back({b.getStringAttr(name), hw::PortDirection::INPUT,
-                       port.value().getType(), port.index()});
+      ports.push_back({name, hw::PortDirection::INPUT, port.value().getType(),
+                       port.index()});
     }
   }
 

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -137,25 +137,18 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // Check extracted module ports take name of instance result when needed.
 
 // CHECK-LABEL: @InstResult(
-// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover(mem1.result_name: %{{[^ ]+}}: i1, mem2.0: %{{[^ ]+}}: i1, clock: %clock: i1)
+// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover(mem.result_name: %{{[^ ]+}}: i1, mem.1: %{{[^ ]+}}: i1, clock: %clock: i1)
 module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>} {
-  hw.module @Mem1() -> (result_name: i1) {
+  hw.module @Mem() -> (result_name: i1, "": i1) {
     %reg = sv.reg : !hw.inout<i1>
     %0 = sv.read_inout %reg : !hw.inout<i1>
-    hw.output %0 : i1
-  }
-  hw.module @Mem2() -> ("": i1) {
-    %reg = sv.reg : !hw.inout<i1>
-    %0 = sv.read_inout %reg : !hw.inout<i1>
-    hw.output %0 : i1
+    hw.output %0, %0 : i1, i1
   }
   // Dummy is needed to prevent the instance itself being extracted
-  hw.module @Dummy(%input: i1) -> () {}
+  hw.module @Dummy(%in1: i1, %in2: i1) -> () {}
   hw.module @InstResult(%clock: i1) -> () {
-    %0 = hw.instance "mem1" @Mem1() -> (result_name: i1)
-    %1 = hw.instance "mem2" @Mem2() -> ("": i1)
-    hw.instance "dummy" sym @keep @Dummy(input: %0 : i1) -> ()
-    hw.instance "dummy" sym @keep2 @Dummy(input: %1 : i1) -> ()
+    %0, %1 = hw.instance "mem" @Mem() -> (result_name: i1, "": i1)
+    hw.instance "dummy" sym @keep @Dummy(in1: %0 : i1, in2: %1 : i1) -> ()
     %2 = comb.and bin %0, %1 : i1
     sv.always posedge %clock  {
       sv.cover %2, immediate


### PR DESCRIPTION
Fix case where port is named "" (`_GEN`), teach to grab name from instance.

Add test based on case found in the wild.