### PR TITLE
Split Ports/Symbols out of HWModuleLike, interface inheritance, InnerSym(DCE) fixes.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -187,7 +187,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     }]>,
 
     // Setters
-    InterfaceMethod<"Set the port symbols", "void",
+    InterfaceMethod<"Set the symbols of all ports and their fields", "void",
     "setPortSymbols", (ins "ArrayRef<Attribute>":$symbols), [{}], [{
       assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
       SmallVector<Attribute> newSyms(symbols.begin(), symbols.end());
@@ -197,7 +197,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
                     ArrayAttr::get($_op.getContext(), newSyms));
     }]>,
 
-    InterfaceMethod<"Set a port symbol attribute", "void",
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
     "setPortSymbolAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}],
     [{
       SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
@@ -235,7 +235,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
                     ArrayAttr::get($_op.getContext(), symbols));
     }]>,
 
-    InterfaceMethod<"Set a port symbol", "void",
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
     "setPortSymbol", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
       $_op.setPortSymbolAttr(portIndex, StringAttr::get($_op.getContext(),
         symbol));

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -179,13 +179,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       return $_op.getPortSymbolsAttr().getValue();
     }]>,
 
-    InterfaceMethod<"Check if port has symbol attribute",
-    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
-      auto syms = $_op.getPortSymbols();
-        return  (!syms.empty() &&
-        !syms[portIndex].template cast<hw::InnerSymAttr>().empty());
-    }]>,
-
     // Setters
     InterfaceMethod<"Set the symbols of all ports and their fields", "void",
     "setPortSymbols", (ins "ArrayRef<Attribute>":$symbols), [{}], [{
@@ -195,50 +188,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       assert(newSyms.empty() || newSyms.size() == $_op.getNumPorts());
       $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
                     ArrayAttr::get($_op.getContext(), newSyms));
-    }]>,
-
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbolAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}],
-    [{
-      SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
-                                     $_op.getPortSymbols().end());
-      if (symbols.empty()) {
-        symbols.resize($_op.getNumPorts(),
-                      hw::InnerSymAttr::get($_op.getContext()));
-      }
-      assert(symbols.size() == $_op.getNumPorts());
-      symbols[portIndex] = hw::InnerSymAttr::get(symbol);
-
-      FModuleLike::fixupPortSymsArray(symbols, $_op.getContext());
-      assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
-      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
-                    ArrayAttr::get($_op.getContext(), symbols));
-    }]>,
-
-    InterfaceMethod<"Set the symbols for a port including its fields", "void",
-    "setPortSymbolsAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol), [{}],
-    [{
-      SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
-                                     $_op.getPortSymbols().end());
-      if (symbols.empty()) {
-        if (symbol.empty())
-          return;
-        symbols.resize($_op.getNumPorts(),
-                      hw::InnerSymAttr::get($_op.getContext()));
-      }
-      assert(symbols.size() == $_op.getNumPorts());
-      symbols[portIndex] = symbol;
-
-      FModuleLike::fixupPortSymsArray(symbols, $_op.getContext());
-      assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
-      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
-                    ArrayAttr::get($_op.getContext(), symbols));
-    }]>,
-
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbol", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
-      $_op.setPortSymbolAttr(portIndex, StringAttr::get($_op.getContext(),
-        symbol));
     }]>,
 
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -215,6 +215,26 @@ def FModuleLike : OpInterface<"FModuleLike"> {
                     ArrayAttr::get($_op.getContext(), symbols));
     }]>,
 
+    InterfaceMethod<"Set the symbols for a port including its fields", "void",
+    "setPortSymbolsAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol), [{}],
+    [{
+      SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
+                                     $_op.getPortSymbols().end());
+      if (symbols.empty()) {
+        if (symbol.empty())
+          return;
+        symbols.resize($_op.getNumPorts(),
+                      hw::InnerSymAttr::get($_op.getContext()));
+      }
+      assert(symbols.size() == $_op.getNumPorts());
+      symbols[portIndex] = symbol;
+
+      FModuleLike::fixupPortSymsArray(symbols, $_op.getContext());
+      assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
+      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
+                    ArrayAttr::get($_op.getContext(), symbols));
+    }]>,
+
     InterfaceMethod<"Set a port symbol", "void",
     "setPortSymbol", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
       $_op.setPortSymbolAttr(portIndex, StringAttr::get($_op.getContext(),

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -65,6 +65,7 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
     IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
     DeclareOpInterfaceMethods<FModuleLike>,
     DeclareOpInterfaceMethods<HWModuleLike>,
+    DeclareOpInterfaceMethods<HWPortsSymbols>,
     OpAsmOpInterface, InnerSymbolTable]> {
 
   /// Additional class definitions inside the module op.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -70,18 +70,40 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
   /// Additional class definitions inside the module op.
   code extraModuleClassDefinition = [{}];
 
+  /// Implement HWModuleLike methods for ports and their symbols.
   let extraClassDefinition = extraModuleClassDefinition # [{
     size_t $cppClass::getNumPorts() {
       return getPortTypesAttr().size();
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
+      assert(portIndex < getNumPorts());
       auto syms = getPortSymbols();
       if (syms.empty() ||
-          syms[portIndex].template cast<hw::InnerSymAttr>().empty())
+          cast<hw::InnerSymAttr>(syms[portIndex]).empty())
         return hw::InnerSymAttr();
-      return syms[portIndex].template cast<hw::InnerSymAttr>();
+      assert(syms.size() == getNumPorts());
+      return cast<hw::InnerSymAttr>(syms[portIndex]);
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, ::circt::hw::InnerSymAttr symbol) {
+      assert(portIndex < getNumPorts());
+      SmallVector<Attribute> symbols(getPortSymbols().begin(),
+                                     getPortSymbols().end());
+      if (symbols.empty()) {
+        if (symbol.empty())
+          return;
+        symbols.resize(getNumPorts(),
+                      hw::InnerSymAttr::get(getContext()));
+      }
+      assert(symbols.size() == getNumPorts());
+      symbols[portIndex] = symbol;
+
+      FModuleLike::fixupPortSymsArray(symbols, getContext());
+      assert(symbols.empty() || symbols.size() == getNumPorts());
+      getOperation()->setAttr(FModuleLike::getPortSymbolsAttrName(),
+                    ArrayAttr::get(getContext(), symbols));
+  }
   }];
 
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -71,7 +71,7 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
   /// Additional class definitions inside the module op.
   code extraModuleClassDefinition = [{}];
 
