### PR TITLE
[ModuleInliner] Mark nla as dead, before removing the nonlocal annotation

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -682,8 +682,6 @@ void Inliner::rename(StringRef prefix, Operation *op,
           auto &mnla = nlaMap[nla];
           mnla.setInnerSym(moduleNamespace.module.moduleNameAttr(), newSymAttr);
         }
-        auto oldInnerRef = InnerRefAttr::get(instanceParent, oldInstSym);
-        instOpHierPaths.erase(oldInnerRef);
       }
     }
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1121,13 +1121,13 @@ firrtl.circuit "Top" {
 // Due to coincidental name collisions, renaming was not updating the actual hierpath.
 firrtl.circuit "Bug4882Rename"  {
   hw.hierpath private @nla_5560 [@Bug4882Rename::@w, @Bar2::@x]
-  firrtl.module @Bar2() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module private @Bar2() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %x = firrtl.wire sym @x  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} : !firrtl.uint<8>
   }
-  firrtl.module @Bar1() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module private @Bar1() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     firrtl.instance bar3 sym @w  @Bar3()
   }
-  firrtl.module @Bar3()  {
+  firrtl.module private @Bar3()  {
     %w = firrtl.wire sym @w1   : !firrtl.uint<8>
   }
   firrtl.module @Bug4882Rename() {

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1113,3 +1113,28 @@ firrtl.circuit "Top" {
     firrtl.refconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
 }
+
+// -----
+
+// PR #4882 fixes a bug, which was producing invalid  NLAs.
+// error: 'hw.hierpath' op  module: "instNameRename" does not contain any instance with symbol: "w"
+// Due to coincidental name collisions, renaming was not updating the actual hierpath.
+firrtl.circuit "Bug4882Rename"  {
+  hw.hierpath private @nla_5560 [@Bug4882Rename::@w, @Bar2::@x]
+  firrtl.module @Bar2() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %x = firrtl.wire sym @x  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} : !firrtl.uint<8>
+  }
+  firrtl.module @Bar1() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    firrtl.instance bar3 sym @w  @Bar3()
+  }
+  firrtl.module @Bar3()  {
+    %w = firrtl.wire sym @w1   : !firrtl.uint<8>
+  }
+  firrtl.module @Bug4882Rename() {
+  // CHECK-LABEL: firrtl.module @Bug4882Rename() {
+    firrtl.instance no sym @no  @Bar1()
+    // CHECK-NEXT: firrtl.instance no_bar3 sym @w_0 @Bar3()
+    firrtl.instance bar2 sym @w  @Bar2()
+    // CHECK-NEXT: %bar2_x = firrtl.wire sym @x {annotations = [{class = "test0"}]}
+  }
+}


### PR DESCRIPTION
Some unused (dead) `hierpath` are escaping the `ModuleInliner`, resulting in invalid paths and the verifier to fail.
If a module is inlined, and it has any non-local `InlineAnnotation`, then the `hw.hierpath` must also be erased.
In the default case, the `hierpath` on an inlined module is marked as dead, when traversing the `instance` at which the module is inlined. 
But if the nla is leftover and not marked dead, it must be removed during the cleanup.
