### PR TITLE
[FIRRTL][NFCI] Cleanup some casting/types, leverage TypedValue a bit.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -270,7 +270,7 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
     ```
     }];
 
-  let arguments = (ins FIRRTLBaseType:$input, I32Attr:$index);
+  let arguments = (ins FVectorType:$input, I32Attr:$index);
   let results = (outs FIRRTLBaseType:$result);
   let hasFolder = 1;
   let hasCanonicalizer = 1;
@@ -281,8 +281,7 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
   let firrtlExtraClassDeclaration = [{
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType().cast<FVectorType>()
-                                            .getFieldID(getIndex()));
+      return FieldRef(getInput(), getInput().getType().getFieldID(getIndex()));
     }
   }];
 }
@@ -300,7 +299,7 @@ def SubaccessOp : FIRRTLExprOp<"subaccess", [
     ```
     }];
 
-  let arguments = (ins FIRRTLBaseType:$input, UIntType:$index);
+  let arguments = (ins FVectorType:$input, UIntType:$index);
   let results = (outs FIRRTLBaseType:$result);
 
   let assemblyFormat =

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -250,6 +250,9 @@ ParseResult parseNestedBaseType(FIRRTLBaseType &result, AsmParser &parser);
 // Print a FIRRTL type without a leading `!firrtl.` dialect tag.
 void printNestedType(Type type, AsmPrinter &os);
 
