### PR TITLE
[HW] Add hw.wire operation

### DIFF
--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -17,6 +17,7 @@ include "circt/Dialect/HW/HWAttributes.td"
 include "circt/Dialect/HW/HWDialect.td"
 include "circt/Dialect/HW/HWTypes.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def ConstantOp
@@ -51,6 +52,66 @@ def ConstantOp
   ];
   let hasFolder = true;
   let hasVerifier = 1;
+}
+
+def WireOp : HWOp<"wire", [
+    SameOperandsAndResultType,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Assign a name or symbol to an SSA edge";
+  let description = [{
+    An `hw.wire` is used to assign a human-readable name or a symbol for remote
+    references to an SSA edge. It takes a single operand and returns its value
+    unchanged as a result. The operation guarantees the following:
+
+    - If the wire has a symbol, the value of its operand remains observable
+      under that symbol within the IR.
+
+    - If the wire has a name, the name is treated as a hint. If the wire
+      persists until code generation the resulting wire will have this name,
+      with a potential suffix to ensure uniqueness. If the wire is canonicalized
+      away, its name is propagated to its input operand as a name hint.
+
+    - The users of its result will always observe the operand through the
+      operation itself, meaning that optimizations cannot bypass the wire. This
+      ensures that if the wire's value is *forced*, for example through a
+      Verilog force statement, the forced value will affect all users of the
+      wire in the output.
+
+    Example:
+    ```
+    %1 = hw.wire %0 : i42
+    %2 = hw.wire %0 sym @mySym : i42
+    %3 = hw.wire %0 name "myWire" : i42
+    %myWire = hw.wire %0 : i42
+    ```
+  }];
+
+  let arguments = (ins AnyType:$input,
+                       OptionalAttr<StrAttr>:$name,
+                       OptionalAttr<SymbolNameAttr>:$inner_sym);
+  let results = (outs AnyType:$result);
+
+  let hasFolder = true;
+  let hasCanonicalizeMethod = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$input,
+                   CArg<"const StringAttrOrRef &", "{}">:$name,
+                   CArg<"const StringAttrOrRef &", "{}">:$inner_sym), [{
+      auto *context = odsBuilder.getContext();
+      odsState.addOperands(input);
+      if (auto attr = name.get(context))
+        odsState.addAttribute(getNameAttrName(odsState.name), attr);
+      if (auto attr = inner_sym.get(context))
+        odsState.addAttribute(getInnerSymAttrName(odsState.name), attr);
+      odsState.addTypes(input.getType());
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    $input (`sym` $inner_sym^)? custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($input))
+  }];
 }
 
 def KnownBitWidthType : Type<CPred<[{getBitWidth($_self) != -1}]>,

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Support/BuilderUtils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"

