### PR TITLE
[FIRRTL] Don't reject probes of non-passive.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2429,11 +2429,6 @@ ParseResult FIRStmtParser::parseProbe(Value &result) {
           staticRef.getDefiningOp()))
     return emitError(startTok.getLoc(), "cannot probe memories or their ports");
 
-  // TODO: Once PR 4801 lands, remove this.
-  if (!cast<FIRRTLBaseType>(staticRef.getType()).isPassive())
-    return emitError(startTok.getLoc(),
-                     "probe of non-passive types not yet supported");
-
   result = builder.create<RefSendOp>(staticRef);
 
   return success();
@@ -2467,11 +2462,6 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
                       MemoryDebugPortOp, MemoryPortAccessOp>(
           staticRef.getDefiningOp()))
     return emitError(startTok.getLoc(), "cannot probe memories or their ports");
-
-  // TODO: Once PR 4801 lands, remove this.
-  if (!cast<FIRRTLBaseType>(staticRef.getType()).isPassive())
-    return emitError(startTok.getLoc(),
-                     "probe of non-passive types not yet supported");
 
   result = builder.create<RefSendOp>(staticRef);
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1197,10 +1197,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     out <= read(rc.rw)
 
     ; ref.sub parsing
-    ; CHECK-DAG: %[[AGG:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a: uint<1>, b: uint>
-    ; CHECK-DAG: %[[AGG2:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a: uint, b: uint<1>>
-    wire agg : { a : UInt<1>, b : UInt }
-    wire agg2 : { a : UInt, b : UInt<1> }
+    ; CHECK-DAG: %[[AGG:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a flip: uint<1>, b: uint>
+    ; CHECK-DAG: %[[AGG2:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a: uint, b flip: uint<1>>
+    wire agg : { flip a : UInt<1>, b : UInt }
+    wire agg2 : { a : UInt, flip b : UInt<1> }
     ; CHECK-DAG: %[[AGG_B:.+]] = firrtl.subfield %[[AGG]][b]
     ; CHECK-DAG: %[[AGG_B_PROBE:.+]] = firrtl.ref.send %[[AGG_B]]
     ; CHECK-DAG: %[[READ_AGG_B_PROBE:.+]] = firrtl.ref.resolve %[[AGG_B_PROBE]]

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -550,11 +550,3 @@ circuit DefineWidths:
     output p : Probe<UInt>
     define p = probe(in) ; expected-error {{may not connect different non-base types}}
 
-;// -----
-
-; This should be supported, needs internal support to land first.
-circuit ProbeNonPassive:
-  module ProbeNonPassive:
-    input in : {a: UInt<1>, flip b: UInt<1>}
-    output p : Probe<{a: UInt<1>, b: UInt<1>}>
-    define p = probe(in) ; expected-error {{probe of non-passive types not yet supported}}


### PR DESCRIPTION
These are now supported as of #4801.

Add basic parse test, drop negative test.