### PR TITLE
[ExportVerilog] Remove unused output port wires

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -105,9 +105,11 @@ static void lowerInstanceResults(InstanceOp op) {
     auto result = op.getResult(nextResultNo);
     ++nextResultNo;
 
-    // If the result has no user, Emitter will omit the connection so don't
-    // create a wire for it.
-    if (result.use_empty())
+    // If the result doesn't have a user, the connection won't be emitted by
+    // Emitter, so there's no need to create a wire for it. However, if the
+    // result is a zero bit value, the normal emission code path should be used,
+    // as zero bit values require special handling by the emitter.
+    if (result.use_empty() && !ExportVerilog::isZeroBitType(result.getType()))
       continue;
 
     if (result.hasOneUse()) {

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -105,6 +105,11 @@ static void lowerInstanceResults(InstanceOp op) {
     auto result = op.getResult(nextResultNo);
     ++nextResultNo;
 
+    // If the result has no user, Emitter will omit the connection so don't
+    // create a wire for it.
+    if (result.use_empty())
+      continue;
+
     if (result.hasOneUse()) {
       OpOperand &use = *result.getUses().begin();
       if (dyn_cast_or_null<OutputOp>(use.getOwner()))

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1040,16 +1040,16 @@ hw.module @renameKeyword(%a: !hw.struct<repeat: i1, repeat_0: i1>) -> (r1: !hw.s
 // CHECK-NEXT:  inout  struct packed {logic repeat_0; logic repeat_0_0; } a,
 // CHECK-NEXT:  output                                                    r1,
 // CHECK-NEXT:                                                            r2,
-// CHECK-NEXT:  output struct packed {logic repeat_0; logic repeat_0_0; } r3
+// CHECK-NEXT:  output struct packed {logic repeat_0; logic repeat_0_0; } r3, 
+// CHECK-NEXT:                                                            r4
 // CHECK-NEXT:  );
-hw.module @useRenamedStruct(%a: !hw.inout<struct<repeat: i1, repeat_0: i1>>) -> (r1: i1, r2: i1, r3: !hw.struct<repeat: i1, repeat_0: i1>) {
-  // CHECK: wire struct packed {logic repeat_0; logic repeat_0_0; } _inst1_r1;
+hw.module @useRenamedStruct(%a: !hw.inout<struct<repeat: i1, repeat_0: i1>>) -> (r1: i1, r2: i1, r3: !hw.struct<repeat: i1, repeat_0: i1>, r4: !hw.struct<repeat: i1, repeat_0: i1>) {
   %read = sv.read_inout %a : !hw.inout<struct<repeat: i1, repeat_0: i1>>
 
   %i0 = hw.instance "inst1" @renameKeyword(a: %read: !hw.struct<repeat: i1, repeat_0: i1>) -> (r1: !hw.struct<repeat: i1, repeat_0: i1>)
   // CHECK:      renameKeyword inst1 (
   // CHECK-NEXT:   .a  (a),
-  // CHECK-NEXT:   .r1 (_inst1_r1)
+  // CHECK-NEXT:   .r1 (r4)
   // CHECK-NEXT: )
 
   %0 = sv.struct_field_inout %a["repeat"] : !hw.inout<struct<repeat: i1, repeat_0: i1>>
@@ -1060,7 +1060,7 @@ hw.module @useRenamedStruct(%a: !hw.inout<struct<repeat: i1, repeat_0: i1>>) -> 
   %true = hw.constant true
   %3 = hw.struct_inject %read["repeat_0"], %true : !hw.struct<repeat: i1, repeat_0: i1>
   // assign r3 = '{repeat_0: a.repeat_0, repeat_0_0: (1'h1)};
-  hw.output %1, %2, %3 : i1, i1, !hw.struct<repeat: i1, repeat_0: i1>
+  hw.output %1, %2, %3, %i0 : i1, i1, !hw.struct<repeat: i1, repeat_0: i1>, !hw.struct<repeat: i1, repeat_0: i1>
 }
 
 
@@ -1283,20 +1283,21 @@ hw.module @parameterizedArrays<param: i32, N: i32>
 // CHECK-LABEL: module UseParameterizedArrays(
 // CHECK-NEXT: input [41:0][11:0] a,
 // CHECK-NEXT: input [23:0][11:0] b
+// CHECK-NEXT: output [23:0][11:0] c
 // CHECK-NEXT: );
-hw.module @UseParameterizedArrays(%a: !hw.array<42xint<12>>, %b: !hw.array<24xint<12>>) {
-// CHECK:  wire [23:0][11:0] _inst_c;
+hw.module @UseParameterizedArrays(%a: !hw.array<42xint<12>>, %b: !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {
 // CHECK:  parameterizedArrays #(
 // CHECK-NEXT:    .param(12),
 // CHECK-NEXT:    .N(24)
 // CHECK-NEXT:  ) inst (
 // CHECK-NEXT:    .a (a),
 // CHECK-NEXT:    .b (b),
-// CHECK-NEXT:    .c (_inst_c)
+// CHECK-NEXT:    .c (c)
 // CHECK-NEXT:  );
 // CHECK-NEXT: endmodule
   %c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
     (a: %a : !hw.array<42xint<12>>, b: %b : !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {}
+  hw.output %c: !hw.array<24xint<12>>
 }
 
 // CHECK-LABEL: module NoneTypeParam

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -74,7 +74,7 @@ hw.module @inout(%inout: i1) -> (output: i1) {
 hw.module @inout_inst(%a: i1) {
   // CHECK: inout_0 foo (
   // CHECK:   .inout_0  (a),
-  // CHECK:   .output_0 (_foo_output)
+  // CHECK:   .output_0 (/* unused */)
   // CHECK: );
   %0 = hw.instance "foo" @inout (inout: %a: i1) -> (output: i1)
 }

--- a/test/Conversion/ExportVerilog/no-wrap.mlir
+++ b/test/Conversion/ExportVerilog/no-wrap.mlir
@@ -39,9 +39,12 @@ hw.module @TestZero(%a: i4, %zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHa
 // CHECK-NEXT: // input  [2:0]/*Zero Width*/ aarrZero
 // CHECK:      // output /*Zero Width*/      rZeroOutputWithAVeryLongNameYepThisToo
 
+// Wire:
+// CHECK: // Zero width: wire /*Zero Width*/ [[ZERO_WIRE:.+]];
+
 // Instance ports:
 // CHECK: //.zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime (azeroBit),
-// CHECK: //.rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo (/* unused */)
+// CHECK: //.rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo ([[ZERO_WIRE]])
 
 // Output:
 // CHECK: // Zero width: assign

--- a/test/Conversion/ExportVerilog/no-wrap.mlir
+++ b/test/Conversion/ExportVerilog/no-wrap.mlir
@@ -39,12 +39,9 @@ hw.module @TestZero(%a: i4, %zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHa
 // CHECK-NEXT: // input  [2:0]/*Zero Width*/ aarrZero
 // CHECK:      // output /*Zero Width*/      rZeroOutputWithAVeryLongNameYepThisToo
 
-// Wire:
-// CHECK: // Zero width: wire /*Zero Width*/ [[ZERO_WIRE:.+]];
-
 // Instance ports:
 // CHECK: //.zeroBitWithAVeryLongNameWhichMightSeemUnlikelyButHappensAllTheTime (azeroBit),
-// CHECK: //.rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo ([[ZERO_WIRE]])
+// CHECK: //.rZeroOutputWithAVeryLongName_YepThisToo_LongNamesAreTheWay_MoreText_GoGoGoGoGo (/* unused */)
 
 // Output:
 // CHECK: // Zero width: assign

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1793,7 +1793,7 @@ hw.module @NastyPort(%.lots$of.dots: i1) -> (".more.dots": i1) {
 sv.bind #hw.innerNameRef<@NastyPortParent::@foo>
 // CHECK-LABEL: bind NastyPortParent NastyPort foo (
 // CHECK-NEXT:    ._lots24of_dots (1'h0)
-// CHECK-NEXT:    ._more_dots     (_foo__more_dots)
+// CHECK-NEXT:    ._more_dots     (/* unused */)
 // CHECK-NEXT:  );
 
 sv.bind #hw.innerNameRef<@InlineBind::@foo1>


### PR DESCRIPTION
Implement https://github.com/llvm/circt/issues/4156. Maybe this could be problematic in some tools but VCS and Verilator are fine with this style. Spec seems OK with this style too: SV Spec 23.3.2.2
<img width="658" alt="Screen Shot 2023-03-21 at 21 41 04" src="https://user-images.githubusercontent.com/19691120/226608850-6de75262-adb4-4817-bd22-14f7f33e080f.png">

w/ PR:
```verilog
module Foo(
  output a
);

  Bar bar (
    .a (a),
    .b (/* unused */)
  );
endmodule
```

w/o PR:
```verilog
module Foo(
  output a
);

  wire _bar_b;
  Bar bar (
    .a (a),
    .b (_bar_b)
  );
endmodule
```
