### PR TITLE
[Arc] Add state allocation passes

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -328,6 +328,22 @@ def RootOutputOp : ArcOp<"root_output", [
 }
 
 //===----------------------------------------------------------------------===//
+// Storage Access
+//===----------------------------------------------------------------------===//
+
+def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType]>;
+
+def StorageGetOp : ArcOp<"storage.get", [MemoryEffects<[MemRead]>]> {
+  let summary = "Access an allocated state, memory, or storage slice";
+  let arguments = (ins StorageType:$storage, I32Attr:$offset);
+  let results = (outs AllocatableType:$result);
+  let assemblyFormat = [{
+    $storage `[` $offset `]` attr-dict
+    `:` qualified(type($storage)) `->` type($result)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // State Read/Write
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Arc/Passes.h
+++ b/include/circt/Dialect/Arc/Passes.h
@@ -22,13 +22,17 @@ namespace arc {
 std::unique_ptr<mlir::Pass>
 createAddTapsPass(llvm::Optional<bool> tapPorts = {},
                   llvm::Optional<bool> tapWires = {});
+std::unique_ptr<mlir::Pass> createAllocateStatePass();
 std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInlineArcsPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
+std::unique_ptr<mlir::Pass> createLegalizeStateUpdatePass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();
 std::unique_ptr<mlir::Pass> createLowerStatePass();
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
+std::unique_ptr<mlir::Pass>
+createPrintStateInfoPass(llvm::StringRef stateFile = "");
 std::unique_ptr<mlir::Pass> createRemoveUnusedArcArgumentsPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();
 std::unique_ptr<mlir::Pass> createSinkInputsPass();

--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -21,6 +21,12 @@ def AddTaps : Pass<"arc-add-taps", "mlir::ModuleOp"> {
   ];
 }
 
+def AllocateState : Pass<"arc-allocate-state", "arc::ModelOp"> {
+  let summary = "Allocate and layout the global simulation state";
+  let constructor = "circt::arc::createAllocateStatePass()";
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
 def Dedup : Pass<"arc-dedup", "mlir::ModuleOp"> {
   let summary = "Deduplicate identical arc definitions";
   let description = [{
@@ -65,6 +71,12 @@ def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
   let constructor = "circt::arc::createInlineModulesPass()";
 }
 
+def LegalizeStateUpdate : Pass<"arc-legalize-state-update", "mlir::ModuleOp"> {
+  let summary = "Insert temporaries such that state reads don't see writes";
+  let constructor = "circt::arc::createLegalizeStateUpdatePass()";
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
 def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
   let summary = "Lowers arc.lut into a comb and hw only representation.";
   let constructor = "circt::arc::createLowerLUTPass()";
@@ -81,6 +93,15 @@ def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let summary = "Transform appropriate arc logic into lookup tables";
   let constructor = "circt::arc::createMakeTablesPass()";
   let dependentDialects = ["arc::ArcDialect"];
+}
+
+def PrintStateInfo : Pass<"arc-print-state-info", "mlir::ModuleOp"> {
+  let summary = "Print the state storage layout in JSON format";
+  let constructor = "circt::arc::createPrintStateInfoPass()";
+  let options = [
+    Option<"stateFile", "state-file", "std::string", "",
+      "Emit file with state description">
+  ];
 }
 
 def RemoveUnusedArcArguments : Pass<"arc-remove-unused-arc-arguments",

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -1,0 +1,163 @@
+//===- AllocateState.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-allocate-state"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+using llvm::SmallMapVector;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct AllocateStatePass : public AllocateStateBase<AllocateStatePass> {
+  void runOnOperation() override;
+  void allocateBlock(Block *block);
+  void allocateOps(Value storage, Block *block, ArrayRef<Operation *> ops);
+};
+} // namespace
+
+void AllocateStatePass::runOnOperation() {
+  ModelOp modelOp = getOperation();
+  LLVM_DEBUG(llvm::dbgs() << "Allocating state in `" << modelOp.getName()
+                          << "`\n");
+
+  // Walk the blocks from innermost to outermost and group all state allocations
+  // in that block in one larger allocation.
+  modelOp.walk([&](Block *block) { allocateBlock(block); });
+}
+
+void AllocateStatePass::allocateBlock(Block *block) {
+  SmallMapVector<Value, std::vector<Operation *>, 1> opsByStorage;
+
+  // Group operations by their storage. There is generally just one storage,
+  // passed into the model as a block argument.
+  for (auto &op : *block) {
+    if (isa<AllocStateOp, RootInputOp, RootOutputOp, AllocMemoryOp,
+            AllocStorageOp>(&op))
+      opsByStorage[op.getOperand(0)].push_back(&op);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "- Visiting block in "
+                          << block->getParentOp()->getName() << "\n");
+
+  // Actually allocate each operation.
+  for (auto &[storage, ops] : opsByStorage)
+    allocateOps(storage, block, ops);
+}
+
+void AllocateStatePass::allocateOps(Value storage, Block *block,
+                                    ArrayRef<Operation *> ops) {
+  SmallVector<std::tuple<Value, Value, IntegerAttr>> gettersToCreate;
+
+  // Helper function to allocate storage aligned to its own size, or 8 bytes at
+  // most.
+  unsigned currentByte = 0;
+  auto allocBytes = [&](unsigned numBytes) {
+    currentByte = llvm::alignToPowerOf2(currentByte,
+                                        llvm::bit_ceil(std::min(numBytes, 8U)));
+    unsigned offset = currentByte;
+    currentByte += numBytes;
+    return offset;
+  };
+
+  // Allocate storage for the operations.
+  OpBuilder builder(block->getParentOp());
+  for (auto *op : ops) {
+    if (isa<AllocStateOp, RootInputOp, RootOutputOp>(op)) {
+      auto result = op->getResult(0);
+      auto storage = op->getOperand(0);
+      auto intType = result.getType().cast<StateType>().getType();
+      unsigned numBytes = (intType.getWidth() + 7) / 8;
+      auto offset = builder.getI32IntegerAttr(allocBytes(numBytes));
+      op->setAttr("offset", offset);
+      gettersToCreate.emplace_back(result, storage, offset);
+      continue;
+    }
+
+    if (auto memOp = dyn_cast<AllocMemoryOp>(op)) {
+      auto memType = memOp.getType();
+      auto intType = memType.getWordType();
+      unsigned stride = (intType.getWidth() + 7) / 8;
+      stride =
+          llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 8U)));
+      unsigned numBytes = memType.getNumWords() * stride;
+      auto offset = builder.getI32IntegerAttr(allocBytes(numBytes));
+      op->setAttr("offset", offset);
+      op->setAttr("stride", builder.getI32IntegerAttr(stride));
+      memOp.getResult().setType(MemoryType::get(memOp.getContext(),
+                                                memType.getNumWords(),
+                                                memType.getWordType(), stride));
+      gettersToCreate.emplace_back(memOp, memOp.getStorage(), offset);
+      continue;
+    }
+
+    if (auto allocStorageOp = dyn_cast<AllocStorageOp>(op)) {
+      auto offset = builder.getI32IntegerAttr(
+          allocBytes(allocStorageOp.getType().getSize()));
+      allocStorageOp.setOffsetAttr(offset);
+      gettersToCreate.emplace_back(allocStorageOp, allocStorageOp.getInput(),
+                                   offset);
+      continue;
+    }
+
+    assert("unsupported op for allocation" && false);
+  }
+
+  // For every user of the alloc op, create a local `StorageGetOp`.
+  SmallVector<StorageGetOp> getters;
+  for (auto [result, storage, offset] : gettersToCreate) {
+    SmallDenseMap<Block *, StorageGetOp> getterForBlock;
+    for (auto *user : llvm::make_early_inc_range(result.getUsers())) {
+      auto &getter = getterForBlock[user->getBlock()];
+      // Create a local getter in front of each user, except for
+      // `AllocStorageOp`s, for which we create a block-wider accessor.
+      if (!getter || !result.getDefiningOp<AllocStorageOp>()) {
+        ImplicitLocOpBuilder builder(result.getLoc(), user);
+        getter =
+            builder.create<StorageGetOp>(result.getType(), storage, offset);
+        getters.push_back(getter);
+      } else if (user->isBeforeInBlock(getter)) {
+        // TODO: This is a very expensive operation since us inserting
+        // operations makes `isBeforeInBlock` re-enumerate the entire block
+        // every single time. This doesn't happen often in practice since there
+        // are relatively few `AllocStorageOp`s, but we should improve this in a
+        // similar fashion as we did in the `LowerStates` pass.
+        getter->moveBefore(user);
+      }
+      user->replaceUsesOfWith(result, getter);
+    }
+  }
+
+  // Create the substorage accessor at the beginning of the block.
+  Operation *storageOwner = storage.getDefiningOp();
+  if (!storageOwner)
+    storageOwner = storage.cast<BlockArgument>().getOwner()->getParentOp();
+
+  if (storageOwner->isProperAncestor(block->getParentOp())) {
+    auto substorage = builder.create<AllocStorageOp>(
+        block->getParentOp()->getLoc(),
+        StorageType::get(&getContext(), currentByte), storage);
+    for (auto *op : ops)
+      op->replaceUsesOfWith(storage, substorage);
+    for (auto op : getters)
+      op->replaceUsesOfWith(storage, substorage);
+  } else {
+    storage.setType(StorageType::get(&getContext(), currentByte));
+  }
+}
+
+std::unique_ptr<Pass> arc::createAllocateStatePass() {
+  return std::make_unique<AllocateStatePass>();
+}

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,12 +1,15 @@
 add_circt_dialect_library(CIRCTArcTransforms
   AddTaps.cpp
+  AllocateState.cpp
   Dedup.cpp
   InferMemories.cpp
   InlineArcs.cpp
   InlineModules.cpp
+  LegalizeStateUpdate.cpp
   LowerLUT.cpp
   LowerState.cpp
   MakeTables.cpp
+  PrintStateInfo.cpp
   RemoveUnusedArcArguments.cpp
   SimplifyVariadicOps.cpp
   SinkInputs.cpp

--- a/lib/Dialect/Arc/Transforms/LegalizeStateUpdate.cpp
+++ b/lib/Dialect/Arc/Transforms/LegalizeStateUpdate.cpp
@@ -1,0 +1,448 @@
+//===- LegalizeStateUpdate.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/Analysis/DataFlow/DenseAnalysis.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-legalize-state-update"
+
+using namespace mlir;
+using namespace mlir::dataflow;
+using namespace circt;
+using namespace arc;
+using namespace hw;
+using llvm::PointerIntPair;
+
+//===----------------------------------------------------------------------===//
+// Data Flow Analysis
+//===----------------------------------------------------------------------===//
+
+/// Check if a type is interesting in terms of state accesses.
+static bool isTypeInteresting(Type type) { return type.isa<StateType>(); }
+
+/// Check if an operation partakes in state accesses.
+static bool isOpInteresting(Operation *op) {
+  if (isa<StateReadOp, StateWriteOp>(op))
+    return true;
+  if (auto callOp = dyn_cast<CallOpInterface>(op))
+    return llvm::any_of(callOp.getArgOperands(), [](auto arg) {
+      return isTypeInteresting(arg.getType());
+    });
+  if (auto callableOp = dyn_cast<CallableOpInterface>(op))
+    if (auto *region = callableOp.getCallableRegion())
+      return llvm::any_of(region->getArguments(), [](auto arg) {
+        return isTypeInteresting(arg.getType());
+      });
+  if (op->getNumRegions() > 0)
+    return true;
+  return false;
+}
+
+namespace {
+struct AccessState : public AnalysisState {
+  using AnalysisState::AnalysisState;
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AccessState)
+
+  enum AccessType { Read = 0, Write = 1 };
+  using Access = PointerIntPair<Value, 1, AccessType>;
+
+  void print(raw_ostream &os) const override {
+    if (accesses.empty()) {
+      os << "no accesses\n";
+      return;
+    }
+    for (auto access : accesses) {
+      os << "- " << (access.getInt() == Read ? "read" : "write") << " "
+         << access.getPointer() << "\n";
+    }
+  }
+
+  ChangeResult join(const AccessState &other) {
+    auto result = ChangeResult::NoChange;
+    for (auto access : other.accesses)
+      if (accesses.insert(access).second)
+        result = ChangeResult::Change;
+    return result;
+  }
+
+  ChangeResult add(Value state, AccessType type) {
+    return add(Access(state, type));
+  }
+
+  ChangeResult add(Access access) {
+    if (accesses.insert(access).second)
+      return ChangeResult::Change;
+    return ChangeResult::NoChange;
+  }
+
+  ChangeResult remove(Value state, AccessType type) {
+    return remove(Access(state, type));
+  }
+
+  ChangeResult remove(Access access) {
+    if (accesses.erase(access))
+      return ChangeResult::Change;
+    return ChangeResult::NoChange;
+  }
+
+  SmallPtrSet<Access, 1> accesses;
+};
+
+struct ArgumentAccessState : public AccessState {
+  using AccessState::AccessState;
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ArgumentAccessState)
+};
+
+struct AccessAnalysis : public DataFlowAnalysis {
+  using DataFlowAnalysis::DataFlowAnalysis;
+
+  LogicalResult initialize(Operation *top) override;
+  LogicalResult visit(ProgramPoint point) override;
+
+  void visitBlock(Block *block);
+  void visitOperation(Operation *op);
+
+  void recordState(Value value) {
+    stateOrder.insert({value, stateOrder.size()});
+  }
+
+  /// A global order assigned to state values. These allow us to not care about
+  /// ordering during the access analysis and only establish a determinstic
+  /// order once we insert additional operations later on.
+  DenseMap<Value, unsigned> stateOrder;
+
+  /// A symbol table cache.
+  SymbolTableCollection symbolTable;
+};
+} // namespace
+
+LogicalResult AccessAnalysis::initialize(Operation *top) {
+  top->walk([&](Block *block) {
+    visitBlock(block);
+    for (Operation &op : *block)
+      if (isOpInteresting(&op))
+        visitOperation(&op);
+  });
+  LLVM_DEBUG(llvm::dbgs() << "Initialized\n");
+  return success();
+}
+
+LogicalResult AccessAnalysis::visit(ProgramPoint point) {
+  if (auto *op = point.dyn_cast<Operation *>()) {
+    visitOperation(op);
+    return success();
+  }
+  if (auto *block = point.dyn_cast<Block *>()) {
+    visitBlock(block);
+    return success();
+  }
+  return emitError(point.getLoc(), "unknown point kind");
+}
+
+void AccessAnalysis::visitBlock(Block *block) {
+  // LLVM_DEBUG(llvm::dbgs() << "Visit block " << block << "\n");
+  for (auto arg : block->getArguments())
+    if (isTypeInteresting(arg.getType()))
+      recordState(arg);
+
+  // Aggregate the accesses performed by the operations in this block.
+  SmallPtrSet<Value, 4> localState;
+  AccessState innerAccesses(block);
+  for (Operation &op : *block) {
+    if (isa<AllocStateOp>(&op)) {
+      localState.insert(op.getResult(0));
+      recordState(op.getResult(0));
+    }
+    if (!isOpInteresting(&op))
+      continue;
+    innerAccesses.join(*getOrCreateFor<AccessState>(block, &op));
+  }
+
+  // Remove any information about locally-defined state which we cannot access
+  // outside the current block. This prevents significant blow-up of the access
+  // sets, since local state accesses don't get transported to parent ops where
+  // they have no meaning.
+  for (auto state : localState) {
+    innerAccesses.remove(state, AccessState::Read);
+    innerAccesses.remove(state, AccessState::Write);
+  }
+
+  // Track block argument accesses in a separate analysis state.
+  auto *argAccesses = getOrCreate<ArgumentAccessState>(block);
+  auto result = ChangeResult::NoChange;
+  for (auto arg : block->getArguments()) {
+    if (innerAccesses.remove(arg, AccessState::Read) == ChangeResult::Change)
+      result |= argAccesses->add(arg, AccessState::Read);
+    if (innerAccesses.remove(arg, AccessState::Write) == ChangeResult::Change)
+      result |= argAccesses->add(arg, AccessState::Write);
+  }
+  propagateIfChanged(argAccesses, result);
+
+  // Update the block's access list.
+  auto *blockAccesses = getOrCreate<AccessState>(block);
+  result = blockAccesses->join(innerAccesses);
+  propagateIfChanged(blockAccesses, result);
+}
+
+void AccessAnalysis::visitOperation(Operation *op) {
+  auto result = ChangeResult::NoChange;
+  auto *accesses = getOrCreate<AccessState>(op);
+
+  TypeSwitch<Operation *>(op)
+      .Case<StateReadOp>([&](auto readOp) {
+        result |= accesses->add(readOp.getState(), AccessState::Read);
+      })
+      .Case<StateWriteOp>([&](auto writeOp) {
+        result |= accesses->add(writeOp.getState(), AccessState::Write);
+      })
+      .Case<CallableOpInterface>([&](auto callableOp) {
+        if (auto *region = callableOp.getCallableRegion()) {
+          auto argResult = ChangeResult::NoChange;
+          auto *argAccesses = getOrCreate<ArgumentAccessState>(op);
+          for (auto &block : *region) {
+            argResult |= argAccesses->join(
+                *getOrCreateFor<ArgumentAccessState>(op, &block));
+          }
+          propagateIfChanged(argAccesses, argResult);
+        }
+      })
+      .Case<CallOpInterface>([&](auto callOp) {
+        if (auto calleeOp = dyn_cast_or_null<CallableOpInterface>(
+                callOp.resolveCallable(&symbolTable))) {
+          auto operands = callOp.getArgOperands();
+          const auto *calleeArgAccesses =
+              getOrCreateFor<ArgumentAccessState>(callOp, calleeOp);
+          for (auto access : calleeArgAccesses->accesses)
+            if (auto arg = access.getPointer()
+                               .template dyn_cast_or_null<BlockArgument>())
+              result |=
+                  accesses->add(operands[arg.getArgNumber()], access.getInt());
+        }
+      });
+
+  // Don't propagate inner state accesses through models, clock trees, and
+  // passthrough ops.
+  if (!isa<ModelOp, ClockTreeOp, PassThroughOp>(op)) {
+    for (auto &region : op->getRegions()) {
+      for (auto &block : region) {
+        const auto *blockAccesses = getOrCreateFor<AccessState>(op, &block);
+        result |= accesses->join(*blockAccesses);
+      }
+    }
+  }
+
+  propagateIfChanged(accesses, result);
+}
+
+//===----------------------------------------------------------------------===//
+// Legalization
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct Legalizer {
+  Legalizer(DataFlowSolver &solver, AccessAnalysis &analysis)
+      : solver(solver), analysis(analysis) {}
+  LogicalResult run(MutableArrayRef<Region> regions);
+  LogicalResult visitBlock(Block *block);
+
+  DataFlowSolver &solver;
+  AccessAnalysis &analysis;
+
+  unsigned numLegalizedWrites = 0;
+  unsigned numUpdatedReads = 0;
+
+  /// A mapping from pre-existing states to temporary states for read
+  /// operations, created during legalization to remove read-after-write
+  /// hazards.
+  DenseMap<Value, Value> legalizedStates;
+};
+} // namespace
+
+LogicalResult Legalizer::run(MutableArrayRef<Region> regions) {
+  for (auto &region : regions)
+    for (auto &block : region)
+      if (failed(visitBlock(&block)))
+        return failure();
+  assert(legalizedStates.empty() && "should be balanced within block");
+  return success();
+}
+
+LogicalResult Legalizer::visitBlock(Block *block) {
+  // In a first reverse pass over the block, find the first write that occurs
+  // before the last read of a state, if any.
+  SmallPtrSet<Value, 4> readStates;
+  DenseMap<Value, Operation *> illegallyWrittenStates;
+  for (Operation &op : llvm::reverse(*block)) {
+    const auto *accesses = solver.lookupState<AccessState>(&op);
+    if (!accesses)
+      continue;
+
+    // Determine the states written by this op for which we have already seen a
+    // read earlier. These writes need to be legalized.
+    SmallVector<Value, 1> affectedStates;
+    for (auto access : accesses->accesses)
+      if (access.getInt() == AccessState::Write)
+        if (readStates.contains(access.getPointer()))
+          illegallyWrittenStates[access.getPointer()] = &op;
+
+    // Determine the states read by this op. This comes after handling of the
+    // writes, such that a block that contains both reads and writes to a state
+    // doesn't mark itself as illegal. Instead, we will descend into that block
+    // further down and do a more fine-grained legalization.
+    for (auto access : accesses->accesses)
+      if (access.getInt() == AccessState::Read)
+        readStates.insert(access.getPointer());
+  }
+
+  // Create a mapping from operations that create a read-after-write hazard to
+  // the states that they modify. Don't consider states that have already been
+  // legalized. This is important since we may have already created a temporary
+  // in a parent block which we can just reuse.
+  DenseMap<Operation *, SmallVector<Value, 1>> illegalWrites;
+  for (auto [state, op] : illegallyWrittenStates)
+    if (!legalizedStates.count(state))
+      illegalWrites[op].push_back(state);
+
+  // In a second forward pass over the block, insert the necessary temporary
+  // state to legalize the writes and recur into subblocks while providing the
+  // necessary rewrites.
+  SmallVector<Value> locallyLegalizedStates;
+
+  auto handleIllegalWrites =
+      [&](Operation *op, SmallVector<Value, 1> &states) -> LogicalResult {
+    LLVM_DEBUG(llvm::dbgs() << "Visiting illegal " << op->getName() << "\n");
+
+    // Sort the states we need to legalize by a determinstic order established
+    // during the access analysis. Without this the exact order in which states
+    // were moved into a temporary would be non-deterministic.
+    llvm::sort(states, [&](Value a, Value b) {
+      return analysis.stateOrder[a] < analysis.stateOrder[b];
+    });
+
+    // Legalize each state individually.
+    for (auto state : states) {
+      LLVM_DEBUG(llvm::dbgs() << "- Legalizing " << state << "\n");
+
+      // HACK: This is ugly, but we need a storage reference to allocate a state
+      // into. Ideally we'd materialize this later on, but the current impl of
+      // the alloc op requires a storage immediately. So try to find one.
+      auto storage = TypeSwitch<Operation *, Value>(state.getDefiningOp())
+                         .Case<AllocStateOp, RootInputOp, RootOutputOp>(
+                             [&](auto allocOp) { return allocOp.getStorage(); })
+                         .Default([](auto) { return Value{}; });
+      if (!storage) {
+        mlir::emitError(
+            state.getLoc(),
+            "cannot find storage pointer to allocate temporary into");
+        return failure();
+      }
+
+      // Allocate a temporary state, read the current value of the state we are
+      // legalizing, and write it to the temporary.
+      ++numLegalizedWrites;
+      ImplicitLocOpBuilder builder(state.getLoc(), op);
+      auto tmpState =
+          builder.create<AllocStateOp>(state.getType(), storage, nullptr);
+      auto stateValue = builder.create<StateReadOp>(state);
+      builder.create<StateWriteOp>(tmpState, stateValue, Value{});
+      locallyLegalizedStates.push_back(state);
+      legalizedStates.insert({state, tmpState});
+    }
+    return success();
+  };
+
+  for (Operation &op : *block) {
+    if (isOpInteresting(&op)) {
+      if (auto it = illegalWrites.find(&op); it != illegalWrites.end())
+        if (failed(handleIllegalWrites(&op, it->second)))
+          return failure();
+    }
+    // BUG: This is insufficient. Actually only reads should have their state
+    // updated, since we want writes to still affect the original state. This
+    // works for `state_read`, but in the case of a function that both reads and
+    // writes a state we only have a single operand to change but we would need
+    // one for reads and one for writes instead.
+    // HACKY FIX: Assume that there is ever only a single write to a state. In
+    // that case it is safe to assume that when an op is marked as writing a
+    // state it wants the original state, not the temporary one for reads.
+    const auto *accesses = solver.lookupState<AccessState>(&op);
+    for (auto &operand : op.getOpOperands()) {
+      if (accesses &&
+          accesses->accesses.contains({operand.get(), AccessState::Read}) &&
+          accesses->accesses.contains({operand.get(), AccessState::Write})) {
+        auto d = op.emitWarning("operation reads and writes state; "
+                                "legalization may be insufficient");
+        d.attachNote()
+            << "state update legalization does not properly handle operations "
+               "that both read and write states at the same time; runtime data "
+               "races between the read and write behavior are possible";
+        d.attachNote(operand.get().getLoc()) << "state defined here:";
+      }
+      if (!accesses ||
+          !accesses->accesses.contains({operand.get(), AccessState::Write})) {
+        if (auto tmpState = legalizedStates.lookup(operand.get())) {
+          operand.set(tmpState);
+          ++numUpdatedReads;
+        }
+      }
+    }
+    for (auto &region : op.getRegions())
+      for (auto &block : region)
+        if (failed(visitBlock(&block)))
+          return failure();
+  }
+
+  // Since we're leaving this block's scope, remove all the locally-legalized
+  // states which are no longer accessible outside.
+  for (auto state : locallyLegalizedStates)
+    legalizedStates.erase(state);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LegalizeStateUpdatePass
+    : public LegalizeStateUpdateBase<LegalizeStateUpdatePass> {
+  LegalizeStateUpdatePass() = default;
+  LegalizeStateUpdatePass(const LegalizeStateUpdatePass &pass)
+      : LegalizeStateUpdatePass() {}
+
+  void runOnOperation() override;
+
+  Statistic numLegalizedWrites{
+      this, "legalized-writes",
+      "Writes that required temporary state for later reads"};
+  Statistic numUpdatedReads{this, "updated-reads", "Reads that were updated"};
+};
+} // namespace
+
+void LegalizeStateUpdatePass::runOnOperation() {
+  auto module = getOperation();
+  DataFlowSolver solver;
+  auto &analysis = *solver.load<AccessAnalysis>();
+  if (failed(solver.initializeAndRun(module)))
+    return signalPassFailure();
+
+  Legalizer legalizer(solver, analysis);
+  if (failed(legalizer.run(module->getRegions())))
+    return signalPassFailure();
+  numLegalizedWrites += legalizer.numLegalizedWrites;
+  numUpdatedReads += legalizer.numUpdatedReads;
+}
+
+std::unique_ptr<Pass> arc::createLegalizeStateUpdatePass() {
+  return std::make_unique<LegalizeStateUpdatePass>();
+}

