### PR TITLE
[Arc] Add module force-inlining pass

### DIFF
--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -20,6 +20,7 @@ namespace circt {
 namespace arc {
 
 std::unique_ptr<mlir::Pass> createDedupPass();
+std::unique_ptr<mlir::Pass> createInlineModulesPass();
 
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/Arc/Passes.h.inc"

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -21,4 +21,18 @@ def Dedup : Pass<"arc-dedup", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
+  let summary = "Eagerly inline private modules";
+  let description = [{
+    This pass eagerly inlines private HW modules into their instantiation sites.
+    After outlining combinational logic and registers into arcs, module bodies
+    become fairly lightweight. Since arc definitions now fulfill the purpose of
+    code reuse by allowing a single definition to be called multiple times, the
+    module hierarchy degenerates into a purely cosmetic construct. At that point
+    it is beneficial to fully flatten the module hierarchy to simplify further
+    analysis and optimization of state transfer arcs.
+  }];
+  let constructor = "circt::arc::createInlineModulesPass()";
+}
+
 #endif // CIRCT_DIALECT_ARC_PASSES_TD

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
+  InlineModules.cpp
 
   DEPENDS
   CIRCTArcTransformsIncGen

--- a/lib/Dialect/Arc/Transforms/InlineModules.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineModules.cpp
@@ -1,0 +1,134 @@
+//===- InlineModules.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Support/BackedgeBuilder.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-inline-modules"
+
+using namespace circt;
+using namespace arc;
+using namespace hw;
+using mlir::InlinerInterface;
+
+namespace {
+struct InlineModulesPass : public InlineModulesBase<InlineModulesPass> {
+  void runOnOperation() override;
+};
+
+/// A simple implementation of the `InlinerInterface` that marks all inlining as
+/// legal since we know that we only ever attempt to inline `HWModuleOp` bodies
+/// at `InstanceOp` sites.
+struct PrefixingInliner : public InlinerInterface {
+  StringRef prefix;
+  PrefixingInliner(MLIRContext *context, StringRef prefix)
+      : InlinerInterface(context), prefix(prefix) {}
+
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  void handleTerminator(Operation *op,
+                        ArrayRef<Value> valuesToRepl) const override {
+    assert(isa<hw::OutputOp>(op));
+    for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
+      from.replaceAllUsesWith(to);
+  }
+
+  void processInlinedBlocks(
+      iterator_range<Region::iterator> inlinedBlocks) override {
+    for (Block &block : inlinedBlocks)
+      block.walk([&](Operation *op) { updateNames(op); });
+  }
+
+  StringAttr updateName(StringAttr attr) const {
+    if (attr.getValue().empty())
+      return attr;
+    return StringAttr::get(attr.getContext(), prefix + "/" + attr.getValue());
+  }
+
+  void updateNames(Operation *op) const {
+    if (auto name = op->getAttrOfType<StringAttr>("name"))
+      op->setAttr("name", updateName(name));
+    if (auto namesAttr = op->getAttrOfType<ArrayAttr>("names")) {
+      SmallVector<Attribute> names(namesAttr.getValue().begin(),
+                                   namesAttr.getValue().end());
+      for (auto &name : names)
+        if (auto nameStr = name.dyn_cast<StringAttr>())
+          name = updateName(nameStr);
+      op->setAttr("names", ArrayAttr::get(namesAttr.getContext(), names));
+    }
+  }
+};
+} // namespace
+
+void InlineModulesPass::runOnOperation() {
+  auto &instanceGraph = getAnalysis<InstanceGraph>();
+  DenseSet<Operation *> handled;
+
+  // Iterate over all instances in the instance graph. This ensures we visit
+  // every module, even private top modules (private and never instantiated).
+  for (auto *startNode : instanceGraph) {
+    if (handled.count(startNode->getModule().getOperation()))
+      continue;
+
+    // Visit the instance subhierarchy starting at the current module, in a
+    // depth-first manner. This allows us to inline child modules into parents
+    // before we attempt to inline parents into their parents.
+    for (InstanceGraphNode *node : llvm::post_order(startNode)) {
+      if (!handled.insert(node->getModule().getOperation()).second)
+        continue;
+
+      unsigned numUsesLeft = node->getNumUses();
+      if (numUsesLeft == 0)
+        continue;
+
+      for (auto *instRecord : node->uses()) {
+        // Only inline private `HWModuleOp`s (no extern or generated modules).
+        auto module =
+            dyn_cast_or_null<HWModuleOp>(node->getModule().getOperation());
+        if (!module || !module.isPrivate())
+          continue;
+
+        // Only inline at plain old HW `InstanceOp`s.
+        auto inst = dyn_cast_or_null<InstanceOp>(
+            instRecord->getInstance().getOperation());
+        if (!inst)
+          continue;
+
+        bool isLastModuleUse = --numUsesLeft == 0;
+
+        PrefixingInliner inliner(&getContext(), inst.instanceName());
+        if (failed(mlir::inlineRegion(inliner, &module.getBody(), inst,
+                                      inst.getOperands(), inst.getResults(),
+                                      std::nullopt, !isLastModuleUse))) {
+          inst.emitError("failed to inline '")
+              << module.moduleName() << "' into instance '"
+              << inst.instanceName() << "'";
+          return signalPassFailure();
+        }
+
+        inst.erase();
+        if (isLastModuleUse)
+          module->erase();
+      }
+    }
+  }
+}
+
+std::unique_ptr<Pass> arc::createInlineModulesPass() {
+  return std::make_unique<InlineModulesPass>();
+}

--- a/test/Dialect/Arc/inline-modules.mlir
+++ b/test/Dialect/Arc/inline-modules.mlir
@@ -1,0 +1,77 @@
+// RUN: circt-opt %s --arc-inline-modules | FileCheck %s
+
+
+// CHECK-LABEL: hw.module @SimpleA
+hw.module @SimpleA(%x: i4) -> (y: i4) {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: %0 = comb.add %x, %x
+  // CHECK-NEXT: %1 = comb.mul %0, %x
+  // CHECK-NEXT: %2 = comb.add %1, %1
+  // CHECK-NEXT: %3 = comb.mul %2, %1
+  %0 = hw.instance "b0" @SimpleB(x: %x: i4) -> (y: i4)
+  %1 = hw.instance "b1" @SimpleB(x: %0: i4) -> (y: i4)
+  // CHECK-NEXT: hw.output %3
+  hw.output %1 : i4
+}
+// CHECK-NEXT: }
+// CHECK-NOT: hw.module private @SimpleB
+hw.module private @SimpleB(%x: i4) -> (y: i4) {
+  %0 = comb.add %x, %x : i4
+  %1 = comb.mul %0, %x : i4
+  hw.output %1 : i4
+}
+
+
+// CHECK-LABEL: hw.module @DontInlinePublicA
+hw.module @DontInlinePublicA(%x: i4) -> (y: i4) {
+  // CHECK-NEXT: hw.instance "b" @DontInlinePublicB
+  %0 = hw.instance "b" @DontInlinePublicB(x: %x: i4) -> (y: i4)
+  hw.output %0 : i4
+}
+hw.module @DontInlinePublicB(%x: i4) -> (y: i4) {
+  %0 = comb.add %x, %x : i4
+  hw.output %0 : i4
+}
+
+
+// CHECK-LABEL: hw.module @NestedRegionsA
+hw.module @NestedRegionsA(%x: i42) {
+  // CHECK-NEXT: sv.ifdef "FOO" {
+  // CHECK-NEXT:   sv.ifdef "BAR" {
+  // CHECK-NEXT:     comb.mul %x, %x : i42
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  sv.ifdef "FOO" {
+    hw.instance "b" @NestedRegionsB(y: %x: i42) -> ()
+  }
+}
+// CHECK-NOT: hw.module private @NestedRegionsB
+hw.module private @NestedRegionsB(%y: i42) {
+  sv.ifdef "BAR" {
+    %0 = comb.mul %y, %y : i42
+  }
+}
+
+
+// CHECK-LABEL: hw.module @NamesA
+hw.module @NamesA() {
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: hw.constant true {name = "b0/c0/x"}
+  // CHECK-NEXT: hw.constant true {name = "b0/c1/x"}
+  // CHECK-NEXT: hw.constant true {names = ["b0/y", "b0/z"]}
+  // CHECK-NEXT: hw.constant true {name = "b1/c0/x"}
+  // CHECK-NEXT: hw.constant true {name = "b1/c1/x"}
+  // CHECK-NEXT: hw.constant true {names = ["b1/y", "b1/z"]}
+  hw.instance "b0" @NamesB() -> ()
+  hw.instance "b1" @NamesB() -> ()
+}
+// CHECK-NOT: hw.module private @NamesB
+hw.module private @NamesB() {
+  hw.instance "c0" @NamesC() -> ()
+  hw.instance "c1" @NamesC() -> ()
+  hw.constant true {names = ["y", "z"]}
+}
+// CHECK-NOT: hw.module private @NamesC
+hw.module private @NamesC() {
+  hw.constant true {name = "x"}
+}


### PR DESCRIPTION
Add the `InlineModules` pass which forcefully inlines all private HW modules. This essentially collapses the entire module hierarchy of a design and leaves a single module where the `arc.state` ops form a state transfer graph that is convenient to analyze and transform.

After outlining combinational logic and registers into arcs through the `ConvertToArcs` pass, module bodies become fairly lightweight. Since arc definitions now fulfill the purpose of code reuse by allowing a single definition to be called multiple times, the module hierarchy degenerates into a purely cosmetic construct. At that point it is beneficial to fully flatten the module hierarchy to simplify further analysis and optimization of state transfer arcs.