### PR TITLE
[PyCDE] Expose signaling and FIFO0

### DIFF
--- a/frontends/PyCDE/src/common.py
+++ b/frontends/PyCDE/src/common.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from .circt.dialects import msft
 from .circt import ir
 
-from .types import Type, Channel, ClockType
+from .types import Type, Channel, ChannelSignaling, ClockType
 
 from functools import singledispatchmethod
 
@@ -33,8 +33,11 @@ class Output(ModuleDecl):
 class OutputChannel(Output):
   """Create an ESI output channel port."""
 
-  def __init__(self, type: Type, name: str = None):
-    type = Channel(type)
+  def __init__(self,
+               type: Type,
+               signaling: int = ChannelSignaling.ValidReady,
+               name: str = None):
+    type = Channel(type, signaling)
     super().__init__(type, name)
 
 
@@ -52,8 +55,11 @@ class Clock(Input):
 class InputChannel(Input):
   """Create an ESI input channel port."""
 
-  def __init__(self, type: Type, name: str = None):
-    type = Channel(type)
+  def __init__(self,
+               type: Type,
+               signaling: int = ChannelSignaling.ValidReady,
+               name: str = None):
+    type = Channel(type, signaling)
     super().__init__(type, name)
 
 

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -8,6 +8,7 @@ from .support import get_user_loc
 
 from .circt import ir, support
 from .circt.dialects import esi, hw, sv
+from .circt.dialects.esi import ChannelSignaling
 
 import typing
 
@@ -497,9 +498,12 @@ class Any(Type):
 class Channel(Type):
   """An ESI channel type."""
 
-  def __new__(cls, inner_type: Type):
-    return super(Channel, cls).__new__(cls,
-                                       esi.ChannelType.get(inner_type._type))
+  def __new__(cls,
+              inner_type: Type,
+              signaling: int = ChannelSignaling.ValidReady):
+    return super(Channel,
+                 cls).__new__(cls,
+                              esi.ChannelType.get(inner_type._type, signaling))
 
   @property
   def inner_type(self):

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -498,6 +498,11 @@ class Any(Type):
 class Channel(Type):
   """An ESI channel type."""
 
+  SignalingNames = {
+      ChannelSignaling.ValidReady: "ValidReady",
+      ChannelSignaling.FIFO0: "FIFO0"
+  }
+
   def __new__(cls,
               inner_type: Type,
               signaling: int = ChannelSignaling.ValidReady):
@@ -518,7 +523,8 @@ class Channel(Type):
     return ChannelSignal
 
   def __repr__(self):
-    return f"Channel<{self.inner_type}>"
+    signaling = Channel.SignalingNames[self.signaling]
+    return f"Channel<{self.inner_type}, {signaling}>"
 
   @property
   def inner(self):

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -6,7 +6,7 @@ from pycde import (Clock, Input, InputChannel, OutputChannel, Module, generator,
 from pycde import esi
 from pycde.common import Output
 from pycde.constructs import Wire
-from pycde.types import Channel
+from pycde.types import Bits, Channel, ChannelSignaling
 from pycde.testing import unittestmodule
 from pycde.signals import BitVectorSignal, ChannelSignal
 
@@ -223,3 +223,15 @@ class PureTest(esi.PureModule):
     Consumer(clk=clk, int_in=p.int_out)
     p2 = Producer(clk=clk, instance_name="prod2")
     esi.PureModule.output_port("p2_int", p2.int_out)
+
+
+# CHECK-LABEL:  msft.module @FIFOSignalingMod {} (%a: !esi.channel<i32, FIFO0>) -> (x: !esi.channel<i32, FIFO0>)
+# CHECK-NEXT:     msft.output %a : !esi.channel<i32, FIFO0>
+@unittestmodule(print=True)
+class FIFOSignalingMod(Module):
+  a = InputChannel(Bits(32), ChannelSignaling.FIFO0)
+  x = OutputChannel(Bits(32), ChannelSignaling.FIFO0)
+
+  @generator
+  def build(self):
+    self.x = self.a

--- a/frontends/PyCDE/test/test_esi_errors.py
+++ b/frontends/PyCDE/test/test_esi_errors.py
@@ -59,7 +59,7 @@ class MultiplexerService(esi.ServiceImplementation):
     v = types.i1(0)
     chan, rdy = types.channel(types.i128).wrap(c, v)
     try:
-      # CHECK: Channel type mismatch. Expected Channel<Bits<32>>, got Channel<Bits<128>>.
+      # CHECK: Channel type mismatch. Expected Channel<Bits<32>, ValidReady>, got Channel<Bits<128>, ValidReady>.
       channels.to_client_reqs[0].assign(chan)
     except Exception as e:
       print(e)

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -25,8 +25,10 @@ MLIR_CAPI_EXPORTED MlirLogicalResult
 circtESIExportCosimSchema(MlirModule, MlirStringCallback, void *userData);
 
 MLIR_CAPI_EXPORTED bool circtESITypeIsAChannelType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType circtESIChannelTypeGet(MlirType inner);
+MLIR_CAPI_EXPORTED MlirType circtESIChannelTypeGet(MlirType inner,
+                                                   uint32_t signaling);
 MLIR_CAPI_EXPORTED MlirType circtESIChannelGetInner(MlirType channelType);
+MLIR_CAPI_EXPORTED uint32_t circtESIChannelGetSignaling(MlirType channelType);
 
 MLIR_CAPI_EXPORTED bool circtESITypeIsAnAnyType(MlirType type);
 MLIR_CAPI_EXPORTED MlirType circtESIAnyTypeGet(MlirContext);

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -70,14 +70,19 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
         py::arg("impl_type"), py::arg("generator"));
 
   mlir_type_subclass(m, "ChannelType", circtESITypeIsAChannelType)
