### PR TITLE
[Arc] Add clock_domain operation

### DIFF
--- a/include/circt/Dialect/Arc/Ops.td
+++ b/include/circt/Dialect/Arc/Ops.td
@@ -100,7 +100,7 @@ def DefineOp : ArcOp<"define", [
 
 def OutputOp : ArcOp<"output", [
   Terminator,
-  ParentOneOf<["DefineOp", "LutOp"]>,
+  ParentOneOf<["DefineOp", "LutOp", "ClockDomainOp"]>,
   Pure,
   ReturnLike
 ]> {
@@ -295,6 +295,33 @@ def MemoryWriteOp : ArcOp<"memory_write", [
 //===----------------------------------------------------------------------===//
 // Trigger Grouping
 //===----------------------------------------------------------------------===//
+
+def ClockDomainOp : ArcOp<"clock_domain", [
+  IsolatedFromAbove,
+  RegionKindInterface,
+  RecursiveMemoryEffects,
+  SingleBlockImplicitTerminator<"arc::OutputOp">
+]> {
+  let summary = "a clock domain";
+
+  let arguments = (ins Variadic<AnyType>:$inputs, I1:$clock);
+  let results = (outs Variadic<AnyType>:$outputs);
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    ` ` `(` $inputs `)` `clock` $clock attr-dict `:`
+    functional-type($inputs, results) $body
+  }];
+
+  let extraClassDeclaration = [{
+    static mlir::RegionKind getRegionKind(unsigned index) {
+      return mlir::RegionKind::Graph;
+    }
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+  }];
+
+  let hasRegionVerifier = 1;
+}
 
 def ClockTreeOp : ArcOp<"clock_tree", [NoTerminator, NoRegionArguments]> {
   let summary = "A clock tree";

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -88,3 +88,21 @@ arc.define @dummyCallee1(%arg0: i1, %arg1: i32) -> i32 {
 arc.define @dummyCallee2() {
   arc.output
 }
+
+// CHECK-LABEL: hw.module @clockDomainTest
+hw.module @clockDomainTest(%clk: i1, %in0: i32, %in1: i16) {
+  // CHECK-NEXT: %{{.+}} = arc.clock_domain (%in0, %in1) clock %clk {someattr} : (i32, i16) -> i32 {
+  %0 = arc.clock_domain (%in0, %in1) clock %clk {someattr} : (i32, i16) -> i32 {
+  // CHECK-NEXT: ^bb0(%arg0: i32, %arg1: i16):
+  ^bb0(%arg0: i32, %arg1: i16):
+    // CHECK-NEXT: [[AND:%.+]] = comb.and %arg0, [[AND]] : i32
+    // COM: check that it is a graph region
+    %1 = comb.and %arg0, %1 : i32
+    // CHECK-NEXT: arc.output [[AND]] : i32
+    arc.output %1 : i32
+  // CHECK-NEXT: }
+  }
+
+  // CHECK-NEXT: arc.clock_domain () clock %clk : () -> () {
+  arc.clock_domain () clock %clk : () -> () {}
+}

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -17,3 +17,12 @@ arc.define @Bar(%arg0: i32) -> i32{
   %c0_i32 = hw.constant 0 : i32
   arc.output %c0_i32 : i32
 }
+
+// CHECK-LABEL: hw.module @clockDomainDCE
+hw.module @clockDomainDCE(%clk: i1) {
+  // CHECK-NOT: arc.clock_domain
+  arc.clock_domain () clock %clk : () -> () {
+  ^bb0:
+    arc.output
+  }
+}


### PR DESCRIPTION
The `arc.clock_domain` operation is a dataflow equivalent of the `arc.clock_tree` operation. It is useful to isolate clocks before lowering state where the region still has to be a graph and arbitrary outputs have to be supported. Several transformations will benefit from an earlier isolation of clocks as they can often only be applied within a single clock domain (e.g., cannot pack differently clocked arcs inside the same vector for vectorization) and, as a result, don't have to check the clock operand manually anymore.

The plan is to implement the clock isolation transformation that is now part of LowerState as a separate pass on the dataflow representation and then let LowerState only lower the clock domains to the corresponding control flow based constructs. The plan is also to adjust the `clock_tree` operation slightly to also be isolated from above, but only take state pointers as input and have no outputs.