### PR TITLE
[SV] Move emitAsComment to SVAttributeAttr; remove SVAttributesAttr

### DIFF
--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -25,19 +25,13 @@ MLIR_CAPI_EXPORTED void registerSVPasses();
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED bool svAttrIsASVAttributeAttr(MlirAttribute);
-MLIR_CAPI_EXPORTED MlirAttribute svSVAttributeAttrGet(MlirContext cCtxt,
+MLIR_CAPI_EXPORTED MlirAttribute svSVAttributeAttrGet(MlirContext,
                                                       MlirStringRef name,
-                                                      MlirStringRef expression);
+                                                      MlirStringRef expression,
+                                                      bool emitAsComment);
 MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetName(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute);
-
-MLIR_CAPI_EXPORTED bool svAttrIsASVAttributesAttr(MlirAttribute);
-MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGet(MlirContext cCtxt,
-                                                       MlirAttribute attributes,
-                                                       bool emitAsComments);
-MLIR_CAPI_EXPORTED MlirAttribute svSVAttributesAttrGetAttributes(MlirAttribute);
-MLIR_CAPI_EXPORTED
-bool svSVAttributesAttrGetEmitAsComments(MlirAttribute);
+MLIR_CAPI_EXPORTED bool svSVAttributeAttrGetEmitAsComment(MlirAttribute);
 
 #ifdef __cplusplus
 }

--- a/include/circt/Dialect/SV/SVAttributes.h
+++ b/include/circt/Dialect/SV/SVAttributes.h
@@ -11,23 +11,65 @@
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include "circt/Dialect/SV/SVEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SV/SVAttributes.h.inc"
 
 namespace circt {
 namespace sv {
-class SVAttributesAttr;
 
 /// Helper functions to handle SV attributes.
 bool hasSVAttributes(mlir::Operation *op);
-SVAttributesAttr getSVAttributes(mlir::Operation *op);
-void setSVAttributes(mlir::Operation *op, mlir::Attribute);
+
+/// Return all the SV attributes of an operation, or null if there are none. All
+/// array elements are `SVAttributeAttr`.
+mlir::ArrayAttr getSVAttributes(mlir::Operation *op);
+
+/// Set the SV attributes of an operation. If `attrs` is null or contains no
+/// attributes, the attribute is removed from the op.
+void setSVAttributes(mlir::Operation *op, mlir::ArrayAttr attrs);
+
+/// Set the SV attributes of an operation. If `attrs` is empty the attribute is
+/// removed from the op. The attributes are deduplicated such that only one copy
+/// of each attribute is kept on the operation.
+void setSVAttributes(mlir::Operation *op,
+                     mlir::ArrayRef<SVAttributeAttr> attrs);
+
+/// Check if an op contains a specific SV attribute.
+inline bool hasSVAttribute(mlir::Operation *op, SVAttributeAttr attr) {
+  return llvm::is_contained(getSVAttributes(op), attr);
+}
+
+/// Modify the list of SV attributes of an operation. This function offers a
+/// read-modify-write interface where the callback can modify the list of
+/// attributes how it sees fit. Returns true if any modifications occurred.
+bool modifySVAttributes(
+    mlir::Operation *op,
+    llvm::function_ref<void(llvm::SmallVectorImpl<SVAttributeAttr> &)>
+        modifyCallback);
+
+/// Add a list of SV attributes to an operation. The attributes are deduplicated
+/// such that only one copy of each attribute is kept on the operation. Returns
+/// the number of attributes that were added.
+unsigned addSVAttributes(mlir::Operation *op,
+                         llvm::ArrayRef<SVAttributeAttr> attrs);
+
+/// Remove the SV attributes from an operation for which `removeCallback`
+/// returns true. Returns the number of attributes actually removed.
+unsigned
+removeSVAttributes(mlir::Operation *op,
+                   llvm::function_ref<bool(SVAttributeAttr)> removeCallback);
+
+/// Remove a list of SV attributes from an operation. Returns the number of
+/// attributes actually removed.
+unsigned removeSVAttributes(mlir::Operation *op,
+                            llvm::ArrayRef<SVAttributeAttr> attrs);
 
 } // namespace sv
-
 } // namespace circt
