### PR TITLE
[CI] Add a workflow for building and uploading Python wheels.

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -1,0 +1,58 @@
+name: Upload Wheels
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels with ${{ matrix.config.cibw_build }}
+    runs-on: ${{ matrix.config.os }}
+    if: github.repository == 'llvm/circt'
+    strategy:
+      matrix:
+        config:
+          - os: ubuntu-20.04
+            cibw_build: cp37-manylinux_x86_64
+          - os: ubuntu-20.04
+            cibw_build: cp310-manylinux_x86_64
+
+    steps:
+      - name: Get CIRCT
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      - name: Unshallow CIRCT
+        run: |
+          git fetch --unshallow --tags --no-recurse-submodules
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.12.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python
+        env:
+          CIBW_BUILD: ${{ matrix.config.cibw_build }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BUILD_FRONTEND: build
+          SETUPTOOLS_SCM_DEBUG: True
+
+      - name: Upload wheels (Non-Tag)
+        uses: actions/upload-artifact@v3
+        if: github.ref_type != 'tag'
+        with:
+          path: ./wheelhouse/*.whl
+          retention-days: 7
+
+      - name: Upload wheels (Tag)
+        uses: AButler/upload-release-assets@v2.0
+        if: github.ref_type == 'tag'
+        with:
+          files: ./wheelhouse/*.whl
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -135,7 +135,7 @@ declare_mlir_dialect_python_bindings(
 
 # Bundle our own, self-contained CAPI library with all of our deps.
 add_mlir_python_common_capi_library(CIRCTBindingsPythonCAPI
-  INSTALL_COMPONENT CIRCTBindingsPythonModules
+  INSTALL_COMPONENT CIRCTPythonModules
   INSTALL_DESTINATION python_packages/circt_core/circt/_mlir_libs
   OUTPUT_DIRECTORY "${CIRCT_PYTHON_PACKAGES_DIR}/circt_core/circt/_mlir_libs"
   RELATIVE_INSTALL_ROOT "../../../.."

--- a/lib/Bindings/Python/pyproject.toml
+++ b/lib/Bindings/Python/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
+    "setuptools_scm>=6.2",
     "wheel",
     "cmake>=3.12",
     # MLIR build depends.
@@ -9,3 +10,10 @@ requires = [
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"
+
+# Enable version inference from Git.
+[tool.setuptools_scm]
+root = "../../.."
+tag_regex = "^firtool-(\\d+\\.\\d+\\.\\d+)?$"
+local_scheme = "no-local-version"
+git_describe_command = "git describe --dirty --tags --long --match firtool*"

--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -26,6 +26,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 import sysconfig
 
 from distutils.command.build import build as _build
@@ -66,6 +67,7 @@ class CMakeBuild(build_py):
     cmake_args = [
         "-DCMAKE_BUILD_TYPE=Release",  # not used on MSVC, but no harm
         "-DCMAKE_INSTALL_PREFIX={}".format(os.path.abspath(cmake_install_dir)),
+        "-DPython3_EXECUTABLE={}".format(sys.executable.replace("\\", "/")),
         "-DLLVM_ENABLE_PROJECTS=mlir",
         "-DLLVM_EXTERNAL_PROJECTS=circt",
         "-DLLVM_EXTERNAL_CIRCT_SOURCE_DIR={}".format(circt_dir),
@@ -92,7 +94,6 @@ class CMakeBuild(build_py):
         subprocess.check_call(["ar", "q", fake_library])
         cmake_args.append("-DPython3_LIBRARY:PATH={}".format(fake_library))
 
-    build_args = []
     os.makedirs(cmake_build_dir, exist_ok=True)
     if os.path.exists(cmake_install_dir):
       shutil.rmtree(cmake_install_dir)
@@ -100,14 +101,15 @@ class CMakeBuild(build_py):
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
     subprocess.check_call(["cmake", llvm_dir] + cmake_args, cwd=cmake_build_dir)
-    subprocess.check_call(["cmake", "--build", ".", "--target", "install"] +
-                          build_args,
-                          cwd=cmake_build_dir)
+    subprocess.check_call(
+        ["cmake", "--build", ".", "--target", "install-CIRCTPythonModules"],
+        cwd=cmake_build_dir)
+    if os.path.exists(target_dir):
+      os.remove(target_dir)
     shutil.copytree(os.path.join(cmake_install_dir, "python_packages",
                                  "circt_core"),
                     target_dir,
-                    symlinks=False,
-                    dirs_exist_ok=True)
+                    symlinks=False)
 
 
 class NoopBuildExtension(build_ext):
@@ -117,11 +119,11 @@ class NoopBuildExtension(build_ext):
 
 
 setup(
-    name="circt-core",
+    name="circt-python",
     version="0.0.1",
     author="Mike Urbach",
-    author_email="mike@alloystack.io",
-    description="CIRCT Core",
+    author_email="mikeurbach@gmail.com",
+    description="CIRCT Python Bindings",
     long_description="",
     include_package_data=True,
     ext_modules=[

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -11,7 +11,7 @@ add_circt_library(CIRCTTransforms
   MLIRMemRefDialect
   MLIRFuncDialect
   MLIRSupport
-  MLIRTransformUtils
+  MLIRTransforms
 
   DEPENDS
   CIRCTTransformsPassIncGen


### PR DESCRIPTION
The workflow uses cibuildwheel to build the wheels, and uploads them to GitHub. They're added to the artifacts for manual runs, and added to the release assets when triggered by a release.

Currently, manylinux wheels are built for CPython 3.7 and 3.10.

This also updates the packaging scripts to include setuptools_scm to take version numbers from Git tags.