### PR TITLE
[Handshake] Fix incorrect operation deletion in EliminateCBranchIntoMux canonicalization pattern

### DIFF
--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -343,8 +343,9 @@ struct EliminateCBranchIntoMuxPattern : OpRewritePattern<MuxOp> {
       rewriter.replaceOp(op, firstParentCBranch.getDataOperand());
     });
 
-    // Remove the cbranch
-    rewriter.eraseOp(firstParentCBranch);
+    // Remove the cbranch if it has no uses
+    if (firstParentCBranch.use_empty())
+      rewriter.eraseOp(firstParentCBranch);
 
     return success();
   }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -343,10 +343,6 @@ struct EliminateCBranchIntoMuxPattern : OpRewritePattern<MuxOp> {
       rewriter.replaceOp(op, firstParentCBranch.getDataOperand());
     });
 
-    // Remove the cbranch if it has no uses
-    if (firstParentCBranch.use_empty())
-      rewriter.eraseOp(firstParentCBranch);
-
     return success();
   }
 };

--- a/test/Dialect/Handshake/canonicalization.mlir
+++ b/test/Dialect/Handshake/canonicalization.mlir
@@ -216,7 +216,7 @@ handshake.func @cbranch_into_mux_extend(%arg0 : i1, %arg1 : index, %arg2 : i32, 
 
 // -----
 
-// CHECK-LABEL:   handshake.func @cbranch_into_mux_elim(
+// CHECK-LABEL:   handshake.func @cbranch_into_mux_no_erase(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                          %[[VAL_1:.*]]: index,
 // CHECK-SAME:                                          %[[VAL_2:.*]]: i32,
@@ -225,7 +225,7 @@ handshake.func @cbranch_into_mux_extend(%arg0 : i1, %arg1 : index, %arg2 : i32, 
 // CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_4]], %[[VAL_4]] : i32
 // CHECK:           return %[[VAL_2]], %[[VAL_6]], %[[VAL_3]] : i32, i32, none
 // CHECK:         }
-handshake.func @cbranch_into_mux_elim(%arg0 : i1, %arg1 : index, %arg2 : i32, %arg3: none) -> (i32, i32, none) {
+handshake.func @cbranch_into_mux_no_erase(%arg0 : i1, %arg1 : index, %arg2 : i32, %arg3: none) -> (i32, i32, none) {
   %trueResult, %falseResult = cond_br %arg0, %arg2 : i32
   %0 = mux %arg1 [%trueResult, %falseResult] : index, i32
   %1 = arith.addi %trueResult, %trueResult : i32 

--- a/test/Dialect/Handshake/canonicalization.mlir
+++ b/test/Dialect/Handshake/canonicalization.mlir
@@ -213,3 +213,21 @@ handshake.func @cbranch_into_mux_extend(%arg0 : i1, %arg1 : index, %arg2 : i32, 
   %0 = mux %arg1 [%trueResult, %falseResult, %arg2] : index, i32
   handshake.return %0, %arg4 : i32, none
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @cbranch_into_mux_elim(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: i1,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: index,
+// CHECK-SAME:                                          %[[VAL_2:.*]]: i32,
+// CHECK-SAME:                                          %[[VAL_3:.*]]: none, ...) -> (i32, i32, none)
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_0]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_4]], %[[VAL_4]] : i32
+// CHECK:           return %[[VAL_2]], %[[VAL_6]], %[[VAL_3]] : i32, i32, none
+// CHECK:         }
+handshake.func @cbranch_into_mux_elim(%arg0 : i1, %arg1 : index, %arg2 : i32, %arg3: none) -> (i32, i32, none) {
+  %trueResult, %falseResult = cond_br %arg0, %arg2 : i32
+  %0 = mux %arg1 [%trueResult, %falseResult] : index, i32
+  %1 = arith.addi %trueResult, %trueResult : i32 
+  handshake.return %0, %1, %arg3 : i32, i32, none
+}


### PR DESCRIPTION
This fixes a bug in the `EliminateCBranchIntoMuxPattern` canonicalization pattern where a `cond_br` operation would get deleted despite still having uses. Below is an example `handshake.func` which would trigger the bug.
```mlir
handshake.func @cbranch_into_mux_elim(%arg0 : i1, %arg1 : index, %arg2 : i32, %arg3: none) -> (i32, i32, none) {
  %trueResult, %falseResult = cond_br %arg0, %arg2 : i32
  %0 = mux %arg1 [%trueResult, %falseResult] : index, i32
  %1 = arith.addi %trueResult, %trueResult : i32 
  handshake.return %0, %1, %arg3 : i32, i32, none
}
```
Here the `cond_br` would get deleted despite `%trueResult` still being used by `arith.addi`. 

The above example is added to Handshake canonicalization tests.