-
-#define GET_ATTRDEF_CLASSES
-#include "circt/Dialect/SV/SVAttributes.h.inc"
 
 #endif // CIRCT_DIALECT_SV_SVATTRIBUTES_H

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -53,42 +53,41 @@ def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
     For more information, refer to Section 5.12 of the SystemVerilog (1800-2017)
     specification.
   }];
-  let parameters = (ins "::mlir::StringAttr":$name,
-                        OptionalParameter<"::mlir::StringAttr">:$expression);
+  let parameters = (ins
+    "::mlir::StringAttr":$name,
+    OptionalParameter<"::mlir::StringAttr">:$expression,
+    DefaultValuedParameter<
+      "mlir::BoolAttr", "mlir::BoolAttr::get($_ctxt, false)">:$emitAsComment
+  );
 
-  let assemblyFormat = [{ `<` $name ( `=` $expression^ )? `>` }];
+  let builders = [
+    AttrBuilder<(ins "::llvm::StringRef":$name,
+                     CArg<"bool", "false">: $emitAsComment), [{
+      return get(context, StringAttr::get(context, name), StringAttr(),
+                 BoolAttr::get(context, emitAsComment));
+    }]>,
+    AttrBuilder<(ins "::mlir::StringAttr":$name,
+                     CArg<"bool", "false">: $emitAsComment), [{
+      return get(context, name, StringAttr(),
+                 BoolAttr::get(context, emitAsComment));
+    }]>,
+    AttrBuilder<(ins "::llvm::StringRef":$name,
+                     "::llvm::StringRef":$expression,
+                     CArg<"bool", "false">: $emitAsComment), [{
+      return get(context, StringAttr::get(context, name),
+                 StringAttr::get(context, expression),
+                 BoolAttr::get(context, emitAsComment));
+    }]>,
+    AttrBuilder<(ins "::mlir::StringAttr":$name,
+                     "::mlir::StringAttr":$expression,
+                     CArg<"bool", "false">: $emitAsComment), [{
+      return get(context, name, expression,
+                 BoolAttr::get(context, emitAsComment));
+    }]>
+  ];
+  let hasCustomAssemblyFormat = true;
   let extraClassDeclaration = [{
     static inline llvm::StringRef
         getSVAttributesAttrName() { return "sv.attributes"; }
   }];
-}
-
-def SVAttributesAttr : AttrDef<SVDialect, "SVAttributes"> {
-  let summary = "A container of system verilog attributes";
-  let mnemonic = "attributes";
-  let description = [{
-    This attribute is used to store SV attributes. The `attributes` field
-    represents SV attributes we want to annotate. The `emitAsComments` field
-    controls its emission style: SV spec defines the syntax of SV attributes as
-    `(* identifier (= identifer)? *)`. However, unfortunately many vendor-specific
-    pragmas violate the syntax and they are intended to be attached as comments.
-    Hence we emit given attributes as comments if `emitAsComments` field is true.
-  }];
-  let parameters = (ins "mlir::ArrayAttr":$attributes,
-                      DefaultValuedParameter<"mlir::BoolAttr",
-                      "mlir::BoolAttr::get($_ctxt, false)">:$emitAsComments);
-  let builders = [
-    AttrBuilder<(ins "llvm::ArrayRef<llvm::StringRef>":$strings,
-                     CArg<"bool", "false">: $emitAsComments), [{
-      SmallVector<Attribute> attrs;
-      for (auto str : strings)
-        attrs.push_back(sv::SVAttributeAttr::get(
-            $_ctxt, ::mlir::StringAttr::get($_ctxt, str), ::mlir::StringAttr()));
-      return $_get($_ctxt, ::mlir::ArrayAttr::get($_ctxt, attrs),
-                   ::mlir::BoolAttr::get($_ctxt, emitAsComments));
-    }]>,
-    AttrBuilder<(ins
-      "llvm::ArrayRef<std::pair<llvm::StringRef, llvm::StringRef>>":$keyValuePairs,
-       CArg<"bool", "false">: $emitAsComments)>];
-  let hasCustomAssemblyFormat = true;
 }

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -44,12 +44,11 @@ with Context() as ctx, Location.unknown():
       # CHECK: %FuBar = seq.compreg {{.+}}
       seq.reg(reg_input, module.clk, name="FuBar")
 
