### PR TITLE
Do not use non-const lvalue-refs with enumerate

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1883,7 +1883,7 @@ Attribute FIRRTLLowering::getOrCreateAggregateConstantAttribute(Attribute value,
 
   // Recursively construct elements.
   SmallVector<Attribute> values;
-  for (auto &e : llvm::enumerate(value.cast<ArrayAttr>())) {
+  for (auto e : llvm::enumerate(value.cast<ArrayAttr>())) {
     Type subType;
     if (auto array = hw::type_dyn_cast<hw::ArrayType>(type))
       subType = array.getElementType();

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -645,7 +645,7 @@ createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
   llvm::SmallVector<PortInfo> ports;
 
   // Add all inputs of funcOp.
-  for (auto &[i, argType] :
+  for (auto [i, argType] :
        llvm::enumerate(funcOp.getFunctionType().getInputs())) {
     auto portName = funcOp.getArgName(i);
     FIRRTLBaseType bundlePortType;
@@ -739,7 +739,7 @@ static void inlineFuncRegion(handshake::FuncOp funcOp, FModuleOp topModuleOp,
 
   // Replace uses of each argument of the second block with the corresponding
   // argument of the entry block.
-  for (auto &oldArg : enumerate(secondBlock->getArguments()))
+  for (auto oldArg : enumerate(secondBlock->getArguments()))
     oldArg.value().replaceAllUsesWith(entryBlock->getArgument(oldArg.index()));
 
   // Move all operations of the second block to the entry block.

--- a/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
+++ b/lib/Conversion/PipelineToCalyx/PipelineToCalyx.cpp
@@ -386,7 +386,7 @@ private:
     assert(addrPorts.size() == addressValues.size() &&
            "Mismatch between number of address ports of the provided memory "
            "and address assignment values");
-    for (auto &address : enumerate(addressValues))
+    for (auto address : enumerate(addressValues))
       rewriter.create<calyx::AssignOp>(loc, addrPorts[address.index()],
                                        address.value());
   }
@@ -751,7 +751,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
     SmallVector<calyx::PortInfo> inPorts, outPorts;
     FunctionType funcType = funcOp.getFunctionType();
     unsigned extMemCounter = 0;
-    for (auto &arg : enumerate(funcOp.getArguments())) {
+    for (auto arg : enumerate(funcOp.getArguments())) {
       if (arg.value().getType().isa<MemRefType>()) {
         /// External memories
         auto memName =
@@ -771,7 +771,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
             DictionaryAttr::get(rewriter.getContext(), {})});
       }
     }
-    for (auto &res : enumerate(funcType.getResults())) {
+    for (auto res : enumerate(funcType.getResults())) {
       funcOpResultMapping[res.index()] = outPorts.size();
       outPorts.push_back(calyx::PortInfo{
           rewriter.getStringAttr("out" + std::to_string(res.index())),

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -51,7 +51,7 @@ static LogicalResult lowerPipeline(PipelineOp pipeline, OpBuilder &builder) {
               Value(), StringAttr());
           stage.getValid().replaceAllUsesWith(validReg);
 
-          for (auto &it : llvm::enumerate(stage.getRegIns())) {
+          for (auto it : llvm::enumerate(stage.getRegIns())) {
             auto regIdx = it.index();
             auto regIn = it.value();
             auto regName =

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -287,7 +287,7 @@ private:
     assert(addrPorts.size() == addressValues.size() &&
            "Mismatch between number of address ports of the provided memory "
            "and address assignment values");
-    for (auto &address : enumerate(addressValues))
+    for (auto address : enumerate(addressValues))
       rewriter.create<calyx::AssignOp>(loc, addrPorts[address.index()],
                                        address.value());
   }
@@ -737,7 +737,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
     SmallVector<calyx::PortInfo> inPorts, outPorts;
     FunctionType funcType = funcOp.getFunctionType();
     unsigned extMemCounter = 0;
-    for (auto &arg : enumerate(funcOp.getArguments())) {
+    for (auto arg : enumerate(funcOp.getArguments())) {
       if (arg.value().getType().isa<MemRefType>()) {
         /// External memories
         auto memName =
@@ -762,7 +762,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
             DictionaryAttr::get(rewriter.getContext(), {})});
       }
     }
-    for (auto &res : enumerate(funcType.getResults())) {
+    for (auto res : enumerate(funcType.getResults())) {
       std::string resName;
       if (auto portNameAttr = funcOp.getResultAttrOfType<StringAttr>(
               res.index(), scfToCalyx::sPortNameAttr))

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -531,7 +531,7 @@ static void insertPorts(FModuleLike op,
       ++oldIdx;
     }
   };
-  for (auto &pair : llvm::enumerate(ports)) {
+  for (auto pair : llvm::enumerate(ports)) {
     auto idx = pair.value().first;
     auto &port = pair.value().second;
     migrateOldPorts(idx);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1089,7 +1089,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
     if (!elementsAttr)
       return std::nullopt;
     SmallVector<Attribute> elements;
-    for (auto &[i, elt] : llvm::enumerate(elementsAttr)) {
+    for (auto [i, elt] : llvm::enumerate(elementsAttr)) {
       auto eltAttr = parseAugmentedType(
           state, elt.cast<DictionaryAttr>(), root, companion, name,
           StringAttr::get(context, ""), id, std::nullopt, clazz, companionAttr,

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -132,7 +132,7 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLBaseType type,
           })
           .Case<BundleType>([&](auto type) {
             auto wireOp = builder.create<WireOp>(type);
-            for (auto &field : llvm::enumerate(type)) {
+            for (auto field : llvm::enumerate(type)) {
               auto zero = createZeroValue(builder, field.value().type, cache);
               auto acc = builder.create<SubfieldOp>(field.value().type, wireOp,
                                                     field.index());

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -694,7 +694,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
   LLVM_DEBUG({ llvm::dbgs() << "Analyzing wiring problems:\n"; });
   DenseMap<FModuleLike, ModuleModifications> moduleModifications;
   DenseSet<Value> visitedSinks;
-  for (auto &e : llvm::enumerate(state.wiringProblems)) {
+  for (auto e : llvm::enumerate(state.wiringProblems)) {
     auto index = e.index();
     auto problem = e.value();
     // This is a unique index that is assigned to this specific wiring problem

--- a/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
@@ -791,7 +791,7 @@ Value Visitor::sinkVecDimIntoOperands(ImplicitLocOpBuilder &builder,
   if (auto bundleType = type.dyn_cast<BundleType>()) {
     SmallVector<Value> newFields;
     SmallVector<BundleType::BundleElement> newElements;
-    for (auto &[i, elt] : llvm::enumerate(bundleType)) {
+    for (auto [i, elt] : llvm::enumerate(bundleType)) {
       SmallVector<Value> subValues;
       for (auto v : values)
         subValues.push_back(getSubfield(v, i));
@@ -919,7 +919,7 @@ LogicalResult Visitor::visit(FModuleOp op) {
     SmallVector<std::pair<unsigned, PortInfo>> newPorts;
     auto ports = op.getPorts();
     auto count = 0;
-    for (auto &[index, port] : llvm::enumerate(ports)) {
+    for (auto [index, port] : llvm::enumerate(ports)) {
       auto oldType = port.type;
       auto newType = convertType(oldType);
       if (newType == oldType)

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -168,7 +168,7 @@ struct ParametricTypeConversionPattern : public ConversionPattern {
     bool ok = true;
     rewriter.updateRootInPlace(op, [&]() {
       // Mutate result types
-      for (auto &it : llvm::enumerate(op->getResultTypes())) {
+      for (auto it : llvm::enumerate(op->getResultTypes())) {
         FailureOr<Type> res =
             evaluateParametricType(op->getLoc(), parameters, it.value());
         ok &= succeeded(res);
@@ -274,14 +274,14 @@ static LogicalResult specializeModule(
   // Update the types of the source module ports based on evaluating any
   // parametric in/output ports.
   auto ports = source.getPorts();
-  for (auto &in : llvm::enumerate(source.getFunctionType().getInputs())) {
+  for (auto in : llvm::enumerate(source.getFunctionType().getInputs())) {
     FailureOr<Type> resType =
         evaluateParametricType(source.getLoc(), parameters, in.value());
     if (failed(resType))
       return failure();
     ports.inputs[in.index()].type = *resType;
   }
-  for (auto &out : llvm::enumerate(source.getFunctionType().getResults())) {
+  for (auto out : llvm::enumerate(source.getFunctionType().getResults())) {
     FailureOr<Type> resolvedType =
         evaluateParametricType(source.getLoc(), parameters, out.value());
     if (failed(resolvedType))

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -169,7 +169,7 @@ struct EliminateUnusedForkResultsPattern : mlir::OpRewritePattern<ForkOp> {
                                 PatternRewriter &rewriter) const override {
     std::set<unsigned> unusedIndexes;
 
-    for (auto &res : llvm::enumerate(op.getResults()))
+    for (auto res : llvm::enumerate(op.getResults()))
       if (res.value().getUses().empty())
         unusedIndexes.insert(res.index());
 
@@ -183,7 +183,7 @@ struct EliminateUnusedForkResultsPattern : mlir::OpRewritePattern<ForkOp> {
         op.getLoc(), operand, op.getNumResults() - unusedIndexes.size());
     rewriter.updateRootInPlace(op, [&] {
       unsigned i = 0;
-      for (auto &oldRes : llvm::enumerate(op.getResults()))
+      for (auto oldRes : llvm::enumerate(op.getResults()))
         if (unusedIndexes.count(oldRes.index()) == 0)
           oldRes.value().replaceAllUsesWith(newFork.getResults()[i++]);
     });

--- a/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
+++ b/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
@@ -264,7 +264,7 @@ hw::ModulePortInfo getPortInfoForOpTypes(Operation *op, TypeRange inputs,
 
   // Add all inputs of funcOp.
   unsigned inIdx = 0;
-  for (auto &arg : llvm::enumerate(inputs)) {
+  for (auto arg : llvm::enumerate(inputs)) {
     ports.inputs.push_back({portNames.inputName(arg.index()),
                             hw::PortDirection::INPUT, esiWrapper(arg.value()),
                             arg.index(), hw::InnerSymAttr{}});
@@ -272,7 +272,7 @@ hw::ModulePortInfo getPortInfoForOpTypes(Operation *op, TypeRange inputs,
   }
 
   // Add all outputs of funcOp.
-  for (auto &res : llvm::enumerate(outputs)) {
+  for (auto res : llvm::enumerate(outputs)) {
     ports.outputs.push_back({portNames.outputName(res.index()),
                              hw::PortDirection::OUTPUT, esiWrapper(res.value()),
                              res.index(), hw::InnerSymAttr{}});

--- a/lib/Dialect/Interop/InteropOps.cpp
+++ b/lib/Dialect/Interop/InteropOps.cpp
@@ -133,7 +133,7 @@ LogicalResult ReturnOp::verify() {
            << " operands, but enclosing interop operation requires "
            << values.size() << " values";
 
-  for (auto &it :
+  for (auto it :
        llvm::enumerate(llvm::zip(getOperandTypes(), values.getTypes()))) {
     auto [returnOperandType, parentType] = it.value();
     if (returnOperandType != parentType)

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -137,7 +137,7 @@ void ExplicitRegsPass::runOnOperation() {
     stageOp.getValid().replaceAllUsesWith(newStageOp.getValid());
 
     // Replace backedges with the outputs of the new stage.
-    for (auto &it : llvm::enumerate(regMap)) {
+    for (auto it : llvm::enumerate(regMap)) {
       auto index = it.index();
       auto &[value, backedge] = it.value();
       backedge.setValue(newStageOp.getRegOuts()[index]);

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -295,7 +295,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   SmallVector<hw::PortInfo> ports;
   {
     auto srcPorts = op.getArgNames();
-    for (auto &port : llvm::enumerate(realInputs)) {
+    for (auto port : llvm::enumerate(realInputs)) {
       auto name = getNameForPort(port.value(), srcPorts);
       ports.push_back({name, hw::PortDirection::INPUT, port.value().getType(),
                        port.index()});
@@ -311,7 +311,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   newMod.setCommentAttr(b.getStringAttr("VCS coverage exclude_file"));
 
   // Update the mapping from old values to cloned values
-  for (auto &port : llvm::enumerate(realInputs)) {
+  for (auto port : llvm::enumerate(realInputs)) {
     cutMap.map(port.value(), newMod.getBody().getArgument(port.index()));
     for (auto extra : realReads[port.value()])
       cutMap.map(extra, newMod.getBody().getArgument(port.index()));

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -326,7 +326,7 @@ static void invalidateOutputs(ImplicitLocOpBuilder &builder, Value value,
 
   // Descend into bundles by creating subfield ops.
   if (auto bundleType = type.dyn_cast<firrtl::BundleType>()) {
-    for (auto &element : llvm::enumerate(bundleType.getElements())) {
+    for (auto element : llvm::enumerate(bundleType.getElements())) {
       auto subfield =
           builder.createOrFold<firrtl::SubfieldOp>(value, element.index());
       invalidateOutputs(builder, subfield, invalidCache,
@@ -366,7 +366,7 @@ static void connectToLeafs(ImplicitLocOpBuilder &builder, Value dest,
   if (!type)
     return;
   if (auto bundleType = type.dyn_cast<firrtl::BundleType>()) {
-    for (auto &element : llvm::enumerate(bundleType.getElements()))
+    for (auto element : llvm::enumerate(bundleType.getElements()))
       connectToLeafs(builder,
                      builder.create<firrtl::SubfieldOp>(dest, element.index()),
                      value);
@@ -400,7 +400,7 @@ static void reduceXor(ImplicitLocOpBuilder &builder, Value &into, Value value) {
   if (!type)
     return;
   if (auto bundleType = type.dyn_cast<firrtl::BundleType>()) {
-    for (auto &element : llvm::enumerate(bundleType.getElements()))
+    for (auto element : llvm::enumerate(bundleType.getElements()))
       reduceXor(
           builder, into,
           builder.createOrFold<firrtl::SubfieldOp>(value, element.index()));


### PR DESCRIPTION
Replace `auto &it : llvm::enumerate(...)` with `auto it : llvm::enumerate(...)` in preparation for this llvm change https://github.com/llvm/llvm-project/commit/a0a76804c4b56058ba3dcd7374bcaec2fec3978e. Based on the suggestions from this commit https://github.com/llvm/llvm-project/commit/8c258fda1f9b33fc847cfff9c2ee33ce4615ff0b