### PR TITLE
[FIRRTL] Do not consider references valid annotation targets.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -210,6 +210,15 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
           << "cannot find name '" << path.name << "' in " << mod.moduleName();
       return {};
     }
+    // AnnoTarget::getType() is not safe (CHIRRTL ops crash, null if instance),
+    // avoid. For now, only references in ports can be targets, check that.
+    // TODO: containsReference().
+    if (ref.isa<PortAnnoTarget>() && isa<RefType>(ref.getType())) {
+      mlir::emitError(circuit.getLoc())
+          << "cannot target reference-type '" << path.name << "' in "
+          << mod.moduleName();
+      return {};
+    }
   }
 
   // If the reference is pointing to an instance op, we have to move the target
@@ -240,8 +249,15 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
         }
       if (!ref) {
         mlir::emitError(circuit.getLoc())
-            << "!cannot find port '" << field << "' in module "
+            << "cannot find port '" << field << "' in module "
             << target.moduleName();
+        return {};
+      }
+      // TODO: containsReference().
+      if (isa<RefType>(ref.getType())) {
+        mlir::emitError(circuit.getLoc())
+            << "annotation cannot target reference-type port '" << field
+            << "' in module " << target.moduleName();
         return {};
       }
       component = component.drop_front();
@@ -360,7 +376,7 @@ InstanceOp firrtl::addPortsToModule(
 void AnnoTargetCache::gatherTargets(FModuleLike mod) {
   // Add ports
   for (const auto &p : llvm::enumerate(mod.getPorts()))
-    targets.insert({p.value().name, PortAnnoTarget(mod, p.index())});
+    insertPort(mod, p.index());
 
   // And named things
   mod.walk([&](Operation *op) { insertOp(op); });

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -239,3 +239,48 @@ firrtl.circuit "GCTDataTapUnsupportedLiteral" attributes {rawAnnotations = [{
     %tap = firrtl.wire : !firrtl.uint<1>
   }
 }
+
+// -----
+// Check instance port target that doesn't exist.
+
+// expected-error @below {{cannot find port 'a' in module Ext}}
+// expected-error @below {{Unable to resolve target of annotation}}
+firrtl.circuit "InstancePortNotFound" attributes {rawAnnotations = [{
+  class = "circt.test",
+  target = "~InstancePortNotFound|InstancePortNotFound>inst.a"
+}]} {
+  firrtl.extmodule @Ext()
+  firrtl.module @InstancePortNotFound() {
+    firrtl.instance inst @Ext()
+  }
+}
+
+// -----
+// Check ref-type instance port is rejected.
+
+// expected-error @below {{annotation cannot target reference-type port 'ref' in module Ext}}
+// expected-error @below {{Unable to resolve target of annotation}}
+firrtl.circuit "InstancePortRef" attributes {rawAnnotations = [{
+  class = "circt.test",
+  target = "~InstancePortRef|InstancePortRef>inst.ref"
+}]} {
+  firrtl.extmodule @Ext(out ref : !firrtl.ref<uint<1>>)
+  firrtl.module @InstancePortRef() {
+    %ref = firrtl.instance inst @Ext(out ref : !firrtl.ref<uint<1>>)
+  }
+}
+
+// -----
+// Reject annotations on references.
+
+// expected-error @below {{cannot target reference-type 'out' in RefAnno}}
+// expected-error @below {{Unable to resolve target of annotation}}
+firrtl.circuit "RefAnno" attributes {rawAnnotations = [{
+  class = "circt.test",
+  target = "~RefAnno|RefAnno>out"
+}]} {
+  firrtl.module @RefAnno(in %in : !firrtl.uint<1>, out %out : !firrtl.ref<uint<1>>) {
+    %ref = firrtl.ref.send %in : !firrtl.uint<1>
+    firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
+  }
+}


### PR DESCRIPTION
Annotations on references don't have defined behavior, and pose problems beyond that.
Reject if found to be the target of an annotation.

Add tests for annotation target instance port that doesn't exist,
instance port of reference type, and directly ref type port.