-      # CHECK: %reg1 = seq.compreg %[[INPUT_VAL]], %clk {sv.attributes = #sv.attributes<[#sv.attribute<"no_merge">]>} : i32
+      # CHECK: %reg1 = seq.compreg %[[INPUT_VAL]], %clk {sv.attributes = [#sv.attribute<"no_merge">]} : i32
       sv_attr = sv.SVAttributeAttr.get("no_merge")
       reg1 = seq.CompRegOp.create(i32, clk=module.clk, name="reg1")
 
-      reg1.attributes["sv.attributes"] = sv.SVAttributesAttr.get(
-          ArrayAttr.get([sv_attr]))
+      reg1.attributes["sv.attributes"] = ArrayAttr.get([sv_attr])
       connect(reg1.input, reg_input)
 
       # CHECK: %reg2 = seq.compreg %[[INPUT_VAL]], %clk

--- a/lib/Bindings/Python/SVModule.cpp
+++ b/lib/Bindings/Python/SVModule.cpp
@@ -31,7 +31,7 @@ void circt::python::populateDialectSVSubmodule(py::module &m) {
       .def_classmethod(
           "get",
           [](py::object cls, std::string name, py::object expressionObj,
-             MlirContext ctxt) {
+             bool emitAsComment, MlirContext ctxt) {
             // Need temporary storage for casted string.
             std::string expr;
             MlirStringRef expression = {nullptr, 0};
@@ -40,11 +40,12 @@ void circt::python::populateDialectSVSubmodule(py::module &m) {
               expression = mlirStringRefCreateFromCString(expr.c_str());
             }
             return cls(svSVAttributeAttrGet(
-                ctxt, mlirStringRefCreateFromCString(name.c_str()),
-                expression));
+                ctxt, mlirStringRefCreateFromCString(name.c_str()), expression,
+                emitAsComment));
           },
           "Create a SystemVerilog attribute", py::arg(), py::arg("name"),
