### PR TITLE
[Arc] Add variadic op simplification pass

### DIFF
--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -23,6 +23,7 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
+std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();
 std::unique_ptr<mlir::Pass> createSinkInputsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();
 std::unique_ptr<mlir::Pass> createStripSVPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -49,6 +49,21 @@ def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def SimplifyVariadicOps : Pass<"arc-simplify-variadic-ops", "mlir::ModuleOp"> {
+  let summary = "Convert variadic ops into distributed binary ops";
+  let constructor = "circt::arc::createSimplifyVariadicOpsPass()";
+  let statistics = [
+    Statistic<"numOpsSkippedMultipleBlocks", "skipped-multiple-blocks",
+      "Ops skipped due to operands in different blocks">,
+    Statistic<"numOpsSimplified", "simplified",
+      "Ops simplified into binary ops">,
+    Statistic<"numOpsCreated", "created",
+      "Ops created as part of simplification">,
+    Statistic<"numOpsReordered", "reordered",
+      "Ops where simplification reordered operands">,
+  ];
+}
+
 def SinkInputs : Pass<"arc-sink-inputs", "mlir::ModuleOp"> {
   let summary = "Sink constant inputs into arcs";
   let constructor = "circt::arc::createSinkInputsPass()";

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   InferMemories.cpp
   InlineModules.cpp
   MakeTables.cpp
+  SimplifyVariadicOps.cpp
   SinkInputs.cpp
   SplitLoops.cpp
   StripSV.cpp

--- a/lib/Dialect/Arc/Transforms/SimplifyVariadicOps.cpp
+++ b/lib/Dialect/Arc/Transforms/SimplifyVariadicOps.cpp
@@ -1,0 +1,117 @@
+//===- SimplifyVariadicOps.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-simplify-variadic-ops"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+using namespace hw;
+
+namespace {
+struct SimplifyVariadicOpsPass
+    : public SimplifyVariadicOpsBase<SimplifyVariadicOpsPass> {
+  SimplifyVariadicOpsPass() = default;
+  SimplifyVariadicOpsPass(const SimplifyVariadicOpsPass &pass)
+      : SimplifyVariadicOpsPass() {}
+
+  void runOnOperation() override;
+  void simplifyOp(Operation *op);
+};
+} // namespace
+
+void SimplifyVariadicOpsPass::runOnOperation() {
+  SmallVector<Operation *> opsToProcess;
+  getOperation().walk([&](Operation *op) {
+    if (op->hasTrait<OpTrait::IsCommutative>() && op->getNumRegions() == 0 &&
+        op->getNumSuccessors() == 0 && op->getNumResults() == 1 &&
+        op->getNumOperands() > 2 && isMemoryEffectFree(op))
+      opsToProcess.push_back(op);
+  });
+  for (auto *op : opsToProcess)
+    simplifyOp(op);
+}
+
+void SimplifyVariadicOpsPass::simplifyOp(Operation *op) {
+  // Gather the list of operands together with the defining op. Block arguments
+  // simply get no op assigned. This is also where we bail out if the block
+  // argument or any of the defining ops is in a different block than the op
+  // itself.
+  auto *block = op->getBlock();
+  SmallVector<Value> operands;
+  for (auto operand : op->getOperands()) {
+    if (auto blockArg = operand.dyn_cast<BlockArgument>()) {
+      if (blockArg.getOwner() != block) {
+        ++numOpsSkippedMultipleBlocks;
+        return;
+      }
+    } else {
+      auto *defOp = operand.getDefiningOp();
+      if (defOp->getBlock() != block) {
+        ++numOpsSkippedMultipleBlocks;
+        return;
+      }
+    }
+    operands.push_back(operand);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Simplifying " << *op << "\n");
+
+  // Sort the list of operands based on the order in which their defining ops
+  // appear in the block.
+  llvm::sort(operands, [](auto a, auto b) {
+    // Sort block args by the arg number.
+    auto aBlockArg = a.template dyn_cast<BlockArgument>();
+    auto bBlockArg = b.template dyn_cast<BlockArgument>();
+    if (aBlockArg && bBlockArg)
+      return aBlockArg.getArgNumber() < bBlockArg.getArgNumber();
+
+    // Sort other values by block order of the defining op.
+    auto *aOp = a.getDefiningOp();
+    auto *bOp = b.getDefiningOp();
+    if (!aOp)
+      return true;
+    if (!bOp)
+      return false;
+    return aOp->isBeforeInBlock(bOp);
+  });
+  for (auto value : operands)
+    LLVM_DEBUG(llvm::dbgs() << "- " << value << "\n");
+
+  // Keep some statistics whether we actually did do some reordering.
+  for (auto [a, b] : llvm::zip(operands, op->getOperands())) {
+    if (a != b) {
+      ++numOpsReordered;
+      break;
+    }
+  }
+
+  // Split up the variadic operation by going through the operands and creating
+  // pairwise versions of the op as close as possible to the operands.
+  Value reduced = operands[0];
+  auto builder = OpBuilder::atBlockBegin(block);
+  for (auto value : llvm::drop_begin(operands)) {
+    if (auto *defOp = value.getDefiningOp())
+      builder.setInsertionPointAfter(defOp);
+    reduced = builder
+                  .create(op->getLoc(), op->getName().getIdentifier(),
+                          ValueRange{reduced, value}, op->getResultTypes(),
+                          op->getAttrs())
+                  ->getResult(0);
+    ++numOpsCreated;
+  }
+  op->getResult(0).replaceAllUsesWith(reduced);
+  op->erase();
+  ++numOpsSimplified;
+}
+
+std::unique_ptr<Pass> arc::createSimplifyVariadicOpsPass() {
+  return std::make_unique<SimplifyVariadicOpsPass>();
+}

--- a/test/Dialect/Arc/simplify-variadic-ops.mlir
+++ b/test/Dialect/Arc/simplify-variadic-ops.mlir
@@ -1,0 +1,51 @@
+// RUN: circt-opt %s --arc-simplify-variadic-ops | FileCheck %s
+
+// Should convert variadic comb ops with arbitrarily shuffled inputs into a
+// reasonable tree with individual nodes as close to their operand definitions
+// as possible.
+// CHECK-LABEL: func @BalancedTree
+func.func @BalancedTree(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1) -> i1 {
+  // CHECK-NEXT: comb.or
+  // CHECK-NEXT: comb.or
+  // CHECK-NEXT: comb.or
+  %0 = builtin.unrealized_conversion_cast to i1 {a}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %1 = builtin.unrealized_conversion_cast to i1 {b}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %2 = builtin.unrealized_conversion_cast to i1 {c}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %3 = builtin.unrealized_conversion_cast to i1 {d}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %4 = builtin.unrealized_conversion_cast to i1 {e}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %5 = builtin.unrealized_conversion_cast to i1 {f}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %6 = builtin.unrealized_conversion_cast to i1 {g}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %7 = builtin.unrealized_conversion_cast to i1 {h}
+  // CHECK-NEXT: unrealized_conversion_cast
+  // CHECK-NEXT: comb.or
+  %8 = comb.or %7, %2, %arg3, %arg1, %5, %1, %arg2, %0, %arg0, %3, %4, %6 : i1
+  return %8 : i1
+}
+
+// Should not touch variadic ops if they cross block boundaries.
+// CHECK-LABEL: func @SkipBlockBoundaries
+func.func @SkipBlockBoundaries() {
+  %0 = builtin.unrealized_conversion_cast to i1 {a}
+  %1 = builtin.unrealized_conversion_cast to i1 {b}
+  scf.execute_region {
+    %2 = builtin.unrealized_conversion_cast to i1 {c}
+    // CHECK: comb.or %0, %1, %2 : i1
+    %3 = comb.or %0, %1, %2 : i1
+    scf.yield
+  }
+  return
+}


### PR DESCRIPTION
Add the `SimplifyVariadicOps` pass which takes the common combinational operations and converts them from their variadic representation into a chain of binary operations. The pass reorders the variadic operands such that they appear in the order in which their definitions appear in the basic block. The binary operations are then inserted as soon as both their operands become available. This distributes the operations through the block and reduces the lifetimes of the original op's operands.