### PR TITLE
[Arc] Add pure CallOp

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -193,6 +193,30 @@ def StateOp : ArcOp<"state", [
   }];
 }
 
+def CallOp : ArcOp<"call", [
+  CallOpInterface, MemRefsNormalizable, Pure,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "calls an arc";
+
+  let arguments = (ins FlatSymbolRefAttr:$arc, Variadic<AnyType>:$inputs);
+  let results = (outs Variadic<AnyType>:$outputs);
+
+  let assemblyFormat = [{
+    $arc `(` $inputs `)` attr-dict `:` functional-type(operands, results)
+  }];
+
+  let extraClassDeclaration = [{
+    operand_range getArgOperands() {
+      return {operand_begin(), operand_end()};
+    }
+
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("arc");
+    }
+  }];
+}
+
 def ClockGateOp : ArcOp<"clock_gate", [Pure]> {
   let summary = "Clock gate";
   let arguments = (ins I1:$input, I1:$enable);

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -61,6 +61,21 @@ struct OutputOpLowering : public OpConversionPattern<arc::OutputOp> {
   }
 };
 
+struct CallOpLowering : public OpConversionPattern<arc::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::CallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Type> newResultTypes;
+    if (failed(
+            typeConverter->convertTypes(op.getResultTypes(), newResultTypes)))
+      return failure();
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, newResultTypes, op.getArcAttr(), adaptor.getInputs());
+    return success();
+  }
+};
+
 struct StateOpLowering : public OpConversionPattern<arc::StateOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -377,6 +392,7 @@ static void populateOpConversion(RewritePatternSet &patterns,
     AllocStateLikeOpLowering<arc::RootInputOp>,
     AllocStateLikeOpLowering<arc::RootOutputOp>,
     AllocStorageOpLowering,
+    CallOpLowering,
     ClockGateOpLowering,
     DefineOpLowering,
     MemoryReadOpLowering,

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -148,3 +148,14 @@ func.func @zeroCount(%arg0 : i32) {
   %1 = arc.zero_count trailing %arg0  : i32
   return
 }
+
+// CHECK-LABEL: llvm.func @callOp
+func.func @callOp(%arg0: i32) -> i32 {
+  // CHECK-NEXT: [[V0:%.+]] = llvm.call @dummyCallee(%arg0) : (i32) -> i32
+  %0 = arc.call @dummyCallee(%arg0) : (i32) -> i32
+  // CHECK-NEXT: return [[V0]] : i32
+  return %0 : i32
+}
+arc.define @dummyCallee(%arg0: i32) -> i32 {
+  arc.output %arg0 : i32
+}

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -74,3 +74,65 @@ arc.model "TooManyArgs" {
 arc.model "WrongArgType" {
 ^bb0(%arg0: i32):
 }
+
+// -----
+
+arc.define @Foo() {
+  // expected-error @+1 {{`Bar` does not reference a valid `arc.define`}}
+  arc.call @Bar() : () -> ()
+  arc.output
+}
+func.func @Bar() {
+  return
+}
+
+// -----
+
+arc.define @Foo() {
+  // expected-error @+1 {{incorrect number of operands for arc}}
+  arc.call @Bar() : () -> ()
+  arc.output
+}
+arc.define @Bar(%arg0: i1) {
+  arc.output
+}
+
+// -----
+
+arc.define @Foo() {
+  // expected-error @+1 {{incorrect number of results for arc}}
+  arc.call @Bar() : () -> ()
+  arc.output
+}
+arc.define @Bar() -> i1 {
+  %false = hw.constant false
+  arc.output %false : i1
+}
+
+// -----
+
+arc.define @Foo(%arg0: i1, %arg1: i32) {
+  // expected-error @+3 {{operand type mismatch: operand 1}}
+  // expected-note @+2 {{expected type: 'i42'}}
+  // expected-note @+1 {{actual type: 'i32'}}
+  arc.call @Bar(%arg0, %arg1) : (i1, i32) -> ()
+  arc.output
+}
+arc.define @Bar(%arg0: i1, %arg1: i42) {
+  arc.output
+}
+
+// -----
+
+arc.define @Foo(%arg0: i1, %arg1: i32) {
+  // expected-error @+3 {{result type mismatch: result 1}}
+  // expected-note @+2 {{expected type: 'i42'}}
+  // expected-note @+1 {{actual type: 'i32'}}
+  %0, %1 = arc.call @Bar() : () -> (i1, i32)
+  arc.output
+}
+arc.define @Bar() -> (i1, i42) {
+  %false = hw.constant false
+  %c0_i42 = hw.constant 0 : i42
+  arc.output %false, %c0_i42 : i1, i42
+}

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -73,3 +73,18 @@ func.func @zeroCount(%arg0 : i32) {
   %1 = arc.zero_count trailing %arg0  : i32
   return
 }
+
+// CHECK-LABEL: @testCallOp
+arc.define @testCallOp(%arg0: i1, %arg1: i32) {
+  // CHECK-NEXT: {{.*}} = arc.call @dummyCallee1(%arg0, %arg1) : (i1, i32) -> i32
+  %0 = arc.call @dummyCallee1(%arg0, %arg1) : (i1, i32) -> i32
+  // CHECK-NEXT: arc.call @dummyCallee2()
+  arc.call @dummyCallee2() : () -> ()
+  arc.output
+}
+arc.define @dummyCallee1(%arg0: i1, %arg1: i32) -> i32 {
+  arc.output %arg1 : i32
+}
+arc.define @dummyCallee2() {
+  arc.output
+}

--- a/test/Dialect/Arc/sink-inputs.mlir
+++ b/test/Dialect/Arc/sink-inputs.mlir
@@ -10,7 +10,16 @@ arc.define @SinkSameConstantsArc(%arg0: i4, %arg1: i4) -> i4 {
 }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: hw.module @SinkSameConstants
+// CHECK: arc.define @Foo
+arc.define @Foo(%arg0: i4) -> i4 {
+  // CHECK-NOT: hw.constant
+  %k1 = hw.constant 2 : i4
+  // CHECK: {{%.+}} = arc.call @SinkSameConstantsArc(%arg0)
+  %0 = arc.call @SinkSameConstantsArc(%arg0, %k1) : (i4, i4) -> i4
+  arc.output %0 : i4
+}
+
+// CHECK: hw.module @SinkSameConstants
 hw.module @SinkSameConstants(%x: i4) {
   // CHECK-NOT: hw.constant
   // CHECK-NEXT: %0 = arc.state @SinkSameConstantsArc(%x)
@@ -44,5 +53,38 @@ hw.module @DontSinkDifferentConstants(%x: i4) {
   %c3_i4 = hw.constant 3 : i4
   %0 = arc.state @DontSinkDifferentConstantsArc(%x, %c2_i4) lat 0 : (i4, i4) -> i4
   %1 = arc.state @DontSinkDifferentConstantsArc(%x, %c3_i4) lat 0 : (i4, i4) -> i4
+}
+// CHECK-NEXT: }
+
+
+// CHECK-LABEL: arc.define @DontSinkDifferentConstantsArc1(%arg0: i4, %arg1: i4)
+arc.define @DontSinkDifferentConstantsArc1(%arg0: i4, %arg1: i4) -> i4 {
+  // CHECK-NEXT: [[TMP:%.+]] = comb.add %arg0, %arg1
+  // CHECK-NEXT: arc.output [[TMP]]
+  %0 = comb.add %arg0, %arg1 : i4
+  arc.output %0 : i4
+}
+// CHECK-NEXT: }
+
+// CHECK: arc.define @Bar
+arc.define @Bar(%arg0: i4) -> i4 {
+  // CHECK: %c1_i4 = hw.constant 1
+  %k1 = hw.constant 1 : i4
+  // CHECK: {{%.+}} = arc.call @DontSinkDifferentConstantsArc1(%arg0, %c1_i4)
+  %0 = arc.call @DontSinkDifferentConstantsArc1(%arg0, %k1) : (i4, i4) -> i4
+  arc.output %0 : i4
+}
+
+// CHECK: hw.module @DontSinkDifferentConstants1
+hw.module @DontSinkDifferentConstants1(%x: i4) {
+  // CHECK-NEXT: %c2_i4 = hw.constant 2 : i4
+  // CHECK-NEXT: %c2_i4_0 = hw.constant 2 : i4
+  // CHECK-NEXT: %0 = arc.state @DontSinkDifferentConstantsArc1(%x, %c2_i4)
+  // CHECK-NEXT: %1 = arc.state @DontSinkDifferentConstantsArc1(%x, %c2_i4_0)
+  // CHECK-NEXT: hw.output
+  %k1 = hw.constant 2 : i4
+  %k2 = hw.constant 2 : i4
+  %0 = arc.state @DontSinkDifferentConstantsArc1(%x, %k1) lat 0 : (i4, i4) -> i4
+  %1 = arc.state @DontSinkDifferentConstantsArc1(%x, %k2) lat 0 : (i4, i4) -> i4
 }
 // CHECK-NEXT: }


### PR DESCRIPTION
Add a call operation that can only call arcs (`arc.define`) and is thus pure, i.e., it can be used inside an `arc.define`. Otherwise, the semantics are the same as for `arc.state` with latency 0. Going forward, there are 3 options for latency 0 state ops:
1. Only allow `arc.call` inside `arc.define` and use `arc.state lat 0` in HWModules such that there is support for changing the latency in for passes that want to do so (otherwise an `arc.call` has to be changed to a `arc.state`, which is also not a big overhead)
2. Add a canonicalizer to convert `arc.state lat 0` to `arc.call`, i.e., both are allowed in HWModules. This probably complicates the IR more than it benefits it.
3. Verify `arc.state` to have a latency > 0. I.e., `arc.call` is the only way to call an arc with latency 0.