### PR TITLE
[Support][NFC] Factor out ImplicitSSAName directive

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -256,7 +256,7 @@ def NodeOp : ReferableDeclOp<"node",
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    $input `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($input))
+    $input `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` qualified(type($input))
   }];
 
   let hasCanonicalizer = true;
@@ -300,7 +300,7 @@ def RegOp : ReferableDeclOp<"reg"> {
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    operands `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 }
@@ -346,7 +346,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands `` custom<ImplicitSSAName>(attr-dict)
+    operands `` custom<FIRRTLImplicitSSAName>(attr-dict)
     `:` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
   }];
 
@@ -390,7 +390,7 @@ def WireOp : ReferableDeclOp<"wire"> {
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind) ``
-    custom<ImplicitSSAName>(attr-dict) `:`
+    custom<FIRRTLImplicitSSAName>(attr-dict) `:`
     qualified(type($result))
   }];
 }

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -204,7 +204,7 @@ def LocalParamOp : SVOp<"localparam",
   let results = (outs HWValueType:$result);
 
   let assemblyFormat = [{
-    `:` qualified(type($result)) `` custom<ImplicitSSAName>(attr-dict)
+    `:` qualified(type($result)) `` custom<SVImplicitSSAName>(attr-dict)
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -38,7 +38,7 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 
@@ -68,7 +68,7 @@ def RegOp : SVOp<"reg", [
 
   // We handle the name in a custom way, so we use a customer parser/printer.
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict)
      `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
@@ -236,7 +236,7 @@ def LogicOp : SVOp<"logic", [DeclareOpInterfaceMethods<OpAsmOpInterface,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict) `:`
+    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict) `:`
                                                 qualified(type($result))
   }];
 

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -223,7 +223,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [HasCustomSSAName]> {
   let results = (outs InterfaceType : $result);
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict)
     `:` qualified(type($result))
   }];
 

--- a/include/circt/Support/CustomDirectiveImpl.h
+++ b/include/circt/Support/CustomDirectiveImpl.h
@@ -1,0 +1,51 @@
+//===- CustomDirectiveImpl.h - Custom TableGen directives -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides common custom directives for table-gen assembly formats.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_CUSTOMDIRECTIVEIMPL_H
+#define CIRCT_SUPPORT_CUSTOMDIRECTIVEIMPL_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace circt {
+
+//===----------------------------------------------------------------------===//
+// ImplicitSSAName Custom Directive
+//===----------------------------------------------------------------------===//
+
+/// Parse an attribute dictionary and ensure that it contains a `name` field by
+/// inferring its value from the SSA name of the operation's first result if
+/// necessary.
+ParseResult parseImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs);
+
+/// Ensure that `attrs` contains a `name` attribute by inferring its value from
+/// the SSA name of the operation's first result if necessary. Returns true if a
+/// name was inferred, false if `attrs` already contained a `name`.
+bool inferImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs);
+
+/// Print an attribute dictionary and elide the `name` field if its value
+/// matches the SSA name of the operation's first result.
+void printImplicitSSAName(OpAsmPrinter &p, Operation *op, DictionaryAttr attrs,
+                          ArrayRef<StringRef> extraElides = {});
+
+/// Check if the `name` attribute in `attrs` matches the SSA name of the
+/// operation's first result. If it does, add `name` to `elides`. This is
+/// helpful during printing of attribute dictionaries in order to determine if
+/// the inclusion of the `name` field would be redundant.
+void elideImplicitSSAName(OpAsmPrinter &printer, Operation *op,
+                          DictionaryAttr attrs,
+                          SmallVectorImpl<StringRef> &elides);
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_CUSTOMDIRECTIVEIMPL_H

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -14,10 +14,11 @@ add_circt_dialect_library(CIRCTSV
   Support
 
   LINK_LIBS PUBLIC
-  MLIRIR
-  CIRCTHW
   CIRCTComb
-   )
+  CIRCTHW
+  CIRCTSupport
+  MLIRIR
+)
 
 add_dependencies(circt-headers MLIRSVIncGen)
 

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -8,6 +8,7 @@ set_source_files_properties("${VERSION_CPP}" PROPERTIES GENERATED TRUE)
 add_circt_library(CIRCTSupport
   APInt.cpp
   BackedgeBuilder.cpp
+  CustomDirectiveImpl.cpp
   FieldRef.cpp
   JSON.cpp
   LoweringOptions.cpp

--- a/lib/Support/CustomDirectiveImpl.cpp
+++ b/lib/Support/CustomDirectiveImpl.cpp
@@ -20,7 +20,7 @@ ParseResult circt::parseImplicitSSAName(OpAsmParser &parser,
 }
 
 bool circt::inferImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs) {
-  // Don't do anythign if a `name` attribute is explicitly provided.
+  // Don't do anything if a `name` attribute is explicitly provided.
   if (attrs.get("name"))
     return false;
 

--- a/lib/Support/CustomDirectiveImpl.cpp
+++ b/lib/Support/CustomDirectiveImpl.cpp
@@ -1,0 +1,57 @@
+//===- CustomDirectiveImpl.cpp - Custom TableGen directives ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/CustomDirectiveImpl.h"
+#include "llvm/ADT/SmallString.h"
+
+using namespace circt;
+
+ParseResult circt::parseImplicitSSAName(OpAsmParser &parser,
+                                        NamedAttrList &attrs) {
+  if (parser.parseOptionalAttrDict(attrs))
+    return failure();
+  inferImplicitSSAName(parser, attrs);
+  return success();
+}
+
+bool circt::inferImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs) {
+  // Don't do anythign if a `name` attribute is explicitly provided.
+  if (attrs.get("name"))
+    return false;
+
+  // Infer the name from the SSA name of the operation's first result.
+  auto resultName = parser.getResultName(0).first;
+  if (!resultName.empty() && isdigit(resultName[0]))
+    resultName = "";
+  auto nameAttr = parser.getBuilder().getStringAttr(resultName);
+  auto *context = parser.getBuilder().getContext();
+  attrs.push_back({StringAttr::get(context, "name"), nameAttr});
+  return true;
+}
+
+void circt::printImplicitSSAName(OpAsmPrinter &printer, Operation *op,
+                                 DictionaryAttr attrs,
+                                 ArrayRef<StringRef> extraElides) {
+  SmallVector<StringRef, 2> elides(extraElides.begin(), extraElides.end());
+  elideImplicitSSAName(printer, op, attrs, elides);
+  printer.printOptionalAttrDict(attrs.getValue(), elides);
+}
+
+void circt::elideImplicitSSAName(OpAsmPrinter &printer, Operation *op,
+                                 DictionaryAttr attrs,
+                                 SmallVectorImpl<StringRef> &elides) {
+  SmallString<32> resultNameStr;
+  llvm::raw_svector_ostream tmpStream(resultNameStr);
+  printer.printOperand(op->getResult(0), tmpStream);
+  auto actualName = tmpStream.str().drop_front();
+  auto expectedName = attrs.getAs<StringAttr>("name").getValue();
+  // Anonymous names are printed as digits, which is fine.
+  if (actualName == expectedName ||
+      (expectedName.empty() && isdigit(actualName[0])))
+    elides.push_back("name");
+}


### PR DESCRIPTION
The FIRRTL and SV dialects have an almost interchangeable implementation of the `ImplicitSSAName` directive, which they apply to the `attr-dict` of the operation. To facilitate adding ops in other dialects that want to use a similar scheme, factor the commonalities of these directives out into the `CIRCTSupport` library.

The SystemC dialect uses a slightly different approach: it also uses a `ImplicitSSAName` directive, but that one is defined in the HW dialect and is applied to the `$name` of the op instead of the `attr-dict`. The benefit is that TableGen automatically generates the list of attrs to be elided (since `$name` is explicitly covered in the assembly format), and printing the name in case it mismatches with the SSA name is handled outside of the generic `attr-dict` printer. We might want to move our ops to this approach in the future. The current refactoring tries to keep changes to a minimum for now.