### PR TITLE
Enhance Upload Firtool Binaries

### DIFF
--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -66,6 +66,7 @@ jobs:
               -DCMAKE_C_COMPILER=${{ matrix.cc }} \
               -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
               -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} \
+              -DLLVM_BUILD_TOOLS=OFF \
               -DLLVM_BUILD_EXAMPLES=OFF \
               -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} \
               -DLLVM_ENABLE_BINDINGS=OFF \

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -106,7 +106,7 @@ jobs:
             -DLLVM_PARALLEL_LINK_JOBS=1 \
             -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} \
             -DCIRCT_RELEASE_TAG_ENABLED=ON \
-            -DCIRCT_RELEASE_TAG=${{ github.ref_name }} \
+            -DCIRCT_RELEASE_TAG=firtool \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../install
           ninja

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -1,4 +1,4 @@
-name: Upload Binaries
+name: Upload Firrtl Binaries
 
 on:
   release:
@@ -110,7 +110,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=`pwd`/../install
           ninja
           ninja check-circt check-circt-unit
-          ninja install
+          ninja install-firtool
           cd ..
 
       - name: Display Files
@@ -128,21 +128,21 @@ jobs:
       - name: Package Binaries
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
-          ${{ matrix.tar }} czf circt-bin-${{ matrix.runner }}.tar.gz ${{ steps.name_dir.outputs.value }}
+          ${{ matrix.tar }} czf firrtl-bin-${{ matrix.runner }}.tar.gz ${{ steps.name_dir.outputs.value }}
       - name: Show Tarball
         run: |
-          ls -l circt-bin-${{ matrix.runner }}.tar.gz
-          shasum -a 256 circt-bin-${{ matrix.runner }}.tar.gz
+          ls -l firrtl-bin-${{ matrix.runner }}.tar.gz
+          shasum -a 256 firrtl-bin-${{ matrix.runner }}.tar.gz
       - name: Upload Binaries (Non-Tag)
         uses: actions/upload-artifact@v3
         if: github.ref_type != 'tag'
         with:
-          name: circt-bin-${{ matrix.runner }}.tar.gz
-          path: circt-bin-${{ matrix.runner }}.tar.gz
+          name: firrtl-bin-${{ matrix.runner }}.tar.gz
+          path: firrtl-bin-${{ matrix.runner }}.tar.gz
           retention-days: 7
       - name: Upload Binaries (Tag)
         uses: AButler/upload-release-assets@v2.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: circt-bin-${{ matrix.runner }}.tar.gz
+          files: firrtl-bin-${{ matrix.runner }}.tar.gz
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This changes workflow "Upload Binaries" to "Upload Firtool Binaries" which substantially reduces the size of the binary distribution. There may be other things we want to include in distributions or maybe we want multiple binary uploads, but I'm opening this draft PR to get discussion started so we can weigh the benefits.

This reduces the size of the uploaded tarball from ~73 MiB to 3.7 MiB for Ubuntu 18.04 (and similar for the rest), the uncompressed reduction is from 258 MiB to 12 MiB.

Selfishly, as a maintainer of Chisel, I would like to distribute firtool separately since it is the only thing needed by Chisel users, but I am also totally open to finding a better compromise, like possibly having separate firtool and circt distributions.

~Also TODO I want to cache the LLVM build, if we do that, then we could have a nightly job to upload binary artifacts which Chisel could then use to test itself against CIRCT [relatively] ToT.~
I'm going to leave the LLVM build caching as later work. @mikeurbach informed me that we're having issues with cache pressure so would need to make sure any caching here didn't exacerbate that, presumably by using the exact same cached artifacts as other CI workflows.