### PR TITLE
[Arc] LowerState: support enable and reset operands

### DIFF
--- a/include/circt/Dialect/Arc/Passes.td
+++ b/include/circt/Dialect/Arc/Passes.td
@@ -99,7 +99,7 @@ def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
 def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
   let summary = "Split state into read and write ops grouped by clock tree";
   let constructor = "circt::arc::createLowerStatePass()";
-  let dependentDialects = ["arc::ArcDialect"];
+  let dependentDialects = ["arc::ArcDialect", "mlir::scf::SCFDialect"];
 }
 
 def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {


### PR DESCRIPTION
Simple implementation to support resets as a foundation for optimizations (e.g., group states with the same reset into one if-statement).