### PR TITLE
[SV] Added DPI import and call ops

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -51,6 +51,7 @@ include "circt/Dialect/SV/SVInOutOps.td"
 include "circt/Dialect/SV/SVGenerate.td"
 include "circt/Dialect/SV/SVStatements.td"
 include "circt/Dialect/SV/SVVerification.td"
+include "circt/Dialect/SV/SVDPI.td"
 include "circt/Dialect/SV/SVTypeDecl.td"
 
 #endif // CIRCT_DIALECT_SV_SV

--- a/include/circt/Dialect/SV/SVDPI.td
+++ b/include/circt/Dialect/SV/SVDPI.td
@@ -1,0 +1,73 @@
+//===- SVDPI.td - SV DPI Interface Ops ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the ops for SystemVerilog verification statements and
+// declarations.
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/FunctionInterfaces.td"
+
+def DPIImportOp : SVOp<"dpi.import", [
+        FunctionOpInterface,
+        Symbol,
+        HasParent<"mlir::ModuleOp">]> {
+  let summary = "Import a DPI-C function";
+  let description = [{
+    Represents a SV DPI-C import statement. Imports a C function for use.
+
+    ```
+    import "DPI-C" function void some_function(
+      input  bit[31:0] value_in,
+      output bit[31:0] value_out
+    )
+    ```
+  }];
+
+  // TODO: Add support for the `pure` attribute.
+  // TODO: Add support for return values.
+
+  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       StrArrayAttr:$argNames,
+                       StrArrayAttr:$resultNames);
+
+  let regions = (region AnyRegion:$body);
+
+  let extraClassDeclaration = [{
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+def DPICallOp : SVOp<"dpi.call", [
+        ProceduralOp,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Call a DPI-C function";
+  let description = [{
+    Invokes a DPI-C function from a procedural block.
+
+    ```
+    test(counter + 1, result)
+    ```
+  }];
+
+  // TODO: turn this into an arbitrary SV expression and support return types.
+
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$args);
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $args `)` attr-dict`:` functional-type($args, results)
+  }];
+}

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -14,9 +14,11 @@
 #define CIRCT_DIALECT_SV_OPS_H
 
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVTypes.h"
+#include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -44,6 +44,8 @@ public:
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
             ReadInterfaceSignalOp,
+            // DPI ops.
+            DPIImportOp, DPICallOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
             CoverConcurrentOp,
@@ -135,6 +137,10 @@ public:
   HANDLE(GetModportOp, Unhandled);
   HANDLE(AssignInterfaceSignalOp, Unhandled);
   HANDLE(ReadInterfaceSignalOp, Unhandled);
+
+  // DPI ops.
+  HANDLE(DPIImportOp, Unhandled);
+  HANDLE(DPICallOp, Unhandled);
 
   // Verification statements.
   HANDLE(AssertOp, Unhandled);

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -120,3 +120,12 @@ hw.module @UniformArrayCreate() -> (arr: !hw.array<5xi8>) {
   %arr = hw.array_create %c0_i8, %c0_i8, %c0_i8, %c0_i8, %c0_i8 : i8
   hw.output %arr : !hw.array<5xi8>
 }
+
+sv.dpi.import @test(%arg0: i32) -> (res0: i5, res1: i6)
+
+hw.module @top(%clk: i1, %arg1: i64) -> () {
+  %arg0 = hw.constant 0 : i32
+  sv.alwaysff(posedge %clk) {
+    %res0, %res1 = sv.dpi.call @test(%arg0) : (i32) -> (i5, i6)
+  }
+}

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3012,6 +3012,9 @@ private:
                             const SmallPtrSetImpl<Operation *> &locationOps,
                             StringRef multiLineComment = StringRef());
 
+  LogicalResult visitSV(DPIImportOp op);
+  LogicalResult visitSV(DPICallOp op);
+
 public:
   ModuleEmitter &emitter;
 
