### PR TITLE
[FIRRTL] Wire To Node Conversion Pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -148,6 +148,8 @@ createResolveTracesPass(mlir::StringRef outputAnnotationFilename = "");
 
 std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
 
+std::unique_ptr<mlir::Pass> createWire2NodePass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -636,4 +636,13 @@ def InnerSymbolDCE : Pass<"firrtl-inner-symbol-dce", "mlir::ModuleOp"> {
   ];
 }
 
+def Wire2Node : Pass<"firrtl-wire-to-node", "firrtl::FModuleOp"> {
+  let summary = "Convert wires to nodes";
+  let description = [{
+    This pass performs a topological sort of each module.  It then converts
+    any wires whose reads are dominated by writes into nodes.
+  }];
+  let constructor = "circt::firrtl::createWire2NodePass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -17,9 +17,8 @@ using namespace firrtl;
 
 FieldSource::FieldSource(Operation *operation) {
   FModuleOp mod = cast<FModuleOp>(operation);
+  // All ports define locations
   for (auto port : mod.getBodyBlock()->getArguments())
-    if (auto ft = dyn_cast<FIRRTLBaseType>(port.getType()))
-      if (!ft.isGround())
         makeNodeForValue(port, port, {});
   for (auto &op : *mod.getBodyBlock())
     visitOp(&op);
@@ -32,7 +31,7 @@ void FieldSource::visitOp(Operation *op) {
     return visitSubindex(si);
   if (auto sa = dyn_cast<SubaccessOp>(op))
     return visitSubaccess(sa);
-  if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp>(op))
+  if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp, BundleCreateOp, VectorCreateOp>(op))
     return makeNodeForValue(op->getResult(0), op->getResult(0), {});
   if (auto mem = dyn_cast<MemOp>(op))
     return visitMem(mem);

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -19,7 +19,7 @@ FieldSource::FieldSource(Operation *operation) {
   FModuleOp mod = cast<FModuleOp>(operation);
   // All ports define locations
   for (auto port : mod.getBodyBlock()->getArguments())
-        makeNodeForValue(port, port, {});
+    makeNodeForValue(port, port, {});
   for (auto &op : *mod.getBodyBlock())
     visitOp(&op);
 }
@@ -31,7 +31,8 @@ void FieldSource::visitOp(Operation *op) {
     return visitSubindex(si);
   if (auto sa = dyn_cast<SubaccessOp>(op))
     return visitSubaccess(sa);
-  if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp, BundleCreateOp, VectorCreateOp>(op))
+  if (isa<WireOp, NodeOp, RegOp, RegResetOp, BitCastOp, BundleCreateOp,
+          VectorCreateOp>(op))
     return makeNodeForValue(op->getResult(0), op->getResult(0), {});
   if (auto mem = dyn_cast<MemOp>(op))
     return visitMem(mem);

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ResolveTraces.cpp
   RemoveUnusedPorts.cpp
   SFCCompat.cpp
+  WireToNode.cpp
   WireDFT.cpp
 
   DEPENDS

--- a/lib/Dialect/FIRRTL/Transforms/WireToNode.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireToNode.cpp
@@ -1,0 +1,135 @@
+//===- Wire2Node.cpp - topo sort and convert wires to nodes -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace circt;
+using namespace firrtl;
+
+
+namespace {
+    struct Wire2Node {
+        FModuleOp mod;
+
+        Wire2Node(FModuleOp mod) : mod(mod) {}
+        LogicalResult run();
+        void orderBlock(Block* block);
+    };
+}
+
+
+
+bool sortTopologicallyEx(
+    Block *block, 
+    function_ref<bool(Value, Operation *)> isOperandReady) {
+        if (block->empty())
+        return true;
+        auto ops =   block->back().hasTrait<OpTrait::IsTerminator>() ?
+     block->without_terminator() : * block;
+     
+  // The set of operations that have not yet been scheduled.
+  DenseSet<Operation *> unscheduledOps;
+  // Mark all operations as unscheduled.
+  for (Operation &op : ops)
+    unscheduledOps.insert(&op);
+
+  Block::iterator nextScheduledOp = ops.begin();
+  Block::iterator end = ops.end();
+
+  bool allOpsScheduled = true;
+  while (!unscheduledOps.empty()) {
+    bool scheduledAtLeastOnce = false;
+
+    // Loop over the ops that are not sorted yet, try to find the ones "ready",
+    // i.e. the ones for which there aren't any operand produced by an op in the
+    // set, and "schedule" it (move it before the `nextScheduledOp`).
+    for (Operation &op :
+         llvm::make_early_inc_range(llvm::make_range(nextScheduledOp, end))) {
+      if (!isOpReady(&op, unscheduledOps, isOperandReady))
+        continue;
+
+      // Schedule the operation by moving it to the start.
+      unscheduledOps.erase(&op);
+      op.moveBefore(block, nextScheduledOp);
+      scheduledAtLeastOnce = true;
+      // Move the iterator forward if we schedule the operation at the front.
+      if (&op == &*nextScheduledOp)
+        ++nextScheduledOp;
+    }
+    // If no operations were scheduled, give up and advance the iterator.
+    if (!scheduledAtLeastOnce) {
+      allOpsScheduled = false;
+      unscheduledOps.erase(&*nextScheduledOp);
+      ++nextScheduledOp;
+    }
+  }
+
+  return allOpsScheduled;
+}
+
+
+void Wire2Node::orderBlock(Block* block) {
+    if (block->empty())
+        return;
+    auto* last = &block->back();
+    for (auto ii = block->rbegin(), ee = block->rend(); ii != ee; ) {
+        Operation& op = *ii++;
+        if (isa<ConnectOp, StrictConnectOp>(op)) {
+                op.moveAfter(last);
+                last = &op;
+        }
+}
+}
+
+LogicalResult Wire2Node::run() {
+    // First, sink all connects to the end of the module
+    auto* block = mod.getBodyBlock();
+    orderBlock(block);
+
+//    mlir::sortTopologically(mod.getBodyBlock(), *mod.getBodyBlock(), wireMover );
+    return success();
+}
+
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct Wire2NodePass : public Wire2NodeBase<Wire2NodePass> {
+  Wire2NodePass() = default;
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+// This is the main entrypoint for the wire2node pass.
+void Wire2NodePass::runOnOperation() {
+    llvm::errs() << "Running on: " << getOperation().getName() << "\n";
+    Wire2Node transform(getOperation());
+    if (failed(transform.run()))
+      signalPassFailure();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createWire2NodePass() {
+  return std::make_unique<Wire2NodePass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/WireToNode.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireToNode.cpp
@@ -18,7 +18,8 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
-#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "circt/Dialect/FIRRTL/FIRRTLFieldSource.h"
+#include "mlir/Pass/Pass.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace circt;
@@ -28,33 +29,85 @@ using namespace firrtl;
 namespace {
     struct Wire2Node {
         FModuleOp mod;
+        FieldSource& fields;
 
-        Wire2Node(FModuleOp mod) : mod(mod) {}
+        Wire2Node(FModuleOp mod, FieldSource& fields) : mod(mod), fields(fields) {}
         LogicalResult run();
-        void orderBlock(Block* block);
     };
 }
 
+static bool isIndexing(Operation* op) {
+    return isa<SubfieldOp, SubindexOp, SubaccessOp>(op);
+}
 
-
-bool sortTopologicallyEx(
-    Block *block, 
-    function_ref<bool(Value, Operation *)> isOperandReady) {
-        if (block->empty())
+/// Return `true` if the given operation is ready to be scheduled.
+static bool isOpReadyEx(Operation *op, DenseSet<Operation *> &unscheduledOps, 
+FieldSource& sources, DenseSet<Value>& readsSeen) {
+  // An operation is ready to be scheduled if all its operands are ready. An
+  // operation is ready if:
+  const auto isReady = [&](Value value) {
+    Operation *parent = value.getDefiningOp();
+    // - it is a block argument,
+    if (!parent)
+      return true;
+    // - or it is not defined by an unscheduled op (and also not nested within
+    //   an unscheduled op).
+    do {
+      // Stop traversal when op under examination is reached.
+      if (parent == op)
         return true;
+      if (unscheduledOps.contains(parent)) {
+        return false;
+      }
+    } while ((parent = parent->getParentOp()));
+    // No unscheduled op found.
+    // If this is a write, it's fine as long as the rhs has been seen.
+    if (isa<ConnectOp, StrictConnectOp>(op) && value == op->getOperand(0) &&
+        readsSeen.count(sources.nodeForValue(op->getOperand(1))->src))
+        return true;
+    // If this reads, then it is ready if its source is in the read set.  That
+    // is, we've had to schedule a read already.  This prioritizes writes.
+    const auto* node = sources.nodeForValue(value);
+    if (node) 
+       return readsSeen.contains(node->src);
+    // It is not a read, so it is ready
+    return true;
+  };
+
+  // An operation is recursively ready to be scheduled of it and its nested
+  // operations are ready.
+  WalkResult readyToSchedule = op->walk([&](Operation *nestedOp) {
+    return llvm::all_of(nestedOp->getOperands(),
+                        [&](Value operand) { return isReady(operand); })
+               ? WalkResult::advance()
+               : WalkResult::interrupt();
+  });
+  return !readyToSchedule.wasInterrupted();
+}
+
+
+static SmallVector<Operation*> sortTopologicallyEx(
+    Block *block, FieldSource& sources) {
+        if (block->empty())
+        return {};
         auto ops =   block->back().hasTrait<OpTrait::IsTerminator>() ?
      block->without_terminator() : * block;
      
   // The set of operations that have not yet been scheduled.
   DenseSet<Operation *> unscheduledOps;
+  DenseSet<Value> readsSeen;
   // Mark all operations as unscheduled.
   for (Operation &op : ops)
     unscheduledOps.insert(&op);
 
+  // All block arguments are already read.  This way we reduce the checks in isReady.
+  for (auto& barg : block->getArguments())
+    readsSeen.insert(barg);
+
   Block::iterator nextScheduledOp = ops.begin();
   Block::iterator end = ops.end();
 
-  bool allOpsScheduled = true;
+  SmallVector<Operation*> nodePoints;
   while (!unscheduledOps.empty()) {
     bool scheduledAtLeastOnce = false;
 
@@ -63,48 +116,51 @@ bool sortTopologicallyEx(
     // set, and "schedule" it (move it before the `nextScheduledOp`).
     for (Operation &op :
          llvm::make_early_inc_range(llvm::make_range(nextScheduledOp, end))) {
-      if (!isOpReady(&op, unscheduledOps, isOperandReady))
+      if (!isOpReadyEx(&op, unscheduledOps, sources, readsSeen))
         continue;
 
       // Schedule the operation by moving it to the start.
       unscheduledOps.erase(&op);
       op.moveBefore(block, nextScheduledOp);
       scheduledAtLeastOnce = true;
+      if (isa<ConnectOp, StrictConnectOp>(&op) && dyn_cast_or_null<WireOp>(op.getOperand(0).getDefiningOp()))
+        nodePoints.push_back(&op);
+        // It doesn't matter that we mark the write value as a read
+      for(auto operand : nextScheduledOp->getOperands())
+        readsSeen.insert(operand); 
       // Move the iterator forward if we schedule the operation at the front.
       if (&op == &*nextScheduledOp)
         ++nextScheduledOp;
     }
     // If no operations were scheduled, give up and advance the iterator.
     if (!scheduledAtLeastOnce) {
-      allOpsScheduled = false;
+          for(auto operand : nextScheduledOp->getOperands())
+            if (const auto* node = sources.nodeForValue(operand))
+                readsSeen.insert(node->src);
       unscheduledOps.erase(&*nextScheduledOp);
       ++nextScheduledOp;
     }
   }
 
-  return allOpsScheduled;
-}
-
-
-void Wire2Node::orderBlock(Block* block) {
-    if (block->empty())
-        return;
-    auto* last = &block->back();
-    for (auto ii = block->rbegin(), ee = block->rend(); ii != ee; ) {
-        Operation& op = *ii++;
-        if (isa<ConnectOp, StrictConnectOp>(op)) {
-                op.moveAfter(last);
-                last = &op;
-        }
-}
+  return nodePoints;
 }
 
 LogicalResult Wire2Node::run() {
     // First, sink all connects to the end of the module
-    auto* block = mod.getBodyBlock();
-    orderBlock(block);
+//    auto* block = mod.getBodyBlock();
+//    orderBlock(block);
+    
+    auto replacePoints = sortTopologicallyEx(mod.getBodyBlock(), fields );
+    OpBuilder builder(mod.getContext());
+    for (auto* op : replacePoints) {
+      auto wire = cast<WireOp>(op->getOperand(0).getDefiningOp());
+        builder.setInsertionPointAfter(op);
+        auto node = builder.create<NodeOp>(wire.getLoc(), wire.getType(),op->getOperand(1), wire.getName(), wire.getNameKind(), wire.getAnnotations(), wire.getInnerSym() ? *wire.getInnerSym() : nullptr);
+        wire.replaceAllUsesWith(node.getResult());
+        wire.erase();
+        op->erase();
 
-//    mlir::sortTopologically(mod.getBodyBlock(), *mod.getBodyBlock(), wireMover );
+    }
     return success();
 }
 
@@ -123,7 +179,8 @@ struct Wire2NodePass : public Wire2NodeBase<Wire2NodePass> {
 // This is the main entrypoint for the wire2node pass.
 void Wire2NodePass::runOnOperation() {
     llvm::errs() << "Running on: " << getOperation().getName() << "\n";
-    Wire2Node transform(getOperation());
+    auto& fields = getAnalysis<FieldSource>();
+    Wire2Node transform(getOperation(), fields);
     if (failed(transform.run()))
       signalPassFailure();
 }


### PR DESCRIPTION
FIXME: Add tests.

This pass performs a topological sort, which tries to schedule all writes of a wire before any other reference.  For all wires which are so scheduled, it replaces them with a node.