-  /// Implement HWModuleLike methods for ports and their symbols.
+  /// Implement HWPortsSymbols methods for ports and their symbols.
   let extraClassDefinition = extraModuleClassDefinition # [{
     size_t $cppClass::getNumPorts() {
       return getPortTypesAttr().size();

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -153,8 +153,6 @@ std::unique_ptr<mlir::Pass> createLowerXMRPass();
 std::unique_ptr<mlir::Pass>
 createResolveTracesPass(mlir::StringRef outputAnnotationFilename = "");
 
-std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
-
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -656,8 +656,9 @@ def InnerSymbolDCE : Pass<"firrtl-inner-symbol-dce", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::firrtl::createInnerSymbolDCEPass()";
   let statistics = [
-    Statistic<"numSymbolsFound", "num-sym-found", "Number of symbols found">,
-    Statistic<"numSymbolsRemoved", "num-sym-removed", "Number of symbols removed">
+    Statistic<"numInnerRefsFound", "num-inner-refs-found", "Number of inner-refs found">,
+    Statistic<"numInnerSymbolsFound", "num-inner-sym-found", "Number of inner symbols found">,
+    Statistic<"numInnerSymbolsRemoved", "num-inner-sym-removed", "Number of inner symbols removed">
   ];
 }
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -647,21 +647,6 @@ def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
-def InnerSymbolDCE : Pass<"firrtl-inner-symbol-dce", "mlir::ModuleOp"> {
-  let summary = "Eliminate dead inner symbols";
-  let description = [{
-    This pass deletes all inner symbols which have no uses. This is necessary to
-    unblock optimizations and removal of the operations which have these unused
-    inner symbols.
-  }];
-  let constructor = "circt::firrtl::createInnerSymbolDCEPass()";
-  let statistics = [
-    Statistic<"numInnerRefsFound", "num-inner-refs-found", "Number of inner-refs found">,
-    Statistic<"numInnerSymbolsFound", "num-inner-sym-found", "Number of inner symbols found">,
-    Statistic<"numInnerSymbolsRemoved", "num-inner-sym-removed", "Number of inner symbols removed">
-  ];
-}
-
 def VBToBV : Pass<"firrtl-vb-to-bv", "firrtl::CircuitOp"> {
   let summary = "Transform vector-of-bundles to bundle-of-vectors";
   let description = [{

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -83,30 +83,6 @@ def MachineOp : FSMOp<"machine", [
       auto machineType = getFunctionType();
       return machineType.getNumInputs() + machineType.getNumResults();
     }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
-    }
-
-    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
-          if (symbol && !symbol.empty())
-            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
-          else
-            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
-          return;
-        }
-      // We cannot add symbols to arguments without assuming the attribute name,
-      // which we're careful above to avoid.  For now, error/assert if this is attempted.
-      emitOpError("adding symbol to port without any symbols is not yet supported");
-      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
-    }
   }];
 
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -91,6 +91,22 @@ def MachineOp : FSMOp<"machine", [
           return sym;
       return circt::hw::InnerSymAttr();
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
+      for (NamedAttribute argAttr :
+           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
+          if (symbol && !symbol.empty())
+            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
+          else
+            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
+          return;
+        }
+      // We cannot add symbols to arguments without assuming the attribute name,
+      // which we're careful above to avoid.  For now, error/assert if this is attempted.
+      emitOpError("adding symbol to port without any symbols is not yet supported");
+      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
+    }
   }];
 
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/HW/CMakeLists.txt
+++ b/include/circt/Dialect/HW/CMakeLists.txt
@@ -16,6 +16,12 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTHWTransformsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS PortsInterfaces.td)
+mlir_tablegen(PortsInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(PortsInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(CIRCTPortsInterfacesIncGen)
+add_dependencies(circt-headers CIRCTPortsInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS HWOpInterfaces.td)
 mlir_tablegen(HWOpInterfaces.h.inc -gen-op-interface-decls)
 mlir_tablegen(HWOpInterfaces.cpp.inc -gen-op-interface-defs)

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_HW_HWOPINTERFACES_H
 
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Dialect/HW/PortsInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -244,6 +244,16 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             InnerSymbolTable::getInnerSymbolAttrName(), hw::InnerSymAttr::get(name));
       }]
     >,
