### PR TITLE
[HW][NFC] InnerSymbolOpInterface: fixup method descriptions to match what they do.

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -220,7 +220,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
 
   let cppNamespace = "::circt::hw";
   let methods = [
-    InterfaceMethod<"Returns the name of this inner symbol.",
+    InterfaceMethod<"Returns the name of the top-level inner symbol defined by this operation, if present.",
       "::mlir::StringAttr", "getInnerNameAttr", (ins), [{}],
       /*defaultImplementation=*/[{
         if (auto attr =
@@ -230,21 +230,21 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
         return {};
       }]
     >,
-    InterfaceMethod<"Returns the name of this inner symbol.",
+    InterfaceMethod<"Returns the name of the top-level inner symbol defined by this operation, if present.",
       "::std::optional<::mlir::StringRef>", "getInnerName", (ins), [{}],
       /*defaultImplementation=*/[{
         auto attr = this->getInnerNameAttr();
         return attr ? ::std::optional<StringRef>(attr.getValue()) : ::std::nullopt;
       }]
     >,
-    InterfaceMethod<"Sets the name of this inner symbol.",
+    InterfaceMethod<"Sets the name of the top-level inner symbol defined by this operation to the specified string, dropping any symbols on fields.",
       "void", "setInnerSymbol", (ins "::mlir::StringAttr":$name), [{}],
       /*defaultImplementation=*/[{
         this->getOperation()->setAttr(
             InnerSymbolTable::getInnerSymbolAttrName(), hw::InnerSymAttr::get(name));
       }]
     >,
-    InterfaceMethod<"Returns an InnerRef to this operation.  Must have inner symbol.",
+    InterfaceMethod<"Returns an InnerRef to this operation's top-level inner symbol, which must be present.",
       "::circt::hw::InnerRefAttr", "getInnerRef", (ins), [{}],
       /*defaultImplementation=*/[{
         auto *op = this->getOperation();
@@ -254,7 +254,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
             InnerSymbolTable::getInnerSymbol(op));
       }]
     >,
-    InterfaceMethod<"Returns the InnerSymAttr.",
+    InterfaceMethod<"Returns the InnerSymAttr representing all inner symbols defined by this operation.",
       "::circt::hw::InnerSymAttr", "getInnerSymAttr", (ins), [{}],
       /*defaultImplementation=*/[{
         return this->getOperation()->template getAttrOfType<hw::InnerSymAttr>(


### PR DESCRIPTION
Touchup method descriptions to match behavior.

cc #4789.