### PR TITLE
[ESI] Add more flexibility to port names during lowering

### DIFF
--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -19,6 +19,12 @@ from typing import Dict, List, Optional
 __dir__ = Path(__file__).parent
 
 FlattenStructPorts = "esi.portFlattenStructs"
+PortInSuffix = "esi.portInSuffix"
+PortOutSuffix = "esi.portOutSuffix"
+PortValidSuffix = "esi.portValidSuffix"
+PortReadySuffix = "esi.portReadySuffix"
+PortRdenSuffix = "esi.portRdenSuffix"
+PortEmptySuffix = "esi.portEmptySuffix"
 
 ToServer = InputChannel
 FromServer = OutputChannel

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -226,7 +226,7 @@ class ModuleLikeBuilderBase(_PyProxy):
 
       if attr_name == "Attributes":
         self.attributes = {
-            mod_attr[0]: mod_attr[1]
+            mod_attr[0]: _obj_to_attribute(mod_attr[1])
             for mod_attr in attr
             if isinstance(mod_attr, tuple)
         }

--- a/include/circt/Dialect/ESI/ESIDialect.h
+++ b/include/circt/Dialect/ESI/ESIDialect.h
@@ -45,6 +45,13 @@ constexpr StringRef extModBundleSignalsAttrName = "esi.bundle";
 /// ports into a bunch of individual 'data' wires.
 constexpr StringRef extModPortFlattenStructsAttrName = "esi.portFlattenStructs";
 
+constexpr StringRef extModPortInSuffix = "esi.portInSuffix";
+constexpr StringRef extModPortOutSuffix = "esi.portOutSuffix";
+constexpr StringRef extModPortValidSuffix = "esi.portValidSuffix";
+constexpr StringRef extModPortReadySuffix = "esi.portReadySuffix";
+constexpr StringRef extModPortRdenSuffix = "esi.portRdenSuffix";
+constexpr StringRef extModPortEmptySuffix = "esi.portEmptySuffix";
+
 /// Find all the port triples on a module which fit the
 /// <name>/<name>_valid/<name>_ready pattern. Ready must be the opposite
 /// direction of the other two.

--- a/include/circt/Dialect/ESI/ESIDialect.h
+++ b/include/circt/Dialect/ESI/ESIDialect.h
@@ -45,11 +45,21 @@ constexpr StringRef extModBundleSignalsAttrName = "esi.bundle";
 /// ports into a bunch of individual 'data' wires.
 constexpr StringRef extModPortFlattenStructsAttrName = "esi.portFlattenStructs";
 
+/// Suffix _all_ lowered input ports with this suffix. Defaults to nothing.
 constexpr StringRef extModPortInSuffix = "esi.portInSuffix";
+/// Suffix _all_ lowered output ports with this suffix. Defaults to nothing.
 constexpr StringRef extModPortOutSuffix = "esi.portOutSuffix";
+/// Suffix lowered valid ports with this suffix. Defaults to "_valid". Applies
+/// only to ValidReady channels.
 constexpr StringRef extModPortValidSuffix = "esi.portValidSuffix";
+/// Suffix lowered ready ports with this suffix. Defaults to "_ready". Applies
+/// only to ValidReady channels.
 constexpr StringRef extModPortReadySuffix = "esi.portReadySuffix";
+/// Suffix lowered read enable ports with this suffix. Defaults to "_rden".
+/// Applies only to FIFO channels.
 constexpr StringRef extModPortRdenSuffix = "esi.portRdenSuffix";
+/// Suffix lowered empty ports with this suffix. Defaults to "_empty". Applies
+/// only to FIFO channels.
 constexpr StringRef extModPortEmptySuffix = "esi.portEmptySuffix";
 
 /// Find all the port triples on a module which fit the

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -463,6 +463,8 @@ static StringAttr appendToRtlName(StringAttr base, Twine suffix) {
   return StringAttr::get(context, base.getValue() + suffix);
 }
 
