### PR TITLE
[FIRRTL][CheckCombLoops] Improve loop reporting diagnostics.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -398,13 +398,14 @@ public:
   }
 
   void reportLoopFound(Value childVal, VisitingSet visiting) {
+    // TODO: Work harder to provide best information possible to user,
+    // especially across instances or when we trace through aliasing values.
+    // We're about to exit, and can afford to do some slower work here.
     auto getName = [&](Value v) {
       if (isa_and_nonnull<SubfieldOp, SubindexOp, SubaccessOp>(
               v.getDefiningOp())) {
         assert(!valRefersTo[v].empty());
-        // TODO: Indicate to user if "alias set" if > 1, and/or pick
-        // representative with "best" name.  Note the selection here is
-        // not deterministic.
+        // Pick representative of the "alias set", not deterministic.
         return getFieldName(*valRefersTo[v].begin()).first;
       }
       return getFieldName(FieldRef(v, 0)).first;

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -420,7 +420,8 @@ public:
     path.pop_back();
 
     // Find a value we can name
-    auto *it = llvm::find_if(path, [&](Value v) { return !getName(v).empty(); });
+    auto *it =
+        llvm::find_if(path, [&](Value v) { return !getName(v).empty(); });
     if (it == path.end()) {
       errorDiag.append(", but unable to find names for any involved values.");
       errorDiag.attachNote(childVal.getLoc()) << "cycle detected here";


### PR DESCRIPTION
* Fixup cases with trailing or leading arrows.
* Fix printing starting value twice, misrepresenting cycle (#4781).
* Walk cycle until a name is found and start from there, improving diagnostic and ensuring the begin/end are named.
  * If nothing can be named, say so explicitly instead empty path and emit note pointing to add location for starting val.
* Avoid printing module name for every named signal
  * mymodule.a <- mymodule.b.c <- mymodule.d is now: mymodule.{a <- b.c <- d} They always start with same module name, compress a bit.
* Use '...' to describe paths not named, only once until next name.

A future improvement would be to improve printing names for values that alias a number of sources-- presently we (non-deterministically) pick the first of the computed alias set, this could be made clearer to the user (indicating it's representative of the set, not necessarily "directly" involved), and perhaps picking "best" representative if some we can't name.

Fixes #4781 .