### PR TITLE
[MemOp] Replace single-address memories with registers

### DIFF
--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -canonicalize='top-down=true region-simplify=true' %s | FileCheck %s
+// RUN: circt-opt --split-input-file -canonicalize='top-down=true region-simplify=true' %s | FileCheck %s
 
 
 firrtl.circuit "ReadOnlyMemory" {
@@ -25,6 +25,8 @@ firrtl.circuit "ReadOnlyMemory" {
     firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
   }
 }
+
+// -----
 
 firrtl.circuit "WriteOnlyMemory" {
   // CHECK-LABEL: firrtl.module public @WriteOnlyMemory
@@ -53,6 +55,8 @@ firrtl.circuit "WriteOnlyMemory" {
     firrtl.connect %14, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+// -----
 
 firrtl.circuit "ReadWriteToWrite" {
   firrtl.module public @ReadWriteToWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<4>, in %indata: !firrtl.uint<42>, out %result: !firrtl.uint<42>) {
@@ -127,6 +131,8 @@ firrtl.circuit "ReadWriteToWrite" {
     firrtl.connect %result, %9 : !firrtl.uint<42>, !firrtl.uint<42>
   }
 }
+
+// -----
 
 firrtl.circuit "UnusedPorts" {
   firrtl.module public @UnusedPorts(
@@ -213,6 +219,8 @@ firrtl.circuit "UnusedPorts" {
   }
 }
 
+// -----
+
 firrtl.circuit "UnusedBits" {
   firrtl.module public @UnusedBits(
       in %clock: !firrtl.clock,
@@ -292,6 +300,7 @@ firrtl.circuit "UnusedBits" {
   }
 }
 
+// -----
 
 firrtl.circuit "UnusedBitsAtEnd" {
   firrtl.module public @UnusedBitsAtEnd(
@@ -338,6 +347,180 @@ firrtl.circuit "UnusedBitsAtEnd" {
     %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_data, %in_data : !firrtl.uint<42>, !firrtl.uint<42>
     %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "OneAddressMasked" {
+  firrtl.module public @OneAddressMasked(
+      in %clock: !firrtl.clock,
+      in %addr: !firrtl.uint<1>,
+      in %in_data: !firrtl.uint<32>,
+      in %in_mask: !firrtl.uint<2>,
+      in %in_wen: !firrtl.uint<1>,
+      out %result_read: !firrtl.uint<32>) {
+
+
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+    %Memory_read, %Memory_write = firrtl.mem Undefined
+      {
+        depth = 1 : i64,
+        name = "Memory",
+        portNames = ["read", "write"],
+        readLatency = 0 : i32,
+        writeLatency = 1 : i32
+      } :
+        !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>,
+        !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    // CHECK: %Memory = firrtl.reg %clock : !firrtl.uint<32>
+
+    // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
+
+    %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
+    %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %result_read, %read_data : !firrtl.uint<32>, !firrtl.uint<32>
+
+    // CHECK: [[DATA_0:%.+]] = firrtl.bits %in_data 15 to 0 : (!firrtl.uint<32>) -> !firrtl.uint<16>
+    // CHECK: [[NEXT_0:%.+]] = firrtl.bits %Memory 15 to 0 : (!firrtl.uint<32>) -> !firrtl.uint<16>
+    // CHECK: [[MASK_0:%.+]] = firrtl.bits %in_mask 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
+    // CHECK: [[CHUNK_0:%.+]] = firrtl.mux([[MASK_0]], [[DATA_0]], [[NEXT_0]]) : (!firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<16>
+    // CHECK: [[DATA_1:%.+]] = firrtl.bits %in_data 31 to 16 : (!firrtl.uint<32>) -> !firrtl.uint<16>
+    // CHECK: [[NEXT_1:%.+]] = firrtl.bits %Memory 31 to 16 : (!firrtl.uint<32>) -> !firrtl.uint<16>
+    // CHECK: [[MASK_1:%.+]] = firrtl.bits %in_mask 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
+    // CHECK: [[CHUNK_1:%.+]] = firrtl.mux([[MASK_1]], [[DATA_1]], [[NEXT_1]]) : (!firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<16>
+    // CHECK: [[NEXT:%.+]] = firrtl.cat [[CHUNK_1]], [[CHUNK_0]] : (!firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<32>
+    // CHECK: [[NEXT_EN:%.+]] = firrtl.mux(%in_wen, [[NEXT]], %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory, [[NEXT_EN]] : !firrtl.uint<32>
+
+    %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    firrtl.connect %write_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    firrtl.connect %write_en, %in_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_clk = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
+    %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    firrtl.connect %write_data, %in_data : !firrtl.uint<32>, !firrtl.uint<32>
+    %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
+    firrtl.connect %write_mask, %in_mask : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+}
+
+// -----
+
+firrtl.circuit "OneAddressNoMask" {
+  firrtl.module public @OneAddressNoMask(
+      in %clock: !firrtl.clock,
+      in %addr: !firrtl.uint<1>,
+      in %in_data: !firrtl.uint<32>,
+      in %wmode_rw: !firrtl.uint<1>,
+      in %in_wen: !firrtl.uint<1>,
+      in %in_rwen: !firrtl.uint<1>,
+      out %result_read: !firrtl.uint<32>,
+      out %result_rw: !firrtl.uint<32>) {
+
+    // Pipeline the inputs.
+    // TODO: It would be good to de-duplicate these either in the pass or in a canonicalizer.
+
+    // CHECK: %Memory_write_en_0 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_write_en_0, %in_wen : !firrtl.uint<1>
+    // CHECK: %Memory_write_en_1 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_write_en_1, %Memory_write_en_0 : !firrtl.uint<1>
+    // CHECK: %Memory_write_en_2 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_write_en_2, %Memory_write_en_1 : !firrtl.uint<1>
+
+    // CHECK: %Memory_write_data_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_write_data_0, %in_data : !firrtl.uint<32>
+    // CHECK: %Memory_write_data_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_write_data_1, %Memory_write_data_0 : !firrtl.uint<32>
+    // CHECK: %Memory_write_data_2 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_write_data_2, %Memory_write_data_1 : !firrtl.uint<32>
+
+    // CHECK: %Memory_rw_wdata_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_rw_wdata_0, %in_data : !firrtl.uint<32>
+    // CHECK: %Memory_rw_wdata_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_rw_wdata_1, %Memory_rw_wdata_0 : !firrtl.uint<32>
+    // CHECK: %Memory_rw_wdata_2 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_rw_wdata_2, %Memory_rw_wdata_1 : !firrtl.uint<32>
+
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+    %Memory_read, %Memory_rw, %Memory_write = firrtl.mem Undefined
+      {
+        depth = 1 : i64,
+        name = "Memory",
+        portNames = ["read", "rw", "write"],
+        readLatency = 2 : i32,
+        writeLatency = 4 : i32
+      } :
+        !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>,
+        !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>,
+        !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+
+    // CHECK: %Memory = firrtl.reg %clock : !firrtl.uint<32>
+
+    // CHECK: %Memory_rw_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_rw_0, %Memory : !firrtl.uint<32>
+    // CHECK: %Memory_rw_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_rw_1, %Memory_rw_0 : !firrtl.uint<32>
+
+    // CHECK: %Memory_data_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_data_0, %Memory : !firrtl.uint<32>
+    // CHECK: %Memory_data_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory_data_1, %Memory_data_0 : !firrtl.uint<32>
+
+    // CHECK: firrtl.strictconnect %result_read, %Memory_data_1 : !firrtl.uint<32>
+    %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_en, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
+    %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
+    firrtl.connect %result_read, %read_data : !firrtl.uint<32>, !firrtl.uint<32>
+
+    // CHECK: firrtl.strictconnect %result_rw, %Memory_rw_1 : !firrtl.uint<32>
+    %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_en, %in_rwen : !firrtl.uint<1>, !firrtl.uint<1>
+    %rw_clk = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_clk, %clock : !firrtl.clock, !firrtl.clock
+    %rw_rdata = firrtl.subfield %Memory_rw[rdata] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %result_rw, %rw_rdata : !firrtl.uint<32>, !firrtl.uint<32>
+    %rw_wmode = firrtl.subfield %Memory_rw[wmode] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_wmode, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
+    %rw_wdata = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_wdata, %in_data : !firrtl.uint<32>, !firrtl.uint<32>
+    %rw_wmask = firrtl.subfield %Memory_rw[wmask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    firrtl.connect %rw_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+
+    // CHECK: [[WRITING:%.+]] = firrtl.and %in_rwen, %wmode_rw : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_0 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_rw_wen_0, [[WRITING]] : !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_1 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_rw_wen_1, %Memory_rw_wen_0 : !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_2 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %Memory_rw_wen_2, %Memory_rw_wen_1 : !firrtl.uint<1>
+    // CHECK: [[WRITE_RW:%.+]] = firrtl.mux(%Memory_rw_wen_2, %Memory_rw_wdata_2, %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    // CHECK: [[WRITE_W:%.+]] = firrtl.mux(%Memory_write_en_2, %Memory_write_data_2, [[WRITE_RW]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %Memory, [[WRITE_W]] : !firrtl.uint<32>
+    %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    firrtl.connect %write_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    firrtl.connect %write_en, %in_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    %write_clk = firrtl.subfield %Memory_write[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    firrtl.connect %write_clk, %clock : !firrtl.clock, !firrtl.clock
+    %write_data = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    firrtl.connect %write_data, %in_data : !firrtl.uint<32>, !firrtl.uint<32>
+    %write_mask = firrtl.subfield %Memory_write[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     firrtl.connect %write_mask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
This pass replaces single-address memories with one register. The write ports are ordered and implemented through muxes. The transformation is enabled only when all writes are driven by the same clock.

Fixes #4579