### PR TITLE
[FIRRTL] prune duplicate conditions from mux trees

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1281,15 +1281,15 @@ public:
       return mux.getLow();
 
     if (Value v = tryCondTrue(mux.getHigh(), cond, rewriter))
-      return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                 rewriter, mux, mux.getType(),
-                 ValueRange{mux.getSel(), v, mux.getLow()})
+      return rewriter
+          .create<MuxPrimOp>(mux.getLoc(), mux.getType(),
+                             ValueRange{mux.getSel(), v, mux.getLow()})
           .getResult();
 
     if (Value v = tryCondTrue(mux.getLow(), cond, rewriter))
-      return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                 rewriter, mux, mux.getType(),
-                 ValueRange{mux.getSel(), mux.getHigh(), v})
+      return rewriter
+          .create<MuxPrimOp>(mux.getLoc(), mux.getType(),
+                             ValueRange{mux.getSel(), mux.getHigh(), v})
           .getResult();
     return {};
   }
@@ -1302,15 +1302,15 @@ public:
     if (mux.getSel() == cond)
       return mux.getHigh();
     if (Value v = tryCondFalse(mux.getHigh(), cond, rewriter))
-      return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                 rewriter, mux, mux.getType(),
-                 ValueRange{mux.getSel(), v, mux.getLow()})
+      return rewriter
+          .create<MuxPrimOp>(mux.getLoc(), mux.getType(),
+                             ValueRange{mux.getSel(), v, mux.getLow()})
           .getResult();
 
     if (Value v = tryCondFalse(mux.getLow(), cond, rewriter))
-      return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                 rewriter, mux, mux.getType(),
-                 ValueRange{mux.getSel(), mux.getHigh(), v})
+      return rewriter
+          .create<MuxPrimOp>(mux.getLoc(), mux.getType(),
+                             ValueRange{mux.getSel(), mux.getHigh(), v})
           .getResult();
     return {};
   }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1272,6 +1272,7 @@ public:
   MuxSharedCond(MLIRContext *context)
       : RewritePattern(MuxPrimOp::getOperationName(), 0, context) {}
 
+  // Walk a dependent mux tree assuming the condition cond is true.
   Value tryCondTrue(Value op, Value cond,
                     mlir::PatternRewriter &rewriter) const {
     MuxPrimOp mux = op.getDefiningOp<MuxPrimOp>();
@@ -1294,6 +1295,7 @@ public:
     return {};
   }
 
+  // Walk a dependent mux tree assuming the condition cond is false.
   Value tryCondFalse(Value op, Value cond,
                      mlir::PatternRewriter &rewriter) const {
     MuxPrimOp mux = op.getDefiningOp<MuxPrimOp>();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1265,89 +1265,89 @@ public:
   }
 };
 