+    InterfaceMethod<"Sets the inner symbols defined by this operation.",
+      "void", "setInnerSymbolAttr", (ins "::circt::hw::InnerSymAttr":$sym), [{}],
+      /*defaultImplementation=*/[{
+        if (sym && !sym.empty())
+          this->getOperation()->setAttr(
+              InnerSymbolTable::getInnerSymbolAttrName(), sym);
+        else
+          this->getOperation()->removeAttr(InnerSymbolTable::getInnerSymbolAttrName());
+      }]
+    >,
     InterfaceMethod<"Returns an InnerRef to this operation.  Must have inner symbol.",
       "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
       /*defaultImplementation=*/[{

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -37,11 +37,40 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
 
+    //===------------------------------------------------------------------===//
+    // Ports and their symbols.
+    //===------------------------------------------------------------------===//
+    // TODO: Refactor this into separate reusable component.
+
+    // Getters
     InterfaceMethod<"Get the number of ports",
     "size_t", "getNumPorts">,
 
     InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
+
+    InterfaceMethod<"Check if port has symbol attribute",
+    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
+      assert(portIndex < $_op.getNumPorts());
+      auto symAttr = $_op.getPortSymbolAttr(portIndex);
+      return symAttr && !symAttr.empty();
+    }]>,
+
+    // Setters
+    InterfaceMethod<"Set the symbols for a port including its fields", "void",
+    "setPortSymbolAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol)>,
+
+    // Convenience methods wrapping setPortSymbolAttr.
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolString", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
+      $_op.setPortSymbolStringAttr(portIndex, StringAttr::get($_op.getContext(),
+        symbol));
+    }]>,
+
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolStringAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}], [{
+      return $_op.setPortSymbolAttr(portIndex, hw::InnerSymAttr::get(symbol));
+    }]>,
   ];
 
   let verify = [{

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -220,7 +220,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
 
   let cppNamespace = "::circt::hw";
   let methods = [
-    InterfaceMethod<"Returns the name of this inner symbol.",
+    InterfaceMethod<"Returns the name of the top-level inner symbol defined by this operation, if present.",
       "::mlir::StringAttr", "getInnerNameAttr", (ins), [{}],
       /*defaultImplementation=*/[{
         if (auto attr =
@@ -230,14 +230,14 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
         return {};
       }]
     >,
-    InterfaceMethod<"Returns the name of this inner symbol.",
+    InterfaceMethod<"Returns the name of the top-level inner symbol defined by this operation, if present.",
       "::std::optional<::mlir::StringRef>", "getInnerName", (ins), [{}],
       /*defaultImplementation=*/[{
         auto attr = this->getInnerNameAttr();
         return attr ? ::std::optional<StringRef>(attr.getValue()) : ::std::nullopt;
       }]
     >,
-    InterfaceMethod<"Sets the name of this inner symbol.",
+    InterfaceMethod<"Sets the name of the top-level inner symbol defined by this operation to the specified string, dropping any symbols on fields.",
       "void", "setInnerSymbol", (ins "::mlir::StringAttr":$name), [{}],
       /*defaultImplementation=*/[{
         this->getOperation()->setAttr(
@@ -254,7 +254,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
           this->getOperation()->removeAttr(InnerSymbolTable::getInnerSymbolAttrName());
       }]
     >,
-    InterfaceMethod<"Returns an InnerRef to this operation.  Must have inner symbol.",
+    InterfaceMethod<"Returns an InnerRef to this operation's top-level inner symbol, which must be present.",
       "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
       /*defaultImplementation=*/[{
         auto *op = this->getOperation();
@@ -264,7 +264,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             InnerSymbolTable::getInnerSymbol(op));
       }]
     >,
-    InterfaceMethod<"Returns the InnerSymAttr.",
+    InterfaceMethod<"Returns the InnerSymAttr representing all inner symbols defined by this operation.",
       "::circt::hw::InnerSymAttr", "getInnerSymAttr", (ins), [{}],
       /*defaultImplementation=*/[{
         return this->getOperation()->template getAttrOfType<hw::InnerSymAttr>(

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -13,9 +13,9 @@
 #ifndef CIRCT_DIALECT_HW_HWOPINTERFACES
 #define CIRCT_DIALECT_HW_HWOPINTERFACES
 
-include "mlir/IR/OpBase.td"
+include "circt/Dialect/HW/PortsInterfaces.td"
 
-def HWModuleLike : OpInterface<"HWModuleLike"> {
+def HWModuleLike : OpInterface<"HWModuleLike", [DeclareOpInterfaceMethods<HWPorts>]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common module information.";
 
@@ -36,41 +36,6 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     "::mlir::StringAttr", "moduleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
-
-    //===------------------------------------------------------------------===//
-    // Ports and their symbols.
-    //===------------------------------------------------------------------===//
-    // TODO: Refactor this into separate reusable component.
-
-    // Getters
-    InterfaceMethod<"Get the number of ports",
-    "size_t", "getNumPorts">,
-
-    InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
-
-    InterfaceMethod<"Check if port has symbol attribute",
-    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
-      assert(portIndex < $_op.getNumPorts());
-      auto symAttr = $_op.getPortSymbolAttr(portIndex);
-      return symAttr && !symAttr.empty();
-    }]>,
-
-    // Setters
-    InterfaceMethod<"Set the symbols for a port including its fields", "void",
-    "setPortSymbolAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol)>,
-
-    // Convenience methods wrapping setPortSymbolAttr.
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbolString", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
-      $_op.setPortSymbolStringAttr(portIndex, StringAttr::get($_op.getContext(),
-        symbol));
-    }]>,
-
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbolStringAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}], [{
-      return $_op.setPortSymbolAttr(portIndex, hw::InnerSymAttr::get(symbol));
-    }]>,
   ];
 
   let verify = [{

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/HW/PortsInterfaces.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -25,6 +25,7 @@ std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass();
+std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -30,6 +30,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
     HWOp<mnemonic, traits # [
       DeclareOpInterfaceMethods<HWModuleLike>,
+      DeclareOpInterfaceMethods<HWPortsSymbols>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
       FunctionOpInterface, Symbol,
       OpAsmOpInterface, HasParent<"mlir::ModuleOp">]> {

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -66,6 +66,24 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
           return sym;
       return ::circt::hw::InnerSymAttr();
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
+      for (NamedAttribute argAttr :
+           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
+          if (symbol && !symbol.empty())
+            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
+          else
+            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
+          return;
+        }
+      // We cannot add symbols to arguments without assuming the attribute name,
+      // which we're careful above to avoid.  For now, error/assert if this is attempted.
+      if (symbol || !symbol.empty()) {
+        emitOpError("adding symbol to port without any symbols is not yet supported");
+        assert(0 && "cannot add symbols to ports");
+      }
+    }
   }];
 
 }

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -145,17 +145,26 @@ def InnerSymAttr : AttrDef<HWDialect, "InnerSym"> {
   let extraClassDeclaration = [{
     /// Get the inner sym name for fieldID, if it exists.
     mlir::StringAttr getSymIfExists(unsigned fieldID) const;
+
     /// Get the inner sym name for fieldID=0, if it exists.
     mlir::StringAttr getSymName() const { return getSymIfExists(0); }
+
     /// Get the number of inner symbols defined.
     size_t size() const { return getProps().size(); }
+
     /// Check if this is an empty array, no sym names stored.
     bool empty() const { return getProps().empty(); }
+
+    /// Return an InnerSymAttr with the inner symbol for the specified fieldID removed.
+    InnerSymAttr erase(unsigned fieldID) const;
+
     using iterator = mlir::ArrayRef<InnerSymPropertiesAttr>::iterator;
     /// Iterator begin for all the InnerSymProperties.
     iterator begin() const { return getProps().begin(); }
+
     /// Iterator end for all the InnerSymProperties.
     iterator end() const { return getProps().end(); }
+
     /// Invoke the func, for all sym names. Return success(),
     /// if the callback function never returns failure().
     mlir::LogicalResult walkSymbols(llvm::function_ref<

--- a/include/circt/Dialect/HW/InnerSymbolTable.h
+++ b/include/circt/Dialect/HW/InnerSymbolTable.h
@@ -179,6 +179,10 @@ public:
   /// A successful walk with no failures returns success.
   static LogicalResult walkSymbols(Operation *op, InnerSymCallbackFn callback);
 
+  /// Remove the specified inner symbol.
+  /// Invalidates existing InnerSymbolTable's including the target.
+  static void erase(const InnerSymTarget &target);
+
 private:
   using TableTy = DenseMap<StringAttr, InnerSymTarget>;
   /// Construct an inner symbol table for the given operation,

--- a/include/circt/Dialect/HW/InnerSymbolTable.h
+++ b/include/circt/Dialect/HW/InnerSymbolTable.h
@@ -181,7 +181,10 @@ public:
 
   /// Remove the specified inner symbol.
   /// Invalidates existing InnerSymbolTable's including the target.
-  static void erase(const InnerSymTarget &target);
+  static void dropSymbol(const InnerSymTarget &target);
+
+  /// Remove the specified inner symbol, and update this table.
+  void erase(const InnerSymTarget &target);
 
 private:
   using TableTy = DenseMap<StringAttr, InnerSymTarget>;

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -68,5 +68,4 @@ def InnerSymbolDCE : Pass<"hw-inner-symbol-dce", "mlir::ModuleOp"> {
   ];
 }
 
-
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -53,4 +53,20 @@ def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   }];
 }
 