-          py::arg("expression") = py::none(), py::arg("ctxt") = py::none())
+          py::arg("expression") = py::none(),
+          py::arg("emit_as_comment") = py::none(), py::arg("ctxt") = py::none())
       .def_property_readonly("name",
                              [](MlirAttribute self) {
                                MlirStringRef name =
@@ -52,28 +53,14 @@ void circt::python::populateDialectSVSubmodule(py::module &m) {
                                return std::string(name.data, name.length);
                              })
       .def_property_readonly(
-          "expression", [](MlirAttribute self) -> py::object {
+          "expression",
+          [](MlirAttribute self) -> py::object {
             MlirStringRef name = svSVAttributeAttrGetExpression(self);
             if (name.data == nullptr)
               return py::none();
             return py::str(std::string(name.data, name.length));
-          });
-
-  mlir_attribute_subclass(m, "SVAttributesAttr", svAttrIsASVAttributesAttr)
-      .def_classmethod(
-          "get",
-          [](py::object cls, MlirAttribute attributes, bool emitAsComments,
-             MlirContext ctxt) {
-            return cls(svSVAttributesAttrGet(ctxt, attributes, emitAsComments));
-          },
-          "Create SV attributes attr", py::arg(), py::arg("attributes"),
-          py::arg("emit_as_comments") = py::none(),
-          py::arg("ctxt") = py::none())
-      .def_property_readonly("attributes",
-                             [](MlirAttribute self) {
-                               return svSVAttributesAttrGetAttributes(self);
-                             })
-      .def_property_readonly("emit_as_comments", [](MlirAttribute self) {
-        return svSVAttributesAttrGetEmitAsComments(self);
+          })
+      .def_property_readonly("emit_as_comment", [](MlirAttribute self) {
+        return svSVAttributeAttrGetEmitAsComment(self);
       });
 }

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -22,13 +22,15 @@ bool svAttrIsASVAttributeAttr(MlirAttribute cAttr) {
 }
 
 MlirAttribute svSVAttributeAttrGet(MlirContext cCtxt, MlirStringRef cName,
-                                   MlirStringRef cExpression) {
+                                   MlirStringRef cExpression,
+                                   bool emitAsComment) {
   mlir::MLIRContext *ctxt = unwrap(cCtxt);
   mlir::StringAttr expr;
   if (cExpression.data != nullptr)
     expr = mlir::StringAttr::get(ctxt, unwrap(cExpression));
-  return wrap(SVAttributeAttr::get(
-      ctxt, mlir::StringAttr::get(ctxt, unwrap(cName)), expr));
+  return wrap(
+      SVAttributeAttr::get(ctxt, mlir::StringAttr::get(ctxt, unwrap(cName)),
+                           expr, mlir::BoolAttr::get(ctxt, emitAsComment)));
 }
 
 MlirStringRef svSVAttributeAttrGetName(MlirAttribute cAttr) {
@@ -42,25 +44,9 @@ MlirStringRef svSVAttributeAttrGetExpression(MlirAttribute cAttr) {
   return {nullptr, 0};
 }
 
-bool svAttrIsASVAttributesAttr(MlirAttribute cAttr) {
-  return unwrap(cAttr).isa<SVAttributesAttr>();
-}
-
-MlirAttribute svSVAttributesAttrGet(MlirContext cCtxt, MlirAttribute attributes,
-                                    bool emitAsComments) {
-  mlir::MLIRContext *ctxt = unwrap(cCtxt);
-  return wrap(SVAttributesAttr::get(ctxt,
-                                    unwrap(attributes).cast<mlir::ArrayAttr>(),
-                                    mlir::BoolAttr::get(ctxt, emitAsComments)));
-}
-
-MlirAttribute svSVAttributesAttrGetAttributes(MlirAttribute attributes) {
-  return wrap(unwrap(attributes).cast<SVAttributesAttr>().getAttributes());
-}
-
-bool svSVAttributesAttrGetEmitAsComments(MlirAttribute attributes) {
-  return unwrap(attributes)
-      .cast<SVAttributesAttr>()
-      .getEmitAsComments()
+bool svSVAttributeAttrGetEmitAsComment(MlirAttribute attribute) {
+  return unwrap(attribute)
+      .cast<SVAttributeAttr>()
+      .getEmitAsComment()
       .getValue();
 }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -767,14 +767,16 @@ static void emitSVAttributesImpl(PPS &ps, ArrayAttr attrs, bool mayBreak) {
     currentContainer = NoContainer;
   };
 
+  bool isFirstContainer = true;
   auto openContainer = [&](Container newContainer) {
     assert(newContainer != NoContainer);
     if (currentContainer == newContainer)
       return false;
     closeContainer();
     // If not first container, insert break point but no space.
-    if (mayBreak && currentContainer != newContainer)
-      ps << PP::zerobreak;
+    if (!isFirstContainer)
+      ps << (mayBreak ? PP::space : PP::nbsp);
+    isFirstContainer = false;
     // fit container on one line if possible, break if needed.
     ps << PP::ibox0;
     if (newContainer == InComment)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3601,14 +3601,14 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
     // Use SV attributes to annotate pragmas.
     circt::sv::setSVAttributes(
         arrayGet,
-        sv::SVAttributesAttr::get(builder.getContext(), {"cadence map_to_mux"},
-                                  /*emitAsComments=*/true));
+        sv::SVAttributeAttr::get(builder.getContext(), "cadence map_to_mux",
+                                 /*emitAsComment=*/true));
 
     auto assignOp = builder.create<sv::AssignOp>(valWire, arrayGet);
-    sv::setSVAttributes(
-        assignOp, sv::SVAttributesAttr::get(builder.getContext(),
-                                            {"synopsys infer_mux_override"},
-                                            /*emitAsComments=*/true));
+    sv::setSVAttributes(assignOp,
+                        sv::SVAttributeAttr::get(builder.getContext(),
+                                                 "synopsys infer_mux_override",
+                                                 /*emitAsComment=*/true));
     inBoundsRead = builder.create<sv::ReadInOutOp>(valWire);
   }
 

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -158,14 +158,14 @@ static Value getMemoryRead(ImplicitLocOpBuilder &b, Value memory, Value addr,
                                 .getSize() <= 1)
     return slot;
   circt::sv::setSVAttributes(
-      slot, sv::SVAttributesAttr::get(b.getContext(), {"cadence map_to_mux"},
-                                      /*emitAsComments=*/true));
+      slot, sv::SVAttributeAttr::get(b.getContext(), "cadence map_to_mux",
+                                     /*emitAsComment=*/true));
   auto valWire = b.create<sv::WireOp>(slot.getType());
   auto assignOp = b.create<sv::AssignOp>(valWire, slot);
   sv::setSVAttributes(assignOp,
-                      sv::SVAttributesAttr::get(b.getContext(),
-                                                {"synopsys infer_mux_override"},
-                                                /*emitAsComments=*/true));
+                      sv::SVAttributeAttr::get(b.getContext(),
+                                               "synopsys infer_mux_override",
+                                               /*emitAsComment=*/true));
 
   return b.create<sv::ReadInOutOp>(valWire);
 }
