### PR TITLE
[FIRRTL] Correct memory lowering behaviour for vb-to-bv conversion

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -50,6 +50,7 @@ enum PreserveMode {
 
 std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass(
     PreserveAggregate::PreserveMode mode = PreserveAggregate::None,
+    PreserveAggregate::PreserveMode memoryMode = PreserveAggregate::None,
     bool preservePublicTypes = true);
 
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -71,6 +71,15 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
             clEnumValN(PreserveAggregate::OneDimVec, "1d-vec", "Preserve 1d vectors"),
             clEnumValN(PreserveAggregate::Vec, "vec", "Preserve vectors"),
             clEnumValN(PreserveAggregate::All, "all", "Preserve vectors and bundles")
+          )}]>,
+    Option<"preserveMemories", "preserve-memories", "PreserveAggregate::PreserveMode",
+          "PreserveAggregate::None",
+          "Specify memory preservation mode",
+          [{::llvm::cl::values(
+            clEnumValN(PreserveAggregate::None, "none", "Preserve no aggregate"),
+            clEnumValN(PreserveAggregate::OneDimVec, "1d-vec", "Preserve 1d vectors"),
+            clEnumValN(PreserveAggregate::Vec, "vec", "Preserve vectors"),
+            clEnumValN(PreserveAggregate::All, "all", "Preserve vectors and bundles")
           )}]>
   ];
   let dependentDialects = ["hw::HWDialect"];

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -662,22 +662,24 @@ static LogicalResult processBuffer(
   if (!disableWireDFT)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 
-  if (!lowerMemories)
-    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        firrtl::createFlattenMemoryPass());
-
   if (vbToBV) {
     if (!disableLowerTypes && preservePublicTypes)
       pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
-          firrtl::PreserveAggregate::All, preservePublicTypes));
+          firrtl::PreserveAggregate::All, firrtl::PreserveAggregate::All,
+          preservePublicTypes));
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createVBToBVPass());
   }
+
+  if (!lowerMemories)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        firrtl::createFlattenMemoryPass());
 
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.
   if (!disableLowerTypes) {
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
-        preserveAggregate, preservePublicTypes));
+        preserveAggregate, firrtl::PreserveAggregate::None,
+        preservePublicTypes));
     // Only enable expand whens if lower types is also enabled.
     if (!disableExpandWhens) {
       auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -242,6 +242,7 @@ static void loadFIRRTLLoweringPipeline(OpPassManager &pm) {
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
       /*preserveAggregate=*/firrtl::PreserveAggregate::PreserveMode::None,
+      /*preserveMemories=*/firrtl::PreserveAggregate::PreserveMode::None,
       /*preservePublicTypes=*/false));
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
   modulePM.addPass(firrtl::createExpandWhensPass());


### PR DESCRIPTION
- use lowerTypes to scalarize public ports before running vb-to-bv. This lets vb-to-bv lower all types, without considering whether a module or extmodule is public.
  - Add a memory preservation option to lower types. This option lets us use lowerTypes to scalarize the ports of public module without modifying memories.
- Perform  flatten-memories after vb-to-bv. The vb-to-bv pass cannot reshape memories that have been flattened.


