### PR TITLE
[Arc] Add lookup table op and lowering pass

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -90,7 +90,7 @@ def DefineOp : ArcOp<"define", [
 
 def OutputOp : ArcOp<"output", [
   Terminator,
-  ParentOneOf<["DefineOp"]>,
+  ParentOneOf<["DefineOp", "LutOp"]>,
   Pure,
   ReturnLike
 ]> {
@@ -240,6 +240,39 @@ def MemoryWriteOp : ArcOp<"memory_write", [
     ( `mask` `(` $mask^ `:` type($mask) `)`)?
     (` ` `(` `reads` $reads^ `:` type($reads) `)`)?
     attr-dict `:` type($memory) `,` type($address)
+  }];
+
+  let hasVerifier = 1;
+}
+
+def LutOp : ArcOp<"lut", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"arc::OutputOp">,
+  Pure
+]> {
+  let summary = "A lookup-table.";
+  let description = [{
+    Represents a lookup-table as one operation. The operations that map the
+    lookup/input values to the corresponding table-entry are collected inside
+    the body of this operation.
+    Note that the operation is marked to be isolated from above to guarantee
+    that all input values have to be passed as an operand. This allows for
+    simpler analyses and canonicalizations of the LUT as well as lowering.
+    Only combinational operations are allowed inside the LUT, i.e., no
+    side-effects, state, time delays, etc.
+  }];
+
+  let arguments = (ins Variadic<AnySignlessInteger>:$inputs);
+  let results = (outs AnySignlessInteger:$output);
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    `(` $inputs `)` `:` functional-type($inputs, $output)
+    attr-dict-with-keyword $body
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Block *getBodyBlock() { return &getBody().front(); }
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -22,6 +22,7 @@ namespace arc {
 std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
+std::unique_ptr<mlir::Pass> createLowerLUTPass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
 std::unique_ptr<mlir::Pass> createRemoveUnusedArcArgumentsPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -43,6 +43,12 @@ def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
   let constructor = "circt::arc::createInlineModulesPass()";
 }
 
+def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
+  let summary = "Lowers arc.lut into a comb and hw only representation.";
+  let constructor = "circt::arc::createLowerLUTPass()";
+  let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];
+}
+
 def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let summary = "Transform appropriate arc logic into lookup tables";
   let constructor = "circt::arc::createMakeTablesPass()";

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
   InferMemories.cpp
   InlineModules.cpp
+  LowerLUT.cpp
   MakeTables.cpp
   RemoveUnusedArcArguments.cpp
   SimplifyVariadicOps.cpp

