### PR TITLE
[Support] Add `ImplicitSSAName` directive for string attributes

### DIFF
--- a/include/circt/Dialect/HW/CustomDirectiveImpl.h
+++ b/include/circt/Dialect/HW/CustomDirectiveImpl.h
@@ -65,19 +65,6 @@ ParseResult parseOptionalParameterList(OpAsmParser &parser,
 void printOptionalParameterList(OpAsmPrinter &p, Operation *op,
                                 ArrayAttr parameters);
 
-//===----------------------------------------------------------------------===//
-// ImplicitSSAName Custom Directive
-//===----------------------------------------------------------------------===//
-
-inline ParseResult parseImplicitSSAName(OpAsmParser &parser,
-                                        StringAttr &nameAttr) {
-  nameAttr = parser.getBuilder().getStringAttr(parser.getResultName(0).first);
-  return success();
-}
-
-inline void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
-                                 StringAttr nameAttr) {}
-
 } // namespace circt
 
 #endif // CIRCT_DIALECT_HW_CUSTOMDIRECTIVEIMPL_H

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -204,7 +204,7 @@ def LocalParamOp : SVOp<"localparam",
   let results = (outs HWValueType:$result);
 
   let assemblyFormat = [{
-    `:` qualified(type($result)) `` custom<SVImplicitSSAName>(attr-dict)
+    `` custom<ImplicitSSAName>($name) attr-dict `:` qualified(type($result))
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -38,7 +38,8 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict) `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 
@@ -68,8 +69,8 @@ def RegOp : SVOp<"reg", [
 
   // We handle the name in a custom way, so we use a customer parser/printer.
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict)
-     `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($result))
   }];
   let hasCanonicalizeMethod = true;
 
@@ -236,8 +237,8 @@ def LogicOp : SVOp<"logic", [DeclareOpInterfaceMethods<OpAsmOpInterface,
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict) `:`
-                                                qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($result))
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -223,7 +223,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [HasCustomSSAName]> {
   let results = (outs InterfaceType : $result);
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<SVImplicitSSAName>(attr-dict)
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
     `:` qualified(type($result))
   }];
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -180,7 +180,9 @@ def SCFuncOp : SystemCOp<"func", [
     Block *getBodyBlock() { return &getBody().front(); }
   }];
 
-  let assemblyFormat = "custom<ImplicitSSAName>($name) attr-dict-with-keyword $body";
+  let assemblyFormat = [{
+    `` custom<ImplicitSSAName>($name) attr-dict-with-keyword $body
+  }];
 
   let hasVerifier = true;
   let skipDefaultBuilders = 1;

--- a/include/circt/Support/CustomDirectiveImpl.h
+++ b/include/circt/Support/CustomDirectiveImpl.h
@@ -23,6 +23,13 @@ namespace circt {
 // ImplicitSSAName Custom Directive
 //===----------------------------------------------------------------------===//
 
+/// Parse an implicit SSA name string attribute. If the name is not provided in
+/// the input text, its value is inferred from the SSA name of the operation's
+/// first result.
+///
+/// implicit-name ::= (`name` str-attr)?
+ParseResult parseImplicitSSAName(OpAsmParser &parser, StringAttr &attr);
+
 /// Parse an attribute dictionary and ensure that it contains a `name` field by
 /// inferring its value from the SSA name of the operation's first result if
 /// necessary.
@@ -32,6 +39,14 @@ ParseResult parseImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs);
 /// the SSA name of the operation's first result if necessary. Returns true if a
 /// name was inferred, false if `attrs` already contained a `name`.
 bool inferImplicitSSAName(OpAsmParser &parser, NamedAttrList &attrs);
+
+/// Print an implicit SSA name string attribute. If the given string attribute
+/// does not match the SSA name of the operation's first result, the name is
+/// explicitly printed. Prints a leading space in front of `name` if any name is
+/// present.
+///
+/// implicit-name ::= (`name` str-attr)?
+void printImplicitSSAName(OpAsmPrinter &p, Operation *op, StringAttr attr);
 
 /// Print an attribute dictionary and elide the `name` field if its value
 /// matches the SSA name of the operation's first result.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -91,22 +91,6 @@ static Operation *lookupSymbolInNested(Operation *symbolTableOp,
 }
 
 //===----------------------------------------------------------------------===//
