### PR TITLE
[Arc] Add state lowering pass

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -248,6 +248,137 @@ def MemoryWriteOp : ArcOp<"memory_write", [
 }
 
 //===----------------------------------------------------------------------===//
+// Trigger Grouping
+//===----------------------------------------------------------------------===//
+
+def ClockTreeOp : ArcOp<"clock_tree", [NoTerminator, NoRegionArguments]> {
+  let summary = "A clock tree";
+  let arguments = (ins I1:$clock, Optional<I1>:$enable);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $clock (`if` $enable^)? attr-dict-with-keyword $body
+  }];
+  let extraClassDeclaration = [{
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+  }];
+}
+
+def PassThroughOp : ArcOp<"passthrough", [NoTerminator, NoRegionArguments]> {
+  let summary = "Clock-less logic that is on the pass-through path";
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    attr-dict-with-keyword $body
+  }];
+  let extraClassDeclaration = [{
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Storage Allocation
+//===----------------------------------------------------------------------===//
+
+def AllocStateOp : ArcOp<"alloc_state", [MemoryEffects<[MemAlloc]>]> {
+  let summary = "Allocate internal state";
+  let arguments = (ins StorageType:$storage, UnitAttr:$tap);
+  let results = (outs StateType:$state);
+  let assemblyFormat = [{
+    $storage (`tap` $tap^)? attr-dict `:` functional-type($storage, $state)
+  }];
+}
+
+def AllocMemoryOp : ArcOp<"alloc_memory", [MemoryEffects<[MemAlloc]>]> {
+  let summary = "Allocate a memory";
+  let arguments = (ins StorageType:$storage);
+  let results = (outs MemoryType:$memory);
+  let assemblyFormat = [{
+    $storage attr-dict `:` functional-type($storage, $memory)
+  }];
+}
+
+def AllocStorageOp : ArcOp<"alloc_storage", [MemoryEffects<[MemAlloc]>]> {
+  let summary = "Allocate contiguous storage space from a larger storage space";
+  let arguments = (ins StorageType:$input, OptionalAttr<I32Attr>:$offset);
+  let results = (outs StorageType:$output);
+  let assemblyFormat = [{
+    $input (`[` $offset^ `]`)? attr-dict `:` functional-type($input, $output)
+  }];
+}
+
+def RootInputOp : ArcOp<"root_input", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = "A root input";
+  let arguments = (ins StrAttr:$name, StorageType:$storage);
+  let results = (outs StateType:$state);
+  let assemblyFormat = [{
+    $name `,` $storage attr-dict `:` functional-type($storage, $state)
+  }];
+}
+
+def RootOutputOp : ArcOp<"root_output", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = "A root output";
+  let arguments = (ins StrAttr:$name, StorageType:$storage);
+  let results = (outs StateType:$state);
+  let assemblyFormat = [{
+    $name `,` $storage attr-dict `:` functional-type($storage, $state)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// State Read/Write
+//===----------------------------------------------------------------------===//
+
+class StateAndValueTypesMatch<string state, string value> : TypesMatchWith<
+  "state and value types must match", state, value,
+  "$_self.cast<StateType>().getType()">;
+
+def StateReadOp : ArcOp<"state_read", [
+  MemoryEffects<[MemRead]>,
+  StateAndValueTypesMatch<"state", "value">
+]> {
+  let summary = "Get a state's current value";
+  let arguments = (ins StateType:$state);
+  let results = (outs AnyInteger:$value);
+  let assemblyFormat = [{
+    $state attr-dict `:` type($state)
+  }];
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$state), [{
+      build($_builder, $_state, state.getType().cast<StateType>().getType(),
+            state);
+    }]>
+  ];
+}
+
+def StateWriteOp : ArcOp<"state_write", [
+  MemoryEffects<[MemWrite]>,
+  StateAndValueTypesMatch<"state", "value">
+]> {
+  let summary = "Update a state's value";
+  let description = [{
+    Changes the value of a state. This operation is treated as a deferred
+    assignment by most transformation passes, which allows them to change the
+    order of `arc.state_read` and `arc.state_write` ops on the same state
+    without affecting the correctness of the model. The reads are always assumed
+    to produce the current value of the state and writes to be deferred until
+    all operations in the model have been executed for the current time step.
+
+    The only exceptions to this are the state update legalization pass, which
+    inserts the necessary temporary variables such that writes can be performed
+    immediately without affecting correctness. This allows later lowering passes
+    to treat `arc.state_write` as an immediate assignment (without defering).
+  }];
+  let arguments = (ins StateType:$state, AnyInteger:$value,
+                       Optional<I1>:$condition);
+  let assemblyFormat = [{
+    $state `=` $value (`if` $condition^)? attr-dict `:` type($state)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Miscellaneous
 //===----------------------------------------------------------------------===//
 
@@ -255,6 +386,26 @@ def TapOp : ArcOp<"tap"> {
   let summary = "A tracker op to observe a value under a given name";
   let arguments = (ins AnySignlessInteger:$value, StrAttr:$name);
   let assemblyFormat = [{ $value attr-dict `:` type($value) }];
+}
+
+def ModelOp : ArcOp<"model", [RegionKindInterface, IsolatedFromAbove,
+                              NoTerminator]> {
+  let summary = "A model with stratified clocks";
+  let arguments = (ins StrAttr:$name);
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    $name attr-dict-with-keyword $body
+  }];
+
+  let extraClassDeclaration = [{
+    static mlir::RegionKind getRegionKind(unsigned index) {
+      return mlir::RegionKind::Graph;
+    }
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+  }];
+
+  let hasVerifier = 1;
 }
 
 def LutOp : ArcOp<"lut", [

--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -27,6 +27,7 @@ std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineArcsPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();
+std::unique_ptr<mlir::Pass> createLowerStatePass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
 std::unique_ptr<mlir::Pass> createRemoveUnusedArcArgumentsPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -71,6 +71,12 @@ def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];
 }
 
+def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
+  let summary = "Split state into read and write ops grouped by clock tree";
+  let constructor = "circt::arc::createLowerStatePass()";
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
 def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let summary = "Transform appropriate arc logic into lookup tables";
   let constructor = "circt::arc::createMakeTablesPass()";

--- a/include/circt/Dialect/Arc/Types.td
+++ b/include/circt/Dialect/Arc/Types.td
@@ -14,11 +14,28 @@ include "mlir/IR/AttrTypeBase.td"
 
 class ArcTypeDef<string name> : TypeDef<ArcDialect, name> { }
 
+def StateType : ArcTypeDef<"State"> {
+  let mnemonic = "state";
+  let parameters = (ins "::mlir::IntegerType":$type);
+  let assemblyFormat = "`<` $type `>`";
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::IntegerType":$type), [{
+      return $_get(type.getContext(), type);
+    }]>
+  ];
+}
+
 def MemoryType : ArcTypeDef<"Memory"> {
   let mnemonic = "memory";
   let parameters = (ins "unsigned":$numWords, "::mlir::IntegerType":$wordType,
     OptionalParameter<"unsigned">:$stride);
   let assemblyFormat = "`<` $numWords `x` $wordType (`,` $stride^)? `>`";
+}
+
+def StorageType : ArcTypeDef<"Storage"> {
+  let mnemonic = "storage";
+  let parameters = (ins OptionalParameter<"unsigned">:$size);
+  let assemblyFormat = "(`<` $size^ `>`)?";
 }
 
 #endif // CIRCT_DIALECT_ARC_TYPES_TD

