### PR TITLE
[FIRRTL] Super Strict Connect: Eliminate all other connects

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -113,19 +113,6 @@ def GTWithConstLHS : Pat<
   (MoveNameHint $old, (LTPrimOp $rhs, $lhs)),
   [(AnyConstantOp $lhs), (NonConstantOp $rhs)]>;
 
-// connect(a:t,b:t) -> strictconnect(a,b)
-def ConnectSameType : Pat<
-  (ConnectOp $dst, $src),
-  (StrictConnectOp $dst, $src),
-  [(EqualTypes $dst, $src), (KnownWidth $dst)]>;
-
-// connect(a:t1,b:(t2<t1) -> strictconnect(a,(pad b))
-def ConnectExtension : Pat<
-  (ConnectOp $dst, $src),
-  (StrictConnectOp $dst, (PadPrimOp $src,
-    (NativeCodeCall<"$0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel()"> $dst))),
-  [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src), (mismatchTypes $src, $dst)]>;
-
 def LimitConstant32 : NativeCodeCall<
   "$_builder.getI32IntegerAttr($0.getValue().getLimitedValue(1ULL << 31))">;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -516,6 +516,22 @@ let inferType = "impl::inferReductionResult" in {
 }
 
 //===----------------------------------------------------------------------===//
+// Special inference Operations
+//===----------------------------------------------------------------------===//
+
+def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure]> {
+  let description = [{
+    Cast between reset types.  This is used to enable strictconnects early in
+    the pipeline by isolating all uninferred reset connections to a single op.
+  }];
+  let arguments = (ins AnyResetType:$input);
+  let results = (outs AnyResetType:$result);
+  
+  let assemblyFormat =
+    "$input attr-dict `:` functional-type($input, $result)";
+}
+
+//===----------------------------------------------------------------------===//
 // Other Operations
 //===----------------------------------------------------------------------===//
 
@@ -754,6 +770,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
 
   let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";
 }
+
 
 //===----------------------------------------------------------------------===//
 // RefOperations: Operations on the RefType.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -46,7 +46,6 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
     "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
 
   let hasVerifier = 1;
-  let hasCanonicalizer = true;
 }
 
 def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]> {

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -52,6 +52,8 @@ std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass(
     PreserveAggregate::PreserveMode mode = PreserveAggregate::None,
     bool preservePublicTypes = true);
 
+std::unique_ptr<mlir::Pass> createLowerFIRRTLConnectsPass();
+
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 
 std::unique_ptr<mlir::Pass> createLowerCHIRRTLPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -76,6 +76,17 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let dependentDialects = ["hw::HWDialect"];
 }
 
