### PR TITLE
[SCFToCalyx] Read "calyx.port_name" Attribute from FuncOp arguments/results

### DIFF
--- a/include/circt/Conversion/SCFToCalyx.h
+++ b/include/circt/Conversion/SCFToCalyx.h
@@ -20,6 +20,13 @@
 
 namespace circt {
 
+namespace scfToCalyx {
+// If this attribute is set as a FuncOp argument or result attribute, it will be
+// used as the Calyx port name.
+static constexpr std::string_view sPortNameAttr = "calyx.port_name";
+
+} // namespace scfToCalyx
+
 /// Create an SCF to Calyx conversion pass.
 std::unique_ptr<OperationPass<ModuleOp>> createSCFToCalyxPass();
 

--- a/integration_test/Dialect/Calyx/custom_port_name.mlir
+++ b/integration_test/Dialect/Calyx/custom_port_name.mlir
@@ -1,0 +1,17 @@
+// This test checks that the custom port name gets propagated all the way down to Verilog
+// RUN: circt-opt %s \
+// RUN:     --lower-scf-to-calyx -canonicalize \
+// RUN:     --calyx-remove-comb-groups --canonicalize \
+// RUN:     --lower-calyx-to-fsm --canonicalize \
+// RUN:     --materialize-calyx-to-fsm --canonicalize \
+// RUN:     --calyx-remove-groups-fsm --canonicalize \
+// RUN:     --lower-calyx-to-hw --canonicalize \
+// RUN:     --convert-fsm-to-sv | FileCheck %s
+
+// CHECK: hw.module @control
+// CHECK: hw.module @main(%a: i32, %b: i32, %clk: i1, %reset: i1, %go: i1) -> (out: i1, done: i1)
+// CHECK: hw.instance "controller" @control
+func.func @main(%arg0 : i32 {calyx.port_name = "a"}, %arg1 : i32 {calyx.port_name = "b"}) -> (i1 {calyx.port_name = "out"}) {
+  %0 = arith.cmpi slt, %arg0, %arg1 : i32
+  return %0 : i1
+}

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -748,7 +748,12 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
                                             extMemCounter++, inPorts, outPorts);
       } else {
         /// Single-port arguments
-        auto inName = "in" + std::to_string(arg.index());
+        std::string inName;
+        if (auto portNameAttr = funcOp.getArgAttrOfType<StringAttr>(
+                arg.index(), scfToCalyx::sPortNameAttr))
+          inName = portNameAttr.str();
+        else
+          inName = "in" + std::to_string(arg.index());
         funcOpArgRewrites[arg.value()] = inPorts.size();
         inPorts.push_back(calyx::PortInfo{
             rewriter.getStringAttr(inName),
@@ -758,9 +763,15 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
       }
     }
     for (auto &res : enumerate(funcType.getResults())) {
+      std::string resName;
+      if (auto portNameAttr = funcOp.getResultAttrOfType<StringAttr>(
+              res.index(), scfToCalyx::sPortNameAttr))
+        resName = portNameAttr.str();
+      else
+        resName = "out" + std::to_string(res.index());
       funcOpResultMapping[res.index()] = outPorts.size();
       outPorts.push_back(calyx::PortInfo{
-          rewriter.getStringAttr("out" + std::to_string(res.index())),
+          rewriter.getStringAttr(resName),
           calyx::convIndexType(rewriter, res.value()), calyx::Direction::Output,
           DictionaryAttr::get(rewriter.getContext(), {})});
     }


### PR DESCRIPTION
If `func::FuncOP` argument attributes/results have the `"calyx.port_name"` Attribute, use it to set `calyx::PortInfo` port name.
With this, the port name gets propagated all the way down to Verilog.

Before:
```verilog
module f0(
  input  [63:0] in0,
  input  [31:0] in1,
  input  [31:0] in2,
...
```

After:
```verilog
module f0(
  input  [63:0] b0_host,
  input  [31:0] b0_dimensions,
  input  [31:0] b0_dim_0_min,
...
```