### PR TITLE
[CombFolds] Propapate bin flags through icmp and variadic op canonicalizer

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1466,3 +1466,11 @@ hw.module @MuxSimplify(%index: i1, %a: i1, %foo_0: i2, %foo_1: i2) -> (r_0: i2, 
 // CHECK-NEXT:  %15 = comb.or %14, %index : i1
 // CHECK-NEXT:  %16 = comb.mux bin %15, %foo_0, %foo_1 : i2
 // CHECK-NEXT:  hw.output %1, %3, %6, %8, %10, %13, %16
+
+// CHECK-LABEL: @twoStateICmp
+hw.module @twoStateICmp(%arg: i4) -> (cond: i1) {
+  // CHECK: %0 = comb.icmp bin eq %arg, %c-1_i4
+  %c-1_i4 = hw.constant -1 : i4
+  %0 = comb.icmp bin eq %c-1_i4, %arg : i4
+  hw.output %0 : i1
+}

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -78,22 +78,22 @@ circuit Qux: %[[{
 ;CHECK:    %[[v5:.+]] = hw.array_create
 ;CHECK:    %[[v6:.+]] = hw.array_get %[[v5]][%[[v4]]]
 ;CHECK:    %[[v7:.+]] = hw.array_get %[[v5]][%rwAddr]
-;CHECK:    %8 = comb.icmp eq %rwAddr, %c0_i2 : i2
-;CHECK:    %9 = comb.and %rwEn, %rwMode, %rwMask, %8 : i1
+;CHECK:    %8 = comb.icmp bin eq %rwAddr, %c0_i2 : i2
+;CHECK:    %9 = comb.and bin %rwEn, %rwMode, %rwMask, %8 : i1
 ;CHECK:    %10 = comb.icmp bin eq %rwAddr, %c1_i2 : i2
-;CHECK:    %11 = comb.and %rwEn, %rwMode, %rwMask, %10 : i1
+;CHECK:    %11 = comb.and bin %rwEn, %rwMode, %rwMask, %10 : i1
 ;CHECK:    %12 = comb.icmp bin eq %rwAddr, %c-2_i2 : i2
-;CHECK:    %13 = comb.and %rwEn, %rwMode, %rwMask, %12 : i1
+;CHECK:    %13 = comb.and bin %rwEn, %rwMode, %rwMask, %12 : i1
 ;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c-1_i2 : i2
-;CHECK:    %15 = comb.and %rwEn, %rwMode, %rwMask, %14 : i1
-;CHECK:    %16 = comb.icmp eq %wAddr, %c0_i2 : i2
-;CHECK:    %17 = comb.and %wEn, %wMask, %16 : i1
+;CHECK:    %15 = comb.and bin %rwEn, %rwMode, %rwMask, %14 : i1
+;CHECK:    %16 = comb.icmp bin eq %wAddr, %c0_i2 : i2
+;CHECK:    %17 = comb.and bin %wEn, %wMask, %16 : i1
 ;CHECK:    %18 = comb.icmp bin eq %wAddr, %c1_i2 : i2
-;CHECK:    %19 = comb.and %wEn, %wMask, %18 : i1
+;CHECK:    %19 = comb.and bin %wEn, %wMask, %18 : i1
 ;CHECK:    %20 = comb.icmp bin eq %wAddr, %c-2_i2 : i2
-;CHECK:    %21 = comb.and %wEn, %wMask, %20 : i1
+;CHECK:    %21 = comb.and bin %wEn, %wMask, %20 : i1
 ;CHECK:    %22 = comb.icmp bin eq %wAddr, %c-1_i2 : i2
-;CHECK:    %23 = comb.and %wEn, %wMask, %22 : i1
+;CHECK:    %23 = comb.and bin %wEn, %wMask, %22 : i1
 ;CHECK:    sv.always posedge %clock {
 ;CHECK:      sv.if %17 {
 ;CHECK:        sv.passign %memory_0, %wData : i8


### PR DESCRIPTION
This commit propgates bin flags through icmp and varidic op canonicalizer.

* `icmp bin eq 1, %x` => `icmp bin eq 1, %x`
* `and bin (and bin %x, %y), %z` => `and bin %x, %y, %z`
*  `icmp bin eq(replicate(v, n), c)` => `icmp bin eq(v, c)`
*  `icmp bin eq x, 0` => `xor bin x, 1`
and etc.