### PR TITLE
[FIRRTL][PortInfo] Add emitError/emitWarning helpers.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -94,6 +94,13 @@ struct PortInfo {
            Location loc, AnnotationSet annos)
       : name(name), type(type), direction(dir), sym(sym), loc(loc),
         annotations(annos) {}
+
+  /// Diagnostic emission helpers.
+  /// Use Port's location if specified, fallback to module's location.
+  InFlightDiagnostic emitError(Location modLoc,
+                               const Twine &message = {}) const;
+  InFlightDiagnostic emitWarning(Location modLoc,
+                                 const Twine &message = {}) const;
 };
 
 /// Verification hook for verifying module like operations.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -938,7 +938,7 @@ FIRRTLModuleLowering::lowerPorts(ArrayRef<PortInfo> firrtlPorts,
     if (firrtlPort.sym)
       if (firrtlPort.sym.size() > 1 ||
           (firrtlPort.sym.size() == 1 && !firrtlPort.sym.getSymName()))
-        return emitError(firrtlPort.loc)
+        return firrtlPort.emitError(moduleOp->getLoc())
                << "cannot lower aggregate port " << firrtlPort.name
                << " with field sensitive symbols, HW dialect does not support "
                   "per field symbols yet.";
@@ -946,7 +946,7 @@ FIRRTLModuleLowering::lowerPorts(ArrayRef<PortInfo> firrtlPorts,
     bool hadDontTouch = firrtlPort.annotations.removeDontTouch();
     if (hadDontTouch && !hwPort.sym) {
       if (hwPort.type.isInteger(0)) {
-        mlir::emitWarning(firrtlPort.loc)
+        firrtlPort.emitWarning(moduleOp->getLoc())
             << "zero width port " << hwPort.name
             << " has dontTouch annotation, removing anyway";
         continue;
@@ -966,7 +966,7 @@ FIRRTLModuleLowering::lowerPorts(ArrayRef<PortInfo> firrtlPorts,
     // input, output, or inout.  We don't want these at the HW level.
     if (hwPort.type.isInteger(0)) {
       if (hwPort.sym && !hwPort.sym.empty()) {
-        return mlir::emitError(firrtlPort.loc)
+        return firrtlPort.emitError(moduleOp->getLoc())
                << "zero width port " << hwPort.name
                << " is referenced by name [" << hwPort.sym
                << "] (e.g. in an XMR) but must be removed";

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -101,4 +101,15 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   return success();
 }
 
+InFlightDiagnostic
+circt::firrtl::PortInfo::emitError(Location modLoc,
+                                   const Twine &message) const {
+  return mlir::emitError(isa<UnknownLoc>(loc) ? modLoc : loc, message);
+}
+InFlightDiagnostic
+circt::firrtl::PortInfo::emitWarning(Location modLoc,
+                                     const Twine &message) const {
+  return mlir::emitWarning(isa<UnknownLoc>(loc) ? modLoc : loc, message);
+}
+
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp.inc"


### PR DESCRIPTION
Use port location if specified, else fallback to module's location.

Use in LowerToHW port diagnostics to help ensure a good location is used.