### PR TITLE
[COMB] disable one folder for 25% end-to-end perf improvement.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -539,6 +539,9 @@ static bool extractFromReplicate(ExtractOp op, ReplicateOp replicate,
 LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
   auto *inputOp = op.getInput().getDefiningOp();
 
+  // This turns out to be incredibly expensive.  Disable until performance is
+  // addressed.
+#if 0
   // If the extracted bits are all known, then return the result.
   auto knownBits = computeKnownBits(op.getInput())
                        .extractBits(op.getType().cast<IntegerType>().getWidth(),
@@ -548,6 +551,7 @@ LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
                                                   knownBits.getConstant());
     return success();
   }
+#endif
 
   // extract(olo, extract(ilo, x)) = extract(olo + ilo, x)
   if (auto innerExtract = dyn_cast_or_null<ExtractOp>(inputOp)) {

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -273,22 +273,6 @@ hw.module @extractNested(%0: i5) -> (o1 : i1) {
   hw.output %3 : i1
 }
 
-// CHECK-LABEL: @extractConstant
-hw.module @extractConstant(%arg0: i5, %cond1: i1, %cond2: i1) -> (o1: i1, o2: i4) {
-  //c2 ? (c1 ? 4'h2 : 4'h4) : 4'h0;
-  %c0 = hw.constant 0 : i4
-  %c2 = hw.constant 2 : i4
-  %c4 = hw.constant 4 : i4
-  %0 = comb.mux %cond1, %c0, %c4 : i4
-  %1 = comb.mux %cond2, %0, %c2 : i4
-
-  // CHECK: %false = hw.constant false
-  // CHECK: hw.output %false, 
-  %2 = comb.extract %1 from 3 : (i4) -> i1
-  hw.output %2, %1 : i1, i4
-}
-
-
 // CHECK-LABEL: @flattenMuxTrue
 hw.module @flattenMuxTrue(%arg0: i1, %arg1: i8, %arg2: i8, %arg3: i8, %arg4 : i8) -> (o1 : i8) {
 // CHECK-NEXT:    [[RET:%[0-9]+]] = comb.mux %arg0, %arg1, %arg4


### PR DESCRIPTION
ExtractOp has a canonicalizer which uses computeKnownBits.  This canonicalizer is very expensive.  Disalbing this to mitigate #4688 until performance is addressed.