### PR TITLE
[PyCDE] Set dialect attributes on modules, expose flatten dialect attr

### DIFF
--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -201,6 +201,7 @@ class ModuleLikeBuilderBase(_PyProxy):
     self.generators = None
     self.generator_port_proxy = None
     self.parameters = None
+    self.attributes: Dict = {}
 
   def go(self):
     """Execute the analysis and mutation to make a `ModuleLike` class operate
@@ -221,6 +222,19 @@ class ModuleLikeBuilderBase(_PyProxy):
     generators = {}
     for attr_name, attr in self.cls_dct.items():
       if attr_name.startswith("_"):
+        continue
+
+      if attr_name == "Attributes":
+        self.attributes = {
+            mod_attr[0]: mod_attr[1]
+            for mod_attr in attr
+            if isinstance(mod_attr, tuple)
+        }
+        self.attributes.update({
+            mod_attr: ir.UnitAttr.get()
+            for mod_attr in attr
+            if not isinstance(mod_attr, tuple)
+        })
         continue
 
       if isinstance(attr, Clock):
@@ -385,6 +399,7 @@ class ModuleBuilder(ModuleLikeBuilderBase):
           [(n, t._type) for (n, t) in self.inputs],
           [(n, t._type) for (n, t) in self.outputs],
           self.parameters if hasattr(self, "parameters") else None,
+          attributes=self.attributes,
           loc=self.loc,
           ip=sys._get_ip(),
       )
@@ -397,12 +412,13 @@ class ModuleBuilder(ModuleLikeBuilderBase):
           hw.ParamDeclAttr.get_nodefault(i.name, i.attr.type)
           for i in self.parameters
       ]
+    self.attributes["verilogName"] = ir.StringAttr.get(self.name)
     return msft.MSFTModuleExternOp(
         symbol,
         [(n, t._type) for (n, t) in self.inputs],
         [(n, t._type) for (n, t) in self.outputs],
         parameters=paramdecl_list,
-        attributes={"verilogName": ir.StringAttr.get(self.name)},
+        attributes=self.attributes,
         loc=self.loc,
         ip=sys._get_ip(),
     )

--- a/lib/Bindings/Python/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/dialects/_msft_ops_ext.py
@@ -74,20 +74,22 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
       output_ports=[],
       parameters: _ir.DictAttr = None,
       file_name: str = None,
+      attributes=None,
       loc=None,
       ip=None,
   ):
-    attrs = {"parameters": parameters}
+    if attributes is None:
+      attributes = {}
     if parameters is not None:
-      attrs["parameters"] = parameters
+      attributes["parameters"] = parameters
     else:
-      attrs["parameters"] = _ir.DictAttr.get({})
+      attributes["parameters"] = _ir.DictAttr.get({})
     if file_name is not None:
-      attrs["fileName"] = _ir.StringAttr.get(file_name)
+      attributes["fileName"] = _ir.StringAttr.get(file_name)
     super().__init__(name,
                      input_ports,
                      output_ports,
-                     attributes=attrs,
+                     attributes=attributes,
                      loc=loc,
                      ip=ip)
 

--- a/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
@@ -160,6 +160,7 @@ ModuleOpLowering::matchAndRewrite(MSFTModuleOp mod, OpAdaptor adaptor,
         rewriter.getContext(), outputFile, false, true);
     hwmod->setAttr("output_file", outputFileAttr);
   }
+  hwmod->setDialectAttrs(mod->getDialectAttrs());
 
   return success();
 }
@@ -193,6 +194,7 @@ LogicalResult ModuleExternOpLowering::matchAndRewrite(
         rewriter.getContext(), outputFile, false, true);
     hwMod->setAttr("output_file", outputFileAttr);
   }
+  hwMod->setDialectAttrs(mod->getDialectAttrs());
 
   return success();
 }


### PR DESCRIPTION
Adds a 'Attribute' python attribute which can be used to set (CIRCT) attributes on modules. Use that mechanism to expose the "FlattenStructPorts" ESI attribute.