### PR TITLE
[FIRParser] Don't try to parse LPKEYWORD as primitive.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1327,11 +1327,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
                                         bool isLeadingStmt) {
   switch (getToken().getKind()) {
 
-    // Handle all the primitive ops: primop exp* intLit*  ')'.  There is a
-    // redundant definition of TOK_LPKEYWORD_PRIM which is needed to get
-    // around a bug in the MSVC preprocessor to properly paste together the
-    // tokens lp_##SPELLING.
-#define TOK_LPKEYWORD(SPELLING) case FIRToken::lp_##SPELLING:
+    // Handle all primitive's.
 #define TOK_LPKEYWORD_PRIM(SPELLING, CLASS, NUMOPERANDS)                       \
   case FIRToken::lp_##SPELLING:
 #include "FIRTokenKinds.def"

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -304,3 +304,12 @@ circuit UnicodeEscape:
     input clk: Clock
     input enable: UInt<1>
     printf(clk, enable, "\u0065") ; expected-error {{unicode escape not supported in string}}
+
+;// -----
+
+circuit PrintfExpr:
+  module PrintfExpr:
+    input clk: Clock
+    input enable: UInt<1>
+    output out : UInt<1>
+    out <= printf(clk, enable, "b1") ; expected-error {{unexpected token in statement}}


### PR DESCRIPTION
Add test.

Previously the error produced for the test input was "primitive not supported yet".

MSVC seems to work in CI with this.

FWIW the issue was with `TOK_LPKEYWORD` defined and not `TOK_LPKEYWORD_PRIM`, so unsure if this would have worked when this workaround was added in 7e52d7c6f605b0f099cea26a39f9cc85f190d407.

None of the `TOK_LPKEYWORD`'s are expressions presently, and when adding such an operation in the future they should be handled separately from primitives (e.g., RefType's "read()" expression) so just narrow this to primitives.