### PR TITLE
[Arc] Add pass to remove unused arc arguments

### DIFF
--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -23,6 +23,7 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
+std::unique_ptr<mlir::Pass> createRemoveUnusedArcArgumentsPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();
 std::unique_ptr<mlir::Pass> createSinkInputsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -49,6 +49,13 @@ def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def RemoveUnusedArcArguments : Pass<"arc-remove-unused-arc-arguments",
+    "mlir::ModuleOp"> {
+  let summary =
+    "Remove unused arc args from the arc itself and the referencing states";
+  let constructor = "circt::arc::createRemoveUnusedArcArgumentsPass()";
+}
+
 def SimplifyVariadicOps : Pass<"arc-simplify-variadic-ops", "mlir::ModuleOp"> {
   let summary = "Convert variadic ops into distributed binary ops";
   let constructor = "circt::arc::createSimplifyVariadicOpsPass()";

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   InferMemories.cpp
   InlineModules.cpp
   MakeTables.cpp
+  RemoveUnusedArcArguments.cpp
   SimplifyVariadicOps.cpp
   SinkInputs.cpp
   SplitLoops.cpp

--- a/lib/Dialect/Arc/Transforms/RemoveUnusedArcArguments.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveUnusedArcArguments.cpp
@@ -1,0 +1,68 @@
+//===- RemoveUnusedArcArguments.cpp - Implement RemoveUnusedArcArgs Pass --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implement pass to remove unused arguments of arc::DefineOps. Also adjusts the
+// arc::StateOps referencing the arc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#define DEBUG_TYPE "arc-remove-unused-arc-arguments"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+//===----------------------------------------------------------------------===//
+// RemoveUnusedArcArguments pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct RemoveUnusedArcArgumentsPass
+    : public RemoveUnusedArcArgumentsBase<RemoveUnusedArcArgumentsPass> {
+  void runOnOperation() override;
+  void runOnStateOp(arc::StateOp stateOp, arc::DefineOp arc,
+                    DenseMap<arc::DefineOp, BitVector> &removedArgsMap);
+};
+} // namespace
+
+void RemoveUnusedArcArgumentsPass::runOnOperation() {
+  SymbolTableCollection symbolTable;
+  DenseMap<arc::DefineOp, BitVector> removedArgsMap;
+
+  getOperation()->walk([&](arc::StateOp stateOp) {
+    auto arc = cast<arc::DefineOp>(cast<CallOpInterface>(stateOp.getOperation())
+                                       .resolveCallable(&symbolTable));
+    runOnStateOp(stateOp, arc, removedArgsMap);
+  });
+}
+
+void RemoveUnusedArcArgumentsPass::runOnStateOp(
+    arc::StateOp stateOp, arc::DefineOp arc,
+    DenseMap<arc::DefineOp, BitVector> &removedArgsMap) {
+  if (!removedArgsMap.count(arc)) {
+    BitVector toErase(arc.getNumArguments());
+    for (auto [i, arg] : llvm::enumerate(arc.getArguments())) {
+      if (arg.use_empty())
+        toErase.set(i);
+    }
+    arc.eraseArguments(toErase);
+    removedArgsMap[arc] = toErase;
+  }
+
+  BitVector toErase = removedArgsMap[arc];
+  for (int i = toErase.size() - 1; i >= 0; --i) {
+    if (toErase[i])
+      stateOp.getInputsMutable().erase(i);
+  }
+}
+
+std::unique_ptr<Pass> arc::createRemoveUnusedArcArgumentsPass() {
+  return std::make_unique<RemoveUnusedArcArgumentsPass>();
+}

--- a/test/Dialect/Arc/remove-unused-arc-arguments.mlir
+++ b/test/Dialect/Arc/remove-unused-arc-arguments.mlir
@@ -1,0 +1,27 @@
+// RUN: circt-opt %s --arc-remove-unused-arc-arguments | FileCheck %s
+
+// CHECK-LABEL: arc.define @OneOfThreeUsed(%arg0: i1)
+arc.define @OneOfThreeUsed(%arg0: i1, %arg1: i1, %arg2: i1) -> i1 {
+  // CHECK-NEXT: arc.output %arg0
+  arc.output %arg1 : i1
+}
+
+// CHECK: @test1
+hw.module @test1 (%arg0: i1, %arg1: i1, %arg2: i1, %clock: i1) -> (out: i1) {
+  // CHECK-NEXT: arc.state @OneOfThreeUsed(%arg1) clock %clock lat 1 : (i1) -> i1
+  %0 = arc.state @OneOfThreeUsed(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
+  hw.output %0 : i1
+}
+
+// CHECK-LABEL: arc.define @NoArgsToRemove()
+arc.define @NoArgsToRemove() -> i1 {
+  %0 = hw.constant 0 : i1
+  arc.output %0 : i1
+}
+
+// CHECK: @test2
+hw.module @test2 () -> (out: i1) {
+  // CHECK-NEXT: arc.state @NoArgsToRemove() lat 0 : () -> i1
+  %0 = arc.state @NoArgsToRemove() lat 0 : () -> i1
+  hw.output %0 : i1
+}

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -142,6 +142,7 @@ static void populatePipeline(PassManager &pm) {
   pm.addPass(arc::createMakeTablesPass());
   pm.addPass(createCSEPass());
   pm.addPass(createSimpleCanonicalizerPass());
+  pm.addPass(arc::createRemoveUnusedArcArgumentsPass());
 }
 
 static LogicalResult


### PR DESCRIPTION
Add the `RemoveUnusedArcArguments` pass that does exactly what it says.