--- a/lib/Dialect/Arc/Transforms/PrintStateInfo.cpp
+++ b/lib/Dialect/Arc/Transforms/PrintStateInfo.cpp
@@ -1,0 +1,195 @@
+//===- PrintStateInfo.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#define DEBUG_TYPE "arc-print-state-info"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+using namespace hw;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct StateInfo {
+  enum Type { Input, Output, Register, Memory, Wire } type;
+  StringAttr name;
+  unsigned offset;
+  unsigned numBits;
+  unsigned memoryStride = 0; // byte separation between memory words
+  unsigned memoryDepth = 0;  // number of words in a memory
+};
+
+struct ModelInfo {
+  size_t numStateBytes;
+  std::vector<StateInfo> states;
+};
+
+struct PrintStateInfoPass : public PrintStateInfoBase<PrintStateInfoPass> {
+  void runOnOperation() override;
+  LogicalResult runOnOperation(llvm::raw_ostream &outputStream);
+  LogicalResult collectStates(Value storage, unsigned offset,
+                              std::vector<StateInfo> &stateInfos);
+
+  using PrintStateInfoBase::stateFile;
+};
+} // namespace
+
+void PrintStateInfoPass::runOnOperation() {
+  // Print to the output file if one was given, or stdout otherwise.
+  if (stateFile.empty()) {
+    auto result = runOnOperation(llvm::outs());
+    llvm::outs() << "\n";
+    if (failed(result))
+      return signalPassFailure();
+  } else {
+    std::error_code ec;
+    llvm::ToolOutputFile outputFile(stateFile, ec,
+                                    llvm::sys::fs::OpenFlags::OF_None);
+    if (ec) {
+      mlir::emitError(getOperation().getLoc(), "unable to open state file: ")
+          << ec.message();
+      return signalPassFailure();
+    }
+    if (failed(runOnOperation(outputFile.os())))
+      return signalPassFailure();
+    outputFile.keep();
+  }
+}
+
+LogicalResult
+PrintStateInfoPass::runOnOperation(llvm::raw_ostream &outputStream) {
+  llvm::json::OStream json(outputStream, 2);
+  bool anyFailed = false;
+  json.array([&] {
+    std::vector<StateInfo> states;
+    for (auto modelOp : getOperation().getOps<ModelOp>()) {
+      auto storageArg = modelOp.getBody().getArgument(0);
+      auto storageType = storageArg.getType().cast<StorageType>();
+      states.clear();
+      if (failed(collectStates(storageArg, 0, states))) {
+        anyFailed = true;
+        return;
+      }
+      llvm::sort(states, [](auto &a, auto &b) { return a.offset < b.offset; });
+
+      json.object([&] {
+        json.attribute("name", modelOp.getName());
+        json.attribute("numStateBytes", storageType.getSize());
+        json.attributeArray("states", [&] {
+          for (const auto &state : states) {
+            json.object([&] {
+              json.attribute("name", state.name.getValue());
+              json.attribute("offset", state.offset);
+              json.attribute("numBits", state.numBits);
+              auto typeStr = [](StateInfo::Type type) {
+                switch (type) {
+                case StateInfo::Input:
+                  return "input";
+                case StateInfo::Output:
+                  return "output";
+                case StateInfo::Register:
+                  return "register";
+                case StateInfo::Memory:
+                  return "memory";
+                case StateInfo::Wire:
+                  return "wire";
+                }
+                return "";
+              };
+              json.attribute("type", typeStr(state.type));
+              if (state.type == StateInfo::Memory) {
+                json.attribute("stride", state.memoryStride);
+                json.attribute("depth", state.memoryDepth);
+              }
+            });
+          }
+        });
+      });
+    }
+  });
+  return failure(anyFailed);
+}
+
+LogicalResult
+PrintStateInfoPass::collectStates(Value storage, unsigned offset,
+                                  std::vector<StateInfo> &stateInfos) {
+  for (auto *op : storage.getUsers()) {
+    if (auto substorage = dyn_cast<AllocStorageOp>(op)) {
+      if (!substorage.getOffset().has_value()) {
+        substorage.emitOpError(
+            "without allocated offset; run state allocation first");
+        return failure();
+      }
+      if (failed(collectStates(substorage.getOutput(),
+                               *substorage.getOffset() + offset, stateInfos)))
+        return failure();
+      continue;
+    }
+    if (!isa<AllocStateOp, RootInputOp, RootOutputOp, AllocMemoryOp>(op))
+      continue;
+    auto opName = op->getAttrOfType<StringAttr>("name");
+    if (!opName || opName.getValue().empty())
+      continue;
+    auto opOffset = op->getAttrOfType<IntegerAttr>("offset");
+    if (!opOffset) {
+      op->emitOpError("without allocated offset; run state allocation first");
+      return failure();
+    }
+    if (isa<AllocStateOp, RootInputOp, RootOutputOp>(op)) {
+      auto result = op->getResult(0);
+      auto &stateInfo = stateInfos.emplace_back();
+      stateInfo.type = StateInfo::Register;
+      if (isa<RootInputOp>(op))
+        stateInfo.type = StateInfo::Input;
+      else if (isa<RootOutputOp>(op))
+        stateInfo.type = StateInfo::Output;
+      else if (auto alloc = dyn_cast<AllocStateOp>(op)) {
+        if (alloc.getTap())
+          stateInfo.type = StateInfo::Wire;
+      }
+      stateInfo.name = opName;
+      stateInfo.offset = opOffset.getValue().getZExtValue() + offset;
+      stateInfo.numBits =
+          result.getType().cast<StateType>().getType().getWidth();
+      continue;
+    }
+    if (auto memOp = dyn_cast<AllocMemoryOp>(op)) {
+      auto stride = op->getAttrOfType<IntegerAttr>("stride");
+      if (!stride) {
+        op->emitOpError("without allocated stride; run state allocation first");
+        return failure();
+      }
+      auto memType = memOp.getType();
+      auto intType = memType.getWordType();
+      auto &stateInfo = stateInfos.emplace_back();
+      stateInfo.type = StateInfo::Memory;
+      stateInfo.name = opName;
+      stateInfo.offset = opOffset.getValue().getZExtValue() + offset;
+      stateInfo.numBits = intType.getWidth();
+      stateInfo.memoryStride = stride.getValue().getZExtValue();
+      stateInfo.memoryDepth = memType.getNumWords();
+      continue;
+    }
+  }
+  return success();
+}
+
+std::unique_ptr<Pass> arc::createPrintStateInfoPass(StringRef stateFile) {
+  auto pass = std::make_unique<PrintStateInfoPass>();
+  if (!stateFile.empty())
+    pass->stateFile.assign(stateFile);
+  return pass;
+}

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -1,0 +1,79 @@
+// RUN: circt-opt %s --arc-allocate-state | FileCheck %s
+
+// CHECK-LABEL: arc.model "test"
+arc.model "test" {
+^bb0(%arg0: !arc.storage):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5724>):
+
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][0] : (!arc.storage<5724>) -> !arc.storage<1143>
+  // CHECK-NEXT: arc.passthrough {
+  arc.passthrough {
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5724> -> !arc.storage<1143>
+    %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i32>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i64>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i9001>
+    %1 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 0 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 1 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 2 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 8 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 16 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 1142 : i32}
+    // CHECK-NEXT: scf.execute_region {
+    scf.execute_region {
+      arc.state_read %0 : <i1>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5724> -> !arc.storage<1143>
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1143> -> !arc.state<i1>
+      // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
+      arc.state_read %1 : <i1>
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][1142] : !arc.storage<1143> -> !arc.state<i1>
+      // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
+      scf.yield
+      // CHECK-NEXT: scf.yield
+    }
+    // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1144] : (!arc.storage<5724>) -> !arc.storage<4577>
+  // CHECK-NEXT: arc.passthrough {
+  arc.passthrough {
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1144] : !arc.storage<5724> -> !arc.storage<4577>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i32>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i64>
+    arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i9001>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 0 : i32, stride = 1 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i1, 1>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 4 : i32, stride = 1 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i8, 1>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 8 : i32, stride = 2 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i16, 2>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 16 : i32, stride = 4 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i32, 4>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 32 : i32, stride = 8 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i64, 8>
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 64 : i32, stride = 1128 : i32}
+    // CHECK-SAME: -> !arc.memory<4 x i9001, 1128>
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4576 : i32}
+  }
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5722] : (!arc.storage<5724>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.passthrough {
+  arc.passthrough {
+    arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
+    arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5722] : !arc.storage<5724> -> !arc.storage<2>
+    // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
+    // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
+  }
+  // CHECK-NEXT: }
+}

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -53,3 +53,14 @@ arc.define @LookupTable(%arg0: i32, %arg1: i8) -> () {
   }
   arc.output
 }
