### PR TITLE
[Arc] Add makeshift input preprocessing

### DIFF
--- a/include/circt/Dialect/Arc/Arc.td
+++ b/include/circt/Dialect/Arc/Arc.td
@@ -12,6 +12,7 @@
 include "mlir/IR/OpBase.td"
 
 include "circt/Dialect/Arc/Dialect.td"
+include "circt/Dialect/Arc/Types.td"
 include "circt/Dialect/Arc/Ops.td"
 
 #endif // CIRCT_DIALECT_ARC_ARC_TD

--- a/include/circt/Dialect/Arc/Dialect.td
+++ b/include/circt/Dialect/Arc/Dialect.td
@@ -17,6 +17,12 @@ def ArcDialect : Dialect {
     in a circuit.
   }];
   let cppNamespace = "circt::arc";
+
+  let useDefaultTypePrinterParser = 1;
+
+  let extraClassDeclaration = [{
+    void registerTypes();
+  }];
 }
 
 #endif // CIRCT_DIALECT_ARC_DIALECT_TD

--- a/include/circt/Dialect/Arc/Ops.h
+++ b/include/circt/Dialect/Arc/Ops.h
@@ -18,6 +18,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "circt/Dialect/Arc/Dialect.h"
+#include "circt/Dialect/Arc/Types.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Arc/Arc.h.inc"

--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -10,6 +10,7 @@
 #define CIRCT_DIALECT_ARC_OPS_TD
 
 include "circt/Dialect/Arc/Dialect.td"
+include "circt/Dialect/Arc/Types.td"
 include "mlir/IR/FunctionInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/RegionKindInterface.td"
@@ -173,6 +174,75 @@ def StateOp : ArcOp<"state", [
       return (*this)->getAttrOfType<mlir::SymbolRefAttr>("arc");
     }
   }];
+}
+
+def ClockGateOp : ArcOp<"clock_gate", [Pure]> {
+  let summary = "Clock gate";
+  let arguments = (ins I1:$input, I1:$enable);
+  let results = (outs I1:$output);
+  let assemblyFormat = [{
+    $input `,` $enable attr-dict
+  }];
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$input, "mlir::Value":$enable), [{
+      build($_builder, $_state, input.getType(), input, enable);
+    }]>
+  ];
+}
+
+def MemoryOp : ArcOp<"memory", [MemoryEffects<[MemAlloc]>]> {
+  let summary = "Memory";
+  let results = (outs MemoryType:$memory);
+  let assemblyFormat = [{
+    type($memory) attr-dict
+  }];
+}
+
+class MemoryAndDataTypesMatch<string mem, string data> : TypesMatchWith<
+  "memory and data types must match", mem, data,
+  "$_self.cast<MemoryType>().getWordType()">;
+
+def MemoryReadOp : ArcOp<"memory_read", [
+  MemoryEffects<[MemRead]>,
+  MemoryAndDataTypesMatch<"memory", "data">
+]> {
+  let summary = "Read word from memory";
+  let arguments = (ins
+    MemoryType:$memory,
+    AnyInteger:$address,
+    I1:$clock,
+    I1:$enable
+  );
+  let results = (outs AnyInteger:$data);
+  let assemblyFormat = [{
+    $memory `[` $address `]` `,` $clock `,` $enable
+    attr-dict `:` type($memory) `,` type($address)
+  }];
+}
+
+def MemoryWriteOp : ArcOp<"memory_write", [
+  MemoryEffects<[MemWrite]>,
+  MemoryAndDataTypesMatch<"memory", "data">,
+  AttrSizedOperandSegments
+]> {
+  let summary = "Write word to memory";
+  let arguments = (ins
+    MemoryType:$memory,
+    AnyInteger:$address,
+    I1:$clock,
+    I1:$enable,
+    AnyInteger:$data,
+    Optional<AnyInteger>:$mask,
+    Variadic<AnyType>:$reads
+  );
+  let assemblyFormat = [{
+    $memory `[` $address `]` `,` $clock `,` $enable `,` $data
+    ( `mask` `(` $mask^ `:` type($mask) `)`)?
+    (` ` `(` `reads` $reads^ `:` type($reads) `)`)?
+    attr-dict `:` type($memory) `,` type($address)
+  }];
+
+  let hasVerifier = 1;
 }
 
 #endif // CIRCT_DIALECT_ARC_OPS_TD

