### PR TITLE
[Arc] Add dialect

### DIFF
--- a/include/circt/Dialect/Arc/Arc.td
+++ b/include/circt/Dialect/Arc/Arc.td
@@ -1,0 +1,17 @@
+//===- Arc.td - Arc dialect definition ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_ARC_TD
+#define CIRCT_DIALECT_ARC_ARC_TD
+
+include "mlir/IR/OpBase.td"
+
+include "circt/Dialect/Arc/Dialect.td"
+include "circt/Dialect/Arc/Ops.td"
+
+#endif // CIRCT_DIALECT_ARC_ARC_TD

--- a/include/circt/Dialect/Arc/CMakeLists.txt
+++ b/include/circt/Dialect/Arc/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_circt_dialect(Arc arc)
+add_circt_dialect_doc(Arc arc)

--- a/include/circt/Dialect/Arc/Dialect.h
+++ b/include/circt/Dialect/Arc/Dialect.h
@@ -1,0 +1,19 @@
+//===- Dialect.h - Arc dialect definition -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_DIALECT_H
+#define CIRCT_DIALECT_ARC_DIALECT_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dialect.h"
+
+// Pull in the dialect definition.
+#include "circt/Dialect/Arc/ArcDialect.h.inc"
+
+#endif // CIRCT_DIALECT_ARC_DIALECT_H

--- a/include/circt/Dialect/Arc/Dialect.td
+++ b/include/circt/Dialect/Arc/Dialect.td
@@ -1,0 +1,24 @@
+//===- Dialect.td - Arc dialect definition -----------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_DIALECT_TD
+#define CIRCT_DIALECT_ARC_DIALECT_TD
+
+def ArcDialect : Dialect {
+  let name = "arc";
+  let summary = "Canonical representation of state transfer in a circuit";
+  let description = [{
+    This is the `arc` dialect, useful for representing state transfer functions
+    in a circuit.
+  }];
+  let cppNamespace = "circt::arc";
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
+}
+
+#endif // CIRCT_DIALECT_ARC_DIALECT_TD

--- a/include/circt/Dialect/Arc/Ops.h
+++ b/include/circt/Dialect/Arc/Ops.h
@@ -1,0 +1,25 @@
+//===- Ops.h - Arc dialect operations ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_OPS_H
+#define CIRCT_DIALECT_ARC_OPS_H
+
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/RegionKindInterface.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "circt/Dialect/Arc/Dialect.h"
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/Arc/Arc.h.inc"
+
+#endif // CIRCT_DIALECT_ARC_OPS_H

