### PR TITLE
[FIRRTL] Add RefCastOp, support ref path becoming more general

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1031,6 +1031,8 @@ def RefCastOp : FIRRTLOp<"ref.cast",
   let arguments = (ins RefType:$input);
   let results = (outs RefType:$result);
 
+  let hasFolder = 1;
+
   let assemblyFormat =
      "$input attr-dict `:` functional-type($input, $result)";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1014,6 +1014,27 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+def RefCastOp : FIRRTLOp<"ref.cast",
+    [HasCustomSSAName,
+     Pure,
+     SameTypeOrUninferredConstraint<"result","input">]> {
+  let summary = "Cast between compatible reference types";
+  let description = [{
+    Losslessly cast between compatible reference types.
+    Source and destination must be recursively identical or destination
+    has uninferred variants of the corresponding element in source.
+    ```
+      %result = firrtl.ref.cast %ref : (t1) -> t2
+    ```
+    }];
+
+  let arguments = (ins RefType:$input);
+  let results = (outs RefType:$result);
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+}
+
 def RefResolveOp: FIRRTLExprOp<"ref.resolve",
                               [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL Resolve a Reference";

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1017,7 +1017,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
 def RefCastOp : FIRRTLOp<"ref.cast",
     [HasCustomSSAName,
      Pure,
-     SameTypeOrUninferredConstraint<"result","input">]> {
+     CompatibleRefTypes<"result","input">]> {
   let summary = "Cast between compatible reference types";
   let description = [{
     Losslessly cast between compatible reference types.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -70,7 +70,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
     "$dest `,` $src  attr-dict `:` qualified(type($dest))";
 }
 
-def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOrUninferredConstraint<"dest", "src">, FConnectLike]> {
+def RefDefineOp : FIRRTLOp<"ref.define", [CompatibleRefTypes<"dest", "src">, FConnectLike]> {
   let summary = "FIRRTL Define References";
   let description = [{
     Define a target reference to the source reference:

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -19,14 +19,6 @@ include "FIRRTLOpInterfaces.td"
 include "FIRRTLTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-class SameTypeOrUninferredConstraint<string dst, string src>
-  : PredOpTrait<"Destination " # dst #
-                " type not recursively same or same and uninferred of " 
-                # src # " type",
-                CPred<"circt::firrtl::isTypeSameOrUninferred("
-                     "cast<RefType>($" # dst # ".getType()).getType(), "
-                     "cast<RefType>($" # src # ".getType()).getType())">>;
-
 def AttachOp : FIRRTLOp<"attach"> {
   let summary = "Analog Attach Statement";
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -19,6 +19,14 @@ include "FIRRTLOpInterfaces.td"
 include "FIRRTLTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+class SameTypeOrUninferredConstraint<string dst, string src>
+  : PredOpTrait<"Destination " # dst #
+                " type not recursively same or same and uninferred of " 
+                # src # " type",
+                CPred<"circt::firrtl::isTypeSameOrUninferred("
+                     "cast<RefType>($" # dst # ".getType()).getType(), "
+                     "cast<RefType>($" # src # ".getType()).getType())">>;
+
 def AttachOp : FIRRTLOp<"attach"> {
   let summary = "Analog Attach Statement";
 
@@ -70,7 +78,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
     "$dest `,` $src  attr-dict `:` qualified(type($dest))";
 }
 
-def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
+def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOrUninferredConstraint<"dest", "src">, FConnectLike]> {
   let summary = "FIRRTL Define References";
   let description = [{
     Define a target reference to the source reference:
@@ -91,7 +99,7 @@ def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
   let hasVerifier = 1;
 
   let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+    "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
 
   let extraClassDeclaration = [{
     static ConnectBehaviorKind getConnectBehaviorKind() {

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -231,6 +231,11 @@ bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
+/// Returns true if destination and source types are the same (was widthless)
+/// AND recursively checks that types are identical or the destination is
+/// uninferred of the source type.
+bool isTypeSameOrUninferred(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
+
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -236,6 +236,10 @@ bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 /// uninferred of the source type.
 bool isTypeSameOrUninferred(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
+/// Return true if destination can be set using source ref type,
+/// e.g., in a ref.define or ref.cast.  Rejects if not ref types.
+bool isCompatibleRefType(Type dstType, Type srcType);
+
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -231,7 +231,7 @@ bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
-/// Returns true if destination and source types are the same (was widthless)
+/// Returns true if destination and source types are the same (as widthless)
 /// AND recursively checks that types are identical or the destination is
 /// uninferred of the source type.
 bool isTypeSameOrUninferred(FIRRTLBaseType dstType, FIRRTLBaseType srcType);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -195,4 +195,11 @@ class RefResultTypeConstraint<string base, string ref>
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
 
+class SameTypeOrUninferredConstraint<string dst, string src>
+  : PredOpTrait<"reference " # dst # " must be compatible with reference " # src #
+                ": recursively same or uninferred of same",
+                CPred<"circt::firrtl::isTypeSameOrUninferred("
+                     "cast<RefType>($" # dst # ".getType()).getType(), "
+                     "cast<RefType>($" # src # ".getType()).getType())">>;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -195,11 +195,9 @@ class RefResultTypeConstraint<string base, string ref>
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
 
-class SameTypeOrUninferredConstraint<string dst, string src>
+class CompatibleRefTypes<string dst, string src>
   : PredOpTrait<"reference " # dst # " must be compatible with reference " # src #
-                ": recursively same or uninferred of same",
-                CPred<"circt::firrtl::isTypeSameOrUninferred("
-                     "cast<RefType>($" # dst # ".getType()).getType(), "
-                     "cast<RefType>($" # src # ".getType()).getType())">>;
+                ": recursively same or uninferred of same and can only demote rwprobe to probe",
+                CPred<"circt::firrtl::isCompatibleRefType($" # dst # ".getType(), $" # src # ".getType())">>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3089,7 +3089,7 @@ LogicalResult ClockGateIntrinsicOp::canonicalize(ClockGateIntrinsicOp op,
 }
 
 //===----------------------------------------------------------------------===//
-// RefOps
+// Reference Ops.
 //===----------------------------------------------------------------------===//
 
 // refresolve(forceable.ref) -> forceable.data
@@ -3108,4 +3108,11 @@ void RefResolveOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
   results.insert<patterns::RefResolveOfRefSend>(context);
   results.insert(canonicalizeRefResolveOfForceable);
+}
+
+OpFoldResult RefCastOp::fold(FoldAdaptor adaptor) {
+  // RefCast is unnecessary if types match.
+  if (getInput().getType() == getType())
+    return getInput();
+  return {};
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2402,6 +2402,9 @@ LogicalResult RefDefineOp::verify() {
     if (isa<RefSubOp>(op))
       return emitError(
           "destination reference cannot be a sub-element of a reference");
+    if (isa<RefCastOp>(op)) // Source flow, check anyway for now.
+      return emitError(
+          "destination reference cannot be a cast of another reference");
   }
 
   return success();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4398,6 +4398,22 @@ void ElementwiseAndPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+void RefCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
                                          std::optional<Location> loc) {
@@ -4418,18 +4434,6 @@ FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
     return emitInferRetTypeError(
         loc, "ref.send operand must be base type, not ", inType);
   return RefType::get(inBaseType.getPassiveType());
-}
-
-void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
 }
 
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1043,6 +1043,18 @@ bool firrtl::isTypeSameOrUninferred(FIRRTLBaseType dstType,
       });
 }
 
+bool firrtl::isCompatibleRefType(Type dstType, Type srcType) {
+  auto dstRefType = dyn_cast<RefType>(dstType);
+  auto srcRefType = dyn_cast<RefType>(srcType);
+  if (!dstRefType || !srcRefType)
+    return false;
+  if (dstRefType == srcRefType)
+    return true;
+  if (dstRefType.getForceable() && !srcRefType.getForceable())
+    return false;
+  return isTypeSameOrUninferred(dstRefType.getType(), srcRefType.getType());
+}
+
 /// Return the passive version of a firrtl type
 /// top level for ODS constraint usage
 Type firrtl::getPassiveType(Type anyBaseFIRRTLType) {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1009,7 +1009,7 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
       });
 }
 
-/// Returns true if destination and source types are the same (was widthless)
+/// Returns true if destination and source types are the same (as widthless)
 /// AND recursively checks that types are identical or the destination is
 /// uninferred of the source type.
 bool firrtl::isTypeSameOrUninferred(FIRRTLBaseType dstType,

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1629,6 +1629,11 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         declareVars(op.getResult(), op.getLoc());
         constrainTypes(op.getResult(), op.getRef());
       })
+      .Case<RefCastOp>([&](auto op) {
+        declareVars(op.getResult(), op.getLoc());
+        constrainTypes(op.getResult(), op.getInput());
+      })
+
       .Case<mlir::UnrealizedConversionCastOp>([&](auto op) {
         for (Value result : op.getResults()) {
           auto ty = result.getType();

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -405,14 +405,17 @@ static void mapResultsToWires(IRMapping &mapper, SmallVectorImpl<Value> &wires,
 /// Resolve RefType 'backedge' placeholder values.
 /// These should have at most one driver that isn't self-connect,
 /// replace each with their driver and remove connections to them.
+/// Insert RefCastOp's as needed.
 /// Also clears out 'edges'.
-static void replaceRefEdges(SmallVectorImpl<Backedge> &edges) {
+static void replaceRefEdges(SmallVectorImpl<Backedge> &edges, OpBuilder &b) {
   /// Find connections to `val` and:
   /// * Mark for removal.
   /// * Identify the single non-self-connect as driver, return it.
   /// * Check for other drivers and error.
-  auto getDriverAndRemoveConnects = [&](Value val) -> Value {
+  auto getDriverAndLocAndRemoveConnects =
+      [&](Value val) -> std::pair<Value, Location> {
     Value driver;
+    Location loc = val.getLoc();
     llvm::SmallPtrSet<Operation *, 16> toRemove;
     for (Operation *use : val.getUsers())
       if (auto connect = dyn_cast<FConnectLike>(use))
@@ -434,13 +437,14 @@ static void replaceRefEdges(SmallVectorImpl<Backedge> &edges) {
           }
           assert(!driver && "unable to resolve through multiple drivers");
           driver = newdriver;
+          loc = connect.getLoc();
         }
 
     // Drop connections to placeholder values.
     for (auto *op : toRemove)
       op->erase();
 
-    return driver;
+    return {driver, loc};
   };
 
   // Ensure that all users of the `opToRemove` are defined after the driver.
@@ -463,7 +467,7 @@ static void replaceRefEdges(SmallVectorImpl<Backedge> &edges) {
     Value v = edge;
     assert(v.getType().isa<RefType>());
 
-    auto driver = getDriverAndRemoveConnects(v);
+    auto [driver, loc] = getDriverAndLocAndRemoveConnects(v);
     if (!driver) {
       v.getDefiningOp()->emitError(
           "unable to find driver for refty placeholder");
@@ -471,6 +475,12 @@ static void replaceRefEdges(SmallVectorImpl<Backedge> &edges) {
     }
     if (!driver.isa<BlockArgument>())
       moveUseAfterDef(v.getDefiningOp(), driver.getDefiningOp());
+
+    // Insert any needed RefCastOp.
+    if (driver.getType() != v.getType()) {
+      b.setInsertionPointAfter(driver.getDefiningOp());
+      driver = b.create<RefCastOp>(loc, v.getType(), driver);
+    }
     // Resolve the edge (RAUW to driver).
     edge.setValue(driver);
   }
@@ -1022,7 +1032,7 @@ void Inliner::flattenInstances(FModuleOp module) {
   }
 
   // Fixup edges for ref types.
-  replaceRefEdges(edges);
+  replaceRefEdges(edges, b);
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -1230,7 +1240,7 @@ void Inliner::inlineInstances(FModuleOp parent) {
   }
 
   // Fixup edges for ref types.
-  replaceRefEdges(edges);
+  replaceRefEdges(edges, b);
 }
 
 void Inliner::identifyNLAsTargetingOnlyModules() {

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -281,7 +281,7 @@ firrtl.circuit "RefAnno" attributes {rawAnnotations = [{
 }]} {
   firrtl.module @RefAnno(in %in : !firrtl.uint<1>, out %out : !firrtl.ref<uint<1>>) {
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1461,13 +1461,13 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   firrtl.module private @Bar() {
     %inv = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %inv : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %inv__bore, %0 : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %inv__bore, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module private @Foo(out %b_inv__bore: !firrtl.probe<uint<1>>)
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
     // CHECK:  %[[b_inv:[a-zA-Z0-9_]+]] = firrtl.instance b interesting_name  @Bar(out inv__bore: !firrtl.probe<uint<1>>)
-    // CHECK:  firrtl.ref.define %b_inv__bore, %[[b_inv]] : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %b_inv__bore, %[[b_inv]] : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK: firrtl.module @Top()
   firrtl.module @Top() {
@@ -1504,7 +1504,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
   // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.probe<uint<1>>)
   // CHECK:  %[[random:.+]] = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
   // CHECK:  %0 = firrtl.ref.send %[[random]] : !firrtl.uint<1>
-  // CHECK:  firrtl.ref.define %[[_gen_ref2]], %0 : !firrtl.probe<uint<1>>
+  // CHECK:  firrtl.ref.define %[[_gen_ref2]], %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   firrtl.module private @Bar() {
   }
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2959,8 +2959,6 @@ firrtl.module @RefTypes(
   firrtl.strictconnect %flipbundle_wire, %flipbundle_read : !firrtl.bundle<a: uint<1>>
 }
 
-}
-
 // CHECK-LABEL: @RefCastSame
 firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
   // Drop no-op ref.cast's.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2062,7 +2062,7 @@ firrtl.module @ForceableRegResetToNode(in %clock: !firrtl.clock, in %dummy : !fi
   %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   // CHECK: %reg, %reg_ref = firrtl.node %dummy forceable : !firrtl.uint<1>
   %reg, %reg_f = firrtl.regreset %clock, %one_asyncreset, %dummy forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
-  firrtl.ref.define %ref, %reg_f: !firrtl.rwprobe<uint<1>>
+  firrtl.ref.define %ref, %reg_f: !firrtl.rwprobe<uint<1>>, !firrtl.rwprobe<uint<1>>
 
   firrtl.connect %reg, %dummy: !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %foo, %reg: !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2960,3 +2960,14 @@ firrtl.module @RefTypes(
 }
 
 }
+
+// CHECK-LABEL: @RefCastSame
+firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
+  // Drop no-op ref.cast's.
+  // CHECK-NEXT:  firrtl.ref.define %out, %in
+  // CHECK-NEXT:  }
+  %same_as_in = firrtl.ref.cast %in : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>>
+  firrtl.ref.define %out, %same_as_in : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+}
+
+}

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -345,8 +345,9 @@ firrtl.circuit "Foo" {
     // CHECK: define a_ref = probe(a)
     // CHECK: define a_rwref = rwprobe(a)
     %a_ref_send = firrtl.ref.send %a : !firrtl.uint<1>
-    firrtl.ref.define %a_ref, %a_ref_send : !firrtl.probe<uint<1>>
-    firrtl.ref.define %a_rwref, %_a_rwref : !firrtl.rwprobe<uint<1>>
+    firrtl.ref.define %a_ref, %a_ref_send : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %a_rwref, %_a_rwref : !firrtl.rwprobe<uint<1>>, !firrtl.rwprobe<uint<1>>
+
   }
 
   // CHECK-LABEL: module RefSink

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -402,8 +402,8 @@ firrtl.circuit "Foo" {
         out a_ref: !firrtl.probe<uint<1>>,
         out a_rwref: !firrtl.rwprobe<uint<1>>
       )
-    firrtl.ref.define %a_ref, %refSource_a_ref : !firrtl.probe<uint<1>>
-    firrtl.ref.define %a_rwref, %refSource_a_rwref : !firrtl.rwprobe<uint<1>>
+    firrtl.ref.define %a_ref, %refSource_a_ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %a_rwref, %refSource_a_rwref : !firrtl.rwprobe<uint<1>>, !firrtl.rwprobe<uint<1>>
   }
 
   // CHECK-LABEL: extmodule ExtOpenAgg
@@ -431,7 +431,7 @@ firrtl.circuit "Foo" {
     %b_0_y_2 = firrtl.ref.sub %b_0_y[2] : !firrtl.probe<vector<uint<2>, 3>>
     // openagg indexing + ref.sub
     // CHECK-NEXT: define out_b_0_y_2 = oa.out.b[0].y[2]
-    firrtl.ref.define %out_b_0_y_2, %b_0_y_2 : !firrtl.probe<uint<2>>
+    firrtl.ref.define %out_b_0_y_2, %b_0_y_2 : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
   }
 
   firrtl.extmodule @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in in: !firrtl.uint, out out: !firrtl.uint<8>) attributes {defname = "name_thing"}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1188,13 +1188,13 @@ firrtl.circuit "NoDefineIntoRefSub" {
 // Can't define into a ref.cast.
 
 firrtl.circuit "NoDefineIntoRefCast" {
-  firrtl.module @NoDefineIntoRefCast(out %r: !firrtl.ref<uint<1>>) {
+  firrtl.module @NoDefineIntoRefCast(out %r: !firrtl.probe<uint<1>>) {
     // expected-note @below {{the destination was defined here}}
-    %dest_cast = firrtl.ref.cast %r : (!firrtl.ref<uint<1>>) -> !firrtl.ref<uint>
+    %dest_cast = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint>
     %x = firrtl.wire : !firrtl.uint<1>
     %xref = firrtl.ref.send %x : !firrtl.uint<1>
     // expected-error @below {{has invalid flow: the destination expression has source flow, expected sink or duplex flow}}
-    firrtl.ref.define %dest_cast, %xref : !firrtl.ref<uint>, !firrtl.ref<uint<1>>
+    firrtl.ref.define %dest_cast, %xref : !firrtl.probe<uint>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1202,11 +1202,11 @@ firrtl.circuit "NoDefineIntoRefCast" {
 // Can't gain width information along define path.
 
 firrtl.circuit "DefineIntoWidth" {
-  firrtl.module @DefineIntoWidth(out %r: !firrtl.ref<uint<1>>) {
+  firrtl.module @DefineIntoWidth(out %r: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint
     %xref = firrtl.ref.send %zero : !firrtl.uint
     // expected-error @below {{reference dest must be compatible with reference src: recursively same or uninferred of same}}
-    firrtl.ref.define %r, %xref : !firrtl.ref<uint<1>>, !firrtl.ref<uint>
+    firrtl.ref.define %r, %xref : !firrtl.probe<uint<1>>, !firrtl.probe<uint>
   }
 }
 
@@ -1214,12 +1214,12 @@ firrtl.circuit "DefineIntoWidth" {
 // Can't cast to gain width information.
 
 firrtl.circuit "CastAwayRefWidth" {
-  firrtl.module @CastAwayRefWidth(out %r: !firrtl.ref<uint<1>>) {
+  firrtl.module @CastAwayRefWidth(out %r: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint
     %xref = firrtl.ref.send %zero : !firrtl.uint
     // expected-error @below {{reference result must be compatible with reference input: recursively same or uninferred of same}}
-    %source = firrtl.ref.cast %xref : (!firrtl.ref<uint>) -> !firrtl.ref<uint<1>>
-    firrtl.ref.define %r, %source : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+    %source = firrtl.ref.cast %xref : (!firrtl.probe<uint>) -> !firrtl.probe<uint<1>>
+    firrtl.ref.define %r, %source : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1185,6 +1185,45 @@ firrtl.circuit "NoDefineIntoRefSub" {
 }
 
 // -----
+// Can't define into a ref.cast.
+
+firrtl.circuit "NoDefineIntoRefCast" {
+  firrtl.module @NoDefineIntoRefCast(out %r: !firrtl.ref<uint<1>>) {
+    // expected-note @below {{the destination was defined here}}
+    %dest_cast = firrtl.ref.cast %r : (!firrtl.ref<uint<1>>) -> !firrtl.ref<uint>
+    %x = firrtl.wire : !firrtl.uint<1>
+    %xref = firrtl.ref.send %x : !firrtl.uint<1>
+    // expected-error @below {{has invalid flow: the destination expression has source flow, expected sink or duplex flow}}
+    firrtl.ref.define %dest_cast, %xref : !firrtl.ref<uint>, !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
+// Can't gain width information along define path.
+
+firrtl.circuit "DefineIntoWidth" {
+  firrtl.module @DefineIntoWidth(out %r: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint
+    %xref = firrtl.ref.send %zero : !firrtl.uint
+    // expected-error @below {{reference dest must be compatible with reference src: recursively same or uninferred of same}}
+    firrtl.ref.define %r, %xref : !firrtl.ref<uint<1>>, !firrtl.ref<uint>
+  }
+}
+
+// -----
+// Can't cast to gain width information.
+
+firrtl.circuit "CastAwayRefWidth" {
+  firrtl.module @CastAwayRefWidth(out %r: !firrtl.ref<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint
+    %xref = firrtl.ref.send %zero : !firrtl.uint
+    // expected-error @below {{reference result must be compatible with reference input: recursively same or uninferred of same}}
+    %source = firrtl.ref.cast %xref : (!firrtl.ref<uint>) -> !firrtl.ref<uint<1>>
+    firrtl.ref.define %r, %source : !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>
+  }
+}
+
+// -----
 // Issue 4174-- handle duplicate module names.
 
 firrtl.circuit "hi" {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1224,6 +1224,31 @@ firrtl.circuit "CastAwayRefWidth" {
 }
 
 // -----
+// Can't promote to rwprobe.
+
+firrtl.circuit "CastPromoteToRWProbe" {
+  firrtl.module @CastPromoteToRWProbe(out %r: !firrtl.rwprobe<uint>) {
+    %zero = firrtl.constant 0 : !firrtl.uint
+    %xref = firrtl.ref.send %zero : !firrtl.uint
+    // expected-error @below {{reference result must be compatible with reference input: recursively same or uninferred of same}}
+    %source = firrtl.ref.cast %xref : (!firrtl.probe<uint>) -> !firrtl.rwprobe<uint>
+    firrtl.ref.define %r, %source : !firrtl.rwprobe<uint>, !firrtl.rwprobe<uint>
+  }
+}
+
+// -----
+// Can't define-promote to rwprobe.
+
+firrtl.circuit "DefinePromoteToRWProbe" {
+  firrtl.module @DefinePromoteToRWProbe(out %r: !firrtl.rwprobe<uint>) {
+    %zero = firrtl.constant 0 : !firrtl.uint
+    %xref = firrtl.ref.send %zero : !firrtl.uint
+    // expected-error @below {{reference dest must be compatible with reference src: recursively same or uninferred of same}}
+    firrtl.ref.define %r, %xref : !firrtl.rwprobe<uint>, !firrtl.probe<uint>
+  }
+}
+
+// -----
 // Issue 4174-- handle duplicate module names.
 
 firrtl.circuit "hi" {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1123,7 +1123,7 @@ firrtl.circuit "Foo" {
     %a = firrtl.wire : !firrtl.uint<1>
     %1 = firrtl.ref.send %a : !firrtl.uint<1>
     // expected-error @+1 {{connect has invalid flow: the destination expression "_a" has source flow, expected sink or duplex flow}}
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1136,8 +1136,8 @@ firrtl.circuit "Bar" {
     %x = firrtl.instance x @Bar2(out _a: !firrtl.probe<uint<1>>)
     %y = firrtl.instance y @Bar2(out _a: !firrtl.probe<uint<1>>)
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>
-    firrtl.ref.define %_a, %y : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %y : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1150,9 +1150,9 @@ firrtl.circuit "Bar" {
     %x = firrtl.instance x @Bar2(out _a: !firrtl.probe<uint<1>>)
     %y = firrtl.wire : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %1 = firrtl.ref.send %y : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1166,8 +1166,8 @@ firrtl.circuit "Bar" {
     %1 = firrtl.ref.send %x : !firrtl.uint<1>
     %2 = firrtl.ref.send %y : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
-    firrtl.ref.define %_a, %2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1180,7 +1180,7 @@ firrtl.circuit "NoDefineIntoRefSub" {
     %x = firrtl.wire : !firrtl.uint<1>
     %xref = firrtl.ref.send %x : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be a sub-element of a reference}}
-    firrtl.ref.define %sub, %xref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %sub, %xref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -531,16 +531,16 @@ firrtl.module @aggregate_regreset(in %clock: !firrtl.clock, in %reset: !firrtl.u
   // CHECK-NEXT: firrtl.connect %2, %2
 }
 
-// CHECK-LABEL: @refdefine
-firrtl.module @refdefine(in %x : !firrtl.uint<1>, out %out : !firrtl.probe<uint<1>>) {
-  // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %x
-  // CHECK-NEXT: firrtl.ref.define %out, %[[REF]]
-  // CHECK-NEXT: }
-  firrtl.when %x : !firrtl.uint<1> {
-    %ref = firrtl.ref.send %x : !firrtl.uint<1>
-    firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>
-  }
-}
+ // CHECK-LABEL: @refdefine
+ firrtl.module @refdefine(in %x : !firrtl.uint<1>, out %out : !firrtl.probe<uint<1>>) {
+   // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %x
+   // CHECK-NEXT: firrtl.ref.define %out, %[[REF]]
+   // CHECK-NEXT: }
+   firrtl.when %x : !firrtl.uint<1> {
+     %ref = firrtl.ref.send %x : !firrtl.uint<1>
+     firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+   }
+ }
 
 // CHECK-LABEL: @WhenCForce
 firrtl.module @WhenCForce(in %c: !firrtl.uint<1>, in %clock : !firrtl.clock, in %x: !firrtl.uint<4>) {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1026,9 +1026,9 @@ firrtl.circuit "Top" attributes {
     %companion_w1__gen_uint = firrtl.instance companion_w1  @Companion_w1(in _gen_uint: !firrtl.probe<uint<1>>)
     %companion_w2__gen_uint = firrtl.instance companion_w2  @Companion_w2(in _gen_uint: !firrtl.probe<uint<2>>)
     %0 = firrtl.ref.send %a_w1 : !firrtl.uint<1>
-    firrtl.ref.define %companion_w1__gen_uint, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %companion_w1__gen_uint, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %1 = firrtl.ref.send %a_w2 : !firrtl.uint<2>
-    firrtl.ref.define %companion_w2__gen_uint, %1 : !firrtl.probe<uint<2>>
+    firrtl.ref.define %companion_w2__gen_uint, %1 : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
   }
   firrtl.module @Top() {
     firrtl.instance dut  @DUT()

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -540,7 +540,7 @@ firrtl.circuit "SendThroughRWProbe" {
     // CHECK: firrtl.node %[[N]]
     %user = firrtl.node %n : !firrtl.uint<1>
     firrtl.strictconnect %out, %user : !firrtl.uint<1>
-    firrtl.ref.define %rw, %n_ref : !firrtl.rwprobe<uint<1>>
+    firrtl.ref.define %rw, %n_ref : !firrtl.rwprobe<uint<1>>, !firrtl.rwprobe<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   firrtl.module @SendThroughRWProbe(out %a: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -494,7 +494,7 @@ firrtl.circuit "SendThroughRef" {
   firrtl.module private @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @SendThroughRef(out %a: !firrtl.uint<1>) {
@@ -511,11 +511,11 @@ firrtl.circuit "ForwardRef" {
   firrtl.module private @RefForward2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module private @RefForward(out %_a: !firrtl.probe<uint<1>>) {
     %fwd_2 = firrtl.instance fwd_2 @RefForward2(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %fwd_2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %fwd_2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @ForwardRef(out %a: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/imdce-nyi.mlir
+++ b/test/Dialect/FIRRTL/imdce-nyi.mlir
@@ -20,7 +20,7 @@ firrtl.circuit "NoWireForLiveRefInputPort" {
     %child_ref = firrtl.instance child @Child(in in: !firrtl.probe<uint<1>>)
     %res = firrtl.ref.resolve %child_ref : !firrtl.probe<uint<1>>
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %child_ref, %ref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %child_ref, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     firrtl.strictconnect %out, %res : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -364,17 +364,18 @@ firrtl.circuit "DeleteInstance" {
 // CHECK-LABEL: firrtl.circuit "NoWireForLiveRefInputPort"
 firrtl.circuit "NoWireForLiveRefInputPort" {
    // CHECK-NOT: @Child
-  firrtl.module private @Child(in %in: !firrtl.probe<uint<1>>) { }
+  firrtl.module private @Child(in %in: !firrtl.probe<uint>) { }
   // CHECK: @NoWireForLiveRefInputPort
-  firrtl.module @NoWireForLiveRefInputPort(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  firrtl.module @NoWireForLiveRefInputPort(in %in: !firrtl.uint<1>, out %out: !firrtl.uint) {
     // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %in
-    // CHECK-NEXT: %[[RES:.+]] = firrtl.ref.resolve %[[REF]]
-    // CHECK-NEXT: firrtl.strictconnect %out, %[[RES]]
+    // CHECK-NEXT: %[[CAST:.+]] = firrtl.ref.cast %[[REF]]
+    // CHECK-NEXT: %[[RES:.+]] = firrtl.ref.resolve %[[CAST]]
+    // CHECK-NEXT: firrtl.connect %out, %[[RES]]
     // CHECK-NEXT: }
-    %child_ref = firrtl.instance child @Child(in in: !firrtl.probe<uint<1>>)
+    %child_ref = firrtl.instance child @Child(in in: !firrtl.probe<uint>)
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %child_ref, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
-    %res = firrtl.ref.resolve %child_ref : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %out, %res : !firrtl.uint<1>
+    firrtl.ref.define %child_ref, %ref : !firrtl.probe<uint>, !firrtl.probe<uint<1>>
+    %res = firrtl.ref.resolve %child_ref : !firrtl.probe<uint>
+    firrtl.connect %out, %res : !firrtl.uint, !firrtl.uint
   }
 }

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -844,7 +844,7 @@ firrtl.circuit "RefReset" {
   // CHECK-NEXT: probe<asyncreset>
   firrtl.module private @SendReset(in %r: !firrtl.reset, out %ref: !firrtl.probe<reset>) {
     %ref_r = firrtl.ref.send %r : !firrtl.reset
-    firrtl.ref.define %ref, %ref_r : !firrtl.probe<reset>
+    firrtl.ref.define %ref, %ref_r : !firrtl.probe<reset>, !firrtl.probe<reset>
   }
   // CHECK-LABEL: firrtl.module @RefReset
   // CHECK-NEXT: in r: !firrtl.asyncreset

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -838,7 +838,8 @@ firrtl.circuit "Foo" {
     firrtl.ref.define %bov_ref, %bov_rw : !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
 
     %ref_w = firrtl.ref.send %w : !firrtl.uint
-    firrtl.ref.define %x, %ref_w : !firrtl.probe<uint>, !firrtl.probe<uint>
+    %cast_ref_w = firrtl.ref.cast %ref_w : (!firrtl.probe<uint>) -> !firrtl.probe<uint>
+    firrtl.ref.define %x, %cast_ref_w : !firrtl.probe<uint>, !firrtl.probe<uint>
     firrtl.ref.define %y, %w_rw : !firrtl.rwprobe<uint>, !firrtl.rwprobe<uint>
 
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -835,7 +835,7 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     %w, %w_rw = firrtl.wire forceable : !firrtl.uint, !firrtl.rwprobe<uint>
     %bov, %bov_rw = firrtl.wire forceable : !firrtl.bundle<a: vector<uint, 2>, b flip: uint>, !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
-    firrtl.ref.define %bov_ref, %bov_rw : !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
+    firrtl.ref.define %bov_ref, %bov_rw : !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>, !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
 
     %ref_w = firrtl.ref.send %w : !firrtl.uint
     %cast_ref_w = firrtl.ref.cast %ref_w : (!firrtl.probe<uint>) -> !firrtl.probe<uint>

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -760,8 +760,8 @@ firrtl.circuit "Foo" {
     firrtl.connect %m_p1_data, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
     firrtl.connect %m_p2_wdata, %c0_ui7 : !firrtl.uint, !firrtl.uint<7>
     firrtl.connect %out, %m_p0_data : !firrtl.uint, !firrtl.uint
-    firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint, 8>>
-    // CHECK:  firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint<7>, 8>>
+    firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint, 8>>, !firrtl.probe<vector<uint, 8>>
+    // CHECK:  firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint<7>, 8>>, !firrtl.probe<vector<uint<7>, 8>>
   }
 
   // CHECK-LABEL: @MemBundle
@@ -838,8 +838,8 @@ firrtl.circuit "Foo" {
     firrtl.ref.define %bov_ref, %bov_rw : !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
 
     %ref_w = firrtl.ref.send %w : !firrtl.uint
-    firrtl.ref.define %x, %ref_w : !firrtl.probe<uint>
-    firrtl.ref.define %y, %w_rw : !firrtl.rwprobe<uint>
+    firrtl.ref.define %x, %ref_w : !firrtl.probe<uint>, !firrtl.probe<uint>
+    firrtl.ref.define %y, %w_rw : !firrtl.rwprobe<uint>, !firrtl.rwprobe<uint>
 
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.connect %w, %c0_ui2 : !firrtl.uint, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "TLRAM" {
       %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
       %debug, %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["dbgs", "MPORT", "MPORT_1"], prefix = "foo_", readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.probe<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-      firrtl.ref.define %dbg_0, %debug : !firrtl.probe<vector<uint<8>, 16>>
+      firrtl.ref.define %dbg_0, %debug : !firrtl.probe<vector<uint<8>, 16>>, !firrtl.probe<vector<uint<8>, 16>>
       %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -41,7 +41,7 @@ firrtl.circuit "TLRAM" {
 // CHECK:  firrtl.strictconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
 // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.strictconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
-// CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.probe<vector<uint<8>, 16>>
+// CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.probe<vector<uint<8>, 16>>, !firrtl.probe<vector<uint<8>, 16>>
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -144,16 +144,16 @@ firrtl.circuit "Refs" attributes {
   } {
 
   firrtl.module private @DUT(
-    in %in: !firrtl.uint<1>, out %out: !firrtl.ref<uint<1>>
+    in %in: !firrtl.uint<1>, out %out: !firrtl.probe<uint<1>>
   ) attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
     ]}
   {
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Refs() {
-    %dut_in, %dut_tap = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>, out out: !firrtl.ref<uint<1>>)
+    %dut_in, %dut_tap = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>, out out: !firrtl.probe<uint<1>>)
   }
 }

--- a/test/Dialect/FIRRTL/inliner-nyi.mlir
+++ b/test/Dialect/FIRRTL/inliner-nyi.mlir
@@ -13,7 +13,7 @@ module {
       %0 = firrtl.subfield %in[a] : !firrtl.bundle<a: uint<1>, b: uint<2>>
       firrtl.when %0 : !firrtl.uint<1> {
         %1 = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
-        firrtl.ref.define %out, %1 : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+        firrtl.ref.define %out, %1 : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>, !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
       }
     }
     firrtl.module @InlinerRefs(in %in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -832,14 +832,14 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -861,14 +861,14 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %bar_pa = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %bar_pa : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -890,18 +890,18 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -948,7 +948,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
@@ -956,15 +956,15 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
     // CHECK:  %child_child__a = firrtl.instance child_child  @Child2(in _a: !firrtl.probe<uint<1>>)
-    // CHECK:  firrtl.ref.define %child_child__a, %xmr__a : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %child_child__a, %xmr__a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -979,7 +979,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
@@ -987,14 +987,14 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
     // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -1009,15 +1009,15 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %xmr2 = firrtl.ref.send %a : !firrtl.uint<1>
     %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.probe<uint<1>>, in  _a2: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
     // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
     // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
@@ -1028,7 +1028,7 @@ firrtl.circuit "Top" {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
     // CHECK:  %0 = firrtl.ref.resolve %_a1 : !firrtl.probe<uint<1>>
     // CHECK:  %1 = firrtl.ref.resolve %_a1 : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
@@ -1036,7 +1036,7 @@ firrtl.circuit "Top" {
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
@@ -1051,7 +1051,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]}{
     %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
@@ -1068,12 +1068,12 @@ firrtl.circuit "Top" {
     // CHECK:  %5 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
     // CHECK:  %child_cw = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %child_cw, %5 : !firrtl.uint<1>
-    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
@@ -1081,7 +1081,7 @@ firrtl.circuit "Top" {
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>){
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>){
     %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
@@ -1095,22 +1095,22 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.module @Top() {
     %c_a, %c_o = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>, out  o_a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %c_o : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %c_o : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK:  %child_bar__a = firrtl.instance child_bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %0 = firrtl.ref.resolve %child_bar__a : !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>, out  %o_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %o_a, %bar_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %o_a, %bar_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -311,9 +311,9 @@ firrtl.module @DbgsMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>,
   firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   }
-  firrtl.ref.define %_a, %port0_data : !firrtl.probe<vector<uint<1>, 2>>
+  firrtl.ref.define %_a, %port0_data : !firrtl.probe<vector<uint<1>, 2>>, !firrtl.probe<vector<uint<1>, 2>>
   // CHECK:    %[[ram_port0:.+]], %ram_ramport = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port0", "ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<1>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  // CHECK:    firrtl.ref.define %_a, %[[ram_port0]] : !firrtl.probe<vector<uint<1>, 2>>
+  // CHECK:    firrtl.ref.define %_a, %[[ram_port0]] : !firrtl.probe<vector<uint<1>, 2>>, !firrtl.probe<vector<uint<1>, 2>>
 }
 
 }

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -6,7 +6,7 @@ firrtl.circuit "Symbol" {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref = firrtl.ref.send %zero : !firrtl.uint<1>
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
-    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -18,7 +18,7 @@ firrtl.circuit "Annotation" {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref = firrtl.ref.send %zero : !firrtl.uint<1>
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
-    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -32,7 +32,7 @@ firrtl.circuit "MixedAnnotation" {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref = firrtl.ref.send %zero : !firrtl.uint<1>
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
-    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %r_a = firrtl.opensubfield %r[a] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
     firrtl.strictconnect %r_a, %zero : !firrtl.uint<1>
   }
@@ -46,7 +46,7 @@ firrtl.circuit "UnhandledOp" {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref = firrtl.ref.send %zero : !firrtl.uint<1>
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
-    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
 
     // expected-error @below {{unhandled use or producer of types containing references}}
     %x = firrtl.wire : !firrtl.openbundle<p : probe<uint<1>>>

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -6,7 +6,8 @@ firrtl.circuit "Bundle" {
   firrtl.module private @Child(in %in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>,
                                out %r: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>) {
     %0 = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
-    firrtl.ref.define %r, %0 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %r, %0 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+
   }
 // CHECK-LABEL: module private @Probe
 // CHECK-SAME: in %in
@@ -50,20 +51,22 @@ firrtl.circuit "Bundle" {
     %18 = firrtl.ref.sub %c2_r[0] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     firrtl.strictconnect %c1_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     firrtl.strictconnect %c2_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
-    firrtl.ref.define %15, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.ref.define %14, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %15, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+
+    firrtl.ref.define %14, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+
     %19 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %13, %19 : !firrtl.uint<1>
     %20 = firrtl.ref.resolve %16 : !firrtl.probe<vector<uint<1>, 2>>
     firrtl.strictconnect %12, %20 : !firrtl.vector<uint<1>, 2>
-    firrtl.ref.define %11, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.ref.define %8, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %11, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %8, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     %21 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %10, %21 : !firrtl.uint<1>
     %22 = firrtl.ref.resolve %18 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %7, %22 : !firrtl.uint<1>
-    firrtl.ref.define %4, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.ref.define %2, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %4, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %2, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
   }
 // CHECK-LABEL: module @Bundle
   firrtl.module @Bundle(in %in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out1: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out2: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out3: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out4: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out5: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out6: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out7: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>) attributes {convention = #firrtl<convention scalarized>} {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1150,8 +1150,8 @@ firrtl.module private @is1436_FOO() {
     %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.rwprobe<uint<2>>
 
-    // TODO: Handle rwprobe --> probe define, enable this.
-    // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
+    // CHECK-NEXT: firrtl.ref.define %probe, %[[X_B_REF]] : !firrtl.probe<uint<2>>, !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>, !firrtl.rwprobe<uint<2>>
 
     // Check resolve of rwprobe is preserved.
     // CHECK-NEXT: = firrtl.ref.resolve %[[X_REF]]

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1069,10 +1069,10 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  %0 = firrtl.ref.send %source_valid : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %source_ready : !firrtl.uint<1>
     // CHECK:  %2 = firrtl.ref.send %source_data : !firrtl.uint<64>
-    firrtl.ref.define %sink, %0 : !firrtl.probe<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
-    // CHECK:  firrtl.ref.define %sink_valid, %0 : !firrtl.probe<uint<1>>
-    // CHECK:  firrtl.ref.define %sink_ready, %1 : !firrtl.probe<uint<1>>
-    // CHECK:  firrtl.ref.define %sink_data, %2 : !firrtl.probe<uint<64>>
+    firrtl.ref.define %sink, %0 : !firrtl.probe<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>, !firrtl.probe<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
+    // CHECK:  firrtl.ref.define %sink_valid, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %sink_ready, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %sink_data, %2 : !firrtl.probe<uint<64>>, !firrtl.probe<uint<64>>
   }
   firrtl.module private @SendRefTypeVectors1(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.probe<vector<uint<1>, 2>>) {
     // CHECK-LABEL: firrtl.module private @SendRefTypeVectors1
@@ -1080,9 +1080,9 @@ firrtl.module private @is1436_FOO() {
     %0 = firrtl.ref.send %a : !firrtl.vector<uint<1>, 2>
     // CHECK:  %0 = firrtl.ref.send %a_0 : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %a_1 : !firrtl.uint<1>
-    firrtl.ref.define %b, %0 : !firrtl.probe<vector<uint<1>, 2>>
-    // CHECK:  firrtl.ref.define %b_0, %0 : !firrtl.probe<uint<1>>
-    // CHECK:  firrtl.ref.define %b_1, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %b, %0 : !firrtl.probe<vector<uint<1>, 2>>, !firrtl.probe<vector<uint<1>, 2>>
+    // CHECK:  firrtl.ref.define %b_0, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %b_1, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module private @RefTypeBundles2() {
     %x = firrtl.wire   : !firrtl.bundle<a: uint<1>, b: uint<2>>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1124,8 +1124,8 @@ firrtl.module private @is1436_FOO() {
     %x, %x_ref = firrtl.wire forceable : !firrtl.bundle<a: vector<uint<1>, 2>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
 
     // Define using forceable ref preserved.
-    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_REF]] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
-    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1> ,2>, b: uint<2>>>
+    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_REF]] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
 
     // Preserve ref.sub uses.
     // CHECK-NEXT: %[[X_REF_A:.+]] = firrtl.ref.sub %[[X_REF]][0]
@@ -1151,7 +1151,7 @@ firrtl.module private @is1436_FOO() {
     %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.rwprobe<uint<2>>
 
     // TODO: Handle rwprobe --> probe define, enable this.
-    // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>
+    // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
 
     // Check resolve of rwprobe is preserved.
     // CHECK-NEXT: = firrtl.ref.resolve %[[X_REF]]

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -15,19 +15,19 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // expected-error @+1 {{op multiply instantiated module with input RefType port '_a'}}
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
@@ -41,13 +41,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -84,6 +84,6 @@ firrtl.circuit "RefSubNotFromOp" {
   firrtl.module @RefSubNotFromOp(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>) {
     %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
     %child_ref = firrtl.instance child @Child(in ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>)
-    firrtl.ref.define %child_ref, %ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    firrtl.ref.define %child_ref, %ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>, !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -665,7 +665,7 @@ firrtl.circuit "ForceRelease" {
     // CHECK-NEXT: %x, %x_ref = firrtl.wire sym @[[TARGET_SYM]] forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     %x, %x_ref = firrtl.wire forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     // CHECK-NEXT: }
-    firrtl.ref.define %p, %x_ref : !firrtl.rwprobe<uint<4>>
+    firrtl.ref.define %p, %x_ref : !firrtl.rwprobe<uint<4>>, !firrtl.rwprobe<uint<4>>
   }
   // CHECK-LABEL: firrtl.module @ForceRelease
   firrtl.module @ForceRelease(in %c: !firrtl.uint<1>, in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -31,12 +31,12 @@ firrtl.circuit "Top" {
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -79,12 +79,12 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @[[xmrSym]]) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -114,12 +114,12 @@ firrtl.circuit "Top" {
     // CHECK:   %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
@@ -130,7 +130,7 @@ firrtl.circuit "Top" {
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
@@ -178,12 +178,12 @@ firrtl.circuit "Top" {
     // CHECK:  %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -195,7 +195,7 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -214,12 +214,12 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -231,7 +231,7 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -250,20 +250,20 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.probe<uint<1>>)
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a, %c_b = firrtl.instance child @Child2p(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
     // CHECK:  firrtl.instance child  @Child2p()
-    firrtl.ref.define %c_a, %foo_a : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %foo_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2p(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -284,13 +284,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
@@ -298,10 +298,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -330,13 +330,13 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
@@ -344,10 +344,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -375,7 +375,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
@@ -387,7 +387,7 @@ firrtl.circuit "Top" {
   firrtl.module @Dut() {
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
@@ -395,10 +395,10 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
@@ -446,7 +446,7 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %6, %clock : !firrtl.clock
     firrtl.strictconnect %8, %c1_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %7, %io_dataIn : !firrtl.uint<8>
-    firrtl.ref.define %_gen_memTap, %rf_memTap : !firrtl.probe<vector<uint<8>, 8>>
+    firrtl.ref.define %_gen_memTap, %rf_memTap : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.probe<vector<uint<8>, 8>>
   }
   // CHECK: firrtl.module @Top
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
@@ -513,9 +513,9 @@ firrtl.circuit "Top"  {
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 2 : i64, name = "rf", portNames = ["memTap", "read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 2 : i64, name = "rf", portNames = ["read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %9 = firrtl.ref.sub %rf_memTap[0] : !firrtl.probe<vector<uint<8>, 2>>
-    firrtl.ref.define %_gen_memTap_0, %9 : !firrtl.probe<uint<8>>
+    firrtl.ref.define %_gen_memTap_0, %9 : !firrtl.probe<uint<8>>, !firrtl.probe<uint<8>>
     %10 = firrtl.ref.sub %rf_memTap[1] : !firrtl.probe<vector<uint<8>, 2>>
-    firrtl.ref.define %_gen_memTap_1, %10 : !firrtl.probe<uint<8>>
+    firrtl.ref.define %_gen_memTap_1, %10 : !firrtl.probe<uint<8>>, !firrtl.probe<uint<8>>
   }
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.probe<uint<8>>, out _gen_memTap_1: !firrtl.probe<uint<8>>)
@@ -546,12 +546,12 @@ firrtl.circuit "Top" {
     // CHECK-NEXT: }
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1>
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -577,12 +577,12 @@ firrtl.circuit "Top" {
     // CHECK:  = firrtl.node sym @xmr_sym  %[[internal:.+]]  : !firrtl.uint<1>
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -603,11 +603,11 @@ firrtl.circuit "Top"  {
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>, out %_a: !firrtl.probe<uint<0>>) {
   // CHECK-LABEL: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>)
     %0 = firrtl.ref.send %pa : !firrtl.uint<0>
-    firrtl.ref.define %_a, %0 : !firrtl.probe<uint<0>>
+    firrtl.ref.define %_a, %0 : !firrtl.probe<uint<0>>, !firrtl.probe<uint<0>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<0>>) {
     %bar_pa, %bar__a = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<0>, out _a: !firrtl.probe<uint<0>>)
-    firrtl.ref.define %_a, %bar__a : !firrtl.probe<uint<0>>
+    firrtl.ref.define %_a, %bar__a : !firrtl.probe<uint<0>>, !firrtl.probe<uint<0>>
   }
   firrtl.module @Top() {
     %bar__a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<0>>)

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -735,26 +735,26 @@ firrtl.circuit "Top" {
                      in %e: !firrtl.probe<uint<1>>) {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
     %0 = firrtl.ref.send %w : !firrtl.uint<1>
-    firrtl.ref.define %a, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     
     %x, %y = firrtl.instance foo sym @foo @Foo(out x: !firrtl.probe<uint<1>>, out y: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %b, %x : !firrtl.probe<uint<1>>
-    firrtl.ref.define %c, %y : !firrtl.probe<uint<1>>
+    firrtl.ref.define %b, %x : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define %c, %y : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     
     %constant = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %constant : !firrtl.uint<1>
-    firrtl.ref.define %d, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %d, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 
   // CHECK-LABEL: firrtl.module @Foo()
   firrtl.module @Foo(out %x: !firrtl.probe<uint<1>>, out %y: !firrtl.probe<uint<1>>) {
     %w = firrtl.wire sym @x : !firrtl.uint<1>
     %0 = firrtl.ref.send %w : !firrtl.uint<1>
-    firrtl.ref.define %x, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %x, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
 
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1>
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.ref.define %y, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %y, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -13,8 +13,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     } : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
         !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>,
         !firrtl.probe<vector<uint<8>, 8>>
-    firrtl.ref.define %d, %debug : !firrtl.probe<vector<uint<8>, 8>>
-    firrtl.ref.define %d2, %dbg : !firrtl.probe<vector<uint<8>, 8>>
+    firrtl.ref.define %d, %debug : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.probe<vector<uint<8>, 8>>
+    firrtl.ref.define %d2, %dbg : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.probe<vector<uint<8>, 8>>
   }
     // CHECK-LABEL: firrtl.circuit "Mem" {
     // CHECK:         firrtl.module public @Mem(
@@ -44,8 +44,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           }
     // CHECK:           %11 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
     // CHECK:           %12 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
-    // CHECK:           firrtl.ref.define %d, %12 : !firrtl.probe<vector<uint<8>, 8>>
-    // CHECK:           firrtl.ref.define %d2, %11 : !firrtl.probe<vector<uint<8>, 8>>
+    // CHECK:           firrtl.ref.define %d, %12 : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.probe<vector<uint<8>, 8>>
+    // CHECK:           firrtl.ref.define %d2, %11 : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.probe<vector<uint<8>, 8>>
 
 
 }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -605,16 +605,6 @@ circuit LeadingProbe:
 
 ;// -----
 
-; This should be supported, needs internal support to land first.
-circuit DefineWidths:
-  module DefineWidths:
-    input in : UInt<1>
-    output p : Probe<UInt>
-    define p = probe(in) ; expected-error {{'firrtl.ref.define' op requires all operands to have the same type}}
-
-
-;// -----
-
 circuit ForceProbe:
   module ForceProbe:
     input in : UInt<1>

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "xmr" {
     %zero = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.strictconnect %w, %zero : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
-    firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
+    firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
   }
   firrtl.module @xmr() {
     %test_x = firrtl.instance test @Test(out x: !firrtl.probe<uint<2>>)
@@ -24,7 +24,7 @@ firrtl.circuit "SimpleRead" {
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @SimpleRead() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -41,11 +41,11 @@ firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @ForwardToInstance() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -62,11 +62,11 @@ firrtl.circuit "ForwardToInstance" {
   firrtl.module @Bar2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1    : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %1    : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     // Reader 1
     %0 = firrtl.ref.resolve %bar_2 : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
@@ -90,12 +90,12 @@ firrtl.circuit "DUT" {
     %w_data1 = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %w_data1, %zero : !firrtl.uint<1>
     %1 = firrtl.ref.send %w_data1 : !firrtl.uint<1>
-    firrtl.ref.define %ref_out1, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %ref_out1, %1 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
     %zero4 = firrtl.constant 0 : !firrtl.uint<4>
     firrtl.strictconnect %w_data2, %zero4 : !firrtl.uint<4>
     %2 = firrtl.ref.send %w_data2 : !firrtl.uint<4>
-    firrtl.ref.define %ref_out2, %2 : !firrtl.probe<uint<4>>
+    firrtl.ref.define %ref_out2, %2 : !firrtl.probe<uint<4>>, !firrtl.probe<uint<4>>
   }
   firrtl.module @DUT() {
     %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.probe<uint<1>>, out ref_out2: !firrtl.probe<uint<4>>)
@@ -150,7 +150,7 @@ firrtl.circuit "Issue3715" {
       %zero = firrtl.constant 1 : !firrtl.uint<2>
       %w = firrtl.wire : !firrtl.uint<2>
       %1 = firrtl.ref.send %w : !firrtl.uint<2>
-      firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
+      firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>, !firrtl.probe<uint<2>>
       firrtl.strictconnect %w, %zero : !firrtl.uint<2>
     }
   }
@@ -171,18 +171,18 @@ firrtl.circuit "UseRefsWithSinkFlow" {
   }
   firrtl.module private @OutChild(in %x: !firrtl.uint, out %y: !firrtl.uint, out %p: !firrtl.probe<uint>) {
     %0 = firrtl.ref.send %x : !firrtl.uint
-    firrtl.ref.define %p, %0 : !firrtl.probe<uint>
+    firrtl.ref.define %p, %0 : !firrtl.probe<uint>, !firrtl.probe<uint>
     %1 = firrtl.ref.resolve %p : !firrtl.probe<uint>
     firrtl.connect %y, %1 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @UseRefsWithSinkFlow(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %zz: !firrtl.uint<1>, out %p: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.send %x : !firrtl.uint<1>
-    firrtl.ref.define %p, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %p, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %1 = firrtl.ref.resolve %p : !firrtl.probe<uint<1>>
     firrtl.strictconnect %y, %1 : !firrtl.uint<1>
     %ic_p = firrtl.instance ic interesting_name @InChild(in p: !firrtl.probe<uint<1>>)
     %2 = firrtl.ref.send %x : !firrtl.uint<1>
-    firrtl.ref.define %ic_p, %2 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %ic_p, %2 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
     %3 = firrtl.ref.resolve %ic_p : !firrtl.probe<uint<1>>
     firrtl.strictconnect %z, %3 : !firrtl.uint<1>
     %oc_x, %oc_y, %oc_p = firrtl.instance oc interesting_name @OutChild(in x: !firrtl.uint, out y: !firrtl.uint, out p: !firrtl.probe<uint>)

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -229,3 +229,12 @@ firrtl.circuit "Forceable" {
   }
 }
 
+// -----
+
+firrtl.circuit "RefDefineAndCastWidths" {
+  firrtl.module @RefDefineAndCastWidths(in %x: !firrtl.uint<2>, out %p : !firrtl.probe<uint>) {
+    %ref = firrtl.ref.send %x : !firrtl.uint<2>
+    %cast = firrtl.ref.cast %ref : (!firrtl.probe<uint<2>>) -> !firrtl.probe<uint>
+    firrtl.ref.define %p, %cast : !firrtl.probe<uint>, !firrtl.probe<uint>
+  }
+}

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -214,18 +214,18 @@ firrtl.circuit "Forceable" {
     out %regreset_ref : !firrtl.rwprobe<uint<2>>) {
 
     %n, %n_f = firrtl.node %value forceable : !firrtl.uint<2>
-    firrtl.ref.define %node_ref, %n_f : !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %node_ref, %n_f : !firrtl.rwprobe<uint<2>>, !firrtl.rwprobe<uint<2>>
 
     // TODO: infer ref result existence + type based on "forceable" or other ref-kind(s) indicator.
     %w, %w_f = firrtl.wire forceable : !firrtl.uint, !firrtl.rwprobe<uint>
-    firrtl.ref.define %wire_ref, %w_f : !firrtl.rwprobe<uint>
+    firrtl.ref.define %wire_ref, %w_f : !firrtl.rwprobe<uint>, !firrtl.rwprobe<uint>
     firrtl.connect %w, %value : !firrtl.uint, !firrtl.uint<2>
 
     %reg, %reg_f = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    firrtl.ref.define %reg_ref, %reg_f : !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %reg_ref, %reg_f : !firrtl.rwprobe<uint<2>>, !firrtl.rwprobe<uint<2>>
 
     %regreset, %regreset_f = firrtl.regreset %clock, %reset, %value forceable : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    firrtl.ref.define %regreset_ref, %regreset_f : !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %regreset_ref, %regreset_f : !firrtl.rwprobe<uint<2>>, !firrtl.rwprobe<uint<2>>
   }
 }
 

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -693,10 +693,10 @@ firrtl.circuit "Test" {
   firrtl.module @RefSender(out %port: !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>) {
    // CHECK: %w = firrtl.wire : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
     // CHECK: %0 = firrtl.ref.send %w : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
-    // CHECK: firrtl.ref.define %port, %0 : !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
+    // CHECK: firrtl.ref.define %port, %0 : !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>, !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
     %w = firrtl.wire : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
     %ref = firrtl.ref.send %w : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
-    firrtl.ref.define %port, %ref : !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
+    firrtl.ref.define %port, %ref : !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>, !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
   }
 
   firrtl.module @RefResolver() {


### PR DESCRIPTION
Want to support inference along reference path, add support for `define` destination to have more general type than source (pending inference).

Add RefCastOp in spirit of recent Strict changes, for use doing this explicitly on source references, and to help touching up IR in passes that drop define operations.

In the future, RefDefineOp might be SameTypeOperands again with the casting always done this way (and resets), but keep it flexible for now.