### PR TITLE
[CalyxToHW] Support multiple guarded assigns to the same destination

### DIFF
--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -263,15 +263,14 @@ private:
                             op.portName(op.getClk()), b);
           auto reset = wireIn(op.getReset(), op.instanceName(),
                               op.portName(op.getReset()), b);
-
-          auto outReg =
-              regCe(in, clk, writeEn, reset, op.instanceName() + "_reg", b);
           auto doneReg =
               reg(writeEn, clk, reset, op.instanceName() + "_done_reg", b);
-
-          auto out = wireOut(outReg, op.instanceName(), "", b);
           auto done =
               wireOut(doneReg, op.instanceName(), op.portName(op.getDone()), b);
+          auto clockEn = b.create<AndOp>(writeEn, createOrFoldNot(done, b));
+          auto outReg =
+              regCe(in, clk, clockEn, reset, op.instanceName() + "_reg", b);
+          auto out = wireOut(outReg, op.instanceName(), "", b);
           wires.append({in.getInput(), writeEn.getInput(), clk.getInput(),
                         reset.getInput(), out, done});
         })

--- a/test/Conversion/CalyxToHW/basic.mlir
+++ b/test/Conversion/CalyxToHW/basic.mlir
@@ -30,6 +30,10 @@
 
 // module attributes {calyx.entrypoint = "main"} {
   calyx.component @main(%a: i32, %b: i32, %go: i1 {go = 1 : i64}, %clk: i1 {clk = 1 : i64}, %reset: i1 {reset = 1 : i64}) -> (%out: i32, %done: i1 {done = 1 : i64}) {
+    // CHECK-DAG:  %out = sv.wire
+    // CHECK-DAG:  %[[OUT_VAL:.+]] = sv.read_inout %out
+    // CHECK-DAG:  %done = sv.wire
+    // CHECK-DAG:  %[[DONE_VAL:.+]] = sv.read_inout %done
     // CHECK-DAG:  %add_left = sv.wire
     // CHECK-DAG:  %[[ADD_LEFT_VAL:.+]] = sv.read_inout %add_left
     // CHECK-DAG:  %add_right = sv.wire
@@ -48,16 +52,19 @@
     // CHECK-DAG:  %[[BUF_CLK_VAL:.+]] = sv.read_inout %buf_clk
     // CHECK-DAG:  %buf_reset = sv.wire
     // CHECK-DAG:  %[[BUF_RESET_VAL:.+]] = sv.read_inout %buf_reset
-    // CHECK-DAG:  %[[C0_I32:.+]] = hw.constant 0 : i32
-    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg.ce sym @buf_reg %[[BUF_IN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_WRITE_EN_VAL]], %[[BUF_RESET_VAL]], %[[C0_I32]]
     // CHECK-DAG:  %[[FALSE:.+]] = hw.constant false
     // CHECK-DAG:  %[[BUF_DONE_REG:.+]] = seq.compreg sym @buf_done_reg %[[BUF_WRITE_EN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_RESET_VAL]], %[[FALSE]]  : i1
-    // CHECK-DAG:  %buf = sv.wire
-    // CHECK-DAG:  sv.assign %buf, %[[BUF_REG]]
-    // CHECK-DAG:  %[[BUF_VAL:.+]] = sv.read_inout %buf
     // CHECK-DAG:  %buf_done = sv.wire
     // CHECK-DAG:  sv.assign %buf_done, %[[BUF_DONE_REG]]
     // CHECK-DAG:  %[[BUF_DONE_VAL:.+]] = sv.read_inout %buf_done
+    // CHECK-DAG:  %[[TRUE:.+]] = hw.constant true
+    // CHECK-DAG:  %[[BUF_DONE_VAL_NEG:.+]] = comb.xor %[[BUF_DONE_VAL]], %true : i1
+    // CHECK-DAG:  %[[BUF_REG_WRITE_EN:.+]] = comb.and %[[BUF_WRITE_EN_VAL]], %[[BUF_DONE_VAL_NEG]] : i1
+    // CHECK-DAG:  %[[C0_I32:.+]] = hw.constant 0 : i32
+    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg.ce sym @buf_reg %[[BUF_IN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_REG_WRITE_EN]], %[[BUF_RESET_VAL]], %[[C0_I32]]
+    // CHECK-DAG:  %buf = sv.wire
+    // CHECK-DAG:  sv.assign %buf, %[[BUF_REG]]
+    // CHECK-DAG:  %[[BUF_VAL:.+]] = sv.read_inout %buf
     %buf.in, %buf.write_en, %buf.clk, %buf.reset, %buf.out, %buf.done = calyx.register @buf : i32, i1, i1, i1, i32, i1
 
     // CHECK-DAG:  %g0_go = sv.wire
@@ -73,13 +80,13 @@
       %true = hw.constant true
 
       // CHECK-DAG:  %[[FALSE_0:.+]] = hw.constant false
-      // CHECK-DAG:  %[[DONE_VAL:.+]] = comb.mux %[[G0_DONE_VAL]], %[[TRUE]], %[[FALSE_0]]
-      // CHECK-DAG:  sv.assign %done, %[[DONE_VAL]]
+      // CHECK-DAG:  %[[VAL_TO_DONE:.+]] = comb.mux %[[G0_DONE_VAL]], %[[TRUE]], %[[FALSE_0]]
+      // CHECK-DAG:  sv.assign %done, %[[VAL_TO_DONE]]
       calyx.assign %done = %g0_done.out ? %true : i1
 
       // CHECK-DAG:  %[[C0_I32_0:.+]] = hw.constant 0
-      // CHECK-DAG:  %[[OUT_VAL:.+]] = comb.mux %[[TRUE]], %[[BUF_VAL]], %[[C0_I32_0]]
-      // CHECK-DAG:  sv.assign %out, %[[OUT_VAL]]
+      // CHECK-DAG:  %[[VAL_TO_OUT:.+]] = comb.mux %[[TRUE]], %[[BUF_VAL]], %[[C0_I32_0]]
+      // CHECK-DAG:  sv.assign %out, %[[VAL_TO_OUT]]
       calyx.assign %out = %true ? %buf.out : i32
 
       // CHECK-DAG:  %[[C0_I32_1:.+]] = hw.constant 0
@@ -122,10 +129,6 @@
       // CHECK-DAG:  sv.assign %g0_go, %[[G0_GO_IN]]
       calyx.assign %g0_go.in = %true ? %go : i1
 
-      // CHECK-DAG:  %out = sv.wire
-      // CHECK-DAG:  %[[OUT_VAL:.+]] = sv.read_inout %out
-      // CHECK-DAG:  %done = sv.wire
-      // CHECK-DAG:  %[[DONE_VAL:.+]] = sv.read_inout %done
       // CHECK-DAG:  hw.output %[[OUT_VAL]], %[[DONE_VAL]]
     }
     calyx.control {

--- a/test/Conversion/CalyxToHW/basic.mlir
+++ b/test/Conversion/CalyxToHW/basic.mlir
@@ -49,7 +49,7 @@
     // CHECK-DAG:  %buf_reset = sv.wire
     // CHECK-DAG:  %[[BUF_RESET_VAL:.+]] = sv.read_inout %buf_reset
     // CHECK-DAG:  %[[C0_I32:.+]] = hw.constant 0 : i32
-    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg sym @buf_reg %[[BUF_IN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_RESET_VAL]], %[[C0_I32]]
+    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg.ce sym @buf_reg %[[BUF_IN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_WRITE_EN_VAL]], %[[BUF_RESET_VAL]], %[[C0_I32]]
     // CHECK-DAG:  %[[FALSE:.+]] = hw.constant false
     // CHECK-DAG:  %[[BUF_DONE_REG:.+]] = seq.compreg sym @buf_done_reg %[[BUF_WRITE_EN_VAL]], %[[BUF_CLK_VAL]], %[[BUF_RESET_VAL]], %[[FALSE]]  : i1
     // CHECK-DAG:  %buf = sv.wire

--- a/test/Conversion/CalyxToHW/primitives.mlir
+++ b/test/Conversion/CalyxToHW/primitives.mlir
@@ -64,3 +64,30 @@ module attributes {calyx.entrypoint = "main"} {
     calyx.control {}
   }
 }