+def InnerSymbolDCE : Pass<"hw-inner-symbol-dce", "mlir::ModuleOp"> {
+  let summary = "Eliminate dead inner symbols";
+  let description = [{
+    This pass deletes all inner symbols which have no uses. This is necessary to
+    unblock optimizations and removal of the operations which have these unused
+    inner symbols.
+  }];
+  let constructor = "circt::hw::createInnerSymbolDCEPass()";
+  let statistics = [
+    Statistic<"numInnerRefsFound", "num-inner-refs-found", "Number of inner-refs found">,
+    Statistic<"numInnerSymbolsFound", "num-inner-sym-found", "Number of inner symbols found">,
+    Statistic<"numInnerSymbolsRemoved", "num-inner-sym-removed", "Number of inner symbols removed">
+  ];
+}
+
+
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/include/circt/Dialect/HW/PortsInterfaces.h
+++ b/include/circt/Dialect/HW/PortsInterfaces.h
@@ -1,0 +1,22 @@
+//===- PortsInterfaces.h - Declare Ports interfaces -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the port-related interfaces for HW.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_PORTSINTERFACES_H
+#define CIRCT_DIALECT_HW_PORTSINTERFACES_H
+
+#include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "circt/Dialect/HW/PortsInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_HW_PORTSINTERFACES_H

