### PR TITLE
[FIRRTL] Remove Buildable from FIRRTL hardware types

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -822,7 +822,7 @@ out <= myport
 ```mlir
 %mymem = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<1>, 8>
 %myport_data, %myport_port = chirrtl.memoryport Infer %mymem {name = "myport"}  : (!chirrtl.cmemory<uint<1>, 8>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
-firrtl.when %cond  {
+firrtl.when %cond : !firrtl.uint<1> {
   chirrtl.memoryport.access %myport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<3>, !firrtl.clock
 }
 firrtl.connect %out, %myport_data : !firrtl.uint<1>, !firrtl.uint<1

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -269,7 +269,7 @@ def RegOp : ReferableDeclOp<"reg"> {
     Declare a new register:
 
     ```
-    %name = firrtl.reg %clockVal : t1
+    %name = firrtl.reg %clockVal : !firrtl.clock, t1
     ```
     }];
 
@@ -300,7 +300,7 @@ def RegOp : ReferableDeclOp<"reg"> {
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    operands `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` type($clockVal) `,` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 }
@@ -310,7 +310,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
   let description = [{
     Declare a new register:
     ```
-      %name = firrtl.regreset %clockVal, %resetSignal, %resetValue : t1
+      %name = firrtl.regreset %clockVal, %resetSignal, %resetValue : !firrtl.clock, t1
     ```
     }];
 
@@ -347,7 +347,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
     operands `` custom<FIRRTLImplicitSSAName>(attr-dict)
-    `:` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
+    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
   }];
 
   let hasCanonicalizer = true;

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -651,7 +651,7 @@ def PlusArgsValueIntrinsicOp
 
   let arguments = (ins StrAttr:$formatString);
   let results = (outs UInt1Type:$found, AnyType:$result);
-  let assemblyFormat = "$formatString attr-dict `:` type($result)";
+  let assemblyFormat = "$formatString attr-dict `:` type($found) `,` type($result)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -78,7 +78,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
 
   let assemblyFormat = [{
     $clock `,` $cond `,` $formatString `` custom<PrintfAttrs>(attr-dict) ` `
-    (`(` $substitutions^ `)` `:` qualified(type($substitutions)))?
+    (`(` $substitutions^ `)`)? `:` type($clock) `,` type($cond) (`,` qualified(type($substitutions))^)?
   }];
 }
 
@@ -106,7 +106,7 @@ def StopOp : FIRRTLOp<"stop"> {
                        StrAttr:$name);
   let results = (outs);
 
-  let assemblyFormat = "$clock `,` $cond `,` $exitCode `` custom<StopAttrs>(attr-dict)";
+  let assemblyFormat = "$clock `,` $cond `,` $exitCode `` custom<StopAttrs>(attr-dict) `:` type($clock) `,` type($cond)";
 }
 
 class VerifOp<string mnemonic, list<Trait> traits = []> :
@@ -126,7 +126,7 @@ class VerifOp<string mnemonic, list<Trait> traits = []> :
 
   let assemblyFormat = [{
     $clock `,` $predicate `,` $enable `,`
-    $message (`(` $substitutions^ `)` `:` qualified(type($substitutions)))?
+    $message (`(` $substitutions^ `)`)? `:` type($clock) `,` type($predicate) `,` type($enable) (`,` qualified(type($substitutions))^)?
     custom<VerifAttrs>(attr-dict)
   }];
 }
@@ -164,7 +164,7 @@ def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
   ];
 
   let assemblyFormat =
-    "$condition $thenRegion (`else` $elseRegion^)? attr-dict-with-keyword";
+    "$condition `:` type($condition) $thenRegion (`else` $elseRegion^)? attr-dict-with-keyword";
 
   let extraClassDeclaration = [{
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -45,8 +45,7 @@ def ForeignType : FIRRTLDialectType<CPred<"!$_self.isa<FIRRTLType>()">,
                                     "foreign type", "::mlir::Type">;
 
 def ClockType : FIRRTLDialectType<CPred<"$_self.isa<ClockType>()">,
-    "clock", "::circt::firrtl::ClockType">,
-  BuildableType<"ClockType::get($_builder.getContext())">;
+    "clock", "::circt::firrtl::ClockType">;
 
 def IntType : FIRRTLDialectType<CPred<"$_self.isa<IntType>()">,
  "sint or uint type", "::circt::firrtl::IntType">;
@@ -102,24 +101,20 @@ def UInt1Type : FIRRTLDialectType<
     CPred<"$_self.isa<UIntType>() && "
           "($_self.cast<UIntType>().getWidth() == 1 ||"
           " $_self.cast<UIntType>().getWidth() == std::nullopt)">,
-    "UInt<1> or UInt", "::circt::firrtl::UIntType">,
-  BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+    "UInt<1> or UInt", "::circt::firrtl::UIntType">;
 
 def UInt32Type : FIRRTLDialectType<
     CPred<"$_self.isa<UIntType>() && "
           "$_self.cast<UIntType>().getWidth() == 32">,
-    "UInt<32>", "::circt::firrtl::UIntType">,
-  BuildableType<"UIntType::get($_builder.getContext(), 32)">;
+    "UInt<32>", "::circt::firrtl::UIntType">;
 
 def AsyncResetType : FIRRTLDialectType<
     CPred<"$_self.isa<AsyncResetType>()">,
-    "AsyncReset", "::circt::firrtl::AsyncResetType">,
-  BuildableType<"AsyncResetType::get($_builder.getContext())">;
+    "AsyncReset", "::circt::firrtl::AsyncResetType">;
 
 def ResetType : FIRRTLDialectType<
     CPred<"$_self.isa<ResetType>()">,
-    "Reset", "::circt::firrtl::ResetType">,
-  BuildableType<"ResetType::get($_builder.getContext())">;
+    "Reset", "::circt::firrtl::ResetType">;
 
 def PassiveType : FIRRTLDialectType<
   CPred<"$_self.isa<FIRRTLBaseType>() && $_self.cast<FIRRTLBaseType>().isPassive()">,

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "ifElseFatalToSVA" {
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "ifElseFatal"}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -59,9 +59,9 @@ firrtl.circuit "unprocessedAnnotations" {
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation2'}}
     %2 = firrtl.node %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation2"}]} : !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation3'}}
-    %3 = firrtl.reg %clock {annotations = [{class = "firrtl.transforms.RemainingAnnotation3"}]} : !firrtl.uint<1>
+    %3 = firrtl.reg %clock {annotations = [{class = "firrtl.transforms.RemainingAnnotation3"}]} : !firrtl.clock, !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation4'}}
-    %4 = firrtl.regreset %clock, %reset, %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation4"}]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %4 = firrtl.regreset %clock, %reset, %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation4"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation5'}}
     %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw",
     "write"], readLatency = 0 : i32, writeLatency = 1 : i32, annotations = [{class =

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -62,7 +62,7 @@ firrtl.circuit "Simple" {
 
     firrtl.connect %xyz#2, %s8 : !firrtl.sint<8>, !firrtl.sint<8>
 
-    firrtl.printf %clock, %reset, "%x"(%xyz#3) : !firrtl.uint<4>
+    firrtl.printf %clock, %reset, "%x"(%xyz#3) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
 
     // Parameterized module reference.
     // hw.instance carries the parameters, unlike at the FIRRTL layer.
@@ -76,7 +76,7 @@ firrtl.circuit "Simple" {
 
     firrtl.connect %myext#0, %reset : !firrtl.uint<1>, !firrtl.uint<1>
 
-    firrtl.printf %clock, %reset, "Something interesting! %x"(%myext#1) : !firrtl.uint<8>
+    firrtl.printf %clock, %reset, "Something interesting! %x"(%myext#1) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
   }
 
   // CHECK-LABEL: hw.module private @OutputFirst(%in1: i1, %in4: i4) -> (out4: i4) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -369,11 +369,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-   firrtl.printf %clock, %reset, "No operands!\0A"
+   firrtl.printf %clock, %reset, "No operands!\0A" : !firrtl.clock, !firrtl.uint<1>
 
     %0 = firrtl.add %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
-    firrtl.printf %clock, %reset, "Hi %x %x\0A"(%0, %b) : !firrtl.uint<5>, !firrtl.uint<4>
+    firrtl.printf %clock, %reset, "Hi %x %x\0A"(%0, %b) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>
 
     firrtl.skip
 
@@ -401,7 +401,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:       sv.fatal
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
-    firrtl.stop %clock1, %reset, 42
+    firrtl.stop %clock1, %reset, 42 : !firrtl.clock, !firrtl.uint<1>
 
     // CHECK-NEXT:   sv.always posedge %clock2 {
     // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref< "STOP_COND_"> : i1
@@ -411,7 +411,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-    firrtl.stop %clock2, %reset, 0
+    firrtl.stop %clock2, %reset, 0 : !firrtl.clock, !firrtl.uint<1>
   }
 
   // circuit Verification:
@@ -435,9 +435,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
     in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
 
-    firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true}
-    firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true, name = "assert_0"}
-    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assert_0"}
+    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %aEn, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %aCond
@@ -456,9 +456,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP4]] label "assume__assert_0"
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP6]]
     // CHECK-NEXT: }
-    firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true}
-    firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true, name = "assume_0"}
-    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
+    firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assume_0"}
+    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %bCond
@@ -472,17 +472,17 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %bCond
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"([[SAMPLED]]) : i42
-    firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
-    firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
-    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    firrtl.cover %clock, %cCond, %cEn, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
+    firrtl.cover %clock, %cCond, %cEn, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "cover_0"}
+    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true}
     // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
     // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover__cover_0"
     // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %cEn, %cCond
     // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
-    firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
-    firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
+    firrtl.cover %clock, %cCond, %cEn, "cover1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
+    firrtl.cover %clock, %cCond, %cEn, "cover2" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
     // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover__cover_1"
     // CHECK: sv.cover.concurrent edge %clock, {{%.+}} label "cover__cover_2"
 
@@ -505,15 +505,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NOT:        label
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-    firrtl.assert %clock, %aCond, %aEn, "assert0"
-    firrtl.assert %clock, %aCond, %aEn, "assert0" {name = "assert_0"}
-    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42>
-    firrtl.assume %clock, %bCond, %bEn, "assume0"
-    firrtl.assume %clock, %bCond, %bEn, "assume0" {name = "assume_0"}
-    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42>
-    firrtl.cover %clock, %cCond, %cEn, "cover0"
-    firrtl.cover %clock, %cCond, %cEn, "cover0" {name = "cover_0"}
-    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42>
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "assert_0"}
+    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "assume_0"}
+    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    firrtl.cover %clock, %cCond, %cEn, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.cover %clock, %cCond, %cEn, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "cover_0"}
+    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     // CHECK-NEXT: hw.output
   }
 
@@ -523,9 +523,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
-    firrtl.assume %clock, %cond, %enable, "assume0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
-    firrtl.cover %clock, %cond, %enable, "cover0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]} 
+    firrtl.assume %clock, %cond, %enable, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    firrtl.cover %clock, %cond, %enable, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
 
     // CHECK-NEXT: sv.ifdef "HELLO" {
     // CHECK-NEXT:   sv.ifdef "WORLD" {
@@ -555,7 +555,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %value: !firrtl.uint<42>,
     in %i0: !firrtl.uint<0>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "sva"}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "sva"}
     // CHECK-NEXT: [[FALSE:%.+]] = hw.constant false
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
@@ -564,7 +564,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
     // CHECK-NEXT: }
-    firrtl.assert %clock, %cond, %enable, "assert1 %d, %d"(%value, %i0) : !firrtl.uint<42>, !firrtl.uint<0> {isConcurrent = true, format = "ifElseFatal"}
+    firrtl.assert %clock, %cond, %enable, "assert1 %d, %d"(%value, %i0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<0> {isConcurrent = true, format = "ifElseFatal"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cond, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.and bin %enable, [[TMP1]]
@@ -884,7 +884,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // https://github.com/llvm/circt/issues/699
   firrtl.module private @ASQ(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %widx_widx_bin = firrtl.regreset %clock, %reset, %c0_ui1 {name = "widx_widx_bin"} : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<4>
+    %widx_widx_bin = firrtl.regreset %clock, %reset, %c0_ui1 {name = "widx_widx_bin"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<4>
   }
 
   // CHECK-LABEL: hw.module private @Struct0bits(%source: !hw.struct<valid: i1, ready: i1, data: i0>) {
@@ -1010,10 +1010,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c9_ui42 = firrtl.constant 9 : !firrtl.uint<42>
     %c-9_si42 = firrtl.constant -9 : !firrtl.sint<42>
     // The following should not error because the reset values are constant.
-    %r0 = firrtl.regreset %clock, %arst, %c9_ui42 : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
-    %r1 = firrtl.regreset %clock, %srst, %c9_ui42 : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
-    %r2 = firrtl.regreset %clock, %arst, %c-9_si42 : !firrtl.asyncreset, !firrtl.sint<42>, !firrtl.sint<42>
-    %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>
+    %r0 = firrtl.regreset %clock, %arst, %c9_ui42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    %r1 = firrtl.regreset %clock, %srst, %c9_ui42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %r2 = firrtl.regreset %clock, %arst, %c-9_si42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.sint<42>, !firrtl.sint<42>
+    %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>
   }
 
   // CHECK-LABEL: hw.module private @BitCast1
@@ -1072,9 +1072,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.assign [[WIRE]], %value
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
     // CHECK: %wireName = sv.wire sym @wireSym : !hw.inout<i42>
-    %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
+    %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: %regName = seq.firreg %regName clock %clock sym @regSym : i42
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
     // CHECK: %regResetName = seq.firreg %regResetName clock %clock sym @regResetSym reset sync %reset, %value : i42
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: {{%.+}} = hw.instance "memName_ext" sym @memSym
@@ -1083,7 +1083,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @connectNarrowUIntVector
   firrtl.module private @connectNarrowUIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 1>, out %b: !firrtl.vector<uint<3>, 1>) {
-    %r1 = firrtl.reg %clock  : !firrtl.vector<uint<2>, 1>
+    %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<uint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<uint<2>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<uint<3>, 1>, !firrtl.vector<uint<2>, 1>
     // CHECK:      %r1 = seq.firreg %3 clock %clock : !hw.array<1xi2>
@@ -1099,7 +1099,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @connectNarrowSIntVector
   firrtl.module private @connectNarrowSIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<sint<1>, 1>, out %b: !firrtl.vector<sint<3>, 1>) {
-    %r1 = firrtl.reg %clock  : !firrtl.vector<sint<2>, 1>
+    %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<sint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<sint<2>, 1>, !firrtl.vector<sint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<sint<3>, 1>, !firrtl.vector<sint<2>, 1>
     // CHECK:      %r1 = seq.firreg %3 clock %clock : !hw.array<1xi2>
@@ -1116,8 +1116,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @SubIndex
   firrtl.module private @SubIndex(in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, in %clock: !firrtl.clock, out %o1: !firrtl.uint<1>, out %o2: !firrtl.vector<uint<1>, 1>) {
-    %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-    %r2 = firrtl.reg %clock  : !firrtl.vector<uint<1>, 1>
+    %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<uint<1>, 1>
     %0 = firrtl.subindex %a[0] : !firrtl.vector<vector<uint<1>, 1>, 1>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %r1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1133,8 +1133,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @SubAccess
   firrtl.module private @SubAccess(in %x: !firrtl.uint<1>, in %y: !firrtl.uint<1>, in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, in %clock: !firrtl.clock, out %o1: !firrtl.uint<1>, out %o2: !firrtl.vector<uint<1>, 1>) {
-    %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-    %r2 = firrtl.reg %clock  : !firrtl.vector<uint<1>, 1>
+    %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<uint<1>, 1>
     %0 = firrtl.subaccess %a[%x] : !firrtl.vector<vector<uint<1>, 1>, 1>, !firrtl.uint<1>
     %1 = firrtl.subaccess %0[%y] : !firrtl.vector<uint<1>, 1>, !firrtl.uint<1>
     firrtl.connect %r1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1224,7 +1224,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[PADDED:%.*]] = comb.concat [[FALSE]], [[A]] : i1, i2
     // CHECK-NEXT: [[STRUCT:%.*]] = hw.struct_create ([[PADDED]]) : !hw.struct<a: i3>
     // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, [[STRUCT]] : !hw.struct<a: i3>
-    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<3>>
+    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<3>>
   }
 
   // CHECK-LABEL: hw.module private @BundleConnection
@@ -1243,7 +1243,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @AggregateInvalidValue
   firrtl.module private @AggregateInvalidValue(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
-    %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
+    %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     // CHECK:      %c0_i101 = hw.constant 0 : i101
     // CHECK-NEXT: %0 = hw.bitcast %c0_i101 : (i101) -> !hw.struct<a: i1, b: !hw.array<10xi10>>
     // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>
@@ -1251,7 +1251,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @AggregateRegAssign
   firrtl.module private @AggregateRegAssign(in %clock: !firrtl.clock, in %value: !firrtl.uint<1>) {
-    %reg = firrtl.reg %clock : !firrtl.vector<uint<1>, 1>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %reg = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<1xi1>
@@ -1261,7 +1261,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @AggregateRegResetAssign
   firrtl.module private @AggregateRegResetAssign(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                                          in %init: !firrtl.vector<uint<1>, 1>, in %value: !firrtl.uint<1>) {
-    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
+    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %reg = seq.firreg [[INPUT:%.+]] clock %clock reset sync %reset, %init : !hw.array<1xi1>
@@ -1423,7 +1423,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                      in %reset: !firrtl.uint<1>,
                      in %value: !firrtl.uint<2>,
                      out %result: !firrtl.uint<2>) {
-    %count = firrtl.reg %clock: !firrtl.uint<2>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.uint<2>
     // CHECK: %count = seq.firreg %value clock %clock : i2
 
     firrtl.strictconnect %result, %count : !firrtl.uint<2>
@@ -1437,7 +1437,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.bundle<a: uint<2>>) {
-    %count = firrtl.reg %clock: !firrtl.bundle<a: uint<2>>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.bundle<a: uint<2>>
     // CHECK: %count = seq.firreg %0 clock %clock : !hw.struct<a: i2>
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>>
@@ -1456,7 +1456,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %value2: !firrtl.uint<2>,
                                  in %value3: !firrtl.uint<3>,
                                  out %result: !firrtl.bundle<a: uint<2>, b: uint<3>>) {
-    %count = firrtl.reg %clock: !firrtl.bundle<a: uint<2>, b: uint<3>>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.bundle<a: uint<2>, b: uint<3>>
     // CHECK: %count = seq.firreg [[AFTER_B:%.+]] clock %clock : !hw.struct<a: i2, b: i3>
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>, b: uint<3>>
@@ -1477,7 +1477,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                        in %reset: !firrtl.uint<1>,
                                        in %value: !firrtl.uint<2>,
                                        out %result: !firrtl.bundle<a: bundle<b: uint<2>>>) {
-    %count = firrtl.reg %clock: !firrtl.bundle<a: bundle<b: uint<2>>>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.bundle<a: bundle<b: uint<2>>>
     // CHECK: %count = seq.firreg %1 clock %clock : !hw.struct<a: !hw.struct<b: i2>>
 
     firrtl.strictconnect %result, %count : !firrtl.bundle<a: bundle<b: uint<2>>>
@@ -1499,7 +1499,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>) {
-    %count = firrtl.reg %clock: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
     %field1 = firrtl.subindex %count[1] : !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
     %field2 = firrtl.subfield %field1[a] : !firrtl.bundle<a: vector<bundle<b: uint<2>>, 3>>
     %field3 = firrtl.subindex %field2[1] : !firrtl.vector<bundle<b: uint<2>>, 3>
@@ -1532,7 +1532,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<uint<2>, 3>) {
-    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<uint<2>, 3>
     // CHECK: %count = seq.firreg [[REG:%.+]] clock %clock : !hw.array<3xi2>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
@@ -1552,7 +1552,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<uint<2>, 1>) {
-    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 1>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<uint<2>, 1>
     // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<1xi2>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 1>
@@ -1568,7 +1568,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<uint<2>, 3>) {
-    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<uint<2>, 3>
     // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<3xi2>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
@@ -1587,7 +1587,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<uint<2>, 3>) {
-    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<uint<2>, 3>
     // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<3xi2>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
@@ -1606,7 +1606,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                  in %reset: !firrtl.uint<1>,
                                  in %value: !firrtl.uint<2>,
                                  out %result: !firrtl.vector<uint<2>, 5>) {
-    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 5>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<uint<2>, 5>
     // CHECK: %count = seq.firreg [[NEXT:%.+]] clock %clock : !hw.array<5xi2>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 5>
@@ -1638,7 +1638,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                                        in %reset: !firrtl.uint<1>,
                                        in %value: !firrtl.uint<2>,
                                        out %result: !firrtl.vector<vector<uint<2>, 3>, 3>) {
-    %count = firrtl.reg %clock: !firrtl.vector<vector<uint<2>, 3>, 3>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.vector<vector<uint<2>, 3>, 3>
     // CHECK: %count = seq.firreg %10 clock %clock : !hw.array<3xarray<3xi2>>
 
     firrtl.strictconnect %result, %count : !firrtl.vector<vector<uint<2>, 3>, 3>
@@ -1667,7 +1667,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                            in %reset: !firrtl.uint<1>,
                            in %value: !firrtl.uint<2>,
                            out %result: !firrtl.uint<2>) {
-    %count = firrtl.regreset %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 
     // CHECK: %count = seq.firreg %count clock %clock reset sync %reset, %value : i2
     // CHECK: hw.output %count : i2
@@ -1680,7 +1680,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                            in %reset: !firrtl.asyncreset,
                            in %value: !firrtl.uint<2>,
                            out %result: !firrtl.uint<2>) {
-    %count = firrtl.regreset %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
 
     // CHECK: %count = seq.firreg %value clock %clock reset async %reset, %value : i2
     // CHECK: hw.output %count : i2
@@ -1693,7 +1693,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @NoConnect(in %clock: !firrtl.clock,
                      in %reset: !firrtl.uint<1>,
                      out %result: !firrtl.uint<2>) {
-    %count = firrtl.reg %clock: !firrtl.uint<2>
+    %count = firrtl.reg %clock: !firrtl.clock, !firrtl.uint<2>
     // CHECK: %count = seq.firreg %count clock %clock : i2
 
     firrtl.strictconnect %result, %count : !firrtl.uint<2>
@@ -1809,7 +1809,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %[[foo:.*]] = sv.constantStr "foo"
     // CHECK: sv.system "test$plusargs"(%[[foo]])
 
-    %3, %4 = firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
+    %3, %4 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
     firrtl.strictconnect %io3, %3 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %4 : !firrtl.uint<5>
     // CHECK: %[[foo:.*]] = sv.constantStr "foo"

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -10,7 +10,7 @@
 
 // Stage 0 ready wire and valid register.
 // CHECK:   %readyWire0 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %ctrlValidWire0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire0 = firrtl.wire : !firrtl.uint<1>
 
@@ -36,7 +36,7 @@
 
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %ctrlValidWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire1 = firrtl.wire : !firrtl.uint<1>
 
@@ -60,7 +60,7 @@
 
 // Stage 2 logics.
 // CHECK:   %readyWire2 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 
 // CHECK:   %[[VAL_10:.+]] = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_11:.+]] = firrtl.or %[[VAL_10:.+]], %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -95,7 +95,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %[[arg1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   %c0_ui64 = firrtl.constant 0 : !firrtl.uint<64>
 
-// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
@@ -104,7 +104,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[SUCC_DATA0:.+]] = firrtl.mux(%readyReg{{.*}}, %ctrlDataReg, %dataReg0)
 // CHECK:   firrtl.connect %ctrlDataWire0, %[[SUCC_DATA0]]
 
-// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK:   %[[CTRL_DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_6 {name = "ctrlDataReg"}
 // CHECK:   %[[SUCC_DATA1:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG1]], %dataReg1)
@@ -133,8 +133,8 @@ handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none
 // -----
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_in_ui64_out_ui64_1slots_seq_init_42
-// CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
 
 handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none) {
   %0 = buffer [1] seq %arg0 {initValues=[42]} : index
@@ -146,7 +146,7 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
 // CHECK-LABEL: firrtl.module @handshake_buffer_in_tuple_ui32_ui32_out_tuple_ui32_ui32_2slots_seq(
 // CHECK: %[[VALUE:.*]] = firrtl.constant 0 : !firrtl.sint<64>
 // CHECK: %[[ZERO_BUNDLE:.*]] = firrtl.bitcast %[[VALUE]] : (!firrtl.sint<64>) -> !firrtl.bundle<field0: uint<32>, field1: uint<32>>
-// CHECK: %dataReg0 = firrtl.regreset %{{.*}}, %{{.*}}, %[[ZERO_BUNDLE]]  : !firrtl.uint<1>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>
+// CHECK: %dataReg0 = firrtl.regreset %{{.*}}, %{{.*}}, %[[ZERO_BUNDLE]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>
 
 handshake.func @test_buffer_tuple_seq(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) {
   %0 = buffer [2] seq %t : tuple<i32, i32>
@@ -167,7 +167,7 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_1slots_seq_init_0_1ins_1outs_ctrl(
 // CHECK: %[[C1:.*]] = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK: %validReg0 = firrtl.regreset  %clock, %reset, %[[C1]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %validReg0 = firrtl.regreset  %clock, %reset, %[[C1]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 handshake.func @test_buffer_init_none_type(%arg0: none, ...) -> (none) {
   %0 = buffer [1] seq %arg0 {initValues = [0]}: none
   return %0 : none

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -24,7 +24,7 @@
 // CHECK:   firrtl.connect %notAllDone, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result 0 logic.
-// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %8 = firrtl.and %done0, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %emtd0, %8 : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -42,7 +42,7 @@
 // CHECK:   firrtl.connect %done0, %12 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result1 logic.
-// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %13 = firrtl.and %done1, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %emtd1, %13 : !firrtl.uint<1>, !firrtl.uint<1>
 

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -63,7 +63,7 @@
 // CHECK: firrtl.connect %[[MEM_STORE_DATA]], %[[ST_DATA_DATA]]
 
 // Create the write valid buffer.
-// CHECK: %[[WRITE_VALID_BUFFER:.+]] = firrtl.regreset {{.+}} !firrtl.uint<1>
+// CHECK: %[[WRITE_VALID_BUFFER:.+]] = firrtl.regreset {{.+}} !firrtl.clock, !firrtl.uint<1>
 
 // Connect the write valid buffer to the store control valid.
 // CHECK: firrtl.connect %[[ST_CONTROL_VALID]], %[[WRITE_VALID_BUFFER]]

--- a/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
@@ -66,7 +66,7 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK:  firrtl.connect %[[VAL_16]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result 0 logic.
-// CHECK:  %[[VAL_18:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  %[[VAL_18:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_19:.*]] = firrtl.and %[[VAL_12]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[VAL_18]], %[[VAL_19]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_20:.*]] = firrtl.wire  : !firrtl.uint<1>
@@ -81,7 +81,7 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK:  firrtl.connect %[[VAL_12]], %[[VAL_25]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result 1 logic.
-// CHECK:  %[[VAL_26:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  %[[VAL_26:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_27:.*]] = firrtl.and %[[VAL_13]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[VAL_26]], %[[VAL_27]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_28:.*]] = firrtl.wire  : !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
@@ -41,7 +41,7 @@
 // CHECK:             %[[VAL_36:.*]] = firrtl.wire   : !firrtl.uint<1>
 // CHECK:             %[[VAL_37:.*]] = firrtl.not %[[VAL_33]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_36]], %[[VAL_37]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_38:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_38:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_39:.*]] = firrtl.and %[[VAL_30]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_38]], %[[VAL_39]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_40:.*]] = firrtl.wire   : !firrtl.uint<1>
@@ -54,7 +54,7 @@
 // CHECK:             firrtl.connect %[[VAL_43]], %[[VAL_44]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_45:.*]] = firrtl.or %[[VAL_43]], %[[VAL_38]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_30]], %[[VAL_45]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_46:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_46:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_47:.*]] = firrtl.and %[[VAL_31]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_46]], %[[VAL_47]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_48:.*]] = firrtl.wire   : !firrtl.uint<1>
@@ -67,7 +67,7 @@
 // CHECK:             firrtl.connect %[[VAL_51]], %[[VAL_52]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_53:.*]] = firrtl.or %[[VAL_51]], %[[VAL_46]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_31]], %[[VAL_53]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_54:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_54:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_55:.*]] = firrtl.and %[[VAL_32]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_54]], %[[VAL_55]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_56:.*]] = firrtl.wire   : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %bundle0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
   }
 }
 
@@ -30,7 +30,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
   }
 }
 
@@ -45,7 +45,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %vector0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
   }
 }
 
@@ -62,7 +62,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %vector1, %vector0 : !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
   }
 }
 
@@ -84,7 +84,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %3, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %r = firrtl.regreset %clock, %reset, %literal  : !firrtl.asyncreset, !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
+    %r = firrtl.regreset %clock, %reset, %literal  : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
     firrtl.connect %r, %x : !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
     firrtl.connect %z, %r : !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
   }
@@ -99,12 +99,12 @@ firrtl.circuit "Foo"   {
     %w = firrtl.wire  : !firrtl.uint<1>
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     firrtl.connect %w, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    firrtl.when %cond  {
+    firrtl.when %cond : !firrtl.uint<1> {
       firrtl.connect %w, %y : !firrtl.uint<1>, !firrtl.uint<1>
     }
     // expected-error @+2 {{register with async reset requires constant reset value}}
     // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
-    %r = firrtl.regreset %clock, %reset, %w  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %w  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
@@ -17,33 +17,33 @@ firrtl.circuit "AsyncResetConst" {
   ) {
     // Constant check should handle trivial cases.
     %c0_ui = firrtl.constant 0 : !firrtl.uint<8>
-    %0 = firrtl.regreset %clock, %reset, %c0_ui : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %0 = firrtl.regreset %clock, %reset, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
 
     // Constant check should see through nodes.
     %node = firrtl.node %c0_ui : !firrtl.uint<8>
-    %1 = firrtl.regreset %clock, %reset, %node : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %1 = firrtl.regreset %clock, %reset, %node : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
 
     // Constant check should see through subfield connects.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %bundle0.a = firrtl.subfield %bundle0[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
-    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
 
     // Constant check should see through multiple connect hops.
     %bundle1 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
-    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
 
     // Constant check should see through subindex connects.
     %vector0 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %vector0.a = firrtl.subindex %vector0[0] : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
-    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
 
     // Constant check should see through multiple connect hops.
     %vector1 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector1, %vector0 : !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
-    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
 
     firrtl.connect %z0, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z1, %1 : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -157,8 +157,8 @@ firrtl.circuit "padConstWire"   {
 firrtl.circuit "padConstReg"   {
   // CHECK-LABEL: firrtl.module @padConstReg
   firrtl.module @padConstReg(in %clock: !firrtl.clock, out %z: !firrtl.uint<16>) {
-    %r_a = firrtl.reg droppable_name %clock  :  !firrtl.uint<8>
-    %r_b = firrtl.reg droppable_name %clock  :  !firrtl.uint<8>
+    %r_a = firrtl.reg droppable_name %clock  :  !firrtl.clock, !firrtl.uint<8>
+    %r_b = firrtl.reg droppable_name %clock  :  !firrtl.clock, !firrtl.uint<8>
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %r_a, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %r_b, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
@@ -222,7 +222,7 @@ firrtl.circuit "constResetReg"   {
   // CHECK-LABEL: firrtl.module @constResetReg(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   firrtl.module @constResetReg(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
     firrtl.connect %r, %r : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C11:.+]] = firrtl.constant 11 : !firrtl.uint<8>
@@ -235,7 +235,7 @@ firrtl.circuit "asyncReset"   {
   // CHECK-LABEL: firrtl.module @asyncReset
   firrtl.module @asyncReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %en: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.asyncreset, !firrtl.uint<4>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<4>, !firrtl.uint<8>
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     %0 = firrtl.mux(%en, %c0_ui4, %r) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
@@ -249,7 +249,7 @@ firrtl.circuit "asyncReset"   {
 firrtl.circuit "constReg2"   {
   // CHECK-LABEL: firrtl.module @constReg2
   firrtl.module @constReg2(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.sint<8>) {
-    %r = firrtl.reg %clock  :  !firrtl.sint<8>
+    %r = firrtl.reg %clock  :  !firrtl.clock, !firrtl.sint<8>
     %c-5_si4 = firrtl.constant -5 : !firrtl.sint<4>
     firrtl.connect %r, %c-5_si4 : !firrtl.sint<8>, !firrtl.sint<4>
     firrtl.connect %z, %r : !firrtl.sint<8>, !firrtl.sint<8>
@@ -263,7 +263,7 @@ firrtl.circuit "regSameConstReset"   {
   // CHECK-LABEL: firrtl.module @regSameConstReset
   firrtl.module @regSameConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
     firrtl.connect %r, %c11_ui4 : !firrtl.uint<8>, !firrtl.uint<4>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C13:.+]] = firrtl.constant 11 : !firrtl.uint<8>
@@ -370,7 +370,7 @@ firrtl.circuit "regConstReset"   {
   // CHECK-LABEL: firrtl.module @regConstReset
   firrtl.module @regConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-    %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
     %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
@@ -383,8 +383,8 @@ firrtl.circuit "regConstReset"   {
 firrtl.circuit "constPropRegMux"   {
   // CHECK-LABEL: firrtl.module @constPropRegMux
   firrtl.module @constPropRegMux(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-  %r2 = firrtl.reg %clock  : !firrtl.uint<1>
+  %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+  %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
@@ -7,7 +7,7 @@
 firrtl.circuit "uninitSelfReg"   {
   // CHECK-LABEL: firrtl.module @uninitSelfReg
   firrtl.module @uninitSelfReg(in %clock: !firrtl.clock, out %z: !firrtl.uint<8>) {
-    %r = firrtl.reg %clock  :  !firrtl.uint<8>
+    %r = firrtl.reg %clock  :  !firrtl.clock, !firrtl.uint<8>
     firrtl.connect %r, %r : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
@@ -19,7 +19,7 @@ firrtl.circuit "uninitSelfReg"   {
 firrtl.circuit "padZeroReg"   {
   // CHECK-LABEL: firrtl.module @padZeroReg
   firrtl.module @padZeroReg(in %clock: !firrtl.clock, out %z: !firrtl.uint<16>) {
-      %_r = firrtl.reg droppable_name %clock  :  !firrtl.uint<8>
+      %_r = firrtl.reg droppable_name %clock  :  !firrtl.clock, !firrtl.uint<8>
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       %0 = firrtl.or %_r, %c0_ui1 : (!firrtl.uint<8>, !firrtl.uint<1>) -> !firrtl.uint<8>
       firrtl.connect %_r, %0 : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
@@ -13,8 +13,8 @@ firrtl.circuit "Foo" {
     %instName_clockIn, %instName_clockOut = firrtl.instance instName sym @instSym @Bar(in extClockIn: !firrtl.clock, out extClockOut: !firrtl.clock)
     %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
-    %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
 
     %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
     firrtl.connect %instName_clockIn, %clock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -114,7 +114,7 @@ firrtl.circuit "Foo"  attributes {rawAnnotations = [
     // expected-error @+3 {{index access '42' into non-vector type}}
     // expected-error @+2 {{cannot resolve field 'qnx' in subtype}}
     // expected-error @+1 {{index access '1337' into non-vector type}}
-    %bar = firrtl.reg %clock : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    %bar = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -301,8 +301,8 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   ) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %bar = firrtl.node %c0_ui1  : !firrtl.uint<1>
-    firrtl.when %cond_0 {
-      firrtl.when %cond_1 {
+    firrtl.when %cond_0 : !firrtl.uint<1> {
+      firrtl.when %cond_1 : !firrtl.uint<1> {
         %baz = firrtl.node %c0_ui1  : !firrtl.uint<1>
       }
     }
@@ -358,9 +358,9 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   }
 ]} {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-    %bar = firrtl.reg %clock  : !firrtl.uint<1>
+    %bar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %baz = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %baz = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -438,7 +438,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   }
 ]} {
   firrtl.module @Foo(in %clock: !firrtl.clock) {
-    %bar = firrtl.reg %clock : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    %bar = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
   }
 }
 
@@ -752,11 +752,11 @@ firrtl.circuit "Foo"  attributes {
     // CHECK-NEXT: %_T_1 = firrtl.node %_T_0 {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
     %_T_1 = firrtl.node %_T_0  : !firrtl.uint<1>
     // CHECK-NEXT: %_T_2 = firrtl.reg %clock {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
-    %_T_2 = firrtl.reg %clock  : !firrtl.uint<1>
+    %_T_2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     // CHECK: %_T_3 = firrtl.regreset
     // CHECK-SAME: {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
-    %_T_3 = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    %_T_3 = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: %_T_4 = chirrtl.seqmem
     // CHECK-SAME: {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
     %_T_4 = chirrtl.seqmem Undefined  : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
@@ -960,7 +960,7 @@ firrtl.circuit "GCTInterface"  attributes {
     firrtl.skip
   }
   firrtl.module @GCTInterface(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>) {
-    %r = firrtl.reg %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
     firrtl.instance view_companion  @view_companion()
   }
 }
@@ -1032,7 +1032,7 @@ firrtl.circuit "GCTInterface"  attributes {
 // The RefSend must be generated.
 // CHECK: firrtl.module @GCTInterface
 // CHECK-SAME: %a: !firrtl.uint<1>
-// CHECK:      %r = firrtl.reg  %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
+// CHECK:      %r = firrtl.reg  %clock  : !firrtl.clock, !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %[[view_companion_view__2refPort:.+]], %[[view_companion_view__2refPort_1:.+]], %[[view_companion_view__1refPort:.+]], %[[view_companion_view__0refPort:.+]], %[[view_companion_view_portrefPort:.+]] = firrtl.instance view_companion  @view_companion(in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>, in {{.*}}: !firrtl.uint<1>)
 // CHECK:      %0 = firrtl.subfield %r[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<1>, 2>
@@ -1179,7 +1179,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
     %w = firrtl.wire : !firrtl.uint<1>
   }
   firrtl.module @GCTDataTap(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
     %tap_0 = firrtl.wire : !firrtl.uint<1>
     %tap_1 = firrtl.wire : !firrtl.vector<uint<1>, 1>
@@ -1643,7 +1643,7 @@ firrtl.circuit "GrandCentralViewInsideCompanion" attributes {
   // CHECK:      firrtl.module @Companion
   firrtl.module @Companion(out %b: !firrtl.uint<2>) {
     %clock = firrtl.specialconstant 0 : !firrtl.clock
-    %a = firrtl.reg %clock : !firrtl.uint<1>
+    %a = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK:      firrtl.node %a
     // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = [[aId]] : i64}
     // CHECK-SAME:   : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -789,8 +789,8 @@ firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) 
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.uint<8>
-  %tmp_b = firrtl.reg droppable_name %clock {name = "_tmp_b"} : !firrtl.uint<8>
+  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.clock, !firrtl.uint<8>
+  %tmp_b = firrtl.reg droppable_name %clock {name = "_tmp_b"} : !firrtl.clock, !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %tmp_b, %_tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
@@ -799,16 +799,16 @@ firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 // Check for DontTouch annotation
 // CHECK-LABEL: @reg_cst_prop1_DontTouch
 // CHECK-NEXT:      %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-// CHECK-NEXT:      %tmp_a = firrtl.reg sym @reg1 %clock : !firrtl.uint<8>
-// CHECK-NEXT:      %tmp_b = firrtl.reg %clock  : !firrtl.uint<8>
+// CHECK-NEXT:      %tmp_a = firrtl.reg sym @reg1 %clock : !firrtl.clock, !firrtl.uint<8>
+// CHECK-NEXT:      %tmp_b = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
 // CHECK-NEXT:      firrtl.strictconnect %tmp_a, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:      firrtl.strictconnect %tmp_b, %tmp_a : !firrtl.uint<8>
 // CHECK-NEXT:      firrtl.strictconnect %out_b, %tmp_b : !firrtl.uint<8>
 
 firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-  %_tmp_a = firrtl.reg  sym @reg1 %clock {name = "tmp_a"} : !firrtl.uint<8>
-  %_tmp_b = firrtl.reg %clock {name = "tmp_b"} : !firrtl.uint<8>
+  %_tmp_a = firrtl.reg  sym @reg1 %clock {name = "tmp_a"} : !firrtl.clock, !firrtl.uint<8>
+  %_tmp_b = firrtl.reg %clock {name = "tmp_b"} : !firrtl.clock, !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %_tmp_b, %_tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %out_b, %_tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
@@ -818,10 +818,10 @@ firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !fi
 // CHECK-NEXT:   firrtl.strictconnect %out_b, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
-  %_tmp_b = firrtl.reg droppable_name %clock {name = "_tmp_b"} : !firrtl.uint<8>
+  %_tmp_b = firrtl.reg droppable_name %clock {name = "_tmp_b"} : !firrtl.clock, !firrtl.uint<8>
   firrtl.connect %out_b, %_tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
 
-  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.uint<8>
+  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.clock, !firrtl.uint<8>
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %_tmp_b, %_tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
@@ -832,7 +832,7 @@ firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 // CHECK-NEXT:   firrtl.strictconnect %out_b, %c0_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
-  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.uint<8>
+  %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.clock, !firrtl.uint<8>
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 
@@ -1865,10 +1865,10 @@ firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
-  // CHECK: %bar1 = firrtl.reg %clock : !firrtl.uint<1>
+  // CHECK: %bar1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %foo2, %dummy : !firrtl.uint<1>
-  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
   firrtl.strictconnect %bar2, %bar1 : !firrtl.uint<1> // Force a use to trigger a crash on a sink replacement
 
@@ -2019,7 +2019,7 @@ firrtl.module @regsyncreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>
   // CHECK-NEXT:  firrtl.strictconnect %bar, %d : !firrtl.uint<2>
   // CHECK-NEXT:  firrtl.strictconnect %d, %foo : !firrtl.uint<2>
   // CHECK-NEXT: }
-  %d = firrtl.reg %clock {firrtl.random_init_end = 1 : ui64, firrtl.random_init_start = 0 : ui64} : !firrtl.uint<2>
+  %d = firrtl.reg %clock {firrtl.random_init_end = 1 : ui64, firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<2>
   firrtl.connect %bar, %d : !firrtl.uint<2>, !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %1 = firrtl.mux(%reset, %c1_ui2, %foo) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
@@ -2034,7 +2034,7 @@ firrtl.module @regsyncreset_no(in %clock: !firrtl.clock, in %reset: !firrtl.uint
   // CHECK-NEXT:  %0 = firrtl.mux(%reset, %[[const]], %foo) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
   // CHECK-NEXT:  firrtl.connect %d, %0 : !firrtl.uint, !firrtl.uint
   // CHECK-NEXT: }
-  %d = firrtl.reg %clock  : !firrtl.uint
+  %d = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint
   firrtl.connect %bar, %d : !firrtl.uint, !firrtl.uint
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint
   %1 = firrtl.mux(%reset, %c1_ui2, %foo) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
@@ -2076,7 +2076,7 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
 // CHECK-LABEL: firrtl.module @constReg
 firrtl.module @constReg(in %clock: !firrtl.clock,
               in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+  %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -2088,8 +2088,8 @@ firrtl.module @constReg(in %clock: !firrtl.clock,
 // CHECK-LABEL: firrtl.module @constReg
 firrtl.module @constReg2(in %clock: !firrtl.clock,
               in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-  %r2 = firrtl.reg %clock  : !firrtl.uint<1>
+  %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+  %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -2105,7 +2105,7 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
 // CHECK-LABEL: firrtl.module @constReg3
 firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11
@@ -2117,7 +2117,7 @@ firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
@@ -2130,7 +2130,7 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
   %resCond = firrtl.and %reset, %cond : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %r = firrtl.regreset %clock, %resCond, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %resCond, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
@@ -2143,7 +2143,7 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
   // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   // CHECK: firrtl.strictconnect %r, %0
@@ -2153,7 +2153,7 @@ firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 
 // Should not crash when the reset value is a block argument.
 firrtl.module @constReg7(in %v: !firrtl.uint<1>, in %clock: !firrtl.clock, in %reset: !firrtl.reset) {
-  %r = firrtl.regreset %clock, %reset, %v  : !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %v  : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<4>
 }
 
 // Check that firrtl.regreset reset mux folding doesn't respects
@@ -2162,14 +2162,14 @@ firrtl.module @constReg7(in %v: !firrtl.uint<1>, in %clock: !firrtl.clock, in %r
 firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.regreset sym @s2
-  %r1 = firrtl.regreset sym @s2 %clock, %reset, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  %r1 = firrtl.regreset sym @s2 %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   %0 = firrtl.mux(%reset, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.regreset
   // CHECK-SAME: Foo
-  %r2 = firrtl.regreset  %clock, %reset, %c1_ui1 {annotations = [{class = "Foo"}]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  %r2 = firrtl.regreset  %clock, %reset, %c1_ui1 {annotations = [{class = "Foo"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   %1 = firrtl.mux(%reset, %c1_ui1, %r2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out2, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -2246,7 +2246,7 @@ firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
 //  // _HECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
 //  // _HECK-NEXT: firrtl.strictconnect %x, [[ZERO]] : !firrtl.uint<2>
 //  %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-//  %_reg = firrtl.reg droppable_name %clock : !firrtl.uint<2>
+//  %_reg = firrtl.reg droppable_name %clock : !firrtl.clock, !firrtl.uint<2>
 //  %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
 //  firrtl.connect %_reg, %0 : !firrtl.uint<2>, !firrtl.uint<2>
 //  firrtl.connect %x, %_reg : !firrtl.uint<2>, !firrtl.uint<2>
@@ -2307,7 +2307,7 @@ firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
 // Issue mentioned in #2289
 // CHECK-LABEL: @Issue2289
 firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %out: !firrtl.uint<5>) {
-  %r = firrtl.reg %clock  : !firrtl.uint<1>
+  %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   firrtl.connect %r, %r : !firrtl.uint<1>, !firrtl.uint<1>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
@@ -2508,20 +2508,19 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, ou
 
   // Never enabled.
   // CHECK-NOT: firrtl.assert
-  firrtl.assert %clock, %p, %c0, "assert0"
+  firrtl.assert %clock, %p, %c0, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.assume
-  firrtl.assume %clock, %p, %c0, "assume0"
+  firrtl.assume %clock, %p, %c0, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.cover
-  firrtl.cover %clock, %p, %c0, "cover0"
+  firrtl.cover %clock, %p, %c0, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 
   // Never fired.
   // CHECK-NOT: firrtl.assert
-  firrtl.assert %clock, %c1, %p, "assert1"
+  firrtl.assert %clock, %c1, %p, "assert1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.assume
-  firrtl.assume %clock, %c1, %p, "assume1"
+  firrtl.assume %clock, %c1, %p, "assume1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.cover
-  firrtl.cover %clock, %c0, %p, "cover0"
-
+  firrtl.cover %clock, %c0, %p, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.int.isX
   %x = firrtl.int.isX %c0 : !firrtl.uint<1>
   firrtl.strictconnect %o, %x : !firrtl.uint<1>
@@ -2561,7 +2560,7 @@ firrtl.module @CrashAllUnusedPorts() {
 firrtl.module @CrashRegResetWithOneReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_d: !firrtl.uint<1>, out %io_q: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>) {
   %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   %0 = firrtl.mux(%io_en, %io_d, %reg) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %reg, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %io_q, %reg : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -149,7 +149,7 @@ firrtl.circuit "strictConnectAndConnect" {
 
 firrtl.circuit "vectorRegInit"   {
   firrtl.module @vectorRegInit(in %clk: !firrtl.clock) {
-    %reg = firrtl.reg %clk : !firrtl.vector<uint<8>, 2>
+    %reg = firrtl.reg %clk : !firrtl.clock, !firrtl.vector<uint<8>, 2>
     %0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<8>, 2>
     firrtl.connect %0, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -159,7 +159,7 @@ firrtl.circuit "vectorRegInit"   {
 
 firrtl.circuit "bundleRegInit"   {
   firrtl.module @bundleRegInit(in %clk: !firrtl.clock) {
-    %reg = firrtl.reg %clk : !firrtl.bundle<a: uint<1>>
+    %reg = firrtl.reg %clk : !firrtl.clock, !firrtl.bundle<a: uint<1>>
     %0 = firrtl.subfield %reg[a] : !firrtl.bundle<a: uint<1>>
     firrtl.connect %0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -285,7 +285,7 @@ firrtl.circuit "registerLoop"   {
   // CHECK: firrtl.module @registerLoop(in %clk: !firrtl.clock)
   firrtl.module @registerLoop(in %clk: !firrtl.clock) {
     %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
-    %r = firrtl.reg %clk : !firrtl.bundle<a: uint<1>>
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.bundle<a: uint<1>>
     %0 = firrtl.subfield %w[a]: !firrtl.bundle<a: uint<1>>
     %1 = firrtl.subfield %w[a]: !firrtl.bundle<a: uint<1>>
     %2 = firrtl.subfield %r[a]: !firrtl.bundle<a: uint<1>>
@@ -370,7 +370,7 @@ firrtl.circuit "hasloops"   {
 // CHECK: firrtl.circuit "hasloops"
 firrtl.circuit "hasloops"  {
   firrtl.module @thru1(in %clk: !firrtl.clock, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    %reg = firrtl.reg  %clk  : !firrtl.uint<1>
+    %reg = firrtl.reg  %clk  : !firrtl.clock, !firrtl.uint<1>
     firrtl.connect %reg, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %reg : !firrtl.uint<1>, !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -127,7 +127,7 @@ firrtl.module @wires4(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
 }
 
 firrtl.module @registers0(in %clock : !firrtl.clock, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
-  %0 = firrtl.reg %clock : !firrtl.uint<1>
+  %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -135,8 +135,8 @@ firrtl.module @registers0(in %clock : !firrtl.clock, in %in : !firrtl.uint<1>, o
 }
 
 firrtl.module @registers1(in %clock : !firrtl.clock) {
-  %0 = firrtl.reg %clock : !firrtl.uint<1>
-  %1 = firrtl.reg %clock : !firrtl.uint<1>
+  %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+  %1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %1
   firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -68,16 +68,16 @@ firrtl.circuit "PrimOps" {
 firrtl.circuit "WhenOps" {
   // CHECK: firrtl.module @WhenOps0
   firrtl.module @WhenOps0(in %p : !firrtl.uint<1>) {
-    // CHECK: firrtl.when %p {
+    // CHECK: firrtl.when %p : !firrtl.uint<1> {
     // CHECK:  %w = firrtl.wire : !firrtl.uint<8>
     // CHECK: }
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       %w = firrtl.wire : !firrtl.uint<8>
     }
   }
   // CHECK-NOT: firrtl.module @PrimOps1
   firrtl.module @WhenOps1(in %p : !firrtl.uint<1>) {
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       %w = firrtl.wire : !firrtl.uint<8>
     }
   }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -46,14 +46,14 @@ firrtl.circuit "Foo" {
   firrtl.module @Statements(in %ui1: !firrtl.uint<1>, in %someAddr: !firrtl.uint<8>, in %someClock: !firrtl.clock, in %someReset: !firrtl.reset, out %someOut: !firrtl.uint<1>) {
     // CHECK: when ui1 :
     // CHECK:   skip
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       firrtl.skip
     }
     // CHECK: when ui1 :
     // CHECK:   skip
     // CHECK: else :
     // CHECK:   skip
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       firrtl.skip
     } else {
       firrtl.skip
@@ -62,34 +62,34 @@ firrtl.circuit "Foo" {
     // CHECK:   skip
     // CHECK: else when ui1 :
     // CHECK:   skip
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       firrtl.skip
     } else {
-      firrtl.when %ui1 {
+      firrtl.when %ui1 : !firrtl.uint<1> {
         firrtl.skip
       }
     }
     // CHECK: wire someWire : UInt<1>
     %someWire = firrtl.wire : !firrtl.uint<1>
     // CHECK: reg someReg : UInt<1>, someClock
-    %someReg = firrtl.reg %someClock : !firrtl.uint<1>
+    %someReg = firrtl.reg %someClock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: reg someReg2 : UInt<1>, someClock with :
     // CHECK:   reset => (someReset, ui1)
-    %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: node someNode = ui1
     %someNode = firrtl.node %ui1 : !firrtl.uint<1>
     // CHECK: stop(someClock, ui1, 42) : foo
-    firrtl.stop %someClock, %ui1, 42 {name = "foo"}
+    firrtl.stop %someClock, %ui1, 42 {name = "foo"} : !firrtl.clock, !firrtl.uint<1>
     // CHECK: skip
     firrtl.skip
     // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"", ui1, someReset) : foo
-    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.uint<1>, !firrtl.reset
+    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
     // CHECK: assert(someClock, ui1, ui1, "msg") : foo
     // CHECK: assume(someClock, ui1, ui1, "msg") : foo
     // CHECK: cover(someClock, ui1, ui1, "msg") : foo
-    firrtl.assert %someClock, %ui1, %ui1, "msg" {name = "foo"}
-    firrtl.assume %someClock, %ui1, %ui1, "msg" {name = "foo"}
-    firrtl.cover %someClock, %ui1, %ui1, "msg" {name = "foo"}
+    firrtl.assert %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
+    firrtl.assume %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
+    firrtl.cover %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
     // CHECK: someOut <= ui1
     firrtl.connect %someOut, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: inst someInst of Simple
@@ -281,7 +281,7 @@ firrtl.circuit "Foo" {
 
     %combmem = chirrtl.combmem : !chirrtl.cmemory<uint<3>, 256>
     %port0_data, %port0_port = chirrtl.memoryport Infer %combmem {name = "port0"} : (!chirrtl.cmemory<uint<3>, 256>) -> (!firrtl.uint<3>, !chirrtl.cmemoryport)
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       chirrtl.memoryport.access %port0_port[%someAddr], %someClock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
     }
     // CHECK:      cmem combmem : UInt<3>[256]
@@ -290,7 +290,7 @@ firrtl.circuit "Foo" {
 
     %seqmem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<3>, 256>
     %port1_data, %port1_port = chirrtl.memoryport Infer %seqmem {name = "port1"} : (!chirrtl.cmemory<uint<3>, 256>) -> (!firrtl.uint<3>, !chirrtl.cmemoryport)
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       chirrtl.memoryport.access %port1_port[%someAddr], %someClock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
     }
     // CHECK:      smem seqmem : UInt<3>[256] undefined
@@ -301,7 +301,7 @@ firrtl.circuit "Foo" {
     // CHECK: port0 <= port1
 
     %invalid_clock = firrtl.invalidvalue : !firrtl.clock
-    %dummyReg = firrtl.reg %invalid_clock : !firrtl.uint<42>
+    %dummyReg = firrtl.reg %invalid_clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: wire [[INV:_invalid.*]] : Clock
     // CHECK-NEXT: [[INV]] is invalid
     // CHECK-NEXT: reg dummyReg : UInt<42>, [[INV]]

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -199,7 +199,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.clock, in %reset: !firrtl.uint<2>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // expected-error @+1 {{'firrtl.regreset' op operand #1 must be Reset, but got '!firrtl.uint<2>'}}
-    %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : !firrtl.uint<2>, !firrtl.uint<1>, !firrtl.uint<1>
+    %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : !firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -850,7 +850,7 @@ firrtl.circuit "Top" {
 firrtl.circuit "AnalogRegister" {
   firrtl.module @AnalogRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.analog'}}
-    %r = firrtl.reg %clock : !firrtl.analog
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.analog
   }
 }
 
@@ -859,7 +859,7 @@ firrtl.circuit "AnalogRegister" {
 firrtl.circuit "AnalogVectorRegister" {
   firrtl.module @AnalogVectorRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
-    %r = firrtl.reg %clock : !firrtl.vector<analog, 2>
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<analog, 2>
   }
 }
 
@@ -869,7 +869,7 @@ firrtl.circuit "MismatchedRegister" {
   firrtl.module @MismatchedRegister(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %z: !firrtl.vector<uint<1>, 1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // expected-error @+1 {{type mismatch between register '!firrtl.vector<uint<1>, 1>' and reset value '!firrtl.uint<1>'}}
-    %r = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>
+    %r = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %z, %r : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
   }
 }
@@ -979,7 +979,7 @@ firrtl.module @NonRefNode(in %in1 : !firrtl.ref<uint<8>>) {
 firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
-    %r = firrtl.reg %clock : !firrtl.ref<uint<8>>
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.ref<uint<8>>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -48,7 +48,7 @@ firrtl.module @CheckInitialization() {
 firrtl.circuit "declaration_in_when" {
 // Check that wires declared inside of a when are detected as uninitialized.
 firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     // expected-error @below {{sink "w_then" not fully initialized}}
     %w_then = firrtl.wire : !firrtl.uint<2>
   }
@@ -60,7 +60,7 @@ firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
 firrtl.circuit "declaration_in_when" {
 // Check that wires declared inside of a when are detected as uninitialized.
 firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
   } else {
     // expected-error @below {{sink "w_else" not fully initialized}}
     %w_else = firrtl.wire : !firrtl.uint<2>
@@ -77,12 +77,12 @@ firrtl.module @complex(in %p : !firrtl.uint<1>, in %q : !firrtl.uint<1>) {
   // expected-error @below {{sink "w" not fully initialized}}
   %w = firrtl.wire : !firrtl.uint<2>
 
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 
-  firrtl.when %q {
+  firrtl.when %q : !firrtl.uint<1> {
   } else {
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/expand-whens-locations.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-locations.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "Basic"  {
 // CHECK-LABEL: @Basic
 firrtl.module @Basic(in %p: !firrtl.uint<1>, in %v0: !firrtl.uint<8>, in %v1: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %v0 : !firrtl.uint<8>, !firrtl.uint<8> loc("then")
   } else {
     firrtl.connect %out, %v1 : !firrtl.uint<8>, !firrtl.uint<8> loc("else")
@@ -18,7 +18,7 @@ firrtl.module @Basic(in %p: !firrtl.uint<1>, in %v0: !firrtl.uint<8>, in %v1: !f
 // CHECK-LABEL: @Default
 firrtl.module @Default(in %p: !firrtl.uint<1>, in %v0: !firrtl.uint<8>, in %v1: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
   firrtl.connect %out, %v1 : !firrtl.uint<8>, !firrtl.uint<8> loc("else")
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %v0 : !firrtl.uint<8>, !firrtl.uint<8> loc("then")
   } loc("when")
   // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %v0, %v1)
@@ -31,8 +31,8 @@ firrtl.module @Default(in %p: !firrtl.uint<1>, in %v0: !firrtl.uint<8>, in %v1: 
 // CHECK-LABEL: @Nested
 firrtl.module @Nested(in %p: !firrtl.uint<1>, in %v0: !firrtl.uint<8>, in %v1: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
   firrtl.connect %out, %v1 : !firrtl.uint<8>, !firrtl.uint<8> loc("else")
-  firrtl.when %p {
-    firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
+    firrtl.when %p : !firrtl.uint<1> {
       firrtl.connect %out, %v0 : !firrtl.uint<8>, !firrtl.uint<8> loc("then")
     } else {
     } loc("inside")

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -20,7 +20,7 @@ firrtl.module @shadow_connects(out %out : !firrtl.uint<1>) {
 firrtl.module @shadow_when(in %p : !firrtl.uint<1>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     %w = firrtl.wire : !firrtl.uint<2>
     firrtl.connect %w, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -36,64 +36,64 @@ firrtl.module @shadow_when(in %p : !firrtl.uint<1>) {
 
 // Test all simulation constructs
 firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>) {
-  firrtl.when %p {
-    firrtl.printf %clock, %enable, "CIRCT Rocks!"
-    firrtl.stop %clock, %enable, 0
-    firrtl.assert %clock, %p, %enable, ""
-    firrtl.assume %clock, %p, %enable, ""
-    firrtl.cover %clock, %p, %enable, ""
+  firrtl.when %p : !firrtl.uint<1> {
+    firrtl.printf %clock, %enable, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
+    firrtl.stop %clock, %enable, 0 : !firrtl.clock, !firrtl.uint<1>
+    firrtl.assert %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.assume %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.cover %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   } else {
-    firrtl.printf %clock, %reset, "CIRCT Rocks!"
-    firrtl.stop %clock, %enable, 1
-    firrtl.assert %clock, %p, %enable, ""
-    firrtl.assume %clock, %p, %enable, ""
-    firrtl.cover %clock, %p, %enable, ""
+    firrtl.printf %clock, %reset, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
+    firrtl.stop %clock, %enable, 1 : !firrtl.clock, !firrtl.uint<1>
+    firrtl.assert %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.assume %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.cover %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 // CHECK-LABEL: firrtl.module @simulation(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
 // CHECK-NEXT:   %0 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.printf %clock, %0, "CIRCT Rocks!"
+// CHECK-NEXT:   firrtl.printf %clock, %0, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.stop %clock, %1, 0
+// CHECK-NEXT:   firrtl.stop %clock, %1, 0 : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %2 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assert %clock, %p, %2, "" {eventControl = 0 : i32, isConcurrent = false}
+// CHECK-NEXT:   firrtl.assert %clock, %p, %2, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %3 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assume %clock, %p, %3, "" {eventControl = 0 : i32, isConcurrent = false}
+// CHECK-NEXT:   firrtl.assume %clock, %p, %3, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %4 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.cover %clock, %p, %4, ""
+// CHECK-NEXT:   firrtl.cover %clock, %p, %4, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   %5 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %6 = firrtl.and %5, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.printf %clock, %6, "CIRCT Rocks!"
+// CHECK-NEXT:   firrtl.printf %clock, %6, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %7 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.stop %clock, %7, 1
+// CHECK-NEXT:   firrtl.stop %clock, %7, 1 : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %8 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assert %clock, %p, %8, "" {eventControl = 0 : i32, isConcurrent = false}
+// CHECK-NEXT:   firrtl.assert %clock, %p, %8, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %9 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.assume %clock, %p, %9, "" {eventControl = 0 : i32, isConcurrent = false}
+// CHECK-NEXT:   firrtl.assume %clock, %p, %9, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT:   %10 = firrtl.and %5, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.cover %clock, %p, %10, "" {eventControl = 0 : i32, isConcurrent = false}
+// CHECK-NEXT:   firrtl.cover %clock, %p, %10, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
 // CHECK-NEXT: }
 
 
 // Test nested when operations work correctly.
 firrtl.module @nested_whens(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p1 : !firrtl.uint<1>, in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>) {
-  firrtl.when %p0 {
-    firrtl.when %p1 {
-      firrtl.printf %clock, %enable, "CIRCT Rocks!"
+  firrtl.when %p0 : !firrtl.uint<1> {
+    firrtl.when %p1 : !firrtl.uint<1> {
+      firrtl.printf %clock, %enable, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
     }
   }
 }
 // CHECK-LABEL: firrtl.module @nested_whens(in %clock: !firrtl.clock, in %p0: !firrtl.uint<1>, in %p1: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
 // CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.and %0, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.printf %clock, %1, "CIRCT Rocks!"
+// CHECK-NEXT:   firrtl.printf %clock, %1, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT: }
 
 
 // Test that a parameter set in both sides of the connect is resolved. The value
 // used is local to each region.
 firrtl.module @set_in_both(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
@@ -117,7 +117,7 @@ firrtl.module @set_before_and_in_both(in %clock : !firrtl.clock, in %p : !firrtl
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
      firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -138,7 +138,7 @@ firrtl.module @set_after(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -160,7 +160,7 @@ firrtl.module @set_in_then0(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, 
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
@@ -176,7 +176,7 @@ firrtl.module @set_in_then0(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, 
 firrtl.module @set_in_then1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -193,7 +193,7 @@ firrtl.module @set_in_else0(in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>)
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
   } else {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
@@ -212,7 +212,7 @@ firrtl.module @check_mux_return_type(in %p : !firrtl.uint<1>, out %out : !firrtl
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   firrtl.connect %out, %c0_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
   } else {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
@@ -223,7 +223,7 @@ firrtl.module @check_mux_return_type(in %p : !firrtl.uint<1>, out %out : !firrtl
 firrtl.module @set_in_else1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
   } else {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
@@ -243,8 +243,8 @@ firrtl.module @nested(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
 
   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p0 {
-    firrtl.when %p1 {
+  firrtl.when %p0 : !firrtl.uint<1> {
+    firrtl.when %p1 : !firrtl.uint<1> {
       firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     }
   }
@@ -267,14 +267,14 @@ firrtl.module @nested2(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
 
-  firrtl.when %p0 {
-    firrtl.when %p1 {
+  firrtl.when %p0 : !firrtl.uint<1> {
+    firrtl.when %p1 : !firrtl.uint<1> {
       firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     } else {
       firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     }
   } else {
-    firrtl.when %p1 {
+    firrtl.when %p1 : !firrtl.uint<1> {
       firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     } else {
       firrtl.connect %out, %c3_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -305,14 +305,14 @@ firrtl.module @InvalidValues(in %p: !firrtl.uint<1>, out %out0: !firrtl.uint<2>,
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
 
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out0, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else  {
     firrtl.connect %out0, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
   // CHECK: firrtl.connect %out0, %c2_ui2
 
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out1, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else  {
     firrtl.connect %out1, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -320,13 +320,13 @@ firrtl.module @InvalidValues(in %p: !firrtl.uint<1>, out %out0: !firrtl.uint<2>,
   // CHECK: firrtl.connect %out1, %c2_ui2
 
   firrtl.connect %out2, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out2, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
   // CHECK: firrtl.connect %out2, %c2_ui2
 
   firrtl.connect %out3, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.skip
   } else  {
     firrtl.connect %out3, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -334,13 +334,13 @@ firrtl.module @InvalidValues(in %p: !firrtl.uint<1>, out %out0: !firrtl.uint<2>,
   // CHECK: firrtl.connect %out3, %c2_ui2
 
   firrtl.connect %out4, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %out4, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
   // CHECK: firrtl.connect %out4, %c2_ui2
 
   firrtl.connect %out5, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p  {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.skip
   } else  {
     firrtl.connect %out5, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -355,26 +355,26 @@ firrtl.module @register_mux(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
 
   // CHECK: %reg0 = firrtl.reg %clock
   // CHECK: firrtl.connect %reg0, %reg0
-  %reg0 = firrtl.reg %clock : !firrtl.uint<2>
+  %reg0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<2>
 
   // CHECK: %reg1 = firrtl.reg %clock
   // CHECK: firrtl.connect %reg1, %c0_ui2
-  %reg1 = firrtl.reg %clock : !firrtl.uint<2>
+  %reg1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<2>
   firrtl.connect %reg1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 
   // CHECK: %reg2 = firrtl.reg %clock
   // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %reg2)
   // CHECK: firrtl.connect %reg2, [[MUX]]
-  %reg2 = firrtl.reg %clock : !firrtl.uint<2>
-  firrtl.when %p {
+  %reg2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<2>
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %reg2, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 
   // CHECK: %reg3 = firrtl.reg %clock
   // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %c1_ui2)
   // CHECK: firrtl.connect %reg3, [[MUX]]
-  %reg3 = firrtl.reg %clock : !firrtl.uint<2>
-  firrtl.when %p {
+  %reg3 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<2>
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %reg3, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
     firrtl.connect %reg3, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -392,7 +392,7 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   // CHECK: [[W_A:%.*]] = firrtl.subfield %w[a]
   // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2)
   // CHECK: firrtl.connect [[W_A]], [[MUX]]
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
     firrtl.connect %w_a, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
@@ -405,7 +405,7 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   // CHECK: firrtl.connect [[W_B]], [[MUX]]
   %w_b0 = firrtl.subfield %w[b] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
   firrtl.connect %w_b0, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
   } else {
     %w_b1 = firrtl.subfield %w[b] : !firrtl.bundle<a : uint<2>, b flip: uint<2>>
     firrtl.connect %w_b1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -432,7 +432,7 @@ firrtl.module @as_passive(in %p : !firrtl.uint<1>) {
   firrtl.connect %simple0_in, %c2_ui3 : !firrtl.uint<3>, !firrtl.uint<3>
 
   %simple1_in = firrtl.instance test0 @simple2(in in : !firrtl.uint<3>)
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     // This is the tricky part, connect the input ports together.
     firrtl.connect %simple1_in, %simple0_in : !firrtl.uint<3>, !firrtl.uint<3>
   } else {
@@ -469,7 +469,7 @@ firrtl.module @vector_simple(in %clock: !firrtl.clock, out %ret: !firrtl.vector<
 firrtl.module @shadow_when_vector(in %p : !firrtl.uint<1>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     %w = firrtl.wire : !firrtl.vector<uint<2>, 1>
     %0 = firrtl.subindex %w[0] : !firrtl.vector<uint<2>, 1>
     firrtl.connect %0, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -488,7 +488,7 @@ firrtl.module @multi_dim_vector(in %p : !firrtl.uint<1>) {
   %0 = firrtl.subindex %w[0] : !firrtl.vector<vector<uint<2>, 2>, 1>
   %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<2>, 2>
   %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<2>, 2>
-  firrtl.when %p {
+  firrtl.when %p : !firrtl.uint<1> {
     firrtl.connect %1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.connect %2, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
@@ -515,7 +515,7 @@ firrtl.module @vector_of_bundle(in %p : !firrtl.uint<1>, out %ret: !firrtl.vecto
 
 // CHECK-LABEL: @aggregate_register
 firrtl.module @aggregate_register(in %clock: !firrtl.clock) {
-  %0 = firrtl.reg %clock : !firrtl.bundle<a : uint<1>, b : uint<1>>
+  %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a : uint<1>, b : uint<1>>
   // CHECK:      %1 = firrtl.subfield %0[a]
   // CHECK-NEXT: firrtl.connect %1, %1
   // CHECK-NEXT: %2 = firrtl.subfield %0[b]
@@ -524,7 +524,7 @@ firrtl.module @aggregate_register(in %clock: !firrtl.clock) {
 
 // CHECK-LABEL: @aggregate_regreset
 firrtl.module @aggregate_regreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %resetval: !firrtl.vector<uint<1>, 2>) {
-  %0 = firrtl.regreset %clock, %reset, %resetval : !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.regreset %clock, %reset, %resetval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // CHECK:      %1 = firrtl.subindex %0[0]
   // CHECK-NEXT: firrtl.connect %1, %1
   // CHECK-NEXT: %2 = firrtl.subindex %0[1]

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "VectorPropagation1" {
   // CHECK-LABEL: @VectorPropagation1
   firrtl.module @VectorPropagation1(in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %tmp = firrtl.reg %clock  : !firrtl.vector<uint<1>, 2>
+    %tmp = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %tmp[0] : !firrtl.vector<uint<1>, 2>
     firrtl.strictconnect %0, %c1_ui1 : !firrtl.uint<1>
     %1 = firrtl.subindex %tmp[1] : !firrtl.vector<uint<1>, 2>
@@ -40,7 +40,7 @@ firrtl.circuit "VectorPropagation2" {
     %c4_ui6 = firrtl.constant 4 : !firrtl.uint<6>
     %c2_ui6 = firrtl.constant 2 : !firrtl.uint<6>
     %c1_ui6 = firrtl.constant 1 : !firrtl.uint<6>
-    %tmp = firrtl.reg %clock  : !firrtl.vector<vector<uint<6>, 2>, 3>
+    %tmp = firrtl.reg %clock  : !firrtl.clock, !firrtl.vector<vector<uint<6>, 2>, 3>
     %0 = firrtl.subindex %tmp[0] : !firrtl.vector<vector<uint<6>, 2>, 3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<6>, 2>
     firrtl.strictconnect %1, %c1_ui6 : !firrtl.uint<6>
@@ -70,7 +70,7 @@ firrtl.circuit "VectorPropagation2" {
 firrtl.circuit "BundlePropagation1"   {
   // CHECK-LABEL: @BundlePropagation1
   firrtl.module @BundlePropagation1(in %clock: !firrtl.clock, out %result: !firrtl.uint<3>) {
-    %tmp = firrtl.reg %clock  : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
+    %tmp = firrtl.reg %clock  : !firrtl.clock, !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
@@ -111,7 +111,7 @@ firrtl.circuit "AggregateAsyncReset" {
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
     %init = firrtl.wire  : !firrtl.vector<uint<3>, 2>
-    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.asyncreset, !firrtl.vector<uint<3>, 2>, !firrtl.vector<uint<3>, 2>
+    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<3>, 2>, !firrtl.vector<uint<3>, 2>
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<3>, 2>
     firrtl.strictconnect %0, %c0_ui3 : !firrtl.uint<3>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<3>, 2>
@@ -134,7 +134,7 @@ firrtl.circuit "AggregateRegReset" {
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 1>
     %true = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.strictconnect %0, %true : !firrtl.uint<1>
-    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
+    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     %1 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.strictconnect %1, %true : !firrtl.uint<1>
     firrtl.strictconnect %out, %1 : !firrtl.uint<1>
@@ -269,8 +269,8 @@ firrtl.circuit "Oscillators"  {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %1 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
-    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %2 : !firrtl.uint<1>
     %3 = firrtl.not %s : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -286,8 +286,8 @@ firrtl.circuit "Oscillators"  {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %0 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %1 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
-    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.xor %1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %2 : !firrtl.uint<1>
     firrtl.strictconnect %s, %2 : !firrtl.uint<1>
@@ -301,8 +301,8 @@ firrtl.circuit "Oscillators"  {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.subfield %a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %1 = firrtl.subfield %a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
-    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %2 : !firrtl.uint<1>
     firrtl.strictconnect %s, %2 : !firrtl.uint<1>
@@ -320,8 +320,8 @@ firrtl.circuit "Oscillators"  {
     %ext_a = firrtl.instance ext  @Ext(in a: !firrtl.bundle<v1: uint<1>, v2: uint<1>>)
     %2 = firrtl.subfield %ext_a[v1] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
     %3 = firrtl.subfield %ext_a[v2] : !firrtl.bundle<v1: uint<1>, v2: uint<1>>
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
-    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %4 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %4 : !firrtl.uint<1>
     firrtl.strictconnect %s, %4 : !firrtl.uint<1>
@@ -395,7 +395,7 @@ firrtl.circuit "Foo"  {
   // CHECK-LABEL: firrtl.module private @Bar
   firrtl.module private @Bar(in %a: !firrtl.vector<uint<1>, 1>, in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
     %0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 1>
-    %r = firrtl.reg  %clock  {firrtl.random_init_start = 0 : ui64} : !firrtl.uint<1>
+    %r = firrtl.reg  %clock  {firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %r, %0 : !firrtl.uint<1>
     firrtl.strictconnect %b, %r : !firrtl.uint<1>
     // CHECK: %r = firrtl.reg

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -80,7 +80,7 @@ firrtl.circuit "Test" {
 
     // regreset
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-    %regreset = firrtl.regreset %clock, %reset, %c0_ui2 : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %regreset = firrtl.regreset %clock, %reset, %c0_ui2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 
     firrtl.connect %regreset, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 
@@ -88,7 +88,7 @@ firrtl.circuit "Test" {
     firrtl.connect %result6, %regreset: !firrtl.uint<2>, !firrtl.uint<2>
 
     // reg
-    %reg = firrtl.reg %clock  : !firrtl.uint<4>
+    %reg = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<4>
     firrtl.connect %reg, %c0_ui2 : !firrtl.uint<4>, !firrtl.uint<2>
     // CHECK: firrtl.connect %result7, %c0_ui4
     firrtl.connect %result7, %reg: !firrtl.uint<4>, !firrtl.uint<4>
@@ -146,7 +146,7 @@ firrtl.circuit "Test" {
 firrtl.circuit "Issue1188"  {
   firrtl.module @Issue1188(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %io_out: !firrtl.uint<6>, out %io_out3: !firrtl.uint<3>) {
     %c1_ui6 = firrtl.constant 1 : !firrtl.uint<6>
-    %D0123456 = firrtl.reg %clock  : !firrtl.uint<6>
+    %D0123456 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<6>
     %0 = firrtl.bits %D0123456 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
     %1 = firrtl.bits %D0123456 5 to 5 : (!firrtl.uint<6>) -> !firrtl.uint<1>
     %2 = firrtl.cat %0, %1 : (!firrtl.uint<5>, !firrtl.uint<1>) -> !firrtl.uint<6>
@@ -172,14 +172,14 @@ firrtl.circuit "testDontTouch"  {
   firrtl.module private @blockProp1(in %clock: !firrtl.clock,
     in %a: !firrtl.uint<1> sym @dntSym, out %b: !firrtl.uint<1>){
     //CHECK: %c = firrtl.reg
-    %c = firrtl.reg %clock : !firrtl.uint<1>
+    %c = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %c : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @allowProp
   firrtl.module private @allowProp(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK: [[CONST:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    %c = firrtl.reg %clock  : !firrtl.uint<1>
+    %c = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.connect %b, [[CONST]]
     firrtl.connect %b, %c : !firrtl.uint<1>, !firrtl.uint<1>
@@ -187,7 +187,7 @@ firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module private @blockProp3
   firrtl.module private @blockProp3(in %clock: !firrtl.clock, in %a: !firrtl.uint<1> , out %b: !firrtl.uint<1>) {
     //CHECK: %c = firrtl.reg
-    %c = firrtl.reg sym @s2 %clock : !firrtl.uint<1>
+    %c = firrtl.reg sym @s2 %clock : !firrtl.clock, !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %c : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -325,7 +325,7 @@ firrtl.circuit "InstanceOut2"   {
 firrtl.circuit "invalidReg1"   {
   // CHECK-LABEL: @invalidReg1
   firrtl.module @invalidReg1(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
-    %foobar = firrtl.reg %clock  : !firrtl.uint<1>
+    %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       //CHECK: %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
       %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
       //CHECK: firrtl.connect %foobar, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -340,7 +340,7 @@ firrtl.circuit "invalidReg1"   {
 firrtl.circuit "invalidReg2"   {
   // CHECK-LABEL: @invalidReg2
   firrtl.module @invalidReg2(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
-    %foobar = firrtl.reg %clock  : !firrtl.uint<1>
+    %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     firrtl.connect %foobar, %foobar : !firrtl.uint<1>, !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %foobar
     //CHECK: %[[inv:.*]] = firrtl.invalidvalue
@@ -363,10 +363,10 @@ firrtl.circuit "Oscillators"   {
   // CHECK: firrtl.module private @Foo
   firrtl.module private @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: firrtl.reg
-    %r = firrtl.reg %clock : !firrtl.uint<1>
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %r, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.not %s : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -377,10 +377,10 @@ firrtl.circuit "Oscillators"   {
   // CHECK: firrtl.module private @Bar
   firrtl.module private @Bar(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: %r = firrtl.reg
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %0 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %r, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -392,10 +392,10 @@ firrtl.circuit "Oscillators"   {
   // CHECK: firrtl.module private @Baz
   firrtl.module private @Baz(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: firrtl.reg
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %r, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -408,10 +408,10 @@ firrtl.circuit "Oscillators"   {
   firrtl.module private @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
     // CHECK: firrtl.reg
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %r, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -512,7 +512,7 @@ firrtl.circuit "Issue3372"  {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %other_zero = firrtl.instance other interesting_name  @Other(out zero: !firrtl.uint<1>)
-    %shared = firrtl.regreset interesting_name %clock, %other_zero, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %shared = firrtl.regreset interesting_name %clock, %other_zero, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %shared, %shared : !firrtl.uint<1>
     %test = firrtl.wire interesting_name  : !firrtl.uint<1>
     firrtl.strictconnect %test, %shared : !firrtl.uint<1>
@@ -598,7 +598,7 @@ firrtl.circuit "Verbatim"  {
 firrtl.circuit "Issue4498"  {
   firrtl.module @Issue4498(in %clock: !firrtl.clock) {
     %a = firrtl.wire : !firrtl.uint<1>
-    %r = firrtl.reg interesting_name %clock : !firrtl.uint<1>
+    %r = firrtl.reg interesting_name %clock : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %r, %a : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -11,10 +11,10 @@ firrtl.circuit "top" {
     %dead_wire = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %dead_wire, %dead_node : !firrtl.uint<1>
 
-    %dead_reg = firrtl.reg %clock : !firrtl.uint<1>
+    %dead_reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %dead_reg, %dead_wire : !firrtl.uint<1>
 
-    %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
 
     %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -86,7 +86,7 @@ firrtl.circuit "top"  {
   }
   // CHECK-NOT: @Child2
   firrtl.module private @Child2(in %input: !firrtl.uint<1>, in %clock: !firrtl.clock, out %output: !firrtl.uint<1>) {
-    %r = firrtl.reg %clock  : !firrtl.uint<1>
+    %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %r, %input : !firrtl.uint<1>
     firrtl.strictconnect %output, %r : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -41,7 +41,7 @@ firrtl.circuit "top" {
     // expected-note @+1 {{sync drive here:}}
     firrtl.connect %w2, %reset2 : !firrtl.reset, !firrtl.uint<1>
     firrtl.connect %out, %w2 : !firrtl.reset, !firrtl.reset
-    firrtl.when %en  {
+    firrtl.when %en : !firrtl.uint<1>  {
       firrtl.connect %out, %w0 : !firrtl.reset, !firrtl.reset
     } else  {
       firrtl.connect %out, %w1 : !firrtl.reset, !firrtl.reset
@@ -61,7 +61,7 @@ firrtl.circuit "top" {
     // expected-note @+1 {{sync drive here:}}
     firrtl.connect %w2, %reset1 : !firrtl.reset, !firrtl.uint<1>
     firrtl.connect %out, %w1 : !firrtl.reset, !firrtl.reset
-    firrtl.when %en  {
+    firrtl.when %en : !firrtl.uint<1>  {
       firrtl.connect %out, %w2 : !firrtl.reset, !firrtl.reset
     }
   }
@@ -204,7 +204,7 @@ firrtl.circuit "top" {
 firrtl.circuit "Top" {
   // expected-error @+1 {{module 'Foo' instantiated in different reset domains}}
   firrtl.module @Foo(in %clock: !firrtl.clock) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
   }
   // expected-note @+1 {{reset domain 'otherReset' of module 'Child' declared here:}}
   firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -63,8 +63,8 @@ firrtl.module @CastingToOtherTypes(in %a: !firrtl.uint<1>, out %v: !firrtl.uint<
 // CHECK-SAME: in %childReset: !firrtl.uint<1>
 firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
   %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
   firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -91,8 +91,8 @@ firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: 
   %c_resetIn, %c_resetOut = firrtl.instance c @MultipleModuleBoundariesChild(in resetIn: !firrtl.reset, out resetOut: !firrtl.reset)
   firrtl.connect %c_resetIn, %reset : !firrtl.reset, !firrtl.uint<1>
   %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
   firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -156,7 +156,7 @@ firrtl.module @OverrideInvalidWithDifferentResetType(in %cond: !firrtl.uint<1>, 
   // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
   firrtl.connect %out, %invalid_reset : !firrtl.reset, !firrtl.reset
-  firrtl.when %cond  {
+  firrtl.when %cond : !firrtl.uint<1>  {
     firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
   }
 }
@@ -189,8 +189,8 @@ firrtl.module @ResetDrivesAsyncResetOrBool3(in %in: !firrtl.uint<1>, out %out: !
 // CHECK-SAME: in %childReset: !firrtl.uint<1>
 firrtl.module @DedupDifferentlyChild1(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
   %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
   firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -198,8 +198,8 @@ firrtl.module @DedupDifferentlyChild1(in %clock: !firrtl.clock, in %childReset: 
 // CHECK-SAME: in %childReset: !firrtl.asyncreset
 firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
   %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.asyncreset, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
   firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -372,12 +372,12 @@ firrtl.circuit "Top" {
     portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
     // CHECK: %reg1 = firrtl.regreset sym @reg1 %clock, %extraReset, %c0_ui8
-    %reg1 = firrtl.reg sym @reg1 %clock : !firrtl.uint<8>
+    %reg1 = firrtl.reg sym @reg1 %clock : !firrtl.clock, !firrtl.uint<8>
     firrtl.connect %reg1, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Existing async reset remains untouched.
     // CHECK: %reg2 = firrtl.regreset %clock, %reset, %c1_ui8
-    %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %reg2, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Existing sync reset is moved to mux.
@@ -385,7 +385,7 @@ firrtl.circuit "Top" {
     // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %reg3)
     // CHECK: %1 = firrtl.mux(%init, %c1_ui8, %in)
     // CHECK: firrtl.connect %reg3, %1
-    %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %reg3, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subfield op.
@@ -396,7 +396,7 @@ firrtl.circuit "Top" {
     // CHECK: %7 = firrtl.mux(%init, %5, %in)
     // CHECK: firrtl.connect %6, %7
     %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
-    %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     %0 = firrtl.subfield %reg4[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %0, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
@@ -409,7 +409,7 @@ firrtl.circuit "Top" {
     // CHECK: %13 = firrtl.mux(%init, %11, %in)
     // CHECK: firrtl.connect %12, %13
     %reset5 = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %1 = firrtl.subindex %reg5[0] : !firrtl.vector<uint<8>, 1>
     firrtl.connect %1, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
@@ -422,7 +422,7 @@ firrtl.circuit "Top" {
     // CHECK: %19 = firrtl.mux(%init, %17, %in)
     // CHECK: firrtl.connect %18, %19
     %reset6 = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %2 = firrtl.subaccess %reg6[%in] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
     firrtl.connect %2, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
@@ -443,10 +443,10 @@ firrtl.circuit "Top" {
     portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %c0_ui = firrtl.constant 0 : !firrtl.uint
     // CHECK: %reg_uint = firrtl.regreset %clock, %reset, %c0_ui
-    %reg_uint = firrtl.reg %clock : !firrtl.uint
+    %reg_uint = firrtl.reg %clock : !firrtl.clock, !firrtl.uint
     // CHECK: %c0_si = firrtl.constant 0 : !firrtl.sint
     // CHECK: %reg_sint = firrtl.regreset %clock, %reset, %c0_si
-    %reg_sint = firrtl.reg %clock : !firrtl.sint
+    %reg_sint = firrtl.reg %clock : !firrtl.clock, !firrtl.sint
     // CHECK: %0 = firrtl.wire : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
     // CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
     // CHECK: %1 = firrtl.subfield %0[a]
@@ -459,7 +459,7 @@ firrtl.circuit "Top" {
     // CHECK: %5 = firrtl.subfield %0[b]
     // CHECK: firrtl.strictconnect %5, %2
     // CHECK: %reg_bundle = firrtl.regreset %clock, %reset, %0
-    %reg_bundle = firrtl.reg %clock : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
+    %reg_bundle = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
     // CHECK: %6 = firrtl.wire : !firrtl.vector<uint<8>, 4>
     // CHECK: %c0_ui8_0 = firrtl.constant 0 : !firrtl.uint<8>
     // CHECK: %7 = firrtl.subindex %6[0]
@@ -471,7 +471,7 @@ firrtl.circuit "Top" {
     // CHECK: %10 = firrtl.subindex %6[3]
     // CHECK: firrtl.strictconnect %10, %c0_ui8_0
     // CHECK: %reg_vector = firrtl.regreset %clock, %reset, %6
-    %reg_vector = firrtl.reg %clock : !firrtl.vector<uint<8>, 4>
+    %reg_vector = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<uint<8>, 4>
   }
 }
 
@@ -483,7 +483,7 @@ firrtl.circuit "ReusePorts" {
   // CHECK-SAME: in %reset: !firrtl.asyncreset
   // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
   firrtl.module @Child(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @BadName
   // CHECK-SAME: in %reset: !firrtl.asyncreset,
@@ -491,7 +491,7 @@ firrtl.circuit "ReusePorts" {
   // CHECK-SAME: in %existingReset: !firrtl.asyncreset
   // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
   firrtl.module @BadName(in %clock: !firrtl.clock, in %existingReset: !firrtl.asyncreset) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @BadType
   // CHECK-SAME: in %reset_0: !firrtl.asyncreset,
@@ -499,7 +499,7 @@ firrtl.circuit "ReusePorts" {
   // CHECK-SAME: in %reset: !firrtl.uint<1>
   // CHECK: %reg = firrtl.regreset %clock, %reset_0, %c0_ui8
   firrtl.module @BadType(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @ReusePorts
   firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
@@ -523,7 +523,7 @@ firrtl.circuit "FullAsyncNested" {
   firrtl.module @FullAsyncNestedDeeper(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1
-    %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<8>
+    %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<8>
     firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %io_out, %io_out_REG : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -534,9 +534,9 @@ firrtl.circuit "FullAsyncNested" {
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c0_ui8
-    %io_out_REG = firrtl.reg %clock : !firrtl.uint<8>
-    // CHECK: %io_out_REG_NO = firrtl.reg %clock : !firrtl.uint<8>
-    %io_out_REG_NO = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}]}: !firrtl.uint<8>
+    %io_out_REG = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %io_out_REG_NO = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+    %io_out_REG_NO = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}]}: !firrtl.clock, !firrtl.uint<8>
     firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
     %0 = firrtl.add %io_out_REG, %inst_io_out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
     %1 = firrtl.bits %0 7 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<8>
@@ -562,7 +562,7 @@ firrtl.circuit "FullAsyncExcluded" {
   // CHECK-SAME: (in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>)
   firrtl.module @FullAsyncExcludedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
     // CHECK: %io_out_REG = firrtl.reg %clock
-    %io_out_REG = firrtl.reg %clock : !firrtl.uint<8>
+    %io_out_REG = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
     firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %io_out, %io_out_REG : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -585,7 +585,7 @@ firrtl.circuit "FullAsyncExcluded" {
 firrtl.circuit "WireShouldDominate" {
   // CHECK-LABEL: firrtl.module @WireShouldDominate
   firrtl.module @WireShouldDominate(in %clock: !firrtl.clock) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     %localReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset = firrtl.wire
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
@@ -601,7 +601,7 @@ firrtl.circuit "MovableNodeShouldDominate" {
   // CHECK-LABEL: firrtl.module @MovableNodeShouldDominate
   firrtl.module @MovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // does not block move of node
-    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
     // CHECK-NEXT: %localReset = firrtl.node sym @theReset %0
@@ -618,7 +618,7 @@ firrtl.circuit "MovableNodeShouldDominate" {
 firrtl.circuit "UnmovableNodeShouldDominate" {
   // CHECK-LABEL: firrtl.module @UnmovableNodeShouldDominate
   firrtl.module @UnmovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
-    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset = firrtl.wire sym @theReset
@@ -636,19 +636,19 @@ firrtl.circuit "MoveAcrossBlocks1" {
   // CHECK-LABEL: firrtl.module @MoveAcrossBlocks1
   firrtl.module @MoveAcrossBlocks1(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     // <-- should move reset here
-    firrtl.when %ui1 {
-      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    firrtl.when %ui1 : !firrtl.uint<1> {
+      %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     }
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     }
     // CHECK-NEXT: %localReset = firrtl.wire
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: }
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
     // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
@@ -661,19 +661,19 @@ firrtl.circuit "MoveAcrossBlocks2" {
   // CHECK-LABEL: firrtl.module @MoveAcrossBlocks2
   firrtl.module @MoveAcrossBlocks2(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     // <-- should move reset here
-    firrtl.when %ui1 {
+    firrtl.when %ui1 : !firrtl.uint<1> {
       %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     }
-    firrtl.when %ui1 {
-      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    firrtl.when %ui1 : !firrtl.uint<1> {
+      %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     }
     // CHECK-NEXT: %localReset = firrtl.wire
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
     // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: }
@@ -686,15 +686,15 @@ firrtl.circuit "MoveAcrossBlocks3" {
   // CHECK-LABEL: firrtl.module @MoveAcrossBlocks3
   firrtl.module @MoveAcrossBlocks3(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     // <-- should move reset here
-    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
-    firrtl.when %ui1 {
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
+    firrtl.when %ui1 : !firrtl.uint<1> {
       %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     }
     // CHECK-NEXT: %localReset = firrtl.wire
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
     // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
@@ -707,13 +707,13 @@ firrtl.circuit "MoveAcrossBlocks4" {
   // CHECK-LABEL: firrtl.module @MoveAcrossBlocks4
   firrtl.module @MoveAcrossBlocks4(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     // <-- should move reset here
-    firrtl.when %ui1 {
-      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    firrtl.when %ui1 : !firrtl.uint<1> {
+      %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     }
     %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset = firrtl.wire
-    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: }
@@ -730,10 +730,10 @@ firrtl.circuit "SubAccess" {
     portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<2>
     %arr = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
     firrtl.strictconnect %2, %in : !firrtl.uint<8>
-    // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
     // CHECK-NEXT: %0 = firrtl.mux(%init, %c1_ui2, %reg6)
     // CHECK: firrtl.connect %reg6, %0
     // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
@@ -750,7 +750,7 @@ firrtl.circuit "SubAccess" {
 firrtl.circuit "ZeroWidthRegister" {
   firrtl.module @ZeroWidthRegister(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
     portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
-    %reg = firrtl.reg %clock : !firrtl.uint<0>
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<0>
     // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %reset, [[TMP]]
   }

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op is constrained to be wider than itself}}
-    %0 = firrtl.reg %clk : !firrtl.uint
+    %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     // expected-note @+1 {{constrained width W >= W+3 here}}
     %1 = firrtl.shl %0, 3 : (!firrtl.uint) -> !firrtl.uint
     // expected-note @+1 {{constrained width W >= W+4 here}}

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -413,17 +413,17 @@ firrtl.circuit "Foo" {
     // CHECK: %ui = firrtl.wire : !firrtl.uint<5>
     %ui = firrtl.wire : !firrtl.uint
 
-    firrtl.printf %clk, %false, "foo"
+    firrtl.printf %clk, %false, "foo" : !firrtl.clock, !firrtl.uint<1>
     firrtl.skip
-    firrtl.stop %clk, %false, 0
-    firrtl.when %a  {
+    firrtl.stop %clk, %false, 0 : !firrtl.clock, !firrtl.uint<1>
+    firrtl.when %a : !firrtl.uint<1> {
       firrtl.connect %ui, %c0_ui4 : !firrtl.uint, !firrtl.uint<4>
     } else  {
       firrtl.connect %ui, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
     }
-    firrtl.assert %clk, %true, %true, "foo"
-    firrtl.assume %clk, %true, %true, "foo"
-    firrtl.cover %clk, %true, %true, "foo"
+    firrtl.assert %clk, %true, %true, "foo" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.assume %clk, %true, %true, "foo" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.cover %clk, %true, %true, "foo" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // Issue #1088
@@ -471,10 +471,10 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @RegSimple
   firrtl.module @RegSimple(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
-    // CHECK: %0 = firrtl.reg %clk : !firrtl.uint<6>
-    // CHECK: %1 = firrtl.reg %clk : !firrtl.uint<6>
-    %0 = firrtl.reg %clk : !firrtl.uint
-    %1 = firrtl.reg %clk : !firrtl.uint
+    // CHECK: %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
+    // CHECK: %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
+    %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
+    %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
     %3 = firrtl.xor %1, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
@@ -484,10 +484,10 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @RegShr
   firrtl.module @RegShr(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
-    // CHECK: %0 = firrtl.reg %clk : !firrtl.uint<6>
-    // CHECK: %1 = firrtl.reg %clk : !firrtl.uint<6>
-    %0 = firrtl.reg %clk : !firrtl.uint
-    %1 = firrtl.reg %clk : !firrtl.uint
+    // CHECK: %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
+    // CHECK: %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
+    %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
+    %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %2 = firrtl.shr %0, 0 : (!firrtl.uint) -> !firrtl.uint
     %3 = firrtl.shr %1, 3 : (!firrtl.uint) -> !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
@@ -498,10 +498,10 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @RegShl
   firrtl.module @RegShl(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
-    // CHECK: %0 = firrtl.reg %clk : !firrtl.uint<6>
-    %0 = firrtl.reg %clk : !firrtl.uint
-    %1 = firrtl.reg %clk : !firrtl.uint
-    %2 = firrtl.reg %clk : !firrtl.uint
+    // CHECK: %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
+    %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
+    %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
+    %2 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %3 = firrtl.shl %0, 0 : (!firrtl.uint) -> !firrtl.uint
     %4 = firrtl.shl %1, 3 : (!firrtl.uint) -> !firrtl.uint
     %5 = firrtl.shr %4, 3 : (!firrtl.uint) -> !firrtl.uint
@@ -521,16 +521,16 @@ firrtl.circuit "Foo" {
     in %rst: !firrtl.asyncreset,
     in %x: !firrtl.uint<6>
   ) {
-    // CHECK: %0 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
-    // CHECK: %1 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
-    // CHECK: %2 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>
-    // CHECK: %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>
+    // CHECK: %0 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
+    // CHECK: %1 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
+    // CHECK: %2 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>
+    // CHECK: %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>
     %c0_ui = firrtl.constant 0 : !firrtl.uint
     %c0_ui17 = firrtl.constant 0 : !firrtl.uint<17>
-    %0 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
-    %1 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
-    %2 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
-    %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
+    %0 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
+    %1 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
+    %2 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
+    %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
     %4 = firrtl.wire : !firrtl.uint
     %5 = firrtl.xor %1, %4 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
@@ -582,9 +582,9 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferBundle
   firrtl.module @InferBundle(in %in : !firrtl.uint<3>, in %clk : !firrtl.clock) {
     // CHECK: firrtl.wire : !firrtl.bundle<a: uint<3>>
-    // CHECK: firrtl.reg %clk : !firrtl.bundle<a: uint<3>>
+    // CHECK: firrtl.reg %clk : !firrtl.clock, !firrtl.bundle<a: uint<3>>
     %w = firrtl.wire : !firrtl.bundle<a: uint>
-    %r = firrtl.reg %clk : !firrtl.bundle<a: uint>
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.bundle<a: uint>
     %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a: uint>
     %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: uint>
     firrtl.connect %w_a, %in : !firrtl.uint, !firrtl.uint<3>
@@ -609,9 +609,9 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferVectorSubindex
   firrtl.module @InferVectorSubindex(in %in : !firrtl.uint<4>, in %clk : !firrtl.clock) {
     // CHECK: firrtl.wire : !firrtl.vector<uint<4>, 10>
-    // CHECK: firrtl.reg %clk : !firrtl.vector<uint<4>, 10>
+    // CHECK: firrtl.reg %clk : !firrtl.clock, !firrtl.vector<uint<4>, 10>
     %w = firrtl.wire : !firrtl.vector<uint, 10>
-    %r = firrtl.reg %clk : !firrtl.vector<uint, 10>
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.vector<uint, 10>
     %w_5 = firrtl.subindex %w[5] : !firrtl.vector<uint, 10>
     %r_5 = firrtl.subindex %r[5] : !firrtl.vector<uint, 10>
     firrtl.connect %w_5, %in : !firrtl.uint, !firrtl.uint<4>
@@ -621,9 +621,9 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferVectorSubaccess
   firrtl.module @InferVectorSubaccess(in %in : !firrtl.uint<4>, in %addr : !firrtl.uint<32>, in %clk : !firrtl.clock) {
     // CHECK: firrtl.wire : !firrtl.vector<uint<4>, 10>
-    // CHECK: firrtl.reg %clk : !firrtl.vector<uint<4>, 10>
+    // CHECK: firrtl.reg %clk : !firrtl.clock, !firrtl.vector<uint<4>, 10>
     %w = firrtl.wire : !firrtl.vector<uint, 10>
-    %r = firrtl.reg %clk : !firrtl.vector<uint, 10>
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.vector<uint, 10>
     %w_addr = firrtl.subaccess %w[%addr] : !firrtl.vector<uint, 10>, !firrtl.uint<32>
     %r_addr = firrtl.subaccess %r[%addr] : !firrtl.vector<uint, 10>, !firrtl.uint<32>
     firrtl.connect %w_addr, %in : !firrtl.uint, !firrtl.uint<4>
@@ -791,10 +791,10 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @Issue1271
   firrtl.module @Issue1271(in %clock: !firrtl.clock, in %cond: !firrtl.uint<1>) {
-    // CHECK: %a = firrtl.reg %clock  : !firrtl.uint<2>
+    // CHECK: %a = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<2>
     // CHECK: %b = firrtl.node %0  : !firrtl.uint<3>
     // CHECK: %c = firrtl.node %1  : !firrtl.uint<2>
-    %a = firrtl.reg %clock  : !firrtl.uint
+    %a = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.add %a, %c0_ui1 : (!firrtl.uint, !firrtl.uint<1>) -> !firrtl.uint
     %b = firrtl.node %0  : !firrtl.uint

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -28,9 +28,9 @@ firrtl.circuit "TLRAM" {
       firrtl.connect %8, %_T_29 : !firrtl.uint<1>, !firrtl.uint<1>
       %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
-      %REG = firrtl.reg %clock  : !firrtl.uint<1>
+      %REG = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       firrtl.connect %REG, %9 : !firrtl.uint<1>, !firrtl.uint<1>
-      %r_0 = firrtl.reg %clock  : !firrtl.uint<8>
+      %r_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
       %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
       firrtl.connect %r_0, %10 : !firrtl.uint<8>, !firrtl.uint<8>
       %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
@@ -273,9 +273,9 @@ firrtl.circuit "TLRAM" {
       firrtl.connect %8, %c1 : !firrtl.uint<2>, !firrtl.uint<2>
       %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
-      %REG = firrtl.reg %clock  : !firrtl.uint<1>
+      %REG = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       firrtl.connect %REG, %9 : !firrtl.uint<1>, !firrtl.uint<1>
-      %r_0 = firrtl.reg %clock  : !firrtl.uint<8>
+      %r_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
       %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
       firrtl.connect %r_0, %10 : !firrtl.uint<8>, !firrtl.uint<8>
       %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -265,15 +265,15 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   chirrtl.memoryport.access %memoryport_port[%u8], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   // CHECK: %myinst_node = firrtl.node %myinst_u8  : !firrtl.uint<8>
   %node = firrtl.node %u8 {name = "node"} : !firrtl.uint<8>
-  // CHECK: %myinst_reg = firrtl.reg %myinst_clock : !firrtl.uint<8>
-  %reg = firrtl.reg %clock {name = "reg"} : !firrtl.uint<8>
-  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: %myinst_reg = firrtl.reg %myinst_clock : !firrtl.clock, !firrtl.uint<8>
+  %reg = firrtl.reg %clock {name = "reg"} : !firrtl.clock, !firrtl.uint<8>
+  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   // CHECK: %myinst_wire = firrtl.wire  : !firrtl.uint<1>
   %wire = firrtl.wire : !firrtl.uint<1>
-  firrtl.when %wire {
+  firrtl.when %wire : !firrtl.uint<1> {
     // CHECK:  %myinst_inwhen = firrtl.wire  : !firrtl.uint<1>
     %inwhen = firrtl.wire : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/inner-names.mlir
+++ b/test/Dialect/FIRRTL/inner-names.mlir
@@ -18,10 +18,10 @@ firrtl.circuit "Foo" {
     %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
     // CHECK: %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
-    // CHECK: %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
-    %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
-    // CHECK: %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    // CHECK: %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
+    %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
+    // CHECK: %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
     // CHECK: %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
   }

--- a/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
@@ -4,7 +4,7 @@ firrtl.circuit "NoInferredEnables" {
 firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %v: !firrtl.uint<32>) {
   %ram = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<32>, 16>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // expected-warning @+1 {{memory port is never enabled}}
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -35,12 +35,12 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
   %ram = chirrtl.combmem  sym @s1 : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
-  // CHECK: firrtl.when %cond {
+  // CHECK: firrtl.when %cond : !firrtl.uint<1> {
   // CHECK:   firrtl.strictconnect [[ADDR]], %addr
   // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
   // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
   // CHECK: }
-  firrtl.when %cond {
+  firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   }
 
@@ -70,13 +70,13 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
-  // CHECK: firrtl.when %cond {
+  // CHECK: firrtl.when %cond : !firrtl.uint<1> {
   // CHECK:   firrtl.strictconnect [[ADDR]], %addr
   // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
   // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
   // CHECK:   firrtl.strictconnect [[MASK]], %c0_ui1
   // CHECK: }
-  firrtl.when %cond {
+  firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   }
 
@@ -232,8 +232,8 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram  {name = "ramport"}: (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%w], %clock : !chirrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
 
-  // CHECK: firrtl.when %p {
-  firrtl.when %p  {
+  // CHECK: firrtl.when %p : !firrtl.uint<1> {
+  firrtl.when %p : !firrtl.uint<1> {
     // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
     // CHECK-NEXT: firrtl.connect %w, %addr
     firrtl.connect %w, %addr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -248,8 +248,8 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   firrtl.connect %v, %invalid_ui32 : !firrtl.uint<32>, !firrtl.uint<32>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
-  // CHECK: firrtl.when %p
-  firrtl.when %p  {
+  // CHECK: firrtl.when %p : !firrtl.uint<1>
+  firrtl.when %p : !firrtl.uint<1> {
    // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
    // CHECK-NEXT: %n = firrtl.node %addr
    // CHECK-NEXT: firrtl.strictconnect [[ADDR]], %n
@@ -308,7 +308,7 @@ firrtl.module @DbgsMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>,
   %port0_data = chirrtl.debugport %ram {name = "port0"} : (!chirrtl.cmemory<uint<1>, 2>) -> !firrtl.ref<vector<uint<1>, 2>>
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 2>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
-  firrtl.when %cond {
+  firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   }
   firrtl.strictconnect %_a, %port0_data : !firrtl.ref<vector<uint<1>, 2>>

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -36,7 +36,7 @@ firrtl.circuit "Foo" {
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter4(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter4
-    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
+    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
     firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }
@@ -75,7 +75,7 @@ firrtl.circuit "Foo" {
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter8(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter8
-    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
+    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
     firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -14,7 +14,7 @@ firrtl.circuit "TopLevel" {
   firrtl.module private @Simple(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
                         out %sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
 
-    // COMMON-NEXT: firrtl.when %[[SOURCE_VALID_NAME]]
+    // COMMON-NEXT: firrtl.when %[[SOURCE_VALID_NAME]] : !firrtl.uint<1>
     // COMMON-NEXT:   firrtl.connect %[[SINK_DATA_NAME]], %[[SOURCE_DATA_NAME]] : [[SINK_DATA_TYPE]], [[SOURCE_DATA_TYPE]]
     // COMMON-NEXT:   firrtl.connect %[[SINK_VALID_NAME]], %[[SOURCE_VALID_NAME]] : [[SINK_VALID_TYPE]], [[SOURCE_VALID_TYPE]]
     // COMMON-NEXT:   firrtl.connect %[[SOURCE_READY_NAME]], %[[SINK_READY_NAME]] : [[SOURCE_READY_TYPE]], [[SINK_READY_TYPE]]
@@ -25,7 +25,7 @@ firrtl.circuit "TopLevel" {
     %3 = firrtl.subfield %sink[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
     %4 = firrtl.subfield %sink[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
     %5 = firrtl.subfield %sink[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-    firrtl.when %0 {
+    firrtl.when %0 : !firrtl.uint<1> {
       firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
       firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -298,10 +298,10 @@ firrtl.circuit "TopLevel" {
 
     // CHECK-LABEL: firrtl.module private @RegBundle(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
     firrtl.module private @RegBundle(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
-      // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.uint<1>
+      // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
-      %x = firrtl.reg %clk {name = "x"} : !firrtl.bundle<a: uint<1>>
+      %x = firrtl.reg %clk {name = "x"} : !firrtl.clock, !firrtl.bundle<a: uint<1>>
       %0 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>>
       %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -312,10 +312,10 @@ firrtl.circuit "TopLevel" {
 
     // CHECK-LABEL: firrtl.module private @RegBundleWithBulkConnect(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
     firrtl.module private @RegBundleWithBulkConnect(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
-      // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.uint<1>
+      // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.strictconnect %x_a, %a_a : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.strictconnect %b_a, %x_a : !firrtl.uint<1>
-      %x = firrtl.reg %clk {name = "x"} : !firrtl.bundle<a: uint<1>>
+      %x = firrtl.reg %clk {name = "x"} : !firrtl.clock, !firrtl.bundle<a: uint<1>>
       firrtl.connect %x, %a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
       firrtl.connect %b, %x : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     }
@@ -393,7 +393,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset, %init {name = "r"} : !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r = firrtl.regreset %clock, %reset, %init {name = "r"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -402,8 +402,8 @@ firrtl.circuit "TopLevel" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %r_0, %a_d_0 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %r_1, %a_d_1 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %a_q_0, %r_0 : !firrtl.uint<1>
@@ -414,7 +414,7 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-NEXT:  firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // AGGREGATE-NEXT:  %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // AGGREGATE-NEXT:  %r = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+  // AGGREGATE-NEXT:  %r = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %2 = firrtl.subindex %a_d[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %3 = firrtl.subindex %r[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  firrtl.strictconnect %3, %2 : !firrtl.uint<1>
@@ -438,7 +438,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset, %init {name = ""} : !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r = firrtl.regreset %clock, %reset, %init {name = ""} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -447,8 +447,8 @@ firrtl.circuit "TopLevel" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %0, %a_d_0 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %1, %a_d_1 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %a_q_0, %0 : !firrtl.uint<1>
@@ -458,12 +458,12 @@ firrtl.circuit "TopLevel" {
 // https://github.com/llvm/circt/issues/795
   // CHECK-LABEL: firrtl.module private @lowerRegOpNoName
   firrtl.module private @lowerRegOpNoName(in %clock: !firrtl.clock, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
-    %r = firrtl.reg %clock {name = ""} : !firrtl.vector<uint<1>, 2>
+    %r = firrtl.reg %clock {name = ""} : !firrtl.clock, !firrtl.vector<uint<1>, 2>
       firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
       firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
- // CHECK:    %0 = firrtl.reg %clock : !firrtl.uint<1>
- // CHECK:    %1 = firrtl.reg %clock : !firrtl.uint<1>
+ // CHECK:    %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+ // CHECK:    %1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
  // CHECK:    firrtl.strictconnect %0, %a_d_0 : !firrtl.uint<1>
  // CHECK:    firrtl.strictconnect %1, %a_d_1 : !firrtl.uint<1>
  // CHECK:    firrtl.strictconnect %a_q_0, %0 : !firrtl.uint<1>
@@ -534,8 +534,8 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %bazInit[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %bar = firrtl.reg %clock  {annotations = [{a = "a"}], name = "bar"} : !firrtl.vector<uint<1>, 2>
-    %baz = firrtl.regreset %clock, %reset, %bazInit  {annotations = [{b = "b"}], name = "baz"} : !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %bar = firrtl.reg %clock  {annotations = [{a = "a"}], name = "bar"} : !firrtl.clock, !firrtl.vector<uint<1>, 2>
+    %baz = firrtl.regreset %clock, %reset, %bazInit  {annotations = [{b = "b"}], name = "baz"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   // CHECK: firrtl.reg
   // CHECK-SAME: annotations = [{a = "a"}]
@@ -552,14 +552,14 @@ firrtl.circuit "TopLevel" {
                          in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
                          out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
     // No else region.
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
       // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
 
     // Else region.
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
       // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
@@ -599,13 +599,13 @@ firrtl.circuit "TopLevel" {
     %bar = firrtl.reg %clock  {annotations = [
       {circt.fieldID = 3, one},
       {circt.fieldID = 5, two}
-    ]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    ]} : !firrtl.clock, !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
     // TODO: Enable this
-    // CHECK: %bar_0_baz = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_0_qux = firrtl.reg %clock  {annotations = [{one}]} : !firrtl.uint<1>
-    // CHECK: %bar_1_baz = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.uint<1>
-    // CHECK: %bar_1_qux = firrtl.reg %clock  : !firrtl.uint<1>
+    // CHECK: %bar_0_baz = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_qux = firrtl.reg %clock  {annotations = [{one}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_baz = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_qux = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   }
 
 // Test that subfield annotations on reg are lowred to appropriate instance based on fieldID. Ignore un-flattened array targets
@@ -618,21 +618,21 @@ firrtl.circuit "TopLevel" {
         {circt.fieldID = 6, one},
         {circt.fieldID = 12, two},
         {circt.fieldID = 8, three}
-      ]} : !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
+      ]} : !firrtl.clock, !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
 
     // TODO: Enable this
-    // CHECK: %bar_0_baz_0 = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_0_baz_1 = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_0_qux_0 = firrtl.reg %clock  {annotations = [{one}]} : !firrtl.uint<1>
-    // CHECK: %bar_0_qux_1 = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_0_yes_a = firrtl.reg %clock  {annotations = [{three}]} : !firrtl.uint<1>
-    // CHECK: %bar_0_yes_b = firrtl.reg %clock  {annotations = [{three}]} : !firrtl.uint<1>
-    // CHECK: %bar_1_baz_0 = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.uint<1>
-    // CHECK: %bar_1_baz_1 = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.uint<1>
-    // CHECK: %bar_1_qux_0 = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_1_qux_1 = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_1_yes_a = firrtl.reg %clock  : !firrtl.uint<1>
-    // CHECK: %bar_1_yes_b = firrtl.reg %clock  : !firrtl.uint<1>
+    // CHECK: %bar_0_baz_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_baz_1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_qux_0 = firrtl.reg %clock  {annotations = [{one}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_qux_1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_yes_a = firrtl.reg %clock  {annotations = [{three}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_0_yes_b = firrtl.reg %clock  {annotations = [{three}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_baz_0 = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_baz_1 = firrtl.reg %clock  {annotations = [{two}]} : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_qux_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_qux_1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_yes_a = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: %bar_1_yes_b = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   }
 
 // Test wire connection semantics.  Based on the flippedness of the destination
@@ -800,12 +800,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:      firrtl.strictconnect %a_1, %default_1 : !firrtl.uint<1>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %0  {
+// CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.strictconnect %a_0, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %1  {
+// CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.strictconnect %a_1, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -827,29 +827,29 @@ firrtl.circuit "TopLevel" {
 // CHECK-LABEL:    firrtl.module private @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a_0_0: !firrtl.uint<2>, out %a_0_1: !firrtl.uint<2>, out %a_1_0: !firrtl.uint<2>, out %a_1_1: !firrtl.uint<2>) {
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %0  {
+// CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:        firrtl.when %2  {
+// CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.strictconnect %a_0_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:        firrtl.when %3  {
+// CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.strictconnect %a_0_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %1  {
+// CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:        firrtl.when %2  {
+// CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.strictconnect %a_1_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:        firrtl.when %3  {
+// CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.strictconnect %a_1_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
@@ -879,12 +879,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:      firrtl.strictconnect %b_1_valid, %def_1_valid : !firrtl.uint<2>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %0  {
+// CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.strictconnect %b_0_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.when %1  {
+// CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.strictconnect %b_1_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -23,11 +23,11 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           %[[v1:.+]] = firrtl.subfield %mem_read[en]
     // CHECK:           %[[v2:.+]] = firrtl.subfield %mem_read[clk]
     // CHECK:           %[[v3:.+]] = firrtl.subfield %mem_read[data]
-    // CHECK:           %mem = firrtl.reg %[[v6:.+]]  : !firrtl.vector<uint<8>, 8>
+    // CHECK:           %mem = firrtl.reg %[[v6:.+]]  : !firrtl.clock, !firrtl.vector<uint<8>, 8>
     // CHECK:           %[[v23:.+]] = firrtl.subaccess %mem[%[[v4:.+]]]
     // CHECK:           %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
     // CHECK:           firrtl.strictconnect %[[v3]], %invalid_ui8 : !firrtl.uint<8>
-    // CHECK:           firrtl.when %[[v1]] {
+    // CHECK:           firrtl.when %[[v1]] : !firrtl.uint<1> {
     // CHECK:             firrtl.strictconnect %[[v3]], %[[v23]]
     // CHECK:           }
     // CHECK:           %mem_write = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
@@ -37,8 +37,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           %[[v8:.+]] = firrtl.subfield %mem_write[data]
     // CHECK:           %[[v9:.+]] = firrtl.subfield %mem_write[mask]
     // CHECK:           %[[v10:.+]] = firrtl.subaccess %mem[%[[v5]]]
-    // CHECK:           firrtl.when %[[v6]] {
-    // CHECK:             firrtl.when %[[v9]] {
+    // CHECK:           firrtl.when %[[v6]] : !firrtl.uint<1> {
+    // CHECK:             firrtl.when %[[v9]] : !firrtl.uint<1> {
     // CHECK:               firrtl.strictconnect %[[v10]], %[[v8]] : !firrtl.uint<8>
     // CHECK:             }
     // CHECK:           }
@@ -151,7 +151,7 @@ firrtl.circuit  "GCTModule" attributes {annotations = [
       // CHECK-SAME:      {circt.fieldID = 5 : i64, class = "firrtl.transforms.DontTouchAnnotation"},
       // CHECK-SAME:      {circt.fieldID = 6 : i64, class = "firrtl.transforms.DontTouchAnnotation"},
       // CHECK-SAME:      {circt.fieldID = 7 : i64, class = "firrtl.transforms.DontTouchAnnotation"},
-      // CHECK-SAME:      {circt.fieldID = 8 : i64, class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.vector<uint<8>, 8>
+      // CHECK-SAME:      {circt.fieldID = 8 : i64, class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.clock, !firrtl.vector<uint<8>, 8>
   }
 }
 
@@ -170,7 +170,7 @@ firrtl.circuit "WriteMask" attributes {annotations = [
     } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 2>>,
         !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
     // CHECK-LABEL: firrtl.module public @WriteMask()
-    // CHECK:         %mem = firrtl.reg %2  : !firrtl.vector<vector<uint<8>, 2>, 8>
+    // CHECK:         %mem = firrtl.reg %2  : !firrtl.clock, !firrtl.vector<vector<uint<8>, 2>, 8>
     // CHECK:         %mem_write = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
     // CHECK:         %[[v5:.+]] = firrtl.subfield %mem_write[addr]
     // CHECK:         %[[v6:.+]] = firrtl.subfield %mem_write[en]
@@ -184,11 +184,11 @@ firrtl.circuit "WriteMask" attributes {annotations = [
     // CHECK:         %[[v14:.+]] = firrtl.subindex
     // CHECK:         %[[v15:.+]] = firrtl.subindex
     // CHECK:         %[[v16:.+]] = firrtl.subindex
-    // CHECK:         firrtl.when %[[v6]] {
-    // CHECK:           firrtl.when %[[v13]] {
+    // CHECK:         firrtl.when %[[v6]] : !firrtl.uint<1> {
+    // CHECK:           firrtl.when %[[v13]] : !firrtl.uint<1> {
     // CHECK:             firrtl.strictconnect %[[v11]], %[[v12]] : !firrtl.uint<8>
     // CHECK:           }
-    // CHECK:           firrtl.when %[[v16]] {
+    // CHECK:           firrtl.when %[[v16]] : !firrtl.uint<1> {
     // CHECK:             firrtl.strictconnect %[[v14]], %[[v15]] : !firrtl.uint<8>
     // CHECK:           }
     %mem_read1, %mem_write1 = firrtl.mem Undefined {
@@ -230,7 +230,7 @@ firrtl.circuit "MemTap" attributes {annotations = [
     // CHECK-SAME:       {circt.fieldID = 2 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 1 : i64},
     // CHECK-SAME:       {circt.fieldID = 3 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 2 : i64},
     // CHECK-SAME:       {circt.fieldID = 4 : i64, class = "sifive.enterprise.grandcentral.MemTapAnnotation.source", id = 11 : i64, portID = 3 : i64}]}
-    // CHECK-SAME:      : !firrtl.vector<uint<32>, 4>
+    // CHECK-SAME:      : !firrtl.clock, !firrtl.vector<uint<32>, 4>
 	}
 
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -245,14 +245,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %c-85_si8 = firrtl.constant -85 : !firrtl.sint<8>
     sauto <= add(s8, SInt<8>(-85))
 
-    ; CHECK: firrtl.when %reset {
+    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: } else {
     ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: }
     when reset : _t <= _t_2 else : _t <- _t_2
 
-    ; CHECK: firrtl.when %reset {
+    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   [[N4A:%.+]] = firrtl.node interesting_name %_t_2
     ; CHECK:   firrtl.strictconnect %_t, [[N4A]]
     ; CHECK: } else {
@@ -268,18 +268,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: [[TMP:%.+]] = firrtl.constant 4
     ; CHECK: [[COND:%.+]] = firrtl.lt %reset, [[TMP]]
-    ; CHECK: firrtl.when [[COND]] {
+    ; CHECK: firrtl.when [[COND]] : !firrtl.uint<1> {
     ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: }
     ; CHECK-NOT: else
     when lt(reset, UInt(4)) :   ;; When with no else.
       _t <= _t_2
 
-    ; CHECK: firrtl.when %reset  {
+    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
-    ; CHECK:   firrtl.when [[COND]]  {
+    ; CHECK:   firrtl.when [[COND]] : !firrtl.uint<1> {
     ; CHECK:     firrtl.strictconnect %_t, %_t_2
     ; CHECK:   }
     ; CHECK: }
@@ -288,11 +288,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     else when not(reset) :
       _t <= _t_2
 
-    ; CHECK: firrtl.when %reset  {
+    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.strictconnect %_t, %_t
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
-    ; CHECK:   firrtl.when [[COND]]  {
+    ; CHECK:   firrtl.when [[COND]] : !firrtl.uint<1> {
     ; CHECK:     firrtl.strictconnect %_t, %_t_2
     ; CHECK:   } else  {
     ; CHECK:     firrtl.strictconnect %_t, %_t_2
@@ -305,16 +305,16 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     else :
       _t <= _t_2
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"} (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"} (%_t, %_t_2) : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2) : printf_0
 
-    ; CHECK: firrtl.stop %clock, %reset, 42
+    ; CHECK: firrtl.stop %clock, %reset, 42 : !firrtl.clock, !firrtl.uint<1>
     stop(clock, reset, 42)
 
-    ; CHECK: firrtl.stop %clock, %reset, 42 {name = "stop_0"}
+    ; CHECK: firrtl.stop %clock, %reset, 42 {name = "stop_0"} : !firrtl.clock, !firrtl.uint<1>
     stop(clock, reset, 42) : stop_0
 
     ; CHECK: firrtl.bits %i8 4 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<3>
@@ -335,11 +335,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint) -> !firrtl.uint
     node n8 = mux(reset, i8, UInt(4))
 
-    ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
     reg _t_2621 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0")) @[Edges.scala 230:27]
 
-    ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     reg _t_1601 : UInt<2>, clock with :
       (reset => (reset, UInt<2>("h00"))) @[Edges.scala 230:27]
 
@@ -357,7 +357,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; The Scala implementation of FIRRTL prints registers without a reset value
     ; using the register name as the reset.  Make sure we handle this for
     ; compatibility.
-    ; CHECK: %_t_2622 = firrtl.reg interesting_name %clock : !firrtl.uint<4>
+    ; CHECK: %_t_2622 = firrtl.reg interesting_name %clock : !firrtl.clock, !firrtl.uint<4>
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 
@@ -372,7 +372,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     myext.in <= i8
     printf(clock, reset, "Something interesting! %x", myext.out)
 
-    ; CHECK: firrtl.when %reset  {
+    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     when reset :
       ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance reset_myext interesting_name @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
       inst reset_myext of MyExtModule
@@ -445,17 +445,17 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire en: UInt <1>
     pred <= eq(i8, i8)
     en <= not(reset)
-    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false}
+    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
     assert(clock, pred, en, "X equals Y when Z is valid")
-    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false, name = "assert_0"}
+    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false, name = "assert_0"}
     assert(clock, pred, en, "X equals Y when Z is valid") : assert_0
-    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false}
+    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
     assume(clock, pred, en, "X equals Y when Z is valid")
-    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid" {eventControl = 0 : i32, isConcurrent = false, name = "assume_0"}
+    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false, name = "assume_0"}
     assume(clock, pred, en, "X equals Y when Z is valid") : assume_0
-    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false}
+    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
     cover(clock, pred, en, "X equals Y when Z is valid")
-    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" {eventControl = 0 : i32, isConcurrent = false, name = "cover_0"}
+    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false, name = "cover_0"}
     cover(clock, pred, en, "X equals Y when Z is valid") : cover_0
 
   ; CHECK-LABEL: firrtl.module private @type_handling(
@@ -505,15 +505,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in : UInt
     wire reset : UInt<1>
 
-  ; CHECK: firrtl.when {{.*}} {
+  ; CHECK: firrtl.when {{.*}} : !firrtl.uint<1> {
     when reset : @[Debug.scala 1176:37]
-    ; CHECK: firrtl.when {{.*}} {
+    ; CHECK: firrtl.when {{.*}} : !firrtl.uint<1> {
       when reset :
         out <= in
     ; CHECK: }
     ; CHECK: } else {
     else :
-        ; CHECK: firrtl.when {{.*}} {
+        ; CHECK: firrtl.when {{.*}} : !firrtl.uint<1> {
       when reset : @[Debug.scala 1180:39]
         out <= in
     ; CHECK: }
@@ -533,13 +533,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     smem memory : UInt<1>[9] [256]
 
     ; CHECK: %xyz0_data, %xyz0_port = chirrtl.memoryport Read %memory {name = "xyz0"} : (!chirrtl.cmemory<vector<uint<1>, 9>, 256>) -> (!firrtl.vector<uint<1>, 9>, !chirrtl.cmemoryport)
-    ; CHECK: firrtl.when %cond  {
+    ; CHECK: firrtl.when %cond : !firrtl.uint<1> {
     ; CHECK:    chirrtl.memoryport.access %xyz0_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint, !firrtl.clock
     ; CHECK: }
     when cond :
       read mport xyz0 = memory[addr], clock
 
-    ; CHECK: firrtl.when %cond  {
+    ; CHECK: firrtl.when %cond : !firrtl.uint<1> {
     ; CHECK:    %n0 = firrtl.node interesting_name %xyz0_data  : !firrtl.vector<uint<1>, 9>
     ; CHECK: }
     when cond :
@@ -561,13 +561,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ;; Constants always get emitted to the top level.
     ; CHECK: [[CST7:%.+]] = firrtl.constant 7 : !firrtl.uint<4>
-    ; CHECK: firrtl.when %cond {
+    ; CHECK: firrtl.when %cond : !firrtl.uint<1> {
     when cond :
       ; CHECK: %c = firrtl.node interesting_name [[CST15]]
       node c = UInt<4>(15)
       ; CHECK: %d = firrtl.node interesting_name [[CST7]]
       node d = UInt<4>(7)
-      ; CHECK: firrtl.when %cond {
+      ; CHECK: firrtl.when %cond : !firrtl.uint<1> {
       when cond :
         ; CHECK:  %e = firrtl.node interesting_name [[CST7]]
         node e = UInt<4>(7)
@@ -590,7 +590,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %n3 = firrtl.node interesting_name [[SUB]]
     node n3 = i.x
 
-    ; CHECK: firrtl.when %cond {
+    ; CHECK: firrtl.when %cond : !firrtl.uint<1> {
     when cond:
       ; CHECK: %n4 = firrtl.node interesting_name [[SUB]]
       node n4 = i.x
@@ -611,7 +611,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %0 = firrtl.subfield %bf[int_1]
     ; CHECK: %_T = firrtl.node interesting_name %0
     node _T = bf.int_1
-    ; CHECK: firrtl.when %_T {
+    ; CHECK: firrtl.when %_T : !firrtl.uint<1> {
     when _T :
       skip
 
@@ -952,56 +952,56 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "assert:foo 0", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0" {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "assume:foo 1", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1" {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "cover:foo 2", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 2" {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 2" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "assert:foo_0:", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_0"}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_0"}
 
     when cond:
       printf(clock, enable, "assume:foo_1:", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_1"}
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_1"}
 
     when cond:
       printf(clock, enable, "cover:foo_2:", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_2"}
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_2"}
 
     when cond:
       printf(clock, enable, "assert:custom label 0:foo 3", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0"}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0"}
 
     when cond:
       printf(clock, enable, "assume:custom label 1:foo 4", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 1"}
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 1"}
 
     when cond:
       printf(clock, enable, "cover:custom label 2:foo 5", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 5" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 2"}
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 5" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 2"}
 
     ; Optional `stop` with same clock and condition should be removed.
     when cond:
       printf(clock, enable, "assert:without_stop")
       stop(clock, enable, 1)
-    ; CHECK: firrtl.assert %clock, {{%.+}}, %enable, "without_stop"
+    ; CHECK: firrtl.assert %clock, {{%.+}}, %enable, "without_stop" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK-NOT: firrtl.stop
 
     when cond:
       ; expected-warning @+1 {{printf-encoded assertion has format string arguments which may cause lint warnings}}
       printf(clock, enable, "assert:foo 6, %d", value, value)
-    ; CHECK: firrtl.assert {{.+}} "foo 6, %d"(%value)
+    ; CHECK: firrtl.assert {{.+}} "foo 6, %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
 
     ; AssertNotX -- usually `cond` only checks for not-in-reset, and `enable` is
     ; just set to 1; the actual check `^value !== 'x` is implicit.