+
+// CHECK-LABEL: func.func @StorageAccess
+func.func @StorageAccess(%arg0: !arc.storage<10000>) {
+  // CHECK-NEXT: arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
+  // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, 4>
+  // CHECK-NEXT: arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
+  %0 = arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
+  %1 = arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, 4>
+  %2 = arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
+  return
+}

--- a/test/Dialect/Arc/legalize-state-update.mlir
+++ b/test/Dialect/Arc/legalize-state-update.mlir
@@ -1,0 +1,188 @@
+// RUN: circt-opt %s --arc-legalize-state-update | FileCheck %s
+
+// CHECK-LABEL: func.func @Unaffected
+func.func @Unaffected(%arg0: !arc.storage, %arg1: i4) -> i4 {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.state_read %0 : <i4>
+  arc.state_write %0 = %arg1 : <i4>
+  return %1 : i4
+  // CHECK-NEXT: arc.alloc_state
+  // CHECK-NEXT: arc.state_read
+  // CHECK-NEXT: arc.state_write
+  // CHECK-NEXT: return
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: func.func @SameBlock
+func.func @SameBlock(%arg0: !arc.storage, %arg1: i4) -> i4 {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.state_read %0 : <i4>
+  // CHECK-NEXT: [[STATE:%.+]] = arc.alloc_state
+  // CHECK-NEXT: arc.state_read [[STATE]]
+
+  arc.state_write %0 = %arg1 : <i4>
+  // CHECK-NEXT: [[TMP:%.+]] = arc.alloc_state
+  // CHECK-NEXT: [[CURRENT:%.+]] = arc.state_read [[STATE]]
+  // CHECK-NEXT: arc.state_write [[TMP]] = [[CURRENT]]
+  // CHECK-NEXT: arc.state_write [[STATE]] = %arg1
+
+  %2 = arc.state_read %0 : <i4>
+  %3 = arc.state_read %0 : <i4>
+  %4 = comb.xor %1, %2, %3 : i4
+  return %4 : i4
+  // CHECK-NEXT: arc.state_read [[TMP]]
+  // CHECK-NEXT: arc.state_read [[TMP]]
+  // CHECK-NEXT: comb.xor
+  // CHECK-NEXT: return
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: func.func @FuncLegal
+func.func @FuncLegal(%arg0: !arc.storage, %arg1: i4) -> i4 {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  %1 = call @ReadFunc(%0) : (!arc.state<i4>) -> i4
+  call @WriteFunc(%0, %arg1) : (!arc.state<i4>, i4) -> ()
+  return %1 : i4
+  // CHECK-NEXT: arc.alloc_state
+  // CHECK-NEXT: call @ReadFunc
+  // CHECK-NEXT: call @WriteFunc
+  // CHECK-NEXT: return
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: func.func @FuncIllegal
+func.func @FuncIllegal(%arg0: !arc.storage, %arg1: i4) -> i4 {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  %1 = call @ReadFunc(%0) : (!arc.state<i4>) -> i4
+  // CHECK-NEXT: [[STATE:%.+]] = arc.alloc_state
+  // CHECK-NEXT: call @ReadFunc
+
+  call @WriteFunc(%0, %arg1) : (!arc.state<i4>, i4) -> ()
+  // CHECK-NEXT: [[TMP:%.+]] = arc.alloc_state
+  // CHECK-NEXT: [[CURRENT:%.+]] = arc.state_read [[STATE]]
+  // CHECK-NEXT: arc.state_write [[TMP]] = [[CURRENT]]
+  // CHECK-NEXT: call @WriteFunc
+
+  %2 = call @ReadFunc(%0) : (!arc.state<i4>) -> i4
+  %3 = call @ReadFunc(%0) : (!arc.state<i4>) -> i4
+  %4 = comb.xor %1, %2, %3 : i4
+  return %4 : i4
+  // CHECK-NEXT: call @ReadFunc([[TMP]])
+  // CHECK-NEXT: call @ReadFunc([[TMP]])
+  // CHECK-NEXT: comb.xor
+  // CHECK-NEXT: return
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: func.func @NestedBlocks
+func.func @NestedBlocks(%arg0: !arc.storage, %arg1: i4) -> i4 {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  %11 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[S0:%.+]] = arc.alloc_state
+  // CHECK-NEXT: [[S1:%.+]] = arc.alloc_state
+
+  // CHECK-NEXT: scf.execute_region
+  %10 = scf.execute_region -> i4 {
+    // CHECK-NEXT: [[TMP0:%.+]] = arc.alloc_state
+    // CHECK-NEXT: [[CURRENT:%.+]] = arc.state_read [[S0]]
+    // CHECK-NEXT: arc.state_write [[TMP0]] = [[CURRENT]]
+    // CHECK-NEXT: [[TMP1:%.+]] = arc.alloc_state
+    // CHECK-NEXT: [[CURRENT:%.+]] = arc.state_read [[S1]]
+    // CHECK-NEXT: arc.state_write [[TMP1]] = [[CURRENT]]
+    // CHECK-NEXT: scf.execute_region
+    %3 = scf.execute_region -> i4 {
+      // CHECK-NEXT: scf.execute_region
+      %1 = scf.execute_region -> i4 {
+        %2 = arc.state_read %0 : <i4>
+        scf.yield %2 : i4
+        // CHECK-NEXT: arc.state_read [[TMP0]]
+        // CHECK-NEXT: scf.yield
+      }
+      // CHECK-NEXT: }
+      // CHECK-NEXT: scf.execute_region
+      scf.execute_region {
+        arc.state_write %0 = %arg1 : <i4>
+        arc.state_write %11 = %arg1 : <i4>
+        scf.yield
+        // CHECK-NEXT: arc.state_write [[S0]]
+        // CHECK-NEXT: arc.state_write [[S1]]
+        // CHECK-NEXT: scf.yield
+      }
+      // CHECK-NEXT: }
+      scf.yield %1 : i4
+      // CHECK-NEXT: scf.yield
+    }
+    // CHECK-NEXT: }
+    func.call @WriteFunc(%0, %arg1) : (!arc.state<i4>, i4) -> ()
+    // CHECK-NEXT: func.call @WriteFunc([[S0]], %arg1)
+    // CHECK-NEXT: scf.execute_region
+    %7, %8 = scf.execute_region -> (i4, i4) {
+      // CHECK-NEXT: scf.execute_region
+      %4 = scf.execute_region -> i4 {
+        %5 = func.call @ReadFunc(%0) : (!arc.state<i4>) -> i4
+        scf.yield %5 : i4
+        // CHECK-NEXT: func.call @ReadFunc([[TMP0]])
+        // CHECK-NEXT: scf.yield
+      }
+      // CHECK-NEXT: }
+      %6 = arc.state_read %0 : <i4>
+      %12 = arc.state_read %11 : <i4>
+      scf.yield %4, %6 : i4, i4
+      // CHECK-NEXT: arc.state_read [[TMP0]]
+      // CHECK-NEXT: arc.state_read [[TMP1]]
+      // CHECK-NEXT: scf.yield
+    }
+    // CHECK-NEXT: }
+    %9 = comb.xor %3, %7, %8 : i4
+    scf.yield %9 : i4
+    // CHECK-NEXT: comb.xor
+    // CHECK-NEXT: scf.yield
+  }
+  // CHECK-NEXT: }
+  return %10 : i4
+  // CHECK-NEXT: return
+}
+
+func.func @ReadFunc(%arg0: !arc.state<i4>) -> i4 {
+  %0 = func.call @InnerReadFunc(%arg0) : (!arc.state<i4>) -> i4
+  return %0 : i4
+}
+
+func.func @WriteFunc(%arg0: !arc.state<i4>, %arg1: i4) {
+  func.call @InnerWriteFunc(%arg0, %arg1) : (!arc.state<i4>, i4) -> ()
+  return
+}
+
+func.func @InnerReadFunc(%arg0: !arc.state<i4>) -> i4 {
+  %0 = arc.state_read %arg0 : <i4>
+  return %0 : i4
+}
+
+func.func @InnerWriteFunc(%arg0: !arc.state<i4>, %arg1: i4) {
+  arc.state_write %arg0 = %arg1 : <i4>
+  return
+}
+
+// State legalization should not happen across clock trees and passthrough ops.
+// CHECK-LABEL: arc.model "DontLeakThroughClockTreeOrPassthrough"
+arc.model "DontLeakThroughClockTreeOrPassthrough" {
+^bb0(%arg0: !arc.storage):
+  %false = hw.constant false
+  %in_a = arc.root_input "a", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %out_b = arc.root_output "b", %arg0 : (!arc.storage) -> !arc.state<i1>
+  // CHECK: arc.alloc_state %arg0 {foo}
+  %0 = arc.alloc_state %arg0 {foo} : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NOT: arc.alloc_state
+  // CHECK-NOT: arc.state_read
+  // CHECK-NOT: arc.state_write
+  // CHECK: arc.clock_tree
+  arc.clock_tree %false {
+    %1 = arc.state_read %in_a : <i1>
+    arc.state_write %0 = %1 : <i1>
+  }
+  // CHECK: arc.passthrough
+  arc.passthrough {
+    %1 = arc.state_read %0 : <i1>
+    arc.state_write %out_b = %1 : <i1>
+  }
+}

--- a/test/Dialect/Arc/print-state-info-errors.mlir
+++ b/test/Dialect/Arc/print-state-info-errors.mlir
@@ -1,0 +1,50 @@
+// RUN: circt-opt %s --arc-print-state-info --verify-diagnostics --split-input-file
+
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // expected-error @below {{'arc.alloc_storage' op without allocated offset}}
+  arc.alloc_storage %arg0 : (!arc.storage<42>) -> !arc.storage<42>
+}
+
+// -----
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // ignore unnamed
+  arc.alloc_state %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  // expected-error @below {{'arc.alloc_state' op without allocated offset}}
+  arc.alloc_state %arg0 {name = "foo"} : (!arc.storage<42>) -> !arc.state<i1>
+}
+
+// -----
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // ignore unnamed
+  arc.root_input "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  // expected-error @below {{'arc.root_input' op without allocated offset}}
+  arc.root_input "foo", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+}
+
+// -----
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // ignore unnamed
+  arc.root_output "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  // expected-error @below {{'arc.root_output' op without allocated offset}}
+  arc.root_output "foo", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+}
+
+// -----
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // ignore unnamed
+  arc.alloc_memory %arg0 : (!arc.storage<42>) -> !arc.memory<4 x i1>
+  // expected-error @below {{'arc.alloc_memory' op without allocated offset}}
+  arc.alloc_memory %arg0 {name = "foo"} : (!arc.storage<42>) -> !arc.memory<4 x i1>
+}
+
+// -----
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<42>):
+  // expected-error @below {{'arc.alloc_memory' op without allocated stride}}
+  arc.alloc_memory %arg0 {name = "foo", offset = 8} : (!arc.storage<42>) -> !arc.memory<4 x i1>
+}

