### PR TITLE
[ESI] Introduce `pure_module.input` and `pure_module.output`

### DIFF
--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -46,8 +46,8 @@ def ESIPureModuleInputOp : ESI_Op<"pure_module.input",
     this op. This op is typically created by a service implementation generator.
 
     If two 'input' ops exist in the same block, the names match, and the type
-    matches they'll become one port during lowering. If two exist with the same
-    name and different types, lowering should error. Useful for 'clk' and 'rst'.
+    matches they'll become one port during lowering. Two or more may not exist
+    with the same name and different types. Useful for 'clk' and 'rst'.
   }];
 
   let arguments = (ins StrAttr:$name);

--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -36,3 +36,37 @@ def ESIPureModuleOp : ESI_Op<"pure_module",
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
   }];
 }
+
+def ESIPureModuleInputOp : ESI_Op<"pure_module.input",
+      [HasParent<"ESIPureModuleOp">]> {
+
+  let summary = "Inputs become input ports when the module is lowered";
+  let description = [{
+    To create input ports when lowering a pure module op into an HWModuleOp, use
+    this op. This op is typically created by a service implementation generator.
+
+    If two 'input' ops exist in the same block, the names match, and the type
+    matches they'll become one port during lowering. If two exist with the same
+    name and different types, lowering should error. Useful for 'clk' and 'rst'.
+  }];
+
+  let arguments = (ins StrAttr:$name);
+  let results = (outs AnyType:$value);
+  let assemblyFormat = [{ $name attr-dict `:` type($value) }];
+}
+
+def ESIPureModuleOutputOp : ESI_Op<"pure_module.output",
+      [HasParent<"ESIPureModuleOp">]> {
+
+  let summary = "Outputs become output ports when the module is lowered";
+  let description = [{
+    To create output ports when lowering a pure module op into an HWModuleOp, use
+    this op. This op is typically created by a service implementation generator.
+
+    Two 'output' ops with the same name cannot exist in the same block.
+  }];
+
+  let arguments = (ins StrAttr:$name, AnyType:$value);
+  let results = (outs);
+  let assemblyFormat = [{ $name `,` $value attr-dict `:` type($value) }];
+}

--- a/test/Dialect/ESI/structure.mlir
+++ b/test/Dialect/ESI/structure.mlir
@@ -1,9 +1,13 @@
 // RUN: circt-opt %s  | circt-opt | FileCheck %s
 
-msft.module @Foo {} (%in0 : !esi.channel<i1>) -> (out: !esi.channel<i1>)
+msft.module @Foo {} (%clk: i1, %in0 : !esi.channel<i1>) -> (out: !esi.channel<i1>, a: i3)
 
 // CHECK-LABEL:  esi.pure_module @top {
-// CHECK-NEXT:     %foo.out = msft.instance @foo @Foo(%foo.out)  : (!esi.channel<i1>) -> !esi.channel<i1>
+// CHECK-NEXT:     [[r0:%.+]] = esi.pure_module.input "clk" : i1
+// CHECK-NEXT:     %foo.out, %foo.a = msft.instance @foo @Foo([[r0]], %foo.out)  : (i1, !esi.channel<i1>) -> (!esi.channel<i1>, i3)
+// CHECK-NEXT:     esi.pure_module.output "a", %foo.a : i3
 esi.pure_module @top {
-  %loopback = msft.instance @foo @Foo(%loopback) : (!esi.channel<i1>) -> (!esi.channel<i1>)
+  %clk = esi.pure_module.input "clk" : i1
+  %loopback, %a = msft.instance @foo @Foo(%clk, %loopback) : (i1, !esi.channel<i1>) -> (!esi.channel<i1>, i3)
+  esi.pure_module.output "a", %a : i3
 }

--- a/test/Dialect/ESI/structure_errors.mlir
+++ b/test/Dialect/ESI/structure_errors.mlir
@@ -26,3 +26,21 @@ esi.pure_module @top {
   %double = comb.add %data, %data : i1
   %loopbackDouble, %ready = esi.wrap.vr %double, %valid : i1
 }
+
+// -----
+
+esi.pure_module @top {
+  // expected-note @+1 {{}}
+  %a0 = esi.pure_module.input "a" : i1
+  // expected-error @+1 {{port 'a' previously declared as type 'i1'}}
+  %a1 = esi.pure_module.input "a" : i5
+}
+
+// -----
+
+esi.pure_module @top {
+  // expected-note @+1 {{}}
+  %a0 = esi.pure_module.input "a" : i1
+  // expected-error @+1 {{port 'a' previously declared}}
+  esi.pure_module.output "a", %a0 : i1
+}


### PR DESCRIPTION
These ops are intended to be produced by service implementation generators to translate service requests into top-level ports when lowering into an RTL level module.