### PR TITLE
[LowerAnnotations] Allow wiring type-equivalent types.

### DIFF
--- a/test/Dialect/FIRRTL/legacy-wiring-errors.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring-errors.mlir
@@ -59,3 +59,34 @@ firrtl.circuit "Foo" attributes {
       firrtl.skip
   }
 }
+
+// -----
+// Error if attempt to wire incompatible types.
+
+firrtl.circuit "Foo" attributes {
+ rawAnnotations = [
+  {
+    class = "firrtl.passes.wiring.SourceAnnotation",
+    target = "~Foo|Bar>y",
+    pin = "xyz"
+  },
+  {
+    class = "firrtl.passes.wiring.SinkAnnotation",
+    target = "~Foo|Foo>x",
+    pin = "xyz"
+  }
+  ]} {
+  firrtl.module private @Bar() {
+    // expected-error @below {{Wiring Problem source type '!firrtl.bundle<a: uint<1>, b: uint<2>>' does not match sink type '!firrtl.uint<1>'}}
+    %y = firrtl.wire interesting_name : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %invalid_reset = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    firrtl.strictconnect %y, %invalid_reset : !firrtl.bundle<a: uint<1>, b: uint<2>>
+  }
+  firrtl.module @Foo() {
+    firrtl.instance bar interesting_name @Bar()
+    // expected-note @below {{The sink is here.}}
+    %x = firrtl.wire interesting_name : !firrtl.uint<1>
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.strictconnect %x, %invalid_ui1 : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Loosen the wiring check: types must be FIRRTL types, and either identical or type-equivalent.

Fixes #4651.