### PR TITLE
[FIRRTL] Add canonicalizers for subaccesses on invalid values

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -212,6 +212,7 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue",
 
   let arguments = (ins);
   let results = (outs FIRRTLBaseType:$result);
+  let hasCanonicalizeMethod = 1;
 
   let assemblyFormat = "attr-dict `:` qualified(type($result))";
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2818,3 +2818,17 @@ void CoverOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                           MLIRContext *context) {
   results.add(canonicalizeImmediateVerifOp<CoverOp, /* EraseIfZero = */ true>);
 }
+
+//===----------------------------------------------------------------------===//
+// InvalidValueOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult InvalidValueOp::canonicalize(InvalidValueOp op,
+                                           PatternRewriter &rewriter) {
+  // Remove `InvalidValueOp`s with no uses.
+  if (op.use_empty()) {
+    rewriter.eraseOp(op);
+    return success();
+  }
+  return failure();
+}

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2611,4 +2611,11 @@ firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>
   firrtl.strictconnect %foo, %0 : !firrtl.uint<3>
 }
 
+// CHECK-LABEL: firrtl.module @RemoveUnusedInvalid
+firrtl.module @RemoveUnusedInvalid() {
+  // CHECK-NOT: firrtl.invalidvalue
+  %0 = firrtl.invalidvalue : !firrtl.uint<1>
+}
+// CHECK-NEXT: }
+
 }


### PR DESCRIPTION
Add canonicalizers for `SubfieldOp`, `SubindexOp`, and `SubaccessOp` on an `InvalidValueOp` input, replacing the subaccess with an `InvalidValueOp` of the field type.