### PR TITLE
Upload full sources with release

### DIFF
--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -42,6 +42,17 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
+      
+      # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
+      - name: Archive Sources
+        if: ${{ matrix.runner }} == ubuntu-20.04
+        run: tar czf --exclude-vcs circt-full-sources.tar.gz .
+      - name: Upload Source Archive
+        uses: AButler/upload-release-assets@v2.0
+        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
+        with:
+          files: circt-full-sources-${{ matrix.runner }}.tar.gz
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # We need unshallow CIRCT for later "git describe"
       - name: Unshallow CIRCT (but not LLVM)

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -57,7 +57,7 @@ jobs:
         uses: AButler/upload-release-assets@v2.0
         if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
         with:
-          files: circt-full-sources-${{ matrix.runner }}.tar.gz
+          files: circt-full-sources.tar.gz
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete Sources Archive
         if: ${{ matrix.runner }} == ubuntu-20.04

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Archive Sources
         if: ${{ matrix.runner }} == ubuntu-20.04
         run: |
+          touch circt-full-sources.tar.gz
           tar \
             --exclude-vcs \
             --exclude=circt-full-sources.tar.gz \

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -46,13 +46,21 @@ jobs:
       # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
       - name: Archive Sources
         if: ${{ matrix.runner }} == ubuntu-20.04
-        run: tar --exclude-vcs -czf circt-full-sources.tar.gz .
+        run: |
+          tar \
+            --exclude-vcs \
+            --exclude=circt-full-sources.tar.gz \
+            -czf \
+            circt-full-sources.tar.gz .
       - name: Upload Source Archive
         uses: AButler/upload-release-assets@v2.0
         if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
         with:
           files: circt-full-sources-${{ matrix.runner }}.tar.gz
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete Sources Archive
+        if: ${{ matrix.runner }} == ubuntu-20.04
+        run: rm circt-full-sources.tar.gz
 
       # We need unshallow CIRCT for later "git describe"
       - name: Unshallow CIRCT (but not LLVM)

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -46,7 +46,7 @@ jobs:
       # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
       - name: Archive Sources
         if: ${{ matrix.runner }} == ubuntu-20.04
-        run: tar czf --exclude-vcs circt-full-sources.tar.gz .
+        run: tar --exclude-vcs -czf circt-full-sources.tar.gz .
       - name: Upload Source Archive
         uses: AButler/upload-release-assets@v2.0
         if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/uploadFirrtlBinaries.yml
+++ b/.github/workflows/uploadFirrtlBinaries.yml
@@ -45,7 +45,7 @@ jobs:
       
       # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
       - name: Archive Sources
-        if: ${{ matrix.runner }} == ubuntu-20.04
+        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
         run: |
           touch circt-full-sources.tar.gz
           tar \
@@ -60,7 +60,7 @@ jobs:
           files: circt-full-sources.tar.gz
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete Sources Archive
-        if: ${{ matrix.runner }} == ubuntu-20.04
+        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
         run: rm circt-full-sources.tar.gz
 
       # We need unshallow CIRCT for later "git describe"

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -1,4 +1,4 @@
-name: Upload Firrtl Binaries
+name: Upload Firrtl Release Artifacts
 
 on:
   release:
@@ -6,6 +6,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  publish-sources: 
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-20.04
+    steps:
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT and LLVM
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
+      - name: Create Source Archive
+        run: |
+          touch circt-full-sources.tar.gz
+          tar \
+            --exclude-vcs \
+            --exclude=circt-full-sources.tar.gz \
+            -czf \
+            circt-full-sources.tar.gz .
+      - name: Upload Source Archive
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: circt-full-sources.tar.gz
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     strategy:
       matrix:
@@ -42,26 +69,6 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
-      
-      # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
-      - name: Archive Sources
-        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
-        run: |
-          touch circt-full-sources.tar.gz
-          tar \
-            --exclude-vcs \
-            --exclude=circt-full-sources.tar.gz \
-            -czf \
-            circt-full-sources.tar.gz .
-      - name: Upload Source Archive
-        uses: AButler/upload-release-assets@v2.0
-        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
-        with:
-          files: circt-full-sources.tar.gz
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Delete Sources Archive
-        if: ${{ matrix.runner }} == ubuntu-20.04 && startsWith(github.ref, 'refs/tags/')
-        run: rm circt-full-sources.tar.gz
 
       # We need unshallow CIRCT for later "git describe"
       - name: Unshallow CIRCT (but not LLVM)

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM. Only runs on the ubuntu-20.04 runner.
+      # Package up sources for distribution, as the default source bundles from GitHub don't include LLVM.
       - name: Create Source Archive
         run: |
           touch circt-full-sources.tar.gz


### PR DESCRIPTION
While GitHub does provide source bundles, those bundles don't include LLVM and thus cannot be used for building from source.

My current use case for this is to build an `aarch64` firtool for use on M1 macs (for example, using the dev container [here](https://github.com/chipsalliance/chisel/blob/5be1fbc0e319ffc939b2cb64fb460e1b416d7e64/.devcontainer/Dockerfile#L63-L73)). Currently, GitHub doesn't seem to offer `aarch64` runners to build a release binary. As a workaround for my devcontainer, I do a `git` checkout which takes a really long time to clone `llvm`. Grabbing a packaged bundle of sources will make this much faster.