### PR TITLE
[HW] Add InnerSymAttr::erase.

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -145,17 +145,26 @@ def InnerSymAttr : AttrDef<HWDialect, "InnerSym"> {
   let extraClassDeclaration = [{
     /// Get the inner sym name for fieldID, if it exists.
     mlir::StringAttr getSymIfExists(unsigned fieldID) const;
+
     /// Get the inner sym name for fieldID=0, if it exists.
     mlir::StringAttr getSymName() const { return getSymIfExists(0); }
+
     /// Get the number of inner symbols defined.
     size_t size() const { return getProps().size(); }
+
     /// Check if this is an empty array, no sym names stored.
     bool empty() const { return getProps().empty(); }
+
+    /// Return an InnerSymAttr with the inner symbol for the specified fieldID removed.
+    InnerSymAttr erase(unsigned fieldID) const;
+
     using iterator = mlir::ArrayRef<InnerSymPropertiesAttr>::iterator;
     /// Iterator begin for all the InnerSymProperties.
     iterator begin() const { return getProps().begin(); }
+
     /// Iterator end for all the InnerSymProperties.
     iterator end() const { return getProps().end(); }
+
     /// Invoke the func, for all sym names. Return success(),
     /// if the callback function never returns failure().
     mlir::LogicalResult walkSymbols(llvm::function_ref<

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -275,6 +275,16 @@ StringAttr InnerSymAttr::getSymIfExists(unsigned fieldId) const {
   return {};
 }
 
+InnerSymAttr InnerSymAttr::erase(unsigned fieldID) const {
+  SmallVector<InnerSymPropertiesAttr> syms(getProps());
+  const auto *it = llvm::find_if(syms, [fieldID](InnerSymPropertiesAttr p) {
+    return p.getFieldID() == fieldID;
+  });
+  assert(it != syms.end());
+  syms.erase(it);
+  return InnerSymAttr::get(getContext(), syms);
+}
+
 LogicalResult InnerSymAttr::walkSymbols(
     llvm::function_ref<LogicalResult(StringAttr)> callback) const {
   for (auto p : getImpl()->props)


### PR DESCRIPTION
Add method to generate a new InnerSymAttr with the specified field's inner symbol removed .

cc #4789 .