### PR TITLE
[FIRRTL] Limit BitCast to passive output, fix non-passive input.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -748,7 +748,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
   }];
 
   let arguments = (ins FIRRTLBaseType:$input);
-  let results = (outs FIRRTLBaseType:$result);
+  let results = (outs PassiveType:$result);
   let hasVerifier = 1;
   let hasFolder = 1;
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3497,7 +3497,7 @@ LogicalResult HWStructCastOp::verify() {
 }
 
 LogicalResult BitCastOp::verify() {
-  auto inTypeBits = getBitWidth(getOperand().getType().cast<FIRRTLBaseType>());
+  auto inTypeBits = getBitWidth(getInput().getType(), /*ignoreFlip=*/true);
   auto resTypeBits = getBitWidth(getType());
   if (inTypeBits.has_value() && resTypeBits.has_value()) {
     // Bitwidths must match for valid bit
@@ -3509,7 +3509,7 @@ LogicalResult BitCastOp::verify() {
   }
   if (!inTypeBits.has_value())
     return emitError("bitwidth cannot be determined for input operand type ")
-           << getOperand().getType();
+           << getInput().getType();
   return emitError("bitwidth cannot be determined for result type ")
          << getType();
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -700,9 +700,19 @@ firrtl.circuit "BitCast2" {
 
 firrtl.circuit "BitCast4" {
   firrtl.module @BitCast4() {
-    %a = firrtl.wire : !firrtl.bundle<valid flip: uint<1>, ready: uint<1>, data: uint<1>>
+    %a = firrtl.wire : !firrtl.analog
     // expected-error @+1 {{bitwidth cannot be determined for input operand type}}
-    %b = firrtl.bitcast %a : (!firrtl.bundle<valid flip: uint<1>, ready: uint<1>, data: uint<1>>) -> (!firrtl.uint<6>)
+    %b = firrtl.bitcast %a : (!firrtl.analog) -> (!firrtl.uint<1>)
+  }
+}
+
+// -----
+
+firrtl.circuit "BitCast5" {
+  firrtl.module @BitCast5() {
+    %a = firrtl.wire : !firrtl.uint<3>
+    // expected-error @below {{'firrtl.bitcast' op result #0 must be a passive base type (contain no flips), but got}}
+    %b = firrtl.bitcast %a : (!firrtl.uint<3>) -> (!firrtl.bundle<valid flip: uint<1>, ready: uint<1>, data: uint<1>>)
   }
 }
 


### PR DESCRIPTION
Casting bits to non-passive types is problematic re:flow, so limit the result to passive types.

Tweak BitCast's verifier to no longer reject non-passive inputs.