### PR TITLE
[FIRRTLType] Add bundle name to BundleType

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -201,13 +201,14 @@ def FVectorTypeImpl : FIRRTLImplType<"FVector", [FieldIDTypeInterface]> {
 
 def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
   let summary = "an aggregate of named elements. This is effectively a struct.";
-  let parameters = (ins "ArrayRef<BundleElement>":$elements, "bool":$isConst, "StringAttr":$bundleName);
+  let parameters = (ins "ArrayRef<BundleElement>":$elements, "bool":$isConst,
+                    "StringAttr":$bundleName);
   let storageClass = "BundleTypeStorage";
   let skipDefaultBuilders = true;
   let builders = [
-    TypeBuilder<(ins "ArrayRef<BundleElement>":$elements, CArg<"bool", "false">:$isConst)>
-    TypeBuilderWithInferredContext<(ins
-      "ArrayRef<BundleElement>":$elements, "StringAttr":$bundleName)>,
+    TypeBuilder<(ins "ArrayRef<BundleElement>":$elements,
+                  CArg<"bool", "false">:$isConst,
+                  CArg<"StringAttr", "{}">:$bundleName)>,
   ];
   let extraClassDeclaration = [{
     /// Each element of a bundle, which is a name and type.
@@ -232,6 +233,8 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
     };
 
     ArrayRef<BundleElement> getElements() const;
+
+    StringAttr getBundleName() const;
 
     size_t getNumElements() { return getElements().size(); }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -215,15 +215,9 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
       StringAttr name;
       bool isFlip;
       FIRRTLBaseType type;
-      // Optional description of the field.
-      StringAttr description;
 
       BundleElement(StringAttr name, bool isFlip, FIRRTLBaseType type)
           : name(name), isFlip(isFlip), type(type) {}
-
-      BundleElement(StringAttr name, bool isFlip, FIRRTLBaseType type,
-          StringAttr description)
-          : name(name), isFlip(isFlip), type(type), description(description) {}
 
       bool operator==(const BundleElement &rhs) const {
         return name == rhs.name && isFlip == rhs.isFlip && type == rhs.type;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -201,11 +201,13 @@ def FVectorTypeImpl : FIRRTLImplType<"FVector", [FieldIDTypeInterface]> {
 
 def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
   let summary = "an aggregate of named elements. This is effectively a struct.";
-  let parameters = (ins "ArrayRef<BundleElement>":$elements, "bool":$isConst);
+  let parameters = (ins "ArrayRef<BundleElement>":$elements, "bool":$isConst, "StringAttr":$bundleName);
   let storageClass = "BundleTypeStorage";
   let skipDefaultBuilders = true;
   let builders = [
     TypeBuilder<(ins "ArrayRef<BundleElement>":$elements, CArg<"bool", "false">:$isConst)>
+    TypeBuilderWithInferredContext<(ins
+      "ArrayRef<BundleElement>":$elements, "StringAttr":$bundleName)>,
   ];
   let extraClassDeclaration = [{
     /// Each element of a bundle, which is a name and type.
@@ -213,9 +215,15 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
       StringAttr name;
       bool isFlip;
       FIRRTLBaseType type;
+      // Optional description of the field.
+      StringAttr description;
 
       BundleElement(StringAttr name, bool isFlip, FIRRTLBaseType type)
           : name(name), isFlip(isFlip), type(type) {}
+
+      BundleElement(StringAttr name, bool isFlip, FIRRTLBaseType type,
+          StringAttr description)
+          : name(name), isFlip(isFlip), type(type), description(description) {}
 
       bool operator==(const BundleElement &rhs) const {
         return name == rhs.name && isFlip == rhs.isFlip && type == rhs.type;

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -171,7 +171,11 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
 /// cannot be lowered.
 Type lowerType(Type type);
 
-Type lowerType(Type type, hw::HWModuleOp module);
+/// Given a type, return the corresponding lowered type for the HW dialect.
+/// If the given type is a named bundle, then create a TypeScope at the Module level and the corresponding typedecl op inside it and return the corresponding TypeAliasType.
+Type lowerType(Type type, Location loc,
+               llvm::function_ref<hw::TypeAliasType(Type, BundleType, Location)>
+                   getTypeDeclFn);
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/Support/Parallel.h"
 
@@ -169,6 +170,8 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
 /// Non-FIRRTL types are simply passed through. This returns a null type if it
 /// cannot be lowered.
 Type lowerType(Type type);
+
+Type lowerType(Type type, hw::HWModuleOp module);
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -172,11 +172,9 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
 /// If the given type is a named bundle, then create a TypeScope at the Module
 /// level and the corresponding typedecl op inside it and return the
 /// corresponding TypeAliasType.
-Type lowerType(
-    Type type, std::optional<Location> loc = {},
-    std::optional<
-        llvm::function_ref<hw::TypeAliasType(Type, BundleType, Location)>>
-        getTypeDeclFn = {});
+Type lowerType(Type type, std::optional<Location> loc = {},
+               std::function<hw::TypeAliasType(Type, BundleType, Location)>
+                   getTypeDeclFn = {});
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -169,13 +169,14 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
 /// Given a type, return the corresponding lowered type for the HW dialect.
 /// Non-FIRRTL types are simply passed through. This returns a null type if it
 /// cannot be lowered.
-Type lowerType(Type type);
-
-/// Given a type, return the corresponding lowered type for the HW dialect.
-/// If the given type is a named bundle, then create a TypeScope at the Module level and the corresponding typedecl op inside it and return the corresponding TypeAliasType.
-Type lowerType(Type type, Location loc,
-               llvm::function_ref<hw::TypeAliasType(Type, BundleType, Location)>
-                   getTypeDeclFn);
+/// If the given type is a named bundle, then create a TypeScope at the Module
+/// level and the corresponding typedecl op inside it and return the
+/// corresponding TypeAliasType.
+Type lowerType(
+    Type type, std::optional<Location> loc = {},
+    std::optional<
+        llvm::function_ref<hw::TypeAliasType(Type, BundleType, Location)>>
+        getTypeDeclFn = {});
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -172,9 +172,10 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
 /// If the given type is a named bundle, then create a TypeScope at the Module
 /// level and the corresponding typedecl op inside it and return the
 /// corresponding TypeAliasType.
-Type lowerType(Type type, std::optional<Location> loc = {},
-               std::function<hw::TypeAliasType(Type, BundleType, Location)>
-                   getTypeDeclFn = {});
+Type lowerType(
+    Type type, std::optional<Location> loc = {},
+    const std::function<hw::TypeAliasType(Type, BundleType, Location)>
+        &getTypeDeclFn = {});
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2753,8 +2753,9 @@ LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
     createBackedge(op.getResult(), origResultType);
     return success();
   }
+  auto hwModule = cast<hw::HWModuleOp>(op->getParentOp());
 
-  auto resultType = lowerType(origResultType);
+  auto resultType = lowerType(origResultType, hwModule);
   if (!resultType)
     return failure();
 
@@ -2765,7 +2766,7 @@ LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
   StringAttr symName = getInnerSymName(op);
   auto name = op.getNameAttr();
   if (AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) && !symName) {
-    auto moduleName = cast<hw::HWModuleOp>(op->getParentOp()).getName();
+    auto moduleName = hwModule.getName();
     // Prepend the name of the module to make the symbol name unique in the
     // symbol table, it is already unique in the module. Checking if the name
     // is unique in the SymbolTable is non-trivial.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3744,8 +3744,7 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
         if (lowName && highName && lowName == highName)
           // Only preserve the names that match, otherwise drop the name.
           return BundleType::get(low.getContext(), newElements, false, lowName);
-        else
-          return BundleType::get(low.getContext(), newElements);
+        return BundleType::get(low.getContext(), newElements);
       }
     }
     return emitInferRetTypeError<FIRRTLBaseType>(

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3721,6 +3721,8 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
     auto highElements = highBundle.getElements();
     auto lowElements = lowBundle.getElements();
     size_t numElements = highElements.size();
+    auto lowName = lowBundle.getBundleName();
+    auto highName = highBundle.getBundleName();
 
     SmallVector<BundleType::BundleElement> newElements;
     if (numElements == lowElements.size()) {
@@ -3738,8 +3740,13 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
           return {};
         newElements.push_back(element);
       }
-      if (!failed)
-        return BundleType::get(low.getContext(), newElements);
+      if (!failed) {
+        if (lowName && highName && lowName == highName)
+          // Only preserve the names that match, otherwise drop the name.
+          return BundleType::get(low.getContext(), newElements, false, lowName);
+        else
+          return BundleType::get(low.getContext(), newElements);
+      }
     }
     return emitInferRetTypeError<FIRRTLBaseType>(
         loc, "incompatible mux operand bundle fields, true value type: ", high,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -942,25 +942,13 @@ UIntType UIntType::getConstType(bool isConst) {
 // Bundle Type
 //===----------------------------------------------------------------------===//
 
-<<<<<<< HEAD
-struct circt::firrtl::detail::BundleTypeStorage
-    : detail::FIRRTLBaseTypeStorage {
-  using KeyTy = std::pair<ArrayRef<BundleType::BundleElement>, char>;
-
-  BundleTypeStorage(ArrayRef<BundleType::BundleElement> elements, bool isConst)
-      : detail::FIRRTLBaseTypeStorage(isConst),
-        elements(elements.begin(), elements.end()), props{true, false, false,
-                                                          false, false} {
-=======
 struct circt::firrtl::detail::BundleTypeStorage : mlir::TypeStorage {
   using ElementsType = ArrayRef<BundleType::BundleElement>;
-  using KeyTy = std::pair<ArrayRef<BundleType::BundleElement>, StringAttr>;
+  using KeyTy = std::tuple<ArrayRef<BundleType::BundleElement>, char, StringAttr>;
 
-  BundleTypeStorage(KeyTy value)
-      : elements(value.first.begin(), value.first.end()),
-        bundleName(value.second) {
-    RecursiveTypeProperties props{true, false, false};
->>>>>>> e7259f548... [FIRRTLType] Add bundle name and field description to BundleType
+  BundleTypeStorage(ArrayRef<BundleType::BundleElement> elements, bool isConst, StringAttr bundleName)
+      : detail::FIRRTLBaseTypeStorage(isConst),
+      elements(value.first.begin(), value.first.end()), bundleName(value.second), props{true, false, false} {
     uint64_t fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {
@@ -980,26 +968,14 @@ struct circt::firrtl::detail::BundleTypeStorage : mlir::TypeStorage {
   }
 
   bool operator==(const KeyTy &key) const {
-<<<<<<< HEAD
-    return key == KeyTy(elements, isConst);
+    return key == KeyTy(elements, isConst, bundleName);
   }
 
   static llvm::hash_code hashKey(const KeyTy &key) {
     return llvm::hash_combine(
-        llvm::hash_combine_range(key.first.begin(), key.first.end()),
-        key.second);
-=======
-    return key.first == (ElementsType)elements && key.second == bundleName;
-  }
+        llvm::hash_combine_range(std::get<0>(key).begin(), std::get<0>(key).end()),
+        std::get<1>(key), std::get<2>(key));
 
-  static llvm::hash_code hashKey(const KeyTy &key) {
-    if (key.second)
-      return llvm::hash_combine(
-          llvm::hash_combine_range(key.first.begin(), key.first.end()),
-          llvm::hash_value(key.second));
-    else
-      return llvm::hash_combine_range(key.first.begin(), key.first.end());
->>>>>>> e7259f548... [FIRRTLType] Add bundle name and field description to BundleType
   }
 
   static BundleTypeStorage *construct(TypeStorageAllocator &allocator,
@@ -1019,24 +995,22 @@ struct circt::firrtl::detail::BundleTypeStorage : mlir::TypeStorage {
   BundleType passiveType;
 };
 
-<<<<<<< HEAD
 BundleType BundleType::get(MLIRContext *context,
                            ArrayRef<BundleElement> elements, bool isConst) {
   return Base::get(context, elements, isConst);
-=======
+}
 auto BundleType::getBundleName() const -> StringAttr {
   return getImpl()->bundleName;
->>>>>>> e7259f548... [FIRRTLType] Add bundle name and field description to BundleType
 }
 
 auto BundleType::getElements() const -> ArrayRef<BundleElement> {
   return getImpl()->elements;
 }
 
-BundleType BundleType::get(ArrayRef<BundleElement> elements,
+BundleType BundleType::get(ArrayRef<BundleElement> elements, bool isConst,
                            StringAttr bundleName) {
   return Base::get(bundleName.getContext(),
-                   std::make_pair(elements, bundleName));
+                   std::make_tuple(elements, isConst, bundleName));
 }
 
 BundleType BundleType::get(MLIRContext *context,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -77,8 +77,6 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
                                 os << element.name.getValue();
                                 if (element.isFlip)
                                   os << " flip";
-                                if (element.description)
-                                  os << " " << element.description << " ";
                                 os << ": ";
                                 printNestedType(element.type, os);
                               });
@@ -200,7 +198,6 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
       std::string nameStr;
       StringRef name;
       FIRRTLBaseType type;
-      StringAttr descriptionAttr;
 
       // The 'name' can be an identifier or an integer.
       uint32_t fieldIntName;
@@ -217,17 +214,10 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
       }
 
       bool isFlip = succeeded(parser.parseOptionalKeyword("flip"));
-      std::string description;
-      if (parser.parseOptionalString(&description).succeeded()) {
-        if (!description.empty())
-          descriptionAttr = StringAttr::get(context, description);
-      }
-
       if (parser.parseColon() || parseNestedBaseType(type, parser))
         return failure();
 
-      elements.push_back(
-          {StringAttr::get(context, name), isFlip, type, descriptionAttr});
+      elements.push_back({StringAttr::get(context, name), isFlip, type});
       return success();
     };
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -805,8 +805,8 @@ circt::firrtl::maybeStringToLocation(StringRef spelling, bool skipParsing,
 /// cannot be lowered.
 Type circt::firrtl::lowerType(
     Type type, std::optional<Location> loc,
-    std::function<hw::TypeAliasType(Type, BundleType, Location)>
-        getTypeDeclFn) {
+    const std::function<hw::TypeAliasType(Type, BundleType, Location)>
+        &getTypeDeclFn) {
   auto firType = type.dyn_cast<FIRRTLBaseType>();
   if (!firType)
     return type;

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -805,8 +805,7 @@ circt::firrtl::maybeStringToLocation(StringRef spelling, bool skipParsing,
 /// cannot be lowered.
 Type circt::firrtl::lowerType(
     Type type, std::optional<Location> loc,
-    std::optional<
-        llvm::function_ref<hw::TypeAliasType(Type, BundleType, Location)>>
+    std::function<hw::TypeAliasType(Type, BundleType, Location)>
         getTypeDeclFn) {
   auto firType = type.dyn_cast<FIRRTLBaseType>();
   if (!firType)
@@ -825,11 +824,11 @@ Type circt::firrtl::lowerType(
     }
     Type rawType = hw::StructType::get(type.getContext(), hwfields);
     if (auto bundleName = bundle.getBundleName())
-      if (getTypeDeclFn.has_value())
-        rawType = getTypeDeclFn.value()(
-            rawType, bundle,
-            loc.has_value() ? loc.value()
-                            : UnknownLoc::get(bundle.getContext()));
+      if (getTypeDeclFn)
+        rawType = getTypeDeclFn(rawType, bundle,
+                                loc.has_value()
+                                    ? loc.value()
+                                    : UnknownLoc::get(bundle.getContext()));
     return rawType;
   }
   if (auto vec = firType.dyn_cast<FVectorType>()) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -13,6 +13,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.type_scope @Simple__TYPESCOPE_ {
   // CHECK-NEXT:  hw.typedecl @Other : !hw.struct<sint: i2, uint: i4>
   // CHECK-NEXT:  hw.typedecl @VecOfBundle : !hw.struct<sint: i2, uint: i4>
+  // CHECK-NEXT:  hw.typedecl @Other_0 : !hw.struct<sint: i3, uint: i4>
   // CHECK-NEXT:  hw.typedecl @OtherOther : !hw.struct<other: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>
   // CHECK:      sv.ifdef  "PRINTF_COND_" {
   // CHECK-NEXT: } else {
@@ -1621,14 +1622,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
 
-  firrtl.extmodule @namedB(in a :!firrtl<bundle "Other" <sint: sint<2>, uint: uint<4>>>, out b: !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>)
+  firrtl.extmodule @namedB(in a :!firrtl<bundle "Other" <sint: sint<2>, uint: uint<4>>>, out b: !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>, out c: !firrtl<bundle "Other" <sint: sint<3>, uint: uint<4>>>)
   // CHECK-LABEL: hw.module.extern @namedB
   // CHECK-SAME: %a: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>
   // CHECK-SAME:  b: !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>
+  // CHECK-SAME:  c: !hw.typealias<@Simple__TYPESCOPE_::@Other_0, !hw.struct<sint: i3, uint: i4>>
   firrtl.module @NamedBundles() {
     %vecOfBundle = firrtl.wire sym @vecOfBundle : !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>
     %otherOther = firrtl.wire sym @otherOther : !firrtl<bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>
-    %r1, %r2 = firrtl.instance inst @namedB(in a :!firrtl<bundle "Other" <sint: sint<2>, uint: uint<4>>>, out b: !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>)
+    %renameOther = firrtl.wire : !firrtl<bundle "Other" <sint: sint<3>, uint: uint<4>>>
+    %r1, %r2, %r3 = firrtl.instance inst @namedB(in a :!firrtl<bundle "Other" <sint: sint<2>, uint: uint<4>>>, out b: !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>, out c: !firrtl<bundle "Other" <sint: sint<3>, uint: uint<4>>>)
     %0 = firrtl.subindex %r2[0] : !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>
     %1 = firrtl.subfield %0[sint] : !firrtl<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>>
     %wire1 = firrtl.wire : !firrtl.sint<2>
@@ -1638,7 +1641,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %z_i6_0 = sv.constantZ : !hw.typealias<@Simple__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>
     // CHECK: %vecOfBundle = hw.wire %inst.b sym @vecOfBundle  : !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>
     // CHECK: %otherOther = hw.wire %z_i6_0 sym @otherOther  : !hw.typealias<@Simple__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>
-    // CHECK: %inst.b = hw.instance "inst" @namedB(a: %z_i6: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>) -> (b: !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>)
+    // CHECK: %inst.b, %inst.c  = hw.instance "inst" @namedB(a: %z_i6: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>) -> (b: !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>, c: !hw.typealias<@Simple__TYPESCOPE_::@Other_0, !hw.struct<sint: i3, uint: i4>>)
     // CHECK: %0 = hw.array_get %inst.b[%false] : !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>, i1
     // CHECK: %sint = hw.struct_extract %0["sint"] : !hw.typealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>
     // CHECK: %wire1 = hw.wire %sint  : i2

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1618,9 +1618,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:  }
 
   firrtl.module @NamedBundles() {
-    %uint = firrtl.wire sym @uint : !firrtl.uint<1>
-    %vec = firrtl.wire sym @vec : !firrtl.vector<uint<1>, 2>
-    %multivec = firrtl.wire sym @multivec : !firrtl.vector<vector<uint<1>, 3>, 2>
     %vecOfBundle = firrtl.wire sym @vecOfBundle : !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>
     %otherOther = firrtl.wire sym @otherOther : !firrtl<bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>
     // CHECK-LABEL: hw.type_scope @NamedBundles__TYPESCOPE_ {
@@ -1628,10 +1625,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:   hw.typedecl @Other : !hw.struct<sint: i2, uint: i4>
     // CHECK-NEXT:   hw.typedecl @OtherOther : !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>
     // CHECK-NEXT: }
-    // CHECK-NEXT: %uint = sv.wire sym @uint : !hw.inout<i1>
-    // CHECK-NEXT: %vec = sv.wire sym @vec : !hw.inout<array<2xi1>>
-    // CHECK-NEXT: %multivec = sv.wire sym @multivec : !hw.inout<array<2xarray<3xi1>>>
-    // CHECK-NEXT: %vecOfBundle = sv.wire sym @vecOfBundle : !hw.inout<array<2xtypealias<@NamedBundles__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>>
-    // CHECK-NEXT: %otherOther = sv.wire sym @otherOther : !hw.inout<typealias<@NamedBundles__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>>
+    // CHECK: %vecOfBundle = hw.wire %z_i12 sym @vecOfBundle  : 
+    // CHECK-SAME: !hw.array<2xtypealias<@NamedBundles__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>
+    // CHECK-NEXT: %otherOther = hw.wire %z_i6 sym @otherOther  : 
+    // CHECK-SAME: !hw.typealias<@NamedBundles__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1616,4 +1616,22 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:      }
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
+
+  firrtl.module @NamedBundles() {
+    %uint = firrtl.wire sym @uint : !firrtl.uint<1>
+    %vec = firrtl.wire sym @vec : !firrtl.vector<uint<1>, 2>
+    %multivec = firrtl.wire sym @multivec : !firrtl.vector<vector<uint<1>, 3>, 2>
+    %vecOfBundle = firrtl.wire sym @vecOfBundle : !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>
+    %otherOther = firrtl.wire sym @otherOther : !firrtl<bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>
+    // CHECK-LABEL: hw.type_scope @NamedBundles__TYPESCOPE_ {
+    // CHECK-NEXT:   hw.typedecl @VecOfBundle : !hw.struct<sint: i2, uint: i4>
+    // CHECK-NEXT:   hw.typedecl @Other : !hw.struct<sint: i2, uint: i4>
+    // CHECK-NEXT:   hw.typedecl @OtherOther : !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>
+    // CHECK-NEXT: }
+    // CHECK-NEXT: %uint = sv.wire sym @uint : !hw.inout<i1>
+    // CHECK-NEXT: %vec = sv.wire sym @vec : !hw.inout<array<2xi1>>
+    // CHECK-NEXT: %multivec = sv.wire sym @multivec : !hw.inout<array<2xarray<3xi1>>>
+    // CHECK-NEXT: %vecOfBundle = sv.wire sym @vecOfBundle : !hw.inout<array<2xtypealias<@NamedBundles__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>>
+    // CHECK-NEXT: %otherOther = sv.wire sym @otherOther : !hw.inout<typealias<@NamedBundles__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>>
+  }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -10,6 +10,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 "sifive.enterprise.firrtl.ExtractAssertionsAnnotation", directory = "dir3",  filename = "./dir3/filename3" }]}
 {
   // Headers
+  // CHECK-LABEL: hw.type_scope @Simple__TYPESCOPE_ {
+  // CHECK-NEXT:  hw.typedecl @VecOfBundle : !hw.struct<sint: i2, uint: i4>
+  // CHECK-NEXT:  hw.typedecl @Other : !hw.struct<sint: i2, uint: i4>
+  // CHECK-NEXT:  hw.typedecl @OtherOther : !hw.struct<other: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>
   // CHECK:      sv.ifdef  "PRINTF_COND_" {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.ifdef  "PRINTF_COND" {
@@ -1620,14 +1624,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @NamedBundles() {
     %vecOfBundle = firrtl.wire sym @vecOfBundle : !firrtl.vector<bundle "VecOfBundle" <sint: sint<2>, uint: uint<4>>, 2>
     %otherOther = firrtl.wire sym @otherOther : !firrtl<bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>
-    // CHECK-LABEL: hw.type_scope @NamedBundles__TYPESCOPE_ {
-    // CHECK-NEXT:   hw.typedecl @VecOfBundle : !hw.struct<sint: i2, uint: i4>
-    // CHECK-NEXT:   hw.typedecl @Other : !hw.struct<sint: i2, uint: i4>
-    // CHECK-NEXT:   hw.typedecl @OtherOther : !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>
-    // CHECK-NEXT: }
     // CHECK: %vecOfBundle = hw.wire %z_i12 sym @vecOfBundle  : 
-    // CHECK-SAME: !hw.array<2xtypealias<@NamedBundles__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>
+    // CHECK-SAME: !hw.array<2xtypealias<@Simple__TYPESCOPE_::@VecOfBundle, !hw.struct<sint: i2, uint: i4>>>
     // CHECK-NEXT: %otherOther = hw.wire %z_i6 sym @otherOther  : 
-    // CHECK-SAME: !hw.typealias<@NamedBundles__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@NamedBundles__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>
+    // CHECK-SAME: !hw.typealias<@Simple__TYPESCOPE_::@OtherOther, !hw.struct<other: !hw.typealias<@Simple__TYPESCOPE_::@Other, !hw.struct<sint: i2, uint: i4>>>>
   }
 }

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -537,3 +537,17 @@ firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.const.uint<1>) {
   firrtl.connect %b, %a : !firrtl.const.uint<1>, !firrtl.uint<1>
 }
 }
+
+// -----
+
+/// Named bundles must match for strict connect.
+
+firrtl.circuit "namedBundles" {
+firrtl.module @namedBundles() {
+  %w1 = firrtl.wire : !firrtl<bundle "B1" <a : uint<1>>>
+  // expected-note @below {{prior use here}}
+  %w2 = firrtl.wire : !firrtl<bundle "B2" <a : uint<1>>>
+  // expected-error @below {{expects different type than prior uses}}
+  firrtl.strictconnect %w1, %w2 : !firrtl<bundle "B1" <a : uint<1>>>
+}
+}

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -224,7 +224,6 @@ firrtl.module @ConstToExplicitConstElementsVec(in %in : !firrtl.const.vector<uin
 firrtl.module @ConstToNonConstVec(in %in : !firrtl.const.vector<uint<1>, 3>, out %out : !firrtl.vector<uint<1>, 3>) {
   // CHECK: firrtl.connect %out, %in : !firrtl.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
   firrtl.connect %out, %in : !firrtl.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
-
 }
 
 firrtl.module @namedBundles(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
@@ -245,4 +244,5 @@ firrtl.module @namedBundles(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>
   firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>, !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
   // CHECK: firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>, !firrtl<bundle "B2" <a: uint<1>, b: uint<1>>>
+}
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -228,21 +228,21 @@ firrtl.module @ConstToNonConstVec(in %in : !firrtl.const.vector<uint<1>, 3>, out
 }
 
 firrtl.module @namedBundles(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
-  %w = firrtl.wire : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
-  %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  %w = firrtl.wire : !firrtl<bundle "B1" <a : uint<1>>>
+  %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a : uint<1>>>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: %w = firrtl.wire : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
-  // CHECK: %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  // CHECK: %w = firrtl.wire : !firrtl<bundle "B1" <a: uint<1>>>
+  // CHECK: %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a: uint<1>>>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  %w1 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b : uint<1>>>
-  %w2 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b : uint<1>>>
+  %w1 = firrtl.wire : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>
+  %w2 = firrtl.wire : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>
   %w3 = firrtl.wire : !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
   firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>
-  // CHECK: %w1 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
-  // CHECK: %w2 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
-  // CHECK: firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
+  // CHECK: %w1 = firrtl.wire : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>
+  // CHECK: %w2 = firrtl.wire : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>
+  // CHECK: firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>
   firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>, !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
-  // CHECK: firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>, !firrtl<bundle "B2" <a: uint<1>, b: uint<1>>>
+  // CHECK: firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>, !firrtl<bundle "B2" <a: uint<1>, b: uint<1>>>
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -244,5 +244,9 @@ firrtl.module @namedBundles(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>
   firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>, !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
   // CHECK: firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a: uint<1>, b: uint<1>>>, !firrtl<bundle "B2" <a: uint<1>, b: uint<1>>>
+    // Note: Output of a mux preseves only the names that are common to both the bundles.
+    %vecOfBundle = firrtl.wire sym @vecOfBundle : !firrtl.vector<bundle "VecOfBundle" <a: bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>, 2>
+    %vecOfBundle2 = firrtl.wire : !firrtl.vector<bundle "VecOfBundle2" <a: bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>, 2>
+    %2 = firrtl.mux(%in, %vecOfBundle, %vecOfBundle2) : (!firrtl.uint<1>, !firrtl.vector<bundle "VecOfBundle" <a: bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>, 2>, !firrtl.vector<bundle "VecOfBundle2" <a: bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>, 2>) -> !firrtl.vector<bundle <a: bundle "OtherOther" <other: bundle "Other" <sint: sint<2>, uint: uint<4>>>>, 2>
 }
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -224,6 +224,25 @@ firrtl.module @ConstToExplicitConstElementsVec(in %in : !firrtl.const.vector<uin
 firrtl.module @ConstToNonConstVec(in %in : !firrtl.const.vector<uint<1>, 3>, out %out : !firrtl.vector<uint<1>, 3>) {
   // CHECK: firrtl.connect %out, %in : !firrtl.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
   firrtl.connect %out, %in : !firrtl.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
+
 }
 
+firrtl.module @namedBundles(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+  %w = firrtl.wire : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: %w = firrtl.wire : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  // CHECK: %0 = firrtl.subfield %w[a] : !firrtl<bundle "B1" <a "description a b c" : uint<1>>>
+  // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  %w1 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b : uint<1>>>
+  %w2 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b : uint<1>>>
+  %w3 = firrtl.wire : !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
+  firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>
+  // CHECK: %w1 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
+  // CHECK: %w2 = firrtl.wire : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
+  // CHECK: firrtl.strictconnect %w2, %w1 : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>
+  firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a : uint<1>, b : uint<1>>>, !firrtl<bundle "B2" <a : uint<1>, b : uint<1>>>
+  // CHECK: firrtl.connect %w2, %w3 : !firrtl<bundle "B1" <a "desc 1" : uint<1>, b: uint<1>>>, !firrtl<bundle "B2" <a: uint<1>, b: uint<1>>>
 }


### PR DESCRIPTION
Represent named bundles in FIRRTL, by adding an optional name attribute to `BundleType`.  The named bundles are lowered to `hw::TypeDeclOp` and `hw::TypeScopeOp`s. 
The `hw::TypeDeclOp` is lowered to verilog `typedef`. So, the named bundles can be used to generate `typedef`s.
Currently there is no user of named bundles, but https://github.com/llvm/circt/pull/4741 is a potential client.
Semantics
1. `strictconnect` can only be used for exactly same bundles, i.e., the names should also match. 
2. `connect` can be used for bundles with different names. This implies individual field connects, and the name will be dropped.
