### PR TITLE
[LowerSeqToSV] Tweak register initialization

### DIFF
--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -217,11 +217,17 @@ void FirRegLower::lower() {
   for (auto reg : toInit)
     if (reg.randStart >= 0)
       maxBit = std::max(maxBit, (uint64_t)reg.randStart + reg.width);
-  for (auto &reg : toInit)
+
+  // This is a map from async reset signals to register info.
+  llvm::MapVector<Value, SmallVector<RegLowerInfo>> asyncResets;
+  for (auto &reg : toInit) {
     if (reg.randStart == -1) {
       reg.randStart = maxBit;
       maxBit += reg.width;
     }
+    if (reg.asyncResetSignal)
+      asyncResets[reg.asyncResetSignal].emplace_back(reg);
+  }
 
   // Create an initial block at the end of the module where random
   // initialisation will be inserted.  Create two builders into the two
@@ -235,7 +241,7 @@ void FirRegLower::lower() {
   //     `INIT_RANDOM_PROLOG_
   //     ... initBuilder ..
   // `endif
-  if (toInit.empty() || disableRegRandomization)
+  if (toInit.empty() || (disableRegRandomization && asyncResets.empty()))
     return;
 
   auto loc = module.getLoc();
@@ -244,6 +250,7 @@ void FirRegLower::lower() {
 
   auto builder =
       ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
+
   builder.create<sv::IfDefOp>(
       "SYNTHESIS", [] {},
       [&] {
@@ -253,51 +260,42 @@ void FirRegLower::lower() {
           });
 
           builder.create<sv::InitialOp>([&] {
-            builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
-              builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
-            });
-            llvm::MapVector<Value, SmallVector<RegLowerInfo>> resets;
-            builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
-              // Create randomization vector
-              SmallVector<Value> randValues;
-              for (uint64_t x = 0; x < (maxBit + 31) / 32; ++x) {
-                auto lhs =
-                    builder.create<sv::LogicOp>(loc, builder.getIntegerType(32),
-                                                "_RANDOM_" + llvm::utostr(x));
-                auto rhs = builder.create<sv::MacroRefExprSEOp>(
-                    loc, builder.getIntegerType(32), "RANDOM");
-                builder.create<sv::BPAssignOp>(loc, lhs, rhs);
-                randValues.push_back(lhs.getResult());
-              }
-
-              // Create initialisers for all registers.
-              for (auto &svReg : toInit) {
-                initialize(builder, svReg, randValues);
-
-                if (svReg.asyncResetSignal)
-                  resets[svReg.asyncResetSignal].emplace_back(svReg);
-              }
-            });
-
-            if (!resets.empty()) {
-              builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
-                // If the register is async reset, we need to insert extra
-                // initialization in post-randomization so that we can set the
-                // reset value to register if the reset signal is enabled.
-                for (auto &reset : resets) {
-                  // Create a block guarded by the RANDOMIZE macro and the
-                  // reset: `ifdef RANDOMIZE
-                  //   if (reset) begin
-                  //     ..
-                  //   end
-                  // `endif
-                  builder.create<sv::IfOp>(reset.first, [&] {
-                    for (auto &reg : reset.second)
-                      builder.create<sv::BPAssignOp>(reg.reg.getLoc(), reg.reg,
-                                                     reg.asyncResetValue);
-                  });
-                }
+            if (!disableRegRandomization) {
+              builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
+                builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
               });
+              builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
+                // Create randomization vector
+                SmallVector<Value> randValues;
+                for (uint64_t x = 0; x < (maxBit + 31) / 32; ++x) {
+                  auto lhs = builder.create<sv::LogicOp>(
+                      loc, builder.getIntegerType(32),
+                      "_RANDOM_" + llvm::utostr(x));
+                  auto rhs = builder.create<sv::MacroRefExprSEOp>(
+                      loc, builder.getIntegerType(32), "RANDOM");
+                  builder.create<sv::BPAssignOp>(loc, lhs, rhs);
+                  randValues.push_back(lhs.getResult());
+                }
+
+                // Create initialisers for all registers.
+                for (auto &svReg : toInit)
+                  initialize(builder, svReg, randValues);
+              });
+            }
+            if (!asyncResets.empty()) {
+              // If the register is async reset, we need to insert extra
+              // initialization in post-randomization so that we can set the
+              // reset value to register if the reset signal is enabled.
+              for (auto &reset : asyncResets) {
+                //  if (reset) begin
+                //    ..
+                //  end
+                builder.create<sv::IfOp>(reset.first, [&] {
+                  for (auto &reg : reset.second)
+                    builder.create<sv::BPAssignOp>(reg.reg.getLoc(), reg.reg,
+                                                   reg.asyncResetValue);
+                });
+              }
             }
           });
 

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -113,11 +113,9 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
   // CHECK-NEXT:          %15 = sv.read_inout %_RANDOM_7 : !hw.inout<i32>
   // CHECK-NEXT:          sv.bpassign %rNoSym, %15 : i32
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE" {
-  // CHECK-NEXT:         sv.if %rst {
-  // CHECK-NEXT:           sv.bpassign %rC, %c0_i32 : i32
-  // CHECK-NEXT:           sv.bpassign %rF, %c0_i32 : i32
-  // CHECK-NEXT:         }
+  // CHECK-NEXT:       sv.if %rst {
+  // CHECK-NEXT:         sv.bpassign %rC, %c0_i32 : i32
+  // CHECK-NEXT:         sv.bpassign %rF, %c0_i32 : i32
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
@@ -228,44 +226,44 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   %3 = comb.extract %2 from 1 : (i33) -> i32
   %4 = comb.mux bin %io_en, %io_d, %3 : i32
 