--- a/include/circt/Support/BuilderUtils.h
+++ b/include/circt/Support/BuilderUtils.h
@@ -1,0 +1,45 @@
+//===- BuilderUtils.h - Operation builder utilities -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_BUILDERUTILS_H
+#define CIRCT_SUPPORT_BUILDERUTILS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace circt {
+
+/// A helper union that can represent a `StringAttr`, `StringRef`, or `Twine`.
+/// It is intended to be used as arguments to an op's `build` function. This
+/// allows a single builder to accept any flavor value for a string attribute.
+/// The `get` function can then be used to obtain a `StringAttr` from any of the
+/// possible variants `StringAttrOrRef` can take.
+class StringAttrOrRef {
+  using Value = llvm::PointerUnion<StringAttr, StringRef *, Twine *>;
+  Value value;
+
+public:
+  StringAttrOrRef() : value() {}
+  StringAttrOrRef(StringAttr attr) : value(attr) {}
+  StringAttrOrRef(const StringRef &str)
+      : value(const_cast<StringRef *>(&str)) {}
+  StringAttrOrRef(const Twine &twine) : value(const_cast<Twine *>(&twine)) {}
+
+  /// Return the represented string as a `StringAttr`.
+  StringAttr get(MLIRContext *context) const {
+    return TypeSwitch<Value, StringAttr>(value)
+        .Case<StringAttr>([&](auto value) { return value; })
+        .Case<StringRef *, Twine *>(
+            [&](auto value) { return StringAttr::get(context, *value); })
+        .Default([](auto) { return StringAttr{}; });
+  }
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_BUILDERUTILS_H

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -377,15 +377,15 @@ private:
 
   ReadInOutOp wireIn(Value source, StringRef instanceName, StringRef portName,
                      ImplicitLocOpBuilder &b) const {
-    auto wire =
-        b.create<WireOp>(source.getType(), createName(instanceName, portName));
+    auto wire = b.create<sv::WireOp>(source.getType(),
+                                     createName(instanceName, portName));
     return b.create<ReadInOutOp>(wire);
   }
 
   ReadInOutOp wireOut(Value source, StringRef instanceName, StringRef portName,
                       ImplicitLocOpBuilder &b) const {
-    auto wire =
-        b.create<WireOp>(source.getType(), createName(instanceName, portName));
+    auto wire = b.create<sv::WireOp>(source.getType(),
+                                     createName(instanceName, portName));
     b.create<sv::AssignOp>(wire, source);
     return b.create<ReadInOutOp>(wire);
   }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -163,7 +163,7 @@ static bool isDuplicatableExpression(Operation *op) {
     if (auto read = dyn_cast<ReadInOutOp>(indexOp)) {
       auto *readSrc = read.getInput().getDefiningOp();
       // A port or wire is ok to duplicate reads.
-      return !readSrc || isa<WireOp, LogicOp>(readSrc);
+      return !readSrc || isa<sv::WireOp, LogicOp>(readSrc);
     }
 
     return false;
@@ -395,7 +395,7 @@ static StringRef getVerilogDeclWord(Operation *op,
 
     return "reg";
   }
-  if (isa<WireOp>(op))
+  if (isa<sv::WireOp>(op))
     return "wire";
   if (isa<ConstantOp, AggregateConstantOp, LocalParamOp, ParamValueOp>(op))
     return "localparam";
@@ -643,7 +643,7 @@ static bool isExpressionUnableToInline(Operation *op,
     if (!options.allowExprInEventControl && isa<AlwaysOp, AlwaysFFOp>(user)) {
       // Anything other than a read of a wire must be out of line.
       if (auto read = dyn_cast<ReadInOutOp>(op))
-        if (read.getInput().getDefiningOp<WireOp>() ||
+        if (read.getInput().getDefiningOp<sv::WireOp>() ||
             read.getInput().getDefiningOp<RegOp>())
           continue;
       return true;
@@ -1151,7 +1151,7 @@ StringAttr ExportVerilog::inferStructuralNameForTemporary(Value expr) {
 
   } else if (auto *op = expr.getDefiningOp()) {
     // Uses of a wire, register or logic can be done inline.
-    if (isa<WireOp, RegOp, LogicOp>(op)) {
+    if (isa<sv::WireOp, RegOp, LogicOp>(op)) {
       StringRef name = getSymOpName(op);
       result = StringAttr::get(expr.getContext(), name);
 
@@ -2931,7 +2931,7 @@ private:
   LogicalResult visitUnhandledSV(Operation *op) { return failure(); }
   LogicalResult visitInvalidSV(Operation *op) { return failure(); }
 
-  LogicalResult visitSV(WireOp op) { return emitDeclaration(op); }
+  LogicalResult visitSV(sv::WireOp op) { return emitDeclaration(op); }
   LogicalResult visitSV(RegOp op) { return emitDeclaration(op); }
   LogicalResult visitSV(LogicOp op) { return emitDeclaration(op); }
   LogicalResult visitSV(LocalParamOp op) { return emitDeclaration(op); }
@@ -4297,7 +4297,7 @@ isExpressionEmittedInlineIntoProceduralDeclaration(Operation *op,
         return false;
 
       // If the operand is a wire, it's OK to inline the read.
-      if (isa<WireOp>(defOp))
+      if (isa<sv::WireOp>(defOp))
         continue;
 
       // Reject struct_field_inout/array_index_inout for now because it's
@@ -4435,7 +4435,7 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     }
 
     // Try inlining an assignment into declarations.
-    if (isa<WireOp, LogicOp>(op) &&
+    if (isa<sv::WireOp, LogicOp>(op) &&
         !op->getParentOp()->hasTrait<ProceduralRegion>()) {
       // Get a single assignments if any.
       if (auto singleAssign = getSingleAssignAndCheckUsers<AssignOp>(op)) {

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -169,7 +169,7 @@ static void legalizeModuleLocalNames(HWModuleOp module,
       if (auto name = op->getAttrOfType<StringAttr>(verilogNameAttr)) {
         nameResolver.insertUsedName(
             op->getAttrOfType<StringAttr>(verilogNameAttr));
-      } else if (isa<WireOp, RegOp, LogicOp, LocalParamOp, hw::InstanceOp,
+      } else if (isa<sv::WireOp, RegOp, LogicOp, LocalParamOp, hw::InstanceOp,
                      sv::InterfaceInstanceOp, sv::GenerateOp>(op)) {
         // Otherwise, get a verilog name via `getSymOpName`.
         nameEntries.emplace_back(

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -25,6 +25,7 @@ add_circt_dialect_library(
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTSupport
   MLIRIR
   MLIRInferTypeOpInterface
 )

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/HW/HWVisitors.h"
 #include "circt/Dialect/HW/InstanceImplementation.h"
 #include "circt/Dialect/HW/ModuleImplementation.h"
+#include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/Namespace.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionImplementation.h"
@@ -365,6 +366,65 @@ void ConstantOp::getAsmResultNames(
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getValueAttr();
+}
+
+//===----------------------------------------------------------------------===//
+// WireOp
+//===----------------------------------------------------------------------===//
+
+/// Check whether an operation has any additional attributes set beyond its
+/// standard list of attributes returned by `getAttributeNames`.
+template <class Op>
+static bool hasAdditionalAttributes(Op op,
+                                    ArrayRef<StringRef> ignoredAttrs = {}) {
+  auto names = op.getAttributeNames();
+  llvm::SmallDenseSet<StringRef> nameSet;
+  nameSet.reserve(names.size() + ignoredAttrs.size());
+  nameSet.insert(names.begin(), names.end());
+  nameSet.insert(ignoredAttrs.begin(), ignoredAttrs.end());
+  return llvm::any_of(op->getAttrs(), [&](auto namedAttr) {
+    return !nameSet.contains(namedAttr.getName());
+  });
+}
+
+void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // If the wire has an optional 'name' attribute, use it.
+  auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
+  if (!nameAttr.getValue().empty())
+    setNameFn(getResult(), nameAttr.getValue());
+}
+
+OpFoldResult WireOp::fold(FoldAdaptor adaptor) {
+  // If the wire has no additional attributes, no name, and no symbol, just
+  // forward its input.
+  if (!hasAdditionalAttributes(*this, {"sv.namehint"}) && !getNameAttr() &&
+      !getInnerSymAttr())
+    return getInput();
+  return {};
+}
+
+LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
+  // Block if the wire has any attributes.
+  if (hasAdditionalAttributes(wire, {"sv.namehint"}))
+    return failure();
+
+  // If the wire has a symbol, then we can't delete it.
+  if (wire.getInnerSymAttr())
+    return failure();
+
+  // If the wire has a name or an `sv.namehint` attribute, propagate it as an
+  // `sv.namehint` to the expression.
+  if (auto *inputOp = wire.getInput().getDefiningOp()) {
+    auto name = wire.getNameAttr();
+    if (!name || name.getValue().empty())
+      name = wire->getAttrOfType<StringAttr>("sv.namehint");
+    if (name)
+      rewriter.updateRootInPlace(
+          inputOp, [&] { inputOp->setAttr("sv.namehint", name); });
+  }
+
+  rewriter.replaceOp(wire, wire.getInput());
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -77,6 +77,20 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !hw.inout<i4>
   %before3 = sv.wire name "after3" {someAttr = "foo"} : !hw.inout<i4>
 
+  // CHECK-NEXT: %w2 = hw.wire [[RES2]] : i7
+  %w2 = hw.wire %d : i7
+
+  // CHECK-NEXT: %after4 = hw.wire [[RES2]] : i7
+  %before4 = hw.wire %d name "after4" : i7
+
+  // CHECK-NEXT: %after5_conflict = hw.wire [[RES2]] : i7
+  // CHECK-NEXT: %after5_conflict_1 = hw.wire [[RES2]] name "after5_conflict" : i7
+  %before5_0 = hw.wire %d name "after5_conflict" : i7
+  %before5_1 = hw.wire %d name "after5_conflict" : i7
+
+  // CHECK-NEXT: %after6 = hw.wire [[RES2]] {someAttr = "foo"} : i7
+  %before6 = hw.wire %d name "after6" {someAttr = "foo"} : i7
+
   // CHECK-NEXT: = comb.mux %arg1, [[RES2]], [[RES2]] : i7
   %mux = comb.mux %arg1, %d, %d : i7
 
@@ -89,8 +103,8 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   // CHECK-NEXT: = hw.struct_inject [[STR]]["foo"], {{.*}} : !hw.struct<foo: i19, bar: i7>
   %s1 = hw.struct_inject %s0["foo"], %foo : !hw.struct<foo: i19, bar: i7>
 
-  // CHECK-NEXT:  %foo_1, %bar = hw.struct_explode [[STR]] : !hw.struct<foo: i19, bar: i7>
-  %foo_1, %bar = hw.struct_explode %s0 : !hw.struct<foo: i19, bar: i7>
+  // CHECK-NEXT:  %foo_2, %bar = hw.struct_explode [[STR]] : !hw.struct<foo: i19, bar: i7>
+  %foo_2, %bar = hw.struct_explode %s0 : !hw.struct<foo: i19, bar: i7>
 
   // CHECK-NEXT: hw.bitcast [[STR]] : (!hw.struct<foo: i19, bar: i7>)
   %structBits = hw.bitcast %s0 : (!hw.struct<foo: i19, bar: i7>) -> i26

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1695,3 +1695,39 @@ hw.module @SwapConstantIndex(%a_0: !hw.array<4xi1>, %a_1: !hw.array<4xi1>, %a_2:
   // CHECK-NEXT: %5 = hw.array_get %4[%sel] : !hw.array<4xi1>, i2
   // CHECK-NEXT: hw.output %5 : i1
 }
+
+// CHECK-LABEL: @Wires
+hw.module @Wires(%a: i42) {
+  // Trivial wires should fold to their input.
+  %0 = hw.wire %a : i42
+  %1 = hw.wire %a {sv.namehint = "foo"} : i42
+  hw.instance "fold1" @WiresKeep(keep: %0: i42) -> ()
+  hw.instance "fold2" @WiresKeep(keep: %1: i42) -> ()
+  // CHECK-NOT: hw.wire
+  // CHECK-NEXT: hw.instance "fold1" @WiresKeep(keep: %a: i42)
+  // CHECK-NEXT: hw.instance "fold2" @WiresKeep(keep: %a: i42)
+
+  // Wires shouldn't fold if they have a symbol or other attributes.
+  hw.wire %a sym @someSym : i42
+  hw.wire %a {someAttr} : i42
+  // CHECK-NEXT: hw.wire %a sym @someSym
+  // CHECK-NEXT: hw.wire %a {someAttr}
+
+  // Wires should push their name or name hint onto their input when folding.
+  %2 = comb.mul %a, %a : i42
+  %3 = comb.mul %a, %a : i42
+  %4 = comb.mul %a, %a : i42
+  %someName1 = hw.wire %2 : i42
+  %5 = hw.wire %3 {sv.namehint = "someName2"} : i42
+  %someName3 = hw.wire %4 {sv.namehint = "ignoredName"} : i42
+  hw.instance "names1" @WiresKeep(keep: %someName1: i42) -> ()
+  hw.instance "names2" @WiresKeep(keep: %5: i42) -> ()
+  hw.instance "names3" @WiresKeep(keep: %someName3: i42) -> ()
+  // CHECK-NEXT: %2 = comb.mul %a, %a {sv.namehint = "someName1"}
+  // CHECK-NEXT: %3 = comb.mul %a, %a {sv.namehint = "someName2"}
+  // CHECK-NEXT: %4 = comb.mul %a, %a {sv.namehint = "someName3"}
+  // CHECK-NEXT: hw.instance "names1" @WiresKeep(keep: %2: i42)
+  // CHECK-NEXT: hw.instance "names2" @WiresKeep(keep: %3: i42)
+  // CHECK-NEXT: hw.instance "names3" @WiresKeep(keep: %4: i42)
+}
+hw.module.extern @WiresKeep(%keep: i42)


### PR DESCRIPTION
Add the `hw.wire` operation to the HW dialect. A wire offers the ability to assign a human-readable name or an inner symbol to an edge in the SSA graph, for human consumption or remote references through a symbol.

This fills a representational gap where language frontends like FIRRTL have to resort to `sv.wire` if they need any of the naming or symbol reference capabilities of a wire, but in doing so they also have to buy into the SV-specific quirks and connect semantics of `sv.wire`, which are annoying to analyze. Almost all uses in FIRRTL don't care about the connect semantics though. The new `hw.wire` op allows for expressing a wire without the connect semantics, leveraging the graph-ness of the HW dialect, which makes analysis a lot easier and will allow frontends to significantly reduce the number of SV-specific ops they emit. Decoupling frontends from the SV emission backend is very valuable in practice, as it allows for the intermediate HW representation to be consumed by other tools like simulators without them having to try and implement the SV semantics of a wire.

In a nutshell, this allows for the following replacement in almost all cases:

```mlir
// before
%myWire = sv.wire sym @mySym : !hw.inout<i42>
%0 = sv.read_inout %myWire : !hw.inout<i42>
sv.assign %myWire, %1 : i42
hw.output %0 : i42

// after
%myWire = hw.wire %1 sym @mySym : i42
hw.output %myWire : i42
```

This commit adds the `hw.wire` op, canonicalizations, and tests for it. It also adds `BuilderUtils` with a helper to accept `StringAttr`, `StringRef`, or `Twine` in a single builder argument, which is going to be useful for other operations as well. The changes to ExportVerilog are limited to qualifying `WireOp` as `sv::WireOp` to disambiguate from the new `hw::WireOp`.