-      .def_classmethod("get",
-                       [](py::object cls, MlirType inner) {
-                         if (circtESITypeIsAChannelType(inner))
-                           return cls(inner);
-                         return cls(circtESIChannelTypeGet(inner));
-                       })
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirType inner, uint32_t signaling = 0) {
+            if (circtESITypeIsAChannelType(inner))
+              return cls(inner);
+            return cls(circtESIChannelTypeGet(inner, signaling));
+          },
+          py::arg("cls"), py::arg("inner"), py::arg("signaling") = 0)
       .def_property_readonly(
-          "inner", [](MlirType self) { return circtESIChannelGetInner(self); });
+          "inner", [](MlirType self) { return circtESIChannelGetInner(self); })
+      .def_property_readonly("signaling", [](MlirType self) {
+        return circtESIChannelGetSignaling(self);
+      });
 
   mlir_type_subclass(m, "AnyType", circtESITypeIsAnAnyType)
       .def_classmethod(

--- a/lib/Bindings/Python/dialects/esi.py
+++ b/lib/Bindings/Python/dialects/esi.py
@@ -4,3 +4,8 @@
 
 from ._esi_ops_gen import *
 from .._mlir_libs._circt._esi import *
+
+
+class ChannelSignaling:
+  ValidReady: int = 0
+  FIFO0: int = 1

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -32,13 +32,19 @@ bool circtESITypeIsAChannelType(MlirType type) {
   return unwrap(type).isa<ChannelType>();
 }
 
-MlirType circtESIChannelTypeGet(MlirType inner) {
+MlirType circtESIChannelTypeGet(MlirType inner, uint32_t signaling) {
+  auto signalEnum = symbolizeChannelSignaling(signaling);
+  if (!signalEnum)
+    return {};
   auto cppInner = unwrap(inner);
-  return wrap(ChannelType::get(cppInner.getContext(), cppInner));
+  return wrap(ChannelType::get(cppInner.getContext(), cppInner, *signalEnum));
 }
 
 MlirType circtESIChannelGetInner(MlirType channelType) {
   return wrap(unwrap(channelType).cast<ChannelType>().getInner());
+}
+uint32_t circtESIChannelGetSignaling(MlirType channelType) {
+  return (uint32_t)unwrap(channelType).cast<ChannelType>().getSignaling();
 }
 
 bool circtESITypeIsAnAnyType(MlirType type) {


### PR DESCRIPTION
- Plumbing through signaling and adding it as an optional argument on Channel ports.
- Teach wrap/unwrap how to operate on FIFO0 signaling.