-  // CHECK:      %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
-  // CHECK-NEXT: %0 = sv.read_inout %reg : !hw.inout<i32>
-  // CHECK-NEXT: %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
-  // CHECK-NEXT: %1 = sv.read_inout %reg2 : !hw.inout<i32>
-  // CHECK-NEXT: %reg3 = sv.reg sym @[[reg3_sym:.+]] : !hw.inout<i32
-  // CHECK-NEXT: %2 = sv.read_inout %reg3 : !hw.inout<i32>
-  // CHECK-NEXT: %3 = comb.concat %false, %0 : i1, i32
-  // CHECK-NEXT: %4 = comb.concat %false, %1 : i1, i32
-  // CHECK-NEXT: %5 = comb.add %3, %4 : i33
-  // CHECK-NEXT: %6 = comb.extract %5 from 1 : (i33) -> i32
-  // CHECK-NEXT: %7 = comb.mux bin %io_en, %io_d, %6 : i32
-  // CHECK-NEXT: sv.always posedge %clock, posedge %reset  {
-  // CHECK-NEXT:   sv.if %reset {
-  // CHECK-NEXT:     sv.passign %reg, %c0_i32 : i32
-  // CHECK-NEXT:     sv.passign %reg3, %c1_i32 : i32
-  // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     sv.if %io_en {
-  // CHECK-NEXT:       sv.passign %reg, %io_d : i32
-  // CHECK-NEXT:     } else {
-  // CHECK-NEXT:       sv.passign %reg, %6 : i32
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.passign %reg3, %2 : i32
-  // CHECK-NEXT:   }
-  // CHECK-NEXT: }
-  // CHECK-NEXT: sv.always posedge %clock  {
-  // CHECK-NEXT:   sv.if %reset  {
-  // CHECK-NEXT:     sv.passign %reg2, %c0_i32 : i32
-  // CHECK-NEXT:   } else  {
-  // CHECK-NEXT:   }
-  // CHECK-NEXT: }
-  // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
-  // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // COMMON:       %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
+  // COMMON-NEXT:  %0 = sv.read_inout %reg : !hw.inout<i32>
+  // COMMON-NEXT:  %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
+  // COMMON-NEXT:  %1 = sv.read_inout %reg2 : !hw.inout<i32>
+  // COMMON-NEXT:  %reg3 = sv.reg sym @[[reg3_sym:.+]] : !hw.inout<i32
+  // COMMON-NEXT:  %2 = sv.read_inout %reg3 : !hw.inout<i32>
+  // COMMON-NEXT:  %3 = comb.concat %false, %0 : i1, i32
+  // COMMON-NEXT:  %4 = comb.concat %false, %1 : i1, i32
+  // COMMON-NEXT:  %5 = comb.add %3, %4 : i33
+  // COMMON-NEXT:  %6 = comb.extract %5 from 1 : (i33) -> i32
+  // COMMON-NEXT:  %7 = comb.mux bin %io_en, %io_d, %6 : i32
+  // COMMON-NEXT:  sv.always posedge %clock, posedge %reset  {
+  // COMMON-NEXT:    sv.if %reset {
+  // COMMON-NEXT:      sv.passign %reg, %c0_i32 : i32
+  // COMMON-NEXT:      sv.passign %reg3, %c1_i32 : i32
+  // COMMON-NEXT:    } else {
+  // COMMON-NEXT:      sv.if %io_en {
+  // COMMON-NEXT:        sv.passign %reg, %io_d : i32
+  // COMMON-NEXT:      } else {
+  // COMMON-NEXT:        sv.passign %reg, %6 : i32
+  // COMMON-NEXT:      }
+  // COMMON-NEXT:      sv.passign %reg3, %2 : i32
+  // COMMON-NEXT:    }
+  // COMMON-NEXT:  }
+  // COMMON-NEXT:  sv.always posedge %clock  {
+  // COMMON-NEXT:    sv.if %reset  {
+  // COMMON-NEXT:      sv.passign %reg2, %c0_i32 : i32
+  // COMMON-NEXT:    } else  {
+  // COMMON-NEXT:    }
+  // COMMON-NEXT:  }
+  // COMMON-NEXT:  sv.ifdef "SYNTHESIS"  {
+  // COMMON-NEXT:  } else {
+  // COMMON-NEXT:    sv.ordered {
+  // COMMON-NEXT:      sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // COMMON-NEXT:        sv.verbatim "`FIRRTL_BEFORE_INITIAL"
+  // COMMON-NEXT:      }
+  // COMMON-NEXT:      sv.initial {
+  // CHECK:            sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
@@ -285,19 +283,17 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
   // CHECK-NEXT:         %10 = sv.read_inout %_RANDOM_2 : !hw.inout<i32>
   // CHECK-NEXT:         sv.bpassign %reg3, %10 : i32
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE"  {
-  // CHECK-NEXT:         sv.if %reset {
-  // CHECK-NEXT:           sv.bpassign %reg, %c0_i32 : i32
-  // CHECK-NEXT:           sv.bpassign %reg3, %c1_i32 : i32
-  // CHECK-NEXT:         }
-  // CHECK-NEXT:       }
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
-  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:   }
-  // CHECK-NEXT: }
-  // CHECK-NEXT: hw.output %0 : i32
+  // COMMON-NEXT:      sv.if %reset {
+  // COMMON-NEXT:        sv.bpassign %reg, %c0_i32 : i32
+  // COMMON-NEXT:        sv.bpassign %reg3, %c1_i32 : i32
+  // COMMON-NEXT:      }
+  // COMMON-NEXT:    }
+  // COMMON-NEXT:    sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // COMMON-NEXT:      sv.verbatim "`FIRRTL_AFTER_INITIAL"
+  // COMMON-NEXT:    }
+  // COMMON-NEXT:  }
+  // COMMON-NEXT: }
+  // COMMON-NEXT: hw.output %0 : i32
   hw.output %reg : i32
 }
 


### PR DESCRIPTION
This PR fixes two issues:
* Async reset registers are not initialized with "disable-register-randomization": https://github.com/llvm/circt/issues/4835
* Remove `RANDOMIZE` ifdef guard around async register initialization

Close #4835.