### PR TITLE
[FIRRTL] Fix Mem Metadata DUT/No-DUT Logic

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -26,6 +26,7 @@
 
 using namespace circt;
 using namespace firrtl;
+using circt::hw::InstancePath;
 
 namespace {
 class CreateSiFiveMetadataPass
@@ -61,6 +62,12 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
   // The instance graph analysis will be required to print the hierarchy names
   // of the memory.
   auto instancePathCache = InstancePathCache(getAnalysis<InstanceGraph>());
+
+  // Everything goes in the DUT if (1) there is no DUT specified or (2) if the
+  // DUT is the top module.
+  bool everythingInDUT =
+      !dutMod ||
+      instancePathCache.instanceGraph.getTopLevelNode()->getModule() == dutMod;
 
   // This lambda, writes to the given Json stream all the relevant memory
   // attributes. Also adds the memory attrbutes to the string for creating the
@@ -106,6 +113,10 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
                      " depth " + Twine(mem.getDepth()) + " width " +
                      Twine(width) + " ports " + portStr + maskGranStr + "\n")
                         .str();
+
+    // Do not emit any JSON for memories which are not in the DUT.
+    if (!everythingInDUT && !dutModuleSet.contains(mem))
+      return;
     // This adds a Json array element entry corresponding to this memory.
     jsonStream.object([&] {
       jsonStream.attribute("module_name", memExtName);
@@ -149,38 +160,27 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
             hierName = (Twine(hierName) + "." + inst.instanceName()).str();
           }
           hierNames.push_back(hierName);
-          jsonStream.value(hierName);
+          // Only include the memory path if it is under the DUT or we are in a
+          // situation where everything is deemed to be "in the DUT", i.e., when
+          // the DUT is the top module or when no DUT is specified.
+          if (everythingInDUT ||
+              llvm::any_of(p, [&](circt::hw::HWInstanceLike inst) {
+                return inst.getReferencedModule() == dutMod;
+              }))
+            jsonStream.value(hierName);
         }
       });
     });
   };
 
-  SmallVector<FMemModuleOp> dutMems;
-  SmallVector<FMemModuleOp> tbMems;
-  for (auto mod : circuitOp.getOps<FMemModuleOp>()) {
-    if (dutModuleSet.contains(mod))
-      dutMems.push_back(mod);
-    else
-      tbMems.push_back(mod);
-  }
-
-  std::string testBenchJsonBuffer;
-  llvm::raw_string_ostream testBenchOs(testBenchJsonBuffer);
-  llvm::json::OStream testBenchJson(testBenchOs, 2);
   std::string dutJsonBuffer;
   llvm::raw_string_ostream dutOs(dutJsonBuffer);
   llvm::json::OStream dutJson(dutOs, 2);
 
   std::string seqMemConfStr;
   dutJson.array([&] {
-    for (auto &dutM : dutMems)
-      createMemMetadata(dutM, dutJson, seqMemConfStr);
-  });
-  testBenchJson.array([&] {
-    // The tbConfStr is populated here, but unused, it will not be printed to
-    // file.
-    for (auto &tbM : tbMems)
-      createMemMetadata(tbM, testBenchJson, seqMemConfStr);
+    for (auto mem : circuitOp.getOps<FMemModuleOp>())
+      createMemMetadata(mem, dutJson, seqMemConfStr);
   });
 
   auto *context = &getContext();
@@ -193,14 +193,9 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
       metadataDir = dir.getValue();
 
   // Use unknown loc to avoid printing the location in the metadata files.
-  auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
-                                                     testBenchJsonBuffer);
-  auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-      context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
-  tbVerbatimOp->setAttr("output_file", fileAttr);
   auto dutVerbatimOp =
       builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
-  fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+  auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
       context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
   dutVerbatimOp->setAttr("output_file", fileAttr);
 

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -1,10 +1,23 @@
 ; RUN: firtool %s -annotation-file %s.sitestblackboxes.anno.json | FileCheck %s -check-prefixes=CHECK,SITEST_NODUT
 ; RUN: firtool %s -annotation-file %s.sitestblackboxes.anno.json -annotation-file %s.markdut.anno.json | FileCheck %s -check-prefixes=CHECK,SITEST_DUT
+; RUN: firtool %s -repl-seq-mem -repl-seq-mem-file=mems.conf -disable-all-randomization -disable-opt | FileCheck %s -check-prefixes=CHECK,MEMS_NODUT
+; RUN: firtool %s -repl-seq-mem -repl-seq-mem-file=mems.conf -disable-all-randomization -disable-opt -annotation-file %s.markdut.anno.json | FileCheck %s -check-prefixes=CHECK,MEMS_DUT
 
 ; CHECK: module Foo
 circuit TestHarness:
   ; Foo* are instantiated only by the TestHarness
   module Foo:
