### PR TITLE
[FIRRTL] connect: Allow non-identical ref types, under special rules

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -171,6 +171,12 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
+
+/// Returns true if destination and source types are the same (was widthless) AND
+/// recursively checks that types are identical or the destination is uninferred
+/// of the source type.
+bool isTypeSameOrUninferred(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
+
 mlir::Type getVectorElementType(mlir::Type array);
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2265,7 +2265,12 @@ LogicalResult ConnectOp::verify() {
   auto dstBaseType = dstType.dyn_cast<FIRRTLBaseType>();
   auto srcBaseType = srcType.dyn_cast<FIRRTLBaseType>();
   if (!dstBaseType || !srcBaseType) {
-    if (dstType != srcType)
+    if (auto dstRef = dyn_cast<RefType>(dstType),
+        srcRef = dyn_cast<RefType>(srcType);
+        dstRef && srcRef) {
+      if (!isTypeSameOrUninferred(dstRef.getType(), srcRef.getType()))
+        return emitError("may not connect references of different widths");
+    } else if (dstType != srcType)
       return emitError("may not connect different non-base types");
   } else {
     // Analog types cannot be connected and must be attached.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -683,6 +683,40 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
       });
 }
 
+/// Returns true if destination and source types are the same (was widthless) AND
+/// recursively checks that types are identical or the destination is uninferred
+/// of the source type.
+bool firrtl::isTypeSameOrUninferred(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
+  if (dstType.getWidthlessType() != srcType.getWidthlessType())
+    return false;
+  // Okay, need to check each element.
+  return TypeSwitch<FIRRTLBaseType, bool>(dstType)
+      .Case<BundleType>([&](auto dstBundle) {
+        auto srcBundle = srcType.cast<BundleType>();
+        for (size_t i = 0, n = dstBundle.getNumElements(); i < n; ++i) {
+          auto srcElem = srcBundle.getElement(i);
+          auto dstElem = dstBundle.getElement(i);
+          if (dstElem.isFlip) {
+            if (!isTypeSameOrUninferred(srcElem.type, dstElem.type))
+              return false;
+          } else {
+            if (!isTypeSameOrUninferred(dstElem.type, srcElem.type))
+              return false;
+          }
+        }
+        return true;
+      })
+      .Case<FVectorType>([&](auto vector) {
+        return isTypeSameOrUninferred(
+            vector.getElementType(),
+            srcType.cast<FVectorType>().getElementType());
+      })
+      .Default([&](auto dstGround) {
+        return dstType == srcType || dstType.getBitWidthOrSentinel() == -1;
+      });
+}
+
+
 /// Return the element of an array type or null.  This strips flip types.
 Type firrtl::getVectorElementType(Type array) {
   auto vectorType = array.dyn_cast<FVectorType>();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1060,7 +1060,7 @@ firrtl.circuit "Top" {
   firrtl.module @Foo (in %in: !firrtl.ref<uint<2>>) {}
   firrtl.module @Top (in %in: !firrtl.ref<uint<1>>) {
     %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint<2>>)
-    // expected-error @+1 {{may not connect different non-base types}}
+    // expected-error @+1 {{may not connect references of different width}}
     firrtl.connect %foo_in, %in : !firrtl.ref<uint<2>>, !firrtl.ref<uint<1>>
   }
 }


### PR DESCRIPTION
Strictconnect is still strict, of course.

Connects soon won't be allowed to use references, but the same predicate will be used to check the validity of that op.

WIP, needs tests, just submitting to get pieces to better interact with other efforts.