+def LowerFIRRTLConnects : Pass<"firrtl-lower-connects", "firrtl::FModuleOp"> {
+  let summary = "Lower FIRRTL aggregate connects types to passive types";
+  let description = [{
+    Lower aggregate FIRRTL connects to passsive types.  This does not split 
+    storage elements, only connects.
+
+    Connect expansion and canonicalization happen in this pass.
+  }];
+  let constructor = "circt::firrtl::createLowerFIRRTLConnectsPass()";
+}
+
 def IMConstProp : Pass<"firrtl-imconstprop", "firrtl::CircuitOp"> {
   let summary = "Intermodule constant propagation and dead code elimination";
   let description = [{

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1598,12 +1598,6 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   return success();
 }
 
-void ConnectOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                            MLIRContext *context) {
-//  results.insert<patterns::ConnectExtension, patterns::ConnectSameType>(
-//      context);
-}
-
 LogicalResult StrictConnectOp::canonicalize(StrictConnectOp op,
                                             PatternRewriter &rewriter) {
   // TODO: Canonicalize towards explicit extensions and flips here.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1600,8 +1600,8 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
 
 void ConnectOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
-  results.insert<patterns::ConnectExtension, patterns::ConnectSameType>(
-      context);
+//  results.insert<patterns::ConnectExtension, patterns::ConnectSameType>(
+//      context);
 }
 
 LogicalResult StrictConnectOp::canonicalize(StrictConnectOp op,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3807,6 +3807,9 @@ void AsSIntPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void AsUIntPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
+void UninferredResetCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
 void BitsPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LegacyWiring.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
+  LowerConnects.cpp
   LowerIntrinsics.cpp
   LowerMemory.cpp
   LowerTypes.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -736,7 +736,9 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
         .Case<ConnectOp, StrictConnectOp>([&](auto op) {
           traceResets(op.getDest(), op.getSrc(), op.getLoc());
         })
-
+        .Case<UninferredResetCastOp>([&](auto op) {
+          traceResets(op.getResult(), op.getInput(), op.getLoc());
+        })
         .Case<InstanceOp>([&](auto op) { traceResets(op); })
         .Case<RefSendOp>([&](auto op) {
           // Trace using base types.
@@ -1070,29 +1072,34 @@ LogicalResult InferResetsPass::updateReset(ResetNetwork net, ResetKind kind) {
   // reset types in aggregates, and then need all the subindex, subfield, and
   // subaccess operations to be updated as appropriate.
   while (!worklist.empty()) {
-    auto op = dyn_cast_or_null<InferTypeOpInterface>(worklist.pop_back_val());
-    if (!op)
-      continue;
 
-    // Determine the new result types.
-    SmallVector<Type, 2> types;
-    if (failed(op.inferReturnTypes(op->getContext(), op->getLoc(),
-                                   op->getOperands(), op->getAttrDictionary(),
-                                   op->getRegions(), types)))
-      return failure();
-    assert(types.size() == op->getNumResults());
+    auto wop = worklist.pop_back_val();
 
-    // Update the results and add the changed ones to the worklist.
-    for (auto it : llvm::zip(op->getResults(), types)) {
-      auto newType = std::get<1>(it);
-      if (std::get<0>(it).getType() == newType)
-        continue;
-      std::get<0>(it).setType(newType);
-      for (auto user : std::get<0>(it).getUsers())
-        worklist.insert(user);
+    if (auto op = dyn_cast<InferTypeOpInterface>(wop)) {
+      // Determine the new result types.
+      SmallVector<Type, 2> types;
+
+      if (failed(op.inferReturnTypes(op->getContext(), op->getLoc(),
+                                     op->getOperands(), op->getAttrDictionary(),
+                                     op->getRegions(), types)))
+        return failure();
+      assert(types.size() == op->getNumResults());
+
+      // Update the results and add the changed ones to the worklist.
+      for (auto it : llvm::zip(op->getResults(), types)) {
+        auto newType = std::get<1>(it);
+        if (std::get<0>(it).getType() == newType)
+          continue;
+        std::get<0>(it).setType(newType);
+        for (auto user : std::get<0>(it).getUsers())
+          worklist.insert(user);
+      }
+      //    LLVM_DEBUG(llvm::dbgs() << "- Inferred " << *op << "\n");
+    } else if (auto uop = dyn_cast<UninferredResetCastOp>(wop)) {
+      uop.replaceAllUsesWith(uop.getInput());
+      LLVM_DEBUG(llvm::dbgs() << "- Inferred " << uop << "\n");
+      uop.erase();
     }
-
-    LLVM_DEBUG(llvm::dbgs() << "- Inferred " << *op << "\n");
   }
 
   // Update module types based on the type of the block arguments.

--- a/lib/Dialect/FIRRTL/Transforms/LowerConnects.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerConnects.cpp
@@ -1,0 +1,164 @@
+//===- LowerConnects.cpp - Lower Aggregate Duplex Connects ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// After this pass, all data flows right to left in a connect.  There are no 
+// connects of an aggregates which still have a flip.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Threading.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Parallel.h"
+
+using namespace circt;
+using namespace firrtl;
+
+/// Emit a connect between two values.
+static void emitStrictConnect(ImplicitLocOpBuilder &builder, Value dst,
+                                Value src) {
+  auto dstFType = dst.getType().cast<FIRRTLType>();
+  auto srcFType = src.getType().cast<FIRRTLType>();
+  auto dstType = dstFType.dyn_cast<FIRRTLBaseType>();
+  auto srcType = srcFType.dyn_cast<FIRRTLBaseType>();
+
+  // Non-base types don't need special handling.
+  if (!srcType || !dstType) {
+    llvm::errs() << "Non-base types\n";
+    dstFType.dump();
+    srcFType.dump();
+    assert(0 && "FIXME");
+    builder.create<ConnectOp>(dst, src);
+    return;
+  }
+
+  if (dstType == srcType && dstType.isPassive() && srcType.isPassive() && !dstType.hasUninferredWidth() && !srcType.hasUninferredWidth()) {
+    builder.create<StrictConnectOp>(dst, src);
+    return;
+  }
+
+  if (auto dstBundle = dstType.dyn_cast<BundleType>()) {
+    // Connect all the bundle elements pairwise.
+    auto numElements = dstBundle.getNumElements();
+    // Connect verifier ensures both sides have the same shape
+    for (size_t i = 0; i < numElements; ++i) {
+      auto dstField = builder.create<SubfieldOp>(dst, i);
+      auto srcField = builder.create<SubfieldOp>(src, i);
+      if (dstBundle.getElement(i).isFlip)
+        std::swap(dstField, srcField);
+      emitStrictConnect(builder, dstField, srcField);
+    }
+    return;
+  }
+
+  if (auto dstVector = dstType.dyn_cast<FVectorType>()) {
+    // Connect all the vector elements pairwise.
+    auto numElements = dstVector.getNumElements();
+    // Connect verifier ensures both sides have the same shape
+    for (size_t i = 0; i < numElements; ++i) {
+      auto dstField = builder.create<SubindexOp>(dst, i);
+      auto srcField = builder.create<SubindexOp>(src, i);
+      emitStrictConnect(builder, dstField, srcField);
+    }
+    return;
+  }
+
+  // Handle ground types with possibly uninferred widths.
+  auto dstWidth = dstType.getBitWidthOrSentinel();
+  auto srcWidth = srcType.getBitWidthOrSentinel();
+  if (dstWidth < 0 || srcWidth < 0) {
+    // If one of these types has an uninferred width, we connect them with a
+    // regular connect operation.
+    llvm::errs() << "Uninferred connect\n";
+    dst.dump();
+    src.dump();
+    builder.create<ConnectOp>(dst, src);
+    return;
+  }
+
+  // The source must be extended or truncated.
+  if (dstWidth < srcWidth) {
+    // firrtl.tail always returns uint even for sint operands.
+    IntType tmpType = dstType.cast<IntType>();
+    if (tmpType.isSigned())
+      tmpType = UIntType::get(dstType.getContext(), dstWidth);
+    src = builder.create<TailPrimOp>(tmpType, src, srcWidth - dstWidth);
+    // Insert the cast back to signed if needed.
+    if (tmpType != dstType)
+      src = builder.create<AsSIntPrimOp>(dstType, src);
+    srcType = src.getType().cast<FIRRTLBaseType>();
+  } else if (srcWidth < dstWidth) {
+    // Need to extend arg.
+    src = builder.create<PadPrimOp>(src, dstWidth);
+    srcType = src.getType().cast<FIRRTLBaseType>();
+  }
+
+  // Deal with reset converting connects
+  if (srcType.isResetType() && dstType.isResetType() && srcType != dstType) {
+    src = builder.create<UninferredResetCastOp>(dstType, src);
+    srcType = src.getType().cast<FIRRTLBaseType>();
+  }
+
+  if (dstType != srcType) {
+    llvm::errs() << "Weird connect\n";
+    dst.getType().dump();
+    src.getType().dump();
+    assert(0);
+  }
+  builder.create<StrictConnectOp>(dst, src);
+}
+
+
+static void lowerConnect(ConnectOp con) {
+  ImplicitLocOpBuilder locBuilder(con.getLoc(), con);
+    emitStrictConnect(locBuilder, con.getDest(), con.getSrc());
+    con.erase();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerConnectsPass : public LowerFIRRTLConnectsBase<LowerConnectsPass> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+// This is the main entrypoint for the lowering pass.
+void LowerConnectsPass::runOnOperation() {
+  FModuleOp mod = getOperation();
+
+  // Record all operations in the circuit.
+  for (auto con : llvm::make_early_inc_range(mod.getOps<ConnectOp>()))
+      lowerConnect(con);
+
+//  if (failed(result))
+//    signalPassFailure();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createLowerFIRRTLConnectsPass() {
+  return std::make_unique<LowerConnectsPass>();
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -640,6 +640,8 @@ static LogicalResult processBuffer(
   if (!disableInferWidths)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
 
+  pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(firrtl::createLowerFIRRTLConnectsPass());
+
   if (!disableMemToRegOfVec)
     pm.nest<firrtl::CircuitOp>().addPass(
         firrtl::createMemToRegOfVecPass(replSeqMem, ignoreReadEnableMem));


### PR DESCRIPTION
This normalized connects early on in the pipeline so they always are connecting things of passive types.  Analog, flip,  uninferred resets, and implicit extensions no longer appear in the code after connect normalization. 

The intent is to significantly simplify later code by narrowing the semantic scope of connect.