### PR TITLE
[FIRRTL] RefConnect for references

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -74,7 +74,7 @@ def KnownWidth : Constraint<CPred<[{
   $0.getType().isa<FIRRTLBaseType>() &&
     !$0.getType().cast<FIRRTLBaseType>().getRecursiveTypeProperties().hasUninferredWidth
   }]>>;
-
+  
 /// Constraint that matches a zero ConstantOp or SpecialConstantOp.
 def ZeroConstantOp : Constraint<Or<[
   CPred<"$0.getDefiningOp<ConstantOp>() &&"

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -59,10 +59,29 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
     ```
     }];
 
-  let arguments = (ins SizedBaseOrRefTypeOrForeignType:$dest,
-                       SizedBaseOrRefTypeOrForeignType:$src);
+  let arguments = (ins SizedOrForeignType:$dest,
+                       SizedOrForeignType:$src);
   let results = (outs);
   let hasCanonicalizeMethod = true;
+
+  let hasVerifier = 1;
+
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+}
+
+def RefConnectOp : FIRRTLOp<"refconnect", [SameTypeOperands, FConnectLike]> {
+  let summary = "Connect two references";
+  let description =  [{
+    Connect two references with strict constraints:
+    ```
+      firrtl.refconnect %dest, %src : ref<t1>
+    ```
+    }];
+
+  let arguments = (ins SizedRefType:$dest,
+                       SizedRefType:$src);
+  let results = (outs);
 
   let hasVerifier = 1;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -124,6 +124,11 @@ def RefType : FIRRTLDialectType<
   CPred<"$_self.isa<RefType>()">,
    "reference type", "::circt::firrtl::RefType">;
 
+def SizedRefType : FIRRTLDialectType<
+  CPred<"$_self.isa<RefType>() &&  "
+        "!$_self.cast<RefType>().getType().hasUninferredWidth()">,
+   "sized reference type", "::circt::firrtl::RefType">;
+
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -170,7 +170,7 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AttachOp, ConnectOp, StrictConnectOp, ForceOp, PrintFOp,
+        .template Case<AttachOp, ConnectOp, StrictConnectOp, RefConnectOp, ForceOp, PrintFOp,
                        SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
                        ProbeOp>([&](auto opNode) -> ResultType {
           return thisCast->visitStmt(opNode, args...);
@@ -200,6 +200,7 @@ public:
   HANDLE(AttachOp);
   HANDLE(ConnectOp);
   HANDLE(StrictConnectOp);
+  HANDLE(RefConnectOp);
   HANDLE(ForceOp);
   HANDLE(PrintFOp);
   HANDLE(SkipOp);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -452,8 +452,7 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
     auto pathStr = builder.create<VerbatimExprOp>(
         portRefType.getType(), internalPathAttr.getValue(), ValueRange{});
     auto sendPath = builder.create<RefSendOp>(pathStr);
-    builder.create<StrictConnectOp>(intMod.getArguments().back(),
-                                    sendPath.getResult());
+    emitConnect(builder, intMod.getArguments().back(), sendPath.getResult());
   }
 
   if (!moduleTarget.instances.empty())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2315,6 +2315,19 @@ LogicalResult StrictConnectOp::verify() {
   return success();
 }
 
+LogicalResult RefConnectOp::verify() {
+  // Check that the flows make sense.
+  if (failed(checkConnectFlow(*this)))
+    return failure();
+
+  // Check constraints on RefType.
+  if (failed(checkRefTypeFlow(*this)))
+    return failure();
+
+  return success();
+}
+
+
 void WhenOp::createElseRegion() {
   assert(!hasElseRegion() && "already has an else region");
   getElseRegion().push_back(new Block());

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -33,19 +33,21 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   auto dstType = dstFType.dyn_cast<FIRRTLBaseType>();
   auto srcType = srcFType.dyn_cast<FIRRTLBaseType>();
 
-  // If the types are the exact same we can just connect them.
-  if (dstFType == srcFType) {
-    // Strict connect does not allow uninferred widths.
-    if (dstType && dstType.hasUninferredWidth())
+  // Special Connects
+  if (!dstType) {
+    if (dstFType.isa<RefType>() && 
+        !dstFType.cast<RefType>().getType().hasUninferredWidth())
+      builder.create<RefConnectOp>(dst, src);
+    else // Other types, give up and leave a connect
       builder.create<ConnectOp>(dst, src);
-    else
-      builder.create<StrictConnectOp>(dst, src);
     return;
   }
 
-  // Non-base types don't need special handling.
-  if (!srcType || !dstType) {
-    builder.create<ConnectOp>(dst, src);
+  // If the types are the exact same we can just connect them.
+    // Strict connect does not allow uninferred widths.
+  if (dstType == srcType && !
+    dstType.hasUninferredWidth()) {
+      builder.create<StrictConnectOp>(dst, src);
     return;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -305,6 +305,10 @@ public:
     setLastConnect(getFieldRefFromValue(op.getDest()), op);
   }
 
+  void visitStmt(RefConnectOp op) {
+    setLastConnect(getFieldRefFromValue(op.getDest()), op);
+  }
+
   void processWhenOp(WhenOp whenOp, Value outerCondition);
 
   /// Combine the connect statements from each side of the block. There are 5
@@ -562,6 +566,7 @@ public:
   void visitStmt(WhenOp whenOp);
   void visitStmt(ConnectOp connectOp);
   void visitStmt(StrictConnectOp connectOp);
+  void visitStmt(RefConnectOp connectOp);
 
   bool run(FModuleOp op);
   LogicalResult checkInitialization();
@@ -599,6 +604,10 @@ void ModuleVisitor::visitStmt(ConnectOp op) {
 }
 
 void ModuleVisitor::visitStmt(StrictConnectOp op) {
+  anythingChanged |= setLastConnect(getFieldRefFromValue(op.getDest()), op);
+}
+
+void ModuleVisitor::visitStmt(RefConnectOp op) {
   anythingChanged |= setLastConnect(getFieldRefFromValue(op.getDest()), op);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -682,7 +682,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
       return success();
     }
     // Otherwise, just connect to the source.
-    builder.create<ConnectOp>(dest, src);
+    emitConnect(builder, dest, src);
     return success();
   };
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -397,6 +397,7 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitExpr(RefResolveOp op);
   bool visitStmt(ConnectOp op);
   bool visitStmt(StrictConnectOp op);
+  bool visitStmt(RefConnectOp op);
   bool visitStmt(WhenOp op);
 
   bool isFailed() const { return encounteredError; }
@@ -840,9 +841,32 @@ bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
   for (const auto &field : llvm::enumerate(fields)) {
     Value src = getSubWhatever(op.getSrc(), field.index());
     Value dest = getSubWhatever(op.getDest(), field.index());
-    if (field.value().isOutput && !op.getDest().getType().isa<RefType>())
+    if (field.value().isOutput)
       std::swap(src, dest);
     builder->create<StrictConnectOp>(dest, src);
+  }
+  return true;
+}
+
+// Expand connects of aggregates
+bool TypeLoweringVisitor::visitStmt(RefConnectOp op) {
+  if (!canLowerConnect(op, aggregatePreservationMode))
+    return false;
+  if (processSAPath(op))
+    return true;
+
+  // Attempt to get the bundle types.
+  SmallVector<FlatBundleFieldEntry> fields;
+
+  // We have to expand connections even if the aggregate preservation is true.
+  if (!peelType(op.getDest().getType(), fields, PreserveAggregate::None))
+    return false;
+
+  // Loop over the leaf aggregates.
+  for (const auto &field : llvm::enumerate(fields)) {
+    Value src = getSubWhatever(op.getSrc(), field.index());
+    Value dest = getSubWhatever(op.getDest(), field.index());
+    builder->create<RefConnectOp>(dest, src);
   }
   return true;
 }

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -72,7 +72,7 @@ circuit Top : %[[
 
   module Bar :
 
-    wire inv : UInt<1>
+    wire inv : UInt<2>
     inv is invalid
 
   module Foo :
@@ -83,13 +83,13 @@ circuit Top : %[[
 
     inst foo of Foo
 
-    wire tap : UInt<1>
+    wire tap : UInt<2>
     tap is invalid
 
-    wire tap2 : UInt<1>
+    wire tap2 : UInt<4>
     tap2 is invalid
 
-    wire tap3 : UInt<1>
+    wire tap3 : UInt<5>
     tap3 is invalid
 
     inst unsigned of ChildWrapper

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1042,11 +1042,11 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK:      %5 = firrtl.subfield %4[_1] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %6 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      firrtl.connect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.connect %view_companion_view_port__bore, %a : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_port__bore, %a : !firrtl.uint<1>, !firrtl.uint<1>
 
 // -----
 
@@ -1202,7 +1202,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-LABEL: firrtl.module private @InnerMod
 // CHECK-SAME:    out %[[tap_6:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
 // CHECK:         %[[w_ref:[a-zA-Z09_]+]] = firrtl.ref.send %w
-// CHECK:         firrtl.connect %[[tap_6]], %[[w_ref]]
+// CHECK:         firrtl.refconnect %[[tap_6]], %[[w_ref]]
 
 // CHECK-LABEL: firrtl.module @GCTDataTap
 // CHECK:         %[[w_a0:[a-zA-Z0-9_]+]] = firrtl.subfield %w[a]
@@ -1211,12 +1211,12 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-DAG:    %tap_0 = firrtl.node %r
 //
 // CHECK-DAG:    %[[tap_1_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_1[0]
-// CHECK-DAG:    firrtl.connect %[[tap_1_0]], %r
+// CHECK-DAG:    firrtl.strictconnect %[[tap_1_0]], %r
 //
 // CHECK-DAG:    %tap_2 = firrtl.node %[[w_a1]]
 //
 // CHECK-DAG:    %[[tap_3_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_3[0]
-// CHECK-DAG:    firrtl.connect %[[tap_3_0]], %[[w_a0]]
+// CHECK-DAG:    firrtl.strictconnect %[[tap_3_0]], %[[w_a0]]
 //
 // CHECK-DAG:    %[[tap_4_port:[a-zA-Z0-9_]+]], %[[tap_5_port:[a-zA-Z0-9_]+]] = firrtl.instance BlackBox
 // CHECK-DAG:    %[[tap_4_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_4_port]]
@@ -1224,7 +1224,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 //
 // CHECK-DAG:    %[[tap_5_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_5_port]]
 // CHECK-DAG:    %[[tap_5_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_5[0]
-// CHECK-DAG:    firrtl.connect %[[tap_5_0]], %[[tap_5_resolve]]
+// CHECK-DAG:    firrtl.strictconnect %[[tap_5_0]], %[[tap_5_resolve]]
 //
 // CHECK-DAG:    %[[tap_6_port:[a-zA-Z0-9_]+]] = firrtl.instance im @InnerMod
 // CHECK-DAG:    %[[tap_6_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_6_port]]
@@ -1377,9 +1377,9 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     // CHECK:      %[[a_0:[a-zA-Z0-9_]+]] = firrtl.subfield %a[a]
     // CHECK-NEXT: %[[a_1:[a-zA-Z0-9_]+]] = firrtl.subfield %a[b]
     // CHECK-NEXT: %[[a_0_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %[[a_0]]
-    // CHECK-NEXT: firrtl.connect %[[refPort_0]], %[[a_0_ref]]
+    // CHECK-NEXT: firrtl.refconnect %[[refPort_0]], %[[a_0_ref]]
     // CHECK-NEXT: %[[a_1_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %[[a_1]]
-    // CHECK-NEXT: firrtl.connect %[[refPort_1]], %[[a_1_ref]]
+    // CHECK-NEXT: firrtl.refconnect %[[refPort_1]], %[[a_1_ref]]
   }
   // CHECK:      firrtl.module @GrandCentralViewsBundle()
   firrtl.module @GrandCentralViewsBundle() {
@@ -1388,9 +1388,9 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     // CHECK-NEXT: %[[companion_port_0:[a-zA-Z0-9_]+]], %[[companion_port_1:[a-zA-Z0-9_]+]] = firrtl.instance companion
     firrtl.instance companion @Companion()
     // CHECK-NEXT: %[[bar_refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_0]]
-    // CHECK-NEXT: firrtl.connect %[[companion_port_0]], %[[bar_refPort_0_resolve]]
+    // CHECK-NEXT: firrtl.strictconnect %[[companion_port_0]], %[[bar_refPort_0_resolve]]
     // CHECK-NEXT: %[[bar_refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_1]]
-    // CHECK-NEXT: firrtl.connect %[[companion_port_1]], %[[bar_refPort_1_resolve]]
+    // CHECK-NEXT: firrtl.strictconnect %[[companion_port_1]], %[[bar_refPort_1_resolve]]
   }
 }
 
@@ -1410,13 +1410,13 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   firrtl.module private @Bar() {
     %inv = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %inv : !firrtl.uint<1>
-    // CHECK:  firrtl.connect %inv__bore, %0 : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %inv__bore, %0 : !firrtl.ref<uint<1>>
   }
   // CHECK-LABEL: firrtl.module private @Foo(out %b_inv__bore: !firrtl.ref<uint<1>>)
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
     // CHECK:  %[[b_inv:[a-zA-Z0-9_]+]] = firrtl.instance b interesting_name  @Bar(out inv__bore: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.connect %b_inv__bore, %[[b_inv]] : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %b_inv__bore, %[[b_inv]] : !firrtl.ref<uint<1>>
   }
   // CHECK: firrtl.module @Top()
   firrtl.module @Top() {
@@ -1453,7 +1453,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
   // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.ref<uint<1>>)
   // CHECK:  %[[random:.+]] = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
   // CHECK:  %0 = firrtl.ref.send %[[random]] : !firrtl.uint<1>
-  // CHECK:  firrtl.strictconnect %[[_gen_ref2]], %0 : !firrtl.ref<uint<1>>
+  // CHECK:  firrtl.refconnect %[[_gen_ref2]], %0 : !firrtl.ref<uint<1>>
   firrtl.module private @Bar() {
   }
 
@@ -1544,7 +1544,7 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
   firrtl.module @Bar() {
     %a = firrtl.wire : !firrtl.uint<1>
     // CHECK:        %[[a_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %a
-    // CHECK-NEXT:   firrtl.connect %[[a_refPort]], %[[a_ref]]
+    // CHECK-NEXT:   firrtl.strictconnect %[[a_refPort]], %[[a_ref]]
   }
   // CHECK:        firrtl.module @Companion()
   firrtl.module @Companion() {

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1042,11 +1042,11 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK:      %5 = firrtl.subfield %4[_1] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %6 = firrtl.subfield %r[_0] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_port__bore, %a : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>
+// CHECK:      firrtl.strictconnect %view_companion_view_port__bore, %a : !firrtl.uint<1>
 
 // -----
 
@@ -1544,7 +1544,7 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
   firrtl.module @Bar() {
     %a = firrtl.wire : !firrtl.uint<1>
     // CHECK:        %[[a_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %a
-    // CHECK-NEXT:   firrtl.strictconnect %[[a_refPort]], %[[a_ref]]
+    // CHECK-NEXT:   firrtl.refconnect %[[a_refPort]], %[[a_ref]]
   }
   // CHECK:        firrtl.module @Companion()
   firrtl.module @Companion() {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2624,22 +2624,22 @@ firrtl.module @RefResolveSend(in %x: !firrtl.uint<1>, out %y : !firrtl.uint<1>) 
 firrtl.module @RefSubHoistVector(in %x: !firrtl.vector<uint<1>,2>, out %y : !firrtl.ref<uint<1>>) {
   // CHECK-NEXT: %[[sub:.+]] = firrtl.subindex %x[1]
   // CHECK-NEXT: %[[ref:.+]] = firrtl.ref.send %[[sub]]
-  // CHECK-NEXT: firrtl.strictconnect %y, %[[ref]]
+  // CHECK-NEXT: firrtl.refconnect %y, %[[ref]]
   // CHECK-NEXT: }
   %ref = firrtl.ref.send %x : !firrtl.vector<uint<1>,2>
   %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<vector<uint<1>,2>>
-  firrtl.strictconnect %y, %sub: !firrtl.ref<uint<1>>
+  firrtl.refconnect %y, %sub: !firrtl.ref<uint<1>>
 }
 
 // CHECK-LABEL: @RefSubHoistBundle
 firrtl.module @RefSubHoistBundle(in %x: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %y : !firrtl.ref<uint<2>>) {
   // CHECK-NEXT: %[[sub:.+]] = firrtl.subfield %x[b]
   // CHECK-NEXT: %[[ref:.+]] = firrtl.ref.send %[[sub]]
-  // CHECK-NEXT: firrtl.strictconnect %y, %[[ref]]
+  // CHECK-NEXT: firrtl.refconnect %y, %[[ref]]
   // CHECK-NEXT: }
   %ref = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
   %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
-  firrtl.strictconnect %y, %sub: !firrtl.ref<uint<2>>
+  firrtl.refconnect %y, %sub: !firrtl.ref<uint<2>>
 }
 
 // CHECK-LABEL: @RefResolveSubSend

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -840,7 +840,7 @@ firrtl.circuit "Top"   {
 firrtl.circuit "Top" {
   firrtl.module @Top (in %in : !firrtl.uint) {
     %a = firrtl.wire : !firrtl.uint
-    // expected-error @+1 {{op operand #0 must be a sized base or ref type}}
+    // expected-error @+1 {{op operand #0 must be a sized type}}
     firrtl.strictconnect %a, %in : !firrtl.uint
   }
 }
@@ -1042,26 +1042,14 @@ firrtl.circuit "BitcastRef" {
 }
 
 // -----
-// Cannot strictconnect unsized types, even when ref's.
+// Cannot refconnect unsized types, even when ref's.
 
 firrtl.circuit "Top" {
   firrtl.module @Foo (in %in: !firrtl.ref<uint>) {}
   firrtl.module @Top (in %in : !firrtl.ref<uint>) {
     %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint>)
-    // expected-error @+1 {{op operand #0 must be a sized base or ref type}}
-    firrtl.strictconnect %foo_in, %in : !firrtl.ref<uint>
-  }
-}
-
-// -----
-// Cannot connect different ref types
-
-firrtl.circuit "Top" {
-  firrtl.module @Foo (in %in: !firrtl.ref<uint<2>>) {}
-  firrtl.module @Top (in %in: !firrtl.ref<uint<1>>) {
-    %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint<2>>)
-    // expected-error @+1 {{may not connect different non-base types}}
-    firrtl.connect %foo_in, %in : !firrtl.ref<uint<2>>, !firrtl.ref<uint<1>>
+    // expected-error @+1 {{op operand #0 must be sized reference type}}
+    firrtl.refconnect %foo_in, %in : !firrtl.ref<uint>
   }
 }
 
@@ -1074,7 +1062,7 @@ firrtl.circuit "Foo" {
     %a = firrtl.wire : !firrtl.uint<1>
     %1 = firrtl.ref.send %a : !firrtl.uint<1>
     // expected-error @+1 {{connect has invalid flow: the destination expression "_a" has source flow, expected sink or duplex flow}}
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
 }
 
@@ -1086,8 +1074,8 @@ firrtl.circuit "Bar" {
     %x = firrtl.instance x @Bar2(out _a: !firrtl.ref<uint<1>>)
     %y = firrtl.instance y @Bar2(out _a: !firrtl.ref<uint<1>>)
     // expected-error @+1 {{output reference port cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.strictconnect %_a, %x : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %_a, %y : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %x : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %y : !firrtl.ref<uint<1>>
   }
 }
 
@@ -1099,9 +1087,9 @@ firrtl.circuit "Bar" {
     %x = firrtl.instance x @Bar2(out _a: !firrtl.ref<uint<1>>)
     %y = firrtl.wire : !firrtl.uint<1>
     // expected-error @+1 {{output reference port cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.strictconnect %_a, %x : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %x : !firrtl.ref<uint<1>>
     %1 = firrtl.ref.send %y : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
 }
 
@@ -1115,8 +1103,8 @@ firrtl.circuit "Bar" {
     %1 = firrtl.ref.send %x : !firrtl.uint<1>
     %2 = firrtl.ref.send %y : !firrtl.uint<1>
     // expected-error @+1 {{output reference port cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %_a, %2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %2 : !firrtl.ref<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -494,7 +494,7 @@ firrtl.circuit "SendThroughRef" {
   firrtl.module private @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %ref_zero : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %ref_zero : !firrtl.ref<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @SendThroughRef(out %a: !firrtl.uint<1>) {
@@ -511,11 +511,11 @@ firrtl.circuit "ForwardRef" {
   firrtl.module private @RefForward2(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %ref_zero : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %ref_zero : !firrtl.ref<uint<1>>
   }
   firrtl.module private @RefForward(out %_a: !firrtl.ref<uint<1>>) {
     %fwd_2 = firrtl.instance fwd_2 @RefForward2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %fwd_2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %fwd_2 : !firrtl.ref<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @ForwardRef(out %a: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -199,21 +199,21 @@ firrtl.circuit "RefPorts" {
   // CHECK-NOT: @dead_ref_send
   firrtl.module private @dead_ref_send(in %source: !firrtl.uint<1>, out %dest: !firrtl.ref<uint<1>>) {
     %ref = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.strictconnect %dest, %ref : !firrtl.ref<uint<1>>
+    firrtl.refconnect %dest, %ref : !firrtl.ref<uint<1>>
   }
 
   // CHECK-LABEL: @dead_ref_port
   // CHECK-NOT: firrtl.ref
   firrtl.module private @dead_ref_port(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, out %ref_dest: !firrtl.ref<uint<1>>) {
     %ref_not = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.strictconnect %ref_dest, %ref_not : !firrtl.ref<uint<1>>
+    firrtl.refconnect %ref_dest, %ref_not : !firrtl.ref<uint<1>>
     firrtl.strictconnect %dest, %source : !firrtl.uint<1>
   }
 
   // CHECK: @live_ref
   firrtl.module private @live_ref(in %source: !firrtl.uint<1>, out %dest: !firrtl.ref<uint<1>>) {
     %ref_source = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.strictconnect %dest, %ref_source : !firrtl.ref<uint<1>>
+    firrtl.refconnect %dest, %ref_source : !firrtl.ref<uint<1>>
   }
 
   // CHECK-LABEL: @RefPorts

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -825,7 +825,7 @@ firrtl.circuit "RefReset" {
   // CHECK-NEXT: ref<asyncreset>
   firrtl.module private @SendReset(in %r: !firrtl.reset, out %ref: !firrtl.ref<reset>) {
     %ref_r = firrtl.ref.send %r : !firrtl.reset
-    firrtl.strictconnect %ref, %ref_r : !firrtl.ref<reset>
+    firrtl.refconnect %ref, %ref_r : !firrtl.ref<reset>
   }
   // CHECK-LABEL: firrtl.module @RefReset
   // CHECK-NEXT: in r: !firrtl.asyncreset

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "TLRAM" {
       %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
       %debug, %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.ref<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-      firrtl.strictconnect %dbg_0, %debug : !firrtl.ref<vector<uint<8>, 16>>
+      firrtl.connect %dbg_0, %debug : !firrtl.ref<vector<uint<8>, 16>>, !firrtl.ref<vector<uint<8>, 16>>
       %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -41,7 +41,7 @@ firrtl.circuit "TLRAM" {
 // CHECK:  firrtl.strictconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
 // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.strictconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
-// CHECK:  firrtl.strictconnect %dbg_0, %mem_0_dbgs : !firrtl.ref<vector<uint<8>, 16>>
+// CHECK:  firrtl.connect %dbg_0, %mem_0_dbgs : !firrtl.ref<vector<uint<8>, 16>>, !firrtl.ref<vector<uint<8>, 16>>
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -832,14 +832,14 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %_a, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %_a, %0 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -861,14 +861,14 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
     // CHECK:  %bar_pa = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %bar_pa : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %_a, %0 : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %_a, %0 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -890,18 +890,18 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -948,7 +948,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -956,15 +956,15 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr : !firrtl.ref<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr : !firrtl.ref<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
     // CHECK:  %child_child__a = firrtl.instance child_child  @Child2(in _a: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.strictconnect %child_child__a, %xmr__a : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %child_child__a, %xmr__a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -979,7 +979,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -987,14 +987,14 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr : !firrtl.ref<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr : !firrtl.ref<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
     // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -1009,15 +1009,15 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %xmr2 = firrtl.ref.send %a : !firrtl.uint<1>
     %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.ref<uint<1>>, in  _a2: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a1, %xmr : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_a2, %xmr2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a1, %xmr : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a2, %xmr2 : !firrtl.ref<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
     // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
     // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
@@ -1028,7 +1028,7 @@ firrtl.circuit "Top" {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
     // CHECK:  %0 = firrtl.ref.resolve %_a1 : !firrtl.ref<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %_a1 : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_a, %_a1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a1 : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %_a2 : !firrtl.ref<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
@@ -1036,7 +1036,7 @@ firrtl.circuit "Top" {
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %c_a = firrtl.instance child @Child3(in  _b: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child3(in  %_b: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
@@ -1051,7 +1051,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]}{
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
@@ -1068,12 +1068,12 @@ firrtl.circuit "Top" {
     // CHECK:  %5 = firrtl.ref.resolve %1 : !firrtl.ref<uint<1>>
     // CHECK:  %child_cw = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %child_cw, %5 : !firrtl.uint<1>
-    firrtl.strictconnect %c_a1, %xmr : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_a2, %xmr2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a1, %xmr : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a2, %xmr2 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a1: !firrtl.ref<uint<1>>, in  %_a2: !firrtl.ref<uint<1>>)  {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %_a1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a1 : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %_a2 : !firrtl.ref<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
@@ -1081,7 +1081,7 @@ firrtl.circuit "Top" {
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>){
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %c_a = firrtl.instance child @Child3(in  _b: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child3(in  %_b: !firrtl.ref<uint<1>>){
     %0 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
@@ -1095,21 +1095,21 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.module @Top() {
     %c_a, %c_o = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>, out  o_a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %c_o : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %c_o : !firrtl.ref<uint<1>>
     // CHECK:  %child_bar__a = firrtl.instance child_bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  %0 = firrtl.ref.resolve %child_bar__a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>, out  %o_a: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %o_a, %bar_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %o_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/legacy-wiring.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring.mlir
@@ -73,21 +73,21 @@ firrtl.circuit "FooBar" attributes {
   firrtl.module @Foo(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.connect %0, %io_out__bore : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @Foo_1
   // CHECK-SAME: in %io_out__bore: !firrtl.uint<1>
   firrtl.module @Foo_1(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.connect %0, %io_out__bore : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @Bar
   // CHECK-SAME: in %io_out__bore: !firrtl.uint<1>
   firrtl.module @Bar(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.connect %0, %io_out__bore : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @FooBar
   firrtl.module @FooBar(out %io: !firrtl.bundle<in flip: uint<1>, out_foo0: uint<1>, out_foo1: uint<1>, out_bar: uint<1>>) {
@@ -110,9 +110,9 @@ firrtl.circuit "FooBar" attributes {
     firrtl.strictconnect %2, %3 : !firrtl.uint<1>
     firrtl.strictconnect %1, %4 : !firrtl.uint<1>
     firrtl.strictconnect %0, %5 : !firrtl.uint<1>
-    // CHECK: firrtl.connect %foo0_io_out__bore, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %foo1_io_out__bore, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %bar_io_out__bore, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %foo0_io_out__bore, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %foo1_io_out__bore, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %bar_io_out__bore, %0 : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -311,9 +311,9 @@ firrtl.module @DbgsMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>,
   firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   }
-  firrtl.strictconnect %_a, %port0_data : !firrtl.ref<vector<uint<1>, 2>>
+  firrtl.refconnect %_a, %port0_data : !firrtl.ref<vector<uint<1>, 2>>
   // CHECK:    %[[ram_port0:.+]], %ram_ramport = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port0", "ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<1>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  // CHECK:    firrtl.strictconnect %_a, %[[ram_port0]] : !firrtl.ref<vector<uint<1>, 2>>
+  // CHECK:    firrtl.refconnect %_a, %[[ram_port0]] : !firrtl.ref<vector<uint<1>, 2>>
 }
 
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1069,10 +1069,10 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  %0 = firrtl.ref.send %source_valid : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %source_ready : !firrtl.uint<1>
     // CHECK:  %2 = firrtl.ref.send %source_data : !firrtl.uint<64>
-    firrtl.strictconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
-    // CHECK:  firrtl.strictconnect %sink_valid, %0 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.strictconnect %sink_ready, %1 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.strictconnect %sink_data, %2 : !firrtl.ref<uint<64>>
+    firrtl.refconnect %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
+    // CHECK:  firrtl.refconnect %sink_valid, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %sink_ready, %1 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %sink_data, %2 : !firrtl.ref<uint<64>>
   }
   firrtl.module private @SendRefTypeVectors1(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {
     // CHECK-LABEL: firrtl.module private @SendRefTypeVectors1
@@ -1080,9 +1080,9 @@ firrtl.module private @is1436_FOO() {
     %0 = firrtl.ref.send %a : !firrtl.vector<uint<1>, 2>
     // CHECK:  %0 = firrtl.ref.send %a_0 : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %a_1 : !firrtl.uint<1>
-    firrtl.strictconnect %b, %0 : !firrtl.ref<vector<uint<1>, 2>>
-    // CHECK:  firrtl.strictconnect %b_0, %0 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.strictconnect %b_1, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %b, %0 : !firrtl.ref<vector<uint<1>, 2>>
+    // CHECK:  firrtl.refconnect %b_0, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.refconnect %b_1, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module private @RefTypeBundles2() {
     %x = firrtl.wire   : !firrtl.bundle<a: uint<1>, b: uint<2>>

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -15,19 +15,19 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %_a : !firrtl.ref<uint<1>>
   }
   // expected-error @+1 {{op multiply instantiated module with input RefType port '_a'}}
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
@@ -41,13 +41,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -84,6 +84,6 @@ firrtl.circuit "RefSubNotFromOp" {
   firrtl.module @RefSubNotFromOp(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>) {
     %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
     %child_ref = firrtl.instance child @Child(in ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>)
-    firrtl.strictconnect %child_ref, %ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+    firrtl.refconnect %child_ref, %ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -31,12 +31,12 @@ firrtl.circuit "Top" {
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -79,12 +79,12 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @[[xmrSym]]) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -114,12 +114,12 @@ firrtl.circuit "Top" {
     // CHECK:   %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
@@ -130,7 +130,7 @@ firrtl.circuit "Top" {
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
@@ -178,12 +178,12 @@ firrtl.circuit "Top" {
     // CHECK:  %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -195,7 +195,7 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -214,12 +214,12 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -231,7 +231,7 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %bar_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -250,20 +250,20 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a, %c_b = firrtl.instance child @Child2p(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
     // CHECK:  firrtl.instance child  @Child2p()
-    firrtl.strictconnect %c_a, %foo_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %foo_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %xmr_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2p(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -284,13 +284,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
@@ -298,10 +298,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %_a : !firrtl.ref<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c3 , %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c3 , %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -330,13 +330,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
@@ -344,10 +344,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %_a : !firrtl.ref<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c3 , %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c3 , %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -375,7 +375,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
@@ -387,7 +387,7 @@ firrtl.circuit "Top" {
   firrtl.module @Dut() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %xmr_a : !firrtl.ref<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
@@ -395,10 +395,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.strictconnect %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.strictconnect %c_b, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_a, %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c_b, %_a : !firrtl.ref<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %c3 , %_a : !firrtl.ref<uint<1>>
+    firrtl.refconnect %c3 , %_a : !firrtl.ref<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
@@ -513,9 +513,9 @@ firrtl.circuit "Top"  {
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 2 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 2 : i64, groupID = 1 : ui32, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %9 = firrtl.ref.sub %rf_memTap[0] : !firrtl.ref<vector<uint<8>, 2>>
-    firrtl.strictconnect %_gen_memTap_0, %9 : !firrtl.ref<uint<8>>
+    firrtl.refconnect %_gen_memTap_0, %9 : !firrtl.ref<uint<8>>
     %10 = firrtl.ref.sub %rf_memTap[1] : !firrtl.ref<vector<uint<8>, 2>>
-    firrtl.strictconnect %_gen_memTap_1, %10 : !firrtl.ref<uint<8>>
+    firrtl.refconnect %_gen_memTap_1, %10 : !firrtl.ref<uint<8>>
   }
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.ref<uint<8>>, out _gen_memTap_1: !firrtl.ref<uint<8>>)
@@ -546,12 +546,12 @@ firrtl.circuit "Top" {
     // CHECK-NEXT: }
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1>
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -577,12 +577,12 @@ firrtl.circuit "Top" {
     // CHECK:  = firrtl.node sym @xmr_sym  %[[internal:.+]]  : !firrtl.uint<1>
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.strictconnect %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %xmr   : !firrtl.ref<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -603,11 +603,11 @@ firrtl.circuit "Top"  {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>, out %_a: !firrtl.ref<uint<0>>) {
   // CHECK-LABEL: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>)
     %0 = firrtl.ref.send %pa : !firrtl.uint<0>
-    firrtl.strictconnect %_a, %0 : !firrtl.ref<uint<0>>
+    firrtl.refconnect %_a, %0 : !firrtl.ref<uint<0>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<0>>) {
     %bar_pa, %bar__a = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<0>, out _a: !firrtl.ref<uint<0>>)
-    firrtl.strictconnect %_a, %bar__a : !firrtl.ref<uint<0>>
+    firrtl.refconnect %_a, %bar__a : !firrtl.ref<uint<0>>
   }
   firrtl.module @Top() {
     %bar__a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<0>>)

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -13,8 +13,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     } : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
         !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>,
         !firrtl.ref<vector<uint<8>, 8>>
-    firrtl.strictconnect %d, %debug : !firrtl.ref<vector<uint<8>, 8>>
-    firrtl.strictconnect %d2, %dbg : !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.refconnect %d, %debug : !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.refconnect %d2, %dbg : !firrtl.ref<vector<uint<8>, 8>>
   }
     // CHECK-LABEL: firrtl.circuit "Mem" {
     // CHECK:         firrtl.module public @Mem(
@@ -44,8 +44,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           }
     // CHECK:           %11 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
     // CHECK:           %12 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
-    // CHECK:           firrtl.strictconnect %d, %12 : !firrtl.ref<vector<uint<8>, 8>>
-    // CHECK:           firrtl.strictconnect %d2, %11 : !firrtl.ref<vector<uint<8>, 8>>
+    // CHECK:           firrtl.refconnect %d, %12 : !firrtl.ref<vector<uint<8>, 8>>
+    // CHECK:           firrtl.refconnect %d2, %11 : !firrtl.ref<vector<uint<8>, 8>>
 
 
 }

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -6,7 +6,7 @@ firrtl.circuit "xmr" {
   firrtl.module private @Test(out %x: !firrtl.ref<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
-    firrtl.strictconnect %x, %1 : !firrtl.ref<uint<2>>
+    firrtl.refconnect %x, %1 : !firrtl.ref<uint<2>>
   }
   firrtl.module @xmr() {
     %test_x = firrtl.instance test @Test(out x: !firrtl.ref<uint<2>>)
@@ -21,7 +21,7 @@ firrtl.circuit "SimpleRead" {
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @SimpleRead() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -38,11 +38,11 @@ firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
   }
   firrtl.module @ForwardToInstance() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
@@ -59,11 +59,11 @@ firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.strictconnect %_a, %1    : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %1    : !firrtl.ref<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.strictconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %_a, %bar_2 : !firrtl.ref<uint<1>>
     // Reader 1
     %0 = firrtl.ref.resolve %bar_2 : !firrtl.ref<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
@@ -85,10 +85,10 @@ firrtl.circuit "DUT" {
   firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
     %w_data1 = firrtl.wire : !firrtl.uint<1>
     %1 = firrtl.ref.send %w_data1 : !firrtl.uint<1>
-    firrtl.strictconnect %ref_out1, %1 : !firrtl.ref<uint<1>>
+    firrtl.refconnect %ref_out1, %1 : !firrtl.ref<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
     %2 = firrtl.ref.send %w_data2 : !firrtl.uint<4>
-    firrtl.strictconnect %ref_out2, %2 : !firrtl.ref<uint<4>>
+    firrtl.refconnect %ref_out2, %2 : !firrtl.ref<uint<4>>
   }
   firrtl.module @DUT() {
     %w = firrtl.wire sym @w : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -693,10 +693,10 @@ firrtl.circuit "Test" {
   firrtl.module @RefSender(out %port: !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>) {
    // CHECK: %w = firrtl.wire : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
     // CHECK: %0 = firrtl.ref.send %w : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
-    // CHECK: firrtl.strictconnect %port, %0 : !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
+    // CHECK: firrtl.refconnect %port, %0 : !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
     %w = firrtl.wire : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
     %ref = firrtl.ref.send %w : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
-    firrtl.strictconnect %port, %ref : !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
+    firrtl.refconnect %port, %ref : !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
   }
 
   firrtl.module @RefResolver() {


### PR DESCRIPTION
Reference don't behave quite like normal types, so don't use the same connect operation on them.  This let's strictconnect be stricter and anything which needs to deal with references doesn't have to deal with strictconnect.