### PR TITLE
[FIRRTL] Canonicalizers: simplify resolve-of-send and hoist ref.sub out of ref.send.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -86,6 +86,8 @@ def DropWrite : NativeCodeCall<"dropWrite($_builder, $0, $1)">;
 
 def MoveNameHint : NativeCodeCall<"moveNameHint($0, $1)">;
 
+def SubFieldOrIndex : NativeCodeCall<"subfieldOrIndex($_builder, $_loc, $0, $1)">;
+
 def GetEmptyString : NativeCodeCall<
   "StringAttr::get($_builder.getContext(), {}) ">;
 
@@ -349,5 +351,22 @@ def RegResetWithOneReset : Pat<
   (RegResetOp:$reg $clock, $reset, $resetVal, $name, $nameKind, $annotations, $inner_sym),
   (DropWrite $reg, (NodeOp $resetVal, $name, $nameKind, $annotations, $inner_sym)),
   [(OneConstantOp $reset)]>;
+
+// refresolve(refsend(x)) -> x
+def RefResolveOfSend : Pat<
+  (RefResolveOp (RefSendOp $orig)),
+  (replaceWithValue $orig) >;
+
+// Sink ref.sub through resolve.
+// refresolve(refsub(x, idx)) -> sub{index,field}(refresolve(x))
+def RefResolveOfSub : Pat<
+  (RefResolveOp (RefSubOp $ref, $idx)),
+  (SubFieldOrIndex (RefResolveOp $ref), $idx) >;
+
+// Hoist ref.sub through send.
+// refsub(refsend(orig), idx) -> refsend(sub{index,field}(orig, idx))
+def RefSubOfSend : Pat<
+  (RefSubOp (RefSendOp $orig), $idx),
+  (RefSendOp (SubFieldOrIndex $orig, $idx)) >;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -56,6 +56,19 @@ def UIntTypes : Constraint<CPred<"$0.isa<UIntType>()">>;
 // Constraint that enforces types mismatches
 def mismatchTypes : Constraint<CPred<"$0.getType() != $1.getType()">>;
 
