### PR TITLE
[Arc] Add simple arc inlining pass

### DIFF
--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -21,6 +21,7 @@ namespace arc {
 
 std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
+std::unique_ptr<mlir::Pass> createInlineArcsPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -29,6 +29,18 @@ def InferMemories : Pass<"arc-infer-memories", "mlir::ModuleOp"> {
   ];
 }
 
+def InlineArcs : Pass<"arc-inline" , "mlir::ModuleOp"> {
+  let summary = "Inline very small arcs";
+  let constructor = "circt::arc::createInlineArcsPass()";
+  let statistics = [
+    Statistic<"numInlinedArcs", "inlined-arcs", "Arcs inlined at a use site">,
+    Statistic<"numRemovedArcs", "removed-arcs",
+      "Arcs removed after full inlining">,
+    Statistic<"numTrivialArcs", "trivial-arcs", "Arcs with very few ops">,
+    Statistic<"numSingleUseArcs", "single-use-arcs", "Arcs with a single use">,
+  ];
+}
+
 def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
   let summary = "Eagerly inline private modules";
   let description = [{

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
   InferMemories.cpp
+  InlineArcs.cpp
   InlineModules.cpp
   LowerLUT.cpp
   MakeTables.cpp

--- a/lib/Dialect/Arc/Transforms/InlineArcs.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineArcs.cpp
@@ -1,0 +1,122 @@
+//===- InlineArcs.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-inline"
+
+using namespace circt;
+using namespace arc;
+using llvm::SetVector;
+using llvm::SmallDenseSet;
+using mlir::InlinerInterface;
+using mlir::SymbolUserMap;
+
+namespace {
+
+struct InlineArcsPass : public InlineArcsBase<InlineArcsPass> {
+  InlineArcsPass() = default;
+  InlineArcsPass(const InlineArcsPass &pass) : InlineArcsPass() {}
+
+  void runOnOperation() override;
+  bool shouldInline(DefineOp defOp, ArrayRef<Operation *> users);
+};
+
+/// A simple implementation of the `InlinerInterface` that marks all inlining as
+/// legal since we know that we only ever attempt to inline `DefineOp` bodies
+/// at `StateOp` sites.
+struct ArcInliner : public InlinerInterface {
+  using InlinerInterface::InlinerInterface;
+
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  void handleTerminator(Operation *op,
+                        ArrayRef<Value> valuesToRepl) const override {
+    assert(isa<arc::OutputOp>(op));
+    for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
+      from.replaceAllUsesWith(to);
+  }
+};
+
+} // namespace
+
+void InlineArcsPass::runOnOperation() {
+  auto module = getOperation();
+  SymbolTableCollection symbolTable;
+  SymbolUserMap symbolUserMap(symbolTable, module);
+
+  for (auto defOp : llvm::make_early_inc_range(module.getOps<DefineOp>())) {
+    // Check if we should inline the arc.
+    auto users = symbolUserMap.getUsers(defOp);
+    if (!shouldInline(defOp, users))
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << "Inlining " << defOp.getSymName() << "\n");
+
+    // Inline all uses of the arc. Currently we inline all of them but in the
+    // future we may decide per use site whether to inline or not.
+    unsigned numUsersLeft = users.size();
+    for (auto *user : users) {
+      auto useOp = dyn_cast<StateOp>(user);
+      if (!useOp)
+        continue;
+      if (useOp.getLatency() > 0)
+        continue;
+
+      bool isLastArcUse = --numUsersLeft == 0;
+      ArcInliner inliner(&getContext());
+      if (failed(mlir::inlineRegion(inliner, &defOp.getBody(), useOp,
+                                    useOp.getOperands(), useOp.getResults(),
+                                    std::nullopt, !isLastArcUse))) {
+        useOp.emitError("failed to inline arc '") << defOp.getName() << "'";
+        return signalPassFailure();
+      }
+      useOp.erase();
+      if (isLastArcUse) {
+        defOp.erase();
+        ++numRemovedArcs;
+      }
+      ++numInlinedArcs;
+    }
+  }
+}
+
+bool InlineArcsPass::shouldInline(DefineOp defOp, ArrayRef<Operation *> users) {
+  // Count the number of non-trivial ops in the arc. If there are only a few,
+  // inline the arc.
+  unsigned numNonTrivialOps = 0;
+  defOp.getBodyBlock().walk([&](Operation *op) {
+    if (!op->hasTrait<OpTrait::ConstantLike>() && !isa<OutputOp>(op))
+      ++numNonTrivialOps;
+  });
+  if (numNonTrivialOps <= 3) {
+    ++numTrivialArcs;
+    return true;
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Arc " << defOp.getSymName() << " has "
+                          << numNonTrivialOps << " non-trivial ops\n");
+
+  // Check if the arc is only ever used once.
+  if (users.size() == 1) {
+    ++numSingleUseArcs;
+    return true;
+  }
+
+  return false;
+}
+
+std::unique_ptr<Pass> arc::createInlineArcsPass() {
+  return std::make_unique<InlineArcsPass>();
+}

--- a/test/Dialect/Arc/inline-arcs.mlir
+++ b/test/Dialect/Arc/inline-arcs.mlir
@@ -1,0 +1,98 @@
+// RUN: circt-opt %s --arc-inline | FileCheck %s
+
+// CHECK-LABEL: func.func @Simple
+func.func @Simple(%arg0: i4, %arg1: i1) -> (i4, i4) {
+  // CHECK-NEXT: %0 = comb.and %arg0, %arg0
+  // CHECK-NEXT: %1 = arc.state @SimpleB(%arg0) clock %arg1 lat 1
+  // CHECK-NEXT: return %0, %1
+  %0 = arc.state @SimpleA(%arg0) lat 0 : (i4) -> i4
+  %1 = arc.state @SimpleB(%arg0) clock %arg1 lat 1 : (i4) -> i4
+  return %0, %1 : i4, i4
+}
+// CHECK-NEXT:  }
+// CHECK-NOT: arc.define @SimpleA
+arc.define @SimpleA(%arg0: i4) -> i4 {
+  %0 = comb.and %arg0, %arg0 : i4
+  arc.output %0 : i4
+}
+// CHECK-LABEL: arc.define @SimpleB
+arc.define @SimpleB(%arg0: i4) -> i4 {
+  %0 = comb.xor %arg0, %arg0 : i4
+  arc.output %0 : i4
+}
+
+
+hw.module @nestedRegionTest(%arg0: i4, %arg1: i4) -> (out0: i4) {
+  %0 = arc.state @sub3(%arg0, %arg1) lat 0 : (i4, i4) -> i4
+  hw.output %0 : i4
+}
+
+arc.define @sub3(%arg0: i4, %arg1: i4) -> i4 {
+  %0 = comb.extract %arg0 from 2 : (i4) -> i1
+  %1 = scf.if %0 -> (i4) {
+    %2 = comb.xor bin %arg0, %arg1 : i4
+    scf.yield %2 : i4
+  } else {
+    %2 = comb.and bin %arg0, %arg1 : i4
+    scf.yield %2 : i4
+  }
+  arc.output %1 : i4
+}
+
+// CHECK-LABEL: hw.module @nestedRegionTest
+// CHECK-NEXT: [[EXT:%.+]] = comb.extract %arg0 from 2 : (i4) -> i1
+// CHECK-NEXT: [[IFRES:%.+]] = scf.if [[EXT]] -> (i4) {
+// CHECK-NEXT:   [[XOR:%.+]] = comb.xor bin %arg0, %arg1 : i4
+// CHECK-NEXT:   scf.yield [[XOR]] : i4
+// CHECK-NEXT: } else {
+// CHECK-NEXT:   [[AND:%.+]] = comb.and bin %arg0, %arg1 : i4
+// CHECK-NEXT:   scf.yield [[AND]] : i4
+// CHECK-NEXT: }
+// CHECK-NEXT: hw.output [[IFRES]] : i4
+
+hw.module @opsInNestedRegionsAreAlsoCounted(%arg0: i4, %arg1: i4) -> (out0: i4, out1: i4) {
+  %0 = arc.state @sub4(%arg0, %arg1) lat 0 : (i4, i4) -> i4
+  %1 = arc.state @sub4(%arg0, %arg1) lat 0 : (i4, i4) -> i4
+  hw.output %0, %1 : i4, i4
+}
+
+arc.define @sub4(%arg0: i4, %arg1: i4) -> i4 {
+  %0 = comb.extract %arg0 from 2 : (i4) -> i1
+  %1 = scf.if %0 -> (i4) {
+    %2 = comb.xor bin %arg0, %arg1 : i4
+    %3 = comb.and bin %2, %arg1 : i4
+    scf.yield %3 : i4
+  } else {
+    %2 = comb.and bin %arg0, %arg1 : i4
+    %3 = comb.or bin %arg0, %2 : i4
+    scf.yield %3 : i4
+  }
+  arc.output %1 : i4
+}
+
+// CHECK-LABEL: hw.module @opsInNestedRegionsAreAlsoCounted
+// CHECK-NEXT:   [[STATERES1:%.+]] = arc.state @sub4(%arg0, %arg1) lat 0 : (i4, i4) -> i4
+// CHECK-NEXT:   [[STATERES2:%.+]] = arc.state @sub4(%arg0, %arg1) lat 0 : (i4, i4) -> i4
+// CHECK-NEXT:   hw.output [[STATERES1]], [[STATERES2]] : i4, i4
+
+hw.module @nestedBlockArgumentsTest(%arg0: index, %arg1: i4) -> (out0: i4) {
+  %0 = arc.state @sub5(%arg0, %arg1) lat 0 : (index, i4) -> i4
+  hw.output %0 : i4
+}
+
+arc.define @sub5(%arg0: index, %arg1: i4) -> i4 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = scf.for %iv = %c0 to %arg0 step %c1 iter_args (%i = %arg1) -> (i4) {
+    %1 = comb.add %i, %arg1 : i4
+    scf.yield %1 : i4
+  }
+  arc.output %0 : i4
+}
+
+// CHECK-LABEL: hw.module @nestedBlockArgumentsTest
+// CHECK:      [[RES:%.+]] = scf.for {{%.+}} = %c0 to %arg0 step %c1 iter_args([[A0:%.+]] = %arg1) -> (i4) {
+// CHECK-NEXT:   [[SUM:%.+]] = comb.add [[A0]], %arg1 : i4
+// CHECK-NEXT:   scf.yield [[SUM]] : i4
+// CHECK-NEXT: }
+// CHECK-NEXT: hw.output [[RES]] : i4


### PR DESCRIPTION
Add a pass that inlines all arcs with only one use or with a trivial number of operations in the body (<=3). This provides quite a bit of speed-up (~14%) and a significant reduction of stack ops (4.7x) in some initial experiments