--- a/test/Dialect/Arc/print-state-info.mlir
+++ b/test/Dialect/Arc/print-state-info.mlir
@@ -1,0 +1,47 @@
+// RUN: circt-opt %s --arc-print-state-info=state-file=%t
+// RUN: cat %t | FileCheck %s
+
+// CHECK-LABEL: "name": "Foo"
+// CHECK-DAG: "numStateBytes": 5724
+arc.model "Foo" {
+^bb0(%arg0: !arc.storage<5724>):
+  // CHECK:      "name": "a"
+  // CHECK-NEXT: "offset": 0
+  // CHECK-NEXT: "numBits": 19
+  // CHECK-NEXT: "type": "input"
+  arc.root_input "a", %arg0 {offset = 0} : (!arc.storage<5724>) -> !arc.state<i19>
+
+  // CHECK:      "name": "b"
+  // CHECK-NEXT: "offset": 16
+  // CHECK-NEXT: "numBits": 42
+  // CHECK-NEXT: "type": "output"
+  arc.root_output "b", %arg0 {offset = 16} : (!arc.storage<5724>) -> !arc.state<i42>
+}
+
+// CHECK-LABEL: "name": "Bar"
+// CHECK-DAG: "numStateBytes": 9001
+arc.model "Bar" {
+^bb0(%arg0: !arc.storage<9001>):
+  // CHECK-NOT: "offset": "420"
+  arc.alloc_state %arg0 {offset = 420} : (!arc.storage<9001>) -> !arc.state<i11>
+
+  // CHECK:      "name": "x"
+  // CHECK-NEXT: "offset": 24
+  // CHECK-NEXT: "numBits": 63
+  // CHECK-NEXT: "type": "register"
+  arc.alloc_state %arg0 {name = "x", offset = 24} : (!arc.storage<9001>) -> !arc.state<i63>
+
+  // CHECK:      "name": "y"
+  // CHECK-NEXT: "offset": 48
+  // CHECK-NEXT: "numBits": 17
+  // CHECK-NEXT: "type": "memory"
+  // CHECK-NEXT: "stride": 3
+  // CHECK-NEXT: "depth": 5
+  arc.alloc_memory %arg0 {name = "y", offset = 48, stride = 3} : (!arc.storage<9001>) -> !arc.memory<5 x i17, 3>
+
+  // CHECK:      "name": "z"
+  // CHECK-NEXT: "offset": 92
+  // CHECK-NEXT: "numBits": 1337
+  // CHECK-NEXT: "type": "wire"
+  arc.alloc_state %arg0 tap {name = "z", offset = 92} : (!arc.storage<9001>) -> !arc.state<i1337>
+}

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -17,31 +17,38 @@
 
 // CHECK-NOT: hw.module @Top
 // CHECK-LABEL: arc.model "Top" {
