### PR TITLE
[FIRRTL][MemOp] Removed unused bits from memories

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -216,6 +216,25 @@ struct FirMemory {
     return getTuple() == rhs.getTuple();
   }
   StringAttr getFirMemoryName() const;
+
+  /**
+   * Check whether the memory is a seq mem.
+   *
+   * The following conditions must hold:
+   *   1. read latency and write latency of one.
+   *   2. only one readwrite port or write port.
+   *   3. zero or one read port.
+   *   4. undefined read-under-write behavior.
+   */
+  bool isSeqMem() const {
+    if (readLatency != 1 || writeLatency != 1)
+      return false;
+    if (numWritePorts + numReadWritePorts != 1)
+      return false;
+    if (numReadPorts > 1)
+      return false;
+    return dataWidth > 0;
+  }
 };
 
 // Record of the inner sym name, the module name and the corresponding

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2270,12 +2270,219 @@ struct FoldReadWritePorts : public mlir::RewritePattern {
     return success();
   }
 };
+
+// Eliminate the dead ports of memories.
+struct FoldUnusedBits : public mlir::RewritePattern {
+  FoldUnusedBits(MLIRContext *context)
+      : RewritePattern(MemOp::getOperationName(), 0, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    MemOp mem = cast<MemOp>(op);
+    if (hasDontTouch(mem))
+      return failure();
+
+    // Only apply the transformation if the memory is not sequential.
+    const auto &summary = mem.getSummary();
+    if (summary.isMasked || summary.isSeqMem())
+      return failure();
+
+    auto type = mem.getDataType().dyn_cast<IntType>();
+    if (!type)
+      return failure();
+    auto width = type.getBitWidthOrSentinel();
+    if (width <= 0)
+      return failure();
+
+    llvm::SmallBitVector usedBits(width);
+    DenseMap<unsigned, unsigned> mapping;
+
+    // Find which bits are used out of the users of a read port. This detects
+    // ports whose data/rdata field is used only through bit select ops. The
+    // bit selects are then used to build a bit-mask. The ops are collected.
+    SmallVector<BitsPrimOp> readOps;
+    auto findReadUsers = [&](Value port, StringRef field) {
+      auto portTy = port.getType().cast<BundleType>();
+      auto fieldIndex = portTy.getElementIndex(field);
+      assert(fieldIndex && "missing data port");
+
+      for (auto *op : port.getUsers()) {
+        auto portAccess = cast<SubfieldOp>(op);
+        if (fieldIndex != portAccess.getFieldIndex())
+          continue;
+
+        for (auto *user : op->getUsers()) {
+          auto bits = dyn_cast<BitsPrimOp>(user);
+          if (!bits) {
+            usedBits.set();
+            continue;
+          }
+
+          usedBits.set(bits.getLo(), bits.getHi() + 1);
+          mapping[bits.getLo()] = 0;
+          readOps.push_back(bits);
+        }
+      }
+    };
+
+    // Finds the users of write ports. This expects all the data/wdata fields
+    // of the ports to be used solely as the destination of strict connects.
+    // If a memory has ports with other uses, it is excluded from optimisation.
+    SmallVector<StrictConnectOp> writeOps;
+    auto findWriteUsers = [&](Value port, StringRef field) -> LogicalResult {
+      auto portTy = port.getType().cast<BundleType>();
+      auto fieldIndex = portTy.getElementIndex(field);
+      assert(fieldIndex && "missing data port");
+
+      for (auto *op : port.getUsers()) {
+        auto portAccess = cast<SubfieldOp>(op);
+        if (fieldIndex != portAccess.getFieldIndex())
+          continue;
+
+        auto conn = getSingleConnectUserOf(portAccess);
+        if (!conn)
+          return failure();
+
+        writeOps.push_back(conn);
+      }
+      return success();
+    };
+
+    // Traverse all ports and find the read and used data fields.
+    for (auto [i, port] : llvm::enumerate(mem.getResults())) {
+      // Do not simplify annotated ports.
+      if (!mem.getPortAnnotation(i).empty())
+        return failure();
+
+      switch (mem.getPortKind(i)) {
+      case MemOp::PortKind::Debug:
+        // Skip debug ports.
+        return failure();
+      case MemOp::PortKind::Write:
+        if (failed(findWriteUsers(port, "data")))
+          return failure();
+        continue;
+      case MemOp::PortKind::Read:
+        findReadUsers(port, "data");
+        continue;
+      case MemOp::PortKind::ReadWrite:
+        if (failed(findWriteUsers(port, "wdata")))
+          return failure();
+        findReadUsers(port, "rdata");
+        continue;
+      }
+      llvm_unreachable("unknown port kind");
+    }
+
+    // Perform the transformation is there are some bits missing. Unused
+    // memories are handled in a different canonicalizer.
+    if (usedBits.all() || usedBits.none())
+      return failure();
+
+    // Build a mapping of existing indices to compacted ones.
+    SmallVector<std::pair<unsigned, unsigned>> ranges;
+    unsigned newWidth = 0;
+    for (int i = usedBits.find_first(); 0 <= i && i < width;) {
+      int e = usedBits.find_next_unset(i);
+      if (e < 0)
+        e = width;
+      for (int idx = i; idx < e; ++idx, ++newWidth) {
+        if (auto it = mapping.find(idx); it != mapping.end()) {
+          it->second = newWidth;
+        }
+      }
+      ranges.emplace_back(i, e - 1);
+      i = usedBits.find_next(e);
+    }
+
+    // Create the new op with the new port types.
+    auto newType = IntType::get(op->getContext(), type.isSigned(), newWidth);
+    SmallVector<Type> portTypes;
+    for (auto [i, port] : llvm::enumerate(mem.getResults())) {
+      portTypes.push_back(
+          MemOp::getTypeForPort(mem.getDepth(), newType, mem.getPortKind(i)));
+    }
+    auto newMem = rewriter.replaceOpWithNewOp<MemOp>(
+        mem, portTypes, mem.getReadLatency(), mem.getWriteLatency(),
+        mem.getDepth(), mem.getRuw(), mem.getPortNames(), mem.getName(),
+        mem.getNameKind(), mem.getAnnotations(), mem.getPortAnnotations(),
+        mem.getInnerSymAttr(), mem.getGroupIDAttr(), mem.getInitAttr());
+
+    // Rewrite bundle users to the new data type.
+    auto rewriteSubfield = [&](Value port, StringRef field) {
+      auto portTy = port.getType().cast<BundleType>();
+      auto fieldIndex = portTy.getElementIndex(field);
+      assert(fieldIndex && "missing data port");
+
+      rewriter.setInsertionPointAfter(newMem);
+      auto newPortAccess =
+          rewriter.create<SubfieldOp>(port.getLoc(), port, field);
+
+      for (auto *op : llvm::make_early_inc_range(port.getUsers())) {
+        auto portAccess = cast<SubfieldOp>(op);
+        if (op == newPortAccess || fieldIndex != portAccess.getFieldIndex())
+          continue;
+        rewriter.replaceOp(portAccess, newPortAccess.getResult());
+      }
+    };
+
+    // Rewrite the field accesses.
+    for (auto [i, port] : llvm::enumerate(newMem.getResults())) {
+      switch (newMem.getPortKind(i)) {
+      case MemOp::PortKind::Debug:
+        llvm_unreachable("cannot rewrite debug port");
+      case MemOp::PortKind::Write:
+        rewriteSubfield(port, "data");
+        continue;
+      case MemOp::PortKind::Read:
+        rewriteSubfield(port, "data");
+        continue;
+      case MemOp::PortKind::ReadWrite:
+        rewriteSubfield(port, "rdata");
+        rewriteSubfield(port, "wdata");
+        continue;
+      }
+      llvm_unreachable("unknown port kind");
+    }
+
+    // Rewrite the reads to the new ranges, compacting them.
+    for (auto readOp : readOps) {
+      rewriter.setInsertionPointAfter(readOp);
+      auto it = mapping.find(readOp.getLo());
+      assert(it != mapping.end() && "bit op mapping not found");
+      rewriter.replaceOpWithNewOp<BitsPrimOp>(
+          readOp, readOp.getInput(),
+          readOp.getHi() - readOp.getLo() + it->second, it->second);
+    }
+
+    // Rewrite the writes into a concatenation of slices.
+    for (auto writeOp : writeOps) {
+      Value source = writeOp.getSrc();
+      rewriter.setInsertionPoint(writeOp);
+
+      Value catOfSlices;
+      for (auto &[start, end] : ranges) {
+        Value slice =
+            rewriter.create<BitsPrimOp>(writeOp.getLoc(), source, end, start);
+        if (catOfSlices) {
+          catOfSlices =
+              rewriter.create<CatPrimOp>(writeOp.getLoc(), slice, catOfSlices);
+        } else {
+          catOfSlices = slice;
+        }
+      }
+      rewriter.replaceOpWithNewOp<StrictConnectOp>(writeOp, writeOp.getDest(),
+                                                   catOfSlices);
+    }
+    return success();
+  }
+};
 } // namespace
 
 void MemOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                         MLIRContext *context) {
   results.insert<FoldZeroWidthMemory, FoldReadOrWriteOnlyMemory,
-                 FoldReadWritePorts, FoldUnusedPorts>(context);
+                 FoldReadWritePorts, FoldUnusedPorts, FoldUnusedBits>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -490,15 +490,7 @@ LogicalResult LowerMemoryPass::runOnModule(FModuleOp module, bool shouldDedup) {
           "memories should be flattened before running LowerMemory");
 
     auto summary = getSummary(op);
-
-    // The only remaining memory kind should be seq mems.
-    // 1. read latency and write latency of one.
-    // 2. only one readwrite port or write port.
-    // 3. zero or one read port.
-    // 4. undefined read-under-write behavior.
-    if (!((summary.readLatency == 1 && summary.writeLatency == 1) &&
-          (summary.numWritePorts + summary.numReadWritePorts == 1) &&
-          (summary.numReadPorts <= 1) && summary.dataWidth > 0))
+    if (!summary.isSeqMem())
       continue;
 
     lowerMemory(op, summary, shouldDedup);

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -212,3 +212,132 @@ firrtl.circuit "UnusedPorts" {
     firrtl.connect %pinned_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+firrtl.circuit "UnusedBits" {
+  firrtl.module public @UnusedBits(
+      in %clock: !firrtl.clock,
+      in %addr: !firrtl.uint<4>,
+      in %in_data: !firrtl.uint<42>,
+      in %wmode_rw: !firrtl.uint<1>,
+      out %result_read: !firrtl.uint<5>,
+      out %result_rw: !firrtl.uint<5>) {
+
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+    // CHECK: %Memory_read, %Memory_rw, %Memory_write = firrtl.mem Undefined
+    // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<10>>
+    // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<1>>
+    // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<10>, mask: uint<1>>
+    %Memory_read, %Memory_rw, %Memory_write = firrtl.mem Undefined
+      {
+        depth = 12 : i64,
+        name = "Memory",
+        portNames = ["read", "rw", "write"],
+        readLatency = 0 : i32,
+        writeLatency = 1 : i32
+      } :
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>,
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>,
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+
+    %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
+    %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %read_data_slice = firrtl.bits %read_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    firrtl.connect %result_read, %read_data_slice : !firrtl.uint<5>, !firrtl.uint<5>
+
+    // CHECK-DAG: [[RW_FIELD:%.+]] = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<1>>
+    // CHECK-DAG: [[RW_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    // CHECK-DAG: [[RW_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    // CHECK-DAG: [[RW_SLICE_JOIN:%.+]] = firrtl.cat [[RW_SLICE_HI]], [[RW_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
+    // CHECK-DAG: firrtl.strictconnect [[RW_FIELD]], [[RW_SLICE_JOIN]] : !firrtl.uint<10>
+
+    // CHECK-DAG: [[W_FIELD:%.+]] = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<10>, mask: uint<1>>
+    // CHECK-DAG: [[W_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    // CHECK-DAG: [[W_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    // CHECK-DAG: [[W_SLICE_JOIN:%.+]] = firrtl.cat [[W_SLICE_HI]], [[W_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
+    // CHECK-DAG: firrtl.strictconnect [[W_FIELD]], [[W_SLICE_JOIN]] : !firrtl.uint<10>
+
+    %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %rw_clk = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_clk, %clock : !firrtl.clock, !firrtl.clock
+    %rw_rdata = firrtl.subfield %Memory_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %rw_rdata_slice = firrtl.bits %rw_rdata 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    firrtl.connect %result_rw, %rw_rdata_slice : !firrtl.uint<5>, !firrtl.uint<5>
+    %rw_wmode = firrtl.subfield %Memory_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_wmode, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
+    %rw_wdata = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_wdata, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
+    %rw_wmask = firrtl.subfield %Memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.connect %rw_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+
+
+    %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_clk = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
+    %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_data, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
+    %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+
+firrtl.circuit "UnusedBitsAtEnd" {
+  firrtl.module public @UnusedBitsAtEnd(
+      in %clock: !firrtl.clock,
+      in %addr: !firrtl.uint<4>,
+      in %in_data: !firrtl.uint<42>,
+      out %result_read: !firrtl.uint<5>) {
+
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+    // CHECK: %Memory_read, %Memory_write = firrtl.mem Undefined
+    // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<5>>
+    // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
+    %Memory_read, %Memory_write = firrtl.mem Undefined
+      {
+        depth = 12 : i64,
+        name = "Memory",
+        portNames = ["read", "write"],
+        readLatency = 0 : i32,
+        writeLatency = 1 : i32
+      } :
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>,
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+
+    // CHECK: [[RDATA:%.+]] = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<5>>
+    // CHECK: firrtl.strictconnect %result_read, [[RDATA]] : !firrtl.uint<5>
+    %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
+    %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %read_data_slice = firrtl.bits %read_data 41 to 37 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    firrtl.connect %result_read, %read_data_slice : !firrtl.uint<5>, !firrtl.uint<5>
+
+    // CHECK: firrtl.bits %in_data 41 to 37 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+    %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_clk = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
+    %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_data, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
+    %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
After memories are flattened, subsequent passes can render certain bits of their outputs unused.

This PR introduces a canonicalizer which identifies the bits of a memory output that are used (by looking through `BitsPrimOp` oeprations). Afterwards, the memory is narrowed and write inputs are built by concatenating the chunks of the selected inputs. 