### PR TITLE
[HW] Split out port+symbol interfaces from HWModuleLike.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -179,13 +179,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       return $_op.getPortSymbolsAttr().getValue();
     }]>,
 
-    InterfaceMethod<"Check if port has symbol attribute",
-    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
-      auto syms = $_op.getPortSymbols();
-        return  (!syms.empty() &&
-        !syms[portIndex].template cast<hw::InnerSymAttr>().empty());
-    }]>,
-
     // Setters
     InterfaceMethod<"Set the symbols of all ports and their fields", "void",
     "setPortSymbols", (ins "ArrayRef<Attribute>":$symbols), [{}], [{
@@ -195,30 +188,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       assert(newSyms.empty() || newSyms.size() == $_op.getNumPorts());
       $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
                     ArrayAttr::get($_op.getContext(), newSyms));
-    }]>,
-
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbolAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}],
-    [{
-      SmallVector<Attribute> symbols($_op.getPortSymbols().begin(),
-                                     $_op.getPortSymbols().end());
-      if (symbols.empty()) {
-        symbols.resize($_op.getNumPorts(),
-                      hw::InnerSymAttr::get($_op.getContext()));
-      }
-      assert(symbols.size() == $_op.getNumPorts());
-      symbols[portIndex] = hw::InnerSymAttr::get(symbol);
-
-      FModuleLike::fixupPortSymsArray(symbols, $_op.getContext());
-      assert(symbols.empty() || symbols.size() == $_op.getNumPorts());
-      $_op->setAttr(FModuleLike::getPortSymbolsAttrName(),
-                    ArrayAttr::get($_op.getContext(), symbols));
-    }]>,
-
-    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
-    "setPortSymbol", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
-      $_op.setPortSymbolAttr(portIndex, StringAttr::get($_op.getContext(),
-        symbol));
     }]>,
 
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -65,23 +65,46 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
     IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
     DeclareOpInterfaceMethods<FModuleLike>,
     DeclareOpInterfaceMethods<HWModuleLike>,
+    DeclareOpInterfaceMethods<HWPortsSymbols>,
     OpAsmOpInterface, InnerSymbolTable]> {
 
   /// Additional class definitions inside the module op.
   code extraModuleClassDefinition = [{}];
 
+  /// Implement HWPortsSymbols methods for ports and their symbols.
   let extraClassDefinition = extraModuleClassDefinition # [{
     size_t $cppClass::getNumPorts() {
       return getPortTypesAttr().size();
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
+      assert(portIndex < getNumPorts());
       auto syms = getPortSymbols();
       if (syms.empty() ||
-          syms[portIndex].template cast<hw::InnerSymAttr>().empty())
+          cast<hw::InnerSymAttr>(syms[portIndex]).empty())
         return hw::InnerSymAttr();
-      return syms[portIndex].template cast<hw::InnerSymAttr>();
+      assert(syms.size() == getNumPorts());
+      return cast<hw::InnerSymAttr>(syms[portIndex]);
     }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, ::circt::hw::InnerSymAttr symbol) {
+      assert(portIndex < getNumPorts());
+      SmallVector<Attribute> symbols(getPortSymbols().begin(),
+                                     getPortSymbols().end());
+      if (symbols.empty()) {
+        if (symbol.empty())
+          return;
+        symbols.resize(getNumPorts(),
+                      hw::InnerSymAttr::get(getContext()));
+      }
+      assert(symbols.size() == getNumPorts());
+      symbols[portIndex] = symbol;
+
+      FModuleLike::fixupPortSymsArray(symbols, getContext());
+      assert(symbols.empty() || symbols.size() == getNumPorts());
+      getOperation()->setAttr(FModuleLike::getPortSymbolsAttrName(),
+                    ArrayAttr::get(getContext(), symbols));
+  }
   }];
 
 }

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -83,14 +83,6 @@ def MachineOp : FSMOp<"machine", [
       auto machineType = getFunctionType();
       return machineType.getNumInputs() + machineType.getNumResults();
     }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
-    }
   }];
 
   let skipDefaultBuilders = 1;

