### PR TITLE
[FIRRTL] Merge constants in concatinations and drop double inversion

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -115,8 +115,8 @@ def GTWithConstLHS : Pat<
 
 // not(not(x)) -> x
 def NotNot : Pat <
-  (NotPrimOp (NotPrimOp $x)),
-  (AsUIntPrimOp $x),
+  (NotPrimOp:$old (NotPrimOp $x)),
+  (MoveNameHint $old, (AsUIntPrimOp $x)),
   []>;
 
 // connect(a:t,b:t) -> strictconnect(a,b)
@@ -357,7 +357,7 @@ def NarrowMuxRHS : Pat <
 
 def CatDoubleConst : Pat <
   (CatPrimOp:$old $cst1, (CatPrimOp $cst2, $v)),
-  (MoveNameHint $old, (CatPrimOp (CatPrimOp $cst1, $cst2), $v)),
+  (MoveNameHint $old, (CatPrimOp (CatPrimOp $cst1, (AsUIntPrimOp $cst2)), (AsUIntPrimOp $v))),
   [(KnownWidth $v), (AnyConstantOp $cst1), (AnyConstantOp $cst2)]>;
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -113,6 +113,12 @@ def GTWithConstLHS : Pat<
   (MoveNameHint $old, (LTPrimOp $rhs, $lhs)),
   [(AnyConstantOp $lhs), (NonConstantOp $rhs)]>;
 
+// not(not(x)) -> x
+def NotNot : Pat <
+  (NotPrimOp (NotPrimOp $x)),
+  (AsUIntPrimOp $x),
+  []>;
+
 // connect(a:t,b:t) -> strictconnect(a,b)
 def ConnectSameType : Pat<
   (ConnectOp $dst, $src),

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -349,6 +349,11 @@ def NarrowMuxRHS : Pat <
   (MoveNameHint $old, (CatPrimOp (MuxPrimOp $cond, $a, $c), $b)),
   [(EqualTypes $lhs, $rhs), (KnownWidth $lhs)]>;
 
+def CatDoubleConst : Pat <
+  (CatPrimOp:$old $cst1, (CatPrimOp $cst2, $v)),
+  (MoveNameHint $old, (CatPrimOp (CatPrimOp $cst1, $cst2), $v)),
+  [(KnownWidth $v), (AnyConstantOp $cst1), (AnyConstantOp $cst2)]>;
+
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegResetWithZeroReset : Pat<
   (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym),

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -492,6 +492,7 @@ def AsAsyncResetPrimOp
 def AsClockPrimOp : UnaryPrimOp<"asClock", OneBitCastableType, ClockType>;
 def CvtPrimOp : UnaryPrimOp<"cvt", IntType, SIntType>;
 def NegPrimOp : UnaryPrimOp<"neg", IntType, SIntType>;
+let hasCanonicalizer = true in
 def NotPrimOp : UnaryPrimOp<"not", IntType, UIntType>;
 
 let inferType = "impl::inferReductionResult" in {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1003,6 +1003,11 @@ OpFoldResult NotPrimOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+void NotPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::NotNot>(context);
+}
+
 OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1124,7 +1124,7 @@ struct CatBitsBits : public mlir::RewritePattern {
 
 void CatPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
-  results.insert<CatBitsBits>(context);
+  results.insert<CatBitsBits, patterns::CatDoubleConst>(context);
 }
 
 OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -254,6 +254,22 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
+// CHECK-LABEL: firrtl.module @Not
+firrtl.module @Not(in %in: !firrtl.uint<4>,
+                   in %sin: !firrtl.sint<4>,
+                   out %outu: !firrtl.uint<4>,
+                   out %outs: !firrtl.uint<4>) {
+  %0 = firrtl.not %in : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.not %0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
+  %2 = firrtl.not %sin : (!firrtl.sint<4>) -> !firrtl.uint<4>
+  %3 = firrtl.not %2 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %outs, %3 : !firrtl.uint<4>, !firrtl.uint<4>
+  // CHECK: firrtl.strictconnect %outu, %in
+  // CHECK: %[[cast:.*]] = firrtl.asUInt %sin
+  // CHECK: firrtl.strictconnect %outs, %[[cast]]
+}
+
 // CHECK-LABEL: firrtl.module @EQ
 firrtl.module @EQ(in %in1: !firrtl.uint<1>,
                   in %in4: !firrtl.uint<4>,

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -335,12 +335,15 @@ firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
 
 // CHECK-LABEL: firrtl.module @Cat
 firrtl.module @Cat(in %in4: !firrtl.uint<4>,
+                   in %sin4: !firrtl.sint<4>,
                    out %out4: !firrtl.uint<4>,
                    out %outcst: !firrtl.uint<8>,
                    out %outcst2: !firrtl.uint<8>,
                    in %in0 : !firrtl.uint<0>,
                    out %outpt1: !firrtl.uint<4>,
                    out %outpt2 : !firrtl.uint<4>) {
+  %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+  %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
 
   // CHECK: firrtl.strictconnect %out4, %in4
   %0 = firrtl.bits %in4 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
@@ -360,6 +363,17 @@ firrtl.module @Cat(in %in4: !firrtl.uint<4>,
   // CHECK: firrtl.strictconnect %outpt2, %in4
   %6 = firrtl.cat %in4, %in0 : (!firrtl.uint<4>, !firrtl.uint<0>) -> !firrtl.uint<4>
   firrtl.connect %outpt2, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.cat %c0_ui4, %in4
+  %7 = firrtl.cat %c0_ui2, %in4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<6>
+  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<6>) -> !firrtl.uint<8>
+  firrtl.connect %outcst, %8 : !firrtl.uint<8>, !firrtl.uint<8>
+
+  // CHECK: firrtl.asUInt %sin4
+  // CHECK-NEXT: firrtl.cat %c0_ui4
+  %9  = firrtl.cat %c0_si2, %sin4 : (!firrtl.sint<2>, !firrtl.sint<4>) -> !firrtl.uint<6>
+  %10 = firrtl.cat %c0_ui2, %9 : (!firrtl.uint<2>, !firrtl.uint<6>) -> !firrtl.uint<8>
+  firrtl.connect %outcst, %10 : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
 // CHECK-LABEL: firrtl.module @Bits


### PR DESCRIPTION
Rearrange constants in concatination strings to enable constant merging.
bypass double inversions.