-  class MuxSharedCond : public mlir::RewritePattern {
-  public:
-    MuxSharedCond(MLIRContext *context)
-        : RewritePattern(MuxPrimOp::getOperationName(), 0, context) {}
+// Find muxes which have conditions dominated by other muxes with the same
+// condition.
+class MuxSharedCond : public mlir::RewritePattern {
+public:
+  MuxSharedCond(MLIRContext *context)
+      : RewritePattern(MuxPrimOp::getOperationName(), 0, context) {}
 
-    Value tryCondTrue(MuxPrimOp mux, Value cond,
-                      mlir::PatternRewriter &rewriter) const {
-      if (mux.getSel() == cond)
-        return mux.getLow();
+  Value tryCondTrue(MuxPrimOp mux, Value cond,
+                    mlir::PatternRewriter &rewriter) const {
+    if (mux.getSel() == cond)
+      return mux.getLow();
 
-      if (auto trueMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
-        if (Value v = tryCondTrue(trueMux, cond, rewriter))
-          return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                     rewriter, mux, mux.getType(),
-                     ValueRange{mux.getSel(), v, mux.getLow()})
-              .getResult();
+    if (auto trueMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
+      if (Value v = tryCondTrue(trueMux, cond, rewriter))
+        return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+                   rewriter, mux, mux.getType(),
+                   ValueRange{mux.getSel(), v, mux.getLow()})
+            .getResult();
 
-      if (auto falseMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
-        if (Value v = tryCondTrue(falseMux, cond, rewriter))
-          return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                     rewriter, mux, mux.getType(),
-                     ValueRange{mux.getSel(), mux.getHigh(), v})
-              .getResult();
-      return {};
-    }
+    if (auto falseMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
+      if (Value v = tryCondTrue(falseMux, cond, rewriter))
+        return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+                   rewriter, mux, mux.getType(),
+                   ValueRange{mux.getSel(), mux.getHigh(), v})
+            .getResult();
+    return {};
+  }
 
-    Value tryCondFalse(MuxPrimOp mux, Value cond,
-                       mlir::PatternRewriter &rewriter) const {
-      if (mux.getSel() == cond)
-        return mux.getHigh();
+  Value tryCondFalse(MuxPrimOp mux, Value cond,
+                     mlir::PatternRewriter &rewriter) const {
+    if (mux.getSel() == cond)
+      return mux.getHigh();
 
-      if (auto trueMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
-        if (Value v = tryCondTrue(trueMux, cond, rewriter))
-          return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                     rewriter, mux, mux.getType(),
-                     ValueRange{mux.getSel(), v, mux.getLow()})
-              .getResult();
+    if (auto trueMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
+      if (Value v = tryCondTrue(trueMux, cond, rewriter))
+        return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+                   rewriter, mux, mux.getType(),
+                   ValueRange{mux.getSel(), v, mux.getLow()})
+            .getResult();
 
-      if (auto falseMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
-        if (Value v = tryCondTrue(falseMux, cond, rewriter))
-          return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-                     rewriter, mux, mux.getType(),
-                     ValueRange{mux.getSel(), mux.getHigh(), v})
-              .getResult();
-      return {};
-    }
+    if (auto falseMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
+      if (Value v = tryCondTrue(falseMux, cond, rewriter))
+        return replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+                   rewriter, mux, mux.getType(),
+                   ValueRange{mux.getSel(), mux.getHigh(), v})
+            .getResult();
+    return {};
+  }
 
-    LogicalResult
-    matchAndRewrite(Operation *op,
-                    mlir::PatternRewriter &rewriter) const override {
-      auto mux = cast<MuxPrimOp>(op);
-      auto width = mux.getType().getBitWidthOrSentinel();
-      if (width < 0)
-        return failure();
-
-      if (auto trueMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
-        if (Value v = tryCondTrue(trueMux, mux.getSel(), rewriter)) {
-          replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-              rewriter, op, mux.getType(),
-              ValueRange{mux.getSel(), v, mux.getLow()});
-          return success();
-        }
-
-      if (auto falseMux =
-              dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
-        if (Value v = tryCondFalse(falseMux, mux.getSel(), rewriter)) {
-          replaceOpWithNewOpAndCopyName<MuxPrimOp>(
-              rewriter, op, mux.getType(),
-              ValueRange{mux.getSel(), mux.getHigh(), v});
-          return success();
-        }
-
+  LogicalResult
+  matchAndRewrite(Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto mux = cast<MuxPrimOp>(op);
+    auto width = mux.getType().getBitWidthOrSentinel();
+    if (width < 0)
       return failure();
-    }
-  };
+
+    if (auto trueMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getHigh().getDefiningOp()))
+      if (Value v = tryCondTrue(trueMux, mux.getSel(), rewriter)) {
+        replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+            rewriter, op, mux.getType(),
+            ValueRange{mux.getSel(), v, mux.getLow()});
+        return success();
+      }
+
+    if (auto falseMux =
+            dyn_cast_or_null<MuxPrimOp>(mux.getLow().getDefiningOp()))
+      if (Value v = tryCondFalse(falseMux, mux.getSel(), rewriter)) {
+        replaceOpWithNewOpAndCopyName<MuxPrimOp>(
+            rewriter, op, mux.getType(),
+            ValueRange{mux.getSel(), mux.getHigh(), v});
+        return success();
+      }
+
+    return failure();
+  }
+};
 } // namespace
