### PR TITLE
[ESI] Add parameters to PureModule lowering

### DIFF
--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -530,3 +530,14 @@ class PureModule(Module):
   def output_port(name: str, signal: Signal):
     from .dialects import esi
     return esi.ESIPureModuleOutputOp(name, signal)
+
+  @staticmethod
+  def param(name: str, type: Type = None):
+    """Create a parameter in the resulting module."""
+    from .dialects import esi
+    from .circt import ir
+    if type is None:
+      type_attr = ir.TypeAttr.get(ir.NoneType.get())
+    else:
+      type_attr = ir.TypeAttr.get(type._type)
+    esi.ESIPureModuleParamOp(name, type_attr)

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -206,7 +206,7 @@ class PassUpService(esi.ServiceImplementation):
       req.assign(esi.PureModule.input_port(name, req.type))
 
 
-# CHECK-LABEL:  hw.module @PureTest(%in_Producer_loopback_in: i32, %in_Producer_loopback_in_valid: i1, %in_prod2_loopback_in: i32, %in_prod2_loopback_in_valid: i1, %clk: i1, %out_Consumer_loopback_out_ready: i1, %p2_int_ready: i1) -> (in_Producer_loopback_in_ready: i1, in_prod2_loopback_in_ready: i1, out_Consumer_loopback_out: i32, out_Consumer_loopback_out_valid: i1, p2_int: i32, p2_int_valid: i1) {
+# CHECK-LABEL:  hw.module @PureTest<FOO: i5, STR: none>(%in_Producer_loopback_in: i32, %in_Producer_loopback_in_valid: i1, %in_prod2_loopback_in: i32, %in_prod2_loopback_in_valid: i1, %clk: i1, %out_Consumer_loopback_out_ready: i1, %p2_int_ready: i1) -> (in_Producer_loopback_in_ready: i1, in_prod2_loopback_in_ready: i1, out_Consumer_loopback_out: i32, out_Consumer_loopback_out_valid: i1, p2_int: i32, p2_int_valid: i1) {
 # CHECK-NEXT:     %Producer.loopback_in_ready, %Producer.int_out, %Producer.int_out_valid = hw.instance "Producer" sym @Producer @Producer{{.*}}(clk: %clk: i1, loopback_in: %in_Producer_loopback_in: i32, loopback_in_valid: %in_Producer_loopback_in_valid: i1, int_out_ready: %Consumer.int_in_ready: i1) -> (loopback_in_ready: i1, int_out: i32, int_out_valid: i1)
 # CHECK-NEXT:     %Consumer.int_in_ready, %Consumer.loopback_out, %Consumer.loopback_out_valid = hw.instance "Consumer" sym @Consumer @Consumer{{.*}}(clk: %clk: i1, int_in: %Producer.int_out: i32, int_in_valid: %Producer.int_out_valid: i1, loopback_out_ready: %out_Consumer_loopback_out_ready: i1) -> (int_in_ready: i1, loopback_out: i32, loopback_out_valid: i1)
 # CHECK-NEXT:     %prod2.loopback_in_ready, %prod2.int_out, %prod2.int_out_valid = hw.instance "prod2" sym @prod2 @Producer{{.*}}(clk: %clk: i1, loopback_in: %in_prod2_loopback_in: i32, loopback_in_valid: %in_prod2_loopback_in_valid: i1, int_out_ready: %p2_int_ready: i1) -> (loopback_in_ready: i1, int_out: i32, int_out_valid: i1)
@@ -223,6 +223,8 @@ class PureTest(esi.PureModule):
     Consumer(clk=clk, int_in=p.int_out)
     p2 = Producer(clk=clk, instance_name="prod2")
     esi.PureModule.output_port("p2_int", p2.int_out)
+    esi.PureModule.param("FOO", Bits(5))
+    esi.PureModule.param("STR")
 
 
 # CHECK-LABEL:  msft.module @FIFOSignalingMod {} (%a: !esi.channel<i32, FIFO0>) -> (x: !esi.channel<i32, FIFO0>)

