### PR TITLE
[ToCalyxTranslation] Add 'stable' port attribute in translation

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -60,8 +60,8 @@ constexpr std::array<StringRef, 7> integerAttributes{
 };
 
 /// A list of boolean attributes supported by the native Calyx compiler.
-constexpr std::array<StringRef, 7> booleanAttributes{
-    "clk", "done", "go", "reset", "generated", "precious", "toplevel",
+constexpr std::array<StringRef, 8> booleanAttributes{
+    "clk", "done", "go", "reset", "generated", "precious", "toplevel", "stable",
 };
 
 static std::optional<StringRef> getCalyxAttrIdentifier(NamedAttribute attr) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -60,8 +60,9 @@ constexpr std::array<StringRef, 7> integerAttributes{
 };
 
 /// A list of boolean attributes supported by the native Calyx compiler.
-constexpr std::array<StringRef, 8> booleanAttributes{
-    "clk", "done", "go", "reset", "generated", "precious", "toplevel", "stable",
+constexpr std::array<StringRef, 12> booleanAttributes{
+    "clk",      "done",   "go",          "reset",  "generated",   "precious",
+    "toplevel", "stable", "nointerface", "inline", "state_share", "data",
 };
 
 static std::optional<StringRef> getCalyxAttrIdentifier(NamedAttribute attr) {


### PR DESCRIPTION
Before the pass was ignoring when I gave ports the attribute `{calyx.stable = true}`, so this commit allows `@stable` to be emitted.

Are there any others missing attributes that should be added @rachitnigam ?