### PR TITLE
[ExportVerilog] Add disallowArrayIndexInlining option

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -137,6 +137,11 @@ struct LoweringOptions {
   /// Some lint tools dislike expressions being inlined into input ports so this
   /// option avoids such warnings.
   bool disallowExpressionInliningInPorts = false;
+
+  /// If true, every expression used as an array index is driven by a wire. Some
+  /// tools, notably Vivado, produce incorrect synthesis results for certain
+  /// arithmetic ops inlined into the array index.
+  bool disallowArrayIndexInlining = false;
 };
 } // namespace circt
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -638,6 +638,14 @@ static bool isExpressionUnableToInline(Operation *op,
           continue;
       return true;
     }
+
+    // Force array index expressions to be a simple name when the
+    // `disallowArrayIndexInlining` option is set.
+    if (options.disallowArrayIndexInlining && !isa<sv::ReadInOutOp>(op))
+      if (isa<ArraySliceOp, ArrayGetOp, ArrayIndexInOutOp,
+              IndexedPartSelectInOutOp, IndexedPartSelectOp>(user))
+        if (op->getResult(0) == user->getOperand(1))
+          return true;
   }
   return false;
 }

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -95,6 +95,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       disallowExpressionInliningInPorts = true;
     } else if (option == "disallowMuxInlining") {
       disallowMuxInlining = true;
+    } else if (option == "disallowArrayIndexInlining") {
+      disallowArrayIndexInlining = true;
     } else if (option.consume_front("wireSpillingHeuristic=")) {
       if (auto heuristic = parseWireSpillingHeuristic(option)) {
         wireSpillingHeuristicSet |= *heuristic;
@@ -146,6 +148,8 @@ std::string LoweringOptions::toString() const {
     options += "disallowExpressionInliningInPorts,";
   if (disallowMuxInlining)
     options += "disallowMuxInlining,";
+  if (disallowArrayIndexInlining)
+    options += "disallowArrayIndexInlining,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/test/Conversion/ExportVerilog/disallow-array-index-inlining.mlir
+++ b/test/Conversion/ExportVerilog/disallow-array-index-inlining.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt --export-verilog %s | FileCheck %s
+// RUN: circt-opt --test-apply-lowering-options='options=disallowArrayIndexInlining' --export-verilog %s | FileCheck %s --check-prefix=DISALLOW
+
+// CHECK-LABEL: module Foo(
+// DISALLOW-LABEL: module Foo(
+hw.module @Foo(%a: !hw.array<16xi1>, %b : i4) -> (x: i1, y: i1) {
+  // CHECK: assign x = a[b + 4'h1];
+  // DISALLOW-DAG: wire [3:0] [[IDX0:.+]] = b + 4'h1;
+  // DISALLOW-DAG: assign x = a[[[IDX0]]];
+  %c1_i4 = hw.constant 1 : i4
+  %0 = comb.add %b, %c1_i4 : i4
+  %1 = hw.array_get %a[%0] : !hw.array<16xi1>, i4
+
+  // CHECK: assign y = a[b * (b + 4'h2)];
+  // DISALLOW-DAG: wire [3:0] [[IDX1:.+]] = b * (b + 4'h2);
+  // DISALLOW-DAG: assign y = a[[[IDX1]]];
+  %c2_i4 = hw.constant 2 : i4
+  %2 = comb.add %b, %c2_i4 : i4
+  %3 = comb.mul %b, %2 : i4
+  %4 = hw.array_get %a[%3] : !hw.array<16xi1>, i4
+
+  hw.output %1, %4 : i1, i1
+}


### PR DESCRIPTION
Add an option to disallow the inlining of expressions into the index of array get and slice operations. This affects output as follows:

    // disallowArrayIndexInlining = false
    assign y = a[b * (b + 4'h2)];

    // disallowArrayIndexInlining = true
    wire [3:0] TMP = b * (b + 4'h2);
    assign y = a[TMP];

We have seen Vivado produce incorrect synthesis results for some of these inlined index expressions. This flag is intended as a workaround. Off by default.