### PR TITLE
[FIRRTL][LowerXMR] Don't crash if encounter unexpected ref.sub.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -163,9 +163,12 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             markForRemoval(op);
             if (isZeroWidth(op.getType().getType()))
               return success();
-            auto defMem = dyn_cast<MemOp>(op.getInput().getDefiningOp());
+            auto defMem =
+                dyn_cast_or_null<MemOp>(op.getInput().getDefiningOp());
             if (!defMem) {
-              defMem.emitOpError("can only lower RefSubOp of Memory");
+              op.emitError("can only lower RefSubOp of Memory")
+                      .attachNote(op.getInput().getLoc())
+                  << "input here";
               return failure();
             }
             auto inRef = getInnerRefTo(defMem);


### PR DESCRIPTION
1) Don't dereference op after checking if it's null.
   (shame compiler doesn't see through this enough to warn!)
2) Handle ref.sub coming from port not op.

Add tests.

This shouldn't be reachable presently, but may in the near future (and good to be robust anyway).