--- a/include/circt/Dialect/HW/PortsInterfaces.td
+++ b/include/circt/Dialect/HW/PortsInterfaces.td
@@ -1,0 +1,66 @@
+//===- PortsInterfaces.td - Ports+Symbols Interfaces -------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the HWPorts and HWPortsSymbols interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_PORTSINTERFACES
+#define CIRCT_DIALECT_HW_PORTSINTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def HWPorts : OpInterface<"HWPorts"> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide accessors for ports";
+
+  let methods = [
+    // Getters
+    InterfaceMethod<"Get the number of ports",
+    "size_t", "getNumPorts">,
+  ];
+
+}
+
+def HWPortsSymbols : OpInterface<"HWPortsSymbols", [DeclareOpInterfaceMethods<HWPorts>]> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide accessors for ports and their symbols";
+
+
+  let methods = [
+    // Getters
+    InterfaceMethod<"Get a port symbol attribute",
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
+
+    InterfaceMethod<"Check if port has symbol attribute",
+    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
+      assert(portIndex < $_op.getNumPorts());
+      auto symAttr = $_op.getPortSymbolAttr(portIndex);
+      return symAttr && !symAttr.empty();
+    }]>,
+
+    // Setters
+    InterfaceMethod<"Set the symbols for a port including its fields", "void",
+    "setPortSymbolAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol)>,
+
+    // Convenience methods wrapping setPortSymbolAttr.
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolString", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
+      $_op.setPortSymbolStringAttr(portIndex, StringAttr::get($_op.getContext(),
+        symbol));
+    }]>,
+
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolStringAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}], [{
+      return $_op.setPortSymbolAttr(portIndex, hw::InnerSymAttr::get(symbol));
+    }]>,
+  ];
+
+}
+
+#endif // CIRCT_DIALECT_HW_PORTSINTERFACES

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -190,6 +190,22 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
           return sym;
       return circt::hw::InnerSymAttr();
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
+      for (NamedAttribute argAttr :
+           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
+          if (symbol && !symbol.empty())
+            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
+          else
+            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
+          return;
+        }
+      // We cannot add symbols to arguments without assuming the attribute name,
+      // which we're careful above to avoid.  For now, error/assert if this is attempted.
+      emitOpError("adding symbol to port without any symbols is not yet supported");
+      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
+    }
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -65,7 +65,8 @@ def AppIDArrayAttr : TypedArrayAttrBase<AppIDAttr, "Array of AppIDs">;
 class MSFTModuleOpBase<string mnemonic, list<Trait> traits = []> :
     MSFTOp<mnemonic, traits # [
       IsolatedFromAbove, Symbol, FunctionOpInterface, OpAsmOpInterface,
-      HasParent<"mlir::ModuleOp">, DeclareOpInterfaceMethods<HWModuleLike>
+      HasParent<"mlir::ModuleOp">,
+      DeclareOpInterfaceMethods<HWModuleLike>,
     ]> {
   /// Additional class declarations inside the module op.
   code extraModuleClassDeclaration = ?;
@@ -181,30 +182,6 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
     size_t $cppClass::getNumPorts() {
       auto ports = getPorts();
       return ports.inputs.size() + ports.outputs.size();
-    }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
-    }
-
-    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
-          if (symbol && !symbol.empty())
-            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
-          else
-            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
-          return;
-        }
-      // We cannot add symbols to arguments without assuming the attribute name,
-      // which we're careful above to avoid.  For now, error/assert if this is attempted.
-      emitOpError("adding symbol to port without any symbols is not yet supported");
-      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
     }
   }];
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -108,30 +108,6 @@ def SCModuleOp : SystemCOp<"module", [
     size_t $cppClass::getNumPorts() {
       return getPortNames().size();
     }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
-    }
-
-    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
-          if (symbol && !symbol.empty())
-            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
-          else
-            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
-          return;
-        }
-      // We cannot add symbols to arguments without assuming the attribute name,
-      // which we're careful above to avoid.  For now, error/assert if this is attempted.
-      emitOpError("adding symbol to port without any symbols is not yet supported");
-      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
-    }
   }];
 }
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -116,6 +116,22 @@ def SCModuleOp : SystemCOp<"module", [
           return sym;
       return circt::hw::InnerSymAttr();
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
+      for (NamedAttribute argAttr :
+           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
+          if (symbol && !symbol.empty())
+            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
+          else
+            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
+          return;
+        }
+      // We cannot add symbols to arguments without assuming the attribute name,
+      // which we're careful above to avoid.  For now, error/assert if this is attempted.
+      emitOpError("adding symbol to port without any symbols is not yet supported");
+      assert(!symbol || symbol.empty() && "cannot add symbols to ports");
+    }
   }];
 }
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -556,6 +556,10 @@ hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t portIndex) {
   assert(false);
   return {};
 }
+void ESIPureModuleOp::setPortSymbolAttr(size_t portIndex,
+                                        hw::InnerSymAttr symbol) {
+  assert(false);
+}
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/ESI/ESI.cpp.inc"

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -552,15 +552,6 @@ LogicalResult ESIPureModuleOp::verify() {
 }
 
 size_t ESIPureModuleOp::getNumPorts() { return 0; }
-hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t portIndex) {
-  assert(false);
-  return {};
-}
-void ESIPureModuleOp::setPortSymbolAttr(size_t portIndex,
-                                        hw::InnerSymAttr symbol) {
-  assert(false);
-}
-
 #define GET_OP_CLASSES
 #include "circt/Dialect/ESI/ESI.cpp.inc"
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -211,7 +211,7 @@ DeclKind firrtl::getDeclarationKind(Value val) {
 }
 
 size_t firrtl::getNumPorts(Operation *op) {
-  if (auto module = dyn_cast<hw::HWModuleLike>(*op))
+  if (auto module = dyn_cast<hw::HWPorts>(*op))
     return module.getNumPorts();
   return op->getNumResults();
 }
