### PR TITLE
[ExportVerilog] Lowering option to emit 'wire' in port list

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -142,6 +142,10 @@ struct LoweringOptions {
   /// tools, notably Vivado, produce incorrect synthesis results for certain
   /// arithmetic ops inlined into the array index.
   bool disallowArrayIndexInlining = false;
+
+  /// If true, emit `wire` in port lists rather than nothing. Used in cases
+  /// where `default_nettype is not set to wire.
+  bool emitWireInPorts = false;
 };
 } // namespace circt
 

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -47,7 +47,8 @@ struct LoweringOptionsOption
                 "explicitBitcast, emitReplicatedOpsToHeader, "
                 "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
                 "disallowPortDeclSharing, printDebugInfo, "
-                "disallowExpressionInliningInPorts, disallowMuxInlining"),
+                "disallowExpressionInliningInPorts, disallowMuxInlining, "
+                "emitWireInPort"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}
 };
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4794,6 +4794,9 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
         ps << (hasOutputs ? "inout  " : "inout ");
         break;
       }
+      bool emitWireInPorts = state.options.emitWireInPorts;
+      if (emitWireInPorts)
+        ps << "wire ";
 
       // Emit the type.
       if (!portTypeStrings[portIdx].empty())
@@ -4801,7 +4804,8 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
       if (portTypeStrings[portIdx].size() < maxTypeWidth)
         ps.nbsp(maxTypeWidth - portTypeStrings[portIdx].size());
 
-      size_t startOfNamePos = (hasOutputs ? 7 : 6) + maxTypeWidth;
+      size_t startOfNamePos =
+          (hasOutputs ? 7 : 6) + (emitWireInPorts ? 5 : 0) + maxTypeWidth;
 
       // Emit the name.
       ps << PPExtString(getPortVerilogName(module, portInfo[portIdx]));

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -109,6 +109,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
             "expected integer for number of namehint heurstic term limit");
         wireSpillingNamehintTermLimit = DEFAULT_NAMEHINT_TERM_LIMIT;
       }
+    } else if (option == "emitWireInPorts") {
+      emitWireInPorts = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -156,6 +158,8 @@ std::string LoweringOptions::toString() const {
   if (maximumNumberOfTermsPerExpression != DEFAULT_TERM_LIMIT)
     options += "maximumNumberOfTermsPerExpression=" +
                std::to_string(maximumNumberOfTermsPerExpression) + ',';
+  if (emitWireInPorts)
+    options += "emitWireInPorts,";
 
   // Remove a trailing comma if present.
   if (!options.empty()) {

--- a/test/Conversion/ExportVerilog/misc-lowering-opts.mlir
+++ b/test/Conversion/ExportVerilog/misc-lowering-opts.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt %s -export-verilog --split-input-file | FileCheck %s
+
+!fooTy = !hw.struct<bar: i4>
+
+module attributes {circt.loweringOptions="emitWireInPorts"} {
+// CHECK-LABEL: module Foo(
+// CHECK-NEXT:    input  wire                                   a,
+// CHECK-NEXT:    input  wire struct packed {logic [3:0] bar; } foo,
+// CHECK-NEXT:    output wire [2:0]                             x	
+// CHECK:       endmodule
+hw.module @Foo(%a: i1, %foo: !fooTy) -> (x: i3) {
+  %c0_i3 = hw.constant 0 : i3
+  hw.output %c0_i3 : i3
+} 
+}


### PR DESCRIPTION
Used to avoid warnings and in situations where other code has messed with the `default_nettype`.