### PR TITLE
[HWToLLVM] Remove unnecessary target materializations

### DIFF
--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -2,29 +2,28 @@
 
 // CHECK-LABEL: @convertBitcast
 func.func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struct<foo: i32, bar: i32>) {
+  // CHECK-NEXT: %[[AARG1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[AARG2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.struct<foo: i32, bar: i32> to !llvm.struct<(i32, i32)>
 
-  // CHECK: %[[AARG0:.*]] = builtin.unrealized_conversion_cast %arg0 : i32 to i32
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE1]] x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr<i32>
-  // CHECK-NEXT: llvm.store %[[AARG0]], %[[A1]] : !llvm.ptr<i32>
+  // CHECK-NEXT: llvm.store %arg0, %[[A1]] : !llvm.ptr<i32>
   // CHECK-NEXT: %[[B1:.*]] = llvm.bitcast %[[A1]] : !llvm.ptr<i32> to !llvm.ptr<array<4 x i8>>
   // CHECK-NEXT: llvm.load %[[B1]] : !llvm.ptr<array<4 x i8>>
   %0 = hw.bitcast %arg0 : (i32) -> !hw.array<4xi8>
 
-// CHECK-NEXT: %[[AARG1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-// CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr<array<2 x i32>>
-// CHECK-NEXT: llvm.store %[[AARG1]], %[[A2]] : !llvm.ptr<array<2 x i32>>
-// CHECK-NEXT: %[[B2:.*]] = llvm.bitcast %[[A2]] : !llvm.ptr<array<2 x i32>> to !llvm.ptr<i64>
-// CHECK-NEXT: llvm.load %[[B2]] : !llvm.ptr<i64>
+  // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr<array<2 x i32>>
+  // CHECK-NEXT: llvm.store %[[AARG1]], %[[A2]] : !llvm.ptr<array<2 x i32>>
+  // CHECK-NEXT: %[[B2:.*]] = llvm.bitcast %[[A2]] : !llvm.ptr<array<2 x i32>> to !llvm.ptr<i64>
+  // CHECK-NEXT: llvm.load %[[B2]] : !llvm.ptr<i64>
   %1 = hw.bitcast %arg1 : (!hw.array<2xi32>) -> i64
 
-// CHECK-NEXT: %[[AARG2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.struct<foo: i32, bar: i32> to !llvm.struct<(i32, i32)>
-// CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE3]] x !llvm.struct<(i32, i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT: llvm.store %[[AARG2]], %[[A3]] : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT: %[[B3:.*]] = llvm.bitcast %[[A3]] : !llvm.ptr<struct<(i32, i32)>> to !llvm.ptr<i64>
-// CHECK-NEXT: llvm.load %[[B3]] : !llvm.ptr<i64>
+  // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE3]] x !llvm.struct<(i32, i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr<struct<(i32, i32)>>
+  // CHECK-NEXT: llvm.store %[[AARG2]], %[[A3]] : !llvm.ptr<struct<(i32, i32)>>
+  // CHECK-NEXT: %[[B3:.*]] = llvm.bitcast %[[A3]] : !llvm.ptr<struct<(i32, i32)>> to !llvm.ptr<i64>
+  // CHECK-NEXT: llvm.load %[[B3]] : !llvm.ptr<i64>
   %2 = hw.bitcast %arg2 : (!hw.struct<foo: i32, bar: i32>) -> i64
 
   return
@@ -32,11 +31,10 @@ func.func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struc
 
 // CHECK-LABEL: @convertArray
 func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
-
-
-  // CHECK: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr<array<2 x i32>>
   // CHECK-NEXT: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
+
+  // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr<array<2 x i32>>
   // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA]] : !llvm.ptr<array<2 x i32>>
   // CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-NEXT: %[[ZEXT:.*]] = llvm.zext %arg0 : i1 to i2
@@ -46,9 +44,8 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
 
   // CHECK-NEXT: %[[ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr<array<2 x i32>>
-  // CHECK-NEXT: llvm.store %[[CAST1]], %[[ALLOCA1]] : !llvm.ptr<array<2 x i32>>
+  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA1]] : !llvm.ptr<array<2 x i32>>
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg0 : i1 to i2
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][%[[ZERO1]], %[[ZEXT1]]] : (!llvm.ptr<array<2 x i32>>, i32, i2) -> !llvm.ptr<i32>
   // CHECK-NEXT: %[[BITCAST:.*]] = llvm.bitcast %[[GEP1]] : !llvm.ptr<i32> to !llvm.ptr<array<1 x i32>>
@@ -56,17 +53,13 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
   %1 = hw.array_slice %arg1[%arg0] : (!hw.array<2xi32>) -> !hw.array<1xi32>
 
   // CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %[[CAST2]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %[[CAST0]][0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I1:.*]] = llvm.insertvalue %[[E1]], %[[UNDEF]][0] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %[[CAST3]][1] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %[[CAST0]][1] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I2:.*]] = llvm.insertvalue %[[E2]], %[[I1]][1] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[CAST4:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %[[CAST4]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %[[CAST0]][0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I3:.*]] = llvm.insertvalue %[[E3]], %[[I2]][2] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[CAST5:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK: %[[E4:.*]] = llvm.extractvalue %[[CAST5]][1] : !llvm.array<2 x i32>
+  // CHECK: %[[E4:.*]] = llvm.extractvalue %[[CAST0]][1] : !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.insertvalue %[[E4]], %[[I3]][3] : !llvm.array<4 x i32>
   %2 = hw.array_concat %arg1, %arg1 : !hw.array<2xi32>, !hw.array<2xi32>
 


### PR DESCRIPTION
We should use the adaptors provided by the pattern rewrite system properly.