--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -72,3 +72,19 @@ def ESIPureModuleOutputOp : ESI_Op<"pure_module.output",
   let results = (outs);
   let assemblyFormat = [{ $name `,` $value attr-dict `:` type($value) }];
 }
+
+def ESIPureModuleParamOp : ESI_Op<"pure_module.param",
+      [HasParent<"ESIPureModuleOp">]> {
+
+  let summary = "Params become module parameters when the module is lowered";
+  let description = [{
+    Allows attaching parameters to modules which become HW module parameters
+    when lowering. Currently, they are ignored. Some low-level BSPs instantiate
+    modules with parameters. This allows the modules produced to accept
+    parameters so those BSPs can instantiate them.
+  }];
+
+  let arguments = (ins StrAttr:$name, TypeAttr:$type);
+  let results = (outs);
+  let assemblyFormat = [{ $name `:` $type attr-dict }];
+}

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -358,6 +358,7 @@ PureModuleLowering::matchAndRewrite(ESIPureModuleOp pureMod, OpAdaptor adaptor,
   // List the input and output ops.
   SmallVector<ESIPureModuleInputOp> inputs;
   SmallVector<ESIPureModuleOutputOp> outputs;
+  SmallVector<Attribute> params;
 
   for (Operation &op : llvm::make_early_inc_range(body->getOperations())) {
     if (auto port = dyn_cast<ESIPureModuleInputOp>(op)) {
@@ -387,12 +388,16 @@ PureModuleLowering::matchAndRewrite(ESIPureModuleOp pureMod, OpAdaptor adaptor,
                                    {},
                                    port.getLoc()});
       outputs.push_back(port);
+    } else if (auto param = dyn_cast<ESIPureModuleParamOp>(op)) {
+      params.push_back(
+          ParamDeclAttr::get(param.getNameAttr(), param.getType()));
+      rewriter.eraseOp(param);
     }
   }
 
   // Create the replacement `hw.module`.
-  auto hwMod =
-      rewriter.create<hw::HWModuleOp>(loc, pureMod.getNameAttr(), ports);
+  auto hwMod = rewriter.create<hw::HWModuleOp>(
+      loc, pureMod.getNameAttr(), ports, ArrayAttr::get(getContext(), params));
   rewriter.eraseBlock(hwMod.getBodyBlock());
   rewriter.inlineRegionBefore(*body->getParent(), hwMod.getBodyRegion(),
                               hwMod.getBodyRegion().end());

--- a/test/Dialect/ESI/structure.mlir
+++ b/test/Dialect/ESI/structure.mlir
@@ -8,7 +8,7 @@ msft.module @Foo {} (%clk: i1, %in0 : !esi.channel<i1>) -> (out: !esi.channel<i1
 // CHECK-NEXT:     %foo.out, %foo.a = msft.instance @foo @Foo([[r0]], %foo.out)  : (i1, !esi.channel<i1>) -> (!esi.channel<i1>, i3)
 // CHECK-NEXT:     esi.pure_module.output "a", %foo.a : i3
 
-// PHY-LABEL:    hw.module @top(%clk: i1) -> (a: i3)
+// PHY-LABEL:    hw.module @top<FOO: i8, STR: none>(%clk: i1) -> (a: i3)
 // PHY-NEXT:       %foo.out, %foo.a = msft.instance @foo @Foo(%clk, %foo.out)  : (i1, !esi.channel<i1>) -> (!esi.channel<i1>, i3)
 // PHY-NEXT:       hw.output %foo.a : i3
 
@@ -16,4 +16,6 @@ esi.pure_module @top {
   %clk = esi.pure_module.input "clk" : i1
   %loopback, %a = msft.instance @foo @Foo(%clk, %loopback) : (i1, !esi.channel<i1>) -> (!esi.channel<i1>, i3)
   esi.pure_module.output "a", %a : i3
+  esi.pure_module.param "FOO" : i8
+  esi.pure_module.param "STR" : none
 }


### PR DESCRIPTION
Some low-level BSPs instantiate the top-level module with parameters. We don't care about said parameters' values but they need to be present in the resulting module nonetheless.