### PR TITLE
[LLHD] Only permit signal creation in entity and proc ops

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -13,6 +13,7 @@
 include "mlir/IR/EnumAttr.td"
 
 def LLHD_SigOp : LLHD_Op<"sig", [
+    ParentOneOf<["llhd::EntityOp", "llhd::ProcOp"]>,
     TypesMatchWith<
       "type of 'init' and underlying type of 'signal' have to match.",
       "init", "result", "SigType::get($_self)">

--- a/test/Dialect/LLHD/IR/signal-errors.mlir
+++ b/test/Dialect/LLHD/IR/signal-errors.mlir
@@ -40,3 +40,10 @@ llhd.entity @check_unique_sig_names2 () -> () {
   %sig1 = llhd.sig "sigI1" %cI1 : i1
   %sig2 = llhd.output "sigI1" %cI1 after %time : i1
 }
+
+// -----
+
+func.func @illegal_sig_parent (%arg0: i1) {
+  // expected-error @+1 {{expects parent op to be one of 'llhd.entity, llhd.proc'}}
+  %0 = llhd.sig "sig" %arg0 : i1
+}


### PR DESCRIPTION
LLHDToLLVM crashes when `llhd.sig` is in a op other than `entity` or `proc`. As there is no need to use it in another function we can verify it as such.