@@ -1012,7 +1012,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[TMP3:%.+]] = firrtl.int.isX
     ; CHECK: [[TMP4:%.+]] = firrtl.not
     ; CHECK: [[TMP5:%.+]] = firrtl.or [[TMP1]], [[TMP4]]
-    ; CHECK: firrtl.assert %clock, [[TMP5]], %enable, "value must not be X!"
+    ; CHECK: firrtl.assert %clock, [[TMP5]], %enable, "value must not be X!" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK-SAME: name = "notX"
 
     ; Chisel built-in assertions
@@ -1020,7 +1020,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       printf(clock, enable, "Assertion failed with value %d", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed with value %d"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed with value %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
@@ -1029,7 +1029,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       printf(clock, enable, "Assertion failed: some message with value %d", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message with value %d"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message with value %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
@@ -1041,7 +1041,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
@@ -1054,7 +1054,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
@@ -1066,7 +1066,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_voodoo"
 
@@ -1078,7 +1078,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_voodoo"
 
@@ -1087,9 +1087,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node not_cond = eq(cond, UInt<1>(0))
     when not_cond:
       printf(clock, enable, "Assertion failed: hello")
-    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello"
+    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: name = "chisel3_builtin"
 
@@ -1098,10 +1098,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       node not_cond2 = eq(cond, UInt<1>(0))
       when not_cond2:
         printf(clock, enable, "Assertion failed: hello outside reset")
-    ; CHECK: firrtl.when %not_reset {
-    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello outside reset"
+    ; CHECK: firrtl.when %not_reset : !firrtl.uint<1> {
+    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello outside reset" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond2
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello outside reset"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello outside reset" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: name = "chisel3_builtin"
     ; CHECK: }
@@ -1113,13 +1113,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       node not_cond3 = eq(UInt<1>(1), UInt<1>(0))
       when not_cond3:
         printf(clock, UInt<1>(1), "Assertion failed: double user assert")
-    ; CHECK-NOT: firrtl.assert %clock, {{.+}} "double user assert"
+    ; CHECK-NOT: firrtl.assert %clock, {{.+}} "double user assert" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 
     when cond :
         printf(clock, not(enable), "assert: bar")
     ; CHECK: [[NOT_ENABLE:%.+]] = firrtl.not %enable
     ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]]
+    ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]], " bar" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     ; Verification Library Covers
 
