### PR TITLE
[HW] Add a canonicalization to swap constant index and unknown index of array gets

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2681,9 +2681,9 @@ LogicalResult ArrayGetOp::canonicalize(ArrayGetOp op,
     return failure();
   }
 
-  // array_get(const, array_get sel, (array_create a, b, c, d)) -->
-  // array_get sel, (array_create (array_get const a), (array_get const b),
-  // (array_get const c), (array_get c d))
+  // array_get const, (array_get sel, (array_create a, b, c, d)) -->
+  //   array_get sel, (array_create (array_get const a), (array_get const b),
+  //   (array_get const, c), (array_get const, d))
   if (auto innerGet = dyn_cast_or_null<hw::ArrayGetOp>(inputOp)) {
     if (!innerGet.getIndex().getDefiningOp<hw::ConstantOp>()) {
       if (auto create =

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1678,3 +1678,20 @@ hw.module @ConcatOfSlicesAndGets(%a: !hw.array<5xi1>, %b: !hw.array<5xi1>, %c: !
 
   hw.output %result : !hw.array<13xi1>
 }
+
+// CHECK-LABEL: SwapConstantIndex
+hw.module @SwapConstantIndex(%a_0: !hw.array<4xi1>, %a_1: !hw.array<4xi1>, %a_2: !hw.array<4xi1>, %a_3: !hw.array<4xi1>, %sel: i2) -> (b: i1) {
+  %c0_i2 = hw.constant 0 : i2
+  %0 = hw.array_create %a_3, %a_2, %a_1, %a_0 : !hw.array<4xi1>
+  %1 = hw.array_get %0[%sel] : !hw.array<4xarray<4xi1>>, i2
+  %2 = hw.array_get %1[%c0_i2] : !hw.array<4xi1>, i2
+  hw.output %2 : i1
+  // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2
+  // CHECK-NEXT: %0 = hw.array_get %a_3[%c0_i2] : !hw.array<4xi1>, i2
+  // CHECK-NEXT: %1 = hw.array_get %a_2[%c0_i2] : !hw.array<4xi1>, i2
+  // CHECK-NEXT: %2 = hw.array_get %a_1[%c0_i2] : !hw.array<4xi1>, i2
+  // CHECK-NEXT: %3 = hw.array_get %a_0[%c0_i2] : !hw.array<4xi1>, i2
+  // CHECK-NEXT: %4 = hw.array_create %0, %1, %2, %3 : i1
+  // CHECK-NEXT: %5 = hw.array_get %4[%sel] : !hw.array<4xi1>, i2
+  // CHECK-NEXT: hw.output %5 : i1
+}


### PR DESCRIPTION
This implements canonicalizer to sink constant index to inner array create. 

```
array_get(const, array_get sel, (array_create a, b, c, d)) --> 
array_get sel, (array_create (array_get const a), (array_get const b), (array_get const c), (array_get c d))
```

Though this might increase the size of IR we can reduce the size of a temporary created by array create op.