### PR TITLE
[ExportVerilog] Remove comments for instances emitted as binds

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -118,6 +118,8 @@ The current set of "style" Lowering Options is:
  * `emitWireInPorts` (default=`false`). Emits `wire` in port lists rather than
   relying on 'default_nettype'. For instance, instead of `input a` this option
   would emit that port as `input wire a`.
+* `emitBindComments` (default=`false`). Emits a comment wherever an instance or
+  interface instance is not printed, because it was emitted as a bind elsewhere.
 
 The current set of "lint warnings fix" Lowering Options is:
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -146,6 +146,10 @@ struct LoweringOptions {
   /// If true, emit `wire` in port lists rather than nothing. Used in cases
   /// where `default_nettype is not set to wire.
   bool emitWireInPorts = false;
+
+  /// If true, emit a comment wherever an instance wasn't printed, because
+  /// it's emitted elsewhere as a bind.
+  bool emitBindComments = false;
 };
 } // namespace circt
 

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -48,7 +48,7 @@ struct LoweringOptionsOption
                 "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
                 "disallowPortDeclSharing, printDebugInfo, "
                 "disallowExpressionInliningInPorts, disallowMuxInlining, "
-                "emitWireInPort"),
+                "emitWireInPort, emitBindComments"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}
 };
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3111,12 +3111,16 @@ LogicalResult StmtEmitter::visitSV(AliasOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(InterfaceInstanceOp op) {
+  auto doNotPrint = op->hasAttr("doNotPrint");
+  if (doNotPrint && !state.options.emitBindComments)
+    return success();
+
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   startStatement();
   StringRef prefix = "";
-  if (op->hasAttr("doNotPrint")) {
+  if (doNotPrint) {
     prefix = "// ";
     ps << "// This interface is elsewhere emitted as a bind statement."
        << PP::newline;
@@ -3932,6 +3936,9 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
 
 LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   bool doNotPrint = op->hasAttr("doNotPrint");
+  if (doNotPrint && !state.options.emitBindComments)
+    return success();
+
   // Emit SV attributes if the op is not emitted as a bind statement.
   if (!doNotPrint)
     emitSVAttributes(op);

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -111,6 +111,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       }
     } else if (option == "emitWireInPorts") {
       emitWireInPorts = true;
+    } else if (option == "emitBindComments") {
+      emitBindComments = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -160,6 +162,8 @@ std::string LoweringOptions::toString() const {
                std::to_string(maximumNumberOfTermsPerExpression) + ',';
   if (emitWireInPorts)
     options += "emitWireInPorts,";
+  if (emitBindComments)
+    options += "emitBindComments,";
 
   // Remove a trailing comma if present.
   if (!options.empty()) {

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100' -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s
+// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100,emitBindComments' -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -test-apply-lowering-options='options=explicitBitcast,maximumNumberOfTermsPerExpression=10' -export-verilog -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -test-apply-lowering-options='options=explicitBitcast,maximumNumberOfTermsPerExpression=10,emitBindComments' -export-verilog -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s -test-apply-lowering-options='options=emitBindComments' -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module inputs_only(
 // CHECK-NEXT:   input a,{{.*}}

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,8 +1,8 @@
-; RUN: firtool --annotation-file %s.anno.json --annotation-file %s.Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
-; RUN: firtool --preserve-values=named --annotation-file %s.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
-; RUN: firtool --annotation-file %s.anno.json --annotation-file %s.Extract.anno.json %s --annotation-file %s.YAML.anno.json | FileCheck %s --check-prefixes YAML
-; RUN: firtool --split-verilog --annotation-file %s.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
-; RUN: firtool --annotation-file %s.anno.json --annotation-file %s.Prefix.anno.json %s | FileCheck %s --check-prefixes PREFIX
+; RUN: firtool --lowering-options=emitBindComments --annotation-file %s.anno.json --annotation-file %s.Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
+; RUN: firtool --lowering-options=emitBindComments --preserve-values=named --annotation-file %s.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
+; RUN: firtool --lowering-options=emitBindComments --annotation-file %s.anno.json --annotation-file %s.Extract.anno.json %s --annotation-file %s.YAML.anno.json | FileCheck %s --check-prefixes YAML
+; RUN: firtool --lowering-options=emitBindComments --split-verilog --annotation-file %s.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv  | FileCheck %s --check-prefixes MYVIEW_COMPANION
+; RUN: firtool --lowering-options=emitBindComments --annotation-file %s.anno.json --annotation-file %s.Prefix.anno.json %s | FileCheck %s --check-prefixes PREFIX
 ; RUN: firtool --annotation-file %s.anno.json %s --disable-opt
 
 circuit Top :

--- a/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
+++ b/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
@@ -1,6 +1,6 @@
-; RUN: firtool %s -disable-all-randomization | FileCheck %s --check-prefixes=CHECK,INIT_NONE
-; RUN: firtool %s -annotation-file %s.inline.anno.json -disable-all-randomization | FileCheck %s --check-prefixes=CHECK,INIT_INLINE
-; RUN: firtool %s -annotation-file %s.outline.anno.json -disable-all-randomization | FileCheck %s --check-prefixes=CHECK,INIT_OUTLINE
+; RUN: firtool %s -disable-all-randomization -lowering-options=emitBindComments | FileCheck %s --check-prefixes=CHECK,INIT_NONE
+; RUN: firtool %s -annotation-file %s.inline.anno.json -disable-all-randomization -lowering-options=emitBindComments | FileCheck %s --check-prefixes=CHECK,INIT_INLINE
+; RUN: firtool %s -annotation-file %s.outline.anno.json -disable-all-randomization -lowering-options=emitBindComments | FileCheck %s --check-prefixes=CHECK,INIT_OUTLINE
 
 circuit Foo :
   module Foo :


### PR DESCRIPTION
When emitting instances as binds, we leave a comment where the instance was originally located, indicating that it is now located elsewhere as a bind. This comment, apparently, isn't helpful, and causes some trouble too. The comment includes a summary of what was bound, which can cause some textual differences between verilog code that differs only in how it is bound to a view. This PR removes the comment.

This PR adds a lowering-option, "emitBindComments", which preserves the original behaviour, but it is off by default.