-// ImplicitSSAName Custom Directive
-//===----------------------------------------------------------------------===//
-
-static ParseResult parseSVImplicitSSAName(OpAsmParser &parser,
-                                          NamedAttrList &resultAttrs) {
-  return parseImplicitSSAName(parser, resultAttrs);
-}
-
-static void printSVImplicitSSAName(OpAsmPrinter &printer, Operation *op,
-                                   DictionaryAttr attrs) {
-  printImplicitSSAName(printer, op, attrs,
-                       {SymbolTable::getSymbolAttrName(),
-                        hw::InnerName::getInnerNameAttrName(), "svAttributes"});
-}
-
-//===----------------------------------------------------------------------===//
 // VerbatimExprOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SystemC/CMakeLists.txt
+++ b/lib/Dialect/SystemC/CMakeLists.txt
@@ -21,6 +21,7 @@ add_circt_dialect_library(CIRCTSystemC
   MLIRInferTypeOpInterface
   MLIREmitCDialect
   CIRCTHW
+  CIRCTSupport
 )
 
 add_dependencies(circt-headers MLIRSystemCIncGen)

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/HW/CustomDirectiveImpl.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/ModuleImplementation.h"
+#include "circt/Support/CustomDirectiveImpl.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -22,7 +22,7 @@ hw.module @parametersNameConflict<p2: i42 = 17, wire: i1>(%p1: i8) {
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef "SOMEMACRO" {
     // CHECK: localparam local_0 = wire_0;
-    %local = sv.localparam : i1 { value = #hw.param.decl.ref<"wire">: i1 }
+    %local = sv.localparam { value = #hw.param.decl.ref<"wire">: i1 } : i1
 
     // CHECK: assign myWire = wire_0;
     %0 = hw.param.value i1 = #hw.param.decl.ref<"wire">
@@ -55,7 +55,7 @@ hw.module @useParametersNameConflict(%xxx: i8) {
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef "SOMEMACRO" {
     // CHECK: reg [3:0] xxx_0;
-    %0 = sv.reg  { name = "xxx" } : !hw.inout<i4>
+    %0 = sv.reg name "xxx" : !hw.inout<i4>
   }
 }
 

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -24,7 +24,7 @@ sv.interface @IValidReady_Struct  {
 // CHECK-NEXT:          _GEN_0,
 // CHECK-NEXT:          _GEN_0})};{{.*}}
 hw.module @structs(%clk: i1, %rstn: i1) {
-  %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>
+  %0 = sv.interface.instance name "iface" : !sv.interface<@IValidReady_Struct>
   sv.interface.signal.assign %0(@IValidReady_Struct::@data) = %s : !hw.struct<foo: !hw.array<72xi1>, bar: !hw.array<128xi1>, baz: !hw.array<224xi1>>
   %c0 = hw.constant 0 : i8
   %c64 = hw.constant 100000 : i64

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -11,10 +11,10 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
 
   %c11_i42 = hw.constant 11: i42
   // CHECK: localparam [41:0]{{ *}} param_x = 42'd11;
-  %param_x = sv.localparam : i42 { value = 11: i42 }
+  %param_x = sv.localparam { value = 11 : i42 } : i42
 
   // CHECK: localparam [41:0]{{ *}} param_y = param1;
-  %param_y = sv.localparam : i42 { value = #hw.param.decl.ref<"param1">: i42 }
+  %param_y = sv.localparam { value = #hw.param.decl.ref<"param1"> : i42 } : i42
 
   // CHECK:        logic{{ *}} [7:0]{{ *}} logic_op = val;
   // CHECK-NEXT: struct packed {logic b; } logic_op_struct;

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -126,7 +126,7 @@ module {
   // CHECK: wire struct packed {logic [383:0] foo; } _GEN
   // CHECK: endmodule
   hw.module @structs(%clk: i1, %rstn: i1) {
-    %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>
+    %0 = sv.interface.instance name "iface" : !sv.interface<@IValidReady_Struct>
     sv.interface.signal.assign %0(@IValidReady_Struct::@data) = %s : !hw.struct<foo: !hw.array<384xi1>>
     %c0 = hw.constant 0 : i8
     %c64 = hw.constant 100000 : i64

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -64,18 +64,18 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   %w = sv.wire : !hw.inout<i4>
 
   // CHECK-NEXT: %after1 = sv.wire : !hw.inout<i4>
-  %before1 = sv.wire {name = "after1"} : !hw.inout<i4>
+  %before1 = sv.wire name "after1" : !hw.inout<i4>
 
   // CHECK-NEXT: sv.read_inout %after1 : !hw.inout<i4>
   %read_before1 = sv.read_inout %before1 : !hw.inout<i4>
 
   // CHECK-NEXT: %after2_conflict = sv.wire : !hw.inout<i4>
-  // CHECK-NEXT: %after2_conflict_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
-  %before2_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
-  %before2_1 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
+  // CHECK-NEXT: %after2_conflict_0 = sv.wire name "after2_conflict" : !hw.inout<i4>
+  %before2_0 = sv.wire name "after2_conflict" : !hw.inout<i4>
+  %before2_1 = sv.wire name "after2_conflict" : !hw.inout<i4>
 
   // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !hw.inout<i4>
-  %before3 = sv.wire {name = "after3", someAttr = "foo"} : !hw.inout<i4>
+  %before3 = sv.wire name "after3" {someAttr = "foo"} : !hw.inout<i4>
 
   // CHECK-NEXT: = comb.mux %arg1, [[RES2]], [[RES2]] : i7
   %mux = comb.mux %arg1, %d, %d : i7

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -6,8 +6,8 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   // CHECK: [[FD:%.*]] = hw.constant -2147483646 : i32
   %fd = hw.constant 0x80000002 : i32
 
-  // CHECK: %param_x = sv.localparam : i42 {value = 11 : i42}
-  %param_x = sv.localparam : i42 {value = 11 : i42}
+  // CHECK: %param_x = sv.localparam {value = 11 : i42} : i42
+  %param_x = sv.localparam {value = 11 : i42} : i42
 
 
   // This corresponds to this block of system verilog code:

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -183,7 +183,7 @@ sv.bind #hw.innerNameRef<@InternSrcMod::@A>
 
 hw.module @test() {
   // expected-error @+1 {{op invalid parameter value @test}}
-  %param_x = sv.localparam : i42 {value = @test}
+  %param_x = sv.localparam {value = @test} : i42
 }
 
 // -----

--- a/test/Dialect/SystemC/structure.mlir
+++ b/test/Dialect/SystemC/structure.mlir
@@ -62,6 +62,8 @@ systemc.module @signals () {
   %signal0 = systemc.signal : !systemc.signal<!systemc.uint<32>>
   // CHECK-NEXT: %signal1 = systemc.signal : !systemc.signal<i1>
   %signal1 = systemc.signal : !systemc.signal<i1>
+  // CHECK-NEXT: %signal2 = systemc.signal : !systemc.signal<i1>
+  %ignoredName1 = systemc.signal name "signal2" : !systemc.signal<i1>
 
   // CHECK-NEXT: %namedSignal = systemc.signal named : !systemc.signal<i1>
   %namedSignal = systemc.signal named : !systemc.signal<i1>
@@ -101,6 +103,8 @@ systemc.module @instanceDecl (%input0: !systemc.in<!systemc.uint<32>>) {
   %moduleInstance0 = systemc.instance.decl @adder : !systemc.module<adder(summand_a: !systemc.in<!systemc.uint<32>>, summand_b: !systemc.in<!systemc.uint<32>>, sum: !systemc.out<!systemc.uint<32>>)>
   // CHECK-NEXT: %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
   %moduleInstance1 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
+  // CHECK-NEXT: %moduleInstance2 = systemc.instance.decl @moduleVisibility : !systemc.module<moduleVisibility()>
+  %ignoredName = systemc.instance.decl name "moduleInstance2" @moduleVisibility : !systemc.module<moduleVisibility()>
   // CHECK-NEXT: systemc.ctor
   systemc.ctor {
     // CHECK-NEXT: systemc.instance.bind_port %moduleInstance0["summand_a"] to %input0 : !systemc.module<adder(summand_a: !systemc.in<!systemc.uint<32>>, summand_b: !systemc.in<!systemc.uint<32>>, sum: !systemc.out<!systemc.uint<32>>)>, !systemc.in<!systemc.uint<32>>
@@ -174,4 +178,12 @@ systemc.module @sensitivity (%in: !systemc.in<i1>, %out: !systemc.out<i1>, %inou
     // CHECK-NEXT: systemc.sensitive
     systemc.sensitive
   }
+}
+
+// CHECK-LABEL: systemc.module @funcNames
+systemc.module @funcNames () {
+  // CHECK: %func1 = systemc.func
+  // CHECK: %func2 = systemc.func
+  %func1 = systemc.func {}
+  %ignoredName = systemc.func name "func2" {}
 }


### PR DESCRIPTION
Move the `{parse,print}ImplicitSSAName` directive currently used by the SystemC dialect into the support library and make the SV dialect use it as well. This directive works on a `StringAttr` instead of the entire attribute dictionary of the operation, which has a few advantages:

- Name is an explicit ODS attribute on the operation
- Name gets automatically elided in attr-dict printing (TableGen elides all ODS-defined attributes)
- The fact that the "name" attribute has a specific meaning is exposed in ODS more explicitly, and the assembly format makes this more apparent by having a dedicated `name <ATTR>` portion.

NFC besides the change in assembly format.