### PR TITLE
[FIRRTL][InferWidths] Honor upper bounds on AttachOp

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1703,7 +1703,7 @@ void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller,
   // If the larger expr is a free variable, create a `expr >= x` constraint for
   // it that we can try to satisfy with the smallest width.
   if (auto largerVar = dyn_cast<VarExpr>(larger)) {
-    LLVM_ATTRIBUTE_UNUSED auto c = solver.addGeqConstraint(largerVar, smaller);
+    LLVM_ATTRIBUTE_UNUSED auto *c = solver.addGeqConstraint(largerVar, smaller);
     LLVM_DEBUG(llvm::dbgs()
                << "Constrained " << *largerVar << " >= " << *c << "\n");
     return;
@@ -1714,9 +1714,9 @@ void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller,
   // satisfied. Since we are always picking the smallest width to satisfy all
   // `>=` constraints, any `<=` constraints have no effect on the solution
   // besides indicating that a width is unsatisfiable.
-  if (auto smallerVar = dyn_cast<VarExpr>(smaller)) {
+  if (auto *smallerVar = dyn_cast<VarExpr>(smaller)) {
     if (imposeUpperBounds) {
-      LLVM_ATTRIBUTE_UNUSED auto c =
+      LLVM_ATTRIBUTE_UNUSED auto *c =
           solver.addLeqConstraint(smallerVar, larger);
       LLVM_DEBUG(llvm::dbgs()
                  << "Constrained " << *smallerVar << " <= " << *c << "\n");

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -98,11 +98,6 @@ struct Expr {
   /// Print a human-readable representation of this expr.
   void print(llvm::raw_ostream &os) const;
 
-  // Iterators over the child expressions.
-  typedef Expr *const *iterator;
-  iterator begin() const;
-  iterator end() const;
-
 protected:
   Expr(Kind kind) : kind(kind) {}
   llvm::hash_code hash_value() const { return llvm::hash_value(kind); }
@@ -118,16 +113,12 @@ struct ExprBase : public Expr {
       return *static_cast<DerivedT *>(this) == otherSame;
     return false;
   }
-  iterator begin() const { return nullptr; }
-  iterator end() const { return nullptr; }
 };
 
 /// The root containing all expressions.
 struct RootExpr : public ExprBase<RootExpr, Expr::Kind::Root> {
   RootExpr(std::vector<Expr *> &exprs) : exprs(exprs) {}
   void print(llvm::raw_ostream &os) const { os << "root"; }
-  iterator begin() const { return exprs.data(); }
-  iterator end() const { return exprs.data() + exprs.size(); }
   std::vector<Expr *> &exprs;
 };
 
@@ -138,12 +129,14 @@ struct VarExpr : public ExprBase<VarExpr, Expr::Kind::Var> {
     // this is just for debug dumping, we wrap around at 4096 variables.
     os << "var" << ((size_t)this / llvm::PowerOf2Ceil(sizeof(*this)) & 0xFFF);
   }
-  iterator begin() const { return &constraint; }
-  iterator end() const { return &constraint + (constraint ? 1 : 0); }
 
   /// The constraint expression this variable is supposed to be greater than or
   /// equal to. This is not part of the variable's hash and equality property.
   Expr *constraint = nullptr;
+
+  /// The upper bound this variable is supposed to be smaller than or equal to.
+  Expr *upperBound = nullptr;
+  std::optional<int32_t> upperBoundSolution;
 };
 
 /// An identity expression.
@@ -163,8 +156,6 @@ struct VarExpr : public ExprBase<VarExpr, Expr::Kind::Var> {
 struct IdExpr : public ExprBase<IdExpr, Expr::Kind::Id> {
   IdExpr(Expr *arg) : arg(arg) { assert(arg); }
   void print(llvm::raw_ostream &os) const { os << "*" << *arg; }
-  iterator begin() const { return &arg; }
-  iterator end() const { return &arg + (arg ? 1 : 0); }
   bool operator==(const IdExpr &other) const {
     return kind == other.kind && arg == other.arg;
   }
@@ -197,8 +188,6 @@ struct UnaryExpr : public Expr {
   llvm::hash_code hash_value() const {
     return llvm::hash_combine(Expr::hash_value(), arg);
   }
-  iterator begin() const { return &arg; }
-  iterator end() const { return &arg + 1; }
 
   /// The child expression.
   Expr *const arg;
@@ -233,8 +222,6 @@ struct BinaryExpr : public Expr {
   }
   Expr *lhs() const { return args[0]; }
   Expr *rhs() const { return args[1]; }
-  iterator begin() const { return args; }
-  iterator end() const { return args + 2; }
 
   /// The child expressions.
   Expr *const args[2];
@@ -284,37 +271,7 @@ void Expr::print(llvm::raw_ostream &os) const {
       [&](auto *e) { e->print(os); });
 }
 
-Expr::iterator Expr::begin() const {
-  return TypeSwitch<const Expr *, Expr::iterator>(this).Case<EXPR_CLASSES>(
-      [&](auto *e) { return e->begin(); });
-}
-
-Expr::iterator Expr::end() const {
-  return TypeSwitch<const Expr *, Expr::iterator>(this).Case<EXPR_CLASSES>(
-      [&](auto *e) { return e->end(); });
-}
-
 } // namespace
-
-//===----------------------------------------------------------------------===//
-// GraphTraits on constraint expressions
-//===----------------------------------------------------------------------===//
-
-namespace llvm {
-template <>
-struct GraphTraits<Expr *> {
-  using ChildIteratorType = Expr::iterator;
-  using NodeRef = Expr *;
-
-  static NodeRef getEntryNode(NodeRef node) { return node; }
-  static inline ChildIteratorType child_begin(NodeRef node) {
-    return node->begin();
-  }
-  static inline ChildIteratorType child_end(NodeRef node) {
-    return node->end();
-  }
-};
-} // namespace llvm
 
 //===----------------------------------------------------------------------===//
 // Fast bump allocator with optional interning
@@ -631,6 +588,16 @@ public:
     return lhs->constraint;
   }
 
+  /// Add a constraint `lhs <= rhs`. Multiple constraints on the same variable
+  /// are coalesced into a `min(a, b)` expr.
+  Expr *addLeqConstraint(VarExpr *lhs, Expr *rhs) {
+    if (lhs->upperBound)
+      lhs->upperBound = min(lhs->upperBound, rhs);
+    else
+      lhs->upperBound = id(rhs);
+    return lhs->upperBound;
+  }
+
   void dumpConstraints(llvm::raw_ostream &os);
   LogicalResult solve();
 
@@ -679,7 +646,7 @@ private:
   ConstraintSolver &operator=(ConstraintSolver &&) = delete;
   ConstraintSolver &operator=(const ConstraintSolver &) = delete;
 
-  bool emitUninferredWidthError(VarExpr *var);
+  void emitUninferredWidthError(VarExpr *var);
 
   LinIneq checkCycles(VarExpr *var, Expr *expr,
                       SmallPtrSetImpl<Expr *> &seenVars,
@@ -827,12 +794,11 @@ computeBinary(ExprSolution lhs, ExprSolution rhs,
   return result;
 }
 
-/// Compute the value of a constraint expression`expr`. `seenVars` is used as a
-/// recursion breaker. Recursive variables are treated as zero. Returns the
-/// computed value and a boolean indicating whether a recursion was detected.
-/// This may be used to memoize the result of expressions in case they were not
-/// involved in a cycle (which may alter their value from the perspective of a
-/// variable).
+/// Compute the value of a constraint `expr`. `seenVars` is used as a recursion
+/// breaker. Recursive variables are treated as zero. Returns the computed value
+/// and a boolean indicating whether a recursion was detected. This may be used
+/// to memoize the result of expressions in case they were not involved in a
+/// cycle (which may alter their value from the perspective of a variable).
 static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
                               unsigned indent = 1) {
   // See if we have a memoized result we can return.
@@ -865,6 +831,9 @@ static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
             if (!seenVars.insert(expr).second)
               return ExprSolution{std::nullopt, true};
             auto solution = solveExpr(expr->constraint, seenVars, indent + 1);
+            if (expr->upperBound)
+              expr->upperBoundSolution =
+                  solveExpr(expr->upperBound, seenVars, indent + 1).first;
             seenVars.erase(expr);
             // Constrain variables >= 0.
             if (solution.first && *solution.first < 0)
@@ -1002,8 +971,8 @@ LogicalResult ConstraintSolver::solve() {
     // Complain about unconstrained variables.
     if (!var->constraint) {
       LLVM_DEBUG(llvm::dbgs() << "- Unconstrained " << *var << "\n");
-      if (emitUninferredWidthError(var))
-        anyFailed = true;
+      emitUninferredWidthError(var);
+      anyFailed = true;
       continue;
     }
 
@@ -1012,24 +981,34 @@ LogicalResult ConstraintSolver::solve() {
                << "- Solving " << *var << " >= " << *var->constraint << "\n");
     seenVars.insert(var);
     auto solution = solveExpr(var->constraint, seenVars);
+    if (var->upperBound)
+      var->upperBoundSolution = solveExpr(var->upperBound, seenVars).first;
     seenVars.clear();
 
     // Constrain variables >= 0.
     if (solution.first && *solution.first < 0)
       solution.first = 0;
+    var->solution = solution.first;
 
     // In case the width could not be inferred, complain to the user. This might
     // be the case if the width depends on an unconstrained variable.
     if (!solution.first) {
       LLVM_DEBUG(llvm::dbgs() << "  - UNSOLVED " << *var << "\n");
-      if (emitUninferredWidthError(var))
-        anyFailed = true;
-    } else {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "  - Solved " << *var << " = " << solution.first << " ("
-                 << (solution.second ? "cycle broken" : "unique") << ")\n");
+      emitUninferredWidthError(var);
+      anyFailed = true;
+      continue;
     }
-    var->solution = solution.first;
+    LLVM_DEBUG(llvm::dbgs()
+               << "  = Solved " << *var << " = " << solution.first << " ("
+               << (solution.second ? "cycle broken" : "unique") << ")\n");
+
+    // Check if the solution we have found violates an upper bound.
+    if (var->upperBoundSolution && var->upperBoundSolution < *solution.first) {
+      LLVM_DEBUG(llvm::dbgs() << "  ! Unsatisfiable " << *var
+                              << " <= " << var->upperBoundSolution << "\n");
+      emitUninferredWidthError(var);
+      anyFailed = true;
+    }
   }
 
   return failure(anyFailed);
@@ -1037,7 +1016,7 @@ LogicalResult ConstraintSolver::solve() {
 
 // Emits the diagnostic to inform the user about an uninferred width in the
 // design. Returns true if an error was reported, false otherwise.
-bool ConstraintSolver::emitUninferredWidthError(VarExpr *var) {
+void ConstraintSolver::emitUninferredWidthError(VarExpr *var) {
   FieldRef fieldRef = info.find(var)->second.back();
   Value value = fieldRef.getValue();
 
@@ -1066,14 +1045,23 @@ bool ConstraintSolver::emitUninferredWidthError(VarExpr *var) {
 
   if (!var->constraint) {
     diag << " is unconstrained";
+  } else if (var->solution && var->upperBoundSolution &&
+             var->solution > var->upperBoundSolution) {
+    diag << " cannot satisfy all width requirements";
+    LLVM_DEBUG(llvm::dbgs() << *var->constraint << "\n");
+    LLVM_DEBUG(llvm::dbgs() << *var->upperBound << "\n");
+    auto loc = locs.find(var->constraint)->second.back();
+    diag.attachNote(loc) << "width is constrained to be at least "
+                         << *var->solution << " here:";
+    loc = locs.find(var->upperBound)->second.back();
+    diag.attachNote(loc) << "width is constrained to be at most "
+                         << *var->upperBoundSolution << " here:";
   } else {
     diag << " width cannot be determined";
     LLVM_DEBUG(llvm::dbgs() << *var->constraint << "\n");
     auto loc = locs.find(var->constraint)->second.back();
     diag.attachNote(loc) << "width is constrained by an uninferred width here:";
   }
-
-  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1115,7 +1103,8 @@ public:
 
   /// Constrain the expression "larger" to be greater than or equals to
   /// the expression "smaller".
-  void constrainTypes(Expr *larger, Expr *smaller);
+  void constrainTypes(Expr *larger, Expr *smaller,
+                      bool imposeUpperBounds = false);
 
   /// Assign the constraint expressions of the fields in the `src` argument as
   /// the expressions for the `dst` argument. Both fields must be of the given
@@ -1455,8 +1444,8 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         for (auto operand : op.getAttached().drop_front()) {
           auto e1 = getExpr(prev);
           auto e2 = getExpr(operand);
-          constrainTypes(e1, e2);
-          constrainTypes(e2, e1);
+          constrainTypes(e1, e2, /*imposeUpperBounds=*/true);
+          constrainTypes(e2, e1, /*imposeUpperBounds=*/true);
           prev = operand;
         }
       })
@@ -1701,7 +1690,8 @@ void InferenceMapping::constrainTypes(Value larger, Value smaller) {
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
 /// than or equal to the sizes in the `smaller` type.
-void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller) {
+void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller,
+                                      bool imposeUpperBounds) {
   assert(larger && "Larger expression should be specified");
   assert(smaller && "Smaller expression should be specified");
   // Mimic the Scala implementation here by simply doing nothing if the larger
@@ -1709,10 +1699,28 @@ void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller) {
   // useless constraints can be added, e.g. on multiple well-known values. As
   // long as we don't want to do type checking itself here, but only width
   // inference, we should be fine ignoring expr we cannot constraint anyway.
+
+  // If the larger expr is a free variable, create a `expr >= x` constraint for
+  // it that we can try to satisfy with the smallest width.
   if (auto largerVar = dyn_cast<VarExpr>(larger)) {
     LLVM_ATTRIBUTE_UNUSED auto c = solver.addGeqConstraint(largerVar, smaller);
     LLVM_DEBUG(llvm::dbgs()
                << "Constrained " << *largerVar << " >= " << *c << "\n");
+    return;
+  }
+
+  // If the smaller expr is a free variable but the larger one is not, create a
+  // `expr <= k` upper bound that we can verify once all lower bounds have been
+  // satisfied. Since we are always picking the smallest width to satisfy all
+  // `>=` constraints, any `<=` constraints have no effect on the solution
+  // besides indicating that a width is unsatisfiable.
+  if (auto smallerVar = dyn_cast<VarExpr>(smaller)) {
+    if (imposeUpperBounds) {
+      LLVM_ATTRIBUTE_UNUSED auto c =
+          solver.addLeqConstraint(smallerVar, larger);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Constrained " << *smallerVar << " <= " << *c << "\n");
+    }
   }
 }
 

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -126,11 +126,11 @@ firrtl.circuit "Foo"  {
 // Unsatisfiable widths through AttachOp on analog types should error.
 // https://github.com/llvm/circt/issues/4786
 firrtl.circuit "AnalogWidths" {
-  // expected-error @+1 {{uninferred width: port "a" cannot satisfy all width requirements}}
+  // expected-error @below {{uninferred width: port "a" cannot satisfy all width requirements}}
+  // expected-note @below {{width is constrained to be at least 2 here:}}
+  // expected-note @below {{width is constrained to be at most 1 here:}}
   firrtl.module @AnalogWidths(in %a: !firrtl.analog, out %b: !firrtl.analog<2>, out %c: !firrtl.analog<1>) {
     firrtl.attach %a, %b : !firrtl.analog, !firrtl.analog<2>
-    // expected-note @+2 {{width is constrained to be at least 2 here:}}
-    // expected-note @+1 {{width is constrained to be at most 1 here:}}
     firrtl.attach %a, %c : !firrtl.analog, !firrtl.analog<1>
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -127,10 +127,10 @@ firrtl.circuit "Foo"  {
 // https://github.com/llvm/circt/issues/4786
 firrtl.circuit "AnalogWidths" {
   // expected-error @below {{uninferred width: port "a" cannot satisfy all width requirements}}
-  // expected-note @below {{width is constrained to be at least 2 here:}}
-  // expected-note @below {{width is constrained to be at most 1 here:}}
   firrtl.module @AnalogWidths(in %a: !firrtl.analog, out %b: !firrtl.analog<2>, out %c: !firrtl.analog<1>) {
     firrtl.attach %a, %b : !firrtl.analog, !firrtl.analog<2>
+    // expected-note @below {{width is constrained to be at least 2 here:}}
+    // expected-note @below {{width is constrained to be at most 1 here:}}
     firrtl.attach %a, %c : !firrtl.analog, !firrtl.analog<1>
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -121,3 +121,16 @@ firrtl.circuit "Foo"  {
     firrtl.connect %w, %0 : !firrtl.bundle<x: uint>, !firrtl.bundle<x: uint>
   }
 }
+
+// -----
+// Unsatisfiable widths through AttachOp on analog types should error.
+// https://github.com/llvm/circt/issues/4786
+firrtl.circuit "AnalogWidths" {
+  // expected-error @+1 {{uninferred width: port "a" cannot satisfy all width requirements}}
+  firrtl.module @AnalogWidths(in %a: !firrtl.analog, out %b: !firrtl.analog<2>, out %c: !firrtl.analog<1>) {
+    firrtl.attach %a, %b : !firrtl.analog, !firrtl.analog<2>
+    // expected-note @+2 {{width is constrained to be at least 2 here:}}
+    // expected-note @+1 {{width is constrained to be at most 1 here:}}
+    firrtl.attach %a, %c : !firrtl.analog, !firrtl.analog<1>
+  }
+}


### PR DESCRIPTION
Fix an issue in `InferWidths` where analog values attached to each other would not produce proper errors if the widths are unsatisfiable. For example, the following is unsatisfiable but successfully infers to an incorrect width:

```
firrtl.module @AnalogWidths(
  in %a: !firrtl.analog,
  out %b: !firrtl.analog<2>,
  out %c: !firrtl.analog<1>
) {
  firrtl.attach %a, %b : !firrtl.analog, !firrtl.analog<2>
  firrtl.attach %a, %c : !firrtl.analog, !firrtl.analog<1>
}
```

The `AttachOp` imposes a `lhs >= rhs` *and* `lhs <= rhs` constraint, which is supposed to devolve into `lhs == rhs`. However, `InferWidths` ignores upper bound constraints like `expr <= 42` since the original Scala implementation used to violate upper bounds in obscure and wild ways (see #1088).

This commit adds an optional upper bound to variables which is checked after width inference. Specifically `AttachOp` is made to generate these upper bound constraints. Proper error messages on unsatisfiable widths should now be produced.

Fixes #4786.