@@ -450,7 +450,7 @@ static SmallVector<PortInfo> getPorts(FModuleLike module) {
   for (unsigned i = 0, e = getNumPorts(module); i < e; ++i) {
     results.push_back({module.getPortNameAttr(i), module.getPortType(i),
                        module.getPortDirection(i),
-                       cast<hw::HWModuleLike>(*module).getPortSymbolAttr(i),
+                       cast<hw::HWPortsSymbols>(*module).getPortSymbolAttr(i),
                        module.getPortLocation(i),
                        AnnotationSet::forPort(module, i)});
   }
@@ -517,7 +517,8 @@ static void insertPorts(FModuleLike op,
       newNames.push_back(existingNames[oldIdx]);
       newTypes.push_back(existingTypes[oldIdx]);
       newAnnos.push_back(op.getAnnotationsAttrForPort(oldIdx));
-      newSyms.push_back(cast<hw::HWModuleLike>(*op).getPortSymbolAttr(oldIdx));
+      newSyms.push_back(
+          cast<hw::HWPortsSymbols>(*op).getPortSymbolAttr(oldIdx));
       newLocs.push_back(existingLocs[oldIdx]);
       ++oldIdx;
     }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -592,7 +592,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     FModuleLike mod, size_t portIdx, StringRef nameHint,
     std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
 
-  auto hwmod = cast<hw::HWModuleLike>(*mod);
+  auto hwmod = cast<hw::HWPortsSymbols>(*mod);
   auto attr = hwmod.getPortSymbolAttr(portIdx);
   // TODO: check getSymName if empty, that fields don't have symbols.
   if (attr)

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -592,7 +592,9 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     FModuleLike mod, size_t portIdx, StringRef nameHint,
     std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
 
-  auto attr = cast<hw::HWModuleLike>(*mod).getPortSymbolAttr(portIdx);
+  auto hwmod = cast<hw::HWModuleLike>(*mod);
+  auto attr = hwmod.getPortSymbolAttr(portIdx);
+  // TODO: check getSymName if empty, that fields don't have symbols.
   if (attr)
     return attr.getSymName();
   if (nameHint.empty()) {
@@ -603,7 +605,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
   }
   auto name = getNamespace(mod).newName(nameHint);
   auto sAttr = StringAttr::get(mod.getContext(), name);
-  mod.setPortSymbolAttr(portIdx, sAttr);
+  hwmod.setPortSymbolStringAttr(portIdx, sAttr);
   return sAttr;
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -13,11 +13,10 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentral.cpp
   IMConstProp.cpp
   IMDeadCodeElim.cpp
-  InferResets.cpp
   InferReadWrite.cpp
+  InferResets.cpp
   InferWidths.cpp
   InjectDUTHierarchy.cpp
-  InnerSymbolDCE.cpp
   LegacyWiring.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
@@ -29,7 +29,7 @@ struct InnerSymbolDCEPass : public InnerSymbolDCEBase<InnerSymbolDCEPass> {
 private:
   void findInnerRefs(Attribute attr);
   void insertInnerRef(InnerRefAttr innerRef);
-  void removeInnerSyms(FModuleOp op);
+  void removeInnerSyms(FModuleLike mod);
 
   DenseSet<std::pair<StringAttr, StringAttr>> innerRefs;
 };
@@ -48,42 +48,36 @@ void InnerSymbolDCEPass::insertInnerRef(InnerRefAttr innerRef) {
   StringAttr moduleName = innerRef.getModule();
   StringAttr symName = innerRef.getName();
 
+  // Track total inner refs found.
+  ++numInnerRefsFound;
+
   auto [iter, inserted] = innerRefs.insert({moduleName, symName});
   if (!inserted)
     return;
 
-  ++numSymbolsFound;
-
-  LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": found " << moduleName
+  LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": found reference to " << moduleName
                           << "::" << symName << '\n';);
 }
 
