### PR TITLE
 [FIRRTL] RefSendOp: support non-passive input, return ref-of-passive

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -788,7 +788,7 @@ class RefTypeConstraint<string ref, string base>
 class RefResultTypeConstraint<string base, string ref>
   : TypesMatchWith<"reference base type should match",
                    base, ref,
-                   "RefType::get($_self.cast<FIRRTLBaseType>())">;
+                   "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
 
 //===----------------------------------------------------------------------===//
 // RefOps

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3857,7 +3857,7 @@ FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
   if (!inBaseType)
     return emitInferRetTypeError(
         loc, "ref.send operand must be base type, not ", inType);
-  return RefType::get(inBaseType);
+  return RefType::get(inBaseType.getPassiveType());
 }
 
 void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -741,7 +741,8 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
         .Case<RefSendOp>([&](auto op) {
           // Trace using base types.
           traceResets(op.getType().getType(), op.getResult(), 0,
-                      op.getBase().getType(), op.getBase(), 0, op.getLoc());
+                      op.getBase().getType().getPassiveType(), op.getBase(), 0,
+                      op.getLoc());
         })
         .Case<RefResolveOp>([&](auto op) {
           // Trace using base types.

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -838,3 +838,24 @@ firrtl.circuit "RefReset" {
     %reset = firrtl.ref.resolve %s_ref : !firrtl.ref<reset>
   }
 }
+
+// -----
+
+// Check resets are inferred through references to bundles w/flips.
+
+// CHECK-LABEL: "RefResetBundle"
+firrtl.circuit "RefResetBundle" {
+  // CHECK-LABEL: firrtl.module @RefResetBundle
+  // CHECK-NOT: firrtl.reset
+  firrtl.module @RefResetBundle(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>) {
+  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset> 
+  %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: reset>
+  %reset = firrtl.ref.resolve %ref_r : !firrtl.ref<bundle<a: reset, b: reset>>
+  firrtl.strictconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
+
+   %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
+   %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>
+   firrtl.connect %r_a, %driver : !firrtl.reset, !firrtl.asyncreset
+   firrtl.connect %r_b, %driver : !firrtl.reset, !firrtl.asyncreset
+  }
+}

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -1,10 +1,13 @@
 // RUN: circt-opt %s -split-input-file
+// RUN: firtool %s -split-input-file
 // These tests are just for demonstrating RefOps, and expected to not error.
 
 // Simple 1 level read from wire.
 firrtl.circuit "xmr" {
   firrtl.module private @Test(out %x: !firrtl.ref<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
+    %zero = firrtl.constant 0 : !firrtl.uint<2>
+    firrtl.strictconnect %w, %zero : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
     firrtl.refconnect %x, %1 : !firrtl.ref<uint<2>>
   }
@@ -83,15 +86,18 @@ firrtl.circuit "ForwardToInstance" {
 // Two references passed by value.
 firrtl.circuit "DUT" {
   firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
     %w_data1 = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %w_data1, %zero : !firrtl.uint<1>
     %1 = firrtl.ref.send %w_data1 : !firrtl.uint<1>
     firrtl.refconnect %ref_out1, %1 : !firrtl.ref<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
+    %zero4 = firrtl.constant 0 : !firrtl.uint<4>
+    firrtl.strictconnect %w_data2, %zero4 : !firrtl.uint<4>
     %2 = firrtl.ref.send %w_data2 : !firrtl.uint<4>
     firrtl.refconnect %ref_out2, %2 : !firrtl.ref<uint<4>>
   }
   firrtl.module @DUT() {
-    %w = firrtl.wire sym @w : !firrtl.uint<1>
     %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.ref<uint<1>>, out ref_out2: !firrtl.ref<uint<4>>)
     %view_in1, %view_in2 = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.uint<1>, in ref_in2: !firrtl.uint<4>)
 
@@ -118,7 +124,7 @@ firrtl.circuit "DUT" {
 
 // RefType of aggregates and RefSub. 
 firrtl.circuit "RefTypeVector" {
-  firrtl.module @RefTypeVector() {
+  firrtl.module @RefTypeVector(in %bundle : !firrtl.bundle<a: uint<1>, b flip: uint<2>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<4>
     %z = firrtl.bitcast %zero : (!firrtl.uint<4>) -> !firrtl.vector<uint<1>,4>
     %1 = firrtl.ref.send %z : !firrtl.vector<uint<1>,4>
@@ -126,10 +132,11 @@ firrtl.circuit "RefTypeVector" {
     %11 = firrtl.ref.sub %1[1] : !firrtl.ref<vector<uint<1>,4>>
     %a = firrtl.ref.resolve %10 : !firrtl.ref<uint<1>>
     %b = firrtl.ref.resolve %11 : !firrtl.ref<uint<1>>
-    %z2 = firrtl.constant 0 : !firrtl.uint<3>
-    %bundle = firrtl.bitcast %z2 : (!firrtl.uint<3>) -> !firrtl.bundle<a: uint<1>, b: uint<2>>
-    %b1 = firrtl.ref.send %bundle : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %b1 = firrtl.ref.send %bundle : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
     %12 = firrtl.ref.sub %b1[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
     %rb = firrtl.ref.resolve %12 : !firrtl.ref<uint<2>>
+    %bundle_b = firrtl.subfield %bundle[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    %zero2 = firrtl.constant 0 : !firrtl.uint<2>
+    firrtl.strictconnect %bundle_b, %zero2 : !firrtl.uint<2>
   }
 }


### PR DESCRIPTION
Per Reference Types FIRRTL proposal.

Primarily loosening the restriction, this is only really reachable AFAIK via GCT (see #4815 which builds on this).