### PR TITLE
[HW] Change 'modifyPorts' and ilk to optionally modify the body

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -107,41 +107,45 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
       return getModulePortInfo($_op);
     }]>,
 
-    /// Insert and remove input and output ports of this module. Does not modify
-    /// the block arguments of the module body. The insertion and removal
-    /// indices must be in ascending order. The indices refer to the port
-    /// positions before any insertion or removal occurs. Ports inserted at the
-    /// same index will appear in the module in the same order as they were
-    /// listed in the insertion arrays.
+    /// Insert and remove input and output ports of this module. Modifies the
+    /// body block if 'body' is non-null.  The insertion and removal indices
+    /// must be in ascending order. The indices refer to the port positions
+    /// before any insertion or removal occurs. Ports inserted at the same index
+    /// will appear in the module in the same order as they were listed in the
+    /// insertion arrays. If 'body'
     InterfaceMethod<"Insert and remove input and output ports",
     "void", "modifyPorts", (ins
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertInputs,
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertOutputs,
-      "ArrayRef<unsigned>":$eraseInputs, "ArrayRef<unsigned>":$eraseOutputs),
+      "ArrayRef<unsigned>":$eraseInputs, "ArrayRef<unsigned>":$eraseOutputs,
+      "Block *":$body),
     /*methodBody=*/[{
-      $_op.modifyPorts(insertInputs, insertOutputs, eraseInputs, eraseOutputs);
+      $_op.modifyPorts(insertInputs, insertOutputs,
+                       eraseInputs, eraseOutputs, body);
     }]>,
 
-    /// Insert ports into the module. Does not modify the block arguments of the
-    /// module body.
+    /// Insert ports into the module. Does modifies the block arguments of the
+    /// module body if 'body' is non-null.
     InterfaceMethod<"Insert ports into this module",
     "void", "insertPorts", (ins
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertInputs,
-      "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertOutputs),
+      "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertOutputs,
+      "Block *":$body),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
-      $_op.modifyPorts(insertInputs, insertOutputs, {}, {});
+      $_op.modifyPorts(insertInputs, insertOutputs, {}, {}, body);
     }]>,
 
-    /// Erase ports from the module. Does not modify the block arguments of the
-    /// module body.
+    /// Erase ports from the module. Does modifies the block arguments of the
+    /// module body if 'body' is non-null.
     InterfaceMethod<"Erase ports from this module",
     "void", "erasePorts", (ins
       "ArrayRef<unsigned>":$eraseInputs,
-      "ArrayRef<unsigned>":$eraseOutputs),
+      "ArrayRef<unsigned>":$eraseOutputs,
+      "Block *":$body),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
-      $_op.modifyPorts({}, {}, eraseInputs, eraseOutputs);
+      $_op.modifyPorts({}, {}, eraseInputs, eraseOutputs, body);
     }]>,
 
     /// Appends output ports to the module with the specified names and rewrites

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -108,11 +108,11 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
     }]>,
 
     /// Insert and remove input and output ports of this module. Modifies the
-    /// body block if 'body' is non-null.  The insertion and removal indices
+    /// body block if 'body' is non-null. The insertion and removal indices
     /// must be in ascending order. The indices refer to the port positions
     /// before any insertion or removal occurs. Ports inserted at the same index
     /// will appear in the module in the same order as they were listed in the
-    /// insertion arrays. If 'body'
+    /// insertion arrays.
     InterfaceMethod<"Insert and remove input and output ports",
     "void", "modifyPorts", (ins
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertInputs,
@@ -124,8 +124,8 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
                        eraseInputs, eraseOutputs, body);
     }]>,
 
-    /// Insert ports into the module. Does modifies the block arguments of the
-    /// module body if 'body' is non-null.
+    /// Insert ports into the module. Modifies the block arguments of 'body' if
+    /// non-null.
     InterfaceMethod<"Insert ports into this module",
     "void", "insertPorts", (ins
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertInputs,
@@ -136,8 +136,8 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
       $_op.modifyPorts(insertInputs, insertOutputs, {}, {}, body);
     }]>,
 
-    /// Erase ports from the module. Does modifies the block arguments of the
-    /// module body if 'body' is non-null.
+    /// Erase ports from the module. Modifies the block arguments of 'body' if
+    /// non-null.
     InterfaceMethod<"Erase ports from this module",
     "void", "erasePorts", (ins
       "ArrayRef<unsigned>":$eraseInputs,

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -108,11 +108,12 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
     }]>,
 
     /// Insert and remove input and output ports of this module. Modifies the
-    /// body block if 'body' is non-null. The insertion and removal indices
-    /// must be in ascending order. The indices refer to the port positions
-    /// before any insertion or removal occurs. Ports inserted at the same index
-    /// will appear in the module in the same order as they were listed in the
-    /// insertion arrays.
+    /// body block arguments if 'body' is non-null to match the new inputs. Does
+    /// _not_ modify the terminator to match the outputs. The insertion and
+    /// removal indices must be in ascending order. The indices refer to the
+    /// port positions before any insertion or removal occurs. Ports inserted at
+    /// the same index will appear in the module in the same order as they were
+    /// listed in the insertion arrays.
     InterfaceMethod<"Insert and remove input and output ports",
     "void", "modifyPorts", (ins
       "ArrayRef<std::pair<unsigned, circt::hw::PortInfo>>":$insertInputs,

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -47,7 +47,8 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       ArrayRef<std::pair<unsigned, PortInfo>> insertInputs,
       ArrayRef<std::pair<unsigned, PortInfo>> insertOutputs,
       ArrayRef<unsigned> eraseInputs,
-      ArrayRef<unsigned> eraseOutputs
+      ArrayRef<unsigned> eraseOutputs,
+      Block *body
     );
   }];
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -161,7 +161,8 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
     void modifyPorts(
       ArrayRef<std::pair<unsigned, circt::hw::PortInfo>> insertInputs,
       ArrayRef<std::pair<unsigned, circt::hw::PortInfo>> insertOutputs,
-      ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs);
+      ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs,
+      Block *body);
 
     // Adds input and output ports. Returns a list of new block arguments for
     // the new inputs.

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -331,7 +331,7 @@ static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
     auto inPortInfo =
         getMemoryIOInfo(arg.getLoc(), memName.strref() + "_in", i,
                         portInfo.outputs, hw::PortDirection::INPUT);
