### PR TITLE
[FIRRTL] Add a convention attribute to modules

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -299,6 +299,30 @@ Example:
 }
 ```
 
+### Convention
+
+| Property   | Type   | Description                             |
+| ---------- | ------ | --------------------------------------- |
+| class      | string | `circt.ConventionAnnotation`            |
+| convention | string | `scalarized`                            |
+| target     | string | Reference target                        |
+
+Specify the port convention for a module. The port convention controls how a
+module's ports are transformed, and how that module can be instantiated, in the
+output format.
+
+The options are:
+- `scalarized`: Convert aggregate ports (i.e. vector or bundles) into multiple
+  ground-typed ports.
+
+```json
+{
+  "class": "circt.ConventionAnnotation",
+  "convention": "scalarized",
+  "target": "~Foo|Bar/d:Baz"
+}
+```
+
 ### ElaborationArtefactsDirectory
 
 | Property   | Type   | Description                                              |

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -28,6 +28,7 @@ constexpr const char *rawAnnotations = "rawAnnotations";
 // Annotation Class Names
 //===----------------------------------------------------------------------===//
 
+constexpr const char *conventionAnnoClass = "circt.ConventionAnnotation";
 constexpr const char *dontTouchAnnoClass =
     "firrtl.transforms.DontTouchAnnotation";
 constexpr const char *enumComponentAnnoClass =

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -36,6 +36,8 @@ struct FIRParserOptions {
   /// This, along with numOMIRFiles provides structure to the buffers in the
   /// source manager.
   unsigned numAnnotationFiles;
+  bool scalarizeTopModule = false;
+  bool scalarizeExtModules = false;
 };
 
 mlir::OwningOpRef<mlir::ModuleOp> importFIRFile(llvm::SourceMgr &sourceMgr,

--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -34,6 +34,18 @@ def NameKindEnumImpl: I32EnumAttr<"NameKindEnum", "name kind",
 def NameKindAttr: EnumAttr<FIRRTLDialect, NameKindEnumImpl, "name_kind">;
 
 //===----------------------------------------------------------------------===//
+// Module Instantiation Conventions
+//===----------------------------------------------------------------------===//
+
+def Convention : I32EnumAttr<"Convention", "lowering convention", [
+                           I32EnumAttrCase<"Internal", 0, "internal">,
+                           I32EnumAttrCase<"Scalarized", 1, "scalarized">]> {
+  let genSpecializedAttr = 0;
+}
+
+def ConventionAttr : EnumAttr<FIRRTLDialect, Convention, "convention">;
+
+//===----------------------------------------------------------------------===//
 // Read Under Write Behaviour
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -41,6 +41,16 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     /*methodBody=*/[{ return $_op.getParameters(); }]>,
 
     //===------------------------------------------------------------------===//
+    // Instantiation Convention
+    //===------------------------------------------------------------------===//
+
+    InterfaceMethod<"Get the module's instantiation convention",
+      "ConventionAttr", "getConventionAttr">,
+
+    InterfaceMethod<"Get the module's instantiation convention",
+      "Convention", "getConvention">,
+
+    //===------------------------------------------------------------------===//
     // Port Directions
     //===------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -15,6 +15,7 @@
 
 include "FIRRTLAttributes.td"
 include "FIRRTLDialect.td"
+include "FIRRTLEnums.td"
 include "FIRRTLOpInterfaces.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
@@ -95,7 +96,8 @@ def FModuleOp : FIRRTLModuleLike<"module", [SingleBlock, NoTerminator]> {
     the module.
   }];
   let arguments =
-            (ins DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
+            (ins ConventionAttr:$convention,
+                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
 
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
@@ -104,8 +106,9 @@ def FModuleOp : FIRRTLModuleLike<"module", [SingleBlock, NoTerminator]> {
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let builders = [
-    OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
-               CArg<"ArrayAttr","ArrayAttr()">:$annotations)>
+    OpBuilder<(ins "StringAttr":$name, "ConventionAttr":$convention,
+               "ArrayRef<PortInfo>":$ports,
+               CArg<"ArrayAttr", "ArrayAttr()">:$annotations)>,
   ];
 
   let extraClassDeclaration = [{
@@ -148,6 +151,7 @@ def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
   }];
   let arguments = (ins
                    OptionalAttr<StrAttr>:$defname,
+                   ConventionAttr:$convention,
                    ParamDeclArrayAttr:$parameters,
                    DefaultValuedAttr<AnnotationArrayAttr,
                    "ArrayAttr()">:$annotations,
@@ -159,6 +163,7 @@ def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "StringAttr":$name,
+                      "ConventionAttr":$convention,
                       "ArrayRef<PortInfo>":$ports,
                       CArg<"StringRef", "StringRef()">:$defnamAttr,
                       CArg<"ArrayAttr", "ArrayAttr()">:$annotations,

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -50,8 +50,7 @@ enum PreserveMode {
 
 std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass(
     PreserveAggregate::PreserveMode mode = PreserveAggregate::None,
-    PreserveAggregate::PreserveMode memoryMode = PreserveAggregate::None,
-    bool preservePublicTypes = true);
+    PreserveAggregate::PreserveMode memoryMode = PreserveAggregate::None);
 
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -60,9 +60,6 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let options = [
     Option<"flattenAggregateMemData", "flatten-mem", "bool", "false",
            "Concat all elements of the aggregate data into a single element.">,
-    Option<"preservePublicTypes", "preserve-public-types", "bool",
-           "true", "Force to lower ports of toplevel and external modules even"
-           "when aggregate preservation mode.">,
     Option<"preserveAggregate", "preserve-aggregate", "PreserveAggregate::PreserveMode",
           "PreserveAggregate::None",
           "Specify aggregate preservation mode",

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -706,7 +706,8 @@ createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
   }
   // Create a FIRRTL module and inline the funcOp into the FIRRTL module.
   auto topModuleOp = rewriter.create<TModuleOp>(
-      funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()), ports);
+      funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()),
+      ConventionAttr::get(rewriter.getContext(), Convention::Internal), ports);
 
   if (setFlattenAttr)
     topModuleOp->setAttr(
@@ -778,7 +779,7 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
   auto ports = getPortInfoForOp(rewriter, oldOp);
   return rewriter.create<FModuleOp>(
       topModuleOp.getLoc(), rewriter.getStringAttr(getSubModuleName(oldOp)),
-      ports);
+      ConventionAttr::get(rewriter.getContext(), Convention::Internal), ports);
 }
 
 /// Extract all subfields of all ports of the sub-module.
@@ -2078,7 +2079,9 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
                    Direction::In, StringAttr{}, loc});
 
   builder.setInsertionPointToStart(circuit.getBodyBlock());
-  auto moduleOp = builder.create<FModuleOp>(strAttr(moduleName), ports);
+  auto moduleOp = builder.create<FModuleOp>(
+      strAttr(moduleName),
+      ConventionAttr::get(builder.getContext(), Convention::Internal), ports);
   builder.setInsertionPointToStart(moduleOp.getBodyBlock());
 
   // Unpack module arguments.

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -945,7 +945,7 @@ void ExtractInstancesPass::groupInstances() {
     // Create the wrapper module.
     auto wrapper = builder.create<FModuleOp>(
         builder.getUnknownLoc(), builder.getStringAttr(dutPrefix + wrapperName),
-        ports);
+        ConventionAttr::get(builder.getContext(), Convention::Internal), ports);
     SymbolTable::setSymbolVisibility(wrapper, SymbolTable::Visibility::Private);
 
     // Instantiate the wrapper module in the parent and replace uses of the

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -170,7 +170,8 @@ void InjectDUTHierarchy::runOnOperation() {
   {
     b.setInsertionPointAfter(dut);
     auto newDUT = b.create<FModuleOp>(dut.getLoc(), dut.getNameAttr(),
-                                      dut.getPorts(), dut.getAnnotations());
+                                      dut.getConventionAttr(), dut.getPorts(),
+                                      dut.getAnnotations());
 
     SymbolTable::setSymbolVisibility(newDUT, dut.getVisibility());
     dut.setName(b.getStringAttr(circuitNS.newName(wrapperName.getValue())));

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -222,7 +222,9 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
 
   // Create the wrapper module, inserting it into the bottom of the circuit.
   auto b = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
-  auto wrapper = b.create<FModuleOp>(mem->getLoc(), wrapperName, ports);
+  auto wrapper = b.create<FModuleOp>(
+      mem->getLoc(), wrapperName,
+      ConventionAttr::get(context, Convention::Internal), ports);
   SymbolTable::setSymbolVisibility(wrapper, SymbolTable::Visibility::Private);
 
   // Create an instance of the external memory module. The instance has the

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -730,6 +730,15 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 
 // -----
 
+firrtl.circuit "Test" attributes {rawAnnotations =[
+  {class = "circt.ConventionAnnotation", target = "~Test|Test", convention = "scalarized"}
+  ]} {
+  // CHECK: attributes {convention = #firrtl<convention scalarized>}
+  firrtl.module @Test() attributes {convention = #firrtl<convention internal>} {}
+}
+
+// -----
+
 // DontTouchAnnotations are placed on the things they target.
 
 firrtl.circuit "Foo"  attributes {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -89,7 +89,8 @@ firrtl.module @foo(in %a: !firrtl.uint<1> ["hello"]) {}
 firrtl.circuit "foo" {
 // expected-error @+1 {{requires one region}}
 "firrtl.module"() ( { }, { })
-   {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
+   {sym_name = "foo", convention = #firrtl<convention internal>,
+    portTypes = [!firrtl.uint], portDirections = 1 : i1,
     portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
@@ -99,7 +100,8 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{requires valid port locations}}
 "firrtl.module"() ( {
   ^entry:
-}) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
+}) { sym_name = "foo", convention = #firrtl<convention internal>,
+    portTypes = [!firrtl.uint], portDirections = 1 : i1,
     portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
@@ -109,7 +111,8 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{requires 1 port locations}}
 "firrtl.module"() ( {
   ^entry:
-}) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
+}) {sym_name = "foo", convention = #firrtl<convention internal>,
+    portTypes = [!firrtl.uint], portDirections = 1 : i1,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = []} : () -> ()
 }
@@ -123,7 +126,8 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{entry block must have 1 arguments to match module signature}}
 "firrtl.module"() ( {
   ^entry:
-}) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
+}) {sym_name = "foo", convention = #firrtl<convention internal>,
+    portTypes = [!firrtl.uint], portDirections = 1 : i1,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = [loc("loc")]} : () -> ()
 }
@@ -134,7 +138,8 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{block argument types should match signature types}}
 "firrtl.module"() ( {
   ^entry(%a: i1):
-}) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
+}) {sym_name = "foo", convention = #firrtl<convention internal>,
+    portTypes = [!firrtl.uint], portDirections = 1 : i1,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = [loc("foo")]} : () -> ()
 }

--- a/test/Dialect/FIRRTL/lower-types-aggregate.mlir
+++ b/test/Dialect/FIRRTL/lower-types-aggregate.mlir
@@ -1,29 +1,62 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all}))' %s | FileCheck %s
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all preserve-public-types=false}))' %s | FileCheck --check-prefix=NOT_PRESERVE_PUBLIC_TYPES %s
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=vec}))' %s | FileCheck --check-prefix=VEC %s
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=1d-vec}))' %s | FileCheck --check-prefix=1D_VEC %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=all}))' %s    | FileCheck --check-prefix=PRESERVE_ALL %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=vec}))' %s    | FileCheck --check-prefix=PRESERVE_VEC %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=1d-vec}))' %s | FileCheck --check-prefix=PRESERVE_1D_VEC %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=none}))' %s   | FileCheck --check-prefix=PRESERVE_NONE %s
 
 firrtl.circuit "TopLevel" {
-  // CHECK-LABEL: firrtl.extmodule @External(in source_valid: !firrtl.uint<1>)
-  // CHECK-LABEL: firrtl.module @TopLevel(in %source_valid: !firrtl.uint<1>, out %sink_valid: !firrtl.uint<1>)
-  // NOT_PRESERVE_PUBLIC_TYPES-LABEL: firrtl.extmodule @External(in source_valid: !firrtl.uint<1>)
-  // NOT_PRESERVE_PUBLIC_TYPES-LABEL: firrtl.module @TopLevel(in %source: !firrtl.bundle<valid: uint<1>>, out %sink: !firrtl.bundle<valid: uint<1>>)
-  firrtl.extmodule @External(in source: !firrtl.bundle<valid: uint<1>>)
-  firrtl.module @TopLevel(in %source: !firrtl.bundle<valid: uint<1>>,
-                          out %sink: !firrtl.bundle<valid: uint<1>>) {
-  }
-  // CHECK: @Foo(in %a: !firrtl.bundle<a: vector<vector<uint<1>, 2>, 2>>)
-  // VEC: @Foo(in %a_a: !firrtl.vector<vector<uint<1>, 2>, 2>)
-  // 1D_VEC: @Foo(in %a_a_0: !firrtl.vector<uint<1>, 2>, in %a_a_1: !firrtl.vector<uint<1>, 2>)
-  firrtl.module private @Foo(in %a: !firrtl.bundle<a: vector<vector<uint<1>, 2>, 2>>) {
-  }
-  // 1D_VEC: %a_0: !firrtl.uint<1>
-  firrtl.module private @Bar(in %a: !firrtl.vector<uint<1>, 1>) {
-  }
-  // CHECK-LABEL: PublicModule
-  // CHECK-NOT: firrtl.bundle
-  // NOT_PRESERVE_PUBLIC_TYPES-LABEL: PublicModule
-  // NOT_PRESERVE_PUBLIC_TYPES: firrtl.bundle
-  firrtl.module public @PublicModule(in %source: !firrtl.bundle<valid: uint<1>>) {
-  }
+  firrtl.module @TopLevel() {}
+
+  // * A module using the internal convention will have its ports lowered
+  //   according to the preservation mode.
+
+  // * A module using the scalarized convention will always have it's ports
+  //   fully scalarized, regardless of the preservation mode.
+
+  // 1D Vector Ports
+
+  // PRESERVE_ALL:    @InternalModule1(in %port: !firrtl.vector<uint<8>, 2>)
+  // PRESERVE_VEC:    @InternalModule1(in %port: !firrtl.vector<uint<8>, 2>)
+  // PRESERVE_1D_VEC: @InternalModule1(in %port: !firrtl.vector<uint<8>, 2>)
+  // PRESERVE_NONE:   @InternalModule1(in %port_0: !firrtl.uint<8>, in %port_1: !firrtl.uint<8>)
+  firrtl.module @InternalModule1(in %port: !firrtl.vector<uint<8>, 2>)
+    attributes {convention = #firrtl<convention internal>} {}
+
+  // PRESERVE_ALL:    @ScalarizedModule1(in %port_0: !firrtl.uint<8>, in %port_1: !firrtl.uint<8>)
+  // PRESERVE_VEC:    @ScalarizedModule1(in %port_0: !firrtl.uint<8>, in %port_1: !firrtl.uint<8>)
+  // PRESERVE_1D_VEC: @ScalarizedModule1(in %port_0: !firrtl.uint<8>, in %port_1: !firrtl.uint<8>)
+  // PRESERVE_NONE:   @ScalarizedModule1(in %port_0: !firrtl.uint<8>, in %port_1: !firrtl.uint<8>)
+  firrtl.module @ScalarizedModule1(in %port: !firrtl.vector<uint<8>, 2>)
+    attributes {convention = #firrtl<convention scalarized>} {}
+  
+  // 2D Vector Ports
+
+  // PRESERVE_ALL:    @InternalModule2(in %port: !firrtl.vector<vector<uint<8>, 2>, 2>)
+  // PRESERVE_VEC:    @InternalModule2(in %port: !firrtl.vector<vector<uint<8>, 2>, 2>)
+  // PRESERVE_1D_VEC: @InternalModule2(in %port_0: !firrtl.vector<uint<8>, 2>, in %port_1: !firrtl.vector<uint<8>, 2>)
+  // PRESERVE_NONE:   @InternalModule2(in %port_0_0: !firrtl.uint<8>, in %port_0_1: !firrtl.uint<8>, in %port_1_0: !firrtl.uint<8>, in %port_1_1: !firrtl.uint<8>)
+  firrtl.module @InternalModule2(in %port: !firrtl.vector<vector<uint<8>, 2>, 2>)
+    attributes {convention = #firrtl<convention internal>} {}
+  
+  // PRESERVE_ALL:    ScalarizedModule2(in %port_0_0: !firrtl.uint<8>, in %port_0_1: !firrtl.uint<8>, in %port_1_0: !firrtl.uint<8>, in %port_1_1: !firrtl.uint<8>)
+  // PRESERVE_VEC:    ScalarizedModule2(in %port_0_0: !firrtl.uint<8>, in %port_0_1: !firrtl.uint<8>, in %port_1_0: !firrtl.uint<8>, in %port_1_1: !firrtl.uint<8>)
+  // PRESERVE_1D_VEC: ScalarizedModule2(in %port_0_0: !firrtl.uint<8>, in %port_0_1: !firrtl.uint<8>, in %port_1_0: !firrtl.uint<8>, in %port_1_1: !firrtl.uint<8>)
+  // PRESERVE_NONE:   ScalarizedModule2(in %port_0_0: !firrtl.uint<8>, in %port_0_1: !firrtl.uint<8>, in %port_1_0: !firrtl.uint<8>, in %port_1_1: !firrtl.uint<8>)
+  firrtl.module @ScalarizedModule2(in %port: !firrtl.vector<vector<uint<8>, 2>, 2>)
+    attributes {convention = #firrtl<convention scalarized>} {}
+
+  // Bundle Ports
+      
+  // PRESERVE_ALL:    @InternalModule3(in %port: !firrtl.bundle<field: uint<1>>)
+  // PRESERVE_VEC:    @InternalModule3(in %port_field: !firrtl.uint<1>)
+  // PRESERVE_1D_VEC: @InternalModule3(in %port_field: !firrtl.uint<1>)
+  // PRESERVE_NONE:   @InternalModule3(in %port_field: !firrtl.uint<1>)
+  firrtl.module @InternalModule3(in %port: !firrtl.bundle<field: uint<1>>)
+    attributes {convention = #firrtl<convention internal>} {}
+  
+  // PRESERVE_ALL:    @ScalarizedModule3(in %port_field: !firrtl.uint<1>)
+  // PRESERVE_VEC:    @ScalarizedModule3(in %port_field: !firrtl.uint<1>)
+  // PRESERVE_1D_VEC: @ScalarizedModule3(in %port_field: !firrtl.uint<1>)
+  // PRESERVE_NONE:   @ScalarizedModule3(in %port_field: !firrtl.uint<1>)
+  firrtl.module @ScalarizedModule3(in %port: !firrtl.bundle<field: uint<1>>)
+    attributes {convention = #firrtl<convention scalarized>} {}
 }

--- a/test/firtool/convention.fir
+++ b/test/firtool/convention.fir
@@ -1,0 +1,32 @@
+; RUN: firtool %s --format=fir --parse-only --scalarize-top-module=false --scalarize-ext-modules=false --preserve-aggregate=all | FileCheck --check-prefix=SCALARIZE_NONE %s
+; RUN: firtool %s --format=fir --parse-only --scalarize-top-module=true  --scalarize-ext-modules=false --preserve-aggregate=all | FileCheck --check-prefix=SCALARIZE_TOP  %s
+; RUN: firtool %s --format=fir --parse-only --scalarize-top-module=false --scalarize-ext-modules=true  --preserve-aggregate=all | FileCheck --check-prefix=SCALARIZE_EXT  %s
+; RUN: firtool %s --format=fir --parse-only --scalarize-top-module=true  --scalarize-ext-modules=true  --preserve-aggregate=all | FileCheck --check-prefix=SCALARIZE_BOTH %s
+
+; Ensure that top module and ext modules are marked scalarized.
+
+circuit Top :
+  ; SCALARIZE_NONE-NOT: attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_TOP:      attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_EXT-NOT:  attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_BOTH:     attributes {convention = #firrtl<convention scalarized>}
+  module Top :
+    output port: UInt<8>[2]
+    port[0] <= UInt<8>(0)
+    port[1] <= UInt<8>(0)
+  
+  ; SCALARIZE_NONE-NOT: attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_TOP-NOT:  attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_EXT:      attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_BOTH:     attributes {convention = #firrtl<convention scalarized>}
+  extmodule External :
+    output port: UInt<8>[2]
+
+  ; SCALARIZE_NONE-NOT: attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_TOP-NOT:  attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_EXT-NOT:  attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_BOTH-NOT: attributes {convention = #firrtl<convention scalarized>}
+  module Internal :
+    output port: UInt<8>[2]
+    port[0] <= UInt<8>(0)
+    port[1] <= UInt<8>(0)

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -241,7 +241,8 @@ struct ModuleExternalizer : public Reduction {
     builder.create<firrtl::FExtModuleOp>(
         module->getLoc(),
         module->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()),
-        module.getPorts(), StringRef(), module.getAnnotationsAttr());
+        module.getConventionAttr(), module.getPorts(), StringRef(),
+        module.getAnnotationsAttr());
     module->erase();
     return success();
   }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -174,11 +174,6 @@ static cl::opt<circt::firrtl::PreserveAggregate::PreserveMode>
         cl::init(circt::firrtl::PreserveAggregate::None),
         cl::cat(mainCategory));
 
-static cl::opt<bool> preservePublicTypes(
-    "preserve-public-types",
-    cl::desc("Force to lower ports of toplevel and external modules"),
-    cl::init(true), cl::cat(mainCategory));
-
 static cl::opt<firrtl::PreserveValues::PreserveMode>
     preserveMode("preserve-values",
                  cl::desc("Specify the values which can be optimized away"),
@@ -290,6 +285,16 @@ static cl::opt<RandomKind> disableRandom(
                clEnumValN(RandomKind::All, "disable-all-randomization",
                           "Disable emission of all randomization code")),
     cl::init(RandomKind::None), cl::cat(mainCategory));
+
+static cl::opt<bool>
+    scalarizeTopModule("scalarize-top-module",
+                       cl::desc("Scalarize the ports of the top module"),
+                       cl::init(true), cl::cat(mainCategory));
+
+static cl::opt<bool>
+    scalarizeExtModules("scalarize-ext-modules",
+                        cl::desc("Scalarize the ports of any external modules"),
+                        cl::init(true), cl::cat(mainCategory));
 
 static bool isRandomEnabled(RandomKind kind) {
   return disableRandom != RandomKind::All && disableRandom != kind;
@@ -475,6 +480,8 @@ static LogicalResult processBuffer(
     firrtl::FIRParserOptions options;
     options.ignoreInfoLocators = ignoreFIRLocations;
     options.numAnnotationFiles = numAnnotationFiles;
+    options.scalarizeTopModule = scalarizeTopModule;
+    options.scalarizeExtModules = scalarizeExtModules;
     module = importFIRFile(sourceMgr, &context, parserTimer, options);
   } else {
     auto parserTimer = ts.nest("MLIR Parser");
@@ -554,10 +561,8 @@ static LogicalResult processBuffer(
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 
   if (vbToBV) {
-    if (preservePublicTypes)
-      pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
-          firrtl::PreserveAggregate::All, firrtl::PreserveAggregate::All,
-          preservePublicTypes));
+    pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
+        firrtl::PreserveAggregate::All, firrtl::PreserveAggregate::All));
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createVBToBVPass());
   }
 
@@ -568,8 +573,7 @@ static LogicalResult processBuffer(
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
-      preserveAggregate, firrtl::PreserveAggregate::None, preservePublicTypes));
-  //
+      preserveAggregate, firrtl::PreserveAggregate::None));
   // Only enable expand whens if lower types is also enabled.
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
   modulePM.addPass(firrtl::createExpandWhensPass());

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -242,8 +242,7 @@ static void loadFIRRTLLoweringPipeline(OpPassManager &pm) {
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
       /*preserveAggregate=*/firrtl::PreserveAggregate::PreserveMode::None,
-      /*preserveMemories=*/firrtl::PreserveAggregate::PreserveMode::None,
-      /*preservePublicTypes=*/false));
+      /*preserveMemories=*/firrtl::PreserveAggregate::PreserveMode::None));
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
   modulePM.addPass(firrtl::createExpandWhensPass());
   // a bit of cleanup.


### PR DESCRIPTION
The convention attribute give us module-by-module control over how a module's ports should be lowered. When a module uses the "scalarized" convention, its ports are guaranteed be fully scalarized in the output verilog. When a module uses the "internal" convention, then it's ports will be lowered according to the configured aggregate preservation mode.

A module's convention is internal by default, but can be set using a new annotation, or through the firtool command line options `--scalarize-top-module` and `--scalarize-ext-modules`.

Enabling both `--scalarize-top-module` and `--scalarize-ext-modules` together (which is the default) should be a drop-in replacement of the older `--preserve-public-types` option, which has been removed.


## Changes
- FIRRTL Dialect
  - add new `convention` attribute to `FModuleLike` objects. This property is either `scalarized` or `internal`.
  - The convention controls how a module's ports are lowered by `LowerTypesPass`.
  - `FModule` and `FExtModule` have new builders that let you pass a convention through. Otherwise, they default to `internal` convention.
  - `FMemModule` always uses the `internal` convention, for now.
  - In the printed format, the convention is printed in the attribute-dict, but only if it's set to `scalarized`.
- lowerTypes
  - when a module has the `scalarized` convention, the pass _must_ scalarize it's ports, regardless of the aggregate preservation mode.
  - when a module has the `internal` convention, the pass lowers ports based on the configured aggregate preservation mode.
  - The `preservePublicTypes` option is removed.
- Firtool
  - remove preserve-public-types option
   - add two new options, `--scalarize-top-module` and `--scalarize-ext-modules`.
   - both default to *on*.
   - when `--scalarize-top-module` is enabled, FIRParser will mark the main module with the `scalarized` convention. Otherwise, the top module will use the `internal` convention.
   - when `--scalarize-ext-modules` is enabled, FIRParser will mark any ext modules with the `scalarized` convention.
   - An external top module will be scalarized if either option is enabled.
- Annotations:
  - add a new annotation called `firrtl.module.Convention` (please suggest a better name!)
  - allows the convention to be specified through annotations.
  - conventions applied in lowerAnnotations.
  - Because annotations are applied later in the pipeline, annotations takes precedence over any scalarization option passed to firrtool.