### PR TITLE
Fix Combinational Component Builder

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -518,8 +518,13 @@ static void buildComponentLike(OpBuilder &builder, OperationState &result,
 
   // Build the function type of the component.
   auto functionType = builder.getFunctionType(portTypes, {});
-  result.addAttribute(ComponentOp::getFunctionTypeAttrName(result.name),
-                      TypeAttr::get(functionType));
+  if (!combinational) {
+    result.addAttribute(ComponentOp::getFunctionTypeAttrName(result.name),
+                        TypeAttr::get(functionType));
+  } else {
+    result.addAttribute(CombComponentOp::getFunctionTypeAttrName(result.name),
+                        TypeAttr::get(functionType));
+  }
 
   // Record the port names and number of input ports of the component.
   result.addAttribute("portNames", builder.getArrayAttr(portNames));

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -518,11 +518,11 @@ static void buildComponentLike(OpBuilder &builder, OperationState &result,
 
   // Build the function type of the component.
   auto functionType = builder.getFunctionType(portTypes, {});
-  if (!combinational) {
-    result.addAttribute(ComponentOp::getFunctionTypeAttrName(result.name),
+  if (combinational) {
+    result.addAttribute(CombComponentOp::getFunctionTypeAttrName(result.name),
                         TypeAttr::get(functionType));
   } else {
-    result.addAttribute(CombComponentOp::getFunctionTypeAttrName(result.name),
+    result.addAttribute(ComponentOp::getFunctionTypeAttrName(result.name),
                         TypeAttr::get(functionType));
   }
 


### PR DESCRIPTION
This llvm bump [commit](https://github.com/llvm/circt/commit/88c5572224dcc4a631c22a197f2d2714bad33a30#diff-bbfc48ed5eafd91f51b04a279d09004575d95b14c830dbff851af86fc2169c94) broke building CombComponentOps using the `buildComponentLike` function. This PR fixes the issue by deciding to call a different `getFunctionTypeAttrName` function based on whether we are building a comb or regular component.