-    mod.insertPorts({{i, inPortInfo}}, {});
+    mod.insertPorts({{i, inPortInfo}}, {}, mod.getBodyBlock());
     auto newInPort = mod.getArgument(i);
     // Replace the extmemory submodule outputs with the newly created inputs.
     b.setInsertionPointToStart(mod.getBodyBlock());
@@ -360,7 +360,8 @@ static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
     // Erase the original memref argument of the top-level i/o now that it's use
     // has been removed.
     mod.modifyPorts(/*insertInputs*/ {}, /*insertOutputs*/ {},
-                    /*eraseInputs*/ {i + 1}, /*eraseOutputs*/ {});
+                    /*eraseInputs*/ {i + 1}, /*eraseOutputs*/ {},
+                    mod.getBodyBlock());
   }
 
   return success();

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -671,7 +671,7 @@ bool ESIPortsPass::updateFunc(HWMutableModuleLike mod) {
   if (outOp)
     outOp->setOperands(newOutputOperands);
   mod.modifyPorts(inputsToInsert, outputsToInsert, inputsToErase,
-                  outputsToErase);
+                  outputsToErase, nullptr);
   return true;
 }
 

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -580,7 +580,7 @@ LogicalResult ESIConnectServicesPass::surfaceReqs(
                      origNumInputs, nullptr, toClient.getLoc()}));
     body->addArgument(toClient.getType(), toClient.getLoc());
   }
-  mod.insertPorts(newInputs, {});
+  mod.insertPorts(newInputs, {}, nullptr);
 
   // Replace uses with new block args which will correspond to said ports.
   // Note: no zip or enumerate here because we need mutable access to

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -833,9 +833,10 @@ void HWModuleOp::build(OpBuilder &builder, OperationState &odsState,
 void HWModuleOp::modifyPorts(
     ArrayRef<std::pair<unsigned, PortInfo>> insertInputs,
     ArrayRef<std::pair<unsigned, PortInfo>> insertOutputs,
-    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs) {
+    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs,
+    Block *body) {
   hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
-                        eraseOutputs);
+                        eraseOutputs, body);
 }
 
 /// Return the name to use for the Verilog module that we're referencing
@@ -878,9 +879,10 @@ void HWModuleExternOp::build(OpBuilder &builder, OperationState &result,
 void HWModuleExternOp::modifyPorts(
     ArrayRef<std::pair<unsigned, PortInfo>> insertInputs,
     ArrayRef<std::pair<unsigned, PortInfo>> insertOutputs,
-    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs) {
+    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs,
+    Block *body) {
   hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
-                        eraseOutputs);
+                        eraseOutputs, body);
 }
 
 void HWModuleExternOp::appendOutputs(
@@ -910,9 +912,10 @@ void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
 void HWModuleGeneratedOp::modifyPorts(
     ArrayRef<std::pair<unsigned, PortInfo>> insertInputs,
     ArrayRef<std::pair<unsigned, PortInfo>> insertOutputs,
-    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs) {
+    ArrayRef<unsigned> eraseInputs, ArrayRef<unsigned> eraseOutputs,
+    Block *body) {
   hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
-                        eraseOutputs);
+                        eraseOutputs, body);
 }
 
 void HWModuleGeneratedOp::appendOutputs(
@@ -1326,7 +1329,7 @@ HWModuleOp::insertInput(unsigned index, StringAttr name, Type ty) {
   port.name = nameAttr;
   port.direction = PortDirection::INPUT;
   port.type = ty;
-  insertPorts({std::make_pair(index, port)}, {});
+  insertPorts({std::make_pair(index, port)}, {}, getBodyBlock());
 
   // Add a new argument.
   return {nameAttr, getBody().getArgument(index)};
@@ -1347,7 +1350,7 @@ void HWModuleOp::insertOutputs(unsigned index,
     port.type = value.getType();
     indexedNewPorts.emplace_back(index, port);
   }
-  insertPorts({}, indexedNewPorts);
+  insertPorts({}, indexedNewPorts, getBodyBlock());
 
   // Rewrite the output op.
   for (auto &[name, value] : outputs)

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -608,9 +608,9 @@ void MSFTModuleOp::modifyPorts(
     llvm::ArrayRef<std::pair<unsigned int, circt::hw::PortInfo>> insertInputs,
     llvm::ArrayRef<std::pair<unsigned int, circt::hw::PortInfo>> insertOutputs,
     llvm::ArrayRef<unsigned int> eraseInputs,
-    llvm::ArrayRef<unsigned int> eraseOutputs) {
+    llvm::ArrayRef<unsigned int> eraseOutputs, Block *body) {
   hw::modifyModulePorts(*this, insertInputs, insertOutputs, eraseInputs,
-                        eraseOutputs);
+                        eraseOutputs, body);
 }
 
 void MSFTModuleOp::appendOutputs(


### PR DESCRIPTION
Add an argument to the `HWMutableModuleLike` interface which accepts a block pointer to the body. If non-null, updates the body block.