--- a/include/circt/Dialect/HW/CMakeLists.txt
+++ b/include/circt/Dialect/HW/CMakeLists.txt
@@ -16,6 +16,12 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTHWTransformsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS PortsInterfaces.td)
+mlir_tablegen(PortsInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(PortsInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(CIRCTPortsInterfacesIncGen)
+add_dependencies(circt-headers CIRCTPortsInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS HWOpInterfaces.td)
 mlir_tablegen(HWOpInterfaces.h.inc -gen-op-interface-decls)
 mlir_tablegen(HWOpInterfaces.cpp.inc -gen-op-interface-defs)

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_HW_HWOPINTERFACES_H
 
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Dialect/HW/PortsInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -13,9 +13,9 @@
 #ifndef CIRCT_DIALECT_HW_HWOPINTERFACES
 #define CIRCT_DIALECT_HW_HWOPINTERFACES
 
-include "mlir/IR/OpBase.td"
+include "circt/Dialect/HW/PortsInterfaces.td"
 
-def HWModuleLike : OpInterface<"HWModuleLike"> {
+def HWModuleLike : OpInterface<"HWModuleLike", [DeclareOpInterfaceMethods<HWPorts>]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common module information.";
 
@@ -36,12 +36,6 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     "::mlir::StringAttr", "moduleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
-
-    InterfaceMethod<"Get the number of ports",
-    "size_t", "getNumPorts">,
-
-    InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>
   ];
 
   let verify = [{

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/HW/PortsInterfaces.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -30,6 +30,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
     HWOp<mnemonic, traits # [
       DeclareOpInterfaceMethods<HWModuleLike>,
+      DeclareOpInterfaceMethods<HWPortsSymbols>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
       FunctionOpInterface, Symbol,
       OpAsmOpInterface, HasParent<"mlir::ModuleOp">]> {
@@ -65,6 +66,24 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
         if (auto sym = argAttr.getValue().dyn_cast<::circt::hw::InnerSymAttr>())
           return sym;
       return ::circt::hw::InnerSymAttr();
+    }
+
+    void $cppClass::setPortSymbolAttr(size_t portIndex, circt::hw::InnerSymAttr symbol) {
+      for (NamedAttribute argAttr :
+           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>()) {
+          if (symbol && !symbol.empty())
+            mlir::function_interface_impl::setArgAttr(*this, portIndex, argAttr.getName(), symbol);
+          else
+            mlir::function_interface_impl::removeArgAttr(*this, portIndex, argAttr.getName());
+          return;
+        }
+      // We cannot add symbols to arguments without assuming the attribute name,
+      // which we're careful above to avoid.  For now, error/assert if this is attempted.
+      if (symbol || !symbol.empty()) {
+        emitOpError("adding symbol to port without any symbols is not yet supported");
+        assert(0 && "cannot add symbols to ports");
+      }
     }
   }];
 

--- a/include/circt/Dialect/HW/PortsInterfaces.h
+++ b/include/circt/Dialect/HW/PortsInterfaces.h
@@ -1,0 +1,22 @@
+//===- PortsInterfaces.h - Declare Ports interfaces -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the port-related interfaces for HW.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_PORTSINTERFACES_H
+#define CIRCT_DIALECT_HW_PORTSINTERFACES_H
+
+#include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "circt/Dialect/HW/PortsInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_HW_PORTSINTERFACES_H

--- a/include/circt/Dialect/HW/PortsInterfaces.td
+++ b/include/circt/Dialect/HW/PortsInterfaces.td
@@ -1,0 +1,66 @@
+//===- PortsInterfaces.td - Ports+Symbols Interfaces -------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the HWPorts and HWPortsSymbols interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_PORTSINTERFACES
+#define CIRCT_DIALECT_HW_PORTSINTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def HWPorts : OpInterface<"HWPorts"> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide accessors for ports";
+
+  let methods = [
+    // Getters
+    InterfaceMethod<"Get the number of ports",
+    "size_t", "getNumPorts">,
+  ];
+
+}
+
+def HWPortsSymbols : OpInterface<"HWPortsSymbols", [DeclareOpInterfaceMethods<HWPorts>]> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide accessors for ports and their symbols";
+
+
+  let methods = [
+    // Getters
+    InterfaceMethod<"Get a port symbol attribute",
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
+
+    InterfaceMethod<"Check if port has symbol attribute",
+    "bool", "hasPortSymbolAttr", (ins "size_t":$portIndex), [{}], [{
+      assert(portIndex < $_op.getNumPorts());
+      auto symAttr = $_op.getPortSymbolAttr(portIndex);
+      return symAttr && !symAttr.empty();
+    }]>,
+
+    // Setters
+    InterfaceMethod<"Set the symbols for a port including its fields", "void",
+    "setPortSymbolAttr", (ins "size_t":$portIndex, "circt::hw::InnerSymAttr":$symbol)>,
+
+    // Convenience methods wrapping setPortSymbolAttr.
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolString", (ins "size_t":$portIndex, "StringRef":$symbol), [{}], [{
+      $_op.setPortSymbolStringAttr(portIndex, StringAttr::get($_op.getContext(),
+        symbol));
+    }]>,
+
+    InterfaceMethod<"Set a port's top-level symbol to the specified string, dropping any symbols on its fields", "void",
+    "setPortSymbolStringAttr", (ins "size_t":$portIndex, "StringAttr":$symbol), [{}], [{
+      return $_op.setPortSymbolAttr(portIndex, hw::InnerSymAttr::get(symbol));
+    }]>,
+  ];
+
+}
+
+#endif // CIRCT_DIALECT_HW_PORTSINTERFACES

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -65,7 +65,8 @@ def AppIDArrayAttr : TypedArrayAttrBase<AppIDAttr, "Array of AppIDs">;
 class MSFTModuleOpBase<string mnemonic, list<Trait> traits = []> :
     MSFTOp<mnemonic, traits # [
       IsolatedFromAbove, Symbol, FunctionOpInterface, OpAsmOpInterface,
