### PR TITLE
Bump llvm to 78056e2f2d9510d2ace42fe7e9eb60e5abe8a3e7

### DIFF
--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -25,11 +25,6 @@ def GenerateOp : SVOp<"generate",
   }];
 }
 
-// A region with at most the given number of blocks.
-class MaxSizedRegion<int numBlocks> : Region<
-  CPred<"::llvm::hasNItemsOrLess($_self, " # numBlocks # ")">,
-  "region with at most " # numBlocks # " blocks">;
-
 /// An array of case patterns. This is either a typed attribute of some kind,
 /// an integer constant or a parameter expression for example, or a `unit` attr
 /// that indicates the `default` case.


### PR DESCRIPTION
- removed MaxSizedRegion, it's now defined in `mlir/include/mlir/IR/OpBase.td` via https://reviews.llvm.org/D143253