+
+    mem foo_m :
+      data-type => UInt<8>
+      depth => 1
+      reader => r
+      writer => w
+      read-latency => 1
+      write-latency => 1
+      read-under-write => undefined
+
+    foo_m is invalid
 
   extmodule Foo_BlackBox:
     defname = Foo_BlackBox
@@ -12,11 +25,33 @@ circuit TestHarness:
   ; Bar* are instantiated only by the DUT
   module Bar:
 
+    mem bar_m :
+      data-type => UInt<8>
+      depth => 2
+      reader => r
+      writer => w
+      read-latency => 1
+      write-latency => 1
+      read-under-write => undefined
+
+    bar_m is invalid
+
   extmodule Bar_BlackBox:
     defname = Bar_BlackBox
 
   ; Baz* are instantiated by both the TestHarness and the DUT
   module Baz:
+
+    mem baz_m :
+      data-type => UInt<8>
+      depth => 3
+      reader => r
+      writer => w
+      read-latency => 1
+      write-latency => 1
+      read-under-write => undefined
+
+    baz_m is invalid
 
   extmodule Baz_BlackBox:
     defname = Baz_BlackBox
@@ -57,3 +92,15 @@ circuit TestHarness:
 ; SITEST_NODUT-DAG:   "Foo_BlackBox"
 ; SITEST_NODUT-DAG:   "Bar_BlackBox"{{,?}}
 ; SITEST_NODUT-DAG:   "Baz_BlackBox"{{,?}}
+
+; MEMS_DUT:         FILE "metadata{{[/\]}}seq_mems.json"
+; MEMS_DUT-NOT:     FILE
+; MEMS_DUT-DAG:       "DUT.bar.bar_m.bar_m_ext"
+; MEMS_DUT-DAG:       "DUT.baz.baz_m.baz_m_ext"
+
+; MEMS_NODUT:       FILE "metadata{{[/\]}}seq_mems.json"
+; MEMS_NODUT-NOT:   FILE
+; MEMS_NODUT-DAG:    "TestHarness.foo.foo_m.foo_m_ext"
+; MEMS_NODUT-DAG:    "TestHarness.dut.bar.bar_m.bar_m_ext"
+; MEMS_NODUT-DAG:    "TestHarness.dut.baz.baz_m.baz_m_ext"
+; MEMS_NODUT-DAG:    "TestHarness.baz.baz_m.baz_m_ext"

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -116,7 +116,6 @@ firrtl.circuit "top"
 {
   firrtl.module @top() { }
   // When there are no memories, we still need to emit the memory metadata.
-  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>}
   // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>}
   // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
 }
@@ -156,10 +155,8 @@ firrtl.circuit "top" {
     firrtl.memmodule private @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    // CHECK: sv.verbatim "[\0A  {\0A    \22module_name\22: \22head_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: false,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22top.mem1.head_ext\22\0A    ]\0A  },\0A  {\0A    \22module_name\22: \22head_0_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: false,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22top.mem2.head_0_ext\22\0A    ]\0A  }\0A]"
-    // CHECK-SAME:  {output_file = #hw.output_file<"metadata{{/|\\\\}}tb_seq_mems.json", excludeFromFileList>}
     // CHECK: sv.verbatim "[\0A  {\0A    \22module_name\22: \22memory_ext\22,\0A    \22depth\22: 16,\0A    \22width\22: 8,\0A    \22masked\22: false,\0A    \22read\22: true,\0A    \22write\22: false,\0A    \22readwrite\22: true,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22DUT.mem1.memory_ext\22\0A    ]\0A  },\0A  {\0A    \22module_name\22: \22dumm_ext\22,\0A    \22depth\22: 20,\0A    \22width\22: 5,\0A    \22masked\22: false,\0A    \22read\22: true,\0A    \22write\22: true,\0A    \22readwrite\22: false,\0A    \22extra_ports\22: [],\0A    \22hierarchy\22: [\0A      \22DUT.mem1.dumm_ext\22\0A    ]\0A  }\0A]"
     // CHECK-SAME: output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>
-    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname dumm_ext depth 20 width 5 ports write,read\0Aname head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0A"
+    // CHECK: sv.verbatim "name head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0Aname memory_ext depth 16 width 8 ports rw\0Aname dumm_ext depth 20 width 5 ports write,read\0A"
     // CHECK-SAME: {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
 }

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -175,37 +175,6 @@ circuit test:
 ; CHECK-LABEL: external module tbMemoryKind1_0_ext
 
 