+// Returns either the string dialect attr stored in 'op' going by the name
+// 'attrName' or 'def' if the attribute doesn't exist in 'op'.
 inline static StringRef getStringAttributeOr(Operation *op, StringRef attrName,
                                              StringRef def) {
   auto attr = op->getAttrOfType<StringAttr>(attrName);
@@ -533,7 +535,6 @@ private:
   // Does the module demand that we break out all the struct fields into
   // individual fields?
   bool flattenStructs;
-
   // If the module has a block and it wants to be modified, this'll be non-null.
   Block *body;
   // Did we find an ESI port?

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -158,23 +158,36 @@ hw.module @fifo0LoopbackTop() -> () {
   %chan = hw.instance "foo" @i1Fifo0Loopback(in: %chan: !esi.channel<i3, FIFO0>) -> (out: !esi.channel<i3, FIFO0>)
 }
 
-// IFACE-LABEL:  hw.module @structFifo0Loopback(%in_a: i3, %in_b: i7, %in_empty: i1, %out_rden: i1) -> (in_rden: i1, out_a: i3, out_b: i7, out_empty: i1) attributes {esi.portFlattenStructs}
-// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo [[r0:%.+]], %in_empty : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
-// IFACE-NEXT:     [[r0]] = hw.struct_create (%in_a, %in_b) : !hw.struct<a: i3, b: i7>
-// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_rden : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
+// IFACE-LABEL:  hw.module @structFifo0Loopback(%in_a_in: i3, %in_b_in: i7, %in_flatBroke_in: i1, %out_readEnable_in: i1) -> (in_readEnable: i1, out_a: i3, out_b: i7, out_flatBroke: i1)
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo [[r0:%.+]], %in_flatBroke_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
+// IFACE-NEXT:     [[r0]] = hw.struct_create (%in_a_in, %in_b_in) : !hw.struct<a: i3, b: i7>
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_readEnable_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
 // IFACE-NEXT:     %a, %b = hw.struct_explode %data : !hw.struct<a: i3, b: i7>
 // IFACE-NEXT:     hw.output %rden, %a, %b, %empty : i1, i3, i7, i1
 !st1 = !hw.struct<a: i3, b: i7>
-hw.module @structFifo0Loopback(%in: !esi.channel<!st1, FIFO0>) -> (out: !esi.channel<!st1, FIFO0>) attributes {esi.portFlattenStructs} {
+hw.module @structFifo0Loopback(%in: !esi.channel<!st1, FIFO0>) -> (out: !esi.channel<!st1, FIFO0>)
+    attributes {esi.portFlattenStructs, esi.portRdenSuffix="_readEnable",
+                esi.portEmptySuffix="_flatBroke", esi.portInSuffix="_in"} {
   hw.output %in : !esi.channel<!st1, FIFO0>
 }
 
+
 // IFACE-LABEL:  hw.module @structFifo0LoopbackTop()
-// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_rden : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_readEnable : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
 // IFACE-NEXT:     %a, %b = hw.struct_explode %data : !hw.struct<a: i3, b: i7>
 // IFACE-NEXT:     [[r0:%.+]] = hw.struct_create (%foo.out_a, %foo.out_b) : !hw.struct<a: i3, b: i7>
-// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo [[r0]], %foo.out_empty : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
-// IFACE-NEXT:     %foo.in_rden, %foo.out_a, %foo.out_b, %foo.out_empty = hw.instance "foo" @structFifo0Loopback(in_a: %a: i3, in_b: %b: i7, in_empty: %empty: i1, out_rden: %rden: i1) -> (in_rden: i1, out_a: i3, out_b: i7, out_empty: i1)
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo [[r0]], %foo.out_flatBroke : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
+// IFACE-NEXT:     %foo.in_readEnable, %foo.out_a, %foo.out_b, %foo.out_flatBroke = hw.instance "foo" @structFifo0Loopback(in_a_in: %a: i3, in_b_in: %b: i7, in_flatBroke_in: %empty: i1, out_readEnable_in: %rden: i1) -> (in_readEnable: i1, out_a: i3, out_b: i7, out_flatBroke: i1)
 hw.module @structFifo0LoopbackTop() -> () {
   %chan = hw.instance "foo" @structFifo0Loopback(in: %chan: !esi.channel<!st1, FIFO0>) -> (out: !esi.channel<!st1, FIFO0>)
+}
+
+// IFACE-LABEL:  hw.module @i3LoopbackOddNames(%in: i3, %in_good: i1, %out_letErRip: i1) -> (in_letErRip_out: i1, out: i3, out_good_out: i1)
+// IFACE-NEXT:     %chanOutput, %ready = esi.wrap.vr %in, %in_good : i3
+// IFACE-NEXT:     %rawOutput, %valid = esi.unwrap.vr %chanOutput, %out_letErRip : i3
+// IFACE-NEXT:     hw.output %ready, %rawOutput, %valid : i1, i3, i1
+hw.module @i3LoopbackOddNames(%in: !esi.channel<i3>) -> (out: !esi.channel<i3>)
+    attributes {esi.portFlattenStructs, esi.portValidSuffix="_good",
+                esi.portReadySuffix="_letErRip", esi.portOutSuffix="_out"} {
+  hw.output %in : !esi.channel<i3>
 }


### PR DESCRIPTION
Some external modules use unusual port naming conventions. Since we want
to avoid users needing to write wrappers, provide some flexibility in naming
convention.