### PR TITLE
[Scheduling][ModuloSimplexScheduler] Improve `lastOp` validation.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -48,8 +48,9 @@ LogicalResult scheduleSimplex(SharedOperatorsProblem &prob, Operation *lastOp);
 /// heuristic. The approach tries to determine the smallest feasible initiation
 /// interval, and to minimize the start time of the given \p lastOp, but
 /// optimality is not guaranteed. Fails if the dependence graph contains cycles
-/// that do not include at least one edge with a non-zero distance, or \p prob
-/// does not include \p lastOp.
+/// that do not include at least one edge with a non-zero distance, \p prob
+/// does not include \p lastOp, or \p lastOp is not the unique sink of the
+/// dependence graph.
 LogicalResult scheduleSimplex(ModuloProblem &prob, Operation *lastOp);
 
 /// Solve the acyclic, chaining-enabled problem using linear programming and a

--- a/test/Scheduling/modulo-simplex-errors.mlir
+++ b/test/Scheduling/modulo-simplex-errors.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt %s -ssp-schedule="scheduler=simplex options=last-op-name=last" -verify-diagnostics -split-input-file
+
+// expected-error@+1 {{last operation is not a sink}}
+ssp.instance of "ModuloProblem" {
+  library {
+    operator_type @_1 [latency<1>]
+  }
+  graph {
+    operation<@_1> @last()
+    operation<@_1>(@last)
+  }
+}
+
+// -----
+
+// expected-error@+1 {{multiple sinks detected}}
+ssp.instance of "ModuloProblem" {
+  library {
+    operator_type @_1 [latency<1>]
+  }
+  graph {
+    operation<@_1>()
+    operation<@_1> @last()
+  }
+}


### PR DESCRIPTION
Validate that the given `lastOp` is the unique sink node in the dependence graph.

Fixes #4785.