--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -1,0 +1,176 @@
+//===- Ops.td - Arc dialect operations ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_OPS_TD
+#define CIRCT_DIALECT_ARC_OPS_TD
+
+include "circt/Dialect/Arc/Dialect.td"
+include "mlir/IR/FunctionInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class ArcOp<string mnemonic, list<Trait> traits = []> :
+  Op<ArcDialect, mnemonic, traits>;
+
+def DefineOp : ArcOp<"define", [
+  IsolatedFromAbove,
+  FunctionOpInterface,
+  Symbol,
+  RegionKindInterface,
+  SingleBlockImplicitTerminator<"arc::OutputOp">,
+  HasParent<"mlir::ModuleOp">
+]> {
+  let summary = "State transfer arc definition";
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+  let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    OpBuilder<(ins "mlir::StringAttr":$sym_name, "mlir::TypeAttr":$function_type), [{
+      build($_builder, $_state, sym_name, function_type, mlir::ArrayAttr(), mlir::ArrayAttr());
+    }]>,
+    OpBuilder<(ins "mlir::StringRef":$sym_name, "mlir::FunctionType":$function_type), [{
+      build($_builder, $_state, sym_name, function_type, mlir::ArrayAttr(), mlir::ArrayAttr());
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    static mlir::RegionKind getRegionKind(unsigned index) {
+      return mlir::RegionKind::SSACFG;
+    }
+
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+
+    // Get the arc's symbolic name.
+    mlir::StringAttr getNameAttr() {
+      return (*this)->getAttrOfType<mlir::StringAttr>(
+        ::mlir::SymbolTable::getSymbolAttrName());
+    }
+
+    // Get the arc's symbolic name.
+    mlir::StringRef getName() {
+      return getNameAttr().getValue();
+    }
+
+    /// Returns the argument types of this function.
+    mlir::ArrayRef<mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    mlir::ArrayRef<mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    /// Verify the type attribute of this function. Returns failure and emits
+    /// an error if the attribute is invalid.
+    mlir::LogicalResult verifyType() {
+      auto type = getFunctionTypeAttr().getValue();
+      if (!type.isa<mlir::FunctionType>())
+        return emitOpError("requires '") << getFunctionTypeAttrName() <<
+                           "' attribute of function type";
+      return mlir::success();
+    }
+  }];
+}
+
+def OutputOp : ArcOp<"output", [
+  Terminator,
+  ParentOneOf<["DefineOp"]>,
+  Pure,
+  ReturnLike
+]> {
+  let summary = "Arc terminator";
+  let arguments = (ins Variadic<AnyType>:$outputs);
+  let assemblyFormat = [{
+    attr-dict ($outputs^ `:` qualified(type($outputs)))?
+  }];
+  let builders = [OpBuilder<(ins), [{
+    build($_builder, $_state, std::nullopt);
+  }]>];
+  let hasVerifier = 1;
+}
+
+def StateOp : ArcOp<"state", [
+  CallOpInterface, MemRefsNormalizable,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  AttrSizedOperandSegments, Pure
+]> {
+  let summary = "State transfer arc";
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$arc,
+    Optional<I1>:$clock,
+    Optional<I1>:$enable,
+    I32Attr:$latency,
+    Variadic<AnyType>:$inputs);
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $arc `(` $inputs `)` (`clock` $clock^)? (`enable` $enable^)? `lat` $latency attr-dict
+    `:` functional-type($inputs, results)
+  }];
+
+  let builders = [
+    OpBuilder<(ins "DefineOp":$arc, "mlir::Value":$clock, "mlir::Value":$enable,
+      "unsigned":$latency, CArg<"mlir::ValueRange", "{}">:$inputs), [{
+      build($_builder, $_state, mlir::SymbolRefAttr::get(arc),
+            arc.getFunctionType().getResults(), clock, enable, latency,
+            inputs);
+    }]>,
+    OpBuilder<(ins "mlir::SymbolRefAttr":$arc, "mlir::TypeRange":$results, "mlir::Value":$clock,
+      "mlir::Value":$enable, "unsigned":$latency, CArg<"mlir::ValueRange", "{}">:$inputs
+    ), [{
+      if (clock)
+        $_state.addOperands(clock);
+      if (enable)
+        $_state.addOperands(enable);
+      $_state.addOperands(inputs);
+      $_state.addAttribute("arc", arc);
+      $_state.addAttribute("latency", $_builder.getI32IntegerAttr(latency));
+      $_state.addAttribute(getOperandSegmentSizeAttr(),
+        $_builder.getDenseI32ArrayAttr({
+          clock ? 1 : 0,
+          enable ? 1 : 0,
+          static_cast<int32_t>(inputs.size())}));
+      $_state.addTypes(results);
+    }]>,
+    OpBuilder<(ins "mlir::StringAttr":$arc, "mlir::TypeRange":$results, "mlir::Value":$clock,
+      "mlir::Value":$enable, "unsigned":$latency, CArg<"mlir::ValueRange", "{}">:$inputs
+    ), [{
+      build($_builder, $_state, mlir::SymbolRefAttr::get(arc), results, clock, enable,
+            latency, inputs);
+    }]>,
+    OpBuilder<(ins "mlir::StringRef":$arc, "mlir::TypeRange":$results, "mlir::Value":$clock,
+      "mlir::Value":$enable, "unsigned":$latency, CArg<"mlir::ValueRange", "{}">:$inputs
+    ), [{
+      build($_builder, $_state, mlir::StringAttr::get($_builder.getContext(), arc),
+            results, clock, enable, latency, inputs);
+    }]>
+  ];
+  let skipDefaultBuilders = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    operand_range getArgOperands() {
+      return {operand_begin(), operand_end()};
+    }
+
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("arc");
+    }
+  }];
+}
+
+#endif // CIRCT_DIALECT_ARC_OPS_TD

--- a/include/circt/Dialect/CMakeLists.txt
+++ b/include/circt/Dialect/CMakeLists.txt
@@ -6,6 +6,7 @@
 ##
 ##===----------------------------------------------------------------------===//
 
+add_subdirectory(Arc)
 add_subdirectory(Calyx)
 add_subdirectory(Comb)
 add_subdirectory(ESI)