--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -20,10 +20,12 @@ namespace circt {
 namespace arc {
 
 std::unique_ptr<mlir::Pass> createDedupPass();
+std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
 std::unique_ptr<mlir::Pass> createSinkInputsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();
+std::unique_ptr<mlir::Pass> createStripSVPass();
 
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/Arc/Passes.h.inc"

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -21,6 +21,14 @@ def Dedup : Pass<"arc-dedup", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def InferMemories : Pass<"arc-infer-memories", "mlir::ModuleOp"> {
+  let summary = "Convert `FIRRTL_Memory` instances to dedicated memory ops";
+  let constructor = "circt::arc::createInferMemoriesPass()";
+  let dependentDialects = [
+    "arc::ArcDialect", "comb::CombDialect", "seq::SeqDialect"
+  ];
+}
+
 def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
   let summary = "Eagerly inline private modules";
   let description = [{
@@ -51,6 +59,12 @@ def SplitLoops : Pass<"arc-split-loops", "mlir::ModuleOp"> {
   let summary = "Split arcs to break zero latency loops";
   let constructor = "circt::arc::createSplitLoopsPass()";
   let dependentDialects = ["arc::ArcDialect"];
+}
+
+def StripSV : Pass<"arc-strip-sv", "mlir::ModuleOp"> {
+  let summary = "Remove SV wire, reg, and assigns";
+  let constructor = "circt::arc::createStripSVPass()";
+  let dependentDialects = ["seq::SeqDialect", "arc::ArcDialect"];
 }
 
 #endif // CIRCT_DIALECT_ARC_PASSES_TD

--- a/include/circt/Dialect/Arc/Types.h
+++ b/include/circt/Dialect/Arc/Types.h
@@ -1,0 +1,18 @@
+//===- Types.h - Arc dialect types ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_TYPES_H
+#define CIRCT_DIALECT_ARC_TYPES_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/Arc/ArcTypes.h.inc"
+
+#endif // CIRCT_DIALECT_ARC_TYPES_H

--- a/include/circt/Dialect/Arc/Types.td
+++ b/include/circt/Dialect/Arc/Types.td
@@ -1,0 +1,24 @@
+//===- Types.td - Arc dialect types ------------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_TYPES_TD
+#define CIRCT_DIALECT_ARC_TYPES_TD
+
+include "circt/Dialect/Arc/Dialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class ArcTypeDef<string name> : TypeDef<ArcDialect, name> { }
+
+def MemoryType : ArcTypeDef<"Memory"> {
+  let mnemonic = "memory";
+  let parameters = (ins "unsigned":$numWords, "::mlir::IntegerType":$wordType,
+    OptionalParameter<"unsigned">:$stride);
+  let assemblyFormat = "`<` $numWords `x` $wordType (`,` $stride^)? `>`";
+}
+
+#endif // CIRCT_DIALECT_ARC_TYPES_TD

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -23,7 +23,8 @@ using llvm::MapVector;
 
 static bool isArcBreakingOp(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() ||
-         isa<hw::InstanceOp, seq::CompRegOp, StateOp>(op) ||
+         isa<hw::InstanceOp, seq::CompRegOp, StateOp, ClockGateOp, MemoryOp,
+             MemoryReadOp, MemoryWriteOp>(op) ||
          op->getNumResults() > 1;
 }
 

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTArc
   Dialect.cpp
   Ops.cpp
+  Types.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc

--- a/lib/Dialect/Arc/Dialect.cpp
+++ b/lib/Dialect/Arc/Dialect.cpp
@@ -8,11 +8,13 @@
 
 #include "circt/Dialect/Arc/Dialect.h"
 #include "circt/Dialect/Arc/Ops.h"
+#include "circt/Dialect/Arc/Types.h"
 
 using namespace circt;
 using namespace arc;
 
 void ArcDialect::initialize() {
+  registerTypes();
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/Arc/Arc.cpp.inc"

--- a/lib/Dialect/Arc/Ops.cpp
+++ b/lib/Dialect/Arc/Ops.cpp
@@ -145,5 +145,16 @@ LogicalResult StateOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// MemoryWriteOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MemoryWriteOp::verify() {
+  if (getMask() && getMask().getType() != getData().getType())
+    return emitOpError("mask and data operand types do not match");
+
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/Arc/Arc.cpp.inc"

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,18 +1,22 @@
 add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
+  InferMemories.cpp
   InlineModules.cpp
   MakeTables.cpp
   SinkInputs.cpp
   SplitLoops.cpp
+  StripSV.cpp
 
   DEPENDS
   CIRCTArcTransformsIncGen
 
   LINK_LIBS PUBLIC
   CIRCTArc
-  CIRCTHW
   CIRCTComb
+  CIRCTHW
+  CIRCTSeq
   CIRCTSupport
+  CIRCTSV
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/lib/Dialect/Arc/Transforms/InferMemories.cpp
+++ b/lib/Dialect/Arc/Transforms/InferMemories.cpp
@@ -1,0 +1,193 @@
+//===- InferMemories.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-infer-memories"
+
+using namespace circt;
+using namespace arc;
+
+namespace {
+struct InferMemoriesPass : public InferMemoriesBase<InferMemoriesPass> {
+  void runOnOperation() override;
+  SmallVector<Operation *> opsToDelete;
+  SmallPtrSet<StringAttr, 2> schemaNames;
+  DenseMap<StringAttr, DictionaryAttr> memoryParams;
+};
+} // namespace
+
+void InferMemoriesPass::runOnOperation() {
+  auto module = getOperation();
+  opsToDelete.clear();
+  schemaNames.clear();
+  memoryParams.clear();
+
+  // Find the matching generator schemas.
+  for (auto schemaOp : module.getOps<hw::HWGeneratorSchemaOp>()) {
+    if (schemaOp.getDescriptor() == "FIRRTL_Memory") {
+      schemaNames.insert(schemaOp.getSymNameAttr());
+      opsToDelete.push_back(schemaOp);
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Found " << schemaNames.size() << " schemas\n");
+
+  // Find generated ops using these schemas.
+  for (auto genOp : module.getOps<hw::HWModuleGeneratedOp>()) {
+    if (!schemaNames.contains(genOp.getGeneratorKindAttr().getAttr()))
+      continue;
+    memoryParams[genOp.moduleNameAttr()] = genOp->getAttrDictionary();
+    opsToDelete.push_back(genOp);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Found " << memoryParams.size()
+                          << " memory modules\n");
+
+  // Convert instances of the generated ops into dedicated memories.
+  unsigned numReplaced = 0;
+  module.walk([&](hw::InstanceOp instOp) {
+    auto it = memoryParams.find(instOp.getModuleNameAttr().getAttr());
+    if (it == memoryParams.end())
+      return;
+    ++numReplaced;
+    DictionaryAttr params = it->second;
+    auto width = params.getAs<IntegerAttr>("width").getValue().getZExtValue();
+    auto depth = params.getAs<IntegerAttr>("depth").getValue().getZExtValue();
+    auto maskGranAttr = params.getAs<IntegerAttr>("maskGran");
+    auto maskGran =
+        maskGranAttr ? maskGranAttr.getValue().getZExtValue() : width;
+    auto maskBits = width / maskGran;
+
+    auto writeLatency =
+        params.getAs<IntegerAttr>("writeLatency").getValue().getZExtValue();
+    auto readLatency =
+        params.getAs<IntegerAttr>("readLatency").getValue().getZExtValue();
+    if (writeLatency != 1) {
+      instOp.emitError("unsupported memory write latency ") << writeLatency;
+      return signalPassFailure();
+    }
+
+    ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
+    auto wordType = builder.getIntegerType(width);
+    auto memType = MemoryType::get(&getContext(), depth, wordType, {});
+    auto memOp = builder.create<MemoryOp>(memType);
+    if (!instOp.instanceName().empty())
+      memOp->setAttr("name", instOp.getInstanceNameAttr());
+
+    unsigned argIdx = 0;
+    unsigned resultIdx = 0;
+
+    auto applyReadLatency = [&](Value clock, Value data) {
+      for (unsigned i = 0; i < readLatency; ++i)
+        data = builder.create<seq::CompRegOp>(data, clock, "mem_read_latency");
+      return data;
+    };
+
+    SmallVector<Value> readPorts;
+    SmallVector<std::array<Value, 6>> writePorts;
+
+    // Handle read ports.
+    auto numReadPorts =
+        params.getAs<IntegerAttr>("numReadPorts").getValue().getZExtValue();
+    for (unsigned portIdx = 0; portIdx != numReadPorts; ++portIdx) {
+      auto address = instOp.getOperand(argIdx++);
+      auto enable = instOp.getOperand(argIdx++);
+      auto clock = instOp.getOperand(argIdx++);
+      auto data = instOp.getResult(resultIdx++);
+      Value readOp =
+          builder.create<MemoryReadOp>(wordType, memOp, address, clock, enable);
+      readPorts.push_back(readOp);
+      readOp = applyReadLatency(clock, readOp);
+      data.replaceAllUsesWith(readOp);
+    }
+
+    // Handle read-write ports.
+    auto numReadWritePorts = params.getAs<IntegerAttr>("numReadWritePorts")
+                                 .getValue()
+                                 .getZExtValue();
+    for (unsigned portIdx = 0; portIdx != numReadWritePorts; ++portIdx) {
+      auto address = instOp.getOperand(argIdx++);
+      auto enable = instOp.getOperand(argIdx++);
+      auto clock = instOp.getOperand(argIdx++);
+      auto writeMode = instOp.getOperand(argIdx++);
+      auto writeData = instOp.getOperand(argIdx++);
+      auto writeMask = maskBits > 1 ? instOp.getOperand(argIdx++) : Value{};
+      auto readData = instOp.getResult(resultIdx++);
+
+      auto constOne = builder.create<hw::ConstantOp>(builder.getI1Type(), 1);
+      auto readMode = builder.create<comb::XorOp>(writeMode, constOne);
+      auto readEnable = builder.create<comb::AndOp>(enable, readMode);
+      Value readOp = builder.create<MemoryReadOp>(wordType, memOp, address,
+                                                  clock, readEnable);
+
+      if (writeMask) {
+        unsigned maskWidth = writeMask.getType().cast<IntegerType>().getWidth();
+        SmallVector<Value> toConcat;
+        for (unsigned i = 0; i < maskWidth; ++i) {
+          Value bit = builder.create<comb::ExtractOp>(writeMask, i, 1);
+          Value replicated = builder.create<comb::ReplicateOp>(bit, maskGran);
+          toConcat.push_back(replicated);
+        }
+        writeMask =
+            builder.create<comb::ConcatOp>(writeData.getType(), toConcat);
+      }
+
+      readPorts.push_back(readOp);
+      readOp = applyReadLatency(clock, readOp);
+      readData.replaceAllUsesWith(readOp);
+
+      auto writeEnable = builder.create<comb::AndOp>(enable, writeMode);
+      writePorts.push_back(
+          {memOp, address, clock, writeEnable, writeData, writeMask});
+    }
+
+    // Handle write ports.
+    auto numWritePorts =
+        params.getAs<IntegerAttr>("numWritePorts").getValue().getZExtValue();
+    for (unsigned portIdx = 0; portIdx != numWritePorts; ++portIdx) {
+      auto address = instOp.getOperand(argIdx++);
+      auto enable = instOp.getOperand(argIdx++);
+      auto clock = instOp.getOperand(argIdx++);
+      auto data = instOp.getOperand(argIdx++);
+      auto mask = maskBits > 1 ? instOp.getOperand(argIdx++) : Value{};
+
+      if (mask) {
+        unsigned maskWidth = mask.getType().cast<IntegerType>().getWidth();
+        SmallVector<Value> toConcat;
+        for (unsigned i = 0; i < maskWidth; ++i) {
+          Value bit = builder.create<comb::ExtractOp>(mask, i, 1);
+          Value replicated = builder.create<comb::ReplicateOp>(bit, maskGran);
+          toConcat.push_back(replicated);
+        }
+        mask = builder.create<comb::ConcatOp>(data.getType(), toConcat);
+      }
+
+      writePorts.push_back({memOp, address, clock, enable, data, mask});
+    }
+
+    // Create the actual write ports with a dependency arc to all read
+    // ports.
+    for (auto [memOp, address, clock, enable, data, mask] : writePorts) {
+      builder.create<MemoryWriteOp>(memOp, address, clock, enable, data, mask,
+                                    readPorts);
+    }
+
+    opsToDelete.push_back(instOp);
+  });
+  LLVM_DEBUG(llvm::dbgs() << "Inferred " << numReplaced << " memories\n");
+
+  for (auto *op : opsToDelete)
+    op->erase();
+}
+
+std::unique_ptr<Pass> arc::createInferMemoriesPass() {
+  return std::make_unique<InferMemoriesPass>();
+}

--- a/lib/Dialect/Arc/Transforms/PassDetails.h
+++ b/lib/Dialect/Arc/Transforms/PassDetails.h
@@ -15,6 +15,8 @@
 #include "circt/Dialect/Arc/Dialect.h"
 #include "circt/Dialect/Arc/Ops.h"
 #include "circt/Dialect/Arc/Passes.h"
+#include "circt/Dialect/Arc/Types.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "mlir/Pass/Pass.h"

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -1,0 +1,178 @@
+//===- StripSV.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/Support/Debug.h"
+#include <variant>
+
+#define DEBUG_TYPE "arc-strip-sv"
+
+using namespace circt;
+using namespace arc;
+
+namespace {
+struct StripSVPass : public StripSVBase<StripSVPass> {
+  void runOnOperation() override;
+  SmallVector<Operation *> opsToDelete;
+  SmallPtrSet<StringAttr, 4> clockGateModuleNames;
+  SmallPtrSet<StringAttr, 4> externModuleNames;
+};
+} // namespace
+
+void StripSVPass::runOnOperation() {
+  auto mlirModule = getOperation();
+  opsToDelete.clear();
+  clockGateModuleNames.clear();
+  externModuleNames.clear();
+
+  auto expectedClockGateInputs =
+      ArrayAttr::get(&getContext(), {StringAttr::get(&getContext(), "in"),
+                                     StringAttr::get(&getContext(), "test_en"),
+                                     StringAttr::get(&getContext(), "en")});
+  auto expectedClockGateOutputs =
+      ArrayAttr::get(&getContext(), {StringAttr::get(&getContext(), "out")});
+  auto i1Type = IntegerType::get(&getContext(), 1);
+
+  for (auto extModOp : mlirModule.getOps<hw::HWModuleExternOp>()) {
+    if (extModOp.getVerilogModuleName() == "EICG_wrapper") {
+      if (extModOp.getArgNames() != expectedClockGateInputs ||
+          extModOp.getResultNames() != expectedClockGateOutputs) {
+        extModOp.emitError("clock gate module `")
+            << extModOp.moduleName() << "` has incompatible port names "
+            << extModOp.getArgNamesAttr() << " -> "
+            << extModOp.getResultNamesAttr();
+        return signalPassFailure();
+      }
+      if (extModOp.getArgumentTypes() !=
+              ArrayRef<Type>{i1Type, i1Type, i1Type} ||
+          extModOp.getResultTypes() != ArrayRef<Type>{i1Type}) {
+        extModOp.emitError("clock gate module `")
+            << extModOp.moduleName() << "` has incompatible port types "
+            << extModOp.getArgumentTypes() << " -> "
+            << extModOp.getResultTypes();
+        return signalPassFailure();
+      }
+      clockGateModuleNames.insert(extModOp.moduleNameAttr());
+    } else {
+      externModuleNames.insert(extModOp.moduleNameAttr());
+    }
+    opsToDelete.push_back(extModOp);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Found " << clockGateModuleNames.size()
+                          << " clock gates, " << externModuleNames.size()
+                          << " other extern modules\n");
+
+  // Remove `sv.*` operation attributes.
+  mlirModule.walk([](Operation *op) {
+    auto isSVAttr = [](NamedAttribute attr) {
+      return attr.getName().getValue().startswith("sv.");
+    };
+    if (llvm::any_of(op->getAttrs(), isSVAttr)) {
+      SmallVector<NamedAttribute> newAttrs;
+      newAttrs.reserve(op->getAttrs().size());
+      for (auto attr : op->getAttrs())
+        if (!isSVAttr(attr))
+          newAttrs.push_back(attr);
+      op->setAttrs(newAttrs);
+    }
+  });
+
+  // Remove ifdefs and verbatim.
+  for (auto verb : mlirModule.getOps<sv::VerbatimOp>())
+    opsToDelete.push_back(verb);
+  for (auto verb : mlirModule.getOps<sv::IfDefOp>())
+    opsToDelete.push_back(verb);
+
+  for (auto module : mlirModule.getOps<hw::HWModuleOp>()) {
+    for (Operation &op : *module.getBodyBlock()) {
+      // Remove ifdefs and verbatim.
+      if (isa<sv::IfDefOp, sv::CoverOp, sv::CoverConcurrentOp>(&op)) {
+        opsToDelete.push_back(&op);
+        continue;
+      }
+      if (isa<sv::VerbatimOp, sv::AlwaysOp>(&op)) {
+        opsToDelete.push_back(&op);
+        continue;
+      }
+
+      // Remove wires.
+      if (auto assign = dyn_cast<sv::AssignOp>(&op)) {
+        auto wire = assign.getDest().getDefiningOp<sv::WireOp>();
+        if (!wire) {
+          assign.emitOpError("expected wire lhs");
+          return signalPassFailure();
+        }
+        for (Operation *user : wire->getUsers()) {
+          if (user == assign)
+            continue;
+          auto readInout = dyn_cast<sv::ReadInOutOp>(user);
+          if (!readInout) {
+            user->emitOpError("has user that is not `sv.read_inout`");
+            return signalPassFailure();
+          }
+          readInout.replaceAllUsesWith(assign.getSrc());
+          opsToDelete.push_back(readInout);
+        }
+        opsToDelete.push_back(assign);
+        opsToDelete.push_back(wire);
+        continue;
+      }
+
+      // Canonicalize registers.
+      if (auto reg = dyn_cast<seq::FirRegOp>(&op)) {
+        OpBuilder builder(reg);
+        Value next;
+        // Note: this register will have an sync reset regardless.
+        if (reg.hasReset())
+          next = builder.create<comb::MuxOp>(reg.getLoc(), reg.getReset(),
+                                             reg.getResetValue(), reg.getNext(),
+                                             false);
+        else
+          next = reg.getNext();
+
+        Value compReg = builder.create<seq::CompRegOp>(
+            reg.getLoc(), next.getType(), next, reg.getClk(), reg.getNameAttr(),
+            Value{}, Value{}, reg.getInnerSymAttr());
+        reg.replaceAllUsesWith(compReg);
+        opsToDelete.push_back(reg);
+        continue;
+      }
+
+      // Replace clock gate instances with the dedicated arc op and stub
+      // out other external modules.
+      if (auto instOp = dyn_cast<hw::InstanceOp>(&op)) {
+        auto modName = instOp.getModuleNameAttr().getAttr();
+        ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
+        if (clockGateModuleNames.contains(modName)) {
+          auto enable = builder.createOrFold<comb::OrOp>(
+              instOp.getOperand(1), instOp.getOperand(2), true);
+          auto gated =
+              builder.create<arc::ClockGateOp>(instOp.getOperand(0), enable);
+          instOp.replaceAllUsesWith(gated);
+          opsToDelete.push_back(instOp);
+        } else if (externModuleNames.contains(modName)) {
+          for (auto result : instOp.getResults())
+            result.replaceAllUsesWith(
+                builder.create<hw::ConstantOp>(result.getType(), 0));
+          opsToDelete.push_back(instOp);
+        }
+        continue;
+      }
+    }
+  }
+  for (auto *op : opsToDelete)
+    op->erase();
+}
+
+std::unique_ptr<Pass> arc::createStripSVPass() {
+  return std::make_unique<StripSVPass>();
+}

--- a/lib/Dialect/Arc/Types.cpp
+++ b/lib/Dialect/Arc/Types.cpp
@@ -1,0 +1,27 @@
+//===- Types.cpp ----------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Types.h"
+#include "circt/Dialect/Arc/Dialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace arc;
+using namespace mlir;
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/Arc/ArcTypes.cpp.inc"
+
+void ArcDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/Arc/ArcTypes.cpp.inc"
+      >();
+}

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -1,0 +1,84 @@
+// RUN: circt-opt %s --arc-infer-memories | FileCheck %s
+
+hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs"]
+
+
+// CHECK-LABEL: hw.module @TestWOMemory(
+hw.module @TestWOMemory(%clock: i1, %addr: i10, %enable: i1, %data: i8) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
+  // CHECK-NEXT: arc.memory_write [[FOO]][%addr], %clock, %enable, %data : <1024 x i8>, i10
+  // CHECK-NEXT: hw.output
+  hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i8) -> ()
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module.generated @WOMemory, @FIRRTLMem
+hw.module.generated @WOMemory, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+
+// CHECK-LABEL: hw.module @TestWOMemoryWithMask(
+hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16, %mask: i2) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i16> {name = "foo"}
+  // CHECK-NEXT: [[MASK_BIT0:%.+]] = comb.extract %mask from 0 : (i2) -> i1
+  // CHECK-NEXT: [[MASK_BYTE0:%.+]] = comb.replicate [[MASK_BIT0]] : (i1) -> i8
+  // CHECK-NEXT: [[MASK_BIT1:%.+]] = comb.extract %mask from 1 : (i2) -> i1
+  // CHECK-NEXT: [[MASK_BYTE1:%.+]] = comb.replicate [[MASK_BIT1]] : (i1) -> i8
+  // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE0]], [[MASK_BYTE1]]
+  // CHECK-NEXT: arc.memory_write [[FOO]][%addr], %clock, %enable, %data mask([[MASK]] : i16) : <1024 x i16>, i10
+  // CHECK-NEXT: hw.output
+  hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module.generated @WOMemoryWithMask, @FIRRTLMem
+hw.module.generated @WOMemoryWithMask, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i16, %W0_mask: i2) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+
+// CHECK-LABEL: hw.module @TestROMemory(
+hw.module @TestROMemory(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read [[FOO]][%addr], %clock, %enable : <1024 x i8>, i10
+  // CHECK-NEXT: hw.output [[RDATA]]
+  %0 = hw.instance "foo" @ROMemory(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
+  hw.output %0 : i8
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module.generated @ROMemory, @FIRRTLMem
+hw.module.generated @ROMemory, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+
+// CHECK-LABEL: hw.module @TestROMemoryWithLatency(
+hw.module @TestROMemoryWithLatency(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
+  // CHECK-NEXT: [[D0:%.+]] = arc.memory_read [[FOO]][%addr], %clock, %enable : <1024 x i8>, i10
+  // CHECK-NEXT: [[D1:%.+]] = seq.compreg {{.+}} [[D0]], %clock
+  // CHECK-NEXT: [[D2:%.+]] = seq.compreg {{.+}} [[D1]], %clock
+  // CHECK-NEXT: [[D3:%.+]] = seq.compreg {{.+}} [[D2]], %clock
+  // CHECK-NEXT: hw.output [[D3]]
+  %0 = hw.instance "foo" @ROMemoryWithLatency(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
+  hw.output %0 : i8
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module.generated @ROMemoryWithLatency, @FIRRTLMem
+hw.module.generated @ROMemoryWithLatency, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 3 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+
+// CHECK-LABEL: hw.module @TestRWMemory(
+hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata: i8) -> (rdata: i8) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
+  // CHECK-NEXT: hw.constant true
+  // CHECK-NEXT: [[WMODE_INV:%.+]] = comb.xor %wmode, %true
+  // CHECK-NEXT: [[RENABLE:%.+]] = comb.and %enable, [[WMODE_INV]]
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read [[FOO]][%addr], %clock, [[RENABLE]] : <1024 x i8>, i10
+  // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
+  // CHECK-NEXT: arc.memory_write [[FOO]][%addr], %clock, [[WENABLE]], %wdata (reads [[RDATA]] : i8) : <1024 x i8>, i10
+  // CHECK-NEXT: hw.output [[RDATA]]
+  %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
+  hw.output %0 : i8
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module.generated @RWMemory, @FIRRTLMem
+hw.module.generated @RWMemory, @FIRRTLMem(%RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i8) -> (RW0_rdata: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt %s --arc-strip-sv | FileCheck %s
+
+// CHECK-NOT: sv.verbatim
+// CHECK-NOT: sv.ifdef
+sv.verbatim "// Standard header to adapt well known macros to our needs." {symbols = []}
+sv.ifdef  "RANDOMIZE_REG_INIT" {
+  sv.verbatim "`define RANDOMIZE" {symbols = []}
+}
+
+// CHECK-LABEL: hw.module @Foo(
+hw.module @Foo(%clock: i1, %a: i4) -> (z: i4) {
+  // CHECK-NEXT: [[REG:%.+]] = seq.compreg %a, %clock
+  %0 = seq.firreg %a clock %clock : i4
+  %1 = sv.wire : !hw.inout<i4>
+  sv.assign %1, %0 : i4
+  %2 = sv.read_inout %1 : !hw.inout<i4>
+  // CHECK-NEXT: hw.output [[REG]]
+  hw.output %2 : i4
+}
+// CHECK-NEXT: }


### PR DESCRIPTION
Many CIRCT frontends don't generate clean HW representations of their inputs, but instead intersperse SV dialect operations to explicitly materialize named wires. Add a makeshift `StripSV` pass to remove some of the trivial SV dialect ops (wires just for the sake of naming) and to replace `seq.firreg` with `seq.compreg` throughout the input. At a later point we'll want to introduce a "register" op interface such that passes can inquire about a register op's semantics in a uniform manner.

Similarly, the Seq dialect lacks a memory construct. The FIRRTL pipeline lowers its `firrtl.mem` ops into HW generator ops. Add a `InferMemories` pass that converts this generator op into a proper `arc.memory` op with associated `arc.memory_read` and `arc.memory_write` operations.

**Do a rebase merge, not a squash merge, to preserve the individual commits.**