### PR TITLE
Remove pipelining from simplified single-address memory reads

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2591,7 +2591,6 @@ struct FoldRegMems : public mlir::RewritePattern {
       return value;
     };
 
-    const unsigned readStages = info.readLatency;
     const unsigned writeStages = info.writeLatency - 1;
 
     // Traverse each port. Replace reads with the pipelined register, discarding
@@ -2613,9 +2612,12 @@ struct FoldRegMems : public mlir::RewritePattern {
       case MemOp::PortKind::Debug:
         llvm_unreachable("unknown port kind");
       case MemOp::PortKind::Read: {
+        // Read ports pipeline the addr and enable signals. However, the
+        // address must be 0 for single-address memories and the enable signal
+        // is ignored, always reading out the register. Under these constraints,
+        // the read port can be replaced with the value from the register.
         rewriter.setInsertionPointAfterValue(reg);
-        Value data = pipeline(reg, portClock, "data", readStages);
-        replacePortField(rewriter, port, "data", data);
+        replacePortField(rewriter, port, "data", reg);
         break;
       }
       case MemOp::PortKind::Write: {
@@ -2628,8 +2630,7 @@ struct FoldRegMems : public mlir::RewritePattern {
       case MemOp::PortKind::ReadWrite: {
         // Always read the register into the read end.
         rewriter.setInsertionPointAfterValue(reg);
-        Value rdata = pipeline(reg, portClock, name, readStages);
-        replacePortField(rewriter, port, "rdata", rdata);
+        replacePortField(rewriter, port, "rdata", reg);
 
         // Create a write enable and pipeline stages.
         auto wdata = portPipeline("wdata", writeStages);
@@ -2692,8 +2693,10 @@ struct FoldRegMems : public mlir::RewritePattern {
 
 void MemOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                         MLIRContext *context) {
-  results.insert<FoldZeroWidthMemory, FoldReadOrWriteOnlyMemory,
-                 FoldReadWritePorts, FoldUnusedPorts, FoldUnusedBits>(context);
+  results
+      .insert<FoldZeroWidthMemory, FoldReadOrWriteOnlyMemory,
+              FoldReadWritePorts, FoldUnusedPorts, FoldUnusedBits, FoldRegMems>(
+          context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -134,10 +134,6 @@ firrtl.circuit "ReadWriteToWrite" {
 
 // -----
 
-// Pending 4734
-
-// XFAIL: *
-
 firrtl.circuit "UnusedPorts" {
   firrtl.module public @UnusedPorts(
       in %clock: !firrtl.clock,
@@ -470,17 +466,7 @@ firrtl.circuit "OneAddressNoMask" {
 
     // CHECK: %Memory = firrtl.reg %clock : !firrtl.uint<32>
 
-    // CHECK: %Memory_rw_0 = firrtl.reg %clock : !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_rw_0, %Memory : !firrtl.uint<32>
-    // CHECK: %Memory_rw_1 = firrtl.reg %clock : !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_rw_1, %Memory_rw_0 : !firrtl.uint<32>
-
-    // CHECK: %Memory_data_0 = firrtl.reg %clock : !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_data_0, %Memory : !firrtl.uint<32>
-    // CHECK: %Memory_data_1 = firrtl.reg %clock : !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_data_1, %Memory_data_0 : !firrtl.uint<32>
-
-    // CHECK: firrtl.strictconnect %result_read, %Memory_data_1 : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -490,7 +476,7 @@ firrtl.circuit "OneAddressNoMask" {
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %result_read, %read_data : !firrtl.uint<32>, !firrtl.uint<32>
 
-    // CHECK: firrtl.strictconnect %result_rw, %Memory_rw_1 : !firrtl.uint<32>
+    // CHECK: firrtl.strictconnect %result_rw, %Memory : !firrtl.uint<32>
     %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
     firrtl.connect %rw_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>


### PR DESCRIPTION
My initial understanding of memory latencies was incorrect and I wrongly inserted pipelining after the resulting register. However, it is the address and enable signals that must be pipelined. For these memories, the address is always 0 and the enable signal can be discarded, allowing the read ports to be folded to the resulting register.

Fixes #4734