-// CHECK-NEXT: ^bb0(%arg0: !arc.storage):
+// CHECK-NEXT: ^bb0(%arg0: !arc.storage<6>):
 hw.module @Top(%clock: i1, %i0: i4, %i1: i4) -> (out: i4) {
-  // CHECK-DAG: [[CLOCK:%.+]] = arc.root_input "clock"
-  // CHECK-DAG: [[I0:%.+]] = arc.root_input "i0"
-  // CHECK-DAG: [[I1:%.+]] = arc.root_input "i1"
-  // CHECK-DAG: [[OUT:%.+]] = arc.root_output "out"
-
-  // CHECK-DAG: [[FOO:%.+]] = arc.alloc_state %arg0 {name = "foo"}
-  // CHECK-DAG: [[BAR:%.+]] = arc.alloc_state %arg0 {name = "bar"}
+  // CHECK-DAG: arc.root_input "clock", %arg0 {offset = 0
+  // CHECK-DAG: arc.root_input "i0", %arg0 {offset = 1
+  // CHECK-DAG: arc.root_input "i1", %arg0 {offset = 2
+  // CHECK-DAG: arc.root_output "out", %arg0 {offset = 3
+  // CHECK-DAG: arc.alloc_state %arg0 {name = "foo", offset = 4
+  // CHECK-DAG: arc.alloc_state %arg0 {name = "bar", offset = 5
 
   // CHECK-DAG: arc.passthrough {
+  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[4]
   // CHECK-DAG:   [[READ_FOO:%.+]] = arc.state_read [[FOO]]
+  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[5]
   // CHECK-DAG:   [[READ_BAR:%.+]] = arc.state_read [[BAR]]
   // CHECK-DAG:   [[MUL:%.+]] = arc.state @[[MUL_ARC]]([[READ_FOO]], [[READ_BAR]]) lat 0
-  // CHECK-DAG:   arc.state_write [[OUT]] = [[MUL]]
+  // CHECK-DAG:   [[PTR_OUT:%.+]] = arc.storage.get %arg0[3]
+  // CHECK-DAG:   arc.state_write [[PTR_OUT]] = [[MUL]]
   // CHECK-DAG: }
 
+  // CHECK-DAG: [[CLOCK:%.+]] = arc.storage.get %arg0[0]
   // CHECK-DAG: [[READ_CLOCK:%.+]] = arc.state_read [[CLOCK]]
   // CHECK-DAG:  arc.clock_tree [[READ_CLOCK]] {
+  // CHECK-DAG:   [[I0:%.+]] = arc.storage.get %arg0[1]
   // CHECK-DAG:   [[READ_I0:%.+]] = arc.state_read [[I0]]
+  // CHECK-DAG:   [[I1:%.+]] = arc.storage.get %arg0[2]
   // CHECK-DAG:   [[READ_I1:%.+]] = arc.state_read [[I1]]
   // CHECK-DAG:   [[ADD:%.+]] = arc.state @[[ADD_ARC]]([[READ_I0]], [[READ_I1]]) lat 0
   // CHECK-DAG:   [[XOR1:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I0]]) lat 0
   // CHECK-DAG:   [[XOR2:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I1]]) lat 0
+  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[4]
   // CHECK-DAG:   arc.state_write [[FOO]] = [[XOR1]]
+  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[5]
   // CHECK-DAG:   arc.state_write [[BAR]] = [[XOR2]]
   // CHECK-DAG:  }
 


### PR DESCRIPTION
Add three passes that implement state allocation. The passes take the abstract state allocation ops, compute a memory layout for the overall state of the model, and replace the allocation ops with simple pointer getter ops that access the allocated piece of memory. The passes operate as follows:

- `LegalizeStateUpdate` detects read-after-write hazards and introduces temporary storage locations that allow the read and write ops to occur without infringing on each other.
- `AllocateState` computes the overall memory layout and replaces allocation ops with simple accessor ops.
- `PrintStateInfo` emits the memory layout as a JSON file. This allows other tools to reason about the exact memory layout of the design.

State update legalization is still lacking proper handling of memory reads and writes, which are significantly more involved than the simple scalar registers. Follow-up work.