@@ -1129,8 +1129,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     assert(clock, cond, enable, "")
     ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
-    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
-    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.uint<42>
+    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_cover_label"
 

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -12,7 +12,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1_dead = firrtl.invalidvalue : !firrtl.uint<1>
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %invalid_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %invalid_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -25,7 +25,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.connect %inv, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %inv  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -46,8 +46,8 @@ firrtl.circuit "SFCCompatTests" {
     %inv1_1 = firrtl.subindex %inv1[0] : !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.strictconnect %inv1_1, %inv : !firrtl.bundle<a: uint<1>>
 
-    // CHECK: firrtl.reg %clock : !firrtl.vector<bundle<a: uint<1>>, 2>
-    %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>, !firrtl.vector<bundle<a: uint<1>>, 2>
+    // CHECK: firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<a: uint<1>>, 2>
+    %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>, !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.strictconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.strictconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
   }
@@ -61,7 +61,7 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.connect %inv, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %x, %inv : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %x  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %x  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -78,7 +78,7 @@ firrtl.circuit "SFCCompatTests" {
     %submodule_inv = firrtl.instance submodule  @InvalidInstancePort_Submodule(in inv: !firrtl.uint<1>)
     firrtl.connect %submodule_inv, %inv : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %submodule_inv  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %submodule_inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -88,7 +88,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     %0 = firrtl.not %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: firrtl.regreset %clock
-    %r = firrtl.regreset %clock, %reset, %0  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %0  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -100,7 +100,7 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.connect %inv, %invalid_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
     %_T = firrtl.node %inv  : !firrtl.uint<8>
     // CHECK: firrtl.regreset %clock
-    %r = firrtl.regreset %clock, %reset, %_T  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %_T  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %r, %d : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %q, %r : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -127,21 +127,21 @@ firrtl.circuit "SFCCompatTests" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
     firrtl.strictconnect %r0_init, %c0_ui1 : !firrtl.uint<1>
-    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %r1_init = firrtl.node %c0_ui1 : !firrtl.uint<1>
-    %r1 = firrtl.regreset %clock, %reset, %r1_init : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r1 = firrtl.regreset %clock, %reset, %r1_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %inv_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     %r2_init = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %r2_init, %inv_ui1 : !firrtl.uint<1>
-    %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %c0_si1 = firrtl.asSInt %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
     %c0_clock = firrtl.asClock %c0_si1 : (!firrtl.sint<1>) -> !firrtl.clock
     %c0_asyncreset = firrtl.asAsyncReset %c0_clock : (!firrtl.clock) -> !firrtl.asyncreset
     %r3_init = firrtl.asUInt %c0_asyncreset : (!firrtl.asyncreset) -> !firrtl.uint<1>
-    %r3 = firrtl.regreset %clock, %reset, %r3_init : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r3 = firrtl.regreset %clock, %reset, %r3_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @TailPrimOp
@@ -151,7 +151,7 @@ firrtl.circuit "SFCCompatTests" {
     %1 = firrtl.tail %0, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
     firrtl.strictconnect %r0_init, %1: !firrtl.uint<1>
-    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -161,7 +161,7 @@ firrtl.circuit "NonConstantAsyncReset_Port" {
   // expected-note @below {{reset driver is "x"}}
   firrtl.module @NonConstantAsyncReset_Port(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %x: !firrtl.uint<1>) {
     // expected-error @below {{register "r0" has an async reset, but its reset value "x" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %x : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %x : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -173,7 +173,7 @@ firrtl.circuit "NonConstantAsyncReset_PrimOp" {
     // expected-note @+1 {{reset driver is here}}
     %c1_ui1 = firrtl.not %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-error @below {{register "r0" has an async reset, but its reset value is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -185,7 +185,7 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate0" {
     %value = firrtl.wire : !firrtl.vector<uint<1>, 2>
     firrtl.strictconnect %value, %x : !firrtl.vector<uint<1>, 2>
     // expected-error @below {{register "r0" has an async reset, but its reset value "value" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
 }
 
@@ -211,6 +211,6 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate1" {
     firrtl.strictconnect %value_1, %subfield : !firrtl.uint<1>
 
     // expected-error @below {{register "r0" has an async reset, but its reset value "value[1]" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
 }

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -163,8 +163,8 @@ firrtl.circuit "UnusedPorts" {
         !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>,
         !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
 
-    // CHECK: [[REG1:%.+]] = firrtl.reg %c0_clock : !firrtl.uint<42>
-    // CHECK: [[REG2:%.+]] = firrtl.reg %c0_clock : !firrtl.uint<42>
+    // CHECK: [[REG1:%.+]] = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<42>
+    // CHECK: [[REG2:%.+]] = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: firrtl.strictconnect %result_read, [[REG1]] : !firrtl.uint<42>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -375,7 +375,7 @@ firrtl.circuit "OneAddressMasked" {
       } :
         !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>,
         !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
-    // CHECK: %Memory = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
 
     // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
 
@@ -429,25 +429,25 @@ firrtl.circuit "OneAddressNoMask" {
     // Pipeline the inputs.
     // TODO: It would be good to de-duplicate these either in the pass or in a canonicalizer.
 
-    // CHECK: %Memory_write_en_0 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_write_en_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_write_en_0, %in_wen : !firrtl.uint<1>
-    // CHECK: %Memory_write_en_1 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_write_en_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_write_en_1, %Memory_write_en_0 : !firrtl.uint<1>
-    // CHECK: %Memory_write_en_2 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_write_en_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_write_en_2, %Memory_write_en_1 : !firrtl.uint<1>
 
-    // CHECK: %Memory_write_data_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_write_data_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_write_data_0, %in_data : !firrtl.uint<32>
-    // CHECK: %Memory_write_data_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_write_data_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_write_data_1, %Memory_write_data_0 : !firrtl.uint<32>
-    // CHECK: %Memory_write_data_2 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_write_data_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_write_data_2, %Memory_write_data_1 : !firrtl.uint<32>
 
-    // CHECK: %Memory_rw_wdata_0 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_rw_wdata_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_rw_wdata_0, %in_data : !firrtl.uint<32>
-    // CHECK: %Memory_rw_wdata_1 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_rw_wdata_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_rw_wdata_1, %Memory_rw_wdata_0 : !firrtl.uint<32>
-    // CHECK: %Memory_rw_wdata_2 = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory_rw_wdata_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
     // CHECK: firrtl.strictconnect %Memory_rw_wdata_2, %Memory_rw_wdata_1 : !firrtl.uint<32>
 
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
@@ -464,7 +464,7 @@ firrtl.circuit "OneAddressNoMask" {
         !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>,
         !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
 
-    // CHECK: %Memory = firrtl.reg %clock : !firrtl.uint<32>
+    // CHECK: %Memory = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
 
     // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -493,11 +493,11 @@ firrtl.circuit "OneAddressNoMask" {
     firrtl.connect %rw_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: [[WRITING:%.+]] = firrtl.and %in_rwen, %wmode_rw : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: %Memory_rw_wen_0 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_rw_wen_0, [[WRITING]] : !firrtl.uint<1>
-    // CHECK: %Memory_rw_wen_1 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_rw_wen_1, %Memory_rw_wen_0 : !firrtl.uint<1>
-    // CHECK: %Memory_rw_wen_2 = firrtl.reg %clock : !firrtl.uint<1>
+    // CHECK: %Memory_rw_wen_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %Memory_rw_wen_2, %Memory_rw_wen_1 : !firrtl.uint<1>
     // CHECK: [[WRITE_RW:%.+]] = firrtl.mux(%Memory_rw_wen_2, %Memory_rw_wdata_2, %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
     // CHECK: [[WRITE_W:%.+]] = firrtl.mux(%Memory_write_en_2, %Memory_write_data_2, [[WRITE_RW]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -130,7 +130,7 @@ firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {
 // We allow implicit truncation of a register's reset value.
 // CHECK-LABEL: @RegResetTruncation
 firrtl.module @RegResetTruncation(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %value: !firrtl.bundle<a: uint<2>>, out %out: !firrtl.bundle<a: uint<1>>) {
-  %r2 = firrtl.regreset %clock, %reset, %value  : !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<1>>
+  %r2 = firrtl.regreset %clock, %reset, %value  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<1>>
   firrtl.connect %out, %r2 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
 }
 

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -180,8 +180,8 @@ firrtl.circuit "Test" {
   
   // CHECK-LABEL: @TestReg
   firrtl.module @TestReg(in %clock: !firrtl.clock) {
-    // CHECK: %r = firrtl.reg %clock : !firrtl.bundle<a: vector<uint<8>, 2>>
-    %r = firrtl.reg %clock : !firrtl.vector<bundle<a: uint<8>>, 2>
+    // CHECK: %r = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: vector<uint<8>, 2>>
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<a: uint<8>>, 2>
   }
 
   // CHECK-LABEL: @TestRegReset
@@ -190,8 +190,8 @@ firrtl.circuit "Test" {
      %rval = firrtl.aggregateconstant [[1, 2], [3, 4]] : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2> 
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %rsig = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %0 : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
-    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
+    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
+    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
   }
 
   // CHECK-LABEL: @TestRegResetMaterializedFromExplodedBundle
@@ -206,8 +206,8 @@ firrtl.circuit "Test" {
     %rval = firrtl.subindex %storage[0] : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %rsig = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %5 : !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
-    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
+    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
+    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
   }
 
   // CHECK-LABEL: @TestRegResetMaterializedFromDeepExplodedBundle
@@ -223,11 +223,11 @@ firrtl.circuit "Test" {
     // CHECK: %8 = firrtl.bundlecreate %5, %3 : (!firrtl.uint<8>, !firrtl.uint<16>) -> !firrtl.bundle<c: uint<8>, d: uint<16>>
     // CHECK: %9 = firrtl.bundlecreate %7, %8 : (!firrtl.uint<4>, !firrtl.bundle<c: uint<8>, d: uint<16>>) -> !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %reg = firrtl.regreset %clock, %c0_ui1, %9 : !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
+    // CHECK: %reg = firrtl.regreset %clock, %c0_ui1, %9 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
     %reset_value_storage = firrtl.aggregateconstant [[1, [2, 3]], [4, [5, 6]]] : !firrtl.vector<bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, 2> 
     %reset_value = firrtl.subindex %reset_value_storage[1] : !firrtl.vector<bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, 2>
     %reset = firrtl.constant 0 : !firrtl.uint<1>
-    %reg = firrtl.regreset %clock, %reset, %reset_value : !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
+    %reg = firrtl.regreset %clock, %reset, %reset_value : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
   }
 
   // CHECK-LABEL: @TestInstance
@@ -543,21 +543,21 @@ firrtl.circuit "Test" {
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: uint<8>>
     // CHECK: %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
     // CHECK: %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    // CHECK: firrtl.when %c1_ui1 {
+    // CHECK: firrtl.when %c1_ui1 : !firrtl.uint<1> {
     // CHECK:   %n2 = firrtl.node %0 : !firrtl.uint<8>
     // CHECK: }
     // CHECK: %n3 = firrtl.node %0 : !firrtl.uint<8>
-    // CHECK: firrtl.when %c1_ui1 {
+    // CHECK: firrtl.when %c1_ui1 : !firrtl.uint<1> {
     // CHECK:   %w2 = firrtl.wire : !firrtl.bundle<a: vector<uint<8>, 2>>
     // CHECK: }
     %w = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %a = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
     %p = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       %n2 = firrtl.node %a : !firrtl.uint<8>
     }
     %n3 = firrtl.node %a : !firrtl.uint<8>
-    firrtl.when %p {
+    firrtl.when %p : !firrtl.uint<1> {
       %w2 = firrtl.wire : !firrtl.vector<bundle<a: uint<8>>, 2>
     }
   }
@@ -567,7 +567,7 @@ firrtl.circuit "Test" {
     // CHECK: %0 = firrtl.aggregateconstant [123] : !firrtl.vector<uint<8>, 1>
     // CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
     // CHECK: %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    // CHECK: firrtl.when %c1_ui1 {
+    // CHECK: firrtl.when %c1_ui1 : !firrtl.uint<1> {
     // CHECK:   %2 = firrtl.subaccess %0[%c0_ui8] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
     // CHECK:   %nod_0 = firrtl.node %2 {name = "nod"} : !firrtl.uint<8>
     // CHECK: }
@@ -576,7 +576,7 @@ firrtl.circuit "Test" {
     %vec = firrtl.aggregateconstant [123] :  !firrtl.vector<uint<8>, 1>
     %idx = firrtl.constant 0 : !firrtl.uint<8>
     %cnd = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.when %cnd {
+    firrtl.when %cnd : !firrtl.uint<1> {
       %val = firrtl.subaccess %vec[%idx] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
       %nod = firrtl.node %val : !firrtl.uint<8>
     }

--- a/test/circt-reduce/test/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/test/connect-source-operand-forward.mlir
@@ -5,15 +5,15 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %val: !firrtl.uint<2>) {
     %a = firrtl.wire : !firrtl.uint<1>
-    %b = firrtl.reg %clock : !firrtl.uint<1>
-    %c = firrtl.regreset %clock, %reset, %reset : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %b = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+    %c = firrtl.regreset %clock, %reset, %reset : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.bits %val 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT:   %a = firrtl.wire  : !firrtl.uint<2>
-    // CHECK-NEXT:   %b = firrtl.reg %clock  : !firrtl.uint<2>
-    // CHECK-NEXT:   %c = firrtl.reg %clock  : !firrtl.uint<2>
+    // CHECK-NEXT:   %b = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<2>
+    // CHECK-NEXT:   %c = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<2>
     // CHECK-NEXT:   firrtl.connect %a, %val : !firrtl.uint<2>, !firrtl.uint<2>
     // CHECK-NEXT:   firrtl.connect %b, %val : !firrtl.uint<2>, !firrtl.uint<2>
     // CHECK-NEXT:   firrtl.connect %c, %val : !firrtl.uint<2>, !firrtl.uint<2>

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -5,7 +5,7 @@
 
 ; CHECK-LABEL: firrtl.module @Issue794
 ; CHECK-SAME: (in %clock: !firrtl.clock,
-; CHECK:       %[[memory_0:.+]] = firrtl.reg %clock {{.*}}: !firrtl.uint<8>
+; CHECK:       %[[memory_0:.+]] = firrtl.reg %clock {{.*}}: !firrtl.clock, !firrtl.uint<8>
 ; CHECK:       firrtl.mux(%[[v14:.+]], %wData_0, %[[memory_0]])
 ; CHECK:       firrtl.mux(%[[v19:.+]], %wData_1, %[[v5:.+]])
 ; CHECK:       firrtl.strictconnect %[[memory_0]], %[[v22:.+]]


### PR DESCRIPTION
Since all hardware types will be able to be 'const', previously buildable types will no longer be able to be default constructed. This change will facilitate adding const support to various FIRRTL ops.

This change only affects op type printing and parsing.