+// Constraint that argument is ref-of-vector type.
+def IsRefVectorType : Constraint<CPred<[{
+  $0.getType().isa<RefType>() &&
+  $0.getType().cast<RefType>().getType().isa<FVectorType>()
+}]>>;
+
+// Constraint that argument is ref-of-bundle type.
+def IsRefBundleType : Constraint<CPred<[{
+  $0.getType().isa<RefType>() &&
+  $0.getType().cast<RefType>().getType().isa<BundleType>()
+}]>>;
+
+
 // Constraint that enforces types of known width
 def KnownWidth : Constraint<CPred<[{
   $0.getType().isa<FIRRTLBaseType>() &&
@@ -85,8 +98,6 @@ def AllOneConstantOp : Constraint<CPred<"$0.getDefiningOp<ConstantOp>() && $0.ge
 def DropWrite : NativeCodeCall<"dropWrite($_builder, $0, $1)">;
 
 def MoveNameHint : NativeCodeCall<"moveNameHint($0, $1)">;
-
-def SubFieldOrIndex : NativeCodeCall<"subfieldOrIndex($_builder, $_loc, $0, $1)">;
 
 def GetEmptyString : NativeCodeCall<
   "StringAttr::get($_builder.getContext(), {}) ">;
@@ -357,16 +368,18 @@ def RefResolveOfSend : Pat<
   (RefResolveOp (RefSendOp $orig)),
   (replaceWithValue $orig) >;
 
-// Sink ref.sub through resolve.
-// refresolve(refsub(x, idx)) -> sub{index,field}(refresolve(x))
-def RefResolveOfSub : Pat<
-  (RefResolveOp (RefSubOp $ref, $idx)),
-  (SubFieldOrIndex (RefResolveOp $ref), $idx) >;
+// Hoist ref.sub through send, vector variant.
+// refsub(refsend(orig), idx) -> refsend(subindex(orig, idx))
+def RefSubOfSendVector : Pat<
+  (RefSubOp (RefSendOp:$send $orig), $idx),
+  (RefSendOp (SubindexOp $orig, $idx)),
+  [(IsRefVectorType $send)] >;
 
-// Hoist ref.sub through send.
-// refsub(refsend(orig), idx) -> refsend(sub{index,field}(orig, idx))
-def RefSubOfSend : Pat<
-  (RefSubOp (RefSendOp $orig), $idx),
-  (RefSendOp (SubFieldOrIndex $orig, $idx)) >;
+// Hoist ref.sub through send, bundle variant.
+// refsub(refsend(orig), idx) -> refsend(subfield(orig, idx))
+def RefSubOfSendBundle : Pat<
+  (RefSubOp (RefSendOp:$send $orig), $idx),
+  (RefSendOp (SubfieldOp $orig, $idx)),
+  [(IsRefBundleType $send)] >;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -808,6 +808,7 @@ def RefResolveOp: FIRRTLExprOp<"ref.resolve",
   let results = (outs FIRRTLBaseType:$result);
 
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
+  let hasCanonicalizer = true;
 }
 
 def RefSendOp: FIRRTLExprOp<"ref.send", [RefResultTypeConstraint<"base", "result">]> {
@@ -840,6 +841,7 @@ def RefSubOp : FIRRTLExprOp<"ref.sub"> {
 
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` qualified(type($input))";
+  let hasCanonicalizer = true;
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLEXPRESSIONS_TD

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -55,6 +55,17 @@ static Value moveNameHint(OpResult old, Value passthrough) {
   return passthrough;
 }
 
+template <typename BaseTy>
+static Value subfieldOrIndex(PatternRewriter &rewriter, Location loc,
+                             BaseTy base, IntegerAttr index) {
+  return TypeSwitch<Type, Value>(base.getType())
+      .template Case<FVectorType>(
+          [&](auto _) { return rewriter.create<SubindexOp>(loc, base, index); })
+      .template Case<BundleType>([&](auto _) {
+        return rewriter.create<SubfieldOp>(loc, base, index);
+      });
+}
+
 // Declarative canonicalization patterns
 namespace circt {
 namespace firrtl {
@@ -2827,4 +2838,19 @@ void AssumeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 void CoverOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                           MLIRContext *context) {
   results.add(canonicalizeImmediateVerifOp<CoverOp, /* EraseIfZero = */ true>);
+}
+
+//===----------------------------------------------------------------------===//
+// References.
+//===----------------------------------------------------------------------===//
+
+void RefResolveOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                               MLIRContext *context) {
+  results.insert<patterns::RefResolveOfSend, patterns::RefResolveOfSub>(
+      context);
+}
+
+void RefSubOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                           MLIRContext *context) {
+  results.insert<patterns::RefSubOfSend>(context);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -55,17 +55,6 @@ static Value moveNameHint(OpResult old, Value passthrough) {
   return passthrough;
 }
 
-template <typename BaseTy>
-static Value subfieldOrIndex(PatternRewriter &rewriter, Location loc,
-                             BaseTy base, IntegerAttr index) {
-  return TypeSwitch<Type, Value>(base.getType())
-      .template Case<FVectorType>(
-          [&](auto _) { return rewriter.create<SubindexOp>(loc, base, index); })
-      .template Case<BundleType>([&](auto _) {
-        return rewriter.create<SubfieldOp>(loc, base, index);
-      });
-}
-
 // Declarative canonicalization patterns
 namespace circt {
 namespace firrtl {
@@ -2846,11 +2835,11 @@ void CoverOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 void RefResolveOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
-  results.insert<patterns::RefResolveOfSend, patterns::RefResolveOfSub>(
-      context);
+  results.insert<patterns::RefResolveOfSend>(context);
 }
 
 void RefSubOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
-  results.insert<patterns::RefSubOfSend>(context);
+  results.insert<patterns::RefSubOfSendVector, patterns::RefSubOfSendBundle>(
+      context);
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2612,4 +2612,57 @@ firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>
   firrtl.strictconnect %foo, %0 : !firrtl.uint<3>
 }
 
+// CHECK-LABEL: @RefResolveSend
+firrtl.module @RefResolveSend(in %x: !firrtl.uint<1>, out %y : !firrtl.uint<1>) {
+  // CHECK-NEXT: firrtl.strictconnect %y, %x
+  // CHECK-NEXT: }
+  %ref = firrtl.ref.send %x : !firrtl.uint<1>
+  %res = firrtl.ref.resolve %ref : !firrtl.ref<uint<1>>
+  firrtl.strictconnect %y, %res : !firrtl.uint<1>
+}
+
+// CHECK-LABEL: @RefSubHoistVector
+firrtl.module @RefSubHoistVector(in %x: !firrtl.vector<uint<1>,2>, out %y : !firrtl.ref<uint<1>>) {
+  // CHECK-NEXT: %[[sub:.+]] = firrtl.subindex %x[1]
+  // CHECK-NEXT: %[[ref:.+]] = firrtl.ref.send %[[sub]]
+  // CHECK-NEXT: firrtl.strictconnect %y, %[[ref]]
+  // CHECK-NEXT: }
+  %ref = firrtl.ref.send %x : !firrtl.vector<uint<1>,2>
+  %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<vector<uint<1>,2>>
+  firrtl.strictconnect %y, %sub: !firrtl.ref<uint<1>>
+}
+
+// CHECK-LABEL: @RefSubHoistBundle
+firrtl.module @RefSubHoistBundle(in %x: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %y : !firrtl.ref<uint<2>>) {
+  // CHECK-NEXT: %[[sub:.+]] = firrtl.subfield %x[b]
+  // CHECK-NEXT: %[[ref:.+]] = firrtl.ref.send %[[sub]]
+  // CHECK-NEXT: firrtl.strictconnect %y, %[[ref]]
+  // CHECK-NEXT: }
+  %ref = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
+  %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+  firrtl.strictconnect %y, %sub: !firrtl.ref<uint<2>>
+}
+
+// CHECK-LABEL: @RefSubSink
+firrtl.module private @RefSubSink(in %xref: !firrtl.ref<vector<uint<1>,2>>, out %y : !firrtl.uint<1>) {
+  // CHECK-NEXT: %[[res:.+]] = firrtl.ref.resolve %xref
+  // CHECK-NEXT: %[[sub:.+]] = firrtl.subindex %[[res]][1]
+  // CHECK-NEXT: firrtl.strictconnect %y, %[[sub]]
+  // CHECK-NEXT: }
+  %sub = firrtl.ref.sub %xref[1] : !firrtl.ref<vector<uint<1>,2>>
+  %res = firrtl.ref.resolve %sub: !firrtl.ref<uint<1>>
+  firrtl.strictconnect %y, %res : !firrtl.uint<1>
+}
+
+// CHECK-LABEL: @RefResolveSubSend
+firrtl.module private @RefResolveSubSend(in %x: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %y : !firrtl.uint<2>) {
+  // CHECK-NEXT: %[[sub:.+]] = firrtl.subfield %x[b]
+  // CHECK-NEXT: firrtl.strictconnect %y, %[[sub]]
+  // CHECK-NEXT: }
+  %ref = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
+  %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+  %res = firrtl.ref.resolve %sub: !firrtl.ref<uint<2>>
+  firrtl.strictconnect %y, %res : !firrtl.uint<2>
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2643,17 +2643,6 @@ firrtl.module @RefSubHoistBundle(in %x: !firrtl.bundle<a: uint<1>, b: uint<2>>, 
   firrtl.strictconnect %y, %sub: !firrtl.ref<uint<2>>
 }
 
-// CHECK-LABEL: @RefSubSink
-firrtl.module private @RefSubSink(in %xref: !firrtl.ref<vector<uint<1>,2>>, out %y : !firrtl.uint<1>) {
-  // CHECK-NEXT: %[[res:.+]] = firrtl.ref.resolve %xref
-  // CHECK-NEXT: %[[sub:.+]] = firrtl.subindex %[[res]][1]
-  // CHECK-NEXT: firrtl.strictconnect %y, %[[sub]]
-  // CHECK-NEXT: }
-  %sub = firrtl.ref.sub %xref[1] : !firrtl.ref<vector<uint<1>,2>>
-  %res = firrtl.ref.resolve %sub: !firrtl.ref<uint<1>>
-  firrtl.strictconnect %y, %res : !firrtl.uint<1>
-}
-
 // CHECK-LABEL: @RefResolveSubSend
 firrtl.module private @RefResolveSubSend(in %x: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %y : !firrtl.uint<2>) {
   // CHECK-NEXT: %[[sub:.+]] = firrtl.subfield %x[b]


### PR DESCRIPTION
1) Collapse a trivial ref.resolve of an ref.send:
ref.resolve(ref.send(x)) -> x

2) Hoist ref.sub through ref.send:
ref.sub(ref.send(x), idx) -> ref.send(sub{field,index}(x, idx))
(split into a pattern for each)

Add tests for each and their combination.

Fixes #4693.