### PR TITLE
[LowerAnnotations] Make DUT module public

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -294,6 +294,7 @@ static LogicalResult applyDUTAnno(const AnnoPathValue &target,
 
   auto moduleOp = cast<FModuleOp>(op);
 
+  // DUT has public visibility.
   moduleOp.setPublic();
   SmallVector<NamedAttribute> newAnnoAttrs;
   for (auto &na : anno)

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1826,3 +1826,26 @@ firrtl.circuit "MemoryInitializationAnnotations" attributes {
     %m6 = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: firrtl.circuit "Top"
+firrtl.circuit "Top" attributes {
+  rawAnnotations = [
+    {
+      class = "sifive.enterprise.firrtl.MarkDUTAnnotation",
+      target = "~Top|DUT"
+    }]
+  } {
+  // CHECK-LABEL: firrtl.module
+  // CHECK-NOT:     private
+  // CHECK-SAME:     @DUT()
+  // CHECK-SAME:    class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+  firrtl.module private @DUT() {}
+
+  // CHECK-LABEL:      firrtl.module @Top
+  // CHECK-NEXT:   firrtl.instance dut @DUT
+  firrtl.module @Top() {
+    firrtl.instance dut @DUT()
+  }
+}


### PR DESCRIPTION
This changes LowerAnnotations to make the module visility public. DUT interface is intended to be exposed to users/costomers and its ports are dontTouched so it's reasonable to mark the module public