### PR TITLE
[FIRRTLUtils] Add more getBaseType helpers to reduce boilerplate.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -140,6 +140,20 @@ inline FIRRTLBaseType getBaseType(FIRRTLType type) {
       .Case<RefType>([](auto ref) { return ref.getType(); });
 }
 
+/// Return base type or passthrough if FIRRTLType, else null.
+inline FIRRTLBaseType getBaseTypeOrNull(Type type) {
+  auto ftype = dyn_cast_or_null<FIRRTLType>(type);
+  if (!ftype)
+    return {};
+  return getBaseType(ftype);
+}
+
+/// Get base type if isa<> the requested type, else null.
+template <typename T>
+inline T getBaseOfType(Type type) {
+  return dyn_cast_or_null<T>(getBaseTypeOrNull(type));
+}
+
 /// Return a FIRRTLType with its base type component mutated by the given
 /// function. (i.e., ref<T> -> ref<f(T)> and T -> f(T)).
 inline FIRRTLType mapBaseType(FIRRTLType type,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1536,9 +1536,7 @@ ParseResult FIRStmtParser::parsePostFixFieldId(Value &result) {
   StringRef fieldName;
   if (parseFieldId(fieldName, "expected field name"))
     return failure();
-  auto bundle =
-      dyn_cast<BundleType>(getBaseType(cast<FIRRTLType>(result.getType())));
-
+  auto bundle = getBaseOfType<BundleType>(result.getType());
   if (!bundle)
     return emitError(loc, "subfield requires bundle operand ");
   auto indexV = bundle.getElementIndex(fieldName);

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1762,16 +1762,14 @@ LogicalResult InferResetsPass::verifyNoAbstractReset() {
   for (FModuleLike module :
        getOperation().getBodyBlock()->getOps<FModuleLike>()) {
     for (PortInfo port : module.getPorts()) {
-      if (auto portType = port.type.dyn_cast<FIRRTLType>()) {
-        if (getBaseType(portType).isa<ResetType>()) {
-          auto diag = emitError(port.loc)
-                      << "a port \"" << port.getName()
-                      << "\" with abstract reset type was unable to be "
-                         "inferred by InferResets (is this a top-level port?)";
-          diag.attachNote(module->getLoc())
-              << "the module with this uninferred reset port was defined here";
-          hasAbstractResetPorts = true;
-        }
+      if (getBaseOfType<ResetType>(port.type)) {
+        auto diag = emitError(port.loc)
+                    << "a port \"" << port.getName()
+                    << "\" with abstract reset type was unable to be "
+                       "inferred by InferResets (is this a top-level port?)";
+        diag.attachNote(module->getLoc())
+            << "the module with this uninferred reset port was defined here";
+        hasAbstractResetPorts = true;
       }
     }
   }


### PR DESCRIPTION
Use to simplify some cast chains involving getBaseType.