### PR TITLE
[FIRRTL][LowerXMR] Fix XMR to instance port/result.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -90,6 +90,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                   return success();
                 }
               if (!isa<hw::InnerSymbolOpInterface>(xmrDefOp) ||
+                  /* No innner symbols for results of instances */
+                  isa<InstanceOp>(xmrDefOp) ||
+                  /* Similarly, anything with multiple results isn't named by
+                     the inner sym */
                   xmrDefOp->getResults().size() > 1) {
                 // Add a node, for non-innerSym ops. Otherwise the sym will be
                 // dropped after LowerToHW.

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -618,3 +618,21 @@ firrtl.circuit "Top"  {
     // CHECK: firrtl.strictconnect %a, %c0_ui0 : !firrtl.uint<0>
   }
 }
+
+// -----
+// Test lowering of XMR to instance port (result).
+// https://github.com/llvm/circt/issues/4559
+
+firrtl.circuit "Issue4559" {
+  firrtl.extmodule @Source(out sourceport: !firrtl.uint<1>)
+  // CHECK-LABEL: @Issue4559
+  firrtl.module @Issue4559() {
+    // CHECK-NEXT: %[[PORT:.+]] = firrtl.instance source @Source
+    // CHECK-NEXT: %[[NODE:.+]] = firrtl.node sym @[[SYM:.+]] interesting_name %[[PORT]]
+    // CHECK-NEXT: = sv.xmr.ref
+    // CHECK-SAME: @Issue4559::@[[SYM]]
+    %port = firrtl.instance source @Source(out sourceport: !firrtl.uint<1>)
+    %port_ref = firrtl.ref.send %port : !firrtl.uint<1>
+    %port_val = firrtl.ref.resolve %port_ref : !firrtl.ref<uint<1>>
+  }
+}


### PR DESCRIPTION
InstanceOp is "special" in that the inner symbol targets the instance itself and its results cannot have symbols.

Fixes #4559.