@@ -245,8 +245,8 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
   if (addVivadoRAMAddressConflictSynthesisBugWorkaround && mem.readLatency == 0)
     circt::sv::setSVAttributes(
         reg,
-        sv::SVAttributesAttr::get(
-            b.getContext(), {std::make_pair("ram_style", R"("distributed")")}));
+        sv::SVAttributeAttr::get(b.getContext(), "ram_style",
+                                 R"("distributed")", /*emitAsComment=*/false));
 
   SmallVector<Value, 4> outputs;
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -81,8 +81,7 @@ public:
     if (reg.getSymName().has_value())
       svReg.setInnerSymAttr(reg.getSymNameAttr());
 
-    if (auto attribute = circt::sv::getSVAttributes(reg))
-      circt::sv::setSVAttributes(svReg, attribute);
+    circt::sv::setSVAttributes(svReg, circt::sv::getSVAttributes(reg));
 
     auto regVal = rewriter.create<sv::ReadInOutOp>(loc, svReg);
     if (reg.getReset() && reg.getResetValue()) {
@@ -397,9 +396,9 @@ FirRegLower::RegLowerInfo FirRegLower::lower(FirRegOp reg) {
   if (addVivadoRAMAddressConflictSynthesisBugWorkaround &&
       hw::type_isa<hw::ArrayType, hw::UnpackedArrayType>(reg.getType()))
     circt::sv::setSVAttributes(
-        svReg.reg, sv::SVAttributesAttr::get(
-                       builder.getContext(),
-                       {std::make_pair("ram_style", R"("distributed")")}));
+        svReg.reg,
+        sv::SVAttributeAttr::get(builder.getContext(), "ram_style",
+                                 R"("distributed")", /*emitAsComment=*/false));
 
   if (auto innerSymAttr = reg.getInnerSymAttr())
     svReg.reg.setInnerSymAttr(innerSymAttr);

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -21,7 +21,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   r42: !hw.struct<a: !hw.array<1xi1>>, r43: i4,
   r44: !hw.struct<foo: i2, bar: i4>, r45: !hw.struct<foo: i2, bar: i4>,
   r46: !hw.struct<foo: i2, bar: i4>, r47: i1
-  ) attributes {sv.attributes=#sv.attributes<[#sv.attribute<"svAttr">]>} {
+  ) attributes {sv.attributes = [#sv.attribute<"svAttr">]} {
 
   %0 = comb.add %a, %b : i4
   %2 = comb.sub %a, %b : i4
@@ -75,7 +75,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 
   %36 = hw.array_concat %subArr, %subArr : !hw.array<3 x i4>, !hw.array<3 x i4>
   %elem2d = hw.array_get %array2d[%a] : !hw.array<12 x array<10xi4>>, i4
-  %37 = hw.array_get %elem2d[%b] {sv.attributes=#sv.attributes<[#sv.attribute<"svAttr">]>}: !hw.array<10xi4>, i4
+  %37 = hw.array_get %elem2d[%b] {sv.attributes = [#sv.attribute<"svAttr">]}: !hw.array<10xi4>, i4
 
   %38 = comb.replicate %a : (i4) -> i12
 

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -158,3 +158,79 @@ hw.module @MuxChain(%a_0: i1, %a_1: i1, %a_2: i1, %c_0: i1, %c_1: i1, %c_2: i1) 
 // CHECK-NEXT:                                                                                                               : c_2)
 // CHECK-NEXT:                                                                                                          : c_1;{{.*}}
 }
+
+// -----
+
+// CHECK-LABEL:module svattrs{{.*}}
+hw.module @svattrs() {
+//      CHECK:  (* dont_merge, dont_retime = true, foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3,
+// CHECK-NEXT:     foo4 = bar4, foo5 = bar5, foo6 = bar6 *)
+// CHECK-NEXT:  reg [9:0] reg0;{{.*}}
+  %reg0 = sv.reg {
+    sv.attributes = [
+      #sv.attribute<"dont_merge">,
+      #sv.attribute<"dont_retime" ="true">,
+      #sv.attribute<"foo0"="bar0">,
+      #sv.attribute<"foo1"="bar1">,
+      #sv.attribute<"foo2"="bar2">,
+      #sv.attribute<"foo3"="bar3">,
+      #sv.attribute<"foo4"="bar4">,
+      #sv.attribute<"foo5"="bar5">,
+      #sv.attribute<"foo6"="bar6">
+   ]} : !hw.inout<i10>
+
+//      CHECK:  (* start *)
+// CHECK-NEXT:  /* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
+// CHECK-NEXT:     foo6 = bar6 */
+// CHECK-NEXT:  (* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
+// CHECK-NEXT:     foo6 = bar6 *)
+// CHECK-NEXT:  reg [9:0] reg1;{{.*}}
+  %reg1 = sv.reg {
+    sv.attributes = [
+      #sv.attribute<"start">,
+      #sv.attribute<"foo0"="bar0", emitAsComment>,
+      #sv.attribute<"foo1"="bar1", emitAsComment>,
+      #sv.attribute<"foo2"="bar2", emitAsComment>,
+      #sv.attribute<"foo3"="bar3", emitAsComment>,
+      #sv.attribute<"foo4"="bar4", emitAsComment>,
+      #sv.attribute<"foo5"="bar5", emitAsComment>,
+      #sv.attribute<"foo6"="bar6", emitAsComment>,
+      #sv.attribute<"foo0"="bar0">,
+      #sv.attribute<"foo1"="bar1">,
+      #sv.attribute<"foo2"="bar2">,
+      #sv.attribute<"foo3"="bar3">,
+      #sv.attribute<"foo4"="bar4">,
+      #sv.attribute<"foo5"="bar5">,
+      #sv.attribute<"foo6"="bar6">
+   ]} : !hw.inout<i10>
+
+// Put containers on same line if they fit!
+//      CHECK:  (* start *)/* comment */(* end *)
+// CHECK-NEXT:  reg [9:0] reg2;{{.*}}
+  %reg2 = sv.reg {
+    sv.attributes = [
+      #sv.attribute<"start">,
+      #sv.attribute<"comment", emitAsComment>,
+      #sv.attribute<"end">
+   ]} : !hw.inout<i10>
+
+// Check behavior where some fit and some don't:
+// (notably don't glue '(* end *)' after the comment container)
+//      CHECK:  (* start *)
+// CHECK-NEXT:  /* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
+// CHECK-NEXT:     foo6 = bar6 */
+// CHECK-NEXT:  (* end *)
+// CHECK-NEXT:  reg [9:0] reg3;{{.*}}
+  %reg3 = sv.reg {
+    sv.attributes = [
+      #sv.attribute<"start">,
+      #sv.attribute<"foo0"="bar0", emitAsComment>,
+      #sv.attribute<"foo1"="bar1", emitAsComment>,
+      #sv.attribute<"foo2"="bar2", emitAsComment>,
+      #sv.attribute<"foo3"="bar3", emitAsComment>,
+      #sv.attribute<"foo4"="bar4", emitAsComment>,
+      #sv.attribute<"foo5"="bar5", emitAsComment>,
+      #sv.attribute<"foo6"="bar6", emitAsComment>,
+      #sv.attribute<"end">
+   ]} : !hw.inout<i10>
+}

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -205,7 +205,7 @@ hw.module @svattrs() {
    ]} : !hw.inout<i10>
 
 // Put containers on same line if they fit!
-//      CHECK:  (* start *)/* comment */(* end *)
+//      CHECK:  (* start *) /* comment */ (* end *)
 // CHECK-NEXT:  reg [9:0] reg2;{{.*}}
   %reg2 = sv.reg {
     sv.attributes = [

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -485,8 +485,16 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   %myReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i8>
 
   // CHECK-NEXT: (* dont_merge, dont_retime = true *)
+  // CHECK-NEXT: /* comment_merge, comment_retime = true */
+  // CHECK-NEXT: (* another_attr *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">]} : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg {sv.attributes = [
+    #sv.attribute<"dont_merge">,
+    #sv.attribute<"dont_retime" = "true">,
+    #sv.attribute<"comment_merge", emitAsComment>,
+    #sv.attribute<"comment_retime" = "true", emitAsComment>,
+    #sv.attribute<"another_attr">
+  ]} : !hw.inout<array<42 x i8>>
 
   // CHECK:      /* assign_attr */
   // CHECK-NEXT: assign myReg = in8;

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -53,7 +53,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT:   `endif
   // CHECK-NEXT: end // always @(posedge)
     }
-  } {sv.attributes = #sv.attributes<[#sv.attribute<"sv attr">]>}
+  } {sv.attributes = [#sv.attribute<"sv attr">]}
 
   // CHECK-NEXT: always @(negedge clock) begin
   // CHECK-NEXT: end // always @(negedge)
@@ -255,7 +255,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.fwrite %fd, "M: %x\n"(%text) : i8
 
     }// CHECK-NEXT:   {{end$}}
-  } {sv.attributes = #sv.attributes<[#sv.attribute<"sv attr">]>}
+  } {sv.attributes = [#sv.attribute<"sv attr">]}
   // CHECK-NEXT:  end // initial
 
   // CHECK-NEXT: assert property (@(posedge clock) cond);
@@ -482,15 +482,15 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   // CHECK-EMPTY:
   // CHECK-NEXT: (* dont_merge *)
   // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">]>} : !hw.inout<i8>
+  %myReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i8>
 
   // CHECK-NEXT: (* dont_merge, dont_retime = true *)
   // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">]>} : !hw.inout<array<42 x i8>>
+  %myRegArray1 = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime"="true">]} : !hw.inout<array<42 x i8>>
 
   // CHECK:      /* assign_attr */
   // CHECK-NEXT: assign myReg = in8;
-  sv.assign %myReg, %in8 {sv.attributes = #sv.attributes<[#sv.attribute<"assign_attr">], emitAsComments>} : i8
+  sv.assign %myReg, %in8 {sv.attributes = [#sv.attribute<"assign_attr", emitAsComment>]} : i8
 
   %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;
@@ -1165,7 +1165,7 @@ hw.module @verbatim_M1(%clock : i1, %cond : i1, %val : i8) {
   %reg2 = sv.reg sym @verbatim_reg2: !hw.inout<i8>
   // CHECK:      (* dont_merge *)
   // CHECK-NEXT: wire [22:0] wire25
-  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = #sv.attributes<[#sv.attribute<"dont_merge">]>} : !hw.inout<i23>
+  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i23>
   %add = comb.add %val, %c42 : i8
   %c42_2 = hw.constant 42 : i8
   %xor = comb.xor %val, %c42_2 : i8
@@ -1468,7 +1468,7 @@ hw.module @SimplyNestedElseIf(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1, %
         sv.if %flag3 {
           sv.if %flag4 {
             sv.fwrite %fd, "E"
-          } {sv.attributes = #sv.attributes<[#sv.attribute<"sv attr">]>}
+          } {sv.attributes = [#sv.attribute<"sv attr">]}
           sv.fwrite %fd, "C"
         } else {
           sv.fwrite %fd, "D"

--- a/test/Dialect/SV/hw-cleanup.mlir
+++ b/test/Dialect/SV/hw-cleanup.mlir
@@ -345,9 +345,9 @@ hw.module @sv_attributes() {
   // CHECK: sv.initial
   sv.initial  {
     sv.fwrite %fd, "A"
-  } {sv.attributes = #sv.attribute<"dont merge">}
+  } {sv.attributes = [#sv.attribute<"dont_merge">]}
 
   sv.initial  {
     sv.fwrite %fd, "B"
-  } {sv.attributes = #sv.attribute<"dont merge">}
+  } {sv.attributes = [#sv.attribute<"dont_merge">]}
 }


### PR DESCRIPTION
Move the `emitAsComments` flag from `SVAttributesAttr` (plural) to `SVAttributeAttr` (singular). Then remove `SVAttributesAttr` (plural) since it only contains a single array field after `emitAsComments` is gone.

Add add, remove, and read-modify-write functions to deal with SV attributes on operations more conveniently. Also enforce deduplicated SV attributes where easily possible. The new functions now allow for easy addition and removal of individual SV attributes.

Adapt ExportVerilog to handle the fact that emission as comments is now a per-attribute option. The emission code now can emit multiple `/*...*/` and `(*...*)` groups if needed, but tries to pack as many consecutive attributes with the same `emitAsComment` flag into one group.