-      HasParent<"mlir::ModuleOp">, DeclareOpInterfaceMethods<HWModuleLike>
+      HasParent<"mlir::ModuleOp">,
+      DeclareOpInterfaceMethods<HWModuleLike>,
     ]> {
   /// Additional class declarations inside the module op.
   code extraModuleClassDeclaration = ?;
@@ -181,14 +182,6 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
     size_t $cppClass::getNumPorts() {
       auto ports = getPorts();
       return ports.inputs.size() + ports.outputs.size();
-    }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
     }
   }];
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -108,14 +108,6 @@ def SCModuleOp : SystemCOp<"module", [
     size_t $cppClass::getNumPorts() {
       return getPortNames().size();
     }
-
-    circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(*this, portIndex))
-        if (auto sym = argAttr.getValue().dyn_cast<circt::hw::InnerSymAttr>())
-          return sym;
-      return circt::hw::InnerSymAttr();
-    }
   }];
 }
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -552,11 +552,6 @@ LogicalResult ESIPureModuleOp::verify() {
 }
 
 size_t ESIPureModuleOp::getNumPorts() { return 0; }
-hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t portIndex) {
-  assert(false);
-  return {};
-}
-
 #define GET_OP_CLASSES
 #include "circt/Dialect/ESI/ESI.cpp.inc"
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -220,7 +220,7 @@ DeclKind firrtl::getDeclarationKind(Value val) {
 }
 
 size_t firrtl::getNumPorts(Operation *op) {
-  if (auto module = dyn_cast<hw::HWModuleLike>(*op))
+  if (auto module = dyn_cast<hw::HWPorts>(*op))
     return module.getNumPorts();
   return op->getNumResults();
 }