--- a/include/circt/InitAllDialects.h
+++ b/include/circt/InitAllDialects.h
@@ -14,6 +14,7 @@
 #ifndef CIRCT_INITALLDIALECTS_H_
 #define CIRCT_INITALLDIALECTS_H_
 
+#include "circt/Dialect/Arc/Dialect.h"
 #include "circt/Dialect/Calyx/CalyxDialect.h"
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
@@ -40,6 +41,7 @@ namespace circt {
 inline void registerAllDialects(mlir::DialectRegistry &registry) {
   // clang-format off
   registry.insert<
+    arc::ArcDialect,
     calyx::CalyxDialect,
     chirrtl::CHIRRTLDialect,
     comb::CombDialect,

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_circt_dialect_library(CIRCTArc
+  Dialect.cpp
+  Ops.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc
+
+  DEPENDS
+  MLIRArcIncGen
+
+  LINK_COMPONENTS
+  Support
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRInferTypeOpInterface
+  MLIRSideEffectInterfaces
+)
+
+add_dependencies(circt-headers
+  MLIRArcIncGen
+)

--- a/lib/Dialect/Arc/Dialect.cpp
+++ b/lib/Dialect/Arc/Dialect.cpp
@@ -1,0 +1,22 @@
+//===- Dialect.cpp - Arc dialect implementation ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Dialect.h"
+#include "circt/Dialect/Arc/Ops.h"
+
+using namespace circt;
+using namespace arc;
+
+void ArcDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "circt/Dialect/Arc/Arc.cpp.inc"
+      >();
+}
+
+#include "circt/Dialect/Arc/ArcDialect.cpp.inc"

--- a/lib/Dialect/Arc/Ops.cpp
+++ b/lib/Dialect/Arc/Ops.cpp
@@ -1,0 +1,128 @@
+//===- Ops.cpp ------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+using namespace circt;
+using namespace arc;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// DefineOp
+//===----------------------------------------------------------------------===//
+
+ParseResult DefineOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto buildFuncType =
+      [](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
+         function_interface_impl::VariadicFlag,
+         std::string &) { return builder.getFunctionType(argTypes, results); };
+
+  return function_interface_impl::parseFunctionOp(
+      parser, result, /*allowVariadic=*/false,
+      getFunctionTypeAttrName(result.name), buildFuncType,
+      getArgAttrsAttrName(result.name), getResAttrsAttrName(result.name));
+}
+
+void DefineOp::print(OpAsmPrinter &p) {
+  function_interface_impl::printFunctionOp(
+      p, *this, /*isVariadic=*/false, "function_type", getArgAttrsAttrName(),
+      getResAttrsAttrName());
+}
+
+//===----------------------------------------------------------------------===//
+// OutputOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult OutputOp::verify() {
+  return success();
+
+  auto parent = cast<DefineOp>((*this)->getParentOp());
+  ArrayRef<Type> types = parent.getResultTypes();
+  OperandRange values = getOperands();
+  if (types.size() != values.size()) {
+    emitOpError("must have same number of operands as parent arc has results");
+    return failure();
+  }
+
+  for (size_t i = 0, e = types.size(); i < e; ++i) {
+    if (types[i] != values[i].getType()) {
+      emitOpError("output operand ")
+          << i << " type mismatch: arc requires " << types[i] << ", operand is "
+          << values[i].getType();
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// StateOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // Check that the arc attribute was specified.
+  auto arcName = (*this)->getAttrOfType<FlatSymbolRefAttr>("arc");
+  if (!arcName)
+    return emitOpError("requires a `arc` symbol reference attribute");
+  DefineOp arc = symbolTable.lookupNearestSymbolFrom<DefineOp>(*this, arcName);
+  if (!arc)
+    return emitOpError() << "`" << arcName.getValue()
+                         << "` does not reference a valid function";
+
+  // Verify that the operand and result types match the arc.
+  auto type = arc.getFunctionType();
+  if (type.getNumInputs() != getInputs().size())
+    return emitOpError("incorrect number of operands for arc");
+
+  for (unsigned i = 0, e = type.getNumInputs(); i != e; ++i) {
+    if (getInputs()[i].getType() != type.getInput(i)) {
+      auto diag = emitOpError("operand type mismatch: operand ") << i;
+      diag.attachNote() << "expected type: " << type.getInput(i);
+      diag.attachNote() << "  actual type: " << getInputs()[i].getType();
+      return diag;
+    }
+  }
+
+  if (type.getNumResults() != getNumResults())
+    return emitOpError("incorrect number of results for arc");
+
+  for (unsigned i = 0, e = type.getNumResults(); i != e; ++i) {
+    if (getResult(i).getType() != type.getResult(i)) {
+      auto diag = emitOpError("result type mismatch: result ") << i;
+      diag.attachNote() << "expected type: " << type.getResult(i);
+      diag.attachNote() << "  actual type: " << getResult(i).getType();
+      return diag;
+    }
+  }
+
+  return success();
+}
+
+LogicalResult StateOp::verify() {
+  if (getLatency() > 0) {
+    if (getOperation()->getParentOfType<DefineOp>())
+      return emitOpError(
+          "with non-zero latency cannot be in an arc definition");
+    if (!getClock())
+      return emitOpError("with non-zero latency requires a clock");
+  } else {
+    if (getClock())
+      return emitOpError("with zero latency cannot have a clock");
+    if (getEnable())
+      return emitOpError("with zero latency cannot have an enable");
+  }
+  return success();
+}
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/Arc/Arc.cpp.inc"

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -9,6 +9,7 @@
 ##
 ##===----------------------------------------------------------------------===//
 
+add_subdirectory(Arc)
 add_subdirectory(Calyx)
 add_subdirectory(Comb)
 add_subdirectory(ESI)

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+arc.define @Foo(%arg0: i1) {
+  // expected-error @+1 {{'arc.state' op with non-zero latency cannot be in an arc definition}}
+  arc.state @Bar() clock %arg0 lat 1 : () -> ()
+  arc.output
+}
+arc.define @Bar() {
+  arc.output
+}
+
+// -----
+
+hw.module @Foo() {
+  // expected-error @+1 {{'arc.state' op with non-zero latency requires a clock}}
+  arc.state @Bar() lat 1 : () -> ()
+}
+arc.define @Bar() {
+  arc.output
+}
+
+// -----
+
+hw.module @Foo(%clock: i1) {
+  // expected-error @+1 {{'arc.state' op with zero latency cannot have a clock}}
+  arc.state @Bar() clock %clock lat 0 : () -> ()
+}
+arc.define @Bar() {
+  arc.output
+}
+
+// -----
+
+hw.module @Foo(%enable: i1) {
+  // expected-error @+1 {{'arc.state' op with zero latency cannot have an enable}}
+  arc.state @Bar() enable %enable lat 0 : () -> ()
+}
+arc.define @Bar() {
+  arc.output
+}

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+// CHECK-LABEL: arc.define @Foo
+arc.define @Foo(%arg0: i42, %arg1: i9) -> (i42, i9) {
+  // CHECK: arc.state @Bar(%arg0) lat 0 : (i42) -> i42
+  %0 = arc.state @Bar(%arg0) lat 0 : (i42) -> i42
+
+  // CHECK: arc.output %arg0, %arg1 : i42, i9
+  arc.output %arg0, %arg1 : i42, i9
+}
+
+arc.define @Bar(%arg0: i42) -> i42 {
+  arc.output %arg0 : i42
+}
+
+// CHECK-LABEL: hw.module @Module
+hw.module @Module(%clock: i1, %enable: i1, %a: i42, %b: i9) {
+  // CHECK: arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
+  arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
+
+  // CHECK: arc.state @Foo(%a, %b) clock %clock enable %enable lat 1 : (i42, i9) -> (i42, i9)
+  arc.state @Foo(%a, %b) clock %clock enable %enable lat 1 : (i42, i9) -> (i42, i9)
+}

--- a/test/circt-opt/commandline.mlir
+++ b/test/circt-opt/commandline.mlir
@@ -5,6 +5,7 @@
 
 // DIALECT: Available Dialects:
 // DIALECT-NEXT: affine
+// DIALECT-NEXT: arc
 // DIALECT-NEXT: arith
 // DIALECT-NEXT: builtin
 // DIALECT-NEXT: calyx

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(circt-opt
   PRIVATE
   CIRCTAffineToPipeline
   CIRCTAnalysisTestPasses
+  CIRCTArc
   CIRCTCalyx
   CIRCTCalyxToHW
   CIRCTCalyxToFSM


### PR DESCRIPTION
Add the `Arc` dialect which is useful for capturing a canonical representation of the state transfer in a circuit. It does this by introducing function-like arc definitions (`arc.define`) and call-like arc invocations (`arc.state`). The state op represents a transfer function, given by the arc definition, and zero or more registers, as specified by its latency attribute.