--- a/lib/Dialect/Arc/Ops.cpp
+++ b/lib/Dialect/Arc/Ops.cpp
@@ -169,6 +169,39 @@ LogicalResult MemoryWriteOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// RootInputOp
+//===----------------------------------------------------------------------===//
+
+void RootInputOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  SmallString<32> buf("in_");
+  buf += getName();
+  setNameFn(getState(), buf);
+}
+
+//===----------------------------------------------------------------------===//
+// RootOutputOp
+//===----------------------------------------------------------------------===//
+
+void RootOutputOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  SmallString<32> buf("out_");
+  buf += getName();
+  setNameFn(getState(), buf);
+}
+
+//===----------------------------------------------------------------------===//
+// ModelOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ModelOp::verify() {
+  if (getBodyBlock().getArguments().size() != 1)
+    return emitOpError("must have exactly one argument");
+  if (auto type = getBodyBlock().getArgument(0).getType();
+      !isa<StorageType>(type))
+    return emitOpError("argument must be of storage type");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LutOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   InlineArcs.cpp
   InlineModules.cpp
   LowerLUT.cpp
+  LowerState.cpp
   MakeTables.cpp
   RemoveUnusedArcArguments.cpp
   SimplifyVariadicOps.cpp

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -1,0 +1,616 @@
+//===- LowerState.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-lower-state"
+
+using namespace circt;
+using namespace arc;
+using namespace hw;
+using namespace mlir;
+using llvm::SmallDenseSet;
+
+//===----------------------------------------------------------------------===//
+// Data Structures
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Statistics gathered throughout the execution of this pass.
+struct Statistics {
+  Pass *parent;
+  Statistics(Pass *parent) : parent(parent) {}
+  using Statistic = Pass::Statistic;
+
+  Statistic matOpsMoved{parent, "mat-ops-moved",
+                        "Ops moved during value materialization"};
+  Statistic matOpsCloned{parent, "mat-ops-cloned",
+                         "Ops cloned during value materialization"};
+  Statistic opsPruned{parent, "ops-pruned", "Ops removed as dead code"};
+};
+
+/// Lowering info associated with a single primary clock.
+struct ClockLowering {
+  /// The root clock this lowering is for.
+  Value clock;
+  /// A `ClockTreeOp` or `PassThroughOp`.
+  Operation *treeOp;
+  /// Pass statistics.
+  Statistics &stats;
+  OpBuilder builder;
+  /// A mapping from values outside the clock tree to their materialize form
+  /// inside the clock tree.
+  IRMapping materializedValues;
+  /// A cache of AND gates created for aggregating enable conditions.
+  DenseMap<std::pair<Value, Value>, Value> andCache;
+
+  ClockLowering(Value clock, Operation *treeOp, Statistics &stats)
+      : clock(clock), treeOp(treeOp), stats(stats), builder(treeOp) {
+    assert((isa<ClockTreeOp, PassThroughOp>(treeOp)));
+    builder.setInsertionPointToStart(&treeOp->getRegion(0).front());
+  }
+
+  Value materializeValue(Value value);
+  Value getOrCreateAnd(Value lhs, Value rhs, Location loc);
+};
+
+struct GatedClockLowering {
+  /// Lowering info of the primary clock.
+  ClockLowering &clock;
+  /// An optional enable condition of the primary clock. May be null.
+  Value enable;
+};
+
+/// State lowering for a single `HWModuleOp`.
+struct ModuleLowering {
+  HWModuleOp moduleOp;
+  /// Pass statistics.
+  Statistics &stats;
+  MLIRContext *context;
+  DenseMap<Value, std::unique_ptr<ClockLowering>> clockLowerings;
+  DenseMap<Value, GatedClockLowering> gatedClockLowerings;
+  Value storageArg;
+
+  ModuleLowering(HWModuleOp moduleOp, Statistics &stats)
+      : moduleOp(moduleOp), stats(stats), context(moduleOp.getContext()),
+        builder(moduleOp) {
+    builder.setInsertionPointToStart(moduleOp.getBodyBlock());
+  }
+
+  GatedClockLowering getOrCreateClockLowering(Value clock);
+  ClockLowering &getOrCreatePassThrough();
+  void replaceValueWithStateRead(Value value, Value state);
+
+  void addStorageArg();
+  LogicalResult lowerPrimaryInputs();
+  LogicalResult lowerPrimaryOutputs();
+  LogicalResult lowerStates();
+  LogicalResult lowerState(StateOp stateOp);
+  LogicalResult lowerState(MemoryOp memOp);
+  LogicalResult lowerState(MemoryWriteOp memWriteOp);
+  LogicalResult lowerState(TapOp tapOp);
+
+  LogicalResult cleanup();
+
+private:
+  OpBuilder builder;
+  SmallVector<StateReadOp, 0> readsToSink;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Clock Lowering
+//===----------------------------------------------------------------------===//
+
+static bool shouldMaterialize(Operation *op) {
+  // Don't materialize arc uses with latency >0, since we handle these in a
+  // second pass once all other operations have been moved to their respective
+  // clock trees.
+  if (auto stateOp = dyn_cast<StateOp>(op); stateOp && stateOp.getLatency() > 0)
+    return false;
+
+  if (isa<MemoryOp, AllocStateOp, AllocMemoryOp, AllocStorageOp, ClockTreeOp,
+          PassThroughOp, RootInputOp, RootOutputOp, StateWriteOp,
+          MemoryWriteOp>(op))
+    return false;
+
+  return true;
+}
+
+static bool shouldMaterialize(Value value) {
+  assert(value);
+
+  // Block arguments are just used as they are.
+  auto *op = value.getDefiningOp();
+  if (!op)
+    return false;
+
+  return shouldMaterialize(op);
+}
+
+/// Materialize a value within this clock tree. This clones or moves all
+/// operations required to produce this value inside the clock tree.
+Value ClockLowering::materializeValue(Value value) {
+  if (!value)
+    return {};
+  if (!shouldMaterialize(value))
+    return value;
+  if (auto mapped = materializedValues.lookupOrNull(value))
+    return mapped;
+
+  SmallPtrSet<Operation *, 8> seen;
+  SmallVector<std::pair<Operation *, bool>> worklist;
+  seen.insert(value.getDefiningOp());
+  worklist.push_back({value.getDefiningOp(), false});
+
+  while (!worklist.empty()) {
+    auto &[op, operandsHandled] = worklist.back();
+    if (!operandsHandled) {
+      operandsHandled = true;
+      SmallDenseSet<Value> seenOperands;
+      Operation *outerOp = op;
+      bool loopDetected = false;
+      LLVM_DEBUG(llvm::dbgs() << "Operation " << *op << "\n");
+      op->walk([&](Operation *innerOp) {
+        for (auto operand : innerOp->getOperands()) {
+          // Skip operands that are defined within the outer operation.
+          LLVM_DEBUG(llvm::dbgs() << "- Checking operand " << operand << "\n");
+          if (!operand.getParentBlock()->getParentOp()->isProperAncestor(
+                  outerOp))
+            continue;
+          LLVM_DEBUG(llvm::dbgs() << "  - Materialize\n");
+
+          // Skip operands that we have already pushed onto the worklist.
+          if (!seenOperands.insert(operand).second)
+            continue;
+
+          // Skip operands that we have already materialized or that should not
+          // be materialized at all.
+          if (materializedValues.contains(operand) ||
+              !shouldMaterialize(operand))
+            continue;
+
+          // Break combinational loops.
+          auto *defOp = operand.getDefiningOp();
+          if (!seen.insert(defOp).second) {
+            defOp->emitError("combinational loop detected");
+            loopDetected = true;
+            continue;
+          }
+          worklist.push_back({defOp, false});
+        }
+      });
+      if (loopDetected)
+        return {};
+    } else {
+      auto *newOp = builder.clone(*op, materializedValues);
+      LLVM_DEBUG(llvm::dbgs() << "Cloned " << *newOp << "\n");
+      seen.erase(op);
+      worklist.pop_back();
+    }
+  }
+
+  return materializedValues.lookup(value);
+}
+
+/// Create an AND gate if none with the given operands already exists. Note that
+/// the operands may be null, in which case the function will return the
+/// non-null operand, or null if both operands are null.
+Value ClockLowering::getOrCreateAnd(Value lhs, Value rhs, Location loc) {
+  if (!lhs)
+    return rhs;
+  if (!rhs)
+    return lhs;
+  auto &slot = andCache[std::make_pair(lhs, rhs)];
+  if (!slot)
+    slot = builder.create<comb::AndOp>(loc, lhs, rhs);
+  return slot;
+}
+
+//===----------------------------------------------------------------------===//
+// Module Lowering
+//===----------------------------------------------------------------------===//
+
+GatedClockLowering ModuleLowering::getOrCreateClockLowering(Value clock) {
+  // Look through clock gates.
+  if (auto ckgOp = clock.getDefiningOp<ClockGateOp>()) {
+    // Reuse the existing lowering for this clock gate if possible.
+    if (auto it = gatedClockLowerings.find(clock);
+        it != gatedClockLowerings.end())
+      return it->second;
+
+    // Get the lowering for the parent clock gate's input clock. This will give
+    // us the clock tree to emit things into, alongside the compound enable
+    // condition of all the clock gates along the way to the primary clock. All
+    // we have to do is to add this clock gate's condition to that list.
+    auto info = getOrCreateClockLowering(ckgOp.getInput());
+    auto ckgEnable = info.clock.materializeValue(ckgOp.getEnable());
+    info.enable =
+        info.clock.getOrCreateAnd(info.enable, ckgEnable, ckgOp.getLoc());
+    gatedClockLowerings.insert({clock, info});
+    return info;
+  }
+
+  // Create the `ClockTreeOp` that corresponds to this ungated clock.
+  auto &slot = clockLowerings[clock];
+  if (!slot) {
+    auto treeOp = builder.create<ClockTreeOp>(clock.getLoc(), clock, Value{});
+    treeOp.getBody().emplaceBlock();
+    slot = std::make_unique<ClockLowering>(clock, treeOp, stats);
+  }
+  return GatedClockLowering{*slot, Value{}};
+}
+
+ClockLowering &ModuleLowering::getOrCreatePassThrough() {
+  auto &slot = clockLowerings[Value{}];
+  if (!slot) {
+    auto treeOp = builder.create<PassThroughOp>(moduleOp.getLoc());
+    treeOp.getBody().emplaceBlock();
+    slot = std::make_unique<ClockLowering>(Value{}, treeOp, stats);
+  }
+  return *slot;
+}
+
+/// Replace all uses of a value with a `StateReadOp` on a state.
+void ModuleLowering::replaceValueWithStateRead(Value value, Value state) {
+  OpBuilder builder(state.getContext());
+  builder.setInsertionPointAfterValue(state);
+  auto readOp = builder.create<StateReadOp>(value.getLoc(), state);
+  value.replaceAllUsesWith(readOp);
+  readsToSink.push_back(readOp);
+}
+
+/// Add the global state as an argument to the module's body block.
+void ModuleLowering::addStorageArg() {
+  assert(!storageArg);
+  storageArg = moduleOp.getBodyBlock()->addArgument(
+      StorageType::get(context, {}), moduleOp.getLoc());
+}
+
+/// Lower the primary inputs of the module to dedicated ops that allocate the
+/// inputs in the model's storage.
+LogicalResult ModuleLowering::lowerPrimaryInputs() {
+  builder.setInsertionPointToStart(moduleOp.getBodyBlock());
+  for (auto blockArg : moduleOp.getArguments()) {
+    if (blockArg == storageArg)
+      continue;
+    auto name =
+        moduleOp.getArgNames()[blockArg.getArgNumber()].cast<StringAttr>();
+    auto intType = blockArg.getType().dyn_cast<IntegerType>();
+    if (!intType)
+      return mlir::emitError(blockArg.getLoc(), "input ")
+             << name << " is of non-integer type " << blockArg.getType();
+    auto state = builder.create<RootInputOp>(
+        blockArg.getLoc(), StateType::get(intType), name, storageArg);
+    replaceValueWithStateRead(blockArg, state);
+  }
+  return success();
+}
+
+/// Lower the primary outputs of the module to dedicated ops that allocate the
+/// outputs in the model's storage.
+LogicalResult ModuleLowering::lowerPrimaryOutputs() {
+  auto outputOp = cast<hw::OutputOp>(moduleOp.getBodyBlock()->getTerminator());
+  if (outputOp.getNumOperands() > 0) {
+    auto &passThrough = getOrCreatePassThrough();
+    for (auto [value, name] :
+         llvm::zip(outputOp.getOperands(), moduleOp.getResultNames())) {
+      auto intType = value.getType().dyn_cast<IntegerType>();
+      if (!intType)
+        return mlir::emitError(outputOp.getLoc(), "output ")
+               << name << " is of non-integer type " << value.getType();
+      auto materializedValue = passThrough.materializeValue(value);
+      auto state = builder.create<RootOutputOp>(
+          outputOp.getLoc(), StateType::get(intType), name.cast<StringAttr>(),
+          storageArg);
+      passThrough.builder.create<StateWriteOp>(outputOp.getLoc(), state,
+                                               materializedValue, Value{});
+    }
+  }
+  return success();
+}
+
+LogicalResult ModuleLowering::lowerStates() {
+  for (auto &op : llvm::make_early_inc_range(*moduleOp.getBodyBlock())) {
+    auto result = TypeSwitch<Operation *, LogicalResult>(&op)
+                      .Case<StateOp, MemoryOp, MemoryWriteOp, TapOp>(
+                          [&](auto op) { return lowerState(op); })
+                      .Default(success());
+    if (failed(result))
+      return failure();
+  }
+  return success();
+}
+
+LogicalResult ModuleLowering::lowerState(StateOp stateOp) {
+  // Latency zero arcs incur no state and remain in the IR unmodified.
+  if (stateOp.getLatency() == 0)
+    return success();
+
+  // We don't support arcs beyond latency 1 yet. These should be easy to add in
+  // the future though.
+  if (stateOp.getLatency() > 1)
+    return stateOp.emitError("state with latency > 1 not supported");
+
+  // Get the clock tree and enable condition for this state's clock. If this arc
+  // carries an explicit enable condition, fold that into the enable provided by
+  // the clock gates in the arc's clock tree.
+  auto info = getOrCreateClockLowering(stateOp.getClock());
+  info.enable = info.clock.getOrCreateAnd(
+      info.enable, info.clock.materializeValue(stateOp.getEnable()),
+      stateOp.getLoc());
+
+  // Allocate the necessary state within the model.
+  SmallVector<Value> allocatedStates;
+  for (unsigned stateIdx = 0; stateIdx < stateOp.getNumResults(); ++stateIdx) {
+    auto type = stateOp.getResult(stateIdx).getType();
+    auto intType = dyn_cast<IntegerType>(type);
+    if (!intType)
+      return stateOp.emitOpError("result ")
+             << stateIdx << " has non-integer type " << type
+             << "; only integer types are supported";
+    auto stateType = StateType::get(intType);
+    auto state =
+        builder.create<AllocStateOp>(stateOp.getLoc(), stateType, storageArg);
+    if (auto names = stateOp->getAttrOfType<ArrayAttr>("names"))
+      state->setAttr("name", names[stateIdx]);
+    allocatedStates.push_back(state);
+  }
+
+  // Create a copy of the arc use with latency zero. This will effectively be
+  // the computation of the arc's transfer function, while the latency is
+  // implemented through read and write functions.
+  SmallVector<Value> materializedOperands;
+  materializedOperands.reserve(stateOp.getInputs().size());
+  SmallVector<Value> inputs(stateOp.getInputs());
+  stateOp->dropAllReferences();
+  for (auto input : inputs)
+    materializedOperands.push_back(info.clock.materializeValue(input));
+  auto newStateOp = info.clock.builder.create<StateOp>(
+      stateOp.getLoc(), stateOp.getArcAttr(), stateOp.getResultTypes(), Value{},
+      Value{}, 0, materializedOperands);
+
+  // Create the write ops that write the result of the transfer function to the
+  // allocated state storage.
+  for (auto [alloc, result] :
+       llvm::zip(allocatedStates, newStateOp.getResults()))
+    info.clock.builder.create<StateWriteOp>(stateOp.getLoc(), alloc, result,
+                                            info.enable);
+
+  // Replace all uses of the arc with reads from the allocated state.
+  for (auto [alloc, result] : llvm::zip(allocatedStates, stateOp.getResults()))
+    replaceValueWithStateRead(result, alloc);
+  builder.setInsertionPointAfter(stateOp);
+  stateOp.erase();
+  return success();
+}
+
+LogicalResult ModuleLowering::lowerState(MemoryOp memOp) {
+  auto allocMemOp = builder.create<AllocMemoryOp>(
+      memOp.getLoc(), memOp.getType(), storageArg, memOp->getAttrs());
+  memOp.replaceAllUsesWith(allocMemOp.getResult());
+  builder.setInsertionPointAfter(memOp);
+  memOp.erase();
+  return success();
+}
+
+LogicalResult ModuleLowering::lowerState(MemoryWriteOp memWriteOp) {
+  // Get the clock tree and enable condition for this write port's clock. If the
+  // port carries an explicit enable condition, fold that into the enable
+  // provided by the clock gates in the port's clock tree.
+  auto info = getOrCreateClockLowering(memWriteOp.getClock());
+  auto enable = info.clock.materializeValue(memWriteOp.getEnable());
+  info.enable =
+      info.clock.getOrCreateAnd(info.enable, enable, memWriteOp.getLoc());
+
+  // Materialize the operands for the write op within the surrounding clock
+  // tree.
+  auto address = info.clock.materializeValue(memWriteOp.getAddress());
+  auto data = info.clock.materializeValue(memWriteOp.getData());
+  Value mask = memWriteOp.getMask();
+  if (mask) {
+    mask = info.clock.materializeValue(mask);
+    Value oldData = info.clock.builder.create<arc::MemoryReadOp>(
+        mask.getLoc(), data.getType(), memWriteOp.getMemory(), address,
+        info.clock.clock, info.enable);
+    Value allOnes = info.clock.builder.create<hw::ConstantOp>(
+        mask.getLoc(), oldData.getType(), -1);
+    Value negatedMask = info.clock.builder.create<comb::XorOp>(
+        mask.getLoc(), mask, allOnes, true);
+    Value maskedOldData = info.clock.builder.create<comb::AndOp>(
+        mask.getLoc(), negatedMask, oldData, true);
+    Value maskedNewData =
+        info.clock.builder.create<comb::AndOp>(mask.getLoc(), mask, data, true);
+    data = info.clock.builder.create<comb::OrOp>(mask.getLoc(), maskedOldData,
+                                                 maskedNewData, true);
+  }
+
+  // Filter the list of reads such that they only contain read ports within the
+  // same clock domain.
+  // TODO: This really needs to go now that we have the `LegalizeStateUpdates`
+  // pass. Instead, we should just have memory read and write accesses all over
+  // the place, then lower them into proper reads and writes, and let the
+  // legalization pass insert any necessary temporaries.
+  SmallVector<Value> newReads;
+  for (auto read : memWriteOp.getReads()) {
+    if (auto readOp = read.getDefiningOp<MemoryReadOp>())
+      // HACK: This check for a constant clock is ugly. The read ops should
+      // instead be replicated for every clock domain that they are used in,
+      // and then dependencies should be tracked between reads and writes
+      // within that clock domain. Lack of a clock (comb mem) should be
+      // handled properly as well. Presence of a clock should group the read
+      // under that clock as expected, and write to a "read buffer" that can
+      // be read again by actual uses in different clock domains. LLVM
+      // lowering already has such a read buffer. Just need to formalize it.
+      if (!readOp.getClock().getDefiningOp<hw::ConstantOp>() &&
+          getOrCreateClockLowering(readOp.getClock()).clock.clock !=
+              info.clock.clock)
+        continue;
+    newReads.push_back(info.clock.materializeValue(read));
+  }
+  // TODO: This just creates a write without any reads. Instead, there should be
+  // a separate memory write op that we can lower to here which doesn't need to
+  // track its reads, but will get legalized by the LegalizeStateUpdate pass.
+  info.clock.builder.create<MemoryWriteOp>(
+      memWriteOp.getLoc(), memWriteOp.getMemory(), address, info.clock.clock,
+      info.enable, data, Value(), newReads);
+  builder.setInsertionPointAfter(memWriteOp);
+  memWriteOp.erase();
+  return success();
+}
+
+// Add state for taps into the passthrough block.
+LogicalResult ModuleLowering::lowerState(TapOp tapOp) {
+  auto intType = tapOp.getValue().getType().dyn_cast<IntegerType>();
+  if (!intType)
+    return mlir::emitError(tapOp.getLoc(), "tapped value ")
+           << tapOp.getNameAttr() << " is of non-integer type "
+           << tapOp.getValue().getType();
+  auto &passThrough = getOrCreatePassThrough();
+  auto materializedValue = passThrough.materializeValue(tapOp.getValue());
+  auto state = builder.create<AllocStateOp>(
+      tapOp.getLoc(), StateType::get(intType), storageArg, true);
+  state->setAttr("name", tapOp.getNameAttr());
+  passThrough.builder.create<StateWriteOp>(tapOp.getLoc(), state,
+                                           materializedValue, Value{});
+  builder.setInsertionPointAfter(tapOp);
+  tapOp.erase();
+  return success();
+}
+
+LogicalResult ModuleLowering::cleanup() {
+  // Establish an order among all operations (to avoid an O(n²) pathological
+  // pattern with `moveBefore`) and replicate read operations into the blocks
+  // where they have uses. The established order is used to create the read
+  // operation as late in the block as possible, just before the first use.
+  DenseMap<Operation *, unsigned> opOrder;
+  moduleOp.walk([&](Operation *op) { opOrder.insert({op, opOrder.size()}); });
+  for (auto readToSink : readsToSink) {
+    SmallDenseMap<Block *, std::pair<StateReadOp, unsigned>> readsByBlock;
+    for (auto &use : llvm::make_early_inc_range(readToSink->getUses())) {
+      auto *user = use.getOwner();
+      auto userOrder = opOrder.lookup(user);
+      auto &localRead = readsByBlock[user->getBlock()];
+      if (!localRead.first) {
+        localRead.first = OpBuilder(user).cloneWithoutRegions(readToSink);
+        localRead.second = userOrder;
+      } else if (userOrder < localRead.second) {
+        localRead.first->moveBefore(user);
+        localRead.second = userOrder;
+      }
+      use.set(localRead.first);
+    }
+    readToSink.erase();
+  }
+
+  // For each operation left in the module body, make sure that all uses are in
+  // the module body as well, not inside any clock trees. The clock trees should
+  // have created copies of the operations that they need for computation.
+  for (auto &op : llvm::make_early_inc_range(*moduleOp.getBodyBlock())) {
+    if (!shouldMaterialize(&op) || isa<hw::OutputOp>(&op))
+      continue;
+    for (auto *user : op.getUsers()) {
+      auto *clockParent = user->getParentOp();
+      while (clockParent && !isa<ClockTreeOp, PassThroughOp>(clockParent))
+        clockParent = clockParent->getParentOp();
+      if (!clockParent)
+        continue;
+      auto d = op.emitError(
+          "has uses in clock trees but has been left outside the clock tree");
+      d.attachNote(user->getLoc()) << "use is here";
+      return failure();
+    }
+
+    // Delete ops as we go.
+    if (!llvm::any_of(op.getUsers(),
+                      [&](auto *user) { return isa<ClockTreeOp>(user); })) {
+      op.dropAllReferences();
+      op.dropAllUses();
+      op.erase();
+      ++stats.opsPruned;
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerStatePass : public LowerStateBase<LowerStatePass> {
+  LowerStatePass() = default;
+  LowerStatePass(const LowerStatePass &pass) : LowerStatePass() {}
+
+  void runOnOperation() override;
+  LogicalResult runOnModule(HWModuleOp moduleOp);
+
+  Statistics stats{this};
+};
+} // namespace
+
+void LowerStatePass::runOnOperation() {
+  for (auto op :
+       llvm::make_early_inc_range(getOperation().getOps<HWModuleOp>()))
+    if (failed(runOnModule(op)))
+      return signalPassFailure();
+}
+
+LogicalResult LowerStatePass::runOnModule(HWModuleOp moduleOp) {
+  LLVM_DEBUG(llvm::dbgs() << "Lowering state in `" << moduleOp.moduleName()
+                          << "`\n");
+  ModuleLowering lowering(moduleOp, stats);
+  lowering.addStorageArg();
+  if (failed(lowering.lowerStates()))
+    return failure();
+
+  // Since we don't yet support derived clocks, simply delete all clock trees
+  // that are not driven by a primary input and emit a warning.
+  for (auto clockTreeOp :
+       llvm::make_early_inc_range(moduleOp.getOps<ClockTreeOp>())) {
+    if (clockTreeOp.getClock().isa<BlockArgument>())
+      continue;
+    auto d = mlir::emitWarning(clockTreeOp.getClock().getLoc(),
+                               "unsupported derived clock ignored");
+    d.attachNote()
+        << "only clocks through a top-level input are supported at the moment";
+    clockTreeOp.erase();
+  }
+
+  if (failed(lowering.lowerPrimaryInputs()))
+    return failure();
+  if (failed(lowering.lowerPrimaryOutputs()))
+    return failure();
+
+  // Clean up the module body which contains a lot of operations that the
+  // pessimistic value materialization has left behind because it couldn't
+  // reliably determine that the ops were no longer needed.
+  if (failed(lowering.cleanup()))
+    return failure();
+
+  // Replace the `HWModuleOp` with a `ModelOp`.
+  moduleOp.getBodyBlock()->eraseArguments(
+      [&](auto arg) { return arg != lowering.storageArg; });
+  moduleOp.getBodyBlock()->getTerminator()->erase();
+  ImplicitLocOpBuilder builder(moduleOp.getLoc(), moduleOp);
+  auto modelOp =
+      builder.create<ModelOp>(moduleOp.getLoc(), moduleOp.moduleNameAttr());
+  modelOp.getBody().takeBody(moduleOp.getBody());
+  moduleOp->erase();
+  return success();
+}
+
+std::unique_ptr<Pass> arc::createLowerStatePass() {
+  return std::make_unique<LowerStatePass>();
+}

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -53,3 +53,24 @@ arc.define @SupportRecurisveMemoryEffects(%arg0: i1, %arg1: i1) {
 arc.define @Bar() {
   arc.output
 }
+
+// -----
+
+// expected-error @below {{op must have exactly one argument}}
+arc.model "MissingArg" {
+^bb0:
+}
+
+// -----
+
+// expected-error @below {{op must have exactly one argument}}
+arc.model "TooManyArgs" {
+^bb0(%arg0: !arc.storage, %arg1: !arc.storage):
+}
+
+// -----
+
+// expected-error @below {{op argument must be of storage type}}
+arc.model "WrongArgType" {
+^bb0(%arg0: i32):
+}

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -1,0 +1,191 @@
+// RUN: circt-opt %s --arc-lower-state | FileCheck %s
+
+// CHECK-LABEL: arc.model "Empty" {
+// CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
+// CHECK-NEXT:  }
+hw.module @Empty() {
+}
+
+// CHECK-LABEL: arc.model "InputsAndOutputs" {
+hw.module @InputsAndOutputs(%a: i42, %b: i17) -> (c: i42, d: i17) {
+  %0 = comb.add %a, %a : i42
+  %1 = comb.add %b, %b : i17
+  hw.output %0, %1 : i42, i17
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
+  // CHECK-NEXT: [[INA:%.+]] = arc.root_input "a", [[PTR]] : (!arc.storage) -> !arc.state<i42>
+  // CHECK-NEXT: [[INB:%.+]] = arc.root_input "b", [[PTR]] : (!arc.storage) -> !arc.state<i17>
+  // CHECK-NEXT: arc.passthrough {
+  // CHECK-NEXT:   [[A:%.+]] = arc.state_read [[INA]] : <i42>
+  // CHECK-NEXT:   [[TMP:%.+]] = comb.add [[A]], [[A]] : i42
+  // CHECK-NEXT:   arc.state_write [[OUTA:%.+]] = [[TMP]] : <i42>
+  // CHECK-NEXT:   [[B:%.+]] = arc.state_read [[INB]] : <i17>
+  // CHECK-NEXT:   [[TMP:%.+]] = comb.add [[B]], [[B]] : i17
+  // CHECK-NEXT:   arc.state_write [[OUTB:%.+]] = [[TMP]] : <i17>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[OUTA]] = arc.root_output "c", [[PTR]] : (!arc.storage) -> !arc.state<i42>
+  // CHECK-NEXT: [[OUTB]] = arc.root_output "d", [[PTR]] : (!arc.storage) -> !arc.state<i17>
+}
+
+// CHECK-LABEL: arc.model "State" {
+hw.module @State(%clk: i1, %en: i1) {
+  %gclk = arc.clock_gate %clk, %en
+  %3 = arc.state @DummyArc(%6) clock %clk lat 1 : (i42) -> i42
+  %4 = arc.state @DummyArc(%5) clock %gclk lat 1 : (i42) -> i42
+  %5 = comb.add %3, %3 : i42
+  %6 = comb.add %4, %4 : i42
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
+  // CHECK-NEXT: [[INCLK:%.+]] = arc.root_input "clk", [[PTR]] : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: [[INEN:%.+]] = arc.root_input "en", [[PTR]] : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: [[CLK:%.+]] = arc.state_read [[INCLK]] : <i1>
+  // CHECK-NEXT: arc.clock_tree [[CLK]] {
+  // CHECK-NEXT:   [[TMP0:%.+]] = arc.state_read [[S1:%.+]] : <i42>
+  // CHECK-NEXT:   [[TMP1:%.+]] = comb.add [[TMP0]], [[TMP0]]
+  // CHECK-NEXT:   [[TMP2:%.+]] = arc.state @DummyArc([[TMP1]]) lat 0 : (i42) -> i42
+  // CHECK-NEXT:   arc.state_write [[S0:%.+]] = [[TMP2]] : <i42>
+  // CHECK-NEXT:   [[TMP0:%.+]] = arc.state_read [[S0]] : <i42>
+  // CHECK-NEXT:   [[TMP1:%.+]] = comb.add [[TMP0]], [[TMP0]]
+  // CHECK-NEXT:   [[TMP2:%.+]] = arc.state @DummyArc([[TMP1]]) lat 0 : (i42) -> i42
+  // CHECK-NEXT:   [[EN:%.+]] = arc.state_read [[INEN]] : <i1>
+  // CHECK-NEXT:   arc.state_write [[S1]] = [[TMP2]] if [[EN]] : <i42>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[S0]] = arc.alloc_state [[PTR]] : (!arc.storage) -> !arc.state<i42>
+  // CHECK-NEXT: [[S1]] = arc.alloc_state [[PTR]] : (!arc.storage) -> !arc.state<i42>
+}
+
+// CHECK-LABEL: arc.model "State2" {
+hw.module @State2(%clk: i1) {
+  %3 = arc.state @DummyArc(%3) clock %clk lat 1 : (i42) -> i42
+  %4 = arc.state @DummyArc(%4) clock %clk lat 1 : (i42) -> i42
+  // CHECK-NEXT: ^bb
+  // CHECK-NEXT: %in_clk = arc.root_input "clk", %arg0 : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: [[CLK:%.+]] = arc.state_read %in_clk : <i1>
+  // CHECK-NEXT: arc.clock_tree [[CLK]] {
+  // CHECK-NEXT:   [[TMP0:%.+]] = arc.state_read [[S0:%.+]] : <i42>
+  // CHECK-NEXT:   [[TMP1:%.+]] = arc.state @DummyArc([[TMP0]]) lat 0 : (i42) -> i42
+  // CHECK-NEXT:   arc.state_write [[S0]] = [[TMP1]] : <i42>
+  // CHECK-NEXT:   [[TMP2:%.+]] = arc.state_read [[S1:%.+]] : <i42>
+  // CHECK-NEXT:   [[TMP3:%.+]] = arc.state @DummyArc([[TMP2]]) lat 0 : (i42) -> i42
+  // CHECK-NEXT:   arc.state_write [[S1]] = [[TMP3]] : <i42>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[S0]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
+  // CHECK-NEXT: [[S1]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
+}
+
+arc.define @DummyArc(%arg0: i42) -> i42 {
+  arc.output %arg0 : i42
+}
+
+// CHECK-LABEL: arc.model "MemoryWriteDependencyUpdates"
+hw.module @MemoryWriteDependencyUpdates(%clk0: i1, %clk1: i1) {
+  %true = hw.constant true
+  %c0_i2 = hw.constant 0 : i2
+  %c1_i2 = hw.constant 1 : i2
+  %c9001_i42 = hw.constant 9001 : i42
+  %mem = arc.memory <4 x i42>
+  %read0 = arc.memory_read %mem[%c0_i2], %clk0, %true : <4 x i42>, i2
+  %read1 = arc.memory_read %mem[%c1_i2], %clk1, %true : <4 x i42>, i2
+  arc.memory_write %mem[%c0_i2], %clk0, %true, %c9001_i42 (reads %read0, %read1 : i42, i42) : <4 x i42>, i2
+  arc.memory_write %mem[%c1_i2], %clk1, %true, %c9001_i42 (reads %read0, %read1 : i42, i42) : <4 x i42>, i2
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
+  // CHECK-NEXT: [[INCLK0:%.+]] = arc.root_input "clk0", [[PTR]] : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: [[INCLK1:%.+]] = arc.root_input "clk1", [[PTR]] : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: [[MEM:%.+]] = arc.alloc_memory [[PTR]] : (!arc.storage) -> !arc.memory<4 x i42>
+  // CHECK-NEXT: [[CLK0:%.+]] = arc.state_read [[INCLK0]] : <i1>
+  // CHECK-NEXT: arc.clock_tree [[CLK0]] {
+  // CHECK:        [[CLK:%.+]] = arc.state_read [[INCLK0]]
+  // CHECK-NEXT:   [[TMP:%.+]] = arc.memory_read [[MEM]][%c0_i2], [[CLK]], %true : <4 x i42>, i2
+  //               Only one read should remain.
+  // CHECK-NEXT:   arc.memory_write [[MEM]][%c0_i2], [[CLK]], %true, %c9001_i42 (reads [[TMP]] : i42) : <4 x i42>, i2
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[CLK1:%.+]] = arc.state_read [[INCLK1]] : <i1>
+  // CHECK-NEXT: arc.clock_tree [[CLK1]] {
+  // CHECK:        [[CLK:%.+]] = arc.state_read [[INCLK1]]
+  // CHECK-NEXT:   [[TMP:%.+]] = arc.memory_read [[MEM]][%c1_i2], [[CLK]], %true : <4 x i42>, i2
+  //               Only one read should remain.
+  // CHECK-NEXT:   arc.memory_write [[MEM]][%c1_i2], [[CLK]], %true, %c9001_i42 (reads [[TMP]] : i42) : <4 x i42>, i2
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL:  arc.model "maskedMemoryWrite"
+hw.module @maskedMemoryWrite(%clk: i1) {
+  %true = hw.constant true
+  %c0_i2 = hw.constant 0 : i2
+  %c9001_i42 = hw.constant 9001 : i42
+  %c1010_i42 = hw.constant 1010 : i42
+  %mem = arc.memory <4 x i42>
+  arc.memory_write %mem[%c0_i2], %clk, %true, %c9001_i42 mask (%c1010_i42 : i42) : <4 x i42>, i2
+}
+// CHECK:      %c9001_i42 = hw.constant 9001 : i42
+// CHECK:      %c1010_i42 = hw.constant 1010 : i42
+// CHECK:      [[RD:%.+]] = arc.memory_read [[MEM:%.+]][%c0_i2], [[CLK:%.+]], %true : <4 x i42>, i2
+// CHECK:      %c-1_i42 = hw.constant -1 : i42
+// CHECK:      [[NEG_MASK:%.+]] = comb.xor bin %c1010_i42, %c-1_i42 : i42
+// CHECK:      [[OLD_MASKED:%.+]] = comb.and bin [[NEG_MASK]], [[RD]] : i42
+// CHECK:      [[NEW_MASKED:%.+]] = comb.and bin %c1010_i42, %c9001_i42 : i42
+// CHECK:      [[DATA:%.+]] = comb.or bin [[OLD_MASKED]], [[NEW_MASKED]] : i42
+// CHECK:      arc.memory_write [[MEM]][%c0_i2], [[CLK]], %true, [[DATA]] : <4 x i42>, i2
+
+// CHECK-LABEL: arc.model "Taps"
+hw.module @Taps() {
+  // CHECK-NOT: arc.tap
+  // CHECK-DAG: [[VALUE:%.+]] = hw.constant 0 : i42
+  // CHECK-DAG: [[STATE:%.+]] = arc.alloc_state %arg0 tap {name = "myTap"}
+  // CHECK-DAG: arc.state_write [[STATE]] = [[VALUE]]
+  %c0_i42 = hw.constant 0 : i42
+  arc.tap %c0_i42 {name = "myTap"} : i42
+}
+
+// CHECK-LABEL: arc.model "MaterializeOpsWithRegions"
+hw.module @MaterializeOpsWithRegions(%clk0: i1, %clk1: i1) -> (z: i42) {
+  %true = hw.constant true
+  %c19_i42 = hw.constant 19 : i42
+  %0 = scf.if %true -> (i42) {
+    scf.yield %c19_i42 : i42
+  } else {
+    %c42_i42 = hw.constant 42 : i42
+    scf.yield %c42_i42 : i42
+  }
+  // CHECK:      arc.passthrough {
+  // CHECK-NEXT:   %true = hw.constant true
+  // CHECK-NEXT:   %c19_i42 = hw.constant 19
+  // CHECK-NEXT:   [[TMP:%.+]] = scf.if %true -> (i42) {
+  // CHECK-NEXT:     scf.yield %c19_i42
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     %c42_i42 = hw.constant 42
+  // CHECK-NEXT:     scf.yield %c42_i42
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   arc.state_write
+  // CHECK-NEXT: }
+
+  // CHECK:      [[CLK0:%.+]] = arc.state_read %in_clk0
+  // CHECK-NEXT: arc.clock_tree [[CLK0]] {
+  // CHECK-NEXT:   %true = hw.constant true
+  // CHECK-NEXT:   %c19_i42 = hw.constant 19
+  // CHECK-NEXT:   [[TMP:%.+]] = scf.if %true -> (i42) {
+  // CHECK-NEXT:     scf.yield %c19_i42
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     %c42_i42 = hw.constant 42
+  // CHECK-NEXT:     scf.yield %c42_i42
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   arc.state @DummyArc([[TMP]]) lat 0
+  // CHECK-NEXT:   arc.state_write
+  // CHECK-NEXT: }
+
+  // CHECK:      [[CLK1:%.+]] = arc.state_read %in_clk1
+  // CHECK-NEXT: arc.clock_tree [[CLK1]] {
+  // CHECK-NEXT:   %true = hw.constant true
+  // CHECK-NEXT:   %c19_i42 = hw.constant 19
+  // CHECK-NEXT:   [[TMP:%.+]] = scf.if %true -> (i42) {
+  // CHECK-NEXT:     scf.yield %c19_i42
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     %c42_i42 = hw.constant 42
+  // CHECK-NEXT:     scf.yield %c42_i42
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   arc.state @DummyArc([[TMP]]) lat 0
+  // CHECK-NEXT:   arc.state_write
+  // CHECK-NEXT: }
+
+  %1 = arc.state @DummyArc(%0) clock %clk0 lat 1 : (i42) -> i42
+  %2 = arc.state @DummyArc(%0) clock %clk1 lat 1 : (i42) -> i42
+  hw.output %0 : i42
+}


### PR DESCRIPTION
Add the `LowerState` pass and accompanying operations to convert a design from a pure state transfer graph composed of arcs to a more procedural read-modify-write representation. After this transformation the design is a significant step down the path of becoming a software model.

The `LowerState` pass proceeds as follows:

- Group all `arc.state` ops according to their clock into `arc.clock_tree`s. Operations that are on direct input-to-output passthrough or on state-to-output paths are grouped into a `arc.passthrough` op.
- Introduce an explicit state storage allocation op for every state op, memory op, as well as every input and output port of the root module.
- Replace the root `hw.module` with a `arc.model` which no longer has any input and output ports, but a storage pointer argument instead. Storage allocation ops represent specific chunks of memory behind this pointer.
- Split every `arc.state` op with latency >0 up into a `arc.state_read`, `arc.state` with latency 0, and `arc.state_write` operation. This essentially breaks `arc.state` up into two parts: a read for all users of the state, and a transfer function plus write for all operands of the arc.

In doing so, the sea-of-gates representation of the HW dialect, which is a pure graph without op ordering constraints, is converted into a a sea-of-clocks, where each group contains the parts of the circuit that are triggered by the same clock. The actual computation that occurs on that trigger is represented procedurally in a proper SSA/CFG block.

TL;DR: This goes from "How do the gates connect together?" to "How does a computer simulate these gates?".