### PR TITLE
[CI] Swap build mode of gcc and clang

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -163,14 +163,14 @@ jobs:
           # gcc   + debug   + assert   + shared
           - cc: clang
             cxx: clang++
-            mode: release
-            assert: OFF
-            shared: OFF
-          - cc: gcc
-            cxx: g++
             mode: debug
             assert: ON
             shared: ON
+          - cc: gcc
+            cxx: g++
+            mode: release
+            assert: OFF
+            shared: OFF
 
     steps:
       - name: Configure Environment


### PR DESCRIPTION
GCC+debug consumes too much memory. This swaps gcc and clang build mode.

CI: https://github.com/llvm/circt/actions/runs/4306635035 

Close https://github.com/llvm/circt/issues/4740