### PR TITLE
[FIRRTL][FIRParser] Relax 'ref' statement requirement.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3348,16 +3348,14 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
           "references in ports must be output on extmodule and intmodule");
     auto *refStmtIt = llvm::find_if(
         refStatements, [&](const auto &r) { return r.refName == port.name; });
-    // Error if no ref statement found.
+    // Deviate from FIRRTL 2.0 requirement, allow missing ref.
+    // If used/needed, will error later in pipeline.
     if (refStmtIt == refStatements.end())
-      return mlir::emitError(port.loc, "no ref statement found for ref port ")
-          .append(port.name);
-
+      continue;
     usedRefs.set(std::distance(refStatements.begin(), refStmtIt));
     internalPathAttrs.push_back(refStmtIt->resolvedPath);
   }
-  if (internalPathAttrs.size() != refStatements.size()) {
-    assert(internalPathAttrs.size() < refStatements.size());
+  if (internalPathAttrs.size() < refStatements.size()) {
     assert(!usedRefs.all());
     auto idx = usedRefs.find_first_unset();
     assert(idx != -1);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1218,7 +1218,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: ref.define %agg_out, %[[AGG3_PROBE]]
     define agg_out = probe(agg3)
 
-    ; CHECK: %{{.+}}, %[[REM_R:.+]], %{{.+}}, %[[REM_R2:.+]] = firrtl.instance rem
+    ; CHECK: %{{.+}}, %[[REM_R:.+]], %{{.+}}, %[[REM_R2:.+]], %[[REM_UNUSED_REF:.+]] = firrtl.instance rem
     ; CHECK-NEXT: %[[REM_R2_1:.+]] = firrtl.ref.sub %[[REM_R2]][1]
     ; CHECK-NEXT: %[[REM_R2_1_A:.+]] = firrtl.ref.sub %[[REM_R2_1]][0]
     ; CHECK-NEXT: %[[READ_REM_R2_1_A:.+]] = firrtl.ref.resolve %[[REM_R2_1_A]]
@@ -1250,9 +1250,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output r : Probe<UInt<1>>
     output data : UInt<3>
     output r2 : Probe<{a : UInt<3>}[3]>
+    output no_ref_for_this : Probe<UInt<1>>
     ref r2 is "in"
     ref r is "path.to.internal.signal"
-
 
   ; CHECK-LABEL: module private @ProbeInvalidate
   ; CHECK-NEXT: }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -447,12 +447,6 @@ circuit RefDupe:
 
 ;// -----
 
-circuit MissingRef:
-  extmodule MissingRef:
-    output p : Probe<UInt<2>> ; expected-error {{no ref statement found for ref port "p"}}
-
-;// -----
-
 circuit UnusedRef:
   extmodule UnusedRef:
     ref p is "x.y" ; expected-error {{unused ref statement}}


### PR DESCRIPTION
Went back and forth on this in spec.

Let's allow it, to support unused references or to resolve the reference after parsing.