-/// Remove all InnerSymAttrs within the FModuleOp that are dead code.
-void InnerSymbolDCEPass::removeInnerSyms(FModuleOp moduleOp) {
-  // Walk all ops in the FModuleOp.
-  moduleOp.walk([&](Operation *op) {
-    // Check if the op has an InnerSymAttr.
-    auto innerSym = op->getAttrOfType<InnerSymAttr>("inner_sym");
-    if (!innerSym)
-      return;
+/// Remove all dead inner symbols from the specified module.
+void InnerSymbolDCEPass::removeInnerSyms(FModuleLike mod) {
+  auto moduleName = mod.moduleNameAttr();
 
-    assert(moduleOp == op->getParentOfType<FModuleOp>() &&
-           "ops with inner_sym must be inside an FModuleOp");
+  // Walk inner symbols, removing any not referenced.
+  InnerSymbolTable::walkSymbols(
+      mod, [&](StringAttr name, const InnerSymTarget &target) {
+        ++numInnerSymbolsFound;
 
-    // Check if the InnerSymAttr was found as part of any InnerRefAttr.
-    auto moduleName = moduleOp.moduleNameAttr();
-    auto symName = innerSym.getSymName();
-    if (innerRefs.contains({moduleName, symName}))
-      return;
+        // Check if the name is referenced by any InnerRef.
+        if (innerRefs.contains({moduleName, name}))
+          return;
 
-    // If not, it's dead code.
-    op->removeAttr("inner_sym");
+        InnerSymbolTable::erase(target);
+        ++numInnerSymbolsRemoved;
 
-    ++numSymbolsRemoved;
-
-    LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": removed " << moduleName
-                            << "::" << symName << '\n';);
-  });
+        LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": removed " << moduleName
+                                << "::" << name << '\n';);
+      });
 }
 
 void InnerSymbolDCEPass::runOnOperation() {
@@ -92,21 +86,21 @@ void InnerSymbolDCEPass::runOnOperation() {
   ModuleOp topModule = getOperation();
 
   // Traverse the entire IR once.
-  SmallVector<FModuleOp> modules;
+  SmallVector<FModuleLike> modules;
   topModule.walk([&](Operation *op) {
     // Find all InnerRefAttrs.
     for (NamedAttribute namedAttr : op->getAttrs())
       findInnerRefs(namedAttr.getValue());
 
-    // Collect all FModuleOps.
-    if (auto moduleOp = dyn_cast<FModuleOp>(op))
-      modules.push_back(moduleOp);
+    // Collect all FModuleLike operations.
+    if (auto mod = dyn_cast<FModuleLike>(op))
+      modules.push_back(mod);
   });
 
   // Traverse all FModuleOps in parallel, removing any InnerSymAttrs that are
   // dead code.
   parallelForEach(&getContext(), modules,
-                  [&](FModuleOp moduleOp) { removeInnerSyms(moduleOp); });
+                  [&](FModuleLike mod) { removeInnerSyms(mod); });
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createInnerSymbolDCEPass() {

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -8,10 +8,11 @@ add_circt_dialect_library(
   HWOps.cpp
   HWTypeInterfaces.cpp
   HWTypes.cpp
+  InnerSymbolTable.cpp
   InstanceGraphBase.cpp
   InstanceImplementation.cpp
   ModuleImplementation.cpp
-  InnerSymbolTable.cpp
+  PortsInterfaces.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/HW

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -275,6 +275,16 @@ StringAttr InnerSymAttr::getSymIfExists(unsigned fieldId) const {
   return {};
 }
 
+InnerSymAttr InnerSymAttr::erase(unsigned fieldID) const {
+  SmallVector<InnerSymPropertiesAttr> syms(getProps());
+  const auto *it = llvm::find_if(syms, [fieldID](InnerSymPropertiesAttr p) {
+    return p.getFieldID() == fieldID;
+  });
+  assert(it != syms.end());
+  syms.erase(it);
+  return InnerSymAttr::get(getContext(), syms);
+}
+
 LogicalResult InnerSymAttr::walkSymbols(
     llvm::function_ref<LogicalResult(StringAttr)> callback) const {
   for (auto p : getImpl()->props)

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -94,8 +94,7 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
                  return WalkResult::interrupt();
 
            // Check for ports
-           // TODO: Add fields per port, once they work that way (use addSyms)
-           if (auto mod = dyn_cast<HWModuleLike>(curOp)) {
+           if (auto mod = dyn_cast<HWPortsSymbols>(curOp)) {
              for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i) {
                if (auto symAttr = mod.getPortSymbolAttr(i))
                  if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
@@ -143,8 +142,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   // Obtain the base InnerSymAttr for the specified target.
   auto getBase = [](auto &target) -> hw::InnerSymAttr {
     if (target.isPort()) {
-      // TODO: This needs to be made to work with HWModuleLike
-      if (auto mod = dyn_cast<HWModuleLike>(target.getOp())) {
+      if (auto mod = dyn_cast<HWPortsSymbols>(target.getOp())) {
         assert(target.getPort() < mod.getNumPorts());
         return mod.getPortSymbolAttr(target.getPort());
       }
@@ -166,7 +164,7 @@ void InnerSymbolTable::dropSymbol(const InnerSymTarget &target) {
   assert(getInnerSymbol(target));
 
   if (target.isPort()) {
-    auto mod = cast<HWModuleLike>(target.getOp());
+    auto mod = cast<HWPortsSymbols>(target.getOp());
     assert(target.getPort() < mod.getNumPorts());
     auto base = mod.getPortSymbolAttr(target.getPort());
     mod.setPortSymbolAttr(target.getPort(), base.erase(target.getField()));

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -161,7 +161,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   return {};
 }
 
-void InnerSymbolTable::erase(const InnerSymTarget &target) {
+void InnerSymbolTable::dropSymbol(const InnerSymTarget &target) {
   assert(target);
   assert(getInnerSymbol(target));
 
@@ -176,6 +176,11 @@ void InnerSymbolTable::erase(const InnerSymTarget &target) {
   auto symOp = cast<InnerSymbolOpInterface>(target.getOp());
   auto base = symOp.getInnerSymAttr();
   symOp.setInnerSymbolAttr(base.erase(target.getField()));
+}
+
+void InnerSymbolTable::erase(const InnerSymTarget &target) {
+  symbolTable.erase(getInnerSymbol(target));
+  InnerSymbolTable::dropSymbol(target);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -166,10 +166,10 @@ void InnerSymbolTable::erase(const InnerSymTarget &target) {
   assert(getInnerSymbol(target));
 
   if (target.isPort()) {
-    auto mod = cast<FModuleLike>(target.getOp());
+    auto mod = cast<HWModuleLike>(target.getOp());
     assert(target.getPort() < mod.getNumPorts());
     auto base = mod.getPortSymbolAttr(target.getPort());
-    mod.setPortSymbolsAttr(target.getPort(), base.erase(target.getField()));
+    mod.setPortSymbolAttr(target.getPort(), base.erase(target.getField()));
     return;
   }
 

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -161,6 +161,23 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   return {};
 }
 
+void InnerSymbolTable::erase(const InnerSymTarget &target) {
+  assert(target);
+  assert(getInnerSymbol(target));
+
+  if (target.isPort()) {
+    auto mod = cast<FModuleLike>(target.getOp());
+    assert(target.getPort() < mod.getNumPorts());
+    auto base = mod.getPortSymbolAttr(target.getPort());
+    mod.setPortSymbolsAttr(target.getPort(), base.erase(target.getField()));
+    return;
+  }
+
+  auto symOp = cast<InnerSymbolOpInterface>(target.getOp());
+  auto base = symOp.getInnerSymAttr();
+  symOp.setInnerSymbolAttr(base.erase(target.getField()));
+}
+
 //===----------------------------------------------------------------------===//
 // InnerSymbolTableCollection
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/PortsInterfaces.cpp
+++ b/lib/Dialect/HW/PortsInterfaces.cpp
@@ -1,0 +1,14 @@
+//===- PortsInterfaces.cpp - Implement the Ports/Syms interfaces ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the HWPorts and HWPortsSymbols interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/PortsInterfaces.h"
+#include "circt/Dialect/HW/PortsInterfaces.cpp.inc"

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -1,8 +1,9 @@
 add_circt_dialect_library(CIRCTHWTransforms
+  FlattenIO.cpp
   HWPrintInstanceGraph.cpp
   HWSpecialize.cpp
+  InnerSymbolDCE.cpp
   PrintHWModuleGraph.cpp
-  FlattenIO.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/HW/Transforms/InnerSymbolDCE.cpp
@@ -10,17 +10,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
-#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "firrtl-inner-symbol-dce"
+#define DEBUG_TYPE "hw-inner-symbol-dce"
 
 using namespace mlir;
 using namespace circt;
-using namespace firrtl;
 using namespace hw;
 
 struct InnerSymbolDCEPass : public InnerSymbolDCEBase<InnerSymbolDCEPass> {
@@ -103,6 +103,6 @@ void InnerSymbolDCEPass::runOnOperation() {
                   [&](HWModuleLike mod) { removeInnerSyms(mod); });
 }
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createInnerSymbolDCEPass() {
+std::unique_ptr<mlir::Pass> circt::hw::createInnerSymbolDCEPass() {
   return std::make_unique<InnerSymbolDCEPass>();
 }

--- a/lib/Dialect/HW/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/HW/Transforms/InnerSymbolDCE.cpp
@@ -72,7 +72,7 @@ void InnerSymbolDCEPass::removeInnerSyms(HWModuleLike mod) {
         if (innerRefs.contains({moduleName, name}))
           return;
 
-        InnerSymbolTable::erase(target);
+        InnerSymbolTable::dropSymbol(target);
         ++numInnerSymbolsRemoved;
 
         LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": removed " << moduleName

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -26,16 +26,49 @@ firrtl.circuit "Simple" attributes {
     // CHECK-NOT:  @w4
     %w4 = firrtl.wire sym @w4 : !firrtl.uint<1>
 
-    firrtl.instance child sym @child @Child()
+    %out, %out2, %out3 = firrtl.instance child sym @child @Child(out out: !firrtl.uint<1>, out out2: !firrtl.uint<1>, out out3: !firrtl.vector<uint<1>,2>)
+    %eo, %eo2, %eo3 = firrtl.instance child sym @extchild @ExtChild(out out: !firrtl.uint<1>, out out2: !firrtl.uint<1>, out out3: !firrtl.vector<uint<1>,2>)
   }
 
   // CHECK-LABEL: firrtl.module @Child
-  firrtl.module @Child() {
+  // CHECK-NOT: @deadportsym
+  // CHECK-SAME: @outsym2
+  // CHECK-SAME: @outsym3
+  firrtl.module @Child(
+    out %out : !firrtl.uint<1> sym @deadportsym,
+    out %out2 : !firrtl.uint<1> sym @outsym2,
+    out %out3 : !firrtl.vector<uint<1>,2> sym [<@outsym3,1,public>])
+  {
     // CHECK-NEXT: @w5
     %w5 = firrtl.wire sym @w5 : !firrtl.uint<1>
+
+    %c0_ui1 = firrtl.constant 0: !firrtl.uint<1>
+    firrtl.strictconnect %out, %c0_ui1 : !firrtl.uint<1>
+    firrtl.strictconnect %out2, %c0_ui1 : !firrtl.uint<1>
+
+    // CHECK: @x
+    // CHECK-NOT: @y
+    %wire = firrtl.wire sym [<@x,1,public>,<@y,2,public>] : !firrtl.vector<uint<1>,2>
+    firrtl.strictconnect %out3, %wire : !firrtl.vector<uint<1>,2>
   }
 
-  hw.hierpath private @nla [@Simple::@child, @Child::@w5]
+  // CHECK-LABEL: firrtl.extmodule @ExtChild
+  // CHECK-NOT: @deadportsym
+  // CHECK-SAME: @outsym2
+  // CHECK-SAME: @outsym3
+  firrtl.extmodule @ExtChild(
+    out out : !firrtl.uint<1> sym @deadportsym,
+    out out2 : !firrtl.uint<1> sym @outsym2,
+    out out3 : !firrtl.vector<uint<1>,2> sym [<@outsym3,1,public>])
+
+  hw.hierpath private @wire [@Simple::@child, @Child::@w5]
+  hw.hierpath private @wireField [@Simple::@child, @Child::@x]
+
+  hw.hierpath private @port [@Simple::@child, @Child::@outsym2]
+  hw.hierpath private @portField [@Simple::@child, @Child::@outsym3]
+
+  hw.hierpath private @extPort [@Simple::@extchild, @ExtChild::@outsym2]
+  hw.hierpath private @extPortField [@Simple::@extchild, @ExtChild::@outsym3]
 }
 
 sv.verbatim "{{0}}" {symbols = [#hw.innerNameRef<@Simple::@w3>]}

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl-inner-symbol-dce)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(hw-inner-symbol-dce)' %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Simple"
 firrtl.circuit "Simple" attributes {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -766,7 +766,7 @@ static LogicalResult processBuffer(
   pm.addNestedPass<firrtl::CircuitOp>(mlir::createSymbolDCEPass());
 
   // Run InnerSymbolDCE as late as possible, but before IMDCE.
-  pm.addPass(firrtl::createInnerSymbolDCEPass());
+  pm.addPass(hw::createInnerSymbolDCEPass());
 
   // The above passes, IMConstProp in particular, introduce additional
   // canonicalization opportunities that we should pick up here before we

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
@@ -1094,6 +1095,7 @@ int main(int argc, char **argv) {
 
     // Dialect passes:
     firrtl::registerPasses();
+    hw::registerPasses();
     sv::registerPasses();
 
     // Export passes:


### PR DESCRIPTION
#4418 +

Don't require all HWModuleLike's to support everything found
useful in some dialects, use interface inheritance.

Pull notion of having "ports" into HWPorts, and methods
for attaching/removing symbols to those ports to HWPortsSymbols.
Keep HWModuleLike using HWPorts, but make HWPortsSymbols optional
(still on HW/FIRRTL module ops).

Remove stubbed/unused methods added to dialects that never
add symbols, let them implement the interface if/when that makes sense.