### PR TITLE
[FIRRTL] Add folders for bundle/vector create

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1978,11 +1978,11 @@ OpFoldResult BundleCreateOp::fold(FoldAdaptor adaptor) {
   if (SubfieldOp first = getOperand(0).getDefiningOp<SubfieldOp>())
     if (first.getFieldIndex() == 0 && first.getInput().getType() == getType() &&
         llvm::all_of(
-            llvm::enumerate(getOperands().drop_front()), [&](auto elem) {
-              auto index = elem.index() + 1;
+            llvm::drop_begin(llvm::enumerate(getOperands().drop_front())),
+            [&](auto elem) {
               auto subindex = elem.value().template getDefiningOp<SubfieldOp>();
               return subindex && subindex.getInput() == first.getInput() &&
-                     subindex.getFieldIndex() == index;
+                     subindex.getFieldIndex() == elem.index();
             }))
       return first.getInput();
 
@@ -1995,11 +1995,10 @@ OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
   if (SubindexOp first = getOperand(0).getDefiningOp<SubindexOp>())
     if (first.getIndex() == 0 && first.getInput().getType() == getType() &&
         llvm::all_of(
-            llvm::enumerate(getOperands().drop_front()), [&](auto elem) {
-              auto index = elem.index() + 1;
+            llvm::drop_begin(llvm::enumerate(getOperands())), [&](auto elem) {
               auto subindex = elem.value().template getDefiningOp<SubindexOp>();
               return subindex && subindex.getInput() == first.getInput() &&
-                     subindex.getIndex() == index;
+                     subindex.getIndex() == elem.index();
             }))
       return first.getInput();
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2793,4 +2793,22 @@ firrtl.module @RemoveUnusedInvalid() {
 }
 // CHECK-NEXT: }
 
+// CHECK-LABEL: firrtl.module @AggregateCreate
+firrtl.module @AggregateCreate(in %vector_in: !firrtl.vector<uint<1>, 2>,
+                               in %bundle_in: !firrtl.bundle<a: uint<1>, b: uint<1>>,
+                               out %vector_out: !firrtl.vector<uint<1>, 2>,
+                               out %bundle_out: !firrtl.bundle<a: uint<1>, b: uint<1>>) {
+  %0 = firrtl.subindex %vector_in[0] : !firrtl.vector<uint<1>, 2>
+  %1 = firrtl.subindex %vector_in[1] : !firrtl.vector<uint<1>, 2>
+  %vector = firrtl.vectorcreate %0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
+  firrtl.strictconnect %vector_out, %vector : !firrtl.vector<uint<1>, 2>
+
+  %2 = firrtl.subfield %bundle_in["a"] : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %3 = firrtl.subfield %bundle_in["b"] : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %bundle = firrtl.bundlecreate %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  firrtl.strictconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK-NEXT: firrtl.strictconnect %vector_out, %vector_in : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.strictconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>, b: uint<1>>
+}
+
 }


### PR DESCRIPTION
Add folders for aggregate create operations: 
```
vector_create(%foo[0], %foo[1]) -> %foo : vec<uint<2>, 2>
bundle_create(%foo["a"], %foo["b"]) -> %foo : bundle<a:uint<1>, b:uint<1>>
```