--- a/lib/Dialect/Arc/Transforms/LowerLUT.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerLUT.cpp
@@ -1,0 +1,369 @@
+//===- LowerLUT.cpp -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-lower-lut"
+
+using namespace circt;
+using namespace arc;
+
+//===----------------------------------------------------------------------===//
+// Data structures
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Allows to compute the constant lookup-table entries given the LutOp
+/// operation and caches the result. Also provides additional utility functions
+/// related to lookup-table materialization.
+class LutCalculator {
+public:
+  /// Compute all the lookup-table enties if they haven't already been computed
+  /// and cache the results. Note that calling this function is very expensive
+  /// in terms of runtime as it calls the constant folders of all operations
+  /// inside the LutOp for all possible input values.
+  LogicalResult computeTableEntries(LutOp lut);
+
+  /// Get a reference to the cached lookup-table entries. `computeTableEntries`
+  /// has to be called before calling this function.
+  ArrayRef<IntegerAttr> getRefToTableEntries();
+  /// Get a copy of the cached lookup-table entries. `computeTableEntries` has
+  /// to be called before calling this function.
+  void getCopyOfTableEntries(SmallVector<IntegerAttr> &tableEntries);
+  /// Materialize uniqued hw::ConstantOp operations for all cached lookup-table
+  /// entries. `computeTableEntries` has to be called before calling this
+  /// function.
+  void getTableEntriesAsConstValues(OpBuilder &builder,
+                                    SmallVector<Value> &tableEntries);
+  /// Compute and return the total size of the table in bits.
+  uint32_t getTableSize();
+  /// Compute and return the summed up bit-width of all input values.
+  uint32_t getInputBitWidth();
+
+private:
+  LutOp lut;
+  SmallVector<IntegerAttr> table;
+};
+
+/// A wrapper around ConversionPattern that matches specifically on LutOp
+/// operations and hold a LutCalculator member variable that allows to compute
+/// the lookup-table entries and cache the result.
+class LutLoweringPattern : public ConversionPattern {
+public:
+  LutLoweringPattern(LutCalculator &lutCalculator, MLIRContext *context,
+                     mlir::PatternBenefit benefit = 1)
+      : ConversionPattern(LutOp::getOperationName(), benefit, context),
+        lutCalculator(lutCalculator) {}
+  LutLoweringPattern(LutCalculator &lutCalculator, TypeConverter &typeConverter,
+                     MLIRContext *context, mlir::PatternBenefit benefit = 1)
+      : ConversionPattern(typeConverter, LutOp::getOperationName(), benefit,
+                          context),
+        lutCalculator(lutCalculator) {}
+
+  /// Wrappers around the ConversionPattern methods that pass the LutOp
+  /// type and guarantee that the LutCalculator is up-to-date.
+  LogicalResult match(Operation *op) const final {
+    auto lut = cast<LutOp>(op);
+    if (failed(lutCalculator.computeTableEntries(lut)))
+      return failure();
+    return match(lut);
+  }
+  void rewrite(Operation *op, ArrayRef<Value> operands,
+               ConversionPatternRewriter &rewriter) const final {
+    rewrite(cast<LutOp>(op), LutOpAdaptor(operands, op->getAttrDictionary()),
+            rewriter);
+  }
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto lut = cast<LutOp>(op);
+    if (failed(lutCalculator.computeTableEntries(lut)))
+      return failure();
+    return matchAndRewrite(lut, LutOpAdaptor(operands, op->getAttrDictionary()),
+                           rewriter);
+  }
+
+  /// Rewrite and Match methods that operate on the LutOp type. These must be
+  /// overridden by the derived pattern class.
+  virtual LogicalResult match(LutOp op) const {
+    llvm_unreachable("must override match or matchAndRewrite");
+  }
+  virtual void rewrite(LutOp op, LutOpAdaptor adaptor,
+                       ConversionPatternRewriter &rewriter) const {
+    llvm_unreachable("must override matchAndRewrite or a rewrite method");
+  }
+  virtual LogicalResult
+  matchAndRewrite(LutOp op, LutOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const {
+    if (failed(match(op)))
+      return failure();
+    rewrite(op, adaptor, rewriter);
+    return success();
+  }
+
+protected:
+  LutCalculator &lutCalculator;
+
+private:
+  using ConversionPattern::matchAndRewrite;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Data structure implementations
+//===----------------------------------------------------------------------===//
+
+// Note that this function is very expensive in terms of runtime since it
+// computes the LUT entries by calling the operation's folders
+// O(2^inputBitWidth) times.
+LogicalResult LutCalculator::computeTableEntries(LutOp lut) {
+  // If we already have precomputed the entries for this LUT operation, we don't
+  // need to re-compute it. This is important, because the dialect conversion
+  // framework may try several lowering patterns for the same LutOp after
+  // another and recomputing it every time would be very expensive.
+  if (this->lut == lut && !table.empty())
+    return success();
+
+  // Cache this LUT to be able to apply above shortcut next time and clear the
+  // currently cached table entries from a previous LUT.
+  this->lut = lut;
+  table.clear();
+
+  // Allocate memory
+  DenseMap<Value, SmallVector<Attribute>> vals;
+  const uint32_t bw = getInputBitWidth();
+
+  for (auto arg : lut.getBodyBlock()->getArguments())
+    vals[arg] = SmallVector<Attribute>(1U << bw);
+
+  for (auto &operation : lut.getBodyBlock()->without_terminator()) {
+    for (auto operand : operation.getResults()) {
+      if (vals.count(operand))
+        continue;
+      vals[operand] = SmallVector<Attribute>(1U << bw);
+    }
+  }
+
+  // Initialize inputs
+  for (int i = 0; i < (1 << bw); ++i) {
+    const APInt input(bw, i);
+    size_t offset = bw;
+    for (auto arg : lut.getBodyBlock()->getArguments()) {
+      const unsigned argBitWidth = arg.getType().getIntOrFloatBitWidth();
+      offset -= argBitWidth;
+      vals[arg][i] = IntegerAttr::get(arg.getType(),
+                                      input.extractBits(argBitWidth, offset));
+    }
+  }
+
+  for (auto &operation : lut.getBodyBlock()->without_terminator()) {
+    // We need to rearange the vectors to use the operation folers. There is
+    // probably still some potential for optimization here.
+    SmallVector<SmallVector<Attribute>, 8> constants(1U << bw);
+    for (size_t j = 0, e = operation.getNumOperands(); j < e; ++j) {
+      SmallVector<Attribute> &tmp = vals[operation.getOperand(j)];
+      for (int i = (1U << bw) - 1; i >= 0; i--)
+        constants[i].push_back(tmp[i]);
+    }
+
+    // Call the operation folders
+    SmallVector<SmallVector<OpFoldResult>, 8> results(
+        1U << bw, SmallVector<OpFoldResult, 8>());
+    for (int i = (1U << bw) - 1; i >= 0; i--) {
+      if (failed(operation.fold(constants[i], results[i]))) {
+        LLVM_DEBUG(llvm::dbgs() << "Failed to fold operation '";
+                   operation.print(llvm::dbgs()); llvm::dbgs() << "'\n");
+        return failure();
+      }
+    }
+
+    // Store the folder's results in the value map.
+    for (size_t i = 0, e = operation.getNumResults(); i < e; ++i) {
+      SmallVector<Attribute> &ref = vals[operation.getResult(i)];
+      for (int j = (1U << bw) - 1; j >= 0; j--) {
+        Attribute foldAttr;
+        if (!(foldAttr = results[j][i].dyn_cast<Attribute>()))
+          foldAttr = vals[results[j][i].get<Value>()][j];
+        ref[j] = foldAttr;
+      }
+    }
+  }
+
+  // Store the LUT's output values in the correct order in the table entry
+  // cache.
+  auto outValue = lut.getBodyBlock()->getTerminator()->getOperand(0);
+  for (int j = (1U << bw) - 1; j >= 0; j--)
+    table.push_back(vals[outValue][j].cast<IntegerAttr>());
+
+  return success();
+}
+
+ArrayRef<IntegerAttr> LutCalculator::getRefToTableEntries() { return table; }
+
+void LutCalculator::getCopyOfTableEntries(
+    SmallVector<IntegerAttr> &tableEntries) {
+  tableEntries.append(table);
+}
+
+void LutCalculator::getTableEntriesAsConstValues(
+    OpBuilder &builder, SmallVector<Value> &tableEntries) {
+  // Since LUT entries tend to have a very small bit-width (mostly 1-3 bits),
+  // there are many duplicate constants. Creating a single constant operation
+  // for each unique number saves us a lot of CSE afterwards.
+  DenseMap<IntegerAttr, Value> map;
+  for (auto entry : table) {
+    if (!map.count(entry))
+      map[entry] = builder.create<hw::ConstantOp>(lut.getLoc(), entry);
+
+    tableEntries.push_back(map[entry]);
+  }
+}
+
+uint32_t LutCalculator::getInputBitWidth() {
+  unsigned bw = 0;
+  for (auto val : lut.getInputs())
+    bw += val.getType().cast<IntegerType>().getWidth();
+  return bw;
+}
+
+uint32_t LutCalculator::getTableSize() {
+  return (1 << getInputBitWidth()) *
+         lut.getOutput().getType().getIntOrFloatBitWidth();
+}
+
+//===----------------------------------------------------------------------===//
+// Conversion patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Lower lookup-tables that have a total size of less than 256 bits to an
+/// integer that is shifed and truncated according to the lookup/index value.
+/// Encoding the lookup tables as intermediate values in the instruction stream
+/// should provide better performnace than loading from some global constant.
+struct LutToInteger : LutLoweringPattern {
+  using LutLoweringPattern::LutLoweringPattern;
+
+  LogicalResult
+  matchAndRewrite(LutOp lut, LutOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+
+    const uint32_t tableSize = lutCalculator.getTableSize();
+    const uint32_t inputBw = lutCalculator.getInputBitWidth();
+
+    if (tableSize > 256)
+      return failure();
+
+    // Concatenate the lookup table entries to a single integer.
+    auto constants = lutCalculator.getRefToTableEntries();
+    APInt result(tableSize, 0);
+    unsigned nextInsertion = tableSize;
+
+    for (auto attr : constants) {
+      auto chunk = attr.getValue();
+      nextInsertion -= chunk.getBitWidth();
+      result.insertBits(chunk, nextInsertion);
+    }
+
+    Value table = rewriter.create<hw::ConstantOp>(lut.getLoc(), result);
+
+    // Zero-extend the lookup/index value to the same bit-width as the table,
+    // because the shift operation requires both operands to have the same
+    // bit-width.
+    Value zextValue = rewriter.create<hw::ConstantOp>(
+        lut->getLoc(), rewriter.getIntegerType(tableSize - inputBw), 0);
+    Value entryOffset = rewriter.create<comb::ConcatOp>(lut.getLoc(), zextValue,
+                                                        lut.getInputs());
+    Value resultBitWidth = rewriter.create<hw::ConstantOp>(
+        lut.getLoc(), entryOffset.getType(),
+        lut.getResult().getType().getIntOrFloatBitWidth());
+    Value lookupValue =
+        rewriter.create<comb::MulOp>(lut.getLoc(), entryOffset, resultBitWidth);
+
+    // Shift the table and truncate to the bitwidth of the output value.
+    Value shiftedTable =
+        rewriter.create<comb::ShrUOp>(lut->getLoc(), table, lookupValue);
+    const Value extracted = rewriter.create<comb::ExtractOp>(
+        lut.getLoc(), shiftedTable, 0,
+        lut.getOutput().getType().getIntOrFloatBitWidth());
+
+    rewriter.replaceOp(lut, extracted);
+    return success();
+  }
+};
+
+/// Lower lookup-tables with a total size bigger than 256 bits to a constant
+/// array that is stored as constant global data and thus a lookup consists of a
+/// memory load at the correct offset of that global data frame.
+struct LutToArray : LutLoweringPattern {
+  using LutLoweringPattern::LutLoweringPattern;
+
+  LogicalResult
+  matchAndRewrite(LutOp lut, LutOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto constants = lutCalculator.getRefToTableEntries();
+    SmallVector<Attribute> constantAttrs(constants.begin(), constants.end());
+    auto tableSize = lutCalculator.getTableSize();
+    auto inputBw = lutCalculator.getInputBitWidth();
+
+    if (tableSize <= 256)
+      return failure();
+
+    Value table = rewriter.create<hw::AggregateConstantOp>(
+        lut.getLoc(), hw::ArrayType::get(lut.getType(), constantAttrs.size()),
+        rewriter.getArrayAttr(constantAttrs));
+    Value lookupValue = rewriter.create<comb::ConcatOp>(
+        lut.getLoc(), rewriter.getIntegerType(inputBw), lut.getInputs());
+    const Value extracted =
+        rewriter.create<hw::ArrayGetOp>(lut.getLoc(), table, lookupValue);
+
+    rewriter.replaceOp(lut, extracted);
+    return success();
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Lower LUT pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Lower LutOp operations to comb and hw operations.
+struct LowerLUTPass : public LowerLUTBase<LowerLUTPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void LowerLUTPass::runOnOperation() {
+  MLIRContext &context = getContext();
+  ConversionTarget target(context);
+  RewritePatternSet patterns(&context);
+  target.addLegalDialect<comb::CombDialect, hw::HWDialect, arc::ArcDialect>();
+  target.addIllegalOp<arc::LutOp>();
+
+  // TODO: This class could be factored out into an analysis if there is a need
+  // to access precomputed lookup-tables in some other pass.
+  LutCalculator lutCalculator;
+  patterns.add<LutToInteger, LutToArray>(lutCalculator, &context);
+
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> arc::createLowerLUTPass() {
+  return std::make_unique<LowerLUTPass>();
+}

--- a/test/Dialect/Arc/basic-error.mlir
+++ b/test/Dialect/Arc/basic-error.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+arc.define @lut () -> () {
+  // expected-error @+1 {{requires one result}}
+  arc.lut () : () -> () {
+    arc.output
+  }
+  arc.output
+}
+
+// -----
+
+arc.define @lut (%arg0: i32, %arg1: i8) -> () {
+  // expected-note @+1 {{required by region isolation constraints}}
+  %1 = arc.lut (%arg1, %arg0) : (i8, i32) -> i32 {
+    ^bb0(%arg2: i8, %arg3: i32):
+      // expected-error @+1 {{using value defined outside the region}}
+      arc.output %arg0 : i32
+  }
+  arc.output
+}
+
+// -----
+
+arc.define @lutSideEffects () -> i32 {
+  // expected-error @+1 {{no operations with side-effects allowed inside a LUT}}
+  %0 = arc.lut () : () -> i32 {
+    %true = hw.constant true
+    // expected-note @+1 {{first operation with side-effects here}}
+    %1 = arc.memory !arc.memory<20 x i32>
+    %2 = arc.memory_read %1[%true], %true, %true : !arc.memory<20 x i32>, i1
+    arc.output %2 : i32
+  }
+  arc.output %0 : i32
+}

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -31,3 +31,25 @@ arc.define @SupportRecurisveMemoryEffects(%arg0: i42, %arg1: i1) {
   }
   arc.output
 }
+
+// CHECK-LABEL: @LookupTable(%arg0: i32, %arg1: i8)
+arc.define @LookupTable(%arg0: i32, %arg1: i8) -> () {
+  // CHECK-NEXT: %{{.+}} = arc.lut() : () -> i32 {
+  // CHECK-NEXT:   %c0_i32 = hw.constant 0 : i32
+  // CHECK-NEXT:   arc.output %c0_i32 : i32
+  // CHECK-NEXT: }
+  %0 = arc.lut () : () -> i32 {
+    ^bb0():
+      %0 = hw.constant 0 : i32
+      arc.output %0 : i32
+  }
+  // CHECK-NEXT: %{{.+}} = arc.lut(%arg1, %arg0) : (i8, i32) -> i32 {
+  // CHECK-NEXT: ^bb0(%arg2: i8, %arg3: i32):
+  // CHECK-NEXT:   arc.output %arg3 : i32
+  // CHECK-NEXT: }
+  %1 = arc.lut (%arg1, %arg0) : (i8, i32) -> i32 {
+    ^bb0(%arg2: i8, %arg3: i32):
+      arc.output %arg3 : i32
+  }
+  arc.output
+}

--- a/test/Dialect/Arc/lower-lut.mlir
+++ b/test/Dialect/Arc/lower-lut.mlir
@@ -1,0 +1,104 @@
+// RUN: circt-opt %s --arc-lower-lut | FileCheck %s
+
+// CHECK-LABEL: arc.define @checkEndianess(%arg0: i1, %arg1: i1, %arg2: i1) -> i3 {
+// CHECK-NEXT:   %c-342392_i24 = hw.constant -342392 : i24
+// CHECK-NEXT:   %c0_i21 = hw.constant 0 : i21
+// CHECK-NEXT:   %0 = comb.concat %c0_i21, %arg0, %arg1, %arg2 : i21, i1, i1, i1
+// CHECK-NEXT:   %c3_i24 = hw.constant 3 : i24
+// CHECK-NEXT:   %1 = comb.mul %0, %c3_i24 : i24
+// CHECK-NEXT:   %2 = comb.shru %c-342392_i24, %1 : i24
+// CHECK-NEXT:   %3 = comb.extract %2 from 0 : (i24) -> i3
+// CHECK-NEXT:   arc.output %3 : i3
+// CHECK-NEXT: }
+arc.define @checkEndianess(%arg0: i1, %arg1: i1, %arg2: i1) -> i3 {
+  %0 = arc.lut(%arg0, %arg1, %arg2) : (i1, i1, i1) -> i3 {
+  ^bb0(%arg3: i1, %arg4: i1, %arg5: i1):
+    %1 = comb.concat %arg3, %arg4, %arg5 : i1, i1, i1
+    // Desired LUT: 111_110_101_100_011_010_001_000 (underscores are just for readability)
+    // This is -342392 in decimal
+    arc.output %1 : i3
+  }
+  arc.output %0 : i3
+}
+
+// CHECK-LABEL:  arc.define @integerLut(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i1) -> i1 {
+// CHECK-NEXT:    %c15921664_i32 = hw.constant 15921664 : i32
+// CHECK-NEXT:    %c0_i27 = hw.constant 0 : i27
+// CHECK-NEXT:    %0 = comb.concat %c0_i27, %arg0, %arg1, %arg4, %arg2, %arg3 : i27, i1, i1, i1, i1, i1
+// CHECK-NEXT:    %c1_i32 = hw.constant 1 : i32
+// CHECK-NEXT:    %1 = comb.mul %0, %c1_i32 : i32
+// CHECK-NEXT:    %2 = comb.shru %c15921664_i32, %1 : i32
+// CHECK-NEXT:    %3 = comb.extract %2 from 0 : (i32) -> i1
+// CHECK-NEXT:    arc.output %3 : i1
+// CHECK-NEXT:  }
+arc.define @integerLut(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i1) -> i1 {
+  %0 = arc.lut(%arg0, %arg1, %arg4, %arg2, %arg3) : (i1, i1, i1, i1, i1) -> i1 {
+  ^bb0(%arg5: i1, %arg6: i1, %arg7: i1, %arg8: i1, %arg9: i1):
+    %1 = comb.and %arg8, %arg9 : i1
+    %2 = comb.icmp ne %arg7, %1 : i1
+    %3 = comb.mux %2, %arg7, %arg9 : i1
+    %4 = comb.xor %arg5, %arg6 : i1
+    %5 = comb.and %4, %3 : i1
+    arc.output %5 : i1
+  }
+  arc.output %0 : i1
+}
+
+// CHECK-NEXT: arc.define @twoLutInSequence(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i1, %arg5: i1, %arg6: i1, %arg7: i1, %arg8: i1) -> i1 {
+// CHECK-NEXT:   %c-1565873536_i32 = hw.constant -1565873536 : i32
+// CHECK-NEXT:   %c0_i27 = hw.constant 0 : i27
+// CHECK-NEXT:   %0 = comb.concat %c0_i27, %arg3, %arg4, %arg5, %arg6, %arg7 : i27, i1, i1, i1, i1, i1
+// CHECK-NEXT:   %c1_i32 = hw.constant 1 : i32
+// CHECK-NEXT:   %1 = comb.mul %0, %c1_i32 : i32
+// CHECK-NEXT:   %2 = comb.shru %c-1565873536_i32, %1 : i32
+// CHECK-NEXT:   %3 = comb.extract %2 from 0 : (i32) -> i1
+// CHECK-NEXT:   %c-1613786944_i32 = hw.constant -1613786944 : i32
+// CHECK-NEXT:   %c0_i27_0 = hw.constant 0 : i27
+// CHECK-NEXT:   %4 = comb.concat %c0_i27_0, %3, %arg0, %arg1, %arg2, %arg8 : i27, i1, i1, i1, i1, i1
+// CHECK-NEXT:   %c1_i32_1 = hw.constant 1 : i32
+// CHECK-NEXT:   %5 = comb.mul %4, %c1_i32_1 : i32
+// CHECK-NEXT:   %6 = comb.shru %c-1613786944_i32, %5 : i32
+// CHECK-NEXT:   %7 = comb.extract %6 from 0 : (i32) -> i1
+// CHECK-NEXT:   arc.output %7 : i1
+// CHECK-NEXT: }
+arc.define @twoLutInSequence(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i1, %arg5: i1, %arg6: i1, %arg7: i1, %arg8: i1) -> i1 {
+  %0 = arc.lut(%arg3, %arg4, %arg5, %arg6, %arg7) : (i1, i1, i1, i1, i1) -> i1 {
+  ^bb0(%arg9: i1, %arg10: i1, %arg12: i1, %arg11: i1, %arg13: i1):
+    %2 = comb.xor %arg12, %arg10 : i1
+    %3 = comb.and %arg11, %2 : i1
+    %4 = comb.xor %3, %arg10 : i1
+    %5 = comb.xor %arg9, %arg10 : i1
+    %6 = comb.or %5, %4 : i1
+    %7 = comb.and %6, %arg13 : i1
+    arc.output %7 : i1
+  }
+  %1 = arc.lut(%0, %arg0, %arg1, %arg2, %arg8) : (i1, i1, i1, i1, i1) -> i1 {
+  ^bb0(%arg13: i1, %arg12: i1, %arg9: i1, %arg11: i1, %arg10: i1):
+    %2 = comb.icmp ne %arg11, %arg12 : i1
+    %3 = comb.mux %arg10, %arg11, %2 : i1
+    %4 = comb.mux %arg9, %3, %arg13 : i1
+    arc.output %4 : i1
+  }
+  arc.output %1 : i1
+}
+
+// CHECK-LABEL: arc.define @arrayLut(%arg0: i1, %arg1: i1, %arg2: i2, %arg3: i2, %arg4: i2) -> i2 {
+// CHECK-NEXT:   %0 = hw.aggregate_constant [-2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, -2 : i2, -2 : i2, 0 : i2, 0 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -1 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, -1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 1 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, -1 : i2, -2 : i2, 1 : i2, 0 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -1 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -1 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, -1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 1 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 1 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, -1 : i2, -2 : i2, 1 : i2, 0 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, -2 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, 0 : i2, -2 : i2, 0 : i2, 0 : i2, -2 : i2, -2 : i2, 0 : i2, 0 : i2] : !hw.array<256xi2>
+// CHECK-NEXT:   %1 = comb.concat %arg0, %arg1, %arg4, %arg2, %arg3 : i1, i1, i2, i2, i2
+// CHECK-NEXT:   %2 = hw.array_get %0[%1] : !hw.array<256xi2>, i8
+// CHECK-NEXT:   arc.output %2 : i2
+// CHECK-NEXT: }
+arc.define @arrayLut(%arg0: i1, %arg1: i1, %arg2: i2, %arg3: i2, %arg4: i2) -> i2 {
+  %0 = arc.lut(%arg0, %arg1, %arg4, %arg2, %arg3) : (i1, i1, i2, i2, i2) -> i2 {
+  ^bb0(%arg5: i1, %arg6: i1, %arg7: i2, %arg8: i2, %arg9: i2):
+    %true = hw.constant true
+    %1 = comb.and %arg8, %arg9 : i2
+    %2 = comb.icmp ne %arg7, %1 : i2
+    %3 = comb.mux %2, %arg7, %arg9 : i2
+    %4 = comb.xor %arg5, %arg6 : i1
+    %5 = comb.concat %true, %4 : i1, i1
+    %6 = comb.and %5, %3 : i2
+    arc.output %6 : i2
+  }
+  arc.output %0 : i2
+}


### PR DESCRIPTION
Add the `arc.lut` op which groups combinational ops in its body for later conversion into a simple lookup table. Also add the `LowerLUT` pass, which precomputes that lookup table and converts `arc.lut` into a pure Comb and HW dialect representation.