+
+// -----
+
+// CHECK: hw.module @main(%in0: i8, %in1: i8, %cond0: i1, %cond1: i1, %clk: i1, %reset: i1, %go: i1) -> (out: i8, done: i1) {
+// CHECK:   %out = sv.wire  : !hw.inout<i8>
+// CHECK:   %0 = sv.read_inout %out : !hw.inout<i8>
+// CHECK:   %done = sv.wire  : !hw.inout<i1>
+// CHECK:   %1 = sv.read_inout %done : !hw.inout<i1>
+// CHECK:   %true = hw.constant true
+// CHECK:   %c0_i8 = hw.constant 0 : i8
+// CHECK:   %[[MUX0:.*]] = comb.mux %cond0, %in0, %c0_i8 : i8
+// CHECK:   %[[MUX1:.*]] = comb.mux %cond1, %in1, %[[MUX0]] : i8
+// CHECK:   sv.assign %out, %[[MUX1]] : i8
+// CHECK:   sv.assign %done, %true : i1
+// CHECK:   hw.output %0, %1 : i8, i1
+// CHECK: }
+module attributes {calyx.entrypoint = "main"} {
+  calyx.component @main(%in0: i8, %in1: i8, %cond0: i1, %cond1: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out: i8, %done: i1 {done}) {
+    %true = hw.constant true
+    calyx.wires {
+      calyx.assign %out = %cond0 ? %in0 : i8
+      calyx.assign %out = %cond1 ? %in1 : i8
+      calyx.assign %done = %true : i1
+    }
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -842,6 +842,24 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 module attributes {calyx.entrypoint = "main"} {
+  calyx.component @main(%cond: i1, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
+    %c64_i32 = hw.constant 64 : i32
+    %c42_i32 = hw.constant 42 : i32
+    calyx.wires {
+      // expected-error @+1 {{'calyx.assign' op destination is already continuously driven. Other assignment is "calyx.assign"(%0#0, %2) : (i32, i32) -> ()}}
+      calyx.assign %std_lt_0.left = %cond ? %c64_i32 : i32
+      calyx.assign %std_lt_0.left = %c42_i32 : i32
+    }
+    calyx.control {
+      calyx.seq { }
+    }
+  }
+}
+
+// -----
+
+module attributes {calyx.entrypoint = "main"} {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
     %c64_i32 = hw.constant 64 : i32


### PR DESCRIPTION
According to the Calyx [specification](https://docs.calyxir.org/lang/ref.html#guards), guarded assignments to the same destination will not be driven simultaneously.

Therefore, the following Calyx IR is valid:
```llvm
calyx.assign %out = %cond0 ? %val0 : i32
calyx.assign %out = %cond1 ? %val1 : i32
```

This can happen when there is more than one calyx group assigning to the same destination.

Support this by creating a chain of `comb::MuxOp`.
When none of the guards are active, assign 0s to the destination.
This will allow other passes down to HW, and also the synthesizer, to perform optimizations on the mux chain.

Also use `seq::CompRegClockEnabledOp` instead of `seq::CompRegOp` to store the value of the register when converting a `calyx.register`, with the `clockEn` signal driven by the `calyx.register`'s `write_en`.