### PR TITLE
[FIRRTL][NFCI] Use FConnectLike to abstract over connection types.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -31,8 +31,8 @@ using namespace firrtl;
 static Value dropWrite(PatternRewriter &rewriter, OpResult old,
                        Value passthrough) {
   for (auto *user : llvm::make_early_inc_range(old.getUsers())) {
-    if (isa<StrictConnectOp, ConnectOp>(user)) {
-      if (user->getOperand(0) == old)
+    if (auto connect = dyn_cast<FConnectLike>(user)) {
+      if (connect.getDest() == old)
         rewriter.eraseOp(user);
     }
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -733,7 +733,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
       llvm::dbgs() << "\n===----- Tracing uninferred resets -----===\n\n");
   circuit.walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
-        .Case<ConnectOp, StrictConnectOp>([&](auto op) {
+        .Case<FConnectLike>([&](auto op) {
           traceResets(op.getDest(), op.getSrc(), op.getLoc());
         })
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1242,7 +1242,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
     else
       allWidthsKnown = false;
   }
-  if (allWidthsKnown && !isa<ConnectOp, StrictConnectOp, AttachOp>(op))
+  if (allWidthsKnown && !isa<FConnectLike, AttachOp>(op))
     return success();
 
   // Actually generate the necessary constraint expressions.
@@ -1438,7 +1438,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
 
       // Handle the various connect statements that imply a type constraint.
-      .Case<ConnectOp, StrictConnectOp>([&](auto op) {
+      .Case<FConnectLike>([&](auto op) {
         // If the source is an invalid value, we don't set a constraint between
         // these two types.
         if (dyn_cast_or_null<InvalidValueOp>(op.getSrc().getDefiningOp()))
@@ -1844,8 +1844,7 @@ bool InferenceTypeUpdate::updateOperation(Operation *op) {
   // operand width will have definitely been mapped in.
   if (isa<InvalidValueOp>(op) &&
       hasUninferredWidth(op->getResultTypes().front())) {
-    if (op->use_empty() ||
-        !isa<ConnectOp, StrictConnectOp>(*op->getUsers().begin())) {
+    if (op->use_empty() || !isa<FConnectLike>(*op->getUsers().begin())) {
       auto diag = mlir::emitError(
           op->getLoc(), "uninferred width: invalid value is unconstrained");
       anyFailed = true;

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -389,12 +389,10 @@ InstanceOp LowerMemoryPass::emitMemoryInstance(MemOp op, FModuleOp module,
       auto getDriver = [&](StringRef field) -> Operation * {
         auto accesses = getAllFieldAccesses(op.getResult(i), field);
         for (auto a : accesses) {
-          for (auto *connect : a->getUsers()) {
-            // If this is some use that isn't a connect, move on.
-            if (!isa<ConnectOp, StrictConnectOp>(connect))
-              continue;
-            // If this connect is driving a value to the field, return it.
-            if (connect->getOperand(0) == a)
+          for (auto *user : a->getUsers()) {
+            // If this is a connect driving a value to the field, return it.
+            if (auto connect = dyn_cast<FConnectLike>(user);
+                connect && connect.getDest() == a)
               return connect;
           }
         }


### PR DESCRIPTION
Ensure code continues to work for anything that's FConnectLike, without having to add it to each of these locations.

Code with behavior very specific to ConnectOp and/or StrictConnectOp are left unmodified, but if all that matters is source => destination then use FConnectLike.

Prefer `getDest()` (and `getSrc()`) over hardcoding operand numbers.