-; CHECK-LABEL: FILE "metadata{{[/\]}}tb_seq_mems.json"
-; CHECK:      [
-; CHECK-NEXT:   {
-; CHECK-NEXT:     "module_name": "tbMemoryKind1_ext",
-; CHECK-NEXT:     "depth": 16,
-; CHECK-NEXT:     "width": 8,
-; CHECK-NEXT:     "masked": false,
-; CHECK-NEXT:     "read": true,
-; CHECK-NEXT:     "write": true,
-; CHECK-NEXT:     "readwrite": false,
-; CHECK-NEXT:     "extra_ports": [],
-; CHECK-NEXT:     "hierarchy": [
-; CHECK-NEXT:       "test.h2.m.tbMemoryKind1.tbMemoryKind1_ext"
-; CHECK-NEXT:     ]
-; CHECK-NEXT:   },
-; CHECK-NEXT:   {
-; CHECK-NEXT:     "module_name": "tbMemoryKind1_0_ext",
-; CHECK-NEXT:     "depth": 16,
-; CHECK-NEXT:     "width": 8,
-; CHECK-NEXT:     "masked": false,
-; CHECK-NEXT:     "read": true,
-; CHECK-NEXT:     "write": true,
-; CHECK-NEXT:     "readwrite": false,
-; CHECK-NEXT:     "extra_ports": [],
-; CHECK-NEXT:     "hierarchy": [
-; CHECK-NEXT:       "test.h1.tbMemoryKind1.tbMemoryKind1_0_ext"
-; CHECK-NEXT:     ]
-; CHECK-NEXT:   }
-; CHECK-NEXT: ]
-
-
 ; CHECK-LABEL: FILE "metadata{{[/\]}}seq_mems.json"
 ; CHECK:      [
 ; CHECK-NEXT:   {
@@ -225,6 +194,6 @@ circuit test:
 
 
 ; CHECK-LABEL: FILE "dutModule.conf"
-; CHECK: name dutMemory_ext depth 32 width 8 ports write,read
 ; CHECK: name tbMemoryKind1_ext depth 16 width 8 ports write,read
+; CHECK: name dutMemory_ext depth 32 width 8 ports write,read
 ; CHECK: name tbMemoryKind1_0_ext depth 16 width 8 ports write,read


### PR DESCRIPTION
Remove the "tb_seq_mems.json" metadata file as this has not been used for a long time.  This was previously a metadata file that would list memory information about the test harness.

Fix bugs in how memory metadata files are generated for situations where no DUT is specified and when a DUT is specified, but a memory is instantiated in both the DUT and the Testbench.

Previously, if no DUT was specified then all memory instances would be placed in "tb_seq_mems.json".  Now, all instances will be placed in "seq_mems.json".

Previously, if a memory was instantiated in both the DUT and the Testbench, then it would wind up with all instances placed in "seq_mems.json", including the one from the Testbench.  Change this to put the memory module in both the "tb_seq_mems.json" and "seq_mems.json", but with only the proper instances in each.

Can @mwachs5 or @richardxia weight in on what should happen here? _Is the old behavior correct?_ This is complicated because it has aspects of both modules and instances. 😬 

For the second situation, the behavior was changed to:

```
// ----- 8< ----- FILE "metadata/seq_mems.json" ----- 8< -----

[
  {
    "module_name": "bar_m_ext",
    "depth": 2,
    "width": 8,
    "masked": false,
    "read": true,
    "write": true,
    "readwrite": false,
    "extra_ports": [],
    "hierarchy": [
      "DUT.bar.bar_m.bar_m_ext"
    ]
  },
  {
    "module_name": "baz_m_ext",
    "depth": 3,
    "width": 8,
    "masked": false,
    "read": true,
    "write": true,
    "readwrite": false,
    "extra_ports": [],
    "hierarchy": [
      "DUT.baz.baz_m.baz_m_ext"
    ]
  }
]
```

Previously, this was:

```
// ----- 8< ----- FILE "metadata/tb_seq_mems.json" ----- 8< -----

[
  {
    "module_name": "foo_m_ext",
    "depth": 1,
    "width": 8,
    "masked": false,
    "read": true,
    "write": true,
    "readwrite": false,
    "extra_ports": [],
    "hierarchy": [
      "TestHarness.foo.foo_m.foo_m_ext"
    ]
  }
]

// ----- 8< ----- FILE "metadata/seq_mems.json" ----- 8< -----

[
  {
    "module_name": "bar_m_ext",
    "depth": 2,
    "width": 8,
    "masked": false,
    "read": true,
    "write": true,
    "readwrite": false,
    "extra_ports": [],
    "hierarchy": [
      "DUT.bar.bar_m.bar_m_ext"
    ]
  },
  {
    "module_name": "baz_m_ext",
    "depth": 3,
    "width": 8,
    "masked": false,
    "read": true,
    "write": true,
    "readwrite": false,
    "extra_ports": [],
    "hierarchy": [
      "TestHarness.baz.baz_m.baz_m_ext",
      "DUT.baz.baz_m.baz_m_ext"
    ]
  }
]
```

The structure of the test is as follows:

- `Foo*` is instantiated only by the test harness
- `Bar*` is instantiated only by the DUT
- `Baz*` is instantiated by both the test harness and the DUT

<img width="585" alt="image" src="https://user-images.githubusercontent.com/1018530/222879673-3e7ce29e-f303-42a3-a9f4-990e45dccb39.png">