-
-
 
 void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1859,6 +1859,32 @@ firrtl.module @MuxCanon(in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, in %d1
   // CHECK: firrtl.cat %[[mux2]], %d2
 }
 
+// CHECK-LABEL: firrtl.module @MuxShorten
+firrtl.module @MuxShorten(
+  in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, 
+  in %d1: !firrtl.uint<5>, in %d2: !firrtl.uint<5>, 
+  in %d3: !firrtl.uint<5>, in %d4: !firrtl.uint<5>, 
+  in %d5: !firrtl.uint<5>, in %d6: !firrtl.uint<5>, 
+  out %foo: !firrtl.uint<5>, out %foo2: !firrtl.uint<5>) {
+
+  %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %1 = firrtl.mux(%c2, %0, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %2 = firrtl.mux(%c1, %d4, %d5) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %3 = firrtl.mux(%c2, %2, %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %11 = firrtl.mux(%c1, %1, %3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  firrtl.connect %foo, %11 : !firrtl.uint<5>, !firrtl.uint<5>
+  firrtl.connect %foo2, %3 : !firrtl.uint<5>, !firrtl.uint<5>
+
+  // CHECK: %[[n1:.*]] = firrtl.mux(%c2, %d3, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: %[[rem1:.*]] = firrtl.mux(%c1, %d4, %d5) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: %[[rem:.*]] = firrtl.mux(%c2, %[[rem1]], %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: %[[n2:.*]] = firrtl.mux(%c2, %d4, %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: %[[prim:.*]] = firrtl.mux(%c1, %[[n1]], %[[n2]]) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: firrtl.strictconnect %foo, %[[prim]] : !firrtl.uint<5> 
+  // CHECK: firrtl.strictconnect %foo2, %[[rem]] : !firrtl.uint<5> 
+}
+
+
 // CHECK-LABEL: firrtl.module @RegresetToReg
 firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1875,13 +1875,13 @@ firrtl.module @MuxShorten(
   firrtl.connect %foo, %11 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo2, %3 : !firrtl.uint<5>, !firrtl.uint<5>
 
-  // CHECK: %[[n1:.*]] = firrtl.mux(%c2, %d3, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: %[[rem1:.*]] = firrtl.mux(%c1, %d4, %d5) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: %[[rem:.*]] = firrtl.mux(%c2, %[[rem1]], %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: %[[n2:.*]] = firrtl.mux(%c2, %d4, %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: %[[prim:.*]] = firrtl.mux(%c1, %[[n1]], %[[n2]]) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: firrtl.strictconnect %foo, %[[prim]] : !firrtl.uint<5> 
-  // CHECK: firrtl.strictconnect %foo2, %[[rem]] : !firrtl.uint<5> 
+  // CHECK: %[[n1:.*]] = firrtl.mux(%c2, %d3, %d1)
+  // CHECK: %[[rem1:.*]] = firrtl.mux(%c1, %d4, %d5)
+  // CHECK: %[[rem:.*]] = firrtl.mux(%c2, %[[rem1]], %d6)
+  // CHECK: %[[n2:.*]] = firrtl.mux(%c2, %d4, %d6)
+  // CHECK: %[[prim:.*]] = firrtl.mux(%c1, %[[n1]], %[[n2]])
+  // CHECK: firrtl.strictconnect %foo, %[[prim]]
+  // CHECK: firrtl.strictconnect %foo2, %[[rem]]
 }
 
 


### PR DESCRIPTION
This is simple and only considers identity on mux conditions.  A more complete solution would look for complex conditions which are guaranteed by the mux cond assumption.
closes #4871