### PR TITLE
[SCFToCalyx] Add support for sequential read MemRefType memories

### DIFF
--- a/include/circt/Conversion/SCFToCalyx.h
+++ b/include/circt/Conversion/SCFToCalyx.h
@@ -21,9 +21,15 @@
 namespace circt {
 
 namespace scfToCalyx {
-// If this attribute is set as a FuncOp argument or result attribute, it will be
-// used as the Calyx port name.
+// If this string attribute is set as a FuncOp argument or result attribute, it
+// will be used as the Calyx port name.
 static constexpr std::string_view sPortNameAttr = "calyx.port_name";
+
+// If this bool attribute is set as a FuncOp argument of type MemRefType,
+// the memory will be considered as having sequential reads.
+// This adds a "read_en" signal to the external memory interface, driven by
+// memref::LoadOp.
+static constexpr std::string_view sSequentialReads = "calyx.sequential_reads";
 
 } // namespace scfToCalyx
 

--- a/integration_test/Dialect/Calyx/memory_sequential_reads.mlir
+++ b/integration_test/Dialect/Calyx/memory_sequential_reads.mlir
@@ -1,0 +1,12 @@
+// This test checks that the generated Calyx code has and drives the "read_en" signal to the external memory.
+// RUN: circt-opt %s \
+// RUN:     --lower-scf-to-calyx | FileCheck %s
+
+// CHECK: %ext_mem0_read_en: i1 {mem = {id = 0 : i32, tag = "read_en"}}
+// CHECK: calyx.group
+// CHECK: calyx.assign %ext_mem0_read_en = %true : i1
+func.func @main(%arg0 : i32, %arg1: memref<0xi32> {calyx.sequential_reads = true}) -> i32 {
+  %1 = arith.index_cast %arg0 : i32 to index
+  %2 = memref.load %arg1[%1] : memref<0xi32>
+  return %2 : i32
+}


### PR DESCRIPTION
If a FuncOp argument is of `MemRefType` and has the boolean attribute `calyx.sequential_reads` set to true, consider the read accesses to that memory as sequential, which adds a "read_en" signal to the external memory interface. This `read_en` signal is driven by a `memref::LoadOp` to a `memref` with sequential reads.

A register that stores the data read from memory and forwarded to the next group is created.

Currently, the memory access ports contain a single "done" signal, therefore it's not possible to perform a memory write and load at the same time.

This allows interfacing (with extra logic) with protocols such as AXI4.