### PR TITLE
[FIRRTLFolds] Fix width mismatch

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -297,7 +297,7 @@ def SubaccessOfConstant : Pat<
 def MuxNot : Pat<
   (MuxPrimOp:$old $cond, (ConstantOp:$zcst $_), (ConstantOp:$ocst $_)),
   (MoveNameHint $old, (NotPrimOp $cond)), [
-    (EqualTypes $cond, $zcst),
+    (EqualTypes $cond, $zcst), (EqualTypes $cond, $ocst),
     (ZeroConstantOp $zcst) , (OneConstantOp $ocst)
   ]>;
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2604,7 +2604,7 @@ firrtl.module @ReadOnlyFileInitialized(
 // CHECK-LABEL: @MuxCondWidth
 firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>) {
   // Don't canonicalize if the type is not UInt<1>
-  // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : (!firrtl.uint<3>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
   // CHECK-NEXT:  firrtl.strictconnect %foo, %0
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2601,4 +2601,11 @@ firrtl.module @ReadOnlyFileInitialized(
   firrtl.strictconnect %read_data, %3 : !firrtl.uint<8>
 }
 
+firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
+  %0 = firrtl.mux(%cond, %c0_ui1, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  firrtl.strictconnect %foo, %0 : !firrtl.uint<3>
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2601,7 +2601,11 @@ firrtl.module @ReadOnlyFileInitialized(
   firrtl.strictconnect %read_data, %3 : !firrtl.uint<8>
 }
 
+// CHECK-LABEL: @MuxCondWidth
 firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>) {
+  // Don't canonicalize if the type is not UInt<1>
+  // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : (!firrtl.uint<3>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  // CHECK-NEXT:  firrtl.strictconnect %foo, %0
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
   %0 = firrtl.mux(%cond, %c0_ui1, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>


### PR DESCRIPTION
https://github.com/llvm/circt/commit/c4447004c344e5a3391a1d7546565197a7dd324f causes a width mismatch when false value is not UInt<1>. This commit adds a check for type equivalence. 