### PR TITLE
[LowerToHW] Handle port dontTouch, add inner sym.

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -120,7 +120,15 @@ firrtl.circuit "Foo" attributes {annotations = [
 // -----
 
 firrtl.circuit "SymArgZero" {
-  // expected-error @+1 {{zero width port "foo" is referenced by name [#hw<innerSym@symfoo>] (e.g. in an XMR).}}
+  // expected-error @+1 {{zero width port "foo" is referenced by name [#hw<innerSym@symfoo>] (e.g. in an XMR) but must be removed}}
   firrtl.module @SymArgZero(in %foo :!firrtl.uint<0> sym @symfoo) {
+  }
+}
+
+// -----
+
+firrtl.circuit "DTArgZero" {
+  // expected-error @below {{zero width port "foo" has dontTouch annotation but must be removed}}
+  firrtl.module @DTArgZero(in %foo :!firrtl.uint<0> [{class = "firrtl.transforms.DontTouchAnnotation"}]) {
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -268,4 +268,14 @@ firrtl.circuit "Simple" {
   // The following operations should be passed through without an error.
   // CHECK: sv.interface @SVInterface
   sv.interface @SVInterface { }
+
+  // DontTouch on ports becomes symbol.
+  // CHECK-LABEL: hw.module.extern private @PortDT
+  // CHECK-SAME: (%a: i1 {hw.exportPort = #hw<innerSym@__PortDT__a>}, %hassym: i1 {hw.exportPort = #hw<innerSym@hassym>})
+  // CHECK-SAME: -> (b: i2 {hw.exportPort = #hw<innerSym@__PortDT__b>})
+  firrtl.extmodule private @PortDT(
+    in a: !firrtl.uint<1> [{class = "firrtl.transforms.DontTouchAnnotation"}],
+    in hassym: !firrtl.uint<1> sym @hassym [{class = "firrtl.transforms.DontTouchAnnotation"}],
+    out b: !firrtl.uint<2> [{class = "firrtl.transforms.DontTouchAnnotation"}]
+  )
 }


### PR DESCRIPTION
Ensure DontTouched ports have symbols on them to model "don't touch", consume the annotation.

This will cause zero-width dontTouch'd ports to produce an error, emit more specific error in this case.