### PR TITLE
[LowerToHW] Reduce dontTouch+zero-width error to warning.

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -128,7 +128,7 @@ firrtl.circuit "SymArgZero" {
 // -----
 
 firrtl.circuit "DTArgZero" {
-  // expected-error @below {{zero width port "foo" has dontTouch annotation but must be removed}}
+  // expected-warning @below {{zero width port "foo" has dontTouch annotation, removing anyway}}
   firrtl.module @DTArgZero(in %foo :!firrtl.uint<0> [{class = "firrtl.transforms.DontTouchAnnotation"}]) {
   }
 }


### PR DESCRIPTION
Walk back error introduced in #4675, reduce to warning.

This is apparently used, continue to remove despite the annotation, but issue warning.