### PR TITLE
[ExportVerilog] Add hw.wire emission support

### DIFF
--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -169,8 +169,9 @@ static void legalizeModuleLocalNames(HWModuleOp module,
       if (auto name = op->getAttrOfType<StringAttr>(verilogNameAttr)) {
         nameResolver.insertUsedName(
             op->getAttrOfType<StringAttr>(verilogNameAttr));
-      } else if (isa<sv::WireOp, RegOp, LogicOp, LocalParamOp, hw::InstanceOp,
-                     sv::InterfaceInstanceOp, sv::GenerateOp>(op)) {
+      } else if (isa<sv::WireOp, hw::WireOp, RegOp, LogicOp, LocalParamOp,
+                     hw::InstanceOp, sv::InterfaceInstanceOp, sv::GenerateOp>(
+                     op)) {
         // Otherwise, get a verilog name via `getSymOpName`.
         nameEntries.emplace_back(
             op, StringAttr::get(op->getContext(), getSymOpName(op)));

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -34,6 +34,16 @@ hw.module @twoState_variadic(%a: i1, %b: i1, %c: i1) -> (d:i1){
   hw.output %0: i1
 }
 
+// CHECK-LABEL: @carryOverWireAttrs
+hw.module @carryOverWireAttrs(%a: i1) -> (b: i1){
+  // CHECK-NEXT: %foo = sv.wire {magic, sv.attributes = []} : !hw.inout<i1>
+  // CHECK-NEXT: sv.assign %foo, %a
+  // CHECK-NEXT: [[TMP:%.+]] = sv.read_inout %foo
+  // CHECK-NEXT: hw.output [[TMP]] : i1
+  %foo = hw.wire %a {magic, sv.attributes = []} : i1
+  hw.output %foo : i1
+}
+
 // -----
 
 module {

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -286,6 +286,43 @@ hw.module @CmpSign(%a: i4, %b: i4, %c: i4, %d: i4) ->
   hw.output %0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
 }
 
+// CHECK-LABEL: module Wires(
+hw.hierpath @myWirePath [@Wires::@myWire]
+hw.module @Wires(%a: i4) -> (x: i4, y: i4) {
+  // CHECK-DAG: wire [3:0] wire1 = a;
+  // CHECK-DAG: assign x = wire1;
+  %wire1 = hw.wire %a : i4
+
+  // Use before def
+  // CHECK-DAG: wire [3:0] wire2 = wire1;
+  // CHECK-DAG: assign y = wire2 * wire2;
+  %0 = comb.mul %wire2, %wire2 : i4
+  %wire2 = hw.wire %wire1 : i4
+
+  // Nested use before def
+  // CHECK-DAG: wire [3:0] wire4 = a;
+  sv.always {
+    // CHECK-DAG: logic [3:0] wire3 = a;
+    %wire3 = hw.wire %a : i4
+    // CHECK-DAG: assert(wire3 == wire4);
+    %1 = comb.icmp eq %wire3, %wire4 : i4
+    sv.assert %1, immediate
+  }
+  %wire4 = hw.wire %a : i4
+
+  // Inner symbol references
+  // CHECK-DAG: wire [3:0] wire5 = a;
+  // CHECK-DAG: symRef1(wire5);
+  // CHECK-DAG: symRef2(Wires.wire5);
+  %wire5 = hw.wire %a sym @myWire : i4
+  sv.verbatim "symRef1({{0}});" {symbols = [#hw.innerNameRef<@Wires::@myWire>]}
+  %2 = sv.xmr.ref @myWirePath : !hw.inout<i4>
+  %3 = sv.read_inout %2 : !hw.inout<i4>
+  sv.verbatim "symRef2({{0}});"(%3) : i4
+
+  hw.output %wire1, %0 : i4, i4
+}
+
 // CHECK-LABEL: module MultiUseExpr
 hw.module @MultiUseExpr(%a: i4) -> (b0: i1, b1: i1, b2: i1, b3: i1, b4: i2) {
   %false = hw.constant false


### PR DESCRIPTION
Add support for the new `hw.wire` op to ExportVerilog. More specifically this commit makes LegalizeNames consider `hw.wire` during name legalization, and it adds a lowering from `hw.wire` to `sv.wire` to the PrepareForEmission pre-pass. The rationale behind implementing HW wire emission as a lowering in the pre-pass instead of direct support in ExportVerilog is that it makes finding a location for the wire declaration and its assignment an IR problem instead of something done ad-hoc during emission, which makes it a lot easier to solve because we can reason about order based on the ops instead of text snippets.