### PR TITLE
[ExportVerilog] Avoid splitting wire decl and assign in expr inlining

### DIFF
--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -347,6 +347,17 @@ hw.module @SimpleConstPrintReset(%clock: i1, %reset: i1, %in4: i4) -> () {
 
 }
 
+// CHECK-LABEL: module InlineDeclAssignment
+hw.module @InlineDeclAssignment(%a: i1) {
+  // CHECK: wire b = a;
+  %b = sv.wire : !hw.inout<i1>
+  sv.assign %b, %a : i1
+
+  // CHECK: wire c = a + a;
+  %0 = comb.add %a, %a : i1
+  %c = sv.wire : !hw.inout<i1>
+  sv.assign %c, %0 : i1
+}
 
 // CHECK-LABEL: module ordered_region
 // CHECK-NEXT: input a


### PR DESCRIPTION
Currently the `lowerAlwaysInlineOperation` function will happily move ops right in front of their user, which is problematic if the user is an assign op. If the assign immediately follows its wire declaration, `ExportVerilog` would happily emit the expression inline. However, `lowerAlwaysInlineOperation` inserts operations in between the declaration and the assignment, such that the conservative inlining in `ExportVerilog` can no longer to its thing. This leads to unfortunate output Verilog:

    wire foo;
    assign foo = a + b;

The IR here probably initially looked like:

    %0 = comb.add %a, %b
    %foo = sv.wire
    sv.assign %foo, %0

But `lowerAlwaysInlineOperation` would then pull the addition down:

    %foo = sv.wire
    %0 = comb.add %a, %b
    sv.assign %foo, %0

Which can no longer be inlined at the declaration site.

This commit adds a small check to `lowerAlwaysInlineOperation` which repositions the insertion point of the moved operations to be before the associated wire in case the user is an assignment.