### PR TITLE
[Arc] Add constant sinking pass

### DIFF
--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -21,6 +21,7 @@ namespace arc {
 
 std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
+std::unique_ptr<mlir::Pass> createSinkInputsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();
 
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -35,6 +35,12 @@ def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
   let constructor = "circt::arc::createInlineModulesPass()";
 }
 
+def SinkInputs : Pass<"arc-sink-inputs", "mlir::ModuleOp"> {
+  let summary = "Sink constant inputs into arcs";
+  let constructor = "circt::arc::createSinkInputsPass()";
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
 def SplitLoops : Pass<"arc-split-loops", "mlir::ModuleOp"> {
   let summary = "Split arcs to break zero latency loops";
   let constructor = "circt::arc::createSplitLoopsPass()";

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
   InlineModules.cpp
+  SinkInputs.cpp
   SplitLoops.cpp
 
   DEPENDS

--- a/lib/Dialect/Arc/Transforms/SinkInputs.cpp
+++ b/lib/Dialect/Arc/Transforms/SinkInputs.cpp
@@ -1,0 +1,100 @@
+//===- SinkInputs.cpp------ -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-sink-inputs"
+
+using namespace circt;
+using namespace arc;
+using namespace hw;
+
+namespace {
+struct SinkInputsPass : public SinkInputsBase<SinkInputsPass> {
+  void runOnOperation() override;
+  void runOnModule();
+};
+} // namespace
+
+void SinkInputsPass::runOnOperation() {
+  DenseMap<StringAttr, SmallVector<Operation *>> arcConstArgs;
+  DenseMap<StringAttr, SmallVector<StateOp>> arcUses;
+
+  // Find all arc uses that use constant operands.
+  auto module = getOperation();
+  module.walk([&](StateOp stateOp) {
+    auto arcName = stateOp.getArcAttr().getAttr();
+    arcUses[arcName].push_back(stateOp);
+
+    SmallVector<Operation *> stateConsts(stateOp.getInputs().size());
+    for (auto [constArg, input] : llvm::zip(stateConsts, stateOp.getInputs()))
+      if (auto *op = input.getDefiningOp())
+        if (op->hasTrait<OpTrait::ConstantLike>())
+          constArg = op;
+
+    auto &arcConsts = arcConstArgs[arcName];
+    bool isFirst = arcConsts.empty();
+    if (isFirst)
+      arcConsts.resize(stateOp.getInputs().size());
+
+    for (auto [arcConstArg, stateConstArg] :
+         llvm::zip(arcConsts, stateConsts)) {
+      if (isFirst) {
+        arcConstArg = stateConstArg;
+        continue;
+      }
+      if (arcConstArg && stateConstArg &&
+          arcConstArg->getName() == stateConstArg->getName() &&
+          arcConstArg->getAttrDictionary() ==
+              stateConstArg->getAttrDictionary())
+        continue;
+      arcConstArg = nullptr;
+    }
+  });
+
+  // Now we go through all the defines and move the constant ops into the
+  // bodies and rewrite the function types.
+  for (auto defOp : module.getOps<DefineOp>()) {
+    // Move the constants into the arc and erase the block arguments.
+    auto builder = OpBuilder::atBlockBegin(&defOp.getBodyBlock());
+    llvm::BitVector toDelete(defOp.getBodyBlock().getNumArguments());
+    for (auto [constArg, arg] :
+         llvm::zip(arcConstArgs[defOp.getNameAttr()], defOp.getArguments())) {
+      if (!constArg)
+        continue;
+      auto *inlinedConst = builder.clone(*constArg);
+      arg.replaceAllUsesWith(inlinedConst->getResult(0));
+      toDelete.set(arg.getArgNumber());
+    }
+    defOp.getBodyBlock().eraseArguments(toDelete);
+    defOp.setType(builder.getFunctionType(
+        defOp.getBodyBlock().getArgumentTypes(), defOp.getResultTypes()));
+
+    // Rewrite all arc uses to not pass in the constant anymore.
+    for (auto stateOp : arcUses[defOp.getNameAttr()]) {
+      SmallPtrSet<Value, 4> maybeUnusedValues;
+      SmallVector<Value> newInputs;
+      for (auto [index, value] : llvm::enumerate(stateOp.getInputs())) {
+        if (toDelete[index])
+          maybeUnusedValues.insert(value);
+        else
+          newInputs.push_back(value);
+      }
+      stateOp.getInputsMutable().assign(newInputs);
+      for (auto value : maybeUnusedValues)
+        if (value.use_empty())
+          value.getDefiningOp()->erase();
+    }
+  }
+}
+
+std::unique_ptr<Pass> arc::createSinkInputsPass() {
+  return std::make_unique<SinkInputsPass>();
+}

--- a/test/Dialect/Arc/sink-inputs.mlir
+++ b/test/Dialect/Arc/sink-inputs.mlir
@@ -1,0 +1,48 @@
+// RUN: circt-opt %s --arc-sink-inputs | FileCheck %s
+
+// CHECK-LABEL: arc.define @SinkSameConstantsArc(%arg0: i4)
+arc.define @SinkSameConstantsArc(%arg0: i4, %arg1: i4) -> i4 {
+  // CHECK-NEXT: %c2_i4 = hw.constant 2
+  // CHECK-NEXT: [[TMP:%.+]] = comb.add %arg0, %c2_i4
+  // CHECK-NEXT: arc.output [[TMP]]
+  %0 = comb.add %arg0, %arg1 : i4
+  arc.output %0 : i4
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: hw.module @SinkSameConstants
+hw.module @SinkSameConstants(%x: i4) {
+  // CHECK-NOT: hw.constant
+  // CHECK-NEXT: %0 = arc.state @SinkSameConstantsArc(%x)
+  // CHECK-NEXT: %1 = arc.state @SinkSameConstantsArc(%x)
+  // CHECK-NEXT: hw.output
+  %k1 = hw.constant 2 : i4
+  %k2 = hw.constant 2 : i4
+  %0 = arc.state @SinkSameConstantsArc(%x, %k1) lat 0 : (i4, i4) -> i4
+  %1 = arc.state @SinkSameConstantsArc(%x, %k2) lat 0 : (i4, i4) -> i4
+}
+// CHECK-NEXT: }
+
+
+// CHECK-LABEL: arc.define @DontSinkDifferentConstantsArc(%arg0: i4, %arg1: i4)
+arc.define @DontSinkDifferentConstantsArc(%arg0: i4, %arg1: i4) -> i4 {
+  // CHECK-NEXT: comb.add %arg0, %arg1
+  // CHECK-NEXT: arc.output
+  %0 = comb.add %arg0, %arg1 : i4
+  arc.output %0 : i4
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: hw.module @DontSinkDifferentConstants
+hw.module @DontSinkDifferentConstants(%x: i4) {
+  // CHECK-NEXT: %c2_i4 = hw.constant 2 : i4
+  // CHECK-NEXT: %c3_i4 = hw.constant 3 : i4
+  // CHECK-NEXT: %0 = arc.state @DontSinkDifferentConstantsArc(%x, %c2_i4)
+  // CHECK-NEXT: %1 = arc.state @DontSinkDifferentConstantsArc(%x, %c3_i4)
+  // CHECK-NEXT: hw.output
+  %c2_i4 = hw.constant 2 : i4
+  %c3_i4 = hw.constant 3 : i4
+  %0 = arc.state @DontSinkDifferentConstantsArc(%x, %c2_i4) lat 0 : (i4, i4) -> i4
+  %1 = arc.state @DontSinkDifferentConstantsArc(%x, %c3_i4) lat 0 : (i4, i4) -> i4
+}
+// CHECK-NEXT: }

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -125,6 +125,7 @@ static void populatePipeline(PassManager &pm) {
     return;
   pm.addPass(arc::createSplitLoopsPass());
   pm.addPass(arc::createDedupPass());
+  pm.addPass(arc::createSinkInputsPass());
   pm.addPass(createCSEPass());
   pm.addPass(createSimpleCanonicalizerPass());
 }


### PR DESCRIPTION
Add the `SinkInputs` pass which sinks constants into arc definitions where possible. The arc conversion pass keeps constants out of arcs to increase the chance of discovering arcs that only differ by constant values, at the cost of additional arc arguments. The `SinkInputs` pass is intended to run after deduplication, to simplify arc inputs that are set to the same constant at all arc call sites.