+using FIRRTLValue = mlir::TypedValue<FIRRTLType>;
+using FIRRTLBaseValue = mlir::TypedValue<FIRRTLBaseType>;
+
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -72,7 +72,7 @@ static bool isModuleScopedDrivenBy(Value val, bool lookThroughWires,
 /// if walking was broken, and true otherwise.
 using WalkDriverCallback =
     llvm::function_ref<bool(const FieldRef &dst, const FieldRef &src)>;
-bool walkDrivers(Value value, bool lookThroughWires,
+bool walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
                  bool lookTWalkDriverCallbackhroughNodes, bool lookThroughCasts,
                  WalkDriverCallback callback);
 
@@ -95,7 +95,7 @@ FieldRef getFieldRefFromValue(Value value);
 std::pair<std::string, bool> getFieldName(const FieldRef &fieldRef,
                                           bool nameSafe = false);
 
-Value getValueByFieldID(ImplicitLocOpBuilder builder, Value value,
+FIRRTLBaseValue getValueByFieldID(ImplicitLocOpBuilder builder, FIRRTLBaseValue value,
                         unsigned fieldID);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -95,7 +95,7 @@ FieldRef getFieldRefFromValue(Value value);
 std::pair<std::string, bool> getFieldName(const FieldRef &fieldRef,
                                           bool nameSafe = false);
 
-FIRRTLBaseValue getValueByFieldID(ImplicitLocOpBuilder builder, FIRRTLBaseValue value,
+Value getValueByFieldID(ImplicitLocOpBuilder builder, Value value,
                         unsigned fieldID);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -73,7 +73,7 @@ static bool isModuleScopedDrivenBy(Value val, bool lookThroughWires,
 using WalkDriverCallback =
     llvm::function_ref<bool(const FieldRef &dst, const FieldRef &src)>;
 bool walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
-                 bool lookTWalkDriverCallbackhroughNodes, bool lookThroughCasts,
+                 bool lookThroughNodes, bool lookThroughCasts,
                  WalkDriverCallback callback);
 
 /// Get the FieldRef from a value.  This will travel backwards to through the

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1328,9 +1328,7 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
   for (auto op : structValue.getUsers()) {
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
-    auto elemIndex =
-        fieldAccess.getInput().getType().getElementIndex(
-            field);
+    auto elemIndex = fieldAccess.getInput().getType().getElementIndex(field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
   }

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1329,7 +1329,7 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
     auto elemIndex =
-        fieldAccess.getInput().getType().cast<BundleType>().getElementIndex(
+        fieldAccess.getInput().getType().getElementIndex(
             field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1325,7 +1325,7 @@ static Value tryEliminatingConnectsToValue(Value flipValue,
 static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
                                                    StringRef field) {
   SmallVector<SubfieldOp> accesses;
-  for (auto op : structValue.getUsers()) {
+  for (auto *op : structValue.getUsers()) {
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
     auto elemIndex = fieldAccess.getInput().getType().getElementIndex(field);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -676,17 +676,20 @@ void Emitter::emitExpression(SpecialConstantOp op) {
       });
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void Emitter::emitExpression(SubfieldOp op) {
   auto type = op.getInput().getType();
   emitExpression(op.getInput());
   os << "." << type.getElementName(op.getFieldIndex());
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void Emitter::emitExpression(SubindexOp op) {
   emitExpression(op.getInput());
   os << "[" << op.getIndex() << "]";
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void Emitter::emitExpression(SubaccessOp op) {
   emitExpression(op.getInput());
   os << "[";

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -677,7 +677,7 @@ void Emitter::emitExpression(SpecialConstantOp op) {
 }
 
 void Emitter::emitExpression(SubfieldOp op) {
-  auto type = op.getInput().getType().cast<BundleType>();
+  auto type = op.getInput().getType();
   emitExpression(op.getInput());
   os << "." << type.getElementName(op.getFieldIndex());
 }

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -374,7 +374,8 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
                                    const AnnoPathValue &moduleTarget,
                                    const AnnoPathValue &target,
                                    StringAttr internalPathAttr,
-                                   FIRRTLBaseType targetType, ApplyState &state) {
+                                   FIRRTLBaseType targetType,
+                                   ApplyState &state) {
   Value sendVal;
   FModuleLike mod = cast<FModuleLike>(moduleTarget.ref.getOp());
   InstanceOp modInstance;

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -374,7 +374,7 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
                                    const AnnoPathValue &moduleTarget,
                                    const AnnoPathValue &target,
                                    StringAttr internalPathAttr,
-                                   FIRRTLType targetType, ApplyState &state) {
+                                   FIRRTLBaseType targetType, ApplyState &state) {
   Value sendVal;
   FModuleLike mod = cast<FModuleLike>(moduleTarget.ref.getOp());
   InstanceOp modInstance;
@@ -392,7 +392,7 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
   }
   ImplicitLocOpBuilder builder(modInstance.getLoc(), modInstance);
   builder.setInsertionPointAfter(modInstance);
-  auto portRefType = RefType::get(targetType.cast<FIRRTLBaseType>());
+  auto portRefType = RefType::get(targetType);
   SmallString<32> refName;
   for (auto c : internalPathAttr.getValue()) {
     switch (c) {

--- a/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFieldSource.cpp
@@ -53,8 +53,8 @@ void FieldSource::visitOp(Operation *op) {
   // Track all other definitions of aggregates.
   if (op->getNumResults()) {
     auto type = op->getResult(0).getType();
-    if (dyn_cast<FIRRTLBaseType>(type) &&
-        !cast<FIRRTLBaseType>(type).isGround())
+    if (auto baseType = dyn_cast<FIRRTLBaseType>(type);
+        baseType && !baseType.isGround())
       makeNodeForValue(op->getResult(0), op->getResult(0), {},
                        foldFlow(op->getResult(0)));
   }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -605,7 +605,7 @@ void LEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isa<UIntType>();
+  bool isUnsigned = getLhs().getType().isUnsigned();
 
   // leq(x, x) -> 1
   if (getLhs() == getRhs())
@@ -650,7 +650,7 @@ void LTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isa<UIntType>();
+  bool isUnsigned = getLhs().getType().isUnsigned();
 
   // lt(x, x) -> 0
   if (getLhs() == getRhs())
@@ -658,7 +658,7 @@ OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
 
   // lt(x, 0) -> 0 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
-    if (rhsCst->isZero() && getLhs().getType().isa<UIntType>())
+    if (rhsCst->isZero() && getLhs().getType().isUnsigned())
       return getIntAttr(getType(), APInt(1, 0));
   }
 
@@ -701,7 +701,7 @@ void GEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isa<UIntType>();
+  bool isUnsigned = getLhs().getType().isUnsigned();
 
   // geq(x, x) -> 1
   if (getLhs() == getRhs())
@@ -709,7 +709,7 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
 
   // geq(x, 0) -> 1 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
-    if (rhsCst->isZero() && getLhs().getType().isa<UIntType>())
+    if (rhsCst->isZero() && isUnsigned)
       return getIntAttr(getType(), APInt(1, 1));
   }
 
@@ -752,7 +752,7 @@ void GTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isa<UIntType>();
+  bool isUnsigned = getLhs().getType().isUnsigned();
 
   // gt(x, x) -> 0
   if (getLhs() == getRhs())

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -815,8 +815,7 @@ LogicalResult EQPrimOp::canonicalize(EQPrimOp op, PatternRewriter &rewriter) {
   return canonicalizePrimOp(
       op, rewriter, [&](ArrayRef<Attribute> operands) -> OpFoldResult {
         if (auto rhsCst = getConstant(operands[1])) {
-          auto width =
-              op.getLhs().getType().getBitWidthOrSentinel();
+          auto width = op.getLhs().getType().getBitWidthOrSentinel();
 
           // eq(x, 0) ->  not(x) when x is 1 bit.
           if (rhsCst->isZero() && op.getLhs().getType() == op.getType() &&
@@ -867,8 +866,7 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
   return canonicalizePrimOp(
       op, rewriter, [&](ArrayRef<Attribute> operands) -> OpFoldResult {
         if (auto rhsCst = getConstant(operands[1])) {
-          auto width =
-              op.getLhs().getType().getBitWidthOrSentinel();
+          auto width = op.getLhs().getType().getBitWidthOrSentinel();
 
           // neq(x, 1) -> not(x) when x is 1 bit
           if (rhsCst->isAllOnes() && op.getLhs().getType() == op.getType() &&
@@ -1247,8 +1245,7 @@ public:
       return failure();
 
     auto pad = [&](FIRRTLBaseValue input) -> Value {
-      auto inputWidth = input.getType()
-                            .getBitWidthOrSentinel();
+      auto inputWidth = input.getType().getBitWidthOrSentinel();
       if (inputWidth < 0 || width == inputWidth)
         return input;
       return rewriter
@@ -1359,8 +1356,7 @@ OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 LogicalResult ShrPrimOp::canonicalize(ShrPrimOp op, PatternRewriter &rewriter) {
-  auto inputWidth =
-      op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 
@@ -1383,8 +1379,7 @@ LogicalResult ShrPrimOp::canonicalize(ShrPrimOp op, PatternRewriter &rewriter) {
 
 LogicalResult HeadPrimOp::canonicalize(HeadPrimOp op,
                                        PatternRewriter &rewriter) {
-  auto inputWidth =
-      op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 
@@ -1399,9 +1394,7 @@ LogicalResult HeadPrimOp::canonicalize(HeadPrimOp op,
 OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput())) {
-      int shiftAmount =
-          getInput().getType().getWidthOrSentinel() -
-          getAmount();
+      int shiftAmount = getInput().getType().getWidthOrSentinel() - getAmount();
       return getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount()));
     }
 
@@ -1417,8 +1410,7 @@ OpFoldResult TailPrimOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult TailPrimOp::canonicalize(TailPrimOp op,
                                        PatternRewriter &rewriter) {
-  auto inputWidth =
-      op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2674,8 +2674,7 @@ void SubfieldOp::print(::mlir::OpAsmPrinter &printer) {
 }
 
 LogicalResult SubfieldOp::verify() {
-  if (getFieldIndex() >=
-      getInput().getType().getNumElements())
+  if (getFieldIndex() >= getInput().getType().getNumElements())
     return emitOpError("subfield element index is greater than the number "
                        "of fields in the bundle type");
   return success();
@@ -3940,7 +3939,8 @@ void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                      ArrayRef<NamedAttribute> attrs,
                                      std::optional<Location> loc) {
-  // TODO: Don't cast without checking, we're careful to check in all the others.
+  // TODO: Don't cast without checking, we're careful to check in all the
+  // others.
   auto inType = operands[0].getType().cast<RefType>().getType();
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1949,7 +1949,7 @@ FIRRTLType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
     break;
   }
 
-  return BundleType::get(context, portFields).cast<BundleType>();
+  return BundleType::get(context, portFields);
 }
 
 /// Return the name and kind of ports supported by this memory.
@@ -2146,10 +2146,10 @@ void RegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 LogicalResult RegResetOp::verify() {
-  Value reset = getResetValue();
+  auto reset = getResetValue();
 
-  FIRRTLBaseType resetType = reset.getType().cast<FIRRTLBaseType>();
-  FIRRTLBaseType regType = getResult().getType().cast<FIRRTLBaseType>();
+  FIRRTLBaseType resetType = reset.getType();
+  FIRRTLBaseType regType = getResult().getType();
 
   // The type of the initialiser must be equivalent to the register type.
   if (!areTypesEquivalent(resetType, regType))
@@ -2229,8 +2229,8 @@ static LogicalResult checkConnectFlow(Operation *connect) {
 }
 
 LogicalResult ConnectOp::verify() {
-  auto dstType = getDest().getType().cast<FIRRTLType>();
-  auto srcType = getSrc().getType().cast<FIRRTLType>();
+  auto dstType = getDest().getType();
+  auto srcType = getSrc().getType();
   auto dstBaseType = dstType.dyn_cast<FIRRTLBaseType>();
   auto srcBaseType = srcType.dyn_cast<FIRRTLBaseType>();
   if (!dstBaseType || !srcBaseType) {
@@ -2437,7 +2437,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 
 LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  auto intType = getType().cast<IntType>();
+  auto intType = getType();
   auto width = intType.getWidthOrSentinel();
   if (width != -1 && (int)getValue().getBitWidth() != width)
     return emitError(
@@ -2478,22 +2478,19 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
 void ConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // For constants in particular, propagate the value into the result name to
   // make it easier to read the IR.
-  auto intTy = getType().dyn_cast<IntType>();
+  auto intTy = getType();
+  assert(intTy);
 
   // Otherwise, build a complex name with the value and type.
   SmallString<32> specialNameBuffer;
   llvm::raw_svector_ostream specialName(specialNameBuffer);
   specialName << 'c';
-  if (intTy) {
-    getValue().print(specialName, /*isSigned:*/ intTy.isSigned());
+  getValue().print(specialName, /*isSigned:*/ intTy.isSigned());
 
-    specialName << (intTy.isSigned() ? "_si" : "_ui");
-    auto width = intTy.getWidthOrSentinel();
-    if (width != -1)
-      specialName << width;
-  } else {
-    getValue().print(specialName, /*isSigned:*/ false);
-  }
+  specialName << (intTy.isSigned() ? "_si" : "_ui");
+  auto width = intTy.getWidthOrSentinel();
+  if (width != -1)
+    specialName << width;
   setNameFn(getResult(), specialName.str());
 }
 
@@ -2678,7 +2675,7 @@ void SubfieldOp::print(::mlir::OpAsmPrinter &printer) {
 
 LogicalResult SubfieldOp::verify() {
   if (getFieldIndex() >=
-      getInput().getType().cast<BundleType>().getNumElements())
+      getInput().getType().getNumElements())
     return emitOpError("subfield element index is greater than the number "
                        "of fields in the bundle type");
   return success();
@@ -2746,7 +2743,7 @@ FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
 }
 
 bool SubfieldOp::isFieldFlipped() {
-  auto bundle = getInput().getType().cast<BundleType>();
+  auto bundle = getInput().getType();
   return bundle.getElement(getFieldIndex()).isFlip;
 }
 
@@ -3943,6 +3940,7 @@ void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                      ArrayRef<NamedAttribute> attrs,
                                      std::optional<Location> loc) {
+  // TODO: Don't cast without checking, we're careful to check in all the others.
   auto inType = operands[0].getType().cast<RefType>().getType();
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -710,10 +710,10 @@ IntType IntType::get(MLIRContext *context, bool isSigned,
 }
 
 int32_t IntType::getWidthOrSentinel() {
-  if (isa<SIntType>())
-    return this->cast<SIntType>().getWidthOrSentinel();
-  if (isa<UIntType>())
-    return this->cast<UIntType>().getWidthOrSentinel();
+  if (auto sintType = dyn_cast<SIntType>())
+    return sintType.getWidthOrSentinel();
+  if (auto uintType = dyn_cast<UIntType>())
+    return uintType.getWidthOrSentinel();
   return -1;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -241,12 +241,12 @@ Value circt::firrtl::getModuleScopedDriver(Value val, bool lookThroughWires,
   return val;
 }
 
-bool circt::firrtl::walkDrivers(FIRRTLBaseValue val, bool lookThroughWires,
+bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
                                 bool lookThroughNodes, bool lookThroughCasts,
                                 WalkDriverCallback callback) {
   // TODO: what do we want to happen when there are flips in the type? Do we
   // want to filter out fields which have reverse flow?
-  assert(val.getType().isPassive() && "this code was not tested with flips");
+  assert(value.getType().isPassive() && "this code was not tested with flips");
 
   // This method keeps a stack of wires (or ports) and subfields of those that
   // it still has to process.  It keeps track of which fields in the
@@ -288,7 +288,7 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue val, bool lookThroughWires,
 
   // Create an initial fieldRef from the input value.  As a starting state, the
   // dst and src are the same value.
-  auto original = getFieldRefFromValue(val);
+  auto original = getFieldRefFromValue(value);
   auto fieldRef = original;
 
   // This loop wraps the worklist, which processes wires. Initially the worklist

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -537,8 +537,8 @@ circt::firrtl::getFieldName(const FieldRef &fieldRef, bool nameSafe) {
 /// the value itself, it returns it unchanged. If it is targeting a single field
 /// in a aggregate value, such as a bundle or vector, this will create the
 /// necessary subaccesses to get the value.
-FIRRTLBaseValue circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
-                                       FIRRTLBaseValue value, unsigned fieldID) {
+Value circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
+                                       Value value, unsigned fieldID) {
   // When the fieldID hits 0, we've found the target value.
   while (fieldID != 0) {
     auto type = value.getType();

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -263,7 +263,7 @@ public:
             auto fieldIndex = sub.getAccessedField().getFieldID();
             if (memPorts.contains(sub.getInput())) {
               auto memPort = sub.getInput();
-              auto type = memPort.getType().cast<BundleType>();
+              auto type = memPort.getType();
               auto enableFieldId =
                   type.getFieldID((unsigned)ReadPortSubfield::en);
               auto dataFieldId =
@@ -309,7 +309,7 @@ public:
             }
           })
           .Case<SubaccessOp>([&](SubaccessOp sub) {
-            auto vecType = sub.getInput().getType().cast<FVectorType>();
+            auto vecType = sub.getInput().getType();
             auto res = sub.getResult();
             bool isValid = false;
             SmallVector<FieldRef, 4> fields;

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -293,7 +293,7 @@ public:
   void visitDecl(MemOp op) {
     // Track any memory inputs which require connections.
     for (auto result : op.getResults())
-      if (!result.getType().cast<FIRRTLType>().isa<RefType>())
+      if (!result.getType().isa<RefType>())
         declareSinks(result, Flow::Sink);
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -142,8 +142,8 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
           Value realOldField = oldField;
           if (rType.getElement(fieldIndex).isFlip) {
             // Cast the memory read data from flat type to aggregate.
-            auto castField = builder.createOrFold<BitCastOp>(
-                oldField.getType(), newField);
+            auto castField =
+                builder.createOrFold<BitCastOp>(oldField.getType(), newField);
             // Write the aggregate read data.
             emitConnect(builder, realOldField, castField);
           } else {
@@ -177,10 +177,9 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
             }
             // Now set the mask or write data.
             // Ensure that the types match.
-            emitConnect(
-                builder, newField,
-                builder.createOrFold<BitCastOp>(
-                    newField.getType(), realOldField));
+            emitConnect(builder, newField,
+                        builder.createOrFold<BitCastOp>(newField.getType(),
+                                                        realOldField));
           }
         }
       }

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -59,7 +59,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       // implies a memtap and we cannot transform the datatype for a memory that
       // is tapped.
       for (auto res : memOp.getResults())
-        if (res.getType().cast<FIRRTLType>().isa<RefType>())
+        if (res.getType().isa<RefType>())
           return;
       // If subannotations present on aggregate fields, we cannot flatten the
       // memory. It must be split into one memory per aggregate field.
@@ -130,7 +130,8 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
              fieldIndex != fend; ++fieldIndex) {
           auto name = rType.getElement(fieldIndex).name.getValue();
           auto oldField = builder.create<SubfieldOp>(result, fieldIndex);
-          Value newField = builder.create<SubfieldOp>(newResult, fieldIndex);
+          FIRRTLBaseValue newField =
+              builder.create<SubfieldOp>(newResult, fieldIndex);
           // data and mask depend on the memory type which was split.  They can
           // also go both directions, depending on the port direction.
           if (!(name == "data" || name == "mask" || name == "wdata" ||
@@ -141,14 +142,14 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
           Value realOldField = oldField;
           if (rType.getElement(fieldIndex).isFlip) {
             // Cast the memory read data from flat type to aggregate.
-            newField = builder.createOrFold<BitCastOp>(
-                oldField.getType().cast<FIRRTLType>(), newField);
+            auto castField = builder.createOrFold<BitCastOp>(
+                oldField.getType(), newField);
             // Write the aggregate read data.
-            emitConnect(builder, realOldField, newField);
+            emitConnect(builder, realOldField, castField);
           } else {
             // Cast the input aggregate write data to flat type.
             // Cast the input aggregate write data to flat type.
-            auto newFieldType = newField.getType().cast<FIRRTLBaseType>();
+            auto newFieldType = newField.getType();
             auto oldFieldBitWidth = getBitWidth(oldField.getType());
             // Following condition is true, if a data field is 0 bits. Then
             // newFieldType is of smaller bits than old.
@@ -179,7 +180,7 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
             emitConnect(
                 builder, newField,
                 builder.createOrFold<BitCastOp>(
-                    newField.getType().cast<FIRRTLType>(), realOldField));
+                    newField.getType(), realOldField));
           }
         }
       }

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -595,13 +595,12 @@ void IMConstPropPass::visitRegResetOp(RegResetOp regReset) {
 
   // The reset value may be known - if so, merge it in if the enable is greater
   // than invalid.
-  auto srcValue = getExtendedLatticeValue(
-      regReset.getResetValue(), regReset.getType(),
-      /*allowTruncation=*/true);
-  auto enable = getExtendedLatticeValue(
-      regReset.getResetSignal(),
-      regReset.getResetSignal().getType(),
-      /*allowTruncation=*/true);
+  auto srcValue =
+      getExtendedLatticeValue(regReset.getResetValue(), regReset.getType(),
+                              /*allowTruncation=*/true);
+  auto enable = getExtendedLatticeValue(regReset.getResetSignal(),
+                                        regReset.getResetSignal().getType(),
+                                        /*allowTruncation=*/true);
   if (enable.isOverdefined() ||
       (enable.isConstant() && !enable.getConstant().getValue().isZero()))
     mergeLatticeValue(regReset, srcValue);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -440,8 +440,8 @@ void IMConstPropPass::markWireOrRegOp(Operation *wireOrReg) {
   // to handle, mark it as overdefined.
   // TODO: Eventually add a field-sensitive model.
   auto resultValue = wireOrReg->getResult(0);
-  auto type = resultValue.getType().dyn_cast<FIRRTLType>();
-  if (!type || !type.cast<FIRRTLBaseType>().getPassiveType().isGround())
+  auto type = resultValue.getType().dyn_cast<FIRRTLBaseType>();
+  if (!type || !type.getPassiveType().isGround())
     return markOverdefined(resultValue);
 
   if (hasDontTouch(wireOrReg))
@@ -596,11 +596,11 @@ void IMConstPropPass::visitRegResetOp(RegResetOp regReset) {
   // The reset value may be known - if so, merge it in if the enable is greater
   // than invalid.
   auto srcValue = getExtendedLatticeValue(
-      regReset.getResetValue(), regReset.getType().cast<FIRRTLBaseType>(),
+      regReset.getResetValue(), regReset.getType(),
       /*allowTruncation=*/true);
   auto enable = getExtendedLatticeValue(
       regReset.getResetSignal(),
-      regReset.getResetSignal().getType().cast<FIRRTLBaseType>(),
+      regReset.getResetSignal().getType(),
       /*allowTruncation=*/true);
   if (enable.isOverdefined() ||
       (enable.isConstant() && !enable.getConstant().getValue().isZero()))

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -82,8 +82,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
             // Get the field name.
             auto fName =
-                sf.getInput().getType().getElementName(
-                    sf.getFieldIndex());
+                sf.getInput().getType().getElementName(sf.getFieldIndex());
             // If this is the enable field, record the product terms(the And
             // expression tree).
             if (fName.equals("en"))
@@ -188,8 +187,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
         for (Operation *u : portVal.getUsers())
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
             StringRef fName =
-                sf.getInput().getType().getElementName(
-                    sf.getFieldIndex());
+                sf.getInput().getType().getElementName(sf.getFieldIndex());
             Value repl;
             if (isReadPort)
               repl = llvm::StringSwitch<Value>(fName)
@@ -328,14 +326,11 @@ private:
         if (auto sf = dyn_cast<SubfieldOp>(u)) {
           // Get the field name.
           auto fName =
-              sf.getInput().getType().getElementName(
-                  sf.getFieldIndex());
+              sf.getInput().getType().getElementName(sf.getFieldIndex());
           // Check if this is the mask field.
           if (fName.contains("mask")) {
             // Already 1 bit, nothing to do.
-            if (sf.getResult()
-                    .getType()
-                    .getBitWidthOrSentinel() == 1)
+            if (sf.getResult().getType().getBitWidthOrSentinel() == 1)
               continue;
             // Check what is the mask field directly connected to.
             // If, a constant 1, then we can replace with unMasked memory.
@@ -382,8 +377,7 @@ private:
           auto sf =
               builder.create<SubfieldOp>(newPortVal, oldRes.getFieldIndex());
           auto fName =
-              sf.getInput().getType().getElementName(
-                  sf.getFieldIndex());
+              sf.getInput().getType().getElementName(sf.getFieldIndex());
           // Replace all mask fields with a one bit constant 1.
           // Replace all other fields with the new port.
           if (fName.contains("mask")) {

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -82,7 +82,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
             // Get the field name.
             auto fName =
-                sf.getInput().getType().cast<BundleType>().getElementName(
+                sf.getInput().getType().getElementName(
                     sf.getFieldIndex());
             // If this is the enable field, record the product terms(the And
             // expression tree).
@@ -188,7 +188,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
         for (Operation *u : portVal.getUsers())
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
             StringRef fName =
-                sf.getInput().getType().cast<BundleType>().getElementName(
+                sf.getInput().getType().getElementName(
                     sf.getFieldIndex());
             Value repl;
             if (isReadPort)
@@ -328,14 +328,13 @@ private:
         if (auto sf = dyn_cast<SubfieldOp>(u)) {
           // Get the field name.
           auto fName =
-              sf.getInput().getType().cast<BundleType>().getElementName(
+              sf.getInput().getType().getElementName(
                   sf.getFieldIndex());
           // Check if this is the mask field.
           if (fName.contains("mask")) {
             // Already 1 bit, nothing to do.
             if (sf.getResult()
                     .getType()
-                    .cast<FIRRTLBaseType>()
                     .getBitWidthOrSentinel() == 1)
               continue;
             // Check what is the mask field directly connected to.
@@ -383,7 +382,7 @@ private:
           auto sf =
               builder.create<SubfieldOp>(newPortVal, oldRes.getFieldIndex());
           auto fName =
-              sf.getInput().getType().cast<BundleType>().getElementName(
+              sf.getInput().getType().getElementName(
                   sf.getFieldIndex());
           // Replace all mask fields with a one bit constant 1.
           // Replace all other fields with the new port.

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -741,14 +741,13 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
         .Case<RefSendOp>([&](auto op) {
           // Trace using base types.
           traceResets(op.getType().getType(), op.getResult(), 0,
-                      op.getBase().getType(),
-                      op.getBase(), 0, op.getLoc());
+                      op.getBase().getType(), op.getBase(), 0, op.getLoc());
         })
         .Case<RefResolveOp>([&](auto op) {
           // Trace using base types.
           traceResets(op.getType(), op.getResult(), 0,
-                      op.getRef().getType().getType(),
-                      op.getRef(), 0, op.getLoc());
+                      op.getRef().getType().getType(), op.getRef(), 0,
+                      op.getLoc());
         })
 
         .Case<InvalidValueOp>([&](auto op) {
@@ -795,8 +794,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
           // connected. However for the sake of type inference, this is
           // indistinguishable from them having to share the same type (namely
           // the vector element type).
-          auto vectorType =
-              op.getInput().getType();
+          auto vectorType = op.getInput().getType();
           traceResets(op.getType(), op.getResult(), 0,
                       vectorType.getElementType(), op.getInput(),
                       getFieldID(vectorType), op.getLoc());

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -741,13 +741,13 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
         .Case<RefSendOp>([&](auto op) {
           // Trace using base types.
           traceResets(op.getType().getType(), op.getResult(), 0,
-                      op.getBase().getType().template cast<FIRRTLBaseType>(),
+                      op.getBase().getType(),
                       op.getBase(), 0, op.getLoc());
         })
         .Case<RefResolveOp>([&](auto op) {
           // Trace using base types.
           traceResets(op.getType(), op.getResult(), 0,
-                      op.getRef().getType().template cast<RefType>().getType(),
+                      op.getRef().getType().getType(),
                       op.getRef(), 0, op.getLoc());
         })
 
@@ -776,7 +776,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
 
         .Case<SubfieldOp>([&](auto op) {
           // Associate the input bundle's resets with the output field's resets.
-          auto bundleType = op.getInput().getType().template cast<BundleType>();
+          auto bundleType = op.getInput().getType();
           auto index = op.getFieldIndex();
           traceResets(op.getType(), op.getResult(), 0,
                       bundleType.getElements()[index].type, op.getInput(),
@@ -796,7 +796,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
           // indistinguishable from them having to share the same type (namely
           // the vector element type).
           auto vectorType =
-              op.getInput().getType().template cast<FVectorType>();
+              op.getInput().getType();
           traceResets(op.getType(), op.getResult(), 0,
                       vectorType.getElementType(), op.getInput(),
                       getFieldID(vectorType), op.getLoc());

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -313,9 +313,7 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
   for (auto *op : structValue.getUsers()) {
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
-    auto elemIndex =
-        fieldAccess.getInput().getType().getElementIndex(
-            field);
+    auto elemIndex = fieldAccess.getInput().getType().getElementIndex(field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
   }

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -314,7 +314,7 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
     auto elemIndex =
-        fieldAccess.getInput().getType().cast<BundleType>().getElementIndex(
+        fieldAccess.getInput().getType().getElementIndex(
             field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -203,7 +203,7 @@ static bool isNotSubAccess(Operation *op) {
   if (!sao)
     return true;
   ConstantOp arg = dyn_cast_or_null<ConstantOp>(sao.getIndex().getDefiningOp());
-  if (arg && sao.getInput().getType().cast<FVectorType>().getNumElements() != 0)
+  if (arg && sao.getInput().getType().getNumElements() != 0)
     return true;
   return false;
 }
@@ -671,7 +671,7 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
                           "with non-ground type elements");
           return;
         }
-        if (val.getType().cast<FIRRTLType>().isa<FVectorType>())
+        if (isa<FVectorType>(val.getType()))
           accumulate =
               (accumulate ? b.createOrFold<CatPrimOp>(v, accumulate) : v);
         else
@@ -772,7 +772,7 @@ static Value cloneAccess(ImplicitLocOpBuilder *builder, Operation *op,
 void TypeLoweringVisitor::lowerSAWritePath(Operation *op,
                                            ArrayRef<Operation *> writePath) {
   SubaccessOp sao = cast<SubaccessOp>(writePath.back());
-  auto saoType = sao.getInput().getType().cast<FVectorType>();
+  auto saoType = sao.getInput().getType();
   auto selectWidth = llvm::Log2_64_Ceil(saoType.getNumElements());
 
   for (size_t index = 0, e = saoType.getNumElements(); index < e; ++index) {
@@ -1323,7 +1323,7 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
 
 bool TypeLoweringVisitor::visitExpr(SubaccessOp op) {
   auto input = op.getInput();
-  auto vType = input.getType().cast<FVectorType>();
+  auto vType = input.getType();
 
   // Check for empty vectors
   if (vType.getNumElements() == 0) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -203,9 +203,7 @@ static bool isNotSubAccess(Operation *op) {
   if (!sao)
     return true;
   ConstantOp arg = dyn_cast_or_null<ConstantOp>(sao.getIndex().getDefiningOp());
-  if (arg && sao.getInput().getType().getNumElements() != 0)
-    return true;
-  return false;
+  return arg && sao.getInput().getType().getNumElements() != 0;
 }
 
 /// Look through and collect subfields leading to a subaccess.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -125,10 +125,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // is assumed to be "Memory". Note that MemOp creates RefType
             // without a RefSend.
             for (const auto &res : llvm::enumerate(mem.getResults()))
-              if (mem.getResult(res.index())
-                      .getType()
-                      .cast<FIRRTLType>()
-                      .isa<RefType>()) {
+              if (mem.getResult(res.index()) .getType() .isa<RefType>()) {
                 auto inRef = getInnerRefTo(mem);
                 auto ind = addReachingSendsEntry(res.value(), inRef);
                 xmrPathSuffix[ind] = "Memory";
@@ -320,10 +317,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       size_t pathsIndex = 0;
       auto numPorts = inst.getNumResults();
       for (const auto &res : llvm::enumerate(inst.getResults())) {
-        if (!inst.getResult(res.index())
-                 .getType()
-                 .cast<FIRRTLType>()
-                 .isa<RefType>())
+        if (!isa<RefType>(inst.getResult(res.index()).getType()))
           continue;
 
         auto inRef = getInnerRefTo(inst);
@@ -480,10 +474,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
         SmallVector<Attribute, 4> portAnnotations;
         SmallVector<Value, 4> oldResults;
         for (const auto &res : llvm::enumerate(mem.getResults())) {
-          if (mem.getResult(res.index())
-                  .getType()
-                  .cast<FIRRTLType>()
-                  .isa<RefType>())
+          if (isa<RefType>(mem.getResult(res.index()).getType()))
             continue;
           resultNames.push_back(mem.getPortName(res.index()));
           resultTypes.push_back(res.value().getType());

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -125,7 +125,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             // is assumed to be "Memory". Note that MemOp creates RefType
             // without a RefSend.
             for (const auto &res : llvm::enumerate(mem.getResults()))
-              if (mem.getResult(res.index()) .getType() .isa<RefType>()) {
+              if (mem.getResult(res.index()).getType().isa<RefType>()) {
                 auto inRef = getInnerRefTo(mem);
                 auto ind = addReachingSendsEntry(res.value(), inRef);
                 xmrPathSuffix[ind] = "Memory";

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -126,7 +126,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
   }
 
   Value getMask(ImplicitLocOpBuilder &builder, Value bundle) {
-    auto bType = bundle.getType().cast<FIRRTLType>().cast<BundleType>();
+    auto bType = cast<BundleType>(bundle.getType());
     if (bType.getElement("mask"))
       return builder.create<SubfieldOp>(bundle, "mask");
     return builder.create<SubfieldOp>(bundle, "wmask");
@@ -134,7 +134,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
 
   Value getData(ImplicitLocOpBuilder &builder, Value bundle,
                 bool getWdata = false) {
-    auto bType = bundle.getType().cast<FIRRTLType>().cast<BundleType>();
+    auto bType = cast<BundleType>(bundle.getType());
     if (bType.getElement("data"))
       return builder.create<SubfieldOp>(bundle, "data");
     if (bType.getElement("rdata") && !getWdata)
@@ -191,7 +191,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     wdataIn = addPipelineStages(builder, numStages, clock, wdataIn, "wdata");
     maskBits = addPipelineStages(builder, numStages, clock, maskBits, "wmask");
     // Create the register access.
-    auto rdata = builder.create<SubaccessOp>(regOfVec, addr);
+    FIRRTLBaseValue rdata = builder.create<SubaccessOp>(regOfVec, addr);
 
     // The tuple for the access to individual fields of an aggregate data type.
     // Tuple::<register, data, mask>
@@ -389,7 +389,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     for (size_t index = 0, rend = memOp.getNumResults(); index < rend;
          ++index) {
       auto result = memOp.getResult(index);
-      if (result.getType().cast<FIRRTLType>().isa<RefType>()) {
+      if (isa<RefType>(result.getType())) {
         debugPorts.push_back(result);
         continue;
       }

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -106,7 +106,7 @@ void WireDFTPass::runOnOperation() {
 
   // This is the signal marked as the DFT enable, a 1-bit signal to be wired to
   // the EICG modules.
-  Value enableSignal;
+  FIRRTLValue enableSignal;
   FModuleOp enableModule;
 
   // Walk all modules looking for the DUT module and the annotated enable

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -106,7 +106,7 @@ void WireDFTPass::runOnOperation() {
 
   // This is the signal marked as the DFT enable, a 1-bit signal to be wired to
   // the EICG modules.
-  FIRRTLValue enableSignal;
+  Value enableSignal;
   FModuleOp enableModule;
 
   // Walk all modules looking for the DUT module and the annotated enable


### PR DESCRIPTION
Add FIRRTLValue, FIRRTLBaseValue conveniences, use a little.

Narrow SubindexOp/SubaccesOp to FVectorType input, as required.

Mostly remove redundant casting thanks to TypedValue being added
a while back to, e.g., generated accessors via ODS, as well
as no need to cast to FIRRTLType and /then/ do a classof/isa check.

Few cases where we did a dyn_cast followed by a cast, or an isa
and then a cast-- don't check twice.

Generally, prefer pushing up to interfaces implicit requirements/expectations
on Value's or Type's passed around.
(if a function blindly does a cast<FooType>, better to ask for a TypedValue<FooType>).

More work could be done here.  Tackled as preparation for some type
changes and implicit type expectations make that more difficult.