### PR TITLE
[Arc] Verify that arc bodies are pure

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -40,6 +40,8 @@ def DefineOp : ArcOp<"define", [
   let regions = (region SizedRegion<1>:$body);
   let hasCustomAssemblyFormat = 1;
 
+  let hasRegionVerifier = 1;
+
   let builders = [
     OpBuilder<(ins "mlir::StringAttr":$sym_name, "mlir::TypeAttr":$function_type), [{
       build($_builder, $_state, sym_name, function_type, mlir::ArrayAttr(), mlir::ArrayAttr());
@@ -105,7 +107,7 @@ def OutputOp : ArcOp<"output", [
 def StateOp : ArcOp<"state", [
   CallOpInterface, MemRefsNormalizable,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  AttrSizedOperandSegments, Pure
+  AttrSizedOperandSegments
 ]> {
   let summary = "State transfer arc";
 

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -1,7 +1,8 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
+// expected-error @+1 {{body contains non-pure operation}}
 arc.define @Foo(%arg0: i1) {
-  // expected-error @+1 {{'arc.state' op with non-zero latency cannot be in an arc definition}}
+  // expected-note @+1 {{first non-pure operation here:}}
   arc.state @Bar() clock %arg0 lat 1 : () -> ()
   arc.output
 }

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -2,11 +2,10 @@
 
 // CHECK-LABEL: arc.define @Foo
 arc.define @Foo(%arg0: i42, %arg1: i9) -> (i42, i9) {
-  // CHECK: arc.state @Bar(%arg0) lat 0 : (i42) -> i42
-  %0 = arc.state @Bar(%arg0) lat 0 : (i42) -> i42
+  %c-1_i42 = hw.constant -1 : i42
 
-  // CHECK: arc.output %arg0, %arg1 : i42, i9
-  arc.output %arg0, %arg1 : i42, i9
+  // CHECK: arc.output %c-1_i42, %arg1 : i42, i9
+  arc.output %c-1_i42, %arg1 : i42, i9
 }
 
 arc.define @Bar(%arg0: i42) -> i42 {


### PR DESCRIPTION
Arcs are assumed pure everywhere, but it's not properly verified yet. This adds a region verifier to check that all operations in the body have the pure trait.

Also, it removes the pure trait from the stateOp. While it is fine to have it for the case where latency is 0, it is a problem for higher latencies because of 2 reasons:
* They are converted to fields in the datastructure that is exposed to the user and can be read from. If the user want's to observe a state and that state has no users in the design (maybe because they were optimized away), the state will also be optimized away and the user has no read-access to it anymore.
* Even if we separate above concern to another operation (e.g. use the tap op for that), the output of the state op will still not be the same for the same inputs every time, because it also depends on the input x cycles ago (where x is the value of the latency attribute).