### PR TITLE
[FIRRTL][NFCI] Move RefType to ODS

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -232,23 +232,6 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-// Reference Type
-//===----------------------------------------------------------------------===//
-
-class RefType
-    : public FIRRTLType::TypeBase<RefType, FIRRTLType, detail::RefTypeStorage> {
-public:
-  using Base::Base;
-  static RefType get(FIRRTLBaseType type);
-
-  /// Return the underlying type.
-  FIRRTLBaseType getType();
-
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitErrorFn,
-                              FIRRTLBaseType base);
-};
-
-//===----------------------------------------------------------------------===//
 // Type helpers
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -126,20 +126,8 @@ def PassiveType : FIRRTLDialectType<
   "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
 def RefType : FIRRTLDialectType<
-   CPred<"$_self.isa<RefType>()">,
-  "reference type", "::circt::firrtl::RefType", [{
-    A reference type, such as `firrtl.ref<uint<1>>`.
-
-    Used for remote reads and writes of the wrapped base type.
-
-    Parameterized over the referenced base type,
-    which must be passive and for now must also be ground.
-
-    Not a base type.
-
-    Values of this type are used to capture dataflow paths,
-    and do not represent a circuit element or entity.
-  }]>;
+  CPred<"$_self.isa<RefType>()">,
+   "reference type", "::circt::firrtl::RefType">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -221,4 +221,27 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
   }];
 }
 
+def RefImpl : FIRRTLImplType<"Ref", [], "::circt::firrtl::FIRRTLType"> {
+  let summary = [{
+    A reference type, such as `firrtl.ref<uint<1>>`.
+
+    Used for remote reads and writes of the wrapped base type.
+
+    Parameterized over the referenced base type,
+    which must be passive and for now must also be ground.
+
+    Not a base type.
+
+    Values of this type are used to capture dataflow paths,
+    and do not represent a circuit element or entity.
+  }];
+  let parameters = (ins "FIRRTLBaseType":$type);
+  let genVerifyDecl = true;
+
+  let skipDefaultBuilders = true;
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "FIRRTLBaseType":$type)>
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1036,32 +1036,9 @@ std::pair<uint64_t, bool> FVectorType::rootChildFieldID(uint64_t fieldID,
 // RefType
 //===----------------------------------------------------------------------===//
 
-namespace circt {
-namespace firrtl {
-namespace detail {
-struct RefTypeStorage : mlir::TypeStorage {
-  using KeyTy = FIRRTLBaseType;
-
-  RefTypeStorage(KeyTy value) : value(value) {}
-
-  bool operator==(const KeyTy &key) const { return key == value; }
-
-  static RefTypeStorage *construct(TypeStorageAllocator &allocator, KeyTy key) {
-    return new (allocator.allocate<RefTypeStorage>()) RefTypeStorage(key);
-  }
-
-  KeyTy value;
-};
-
-} // namespace detail
-} // namespace firrtl
-} // namespace circt
-
 auto RefType::get(FIRRTLBaseType type) -> RefType {
   return Base::get(type.getContext(), type);
 }
-
-auto RefType::getType() -> FIRRTLBaseType { return getImpl()->value; }
 
 auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
                      FIRRTLBaseType base) -> LogicalResult {


### PR DESCRIPTION
Drop custom storage class too, not needed just to parameterize over a type.

We use these elsewhere to handle computing recursive properties and stashing information about them in the stored type pointer (bundle/vector), but for reference types this isn't needed as references don't have these properties.

For RefTypes, we (already) query the underlying base type for those if needed, and since only one level of references allowed no reason to cache their recursive calculation as we should only need to go one layer into the reference.