### PR TITLE
[ETC] Enhance instance extraction to extract dependent instances.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -90,7 +90,8 @@ static void getBackwardSliceSimple(Operation *rootOp,
 // in the backward slice, and return true.
 static bool getForwardSliceSimple(Operation *rootOp,
                                   SetVector<Operation *> &opsToClone,
-                                  SetVector<Operation *> &forwardSlice) {
+                                  SetVector<Operation *> &forwardSlice,
+                                  SmallVector<hw::InstanceOp> &instanceSinks) {
   SmallPtrSet<Operation *, 32> visited;
   SmallVector<Operation *> worklist;
   worklist.push_back(rootOp);
@@ -101,8 +102,19 @@ static bool getForwardSliceSimple(Operation *rootOp,
     forwardSlice.insert(op);
 
     for (auto *user : op->getUsers()) {
+      // If the dataflow is into an instance, mark it and move along.
+      if (auto sinkInstance = dyn_cast<hw::InstanceOp>(user)) {
+        assert(!opsToClone.contains(sinkInstance) &&
+               "expected instances to not be present in opsToClone");
+        instanceSinks.push_back(sinkInstance);
+        continue;
+      }
+
+      // If the dataflow is into an op that isn't in the clone set, we're done.
       if (!opsToClone.contains(user))
         return false;
+
+      // Otherwise, continue following the dataflow slice.
       if (visited.insert(user).second)
         worklist.push_back(user);
     }
@@ -169,6 +181,16 @@ static void addInstancesToCloneSet(
   // Track inputs to remove, which come from instances that will be extracted.
   SmallVector<Value> inputsToRemove;
 
+  // Track instances to potentially extract.
+  llvm::SmallDenseSet<hw::InstanceOp> instancesToExtract;
+
+  // Track a mapping from instances to other instances that are dataflow sinks.
+  SmallDenseMap<hw::InstanceOp, SmallVector<hw::InstanceOp>>
+      instancesToInstanceSinks;
+
+  // Track a mapping from instances to their forward dataflow slice.
+  SmallDenseMap<hw::InstanceOp, SetVector<Operation *>> instancesToDataflow;
+
   // Check each input into the clone set.
   for (auto value : inputs) {
     // Check if the input comes from an instance, and it isn't already added to
@@ -185,14 +207,38 @@ static void addInstancesToCloneSet(
 
     // Compute the instance's forward slice. If it wasn't fully contained in
     // the clone set, move along.
-    SetVector<Operation *> forwardSlice;
-    if (!getForwardSliceSimple(instance, opsToClone, forwardSlice))
+    if (!getForwardSliceSimple(instance, opsToClone,
+                               instancesToDataflow[instance],
+                               instancesToInstanceSinks[instance]))
       continue;
 
-    // Add the instance to the clone set and mark the input to be removed from
-    // the input set. Add any instance inputs to the input set. Also add the
-    // instance to the map of extracted instances by module.
+    instancesToExtract.insert(instance);
+  }
+
+  // Find instances we can extract and add them to the clone set.
+  for (auto instance : instancesToExtract) {
+    // We know the forward dataflow for this instance ends in either extractable
+    // test code or other instances. Check if all of the other instances are
+    // also marked for extraction.
+    bool allInstanceSinksExtractable = llvm::all_of(
+        instancesToInstanceSinks[instance], [&](hw::InstanceOp sinkInstance) {
+          return instancesToExtract.contains(sinkInstance);
+        });
+
+    if (!allInstanceSinksExtractable)
+      continue;
+
+    // Add the instance to the clone set.
     opsToClone.insert(instance);
+  }
+
+  // Perform the necessary IR mutations for extracted instances.
+  for (auto instance : instancesToExtract) {
+    // Ensure this is one of the instances we actually want to clone.
+    if (!opsToClone.contains(instance))
+      continue;
+
+    // Add any instance inputs to the input set.
     for (auto operand : instance.getOperands()) {
       // Don't add values to the input set if they are the result of an op we
       // are already going to clone.
@@ -202,8 +248,12 @@ static void addInstancesToCloneSet(
 
       inputsToAdd.push_back(operand);
     }
+
+    // Mark the instance results to be removed from the input set.
     for (auto result : instance.getResults())
       inputsToRemove.push_back(result);
+
+    // Add the instance to the map of extracted instances by module.
     extractedInstances[instance.getModuleNameAttr().getAttr()].insert(instance);
 
     // Mark the instance and its forward dataflow to be erased from the pass.
@@ -213,6 +263,7 @@ static void addInstancesToCloneSet(
     // in general. The forward dataflow must be erased because the instance is
     // being erased, and we can't leave null operands after this pass. Also
     // erase any intermediate parents of the forward slice.
+    SetVector<Operation *> forwardSlice = instancesToDataflow[instance];
     opsToErase.insert(instance);
     for (auto *forwardOp : forwardSlice)
       opsToErase.insert(forwardOp);

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -284,6 +284,16 @@ module {
 // CHECK: %[[or1:.+]] = comb.or
 // CHECK-NOT: %[[or1]]
 
+// In InstancesWithCycles, the only_testcode instances should be extracted, but the non_testcode instances should not
+// CHECK-LABEL: @InstancesWithCycles_cover
+// CHECK: hw.instance "only_testcode_and_instance0"
+// CHECK: hw.instance "only_testcode_and_instance1"
+// CHECK-LABEL: @InstancesWithCycles
+// CHECK-NOT: hw.instance "only_testcode_and_instance0"
+// CHECK-NOT: hw.instance "only_testcode_and_instance1"
+// CHECK: hw.instance "non_testcode_and_instance0"
+// CHECK: hw.instance "non_testcode_and_instance1"
+
 module attributes {
   firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
 } {
@@ -383,5 +393,26 @@ module attributes {
       sv.cover %0, immediate
       sv.cover %foo.b, immediate
     }
+  }
+
+  hw.module private @Passthrough(%in: i1) -> (out: i1) {
+    hw.output %in : i1
+  }
+
+  hw.module @InstancesWithCycles(%clock: i1, %in: i1) -> (out: i1) {
+    %0 = hw.instance "non_testcode_and_instance0" @Passthrough(in: %1: i1) -> (out: i1)
+    %1 = hw.instance "non_testcode_and_instance1" @Passthrough(in: %0: i1) -> (out: i1)
+
+    %2 = hw.instance "only_testcode_and_instance0" @Passthrough(in: %3: i1) -> (out: i1)
+    %3 = hw.instance "only_testcode_and_instance1" @Passthrough(in: %2: i1) -> (out: i1)
+    %4 = comb.or %2, %3 : i1
+
+    sv.always posedge %clock {
+      sv.cover %1, immediate
+      sv.cover %2, immediate
+      sv.cover %4, immediate
+    }
+
+    hw.output %0 : i1
   }
 }


### PR DESCRIPTION
We previously extracted instances that only feed the test code. This change enhances that logic to also extract instances that may feed other instances, which transitively only feed the test code. This also works for instances that potentially feed each other, cyclicly, and otherwise only feed the test code.