@@ -3091,6 +3094,9 @@ LogicalResult StmtEmitter::visitSV(AssignOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(BPAssignOp op) {
+  if (dyn_cast_or_null<DPICallOp>(op.getSrc().getDefiningOp()))
+    return success();
+
   // If the assign is emitted into logic declaration, we must not emit again.
   if (emitter.assignsInlined.count(op))
     return success();
@@ -4239,6 +4245,82 @@ LogicalResult StmtEmitter::visitSV(AssignInterfaceSignalOp op) {
   return success();
 }
 
+LogicalResult StmtEmitter::visitSV(DPIImportOp op) {
+  startStatement();
+
+  ps << "import \"DPI-C\" function void ";
+  ps << PPExtString(getSymOpName(op));
+  ps << "(";
+
+  ps.scopedBox(PP::bbox2, [&]() {
+    bool needsComma = false;
+    auto printArg = [&](StringRef kind, Attribute name, Type ty) {
+      if (needsComma)
+        ps << ",";
+      ps << PP::newline << kind << " ";
+
+      // Emit the type.
+      {
+        SmallString<8> typeString;
+        llvm::raw_svector_ostream stringStream(typeString);
+        emitter.printPackedType(stripUnpackedTypes(ty), stringStream,
+                                op->getLoc());
+        if (!typeString.empty())
+          ps << typeString;
+      }
+
+      ps << " " << PPExtString(name.cast<StringAttr>().getValue());
+
+      // Print out any array subscripts or other post-name stuff.
+      ps.invokeWithStringOS(
+          [&](auto &os) { emitter.printUnpackedTypePostfix(ty, os); });
+      needsComma = true;
+    };
+
+    for (const auto &[name, ty] :
+         llvm::zip(op.getArgNames(), op.getArgumentTypes()))
+      printArg("input ", name, ty);
+    for (const auto &[name, ty] :
+         llvm::zip(op.getResultNames(), op.getResultTypes()))
+      printArg("output", name, ty);
+  });
+
+  ps << PP::newline << ");" << PP::newline;
+  setPendingNewline();
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(DPICallOp op) {
+  startStatement();
+
+  auto topModuleOp = op->getParentOfType<ModuleOp>();
+  Operation *callee = topModuleOp.lookupSymbol(op.getCallee());
+
+  ps << PPExtString(getSymOpName(callee)) << "(";
+
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+
+  bool needsComma = false;
+  auto printArg = [&](Value value) {
+    if (needsComma)
+      ps << "," << PP::space;
+    emitExpression(value, ops);
+    needsComma = true;
+  };
+
+  ps.scopedBox(PP::ibox0, [&] {
+    for (Value arg : op.getArgs())
+      printArg(arg);
+    for (Value result : op.getResults())
+      printArg(result.getUsers().begin()->getOperand(0));
+  });
+
+  ps << ");";
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
 void StmtEmitter::emitStatement(Operation *op) {
   // Expressions may either be ignored or emitted as an expression statements.
   if (isVerilogExpression(op))
@@ -5095,7 +5177,7 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
           else
             rootFile.ops.push_back(info);
         })
-        .Case<VerbatimOp, IfDefOp>([&](Operation *op) {
+        .Case<VerbatimOp, IfDefOp, DPIImportOp>([&](Operation *op) {
           // Emit into a separate file using the specified file name or
           // replicate the operation in each outputfile.
           if (!attr) {
@@ -5192,7 +5274,7 @@ static void emitOperation(VerilogEmitterState &state, Operation *op) {
       .Case<BindOp>([&](auto op) { ModuleEmitter(state).emitBind(op); })
       .Case<BindInterfaceOp>(
           [&](auto op) { ModuleEmitter(state).emitBindInterface(op); })
-      .Case<InterfaceOp, VerbatimOp, IfDefOp>(
+      .Case<InterfaceOp, VerbatimOp, IfDefOp, DPIImportOp>(
           [&](auto op) { ModuleEmitter(state).emitStatement(op); })
       .Case<TypeScopeOp>([&](auto typedecls) {
         ModuleEmitter(state).emitStatement(typedecls);

--- a/test/Conversion/ExportVerilog/sv-dpi.mlir
+++ b/test/Conversion/ExportVerilog/sv-dpi.mlir
@@ -1,0 +1,22 @@
+// RUN: circt-opt %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+
+// CHECK:      import "DPI-C" function void test(
+// CHECK-NEXT:   input  [31:0] arg0,
+// CHECK-NEXT:   input  [63:0] arg1,
+// CHECK-NEXT:   output [4:0] res0,
+// CHECK-NEXT:   output [5:0] res1
+// CHECK-NEXT: );
+sv.dpi.import @test(%arg0: i32, %arg1: i64) -> (res0: i5, res1: i6)
+
+hw.module @top(%clk: i1, %arg1: i64) -> () {
+  %arg0 = hw.constant 0 : i32
+  %fd = hw.constant 0x80000002 : i32
+  // CHECK: reg [4:0] [[TMP_0:.+]];
+  // CHECK: reg [5:0] [[TMP_1:.+]];
+  sv.alwaysff(posedge %clk) {
+    // CHECK: test(32'h0, arg1, [[TMP_0]], [[TMP_1]]);
+    // CHECK: $fwrite(32'h80000002, "%d %d\n", [[TMP_0]], [[TMP_1]]);
+    %res0, %res1 = sv.dpi.call @test(%arg0, %arg1) : (i32, i64) -> (i5, i6)
+    sv.fwrite %fd, "%d %d\n"(%res0, %res1) : i5, i6
+  }
+}

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -229,3 +229,69 @@ hw.module @CaseEnum() {
       sv.fwrite %fd, "x"
     }
 }
+
+// -----
+
+hw.module @DPINoFunction(%clk: i1) -> () {
+  sv.alwaysff(posedge %clk) {
+    // expected-error @+1 {{Cannot find function definition 'no_declared_function'}}
+    sv.dpi.call @no_declared_function() : () -> ()
+  }
+}
+
+// -----
+
+sv.dpi.import @func(%arg0: i32) -> (res0: i5)
+
+hw.module @dpi_invalid_result_count(%clk: i1) -> () {
+  %arg0 = hw.constant 0 : i32
+  %arg1 = hw.constant 1 : i64
+  %fd = hw.constant 0x80000002 : i32
+  sv.alwaysff(posedge %clk) {
+    // expected-error @+1 {{2 results present, expected 1}}
+    %res0, %res1 = sv.dpi.call @func(%arg0) : (i32) -> (i5, i8)
+  }
+}
+
+// -----
+
+sv.dpi.import @func(%arg0: i32) -> (res0: i5)
+
+hw.module @dpi_invalid_result(%clk: i1) -> () {
+  %arg0 = hw.constant 0 : i32
+  %arg1 = hw.constant 1 : i64
+  %fd = hw.constant 0x80000002 : i32
+  sv.alwaysff(posedge %clk) {
+    // expected-error @+1 {{invalid result #0: expected 'i5', got 'i7'}}
+    %res2 = sv.dpi.call @func(%arg0) : (i32) -> (i7)
+  }
+}
+
+// -----
+
+sv.dpi.import @func(%arg0: i32) -> (res0: i5)
+
+hw.module @dpi_invalid_argument(%clk: i1) -> () {
+  %arg0 = hw.constant 0 : i32
+  %arg1 = hw.constant 1 : i64
+  %fd = hw.constant 0x80000002 : i32
+  sv.alwaysff(posedge %clk) {
+    // expected-error @+1 {{invalid argument #0: expected 'i32', got 'i64'}}
+    %res3 = sv.dpi.call @func(%arg1) : (i64) -> (i5)
+  }
+}
+
+// -----
+
+sv.dpi.import @func(%arg0: i32) -> (res0: i5)
+
+hw.module @dpi_invalid_argument_count(%clk: i1) -> () {
+  %arg0 = hw.constant 0 : i32
+  %arg1 = hw.constant 1 : i64
+  %fd = hw.constant 0x80000002 : i32
+  sv.alwaysff(posedge %clk) {
+    // expected-error @+1 {{2 arguments present, expected 1}}
+    %res4 = sv.dpi.call @func(%arg0, %arg1) : (i32, i64) -> (i5)
+  }
+}
+

--- a/test/Dialect/SV/round-trip.mlir
+++ b/test/Dialect/SV/round-trip.mlir
@@ -1,0 +1,4 @@
+// RUN: circt-opt %s --verify-diagnostics --split-input-file | circt-opt --verify-diagnostics | FileCheck %s
+
+// CHECK: sv.dpi.import @test(%arg0: i32, %arg1: i64) -> (res0: i5, res1: i6)
+sv.dpi.import @test(%arg0: i32, %arg1: i64) -> (res0: i5, res1: i6)


### PR DESCRIPTION
This PR introduces DPI import and call operations.

To import a function, the following can be declared at the module level:

```sv.dpi.import @test(%arg0: i32) -> (res0: i5, res1: i6)```

This is hard-wire to contextual functions.

To call a function, an op can be added to procedural scopes.

```%res0, %res1 = sv.dpi.call @test(%arg0) : (i32) -> (i5, i6)```

The emission is similar to instances. Temporary registers will be added to capture the results of DPI calls.

In the future, constraints should be relaxed to allow for return types and to place calls in arbitrary contexts.