@@ -459,7 +459,7 @@ static SmallVector<PortInfo> getPorts(FModuleLike module) {
   for (unsigned i = 0, e = getNumPorts(module); i < e; ++i) {
     results.push_back({module.getPortNameAttr(i), module.getPortType(i),
                        module.getPortDirection(i),
-                       cast<hw::HWModuleLike>(*module).getPortSymbolAttr(i),
+                       cast<hw::HWPortsSymbols>(*module).getPortSymbolAttr(i),
                        module.getPortLocation(i),
                        AnnotationSet::forPort(module, i)});
   }
@@ -526,7 +526,8 @@ static void insertPorts(FModuleLike op,
       newNames.push_back(existingNames[oldIdx]);
       newTypes.push_back(existingTypes[oldIdx]);
       newAnnos.push_back(op.getAnnotationsAttrForPort(oldIdx));
-      newSyms.push_back(cast<hw::HWModuleLike>(*op).getPortSymbolAttr(oldIdx));
+      newSyms.push_back(
+          cast<hw::HWPortsSymbols>(*op).getPortSymbolAttr(oldIdx));
       newLocs.push_back(existingLocs[oldIdx]);
       ++oldIdx;
     }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -592,7 +592,9 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     FModuleLike mod, size_t portIdx, StringRef nameHint,
     std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
 
-  auto attr = cast<hw::HWModuleLike>(*mod).getPortSymbolAttr(portIdx);
+  auto hwmod = cast<hw::HWPortsSymbols>(*mod);
+  auto attr = hwmod.getPortSymbolAttr(portIdx);
+  // TODO: check getSymName if empty, that fields don't have symbols.
   if (attr)
     return attr.getSymName();
   if (nameHint.empty()) {
@@ -603,7 +605,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
   }
   auto name = getNamespace(mod).newName(nameHint);
   auto sAttr = StringAttr::get(mod.getContext(), name);
-  mod.setPortSymbolAttr(portIdx, sAttr);
+  hwmod.setPortSymbolStringAttr(portIdx, sAttr);
   return sAttr;
 }
 

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -8,10 +8,11 @@ add_circt_dialect_library(
   HWOps.cpp
   HWTypeInterfaces.cpp
   HWTypes.cpp
+  InnerSymbolTable.cpp
   InstanceGraphBase.cpp
   InstanceImplementation.cpp
   ModuleImplementation.cpp
-  InnerSymbolTable.cpp
+  PortsInterfaces.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/HW

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -94,8 +94,7 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
                  return WalkResult::interrupt();
 
            // Check for ports
-           // TODO: Add fields per port, once they work that way (use addSyms)
-           if (auto mod = dyn_cast<HWModuleLike>(curOp)) {
+           if (auto mod = dyn_cast<HWPortsSymbols>(curOp)) {
              for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i) {
                if (auto symAttr = mod.getPortSymbolAttr(i))
                  if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
@@ -143,8 +142,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   // Obtain the base InnerSymAttr for the specified target.
   auto getBase = [](auto &target) -> hw::InnerSymAttr {
     if (target.isPort()) {
-      // TODO: This needs to be made to work with HWModuleLike
-      if (auto mod = dyn_cast<HWModuleLike>(target.getOp())) {
+      if (auto mod = dyn_cast<HWPortsSymbols>(target.getOp())) {
         assert(target.getPort() < mod.getNumPorts());
         return mod.getPortSymbolAttr(target.getPort());
       }

--- a/lib/Dialect/HW/PortsInterfaces.cpp
+++ b/lib/Dialect/HW/PortsInterfaces.cpp
@@ -1,0 +1,14 @@
+//===- PortsInterfaces.cpp - Implement the Ports/Syms interfaces ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the HWPorts and HWPortsSymbols interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/PortsInterfaces.h"
+#include "circt/Dialect/HW/PortsInterfaces.cpp.inc"


### PR DESCRIPTION
Don't require all HWModuleLike's to support everything found
useful in some dialects, use interface inheritance.

This is a step towards cleaning up / reorganizing the interfaces,
primarily targeting pulling symbols on ports out, since
that required various dialects to stub out methods to comply.

Pull getNumPorts into HWPorts, and methods for attaching/removing symbols to
those ports to HWPortsSymbols.  Keep HWModuleLike using HWPorts, but make
HWPortsSymbols optional (still on HW/FIRRTL module ops).

Remove stubbed/unused methods added to dialects that never
add symbols, let them implement the interface if/when that makes sense.

Also, adds ability to set port symbols in whole or in part.

cc #4789 .