### PR TITLE
[FIRRTL] Options for using both @info and .fir, attach .fir as notes.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -29,9 +29,19 @@ namespace circt {
 namespace firrtl {
 
 struct FIRParserOptions {
-  /// If this is set to true, the @info locators are ignored, and the locations
-  /// are set to the location in the .fir file.
-  bool ignoreInfoLocators = false;
+  /// Specify how @info locators should be handled.
+  enum class InfoLocHandling {
+    /// If this is set to true, the @info locators are ignored, and the
+    /// locations are set to the location in the .fir file.
+    IgnoreInfo,
+    /// Prefer @info locators, fallback to .fir locations.
+    PreferInfo,
+    /// Attach both @info locators (when present) and .fir locations.
+    FusedInfo
+  };
+
+  InfoLocHandling infoLocatorHandling = InfoLocHandling::PreferInfo;
+
   /// The number of annotation files that were specified on the command line.
   /// This, along with numOMIRFiles provides structure to the buffers in the
   /// source manager.

--- a/test/firtool/locators-diagnostics.fir
+++ b/test/firtool/locators-diagnostics.fir
@@ -1,0 +1,33 @@
+; RUN: firtool %s -parse-only -mlir-print-debuginfo --mlir-print-local-scope | FileCheck %s --check-prefixes=COMMON,PREFER
+; RUN: firtool %s -parse-only -mlir-print-debuginfo --mlir-print-local-scope -fuse-info-locators | FileCheck %s --check-prefixes=COMMON,FUSE
+; RUN: firtool %s -parse-only -mlir-print-debuginfo --mlir-print-local-scope -prefer-info-locators | FileCheck %s --check-prefixes=COMMON,PREFER
+; RUN: firtool %s -parse-only -mlir-print-debuginfo --mlir-print-local-scope -ignore-info-locators | FileCheck %s --check-prefixes=COMMON,IGNORE
+
+; RUN: not firtool %s -fuse-info-locators 2>&1 | FileCheck %s --check-prefixes=DIAG
+; DIAG: path/to/Foo.scala:273:69: error:
+; DIAG: locators-diagnostics.fir:20:5: note: FIRRTL location here
+; DIAG: locators-diagnostics.fir:23:5: error:
+; DIAG-NOT: note
+circuit Error:
+  module Error:
+    output xa: UInt<1>
+    output ya: UInt<1>
+
+    ; COMMON: %x = firrtl.wire
+    ; FUSE-SAME: loc(fused["path/to/Foo.scala":273:69, "{{.+}}.fir":20:5])
+    ; PREFER-SAME: loc("path/to/Foo.scala":273:69)
+    ; IGNORE-SAME: loc("{{.+}}.fir":20:5)
+    wire x : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} @[path/to/Foo.scala 273:69]
+    ; COMMON: %y = firrtl.wire
+    ; COMMON-SAME: loc("{{.+}}.fir":23:5)
+    wire y : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} ; (no locator)
+
+    ; invalidate all but .boop.foo.a
+    x.boop.bar is invalid
+    x.boop.foo.b is invalid
+    y.boop.bar is invalid
+    y.boop.foo.b is invalid
+
+    ; Connects
+    xa <= x.boop.foo.a
+    ya <= y.boop.foo.a

--- a/test/firtool/locators-diagnostics.fir
+++ b/test/firtool/locators-diagnostics.fir
@@ -5,7 +5,7 @@
 
 ; RUN: not firtool %s -fuse-info-locators 2>&1 | FileCheck %s --check-prefixes=DIAG
 ; DIAG: path/to/Foo.scala:273:69: error:
-; DIAG: locators-diagnostics.fir:20:5: note: FIRRTL location here
+; DIAG: locators-diagnostics.fir:20:5: note: additional location here
 ; DIAG: locators-diagnostics.fir:23:5: error:
 ; DIAG-NOT: note
 circuit Error:

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -445,15 +445,16 @@ static LogicalResult processBuffer(
   return success();
 }
 
-class AllLocsAsNotesDiagnosticHandler : public ScopedDiagnosticHandler {
+class FileLineColLocsAsNotesDiagnosticHandler : public ScopedDiagnosticHandler {
 public:
-  AllLocsAsNotesDiagnosticHandler(MLIRContext *ctxt)
+  FileLineColLocsAsNotesDiagnosticHandler(MLIRContext *ctxt)
       : ScopedDiagnosticHandler(ctxt) {
     setHandler([](Diagnostic &d) {
       SmallPtrSet<Location, 8> locs;
-      // Recursively scan for locations.
+      // Recursively scan for FileLineColLoc locations.
       d.getLocation().operator LocationAttr().walk([&](Location loc) {
-        locs.insert(loc);
+        if (isa<FileLineColLoc>(loc))
+          locs.insert(loc);
         return WalkResult::advance();
       });
 
@@ -481,7 +482,7 @@ static LogicalResult processInputSplit(
   if (!verifyDiagnostics) {
     SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr,
                                                 &context /*, shouldShow */);
-    AllLocsAsNotesDiagnosticHandler addLocs(&context);
+    FileLineColLocsAsNotesDiagnosticHandler addLocs(&context);
     return processBuffer(context, ts, sourceMgr, outputFile);
   }
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -119,10 +119,18 @@ static cl::opt<bool> lowerAnnotationsNoRefTypePorts(
              "wiring problems inside the LowerAnnotations pass"),
     cl::init(false), cl::Hidden, cl::cat(mainCategory));
 
-static cl::opt<bool>
-    ignoreFIRLocations("ignore-fir-locators",
-                       cl::desc("Ignore the @info locations in the .fir file"),
-                       cl::init(false), cl::cat(mainCategory));
+using InfoLocHandling = firrtl::FIRParserOptions::InfoLocHandling;
+static cl::opt<InfoLocHandling> infoLocHandling(
+    cl::desc("Location tracking:"),
+    cl::values(
+        clEnumValN(InfoLocHandling::IgnoreInfo, "ignore-info-locators",
+                   "Ignore the @info locations in the .fir file"),
+        clEnumValN(InfoLocHandling::FusedInfo, "fuse-info-locators",
+                   "@info locations are fused with .fir locations"),
+        clEnumValN(
+            InfoLocHandling::PreferInfo, "prefer-info-locators",
+            "Use @info locations when present, fallback to .fir locations")),
+    cl::init(InfoLocHandling::PreferInfo), cl::cat(mainCategory));
 
 static cl::opt<bool> exportModuleHierarchy(
     "export-module-hierarchy",
@@ -279,7 +287,7 @@ static LogicalResult processBuffer(
   if (inputFormat == InputFIRFile) {
     auto parserTimer = ts.nest("FIR Parser");
     firrtl::FIRParserOptions options;
-    options.ignoreInfoLocators = ignoreFIRLocations;
+    options.infoLocatorHandling = infoLocHandling;
     options.numAnnotationFiles = numAnnotationFiles;
     options.scalarizeTopModule = scalarizeTopModule;
     options.scalarizeExtModules = scalarizeExtModules;
@@ -437,6 +445,32 @@ static LogicalResult processBuffer(
   return success();
 }
 
+bool isFirLoc(Location loc) {
+  if (auto f = dyn_cast<FileLineColLoc>(loc))
+    return f.getFilename().strref().endswith(".fir");
+  return false;
+}
+
+class FIRDiagnosticHandler : public ScopedDiagnosticHandler {
+public:
+  FIRDiagnosticHandler(MLIRContext *ctxt) : ScopedDiagnosticHandler(ctxt) {
+    setHandler([](Diagnostic &d) {
+      SmallPtrSet<Location, 8> firLocs;
+      d.getLocation().operator LocationAttr().walk([&](Location loc) {
+        if (isFirLoc(loc))
+          firLocs.insert(loc);
+        return WalkResult::advance();
+      });
+
+      assert(!firLocs.contains(d.getLocation()) || hasSingleElement(firLocs));
+      if (!firLocs.contains(d.getLocation()))
+        for (auto l : firLocs)
+          d.attachNote(l) << "FIRRTL location here";
+      return failure();
+    });
+  }
+};
+
 /// Process a single split of the input. This allocates a source manager and
 /// creates a regular or verifying diagnostic handler, depending on whether the
 /// user set the verifyDiagnostics option.
@@ -448,7 +482,9 @@ static LogicalResult processInputSplit(
   sourceMgr.AddNewSourceBuffer(std::move(buffer), llvm::SMLoc());
   sourceMgr.setIncludeDirs(includeDirs);
   if (!verifyDiagnostics) {
-    SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
+    SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr,
+                                                &context /*, shouldShow */);
+    FIRDiagnosticHandler addFIR(&context);
     return processBuffer(context, ts, sourceMgr, outputFile);
   }
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -460,6 +460,8 @@ public:
 
       // Drop top-level location the diagnostic is reported on.
       locs.erase(d.getLocation());
+      // As well as the location the SourceMgrDiagnosticHandler will use.
+      locs.erase(d.getLocation()->findInstanceOf<FileLineColLoc>());
 
       // Attach additional locations as notes on the diagnostic.
       for (auto l : locs)


### PR DESCRIPTION
Exploring optionally including input file locators as well as `@info` locators, here's a POC.  WDYT?

Inject a quick-n-dirty diagnostic handler that finds ".fir" locators and attaches each to in-flight diagnostic as notes before passing on to normal handler (`SourceMgrDiagnosticHandler` variant).
(EDIT: Updated to just attach all file-line-col locations as notes)

Add option to firtool (and FIRParser) to control handling of info locators, with option of attaching a fused location with the info and source file locations.

------

## Demo

### Test file

```firrtl
circuit Error:
  module Error:
    output xa: UInt<1>
    output ya: UInt<1>

    wire x : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} @[path/to/Foo.scala 273:69]
    wire y : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} ; (no locator)

    ; invalidate all but .boop.foo.a
    x.boop.bar is invalid
    x.boop.foo.b is invalid
    y.boop.bar is invalid
    y.boop.foo.b is invalid

    ; Connects
    xa <= x.boop.foo.a
    ya <= y.boop.foo.a
```

### Output

Using each of the new info locator handling options (with `--mlir-print-op-on-diagnostic=false` for neatness),
each produces two errors about initialization-- one for `x` that has an "info" locator in the file, and the other for `y`  which does not.

#### Default (`--prefer-info-locators`):
```
path/to/Foo.scala:273:69: error: sink "x_boop_foo_a" not fully initialized in module "Error"
error.fir:7:5: error: sink "y_boop_foo_a" not fully initialized in module "Error"
    wire y : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} ; (no locator)
    ^
```

#### Ignore (`--ignore-info-locators`) (currently `--ignore-fir-locators`):
```
error.fir:6:5: error: sink "x_boop_foo_a" not fully initialized in module "Error"
    wire x : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} @[path/to/Foo.scala 273:69]
    ^
error.fir:7:5: error: sink "y_boop_foo_a" not fully initialized in module "Error"
    wire y : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} ; (no locator)
    ^
```

#### Fuse (`--fuse-info-locators`):
```
path/to/Foo.scala:273:69: error: sink "x_boop_foo_a" not fully initialized in module "Error"
error.fir:6:5: note: FIRRTL location here
    wire x : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} @[path/to/Foo.scala 273:69]
    ^
error.fir:7:5: error: sink "y_boop_foo_a" not fully initialized in module "Error"
    wire y : { boop: { foo: { a: UInt<1>, b: UInt<2>}, bar: { a: UInt<1> }}} ; (no locator)
    ^
```

---

:thinking: would be neat if the FIR locator pointed to the field in question (that isn't fully initialized), but that's a lot more tracking than we presently do :smile: .

IIRC there was previously discussion about introducing our own Location type(s) (or otherwise tagging the locations with something, e.g., metadata), don't remember why we don't-- might help instead of looking for ".fir" suffix (as done here and elsewhere in the codebase)?  Anyway, LMK if you know about that or what that is/isn't a good idea :+1: .