### PR TITLE
[FIRRTL] Split firrtl.ref into firrtl.probe, firrtl.rwprobe .

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -236,7 +236,7 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
 
 def RefImpl : FIRRTLImplType<"Ref", [], "::circt::firrtl::FIRRTLType"> {
   let summary = [{
-    A reference type, such as `firrtl.ref<uint<1>>`.
+    A reference type, such as `firrtl.probe<uint<1>>` or `firrtl.rwprobe<uint<2>>`.
 
     Used for remote reads and writes of the wrapped base type.
 
@@ -247,14 +247,18 @@ def RefImpl : FIRRTLImplType<"Ref", [], "::circt::firrtl::FIRRTLType"> {
 
     Values of this type are used to capture dataflow paths,
     and do not represent a circuit element or entity.
+    
+    Generally read-only (probe), optionally forceable (rwprobe).
   }];
   let parameters = (ins TypeParameter<"::circt::firrtl::FIRRTLBaseType",
-                                      "Type of reference target">:$type);
+                                      "Type of reference target">:$type,
+                        "bool":$forceable);
   let genVerifyDecl = true;
 
   let skipDefaultBuilders = true;
   let builders = [
-    TypeBuilderWithInferredContext<(ins "::circt::firrtl::FIRRTLBaseType":$type)>
+    TypeBuilderWithInferredContext<(ins "::circt::firrtl::FIRRTLBaseType":$type,
+                                        CArg<"bool", "false">:$forceable)>
   ];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -160,7 +160,9 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
                               function_ref<FIRRTLBaseType(FIRRTLBaseType)> fn) {
   return TypeSwitch<FIRRTLType, FIRRTLType>(type)
       .Case<FIRRTLBaseType>([&](auto base) { return fn(base); })
-      .Case<RefType>([&](auto ref) { return RefType::get(fn(ref.getType())); });
+      .Case<RefType>([&](auto ref) {
+        return RefType::get(fn(ref.getType()), ref.getForceable());
+      });
 }
 
 /// Given a type, return the corresponding lowered type for the HW dialect.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -80,7 +80,9 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         os << ", " << vectorType.getNumElements() << '>';
       })
       .Case<RefType>([&](auto refType) {
-        os << "ref<";
+        if (refType.getForceable())
+          os << "rw";
+        os << "probe<";
         printNestedType(refType.getType(), os);
         os << '>';
       })
@@ -206,17 +208,32 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
     return result = FVectorType::get(elementType, width), success();
   }
 
-  if (name.equals("ref")) {
+  // For now, support both firrtl.ref and firrtl.probe.
+  if (name.equals("ref") || name.equals("probe")) {
     FIRRTLBaseType type;
     if (parser.parseLess() || parseNestedBaseType(type, parser) ||
         parser.parseGreater())
       return failure();
 
     if (failed(RefType::verify(
-            [&]() { return parser.emitError(parser.getNameLoc()); }, type)))
+            [&]() { return parser.emitError(parser.getNameLoc()); }, type,
+            false)))
       return failure();
 
-    return result = RefType::get(type), success();
+    return result = RefType::get(type, false), success();
+  }
+  if (name.equals("rwprobe")) {
+    FIRRTLBaseType type;
+    if (parser.parseLess() || parseNestedBaseType(type, parser) ||
+        parser.parseGreater())
+      return failure();
+
+    if (failed(RefType::verify(
+            [&]() { return parser.emitError(parser.getNameLoc()); }, type,
+            true)))
+      return failure();
+
+    return result = RefType::get(type, true), success();
   }
 
   return {};
@@ -1052,12 +1069,12 @@ std::pair<uint64_t, bool> FVectorType::rootChildFieldID(uint64_t fieldID,
 // RefType
 //===----------------------------------------------------------------------===//
 
-auto RefType::get(FIRRTLBaseType type) -> RefType {
-  return Base::get(type.getContext(), type);
+auto RefType::get(FIRRTLBaseType type, bool forceable) -> RefType {
+  return Base::get(type.getContext(), type, forceable);
 }
 
 auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
-                     FIRRTLBaseType base) -> LogicalResult {
+                     FIRRTLBaseType base, bool forceable) -> LogicalResult {
   if (!base.isPassive())
     return emitErrorFn() << "reference base type must be passive";
   return success();

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
@@ -4,9 +4,9 @@
 ; Test tapping a bundle with flips, tap sink is passive.
 
 ; CHECK-DAG: firrtl.ref.send
-; CHECK-DAG-SAME: !firrtl.ref<bundle<a: uint<2>, b flip: uint<2>>>
+; CHECK-DAG-SAME: !firrtl.probe<bundle<a: uint<2>, b flip: uint<2>>>
 ; CHECK-DAG: firrtl.ref.resolve
-; CHECK-DAG-SAME: !firrtl.ref<bundle<a: uint<2>, b: uint<2>>>
+; CHECK-DAG-SAME: !firrtl.probe<bundle<a: uint<2>, b: uint<2>>>
 circuit Top : %[[
   {
     "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1204,12 +1204,12 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.extmodule private @BlackBox
-// CHECK-SAME:    out [[tap_4:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
-// CHECk-SAME:    out [[tap_5_0:[[a-zA-Z09-_]+]]]: !firrtl.ref<uint<1>>
+// CHECK-SAME:    out [[tap_4:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
+// CHECk-SAME:    out [[tap_5_0:[[a-zA-Z09-_]+]]]: !firrtl.probe<uint<1>>
 // CHECK-SAME:    internalPaths = ["baz.qux", "baz.quz"]
 
 // CHECK-LABEL: firrtl.module private @InnerMod
-// CHECK-SAME:    out %[[tap_6:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
+// CHECK-SAME:    out %[[tap_6:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
 // CHECK:         %[[w_ref:[a-zA-Z09_]+]] = firrtl.ref.send %w
 // CHECK:         firrtl.ref.define %[[tap_6]], %[[w_ref]]
 
@@ -1259,7 +1259,7 @@ firrtl.circuit "GCTMemTap" attributes {rawAnnotations = [{
 // CHECK:      firrtl.module @GCTMemTap
 // CHECK:        %[[debug_port:[a-zA-Z0-9_]+]] = chirrtl.debugport %mem
 // CHECK-SAME:     {name = "memTap"}
-// CHECK-SAME:     (!chirrtl.cmemory<uint<1>, 2>) -> !firrtl.ref<vector<uint<1>, 2>>
+// CHECK-SAME:     (!chirrtl.cmemory<uint<1>, 2>) -> !firrtl.probe<vector<uint<1>, 2>>
 // CHECK-NEXT:   %[[debug_port_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[debug_port]]
 // CHECK-NEXT:   %memTap = firrtl.node %[[debug_port_resolve]]
 
@@ -1379,8 +1379,8 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     // CHECK-SAME:   !firrtl.uint<2>
   }
   // CHECK:      firrtl.module @Bar
-  // CHECK-SAME:   out %[[refPort_0:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
-  // CHECK-SAME:   out %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<2>>
+  // CHECK-SAME:   out %[[refPort_0:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
+  // CHECK-SAME:   out %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<2>>
   firrtl.module @Bar() {
     %a = firrtl.wire interesting_name  : !firrtl.bundle<a: uint<1>, b: uint<2>>
     // CHECK:      %[[a_0:[a-zA-Z0-9_]+]] = firrtl.subfield %a[a]
@@ -1415,24 +1415,24 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   ]}]} {
   // CHECK-LABEL: firrtl.circuit "Top"  {
   // CHECK-NOT:   "sifive.enterprise.grandcentral.DataTapsAnnotation"
-  // CHECK:  firrtl.module private @Bar(out %inv__bore: !firrtl.ref<uint<1>>)
+  // CHECK:  firrtl.module private @Bar(out %inv__bore: !firrtl.probe<uint<1>>)
   firrtl.module private @Bar() {
     %inv = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %inv : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %inv__bore, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.ref.define %inv__bore, %0 : !firrtl.probe<uint<1>>
   }
-  // CHECK-LABEL: firrtl.module private @Foo(out %b_inv__bore: !firrtl.ref<uint<1>>)
+  // CHECK-LABEL: firrtl.module private @Foo(out %b_inv__bore: !firrtl.probe<uint<1>>)
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
-    // CHECK:  %[[b_inv:[a-zA-Z0-9_]+]] = firrtl.instance b interesting_name  @Bar(out inv__bore: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.ref.define %b_inv__bore, %[[b_inv]] : !firrtl.ref<uint<1>>
+    // CHECK:  %[[b_inv:[a-zA-Z0-9_]+]] = firrtl.instance b interesting_name  @Bar(out inv__bore: !firrtl.probe<uint<1>>)
+    // CHECK:  firrtl.ref.define %b_inv__bore, %[[b_inv]] : !firrtl.probe<uint<1>>
   }
   // CHECK: firrtl.module @Top()
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
-    // CHECK:  %[[foo_b_inv:[a-zA-Z0-9_]+]] = firrtl.instance foo interesting_name  @Foo(out b_inv__bore: !firrtl.ref<uint<1>>)
-    // CHECK:  %0 = firrtl.ref.resolve %[[foo_b_inv]] : !firrtl.ref<uint<1>>
+    // CHECK:  %[[foo_b_inv:[a-zA-Z0-9_]+]] = firrtl.instance foo interesting_name  @Foo(out b_inv__bore: !firrtl.probe<uint<1>>)
+    // CHECK:  %0 = firrtl.ref.resolve %[[foo_b_inv]] : !firrtl.probe<uint<1>>
     // CHECK:  %tap = firrtl.node %0 : !firrtl.uint<1>
   }
 }
@@ -1457,23 +1457,23 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
       }
     ]}]} {
   firrtl.extmodule private @ExtBar()
-  // CHECK: firrtl.extmodule private @ExtBar(out random_something_external: !firrtl.ref<uint<1>>)
+  // CHECK: firrtl.extmodule private @ExtBar(out random_something_external: !firrtl.probe<uint<1>>)
   // CHECK-SAME: internalPaths = ["random.something.external"]
-  // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.ref<uint<1>>)
+  // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.probe<uint<1>>)
   // CHECK:  %[[random:.+]] = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
   // CHECK:  %0 = firrtl.ref.send %[[random]] : !firrtl.uint<1>
-  // CHECK:  firrtl.ref.define %[[_gen_ref2]], %0 : !firrtl.ref<uint<1>>
+  // CHECK:  firrtl.ref.define %[[_gen_ref2]], %0 : !firrtl.probe<uint<1>>
   firrtl.module private @Bar() {
   }
 
   // CHECK-LABEL:  firrtl.module private @Foo(
-  // CHECK-SAME: out %b_random_something__bore: !firrtl.ref<uint<1>>, out %b2_random_something_external__bore: !firrtl.ref<uint<1>>
+  // CHECK-SAME: out %b_random_something__bore: !firrtl.probe<uint<1>>, out %b2_random_something_external__bore: !firrtl.probe<uint<1>>
   firrtl.module private @Foo() {
     firrtl.instance b interesting_name  @Bar()
     // CHECK:  %[[gen_refPort:.+]] = firrtl.instance b interesting_name @Bar
-    // CHECK-SAME: (out [[_gen_ref2]]: !firrtl.ref<uint<1>>)
+    // CHECK-SAME: (out [[_gen_ref2]]: !firrtl.probe<uint<1>>)
     firrtl.instance b2 interesting_name  @ExtBar()
-    // CHECK: %b2_random_something_external = firrtl.instance b2 interesting_name  @ExtBar(out random_something_external: !firrtl.ref<uint<1>>)
+    // CHECK: %b2_random_something_external = firrtl.instance b2 interesting_name  @ExtBar(out random_something_external: !firrtl.probe<uint<1>>)
   }
   // CHECK-LABEL firrtl.module @Top()
   firrtl.module @Top() {
@@ -1481,8 +1481,8 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
     %tap = firrtl.wire interesting_name  : !firrtl.uint<1>
     %tap2 = firrtl.wire interesting_name  : !firrtl.uint<1>
     // CHECK:  %[[foo__gen_tap:.+]], %[[foo__gen_tap2:.+]] = firrtl.instance foo interesting_name  @Foo
-    // CHECK-SAME: (out b_random_something__bore: !firrtl.ref<uint<1>>, out b2_random_something_external__bore: !firrtl.ref<uint<1>>)
-    // CHECK:  %[[v0:.+]] = firrtl.ref.resolve %[[foo__gen_tap]] : !firrtl.ref<uint<1>>
+    // CHECK-SAME: (out b_random_something__bore: !firrtl.probe<uint<1>>, out b2_random_something_external__bore: !firrtl.probe<uint<1>>)
+    // CHECK:  %[[v0:.+]] = firrtl.ref.resolve %[[foo__gen_tap]] : !firrtl.probe<uint<1>>
     // CHECK:  %tap = firrtl.node %[[v0]] : !firrtl.uint<1>
   }
 }
@@ -1549,7 +1549,7 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
   ]
 } {
   // CHECK:        firrtl.module @Bar
-  // CHECK-SAME:     out %[[a_refPort:[a-zA-Z0-9_]+]]: !firrtl.ref<uint<1>>
+  // CHECK-SAME:     out %[[a_refPort:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
   firrtl.module @Bar() {
     %a = firrtl.wire : !firrtl.uint<1>
     // CHECK:        %[[a_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %a
@@ -1731,7 +1731,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   firrtl.module @Top() {
     firrtl.instance foo interesting_name  @Foo()
     %tap = firrtl.wire interesting_name  : !firrtl.uint<8>
-    // CHECK:   %[[v0:.+]] = firrtl.ref.resolve %foo_sum__bore : !firrtl.ref<uint>
+    // CHECK:   %[[v0:.+]] = firrtl.ref.resolve %foo_sum__bore : !firrtl.probe<uint>
     // CHECK:   %tap = firrtl.node %[[v0]] : !firrtl.uint
   }
 }
@@ -1749,13 +1749,13 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
     }]}]} {
   firrtl.extmodule private @BlackBox() attributes {defname = "BlackBox"}
   // CHECK:  firrtl.extmodule private @BlackBox
-  // CHECK-SAME:  out [[gen_ref:.+]]: !firrtl.ref<uint<1>>)
+  // CHECK-SAME:  out [[gen_ref:.+]]: !firrtl.probe<uint<1>>)
   // CHECK-SAME: attributes {defname = "BlackBox", internalPaths = ["random.something"]}
   firrtl.module @Top(in %in: !firrtl.uint<1>) {
     %tap2 = firrtl.wire : !firrtl.bundle<wid: uint<1>>
     firrtl.instance localparam @BlackBox()
-    // CHECK:  %[[localparam__gen_ref:.+]] = firrtl.instance localparam @BlackBox(out [[gen_ref]]: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.ref.resolve %[[localparam__gen_ref]] : !firrtl.ref<uint<1>>
+    // CHECK:  %[[localparam__gen_ref:.+]] = firrtl.instance localparam @BlackBox(out [[gen_ref]]: !firrtl.probe<uint<1>>)
+    // CHECK:  firrtl.ref.resolve %[[localparam__gen_ref]] : !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -434,12 +434,12 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
   // expected-note@below {{module port 'a', has a RefType with a different base type '!firrtl.uint<1>' in the same position of the two modules marked as 'must dedup'. (This may be due to Grand Central Taps or Views being different between the two modules.)}}
-  firrtl.module @Test0(in %a : !firrtl.ref<uint<1>>, in %b : !firrtl.ref<uint<2>>) { }
+  firrtl.module @Test0(in %a : !firrtl.probe<uint<1>>, in %b : !firrtl.probe<uint<2>>) { }
   // expected-note@below {{the second module has a different base type '!firrtl.uint<2>'}}
-  firrtl.module @Test1(in %a : !firrtl.ref<uint<2>>, in %b : !firrtl.ref<uint<1>>) { }
+  firrtl.module @Test1(in %a : !firrtl.probe<uint<2>>, in %b : !firrtl.probe<uint<1>>) { }
   firrtl.module @MustDedup() {
-    firrtl.instance test0 @Test0(in a : !firrtl.ref<uint<1>>, in b : !firrtl.ref<uint<2>>)
-    firrtl.instance test1 @Test1(in a : !firrtl.ref<uint<2>>, in b : !firrtl.ref<uint<1>>)
+    firrtl.instance test0 @Test0(in a : !firrtl.probe<uint<1>>, in b : !firrtl.probe<uint<2>>)
+    firrtl.instance test1 @Test1(in a : !firrtl.probe<uint<2>>, in b : !firrtl.probe<uint<1>>)
   }
 }
 
@@ -451,12 +451,12 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
   // expected-note@below {{contains a RefType port named 'b' that only exists in one of the modules (can be due to difference in Grand Central Tap or View of two modules marked with must dedup)}}
-  firrtl.module @Test0(in %a : !firrtl.ref<uint<1>>, in %b : !firrtl.ref<uint<2>>) { }
+  firrtl.module @Test0(in %a : !firrtl.probe<uint<1>>, in %b : !firrtl.probe<uint<2>>) { }
   // expected-note@below {{second module to be deduped that does not have the RefType port}}
-  firrtl.module @Test1(in %a : !firrtl.ref<uint<1>>) { }
+  firrtl.module @Test1(in %a : !firrtl.probe<uint<1>>) { }
   firrtl.module @MustDedup() {
-    firrtl.instance test0 @Test0(in a : !firrtl.ref<uint<1>>, in b : !firrtl.ref<uint<2>>)
-    firrtl.instance test1 @Test1(in a : !firrtl.ref<uint<1>>)
+    firrtl.instance test0 @Test0(in a : !firrtl.probe<uint<1>>, in b : !firrtl.probe<uint<2>>)
+    firrtl.instance test1 @Test1(in a : !firrtl.probe<uint<1>>)
   }
 }
 
@@ -468,11 +468,11 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
   // expected-note@below {{contains a RefType port named 'b' that only exists in one of the modules (can be due to difference in Grand Central Tap or View of two modules marked with must dedup)}}
-  firrtl.module @Test1(in %a : !firrtl.ref<uint<1>>, in %b : !firrtl.ref<uint<2>>) { }
+  firrtl.module @Test1(in %a : !firrtl.probe<uint<1>>, in %b : !firrtl.probe<uint<2>>) { }
   // expected-note@below {{second module to be deduped that does not have the RefType port}}
-  firrtl.module @Test0(in %a : !firrtl.ref<uint<1>>) { }
+  firrtl.module @Test0(in %a : !firrtl.probe<uint<1>>) { }
   firrtl.module @MustDedup() {
-    firrtl.instance test0 @Test1(in a : !firrtl.ref<uint<1>>, in b : !firrtl.ref<uint<2>>)
-    firrtl.instance test1 @Test0(in a : !firrtl.ref<uint<1>>)
+    firrtl.instance test0 @Test1(in a : !firrtl.probe<uint<1>>, in b : !firrtl.probe<uint<2>>)
+    firrtl.instance test1 @Test0(in a : !firrtl.probe<uint<1>>)
   }
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -590,11 +590,11 @@ firrtl.circuit "NoDedup" {
 // CHECK-LABEL:   firrtl.circuit "InputRefTypePorts"
 // CHECK-COUNT-3: firrtl.module
 firrtl.circuit "InputRefTypePorts" {
-  firrtl.module @Foo(in %a: !firrtl.ref<uint<1>>) {}
-  firrtl.module @Bar(in %a: !firrtl.ref<uint<1>>) {}
+  firrtl.module @Foo(in %a: !firrtl.probe<uint<1>>) {}
+  firrtl.module @Bar(in %a: !firrtl.probe<uint<1>>) {}
   firrtl.module @InputRefTypePorts() {
-    %foo_a = firrtl.instance foo @Foo(in a: !firrtl.ref<uint<1>>)
-    %bar_a = firrtl.instance bar @Bar(in a: !firrtl.ref<uint<1>>)
+    %foo_a = firrtl.instance foo @Foo(in a: !firrtl.probe<uint<1>>)
+    %bar_a = firrtl.instance bar @Bar(in a: !firrtl.probe<uint<1>>)
   }
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -971,9 +971,9 @@ firrtl.circuit "DupSymField" {
 // Node ops cannot have reference type
 
 firrtl.circuit "NonRefNode" {
-firrtl.module @NonRefNode(in %in1 : !firrtl.ref<uint<8>>) {
-  // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive base type (contain no flips), but got '!firrtl.ref<uint<8>>'}}
-  %n1 = firrtl.node %in1 : !firrtl.ref<uint<8>>
+firrtl.module @NonRefNode(in %in1 : !firrtl.probe<uint<8>>) {
+  // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive base type (contain no flips), but got '!firrtl.probe<uint<8>>'}}
+  %n1 = firrtl.node %in1 : !firrtl.probe<uint<8>>
   %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
 }
 }
@@ -984,7 +984,7 @@ firrtl.module @NonRefNode(in %in1 : !firrtl.ref<uint<8>>) {
 firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
-    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.ref<uint<8>>
+    %r = firrtl.reg %clock : !firrtl.clock, !firrtl.probe<uint<8>>
   }
 }
 
@@ -993,7 +993,7 @@ firrtl.circuit "NonRefRegister" {
 
 firrtl.circuit "RefBundle" {
   // expected-error @+1 {{reference base type must be passive}}
-  firrtl.module @RefBundle(in %in1 : !firrtl.ref<bundle<valid flip : uint<1>>>) {
+  firrtl.module @RefBundle(in %in1 : !firrtl.probe<bundle<valid flip : uint<1>>>) {
   }
 }
 
@@ -1001,8 +1001,8 @@ firrtl.circuit "RefBundle" {
 // Ref types cannot be ref
 
 firrtl.circuit "RefRef" {
-  // expected-error @+1 {{expected base type, found '!firrtl.ref<uint<1>>'}}
-  firrtl.module @RefRef(in %in1 : !firrtl.ref<ref<uint<1>>>) {
+  // expected-error @+1 {{expected base type, found '!firrtl.probe<uint<1>>'}}
+  firrtl.module @RefRef(in %in1 : !firrtl.probe<probe<uint<1>>>) {
   }
 }
 
@@ -1010,8 +1010,8 @@ firrtl.circuit "RefRef" {
 // No ref in bundle
 
 firrtl.circuit "RefField" {
-  // expected-error @+1 {{expected base type, found '!firrtl.ref<uint<1>>'}}
-  firrtl.module @RefField(in %in1 : !firrtl.bundle<r: ref<uint<1>>>) {
+  // expected-error @+1 {{expected base type, found '!firrtl.probe<uint<1>>'}}
+  firrtl.module @RefField(in %in1 : !firrtl.bundle<r: probe<uint<1>>>) {
   }
 }
 
@@ -1020,8 +1020,8 @@ firrtl.circuit "RefField" {
 
 firrtl.circuit "InvalidRef" {
   firrtl.module @InvalidRef() {
-    // expected-error @+1 {{'firrtl.invalidvalue' op result #0 must be a base type, but got '!firrtl.ref<uint<1>>'}}
-    %0 = firrtl.invalidvalue : !firrtl.ref<uint<1>>
+    // expected-error @+1 {{'firrtl.invalidvalue' op result #0 must be a base type, but got '!firrtl.probe<uint<1>>'}}
+    %0 = firrtl.invalidvalue : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1029,10 +1029,10 @@ firrtl.circuit "InvalidRef" {
 // Mux ref
 
 firrtl.circuit "MuxRef" {
-  firrtl.module @MuxRef(in %a: !firrtl.ref<uint<1>>, in %b: !firrtl.ref<uint<1>>,
+  firrtl.module @MuxRef(in %a: !firrtl.probe<uint<1>>, in %b: !firrtl.probe<uint<1>>,
                           in %cond: !firrtl.uint<1>) {
-    // expected-error @+1 {{'firrtl.mux' op operand #1 must be a passive base type (contain no flips), but got '!firrtl.ref<uint<1>>'}}
-    %a_or_b = firrtl.mux(%cond, %a, %b) : (!firrtl.uint<1>, !firrtl.ref<uint<1>>, !firrtl.ref<uint<1>>) -> !firrtl.ref<uint<1>>
+    // expected-error @+1 {{'firrtl.mux' op operand #1 must be a passive base type (contain no flips), but got '!firrtl.probe<uint<1>>'}}
+    %a_or_b = firrtl.mux(%cond, %a, %b) : (!firrtl.uint<1>, !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>>
   }
 }
 
@@ -1040,9 +1040,9 @@ firrtl.circuit "MuxRef" {
 // Bitcast ref
 
 firrtl.circuit "BitcastRef" {
-  firrtl.module @BitcastRef(in %a: !firrtl.ref<uint<1>>) {
-    // expected-error @+1 {{'firrtl.bitcast' op operand #0 must be a base type, but got '!firrtl.ref<uint<1>>}}
-    %0 = firrtl.bitcast %a : (!firrtl.ref<uint<1>>) -> (!firrtl.ref<uint<1>>)
+  firrtl.module @BitcastRef(in %a: !firrtl.probe<uint<1>>) {
+    // expected-error @+1 {{'firrtl.bitcast' op operand #0 must be a base type, but got '!firrtl.probe<uint<1>>}}
+    %0 = firrtl.bitcast %a : (!firrtl.probe<uint<1>>) -> (!firrtl.probe<uint<1>>)
   }
 }
 
@@ -1050,11 +1050,11 @@ firrtl.circuit "BitcastRef" {
 // Cannot connect ref types
 
 firrtl.circuit "Top" {
-  firrtl.module @Foo (in %in: !firrtl.ref<uint<2>>) {}
-  firrtl.module @Top (in %in: !firrtl.ref<uint<2>>) {
-    %foo_in = firrtl.instance foo @Foo(in in: !firrtl.ref<uint<2>>)
+  firrtl.module @Foo (in %in: !firrtl.probe<uint<2>>) {}
+  firrtl.module @Top (in %in: !firrtl.probe<uint<2>>) {
+    %foo_in = firrtl.instance foo @Foo(in in: !firrtl.probe<uint<2>>)
     // expected-error @below {{must be a sized type (contains no uninferred widths) or foreign type}}
-    firrtl.strictconnect %foo_in, %in : !firrtl.ref<uint<2>>
+    firrtl.strictconnect %foo_in, %in : !firrtl.probe<uint<2>>
   }
 }
 
@@ -1063,11 +1063,11 @@ firrtl.circuit "Top" {
 
 firrtl.circuit "Foo" {
   // expected-note @+1 {{destination was defined here}}
-  firrtl.module @Foo(in  %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @Foo(in  %_a: !firrtl.probe<uint<1>>) {
     %a = firrtl.wire : !firrtl.uint<1>
     %1 = firrtl.ref.send %a : !firrtl.uint<1>
     // expected-error @+1 {{connect has invalid flow: the destination expression "_a" has source flow, expected sink or duplex flow}}
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1075,13 +1075,13 @@ firrtl.circuit "Foo" {
 // Output reference port cannot be reused
 
 firrtl.circuit "Bar" {
-  firrtl.extmodule @Bar2(out _a: !firrtl.ref<uint<1>>)
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %x = firrtl.instance x @Bar2(out _a: !firrtl.ref<uint<1>>)
-    %y = firrtl.instance y @Bar2(out _a: !firrtl.ref<uint<1>>)
+  firrtl.extmodule @Bar2(out _a: !firrtl.probe<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %x = firrtl.instance x @Bar2(out _a: !firrtl.probe<uint<1>>)
+    %y = firrtl.instance y @Bar2(out _a: !firrtl.probe<uint<1>>)
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %x : !firrtl.ref<uint<1>>
-    firrtl.ref.define %_a, %y : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %y : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1089,14 +1089,14 @@ firrtl.circuit "Bar" {
 // Output reference port cannot be reused
 
 firrtl.circuit "Bar" {
-  firrtl.extmodule @Bar2(out _a: !firrtl.ref<uint<1>>)
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %x = firrtl.instance x @Bar2(out _a: !firrtl.ref<uint<1>>)
+  firrtl.extmodule @Bar2(out _a: !firrtl.probe<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %x = firrtl.instance x @Bar2(out _a: !firrtl.probe<uint<1>>)
     %y = firrtl.wire : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %x : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %x : !firrtl.probe<uint<1>>
     %1 = firrtl.ref.send %y : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1104,14 +1104,14 @@ firrtl.circuit "Bar" {
 // Output reference port cannot be reused
 
 firrtl.circuit "Bar" {
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %x = firrtl.wire : !firrtl.uint<1>
     %y = firrtl.wire : !firrtl.uint<1>
     %1 = firrtl.ref.send %x : !firrtl.uint<1>
     %2 = firrtl.ref.send %y : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be reused by multiple operations, it can only capture a unique dataflow}}
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
-    firrtl.ref.define %_a, %2 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %2 : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1119,12 +1119,12 @@ firrtl.circuit "Bar" {
 // Can't define into a ref.sub.
 
 firrtl.circuit "NoDefineIntoRefSub" {
-  firrtl.module @NoDefineIntoRefSub(out %r: !firrtl.ref<vector<uint<1>,2>>) {
-    %sub = firrtl.ref.sub %r[1] : !firrtl.ref<vector<uint<1>,2>>
+  firrtl.module @NoDefineIntoRefSub(out %r: !firrtl.probe<vector<uint<1>,2>>) {
+    %sub = firrtl.ref.sub %r[1] : !firrtl.probe<vector<uint<1>,2>>
     %x = firrtl.wire : !firrtl.uint<1>
     %xref = firrtl.ref.send %x : !firrtl.uint<1>
     // expected-error @below {{destination reference cannot be a sub-element of a reference}}
-    firrtl.ref.define %sub, %xref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %sub, %xref : !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -140,7 +140,7 @@ firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.ve
 
 // Check initialization error is produced for out-references
 firrtl.circuit "RefInitOut" {
-firrtl.module @RefInitOut(out %out : !firrtl.ref<uint<1>>) {
+firrtl.module @RefInitOut(out %out : !firrtl.probe<uint<1>>) {
   // expected-error @above {{port "out" not fully initialized in module "RefInitOut"}}
 }
 }
@@ -149,9 +149,9 @@ firrtl.module @RefInitOut(out %out : !firrtl.ref<uint<1>>) {
 
 // Check initialization error is produced for in-references
 firrtl.circuit "RefInitIn" {
-firrtl.module @Child(in %in: !firrtl.ref<uint<1>>) { }
+firrtl.module @Child(in %in: !firrtl.probe<uint<1>>) { }
 firrtl.module @RefInitIn() {
-  %child_in = firrtl.instance child @Child(in in : !firrtl.ref<uint<1>>)
+  %child_in = firrtl.instance child @Child(in in : !firrtl.probe<uint<1>>)
   // expected-error @above {{sink "child.in" not fully initialized in module "RefInitIn"}}
 }
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -532,13 +532,13 @@ firrtl.module @aggregate_regreset(in %clock: !firrtl.clock, in %reset: !firrtl.u
 }
 
  // CHECK-LABEL: @refdefine
- firrtl.module @refdefine(in %x : !firrtl.uint<1>, out %out : !firrtl.ref<uint<1>>) {
+ firrtl.module @refdefine(in %x : !firrtl.uint<1>, out %out : !firrtl.probe<uint<1>>) {
    // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %x
    // CHECK-NEXT: firrtl.ref.define %out, %[[REF]]
    // CHECK-NEXT: }
    firrtl.when %x : !firrtl.uint<1> {
      %ref = firrtl.ref.send %x : !firrtl.uint<1>
-     firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
+     firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>
    }
  }
 }

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -39,7 +39,7 @@ firrtl.circuit "NonGroundType" attributes {
        name = "View"}]} {
     %_vector = firrtl.verbatim.expr "???" : () -> !firrtl.vector<uint<2>, 1>
     %ref_vector = firrtl.ref.send %_vector : !firrtl.vector<uint<2>, 1>
-    %vector = firrtl.ref.resolve %ref_vector : !firrtl.ref<vector<uint<2>, 1>>
+    %vector = firrtl.ref.resolve %ref_vector : !firrtl.probe<vector<uint<2>, 1>>
     // expected-error @+1 {{'firrtl.node' op cannot be added to interface with id '0' because it is not a ground type}}
     %a = firrtl.node %vector {
       annotations = [

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -350,7 +350,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
     %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
     %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
 
-    %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
+    %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.probe<uint<1>>
     %foo = firrtl.node %ui1 {
       annotations = [
         {
@@ -376,7 +376,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
       ]
     } : !firrtl.uint<1>
 
-    %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
+    %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.probe<uint<2>>
     %bar = firrtl.node %ui2 {
       annotations = [
         {
@@ -418,7 +418,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
       ]
     } : !firrtl.uint<2>
 
-    %ui0 = firrtl.ref.resolve %ref_ui0 : !firrtl.ref<uint<0>>
+    %ui0 = firrtl.ref.resolve %ref_ui0 : !firrtl.probe<uint<0>>
     %baz = firrtl.node %ui0 {
       annotations = [
         {
@@ -561,9 +561,9 @@ firrtl.circuit "InterfaceGroundType" attributes {
 // CHECK-NEXT:       %VectorView = sv.interface.instance sym @[[vectorSym:[a-zA-Z0-9_]+]] : !sv.interface<@VectorView>
 // CHECK-NEXT:       %GroundView = sv.interface.instance sym @[[groundSym:[a-zA-Z0-9_]+]] : !sv.interface<@GroundView>
 //
-// CHECK:            %[[foo_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.ref<uint<1>>
+// CHECK:            %[[foo_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.probe<uint<1>>
 // CHECK-NOT:        sifive.enterprise.grandcentral.AugmentedGroundType
-// CHECK:            %[[bar_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.ref<uint<2>>
+// CHECK:            %[[bar_ref:[a-zA-Z0-9_]+]] = firrtl.ref.resolve {{.+}} : !firrtl.probe<uint<2>>
 // CHECK-NOT:        sifive.enterprise.grandcentral.AugmentedGroundType
 //
 // CHECK{LITERAL}:   sv.verbatim "assign {{1}}.foo = {{0}};"
@@ -978,7 +978,7 @@ firrtl.circuit "Top" attributes {
     }
   ]
 } {
-  firrtl.module @Companion_w1(in %_gen_uint: !firrtl.ref<uint<1>>) attributes {
+  firrtl.module @Companion_w1(in %_gen_uint: !firrtl.probe<uint<1>>) attributes {
     annotations = [
       {
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
@@ -987,7 +987,7 @@ firrtl.circuit "Top" attributes {
       }
     ]
   } {
-    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.probe<uint<1>>
     %view_uintrefPort = firrtl.node  %0  {
       annotations = [
         {
@@ -997,7 +997,7 @@ firrtl.circuit "Top" attributes {
       ]
     } : !firrtl.uint<1>
   }
-  firrtl.module @Companion_w2(in %_gen_uint: !firrtl.ref<uint<2>>) attributes {
+  firrtl.module @Companion_w2(in %_gen_uint: !firrtl.probe<uint<2>>) attributes {
     annotations = [
       {
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
@@ -1006,7 +1006,7 @@ firrtl.circuit "Top" attributes {
       }
     ]
   } {
-    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.ref<uint<2>>
+    %0 = firrtl.ref.resolve %_gen_uint : !firrtl.probe<uint<2>>
     %view_uintrefPort = firrtl.node  %0  {
       annotations = [
         {
@@ -1023,12 +1023,12 @@ firrtl.circuit "Top" attributes {
     firrtl.strictconnect %a_w1, %c0_ui1 : !firrtl.uint<1>
     %a_w2 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
     firrtl.strictconnect %a_w2, %c0_ui2 : !firrtl.uint<2>
-    %companion_w1__gen_uint = firrtl.instance companion_w1  @Companion_w1(in _gen_uint: !firrtl.ref<uint<1>>)
-    %companion_w2__gen_uint = firrtl.instance companion_w2  @Companion_w2(in _gen_uint: !firrtl.ref<uint<2>>)
+    %companion_w1__gen_uint = firrtl.instance companion_w1  @Companion_w1(in _gen_uint: !firrtl.probe<uint<1>>)
+    %companion_w2__gen_uint = firrtl.instance companion_w2  @Companion_w2(in _gen_uint: !firrtl.probe<uint<2>>)
     %0 = firrtl.ref.send %a_w1 : !firrtl.uint<1>
-    firrtl.ref.define %companion_w1__gen_uint, %0 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %companion_w1__gen_uint, %0 : !firrtl.probe<uint<1>>
     %1 = firrtl.ref.send %a_w2 : !firrtl.uint<2>
-    firrtl.ref.define %companion_w2__gen_uint, %1 : !firrtl.ref<uint<2>>
+    firrtl.ref.define %companion_w2__gen_uint, %1 : !firrtl.probe<uint<2>>
   }
   firrtl.module @Top() {
     firrtl.instance dut  @DUT()
@@ -1165,7 +1165,7 @@ firrtl.circuit "Top" attributes {
       %ref_ui1 = firrtl.ref.send %_ui1 : !firrtl.uint<1>
       %ref_ui2 = firrtl.ref.send %_ui2 : !firrtl.uint<2>
 
-      %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.ref<uint<1>>
+      %ui1 = firrtl.ref.resolve %ref_ui1 : !firrtl.probe<uint<1>>
       %foo = firrtl.node %ui1 {
         annotations = [
           {
@@ -1179,7 +1179,7 @@ firrtl.circuit "Top" attributes {
           }
         ]
       } : !firrtl.uint<1>
-      %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.ref<uint<2>>
+      %ui2 = firrtl.ref.resolve %ref_ui2 : !firrtl.probe<uint<2>>
       %bar = firrtl.node %ui2 {
         annotations = [
           {

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -491,15 +491,15 @@ firrtl.circuit "Issue3372"  {
 
 // CHECK-LABEL: "SendThroughRef"
 firrtl.circuit "SendThroughRef" {
-  firrtl.module private @Bar(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module private @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %ref_zero : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @SendThroughRef(out %a: !firrtl.uint<1>) {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -508,19 +508,19 @@ firrtl.circuit "SendThroughRef" {
 
 // CHECK-LABEL: "ForwardRef"
 firrtl.circuit "ForwardRef" {
-  firrtl.module private @RefForward2(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module private @RefForward2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %ref_zero : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>
   }
-  firrtl.module private @RefForward(out %_a: !firrtl.ref<uint<1>>) {
-    %fwd_2 = firrtl.instance fwd_2 @RefForward2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %fwd_2 : !firrtl.ref<uint<1>>
+  firrtl.module private @RefForward(out %_a: !firrtl.probe<uint<1>>) {
+    %fwd_2 = firrtl.instance fwd_2 @RefForward2(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %fwd_2 : !firrtl.probe<uint<1>>
   }
   // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @ForwardRef(out %a: !firrtl.uint<1>) {
-    %fwd_a = firrtl.instance fwd @RefForward(out _a: !firrtl.ref<uint<1>>)
-    %0 = firrtl.ref.resolve %fwd_a : !firrtl.ref<uint<1>>
+    %fwd_a = firrtl.instance fwd @RefForward(out _a: !firrtl.probe<uint<1>>)
+    %0 = firrtl.ref.resolve %fwd_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imdce-nyi.mlir
+++ b/test/Dialect/FIRRTL/imdce-nyi.mlir
@@ -10,17 +10,17 @@
 // CHECK-LABEL: firrtl.circuit "NoWireForLiveRefInputPort"
 firrtl.circuit "NoWireForLiveRefInputPort" {
    // CHECK-NOT: @Child
-  firrtl.module private @Child(in %in: !firrtl.ref<uint<1>>) { }
+  firrtl.module private @Child(in %in: !firrtl.probe<uint<1>>) { }
   // CHECK: @NoWireForLiveRefInputPort
   firrtl.module @NoWireForLiveRefInputPort(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %in
     // CHECK-NEXT: %[[RES:.+]] = firrtl.ref.resolve %[[REF]]
     // CHECK-NEXT: firrtl.strictconnect %out, %[[RES]]
     // CHECK-NEXT: }
-    %child_ref = firrtl.instance child @Child(in in: !firrtl.ref<uint<1>>)
-    %res = firrtl.ref.resolve %child_ref : !firrtl.ref<uint<1>>
+    %child_ref = firrtl.instance child @Child(in in: !firrtl.probe<uint<1>>)
+    %res = firrtl.ref.resolve %child_ref : !firrtl.probe<uint<1>>
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %child_ref, %ref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %child_ref, %ref : !firrtl.probe<uint<1>>
     firrtl.strictconnect %out, %res : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -197,54 +197,54 @@ firrtl.circuit "ForwardConstant" {
 // CHECK-LABEL: "RefPorts"
 firrtl.circuit "RefPorts" {
   // CHECK-NOT: @dead_ref_send
-  firrtl.module private @dead_ref_send(in %source: !firrtl.uint<1>, out %dest: !firrtl.ref<uint<1>>) {
+  firrtl.module private @dead_ref_send(in %source: !firrtl.uint<1>, out %dest: !firrtl.probe<uint<1>>) {
     %ref = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.ref.define %dest, %ref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %dest, %ref : !firrtl.probe<uint<1>>
   }
 
   // CHECK-LABEL: @dead_ref_port
   // CHECK-NOT: firrtl.ref
-  firrtl.module private @dead_ref_port(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, out %ref_dest: !firrtl.ref<uint<1>>) {
+  firrtl.module private @dead_ref_port(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, out %ref_dest: !firrtl.probe<uint<1>>) {
     %ref_not = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.ref.define %ref_dest, %ref_not : !firrtl.ref<uint<1>>
+    firrtl.ref.define %ref_dest, %ref_not : !firrtl.probe<uint<1>>
     firrtl.strictconnect %dest, %source : !firrtl.uint<1>
   }
 
   // CHECK: @live_ref
-  firrtl.module private @live_ref(in %source: !firrtl.uint<1>, out %dest: !firrtl.ref<uint<1>>) {
+  firrtl.module private @live_ref(in %source: !firrtl.uint<1>, out %dest: !firrtl.probe<uint<1>>) {
     %ref_source = firrtl.ref.send %source: !firrtl.uint<1>
-    firrtl.ref.define %dest, %ref_source : !firrtl.ref<uint<1>>
+    firrtl.ref.define %dest, %ref_source : !firrtl.probe<uint<1>>
   }
 
   // CHECK-LABEL: @RefPorts
   firrtl.module @RefPorts(in %source : !firrtl.uint<1>, out %dest : !firrtl.uint<1>) {
     // Delete send's that aren't resolved, and check deletion of modules with ref ops + ports.
     // CHECK-NOT: @dead_ref_send
-    %source1, %dest1 = firrtl.instance dead_ref_send @dead_ref_send(in source: !firrtl.uint<1>, out dest: !firrtl.ref<uint<1>>)
+    %source1, %dest1 = firrtl.instance dead_ref_send @dead_ref_send(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
     firrtl.strictconnect %source1, %source : !firrtl.uint<1>
 
     // Check that an unused resolve doesn't keep send alive, and test ref port removal.
     // CHECK: @dead_ref_port
     // CHECK-NOT: firrtl.ref
-    %source2, %dest2, %ref_dest2 = firrtl.instance dead_ref_port @dead_ref_port(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>, out ref_dest: !firrtl.ref<uint<1>>)
+    %source2, %dest2, %ref_dest2 = firrtl.instance dead_ref_port @dead_ref_port(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>, out ref_dest: !firrtl.probe<uint<1>>)
     firrtl.strictconnect %source2, %source : !firrtl.uint<1>
-    %unused = firrtl.ref.resolve %ref_dest2 : !firrtl.ref<uint<1>>
+    %unused = firrtl.ref.resolve %ref_dest2 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %dest, %dest2 : !firrtl.uint<1>
 
     // Check not deleted if live.
     // CHECK: @live_ref
-    %source3, %dest3 = firrtl.instance live_ref @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.ref<uint<1>>)
+    %source3, %dest3 = firrtl.instance live_ref @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
     firrtl.strictconnect %source3, %source : !firrtl.uint<1>
     // CHECK: firrtl.ref.resolve
-    %dest3_resolved = firrtl.ref.resolve %dest3 : !firrtl.ref<uint<1>>
+    %dest3_resolved = firrtl.ref.resolve %dest3 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %dest, %dest3_resolved : !firrtl.uint<1>
 
     // Check dead resolve is deleted.
     // CHECK-NOT: dead_instance
-    %source4, %dest4 = firrtl.instance dead_instance @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.ref<uint<1>>)
+    %source4, %dest4 = firrtl.instance dead_instance @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
     firrtl.strictconnect %source4, %source : !firrtl.uint<1>
     // CHECK-NOT: firrtl.ref.resolve
-    %unused5 = firrtl.ref.resolve %dest4 : !firrtl.ref<uint<1>>
+    %unused5 = firrtl.ref.resolve %dest4 : !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -242,5 +242,5 @@ firrtl.circuit "UninferredReset" {
 firrtl.circuit "UninferredRefReset" {
   // expected-error @+2 {{a port "reset" with abstract reset type was unable to be inferred by InferResets}}
   // expected-note @+1 {{the module with this uninferred reset port was defined here}}
-  firrtl.module @UninferredRefReset(in %reset: !firrtl.ref<reset>) {}
+  firrtl.module @UninferredRefReset(in %reset: !firrtl.probe<reset>) {}
 }

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -820,22 +820,22 @@ firrtl.circuit "ZeroVec"  {
 firrtl.circuit "RefReset" {
   // CHECK-LABEL: firrtl.module private @SendReset
   // CHECK-SAME: in %r: !firrtl.asyncreset
-  // CHECK-SAME: out %ref: !firrtl.ref<asyncreset>
+  // CHECK-SAME: out %ref: !firrtl.probe<asyncreset>
   // CHECK-NEXT: send %r : !firrtl.asyncreset
-  // CHECK-NEXT: ref<asyncreset>
-  firrtl.module private @SendReset(in %r: !firrtl.reset, out %ref: !firrtl.ref<reset>) {
+  // CHECK-NEXT: probe<asyncreset>
+  firrtl.module private @SendReset(in %r: !firrtl.reset, out %ref: !firrtl.probe<reset>) {
     %ref_r = firrtl.ref.send %r : !firrtl.reset
-    firrtl.ref.define %ref, %ref_r : !firrtl.ref<reset>
+    firrtl.ref.define %ref, %ref_r : !firrtl.probe<reset>
   }
   // CHECK-LABEL: firrtl.module @RefReset
   // CHECK-NEXT: in r: !firrtl.asyncreset
-  // CHECK-SAME: out ref: !firrtl.ref<asyncreset>
+  // CHECK-SAME: out ref: !firrtl.probe<asyncreset>
   // CHECK-NEXT: !firrtl.asyncreset, !firrtl.asyncreset
-  // CHECK-NEXT: %s_ref : !firrtl.ref<asyncreset>
+  // CHECK-NEXT: %s_ref : !firrtl.probe<asyncreset>
   firrtl.module @RefReset(in %r: !firrtl.asyncreset) {
-    %s_r, %s_ref = firrtl.instance s @SendReset(in r: !firrtl.reset, out ref: !firrtl.ref<reset>)
+    %s_r, %s_ref = firrtl.instance s @SendReset(in r: !firrtl.reset, out ref: !firrtl.probe<reset>)
     firrtl.connect %s_r, %r : !firrtl.reset, !firrtl.asyncreset
-    %reset = firrtl.ref.resolve %s_ref : !firrtl.ref<reset>
+    %reset = firrtl.ref.resolve %s_ref : !firrtl.probe<reset>
   }
 }
 
@@ -850,7 +850,7 @@ firrtl.circuit "RefResetBundle" {
   firrtl.module @RefResetBundle(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>) {
   %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset> 
   %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: reset>
-  %reset = firrtl.ref.resolve %ref_r : !firrtl.ref<bundle<a: reset, b: reset>>
+  %reset = firrtl.ref.resolve %ref_r : !firrtl.probe<bundle<a: reset, b: reset>>
   firrtl.strictconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
 
    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -724,10 +724,10 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @MemScalar
   // CHECK-SAME: out %out: !firrtl.uint<7>
-  // CHECK-SAME: out %dbg: !firrtl.ref<vector<uint<7>, 8>>
-  firrtl.module @MemScalar(out %out: !firrtl.uint, out %dbg: !firrtl.ref<vector<uint, 8>>) {
+  // CHECK-SAME: out %dbg: !firrtl.probe<vector<uint<7>, 8>>
+  firrtl.module @MemScalar(out %out: !firrtl.uint, out %dbg: !firrtl.probe<vector<uint, 8>>) {
     // CHECK: firrtl.mem
-    // CHECK-SAME: !firrtl.ref<vector<uint<7>, 8>>
+    // CHECK-SAME: !firrtl.probe<vector<uint<7>, 8>>
     // CHECK-SAME: data flip: uint<7>
     // CHECK-SAME: data: uint<7>
     // CHECK-SAME: data: uint<7>
@@ -737,7 +737,7 @@ firrtl.circuit "Foo" {
       portNames = ["dbg", "p0", "p1", "p2"],
       readLatency = 0 : i32,
       writeLatency = 1 : i32} :
-      !firrtl.ref<vector<uint, 8>>,
+      !firrtl.probe<vector<uint, 8>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint, mask: uint<1>>,
       !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, rdata flip: uint, wmode: uint<1>, wdata: uint, wmask: uint<1>>
@@ -749,8 +749,8 @@ firrtl.circuit "Foo" {
     firrtl.connect %m_p1_data, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
     firrtl.connect %m_p2_wdata, %c0_ui7 : !firrtl.uint, !firrtl.uint<7>
     firrtl.connect %out, %m_p0_data : !firrtl.uint, !firrtl.uint
-    firrtl.ref.define %dbg, %m_dbg : !firrtl.ref<vector<uint, 8>>
-    // CHECK:  firrtl.ref.define %dbg, %m_dbg : !firrtl.ref<vector<uint<7>, 8>>
+    firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint, 8>>
+    // CHECK:  firrtl.ref.define %dbg, %m_dbg : !firrtl.probe<vector<uint<7>, 8>>
   }
 
   // CHECK-LABEL: @MemBundle
@@ -817,21 +817,21 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo() {}
 
   // CHECK-LABEL: @SubRef
-  // CHECK: out %x: !firrtl.ref<uint<2>>
-  firrtl.module private @SubRef(out %x: !firrtl.ref<uint>) {
+  // CHECK: out %x: !firrtl.probe<uint<2>>
+  firrtl.module private @SubRef(out %x: !firrtl.probe<uint>) {
     %w = firrtl.wire : !firrtl.uint
     %ref_w = firrtl.ref.send %w : !firrtl.uint
-    firrtl.ref.define %x, %ref_w : !firrtl.ref<uint>
+    firrtl.ref.define %x, %ref_w : !firrtl.probe<uint>
 
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.connect %w, %c0_ui2 : !firrtl.uint, !firrtl.uint<2>
   }
   // CHECK-LABEL: @Ref
-  // CHECK: out x: !firrtl.ref<uint<2>>
-  // CHECK: %sub_x : !firrtl.ref<uint<2>>
+  // CHECK: out x: !firrtl.probe<uint<2>>
+  // CHECK: %sub_x : !firrtl.probe<uint<2>>
   firrtl.module @Ref(out %r : !firrtl.uint) {
-    %sub_x = firrtl.instance sub @SubRef(out x: !firrtl.ref<uint>)
-    %res = firrtl.ref.resolve %sub_x : !firrtl.ref<uint>
+    %sub_x = firrtl.instance sub @SubRef(out x: !firrtl.probe<uint>)
+    %res = firrtl.ref.resolve %sub_x : !firrtl.probe<uint>
     firrtl.connect %r, %res : !firrtl.uint, !firrtl.uint
   }
 

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -3,11 +3,11 @@
 firrtl.circuit "TLRAM" {
 // Test the case when the enable is a simple not of write enable.
 // CHECK-LABEL: firrtl.module @TLRAM
-    firrtl.module @TLRAM(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %index: !firrtl.uint<4>, in %index2: !firrtl.uint<4>, in %data_0: !firrtl.uint<8>, in %wen: !firrtl.uint<1>, in %_T_29: !firrtl.uint<1>, out %auto_0: !firrtl.uint<8>, out %dbg_0: !firrtl.ref<vector<uint<8>, 16>>) {
+    firrtl.module @TLRAM(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %index: !firrtl.uint<4>, in %index2: !firrtl.uint<4>, in %data_0: !firrtl.uint<8>, in %wen: !firrtl.uint<1>, in %_T_29: !firrtl.uint<1>, out %auto_0: !firrtl.uint<8>, out %dbg_0: !firrtl.probe<vector<uint<8>, 16>>) {
       %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
-      %debug, %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.ref<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-      firrtl.ref.define %dbg_0, %debug : !firrtl.ref<vector<uint<8>, 16>>
+      %debug, %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.probe<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+      firrtl.ref.define %dbg_0, %debug : !firrtl.probe<vector<uint<8>, 16>>
       %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -36,12 +36,12 @@ firrtl.circuit "TLRAM" {
       %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
       firrtl.connect %auto_0, %11 : !firrtl.uint<8>, !firrtl.uint<8>
 
-// CHECK: %mem_0_dbgs, %mem_0_rw = firrtl.mem  Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
+// CHECK: %mem_0_dbgs, %mem_0_rw = firrtl.mem  Undefined  {depth = 16 : i64, groupID = 2 : ui32, name = "mem_0", portNames = ["dbgs", "rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
 // CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 // CHECK:  firrtl.strictconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
 // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.strictconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
-// CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.ref<vector<uint<8>, 16>>
+// CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.probe<vector<uint<8>, 16>>
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>
@@ -184,8 +184,8 @@ firrtl.circuit "TLRAM" {
 // CHECK-LABEL: firrtl.module @memTest3t
   firrtl.module @memTest3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %dbg0, %mem_T_3, %mem_T_5, %dbg = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "T_3", "T_5", "dbg"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.ref<vector<uint<32>,128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.ref<vector<uint<32>,128>>
-// CHECK: %mem_dbg0, %mem_dbg, %mem_rw = firrtl.mem  Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "dbg", "rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<32>, 128>>, !firrtl.ref<vector<uint<32>, 128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    %dbg0, %mem_T_3, %mem_T_5, %dbg = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "T_3", "T_5", "dbg"], readLatency = 1 : i32, writeLatency = 1 : i32} :  !firrtl.probe<vector<uint<32>,128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.probe<vector<uint<32>,128>>
+// CHECK: %mem_dbg0, %mem_dbg, %mem_rw = firrtl.mem  Undefined  {depth = 128 : i64, name = "mem", portNames = ["dbg0", "dbg", "rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<32>, 128>>, !firrtl.probe<vector<uint<32>, 128>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
     %0 = firrtl.subfield %mem_T_3[addr] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
     %1 = firrtl.subfield %mem_T_3[en] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>
     %2 = firrtl.subfield %mem_T_3[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>

--- a/test/Dialect/FIRRTL/inliner-nyi.mlir
+++ b/test/Dialect/FIRRTL/inliner-nyi.mlir
@@ -9,20 +9,20 @@
 
 module {
   firrtl.circuit "InlinerRefs" {
-    firrtl.module private @ChildOut(in %in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out: !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.module private @ChildOut(in %in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out: !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
       %0 = firrtl.subfield %in[a] : !firrtl.bundle<a: uint<1>, b: uint<2>>
       firrtl.when %0 : !firrtl.uint<1> {
         %1 = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
-        firrtl.ref.define %out, %1 : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+        firrtl.ref.define %out, %1 : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
       }
     }
     firrtl.module @InlinerRefs(in %in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out: !firrtl.uint<1>) {
       %0 = firrtl.subfield %in[a] : !firrtl.bundle<a: uint<1>, b: uint<2>>
-      %co_in, %co_out = firrtl.instance co interesting_name @ChildOut(in in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out out: !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>)
-      %1 = firrtl.ref.sub %co_out[0] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+      %co_in, %co_out = firrtl.instance co interesting_name @ChildOut(in in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out out: !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>)
+      %1 = firrtl.ref.sub %co_out[0] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
       firrtl.strictconnect %co_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
       firrtl.when %0 : !firrtl.uint<1> {
-        %2 = firrtl.ref.resolve %1 : !firrtl.ref<uint<1>>
+        %2 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
         firrtl.strictconnect %out, %2 : !firrtl.uint<1>
       }
     }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -829,27 +829,27 @@ firrtl.circuit "CollidingSymbolsMultiInline" {
 // Test proper hierarchical inlining of RefType
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
     // CHECK:  %a = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
     // CHECK:  firrtl.strictconnect %a, %1 : !firrtl.uint<1>
   }
 }
@@ -859,26 +859,26 @@ firrtl.circuit "Top" {
 // Test proper inlining of RefSend to Ports of RefType
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %bar_pa = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %bar_pa : !firrtl.uint<1>
-    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.ref<uint<1>>
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    // CHECK:  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK:  %bar_bar_pa = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %bar_bar_pa : !firrtl.uint<1>
     // CHECK:  %a = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
   }
 }
 
@@ -887,50 +887,50 @@ firrtl.circuit "Top" {
 // Test for multiple readers and multiple instances of RefType
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+  firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]}{
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
-    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
     // CHECK:  %bar_a = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %bar_a, %1 : !firrtl.uint<1>
-    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
+    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %2 = firrtl.ref.send %c0_ui1_0 : !firrtl.uint<1>
-    // CHECK:  %3 = firrtl.ref.resolve %2 : !firrtl.ref<uint<1>>
+    // CHECK:  %3 = firrtl.ref.resolve %2 : !firrtl.probe<uint<1>>
     // CHECK:  %foo_a = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %foo_a, %3 : !firrtl.uint<1>
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %c0_ui1_1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %4 = firrtl.ref.send %c0_ui1_1 : !firrtl.uint<1>
     %a = firrtl.wire : !firrtl.uint<1>
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
-    %1 = firrtl.ref.resolve %foo_a : !firrtl.ref<uint<1>>
-    %2 = firrtl.ref.resolve %xmr_a : !firrtl.ref<uint<1>>
-    // CHECK:  %5 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
-    // CHECK:  %6 = firrtl.ref.resolve %2 : !firrtl.ref<uint<1>>
-    // CHECK:  %7 = firrtl.ref.resolve %4 : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
+    %1 = firrtl.ref.resolve %foo_a : !firrtl.probe<uint<1>>
+    %2 = firrtl.ref.resolve %xmr_a : !firrtl.probe<uint<1>>
+    // CHECK:  %5 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
+    // CHECK:  %6 = firrtl.ref.resolve %2 : !firrtl.probe<uint<1>>
+    // CHECK:  %7 = firrtl.ref.resolve %4 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     firrtl.strictconnect %b, %1 : !firrtl.uint<1>
     firrtl.strictconnect %c, %2 : !firrtl.uint<1>
@@ -945,29 +945,29 @@ firrtl.circuit "Top" {
 // Test for inlining module with RefType input port.
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %xmr : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %xmr : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr : !firrtl.ref<uint<1>>
-    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
-    // CHECK:  %child_child__a = firrtl.instance child_child  @Child2(in _a: !firrtl.ref<uint<1>>)
-    // CHECK:  firrtl.ref.define %child_child__a, %xmr__a : !firrtl.ref<uint<1>>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
+    // CHECK:  %child_child__a = firrtl.instance child_child  @Child2(in _a: !firrtl.probe<uint<1>>)
+    // CHECK:  firrtl.ref.define %child_child__a, %xmr__a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
 
@@ -976,28 +976,28 @@ firrtl.circuit "Top" {
 // Test for inlining module with RefType input port.
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %xmr : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %xmr : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr : !firrtl.ref<uint<1>>
-    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
-    // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr : !firrtl.probe<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
+    // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1006,40 +1006,40 @@ firrtl.circuit "Top" {
 // Test for recursive inlining of modules with RefType input port.
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %xmr2 = firrtl.ref.send %a : !firrtl.uint<1>
-    %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.ref<uint<1>>, in  _a2: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a1, %xmr : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_a2, %xmr2 : !firrtl.ref<uint<1>>
-    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
-    // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.ref<uint<1>>
-    // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.probe<uint<1>>, in  _a2: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
+    // CHECK:  %2 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
+    // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
     // CHECK:  %child_cw = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %child_cw, %3 : !firrtl.uint<1>
   }
-  firrtl.module @Child(in  %_a1: !firrtl.ref<uint<1>>, in  %_a2: !firrtl.ref<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    // CHECK:  %0 = firrtl.ref.resolve %_a1 : !firrtl.ref<uint<1>>
-    // CHECK:  %1 = firrtl.ref.resolve %_a1 : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_a, %_a1 : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %_a2 : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
+    // CHECK:  %0 = firrtl.ref.resolve %_a1 : !firrtl.probe<uint<1>>
+    // CHECK:  %1 = firrtl.ref.resolve %_a1 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child3(in  %_b: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+  firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1048,43 +1048,43 @@ firrtl.circuit "Top" {
 // Test for flatten annotation, and remove unused port wires
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]}{
-    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %xmr = firrtl.instance xmr sym @TopXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.ref.send %c0_ui1 : !firrtl.uint<1>
     %a = firrtl.wire : !firrtl.uint<1>
     %xmr2 = firrtl.ref.send %a : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %xmr : !firrtl.ref<uint<1>>
-    // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %xmr : !firrtl.probe<uint<1>>
+    // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.ref<uint<1>>, in  _a2: !firrtl.ref<uint<1>>)
-    // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
-    // CHECK:  %4 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
-    // CHECK:  %5 = firrtl.ref.resolve %1 : !firrtl.ref<uint<1>>
+    %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.probe<uint<1>>, in  _a2: !firrtl.probe<uint<1>>)
+    // CHECK:  %3 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
+    // CHECK:  %4 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
+    // CHECK:  %5 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
     // CHECK:  %child_cw = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %child_cw, %5 : !firrtl.uint<1>
-    firrtl.ref.define %c_a1, %xmr : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_a2, %xmr2 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a1: !firrtl.ref<uint<1>>, in  %_a2: !firrtl.ref<uint<1>>)  {
-    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %_a1 : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %_a2 : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  {
+    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>){
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>){
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child3(in  %_b: !firrtl.ref<uint<1>>){
-    %0 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+  firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>){
+    %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1094,23 +1094,23 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" {
   firrtl.module @Top() {
-    %c_a, %c_o = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>, out  o_a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %c_o : !firrtl.ref<uint<1>>
-    // CHECK:  %child_bar__a = firrtl.instance child_bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
-    // CHECK:  %0 = firrtl.ref.resolve %child_bar__a : !firrtl.ref<uint<1>>
+    %c_a, %c_o = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>, out  o_a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %c_o : !firrtl.probe<uint<1>>
+    // CHECK:  %child_bar__a = firrtl.instance child_bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
+    // CHECK:  %0 = firrtl.ref.resolve %child_bar__a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>, out  %o_a: !firrtl.ref<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %o_a, %bar_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>, out  %o_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %o_a, %bar_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
-  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -302,18 +302,18 @@ firrtl.module @LargeMem(in %clock: !firrtl.clock, in %addr: !firrtl.uint<35>, ou
   firrtl.connect %out, %r_data : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @DbgsMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %_a: !firrtl.ref<vector<uint<1>, 2>>, in %cond : !firrtl.uint<1>) {
+firrtl.module @DbgsMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %_a: !firrtl.probe<vector<uint<1>, 2>>, in %cond : !firrtl.uint<1>) {
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 2>
   // This port should be deleted.
-  %port0_data = chirrtl.debugport %ram {name = "port0"} : (!chirrtl.cmemory<uint<1>, 2>) -> !firrtl.ref<vector<uint<1>, 2>>
+  %port0_data = chirrtl.debugport %ram {name = "port0"} : (!chirrtl.cmemory<uint<1>, 2>) -> !firrtl.probe<vector<uint<1>, 2>>
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 2>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
   firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   }
-  firrtl.ref.define %_a, %port0_data : !firrtl.ref<vector<uint<1>, 2>>
-  // CHECK:    %[[ram_port0:.+]], %ram_ramport = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port0", "ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<1>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  // CHECK:    firrtl.ref.define %_a, %[[ram_port0]] : !firrtl.ref<vector<uint<1>, 2>>
+  firrtl.ref.define %_a, %port0_data : !firrtl.probe<vector<uint<1>, 2>>
+  // CHECK:    %[[ram_port0:.+]], %ram_ramport = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port0", "ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<1>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+  // CHECK:    firrtl.ref.define %_a, %[[ram_port0]] : !firrtl.probe<vector<uint<1>, 2>>
 }
 
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1057,50 +1057,50 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT: firrtl.connect %z, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   }
 
-  firrtl.module private @SendRefTypeBundles1(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, out %sink: !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>) {
+  firrtl.module private @SendRefTypeBundles1(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, out %sink: !firrtl.probe<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>) {
     // CHECK:  firrtl.module private @SendRefTypeBundles1(
     // CHECK-SAME:  in %source_valid: !firrtl.uint<1>,
     // CHECK-SAME:  in %source_ready: !firrtl.uint<1>,
     // CHECK-SAME:  in %source_data: !firrtl.uint<64>,
-    // CHECK-SAME:  out %sink_valid: !firrtl.ref<uint<1>>,
-    // CHECK-SAME:  out %sink_ready: !firrtl.ref<uint<1>>,
-    // CHECK-SAME:  out %sink_data: !firrtl.ref<uint<64>>) {
+    // CHECK-SAME:  out %sink_valid: !firrtl.probe<uint<1>>,
+    // CHECK-SAME:  out %sink_ready: !firrtl.probe<uint<1>>,
+    // CHECK-SAME:  out %sink_data: !firrtl.probe<uint<64>>) {
     %0 = firrtl.ref.send %source : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     // CHECK:  %0 = firrtl.ref.send %source_valid : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %source_ready : !firrtl.uint<1>
     // CHECK:  %2 = firrtl.ref.send %source_data : !firrtl.uint<64>
-    firrtl.ref.define %sink, %0 : !firrtl.ref<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
-    // CHECK:  firrtl.ref.define %sink_valid, %0 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.ref.define %sink_ready, %1 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.ref.define %sink_data, %2 : !firrtl.ref<uint<64>>
+    firrtl.ref.define %sink, %0 : !firrtl.probe<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
+    // CHECK:  firrtl.ref.define %sink_valid, %0 : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %sink_ready, %1 : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %sink_data, %2 : !firrtl.probe<uint<64>>
   }
-  firrtl.module private @SendRefTypeVectors1(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.ref<vector<uint<1>, 2>>) {
+  firrtl.module private @SendRefTypeVectors1(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.probe<vector<uint<1>, 2>>) {
     // CHECK-LABEL: firrtl.module private @SendRefTypeVectors1
-    // CHECK-SAME: in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.ref<uint<1>>, out %b_1: !firrtl.ref<uint<1>>)
+    // CHECK-SAME: in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.probe<uint<1>>, out %b_1: !firrtl.probe<uint<1>>)
     %0 = firrtl.ref.send %a : !firrtl.vector<uint<1>, 2>
     // CHECK:  %0 = firrtl.ref.send %a_0 : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %a_1 : !firrtl.uint<1>
-    firrtl.ref.define %b, %0 : !firrtl.ref<vector<uint<1>, 2>>
-    // CHECK:  firrtl.ref.define %b_0, %0 : !firrtl.ref<uint<1>>
-    // CHECK:  firrtl.ref.define %b_1, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %b, %0 : !firrtl.probe<vector<uint<1>, 2>>
+    // CHECK:  firrtl.ref.define %b_0, %0 : !firrtl.probe<uint<1>>
+    // CHECK:  firrtl.ref.define %b_1, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module private @RefTypeBundles2() {
     %x = firrtl.wire   : !firrtl.bundle<a: uint<1>, b: uint<2>>
     %0 = firrtl.ref.send %x : !firrtl.bundle<a: uint<1>, b: uint<2>>
     // CHECK:   %0 = firrtl.ref.send %x_a : !firrtl.uint<1>
     // CHECK:   %1 = firrtl.ref.send %x_b : !firrtl.uint<2>
-    %1 = firrtl.ref.resolve %0 : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
-    // CHECK:   %2 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
-    // CHECK:   %3 = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
+    %1 = firrtl.ref.resolve %0 : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    // CHECK:   %2 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
+    // CHECK:   %3 = firrtl.ref.resolve %1 : !firrtl.probe<uint<2>>
   }
   firrtl.module private @RefTypeVectors(out %c: !firrtl.vector<uint<1>, 2>) {
     %x = firrtl.wire   : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.ref.send %x : !firrtl.vector<uint<1>, 2>
     // CHECK:  %0 = firrtl.ref.send %x_0 : !firrtl.uint<1>
     // CHECK:  %1 = firrtl.ref.send %x_1 : !firrtl.uint<1>
-    %1 = firrtl.ref.resolve %0 : !firrtl.ref<vector<uint<1>, 2>>
-    // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.ref<uint<1>>
-    // CHECK:  %3 = firrtl.ref.resolve %1 : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %0 : !firrtl.probe<vector<uint<1>, 2>>
+    // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
+    // CHECK:  %3 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
     firrtl.strictconnect %c, %1 : !firrtl.vector<uint<1>, 2>
     // CHECK:  firrtl.strictconnect %c_0, %2 : !firrtl.uint<1>
     // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -4,57 +4,57 @@
 // CHECK-LABEL: firrtl.circuit "xmr"
 firrtl.circuit "xmr" {
   // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port 'a'}}
-  firrtl.module @xmr(in %a: !firrtl.ref<uint<2>>) {
-    %x = firrtl.ref.resolve %a : !firrtl.ref<uint<2>>
+  firrtl.module @xmr(in %a: !firrtl.probe<uint<2>>) {
+    %x = firrtl.ref.resolve %a : !firrtl.probe<uint<2>>
   }
 }
 
 // -----
 
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_b, %xmr_a : !firrtl.ref<uint<1>>
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
-    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_b, %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
   }
   // expected-error @+1 {{op multiply instantiated module with input RefType port '_a'}}
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
 
 // -----
 
 firrtl.circuit "Top" {
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
+    %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
   // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port '_a'}}
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
 
@@ -66,8 +66,8 @@ firrtl.circuit "RefSubNotFromMemory" {
     // expected-note @below {{input here}}
     %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
     // expected-error @below {{can only lower RefSubOp of Memory}}
-    %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
-    %res = firrtl.ref.resolve %sub : !firrtl.ref<uint<2>>
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    %res = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
   }
 }
 
@@ -76,14 +76,14 @@ firrtl.circuit "RefSubNotFromMemory" {
 
 firrtl.circuit "RefSubNotFromOp" {
   // expected-note @below {{input here}}
-  firrtl.module private @Child(in %ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>) {
+  firrtl.module private @Child(in %ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>) {
     // expected-error @below {{can only lower RefSubOp of Memory}}
-    %sub = firrtl.ref.sub %ref[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
-    %res = firrtl.ref.resolve %sub : !firrtl.ref<uint<2>>
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    %res = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
   }
   firrtl.module @RefSubNotFromOp(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>) {
     %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    %child_ref = firrtl.instance child @Child(in ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>)
-    firrtl.ref.define %child_ref, %ref : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
+    %child_ref = firrtl.instance child @Child(in ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>)
+    firrtl.ref.define %child_ref, %ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -4,11 +4,11 @@
 // CHECK-LABEL: firrtl.circuit "xmr"
 firrtl.circuit "xmr" {
   // CHECK-LABEL: firrtl.module @xmr(out %o: !firrtl.uint<2>)
-  firrtl.module @xmr(out %o: !firrtl.uint<2>, in %2: !firrtl.ref<uint<0>>) {
+  firrtl.module @xmr(out %o: !firrtl.uint<2>, in %2: !firrtl.probe<uint<0>>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
-    %x = firrtl.ref.resolve %1 : !firrtl.ref<uint<2>>
-    %x2 = firrtl.ref.resolve %2 : !firrtl.ref<uint<0>>
+    %x = firrtl.ref.resolve %1 : !firrtl.probe<uint<2>>
+    %x2 = firrtl.ref.resolve %2 : !firrtl.probe<uint<0>>
     // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w = firrtl.wire sym @[[wSym:[a-zA-Z0-9_]+]] : !firrtl.uint<2>
@@ -25,24 +25,24 @@ firrtl.circuit "xmr" {
 firrtl.circuit "Top" {
   // CHECK:      hw.hierpath private @[[path:[a-zA-Z0-9_]+]]
   // CHECK-SAME:   [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
     // CHECK-NEXT; firrtl.strictconnect %a, %[[#cast]] : !firrtl.uint<1>
@@ -55,14 +55,14 @@ firrtl.circuit "Top" {
 // Test 0-width xmrs are handled
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
-  firrtl.module @Top(in %bar_a : !firrtl.ref<uint<0>>, in %bar_b : !firrtl.ref<vector<uint<0>,10>>) {
+  firrtl.module @Top(in %bar_a : !firrtl.probe<uint<0>>, in %bar_b : !firrtl.probe<vector<uint<0>,10>>) {
     %a = firrtl.wire : !firrtl.uint<0>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<0>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<0>>
     // CHECK:  %[[c0_ui0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
     firrtl.strictconnect %a, %0 : !firrtl.uint<0>
     // CHECK:  firrtl.strictconnect %a, %[[c0_ui0]] : !firrtl.uint<0>
     %b = firrtl.wire : !firrtl.vector<uint<0>,10>
-    %1 = firrtl.ref.resolve %bar_b : !firrtl.ref<vector<uint<0>,10>>
+    %1 = firrtl.ref.resolve %bar_b : !firrtl.probe<vector<uint<0>,10>>
     firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>,10>
     // CHECK:	%[[c0_ui0_0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
     // CHECK:  %[[v2:.+]] = firrtl.bitcast %[[c0_ui0_0]] : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
@@ -76,21 +76,21 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @[[xmrSym]]) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -108,30 +108,30 @@ firrtl.circuit "Top" {
   // CHECK-DAG: hw.hierpath private @[[path_2:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym]]]
   // CHECK-DAG: hw.hierpath private @[[path_3:[a-zA-Z0-9_]+]] [@Top::@foo, @Foo::@fooXMR, @XmrSrcMod::@[[xmrSym]]]
   // CHECK-DAG: hw.hierpath private @[[path_4:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK:      firrtl.strictconnect %a, %[[#cast]]
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
-    %0 = firrtl.ref.resolve %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     %a = firrtl.wire : !firrtl.uint<1>
@@ -139,22 +139,22 @@ firrtl.circuit "Top" {
     // CHECK:      firrtl.strictconnect %a, %[[#cast]]
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
-    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
+    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.probe<uint<1>>)
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     // CHECK:  firrtl.instance foo sym @foo  @Foo()
     // CHECK:  firrtl.instance xmr sym @xmr  @XmrSrcMod()
     %a = firrtl.wire : !firrtl.uint<1>
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_2]]
     // CHECK-NEXT: %[[#cast_2:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %foo_a : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %foo_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_3]]
     // CHECK-NEXT: %[[#cast_3:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %2 = firrtl.ref.resolve %xmr_a : !firrtl.ref<uint<1>>
+    %2 = firrtl.ref.resolve %xmr_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_4]]
     // CHECK-NEXT: %[[#cast_4:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -172,33 +172,33 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0
     // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
-    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %bar_a : !firrtl.ref<uint<1>>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
@@ -211,30 +211,30 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %pa, %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(in pa: !firrtl.uint<1>, out _a: !firrtl.probe<uint<1>>)
     // CHECK: %bar_pa = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<1>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
-    %c_a = firrtl.instance child @Child(in  _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %bar_a : !firrtl.ref<uint<1>>
+    %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
@@ -247,29 +247,29 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path_0:[a-zA-Z0-9_]+]] [@Top::@foo, @Foo::@fooXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK: hw.hierpath private @[[path_1:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
-  firrtl.module @Foo(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+  firrtl.module @Foo(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @fooXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.ref<uint<1>>)
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a, %c_b = firrtl.instance child @Child2p(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
+    %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.probe<uint<1>>)
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a, %c_b = firrtl.instance child @Child2p(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
     // CHECK:  firrtl.instance child  @Child2p()
-    firrtl.ref.define %c_a, %foo_a : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_b, %xmr_a : !firrtl.ref<uint<1>>
+    firrtl.ref.define %c_a, %foo_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2p(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2p(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
@@ -281,41 +281,41 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
-  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.ref<uint<1>>
-    %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.ref<uint<1>>
+    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
-  firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
@@ -327,41 +327,41 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
-  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.ref<uint<1>>
-    %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.ref<uint<1>>
+    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
-  firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
@@ -372,10 +372,10 @@ firrtl.circuit "Top" {
 // Multiply instantiated Top works, because the reference port does not flow through it.
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Dut::@xmr, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
     // CHECK: firrtl.node sym @[[xmrSym]]
   }
   firrtl.module @Top() {
@@ -385,34 +385,34 @@ firrtl.circuit "Top" {
     firrtl.instance d2 @Dut()
   }
   firrtl.module @Dut() {
-    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
-    %c_a = firrtl.instance child @Child1(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c_a, %xmr_a : !firrtl.ref<uint<1>>
+    %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
+    %c_a = firrtl.instance child @Child1(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
   }
   // CHECK-LABEL: firrtl.module @Child1() {
-  firrtl.module @Child1(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.ref<uint<1>>, in _b: !firrtl.ref<uint<1>> )
-    firrtl.ref.define %c_a, %_a : !firrtl.ref<uint<1>>
-    firrtl.ref.define %c_b, %_a : !firrtl.ref<uint<1>>
-    %c3 = firrtl.instance child @Child3(in _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %c3 , %_a : !firrtl.ref<uint<1>>
+    %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+    firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
+    %c3 = firrtl.instance child @Child3(in _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c3 , %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.ref<uint<1>>, in  %_b: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %_b : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
   }
-  firrtl.module @Child3(in  %_a: !firrtl.ref<uint<1>>) {
-    %0 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+  firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
-    %1 = firrtl.ref.resolve %_a : !firrtl.ref<uint<1>>
+    %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
   }
@@ -424,9 +424,9 @@ firrtl.circuit "Top"  {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK-LABEL: firrtl.module private @DUTModule
   // CHECK-SAME: (in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
-  firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap: !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+  firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap: !firrtl.probe<vector<uint<8>, 8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 8 : i64, groupID = 1 : ui32, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %0 = firrtl.subfield %rf_read[addr] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
     %1 = firrtl.subfield %rf_read[en] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -446,12 +446,12 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %6, %clock : !firrtl.clock
     firrtl.strictconnect %8, %c1_ui1 : !firrtl.uint<1>
     firrtl.strictconnect %7, %io_dataIn : !firrtl.uint<8>
-    firrtl.ref.define %_gen_memTap, %rf_memTap : !firrtl.ref<vector<uint<8>, 8>>
+    firrtl.ref.define %_gen_memTap, %rf_memTap : !firrtl.probe<vector<uint<8>, 8>>
   }
   // CHECK: firrtl.module @Top
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
-    %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.ref<vector<uint<8>, 8>>)
-    %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.ref<vector<uint<8>, 8>>
+    %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.probe<vector<uint<8>, 8>>)
+    %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.probe<vector<uint<8>, 8>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory"
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
@@ -508,21 +508,21 @@ firrtl.circuit "Top"  {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK-LABEL:  firrtl.module private @DUTModule
   // CHECK-SAME: in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
-  firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap_0: !firrtl.ref<uint<8>>, out %_gen_memTap_1: !firrtl.ref<uint<8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+  firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap_0: !firrtl.probe<uint<8>>, out %_gen_memTap_1: !firrtl.probe<uint<8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 2 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.ref<vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 2 : i64, groupID = 1 : ui32, name = "rf", portNames = ["memTap", "read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 2 : i64, groupID = 1 : ui32, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %9 = firrtl.ref.sub %rf_memTap[0] : !firrtl.ref<vector<uint<8>, 2>>
-    firrtl.ref.define %_gen_memTap_0, %9 : !firrtl.ref<uint<8>>
-    %10 = firrtl.ref.sub %rf_memTap[1] : !firrtl.ref<vector<uint<8>, 2>>
-    firrtl.ref.define %_gen_memTap_1, %10 : !firrtl.ref<uint<8>>
+    %9 = firrtl.ref.sub %rf_memTap[0] : !firrtl.probe<vector<uint<8>, 2>>
+    firrtl.ref.define %_gen_memTap_0, %9 : !firrtl.probe<uint<8>>
+    %10 = firrtl.ref.sub %rf_memTap[1] : !firrtl.probe<vector<uint<8>, 2>>
+    firrtl.ref.define %_gen_memTap_1, %10 : !firrtl.probe<uint<8>>
   }
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
-    %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.ref<uint<8>>, out _gen_memTap_1: !firrtl.ref<uint<8>>)
-    %0 = firrtl.ref.resolve %dut__gen_memTap_0 : !firrtl.ref<uint<8>>
+    %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.probe<uint<8>>, out _gen_memTap_1: !firrtl.probe<uint<8>>)
+    %0 = firrtl.ref.resolve %dut__gen_memTap_0 : !firrtl.probe<uint<8>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[0]"
     // CHECK-NEXT: %[[#cast_0:]] = builtin.unrealized_conversion_cast %[[#xmr]]
-    %1 = firrtl.ref.resolve %dut__gen_memTap_1 : !firrtl.ref<uint<8>>
+    %1 = firrtl.ref.resolve %dut__gen_memTap_1 : !firrtl.probe<uint<8>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[1]"
     // CHECK-NEXT: %[[#cast_1:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
@@ -541,23 +541,23 @@ firrtl.circuit "Top"  {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     // CHECK-NEXT: }
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1>
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".internal.path"
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -571,24 +571,24 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
-  firrtl.module @XmrSrcMod(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     // CHECK{LITERAL}:  firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
     // CHECK:  = firrtl.node sym @xmr_sym  %[[internal:.+]]  : !firrtl.uint<1>
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.ref<uint<1>>)
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
-    firrtl.ref.define %_a, %xmr   : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
   }
   firrtl.module @Top() {
-    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
@@ -600,19 +600,19 @@ firrtl.circuit "Top" {
 
 // Test correct lowering of 0-width ports
 firrtl.circuit "Top"  {
-  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>, out %_a: !firrtl.ref<uint<0>>) {
+  firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>, out %_a: !firrtl.probe<uint<0>>) {
   // CHECK-LABEL: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<0>)
     %0 = firrtl.ref.send %pa : !firrtl.uint<0>
-    firrtl.ref.define %_a, %0 : !firrtl.ref<uint<0>>
+    firrtl.ref.define %_a, %0 : !firrtl.probe<uint<0>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<0>>) {
-    %bar_pa, %bar__a = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<0>, out _a: !firrtl.ref<uint<0>>)
-    firrtl.ref.define %_a, %bar__a : !firrtl.ref<uint<0>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<0>>) {
+    %bar_pa, %bar__a = firrtl.instance bar sym @barXMR  @XmrSrcMod(in pa: !firrtl.uint<0>, out _a: !firrtl.probe<uint<0>>)
+    firrtl.ref.define %_a, %bar__a : !firrtl.probe<uint<0>>
   }
   firrtl.module @Top() {
-    %bar__a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.ref<uint<0>>)
+    %bar__a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<0>>)
     %a = firrtl.wire   : !firrtl.uint<0>
-    %0 = firrtl.ref.resolve %bar__a : !firrtl.ref<uint<0>>
+    %0 = firrtl.ref.resolve %bar__a : !firrtl.probe<uint<0>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<0>
     // CHECK: %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
     // CHECK: firrtl.strictconnect %a, %c0_ui0 : !firrtl.uint<0>
@@ -633,6 +633,6 @@ firrtl.circuit "Issue4559" {
     // CHECK-SAME: @Issue4559::@[[SYM]]
     %port = firrtl.instance source @Source(out sourceport: !firrtl.uint<1>)
     %port_ref = firrtl.ref.send %port : !firrtl.uint<1>
-    %port_val = firrtl.ref.resolve %port_ref : !firrtl.ref<uint<1>>
+    %port_val = firrtl.ref.resolve %port_ref : !firrtl.probe<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec))' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
-  firrtl.module public @Mem(out %d : !firrtl.ref<vector<uint<8>, 8>>, out %d2 : !firrtl.ref<vector<uint<8>, 8>>) attributes {annotations = [
+  firrtl.module public @Mem(out %d : !firrtl.probe<vector<uint<8>, 8>>, out %d2 : !firrtl.probe<vector<uint<8>, 8>>) attributes {annotations = [
     {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
   ]} {
     %dbg, %mem_read, %mem_write, %debug = firrtl.mem Undefined {
@@ -10,11 +10,11 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
       portNames = ["dbg", "read", "write", "debug"],
       readLatency = 0 : i32,
       writeLatency = 1 : i32
-    } : !firrtl.ref<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
+    } : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>,
         !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>,
-        !firrtl.ref<vector<uint<8>, 8>>
-    firrtl.ref.define %d, %debug : !firrtl.ref<vector<uint<8>, 8>>
-    firrtl.ref.define %d2, %dbg : !firrtl.ref<vector<uint<8>, 8>>
+        !firrtl.probe<vector<uint<8>, 8>>
+    firrtl.ref.define %d, %debug : !firrtl.probe<vector<uint<8>, 8>>
+    firrtl.ref.define %d2, %dbg : !firrtl.probe<vector<uint<8>, 8>>
   }
     // CHECK-LABEL: firrtl.circuit "Mem" {
     // CHECK:         firrtl.module public @Mem(
@@ -44,8 +44,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           }
     // CHECK:           %11 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
     // CHECK:           %12 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
-    // CHECK:           firrtl.ref.define %d, %12 : !firrtl.ref<vector<uint<8>, 8>>
-    // CHECK:           firrtl.ref.define %d2, %11 : !firrtl.ref<vector<uint<8>, 8>>
+    // CHECK:           firrtl.ref.define %d, %12 : !firrtl.probe<vector<uint<8>, 8>>
+    // CHECK:           firrtl.ref.define %d2, %11 : !firrtl.probe<vector<uint<8>, 8>>
 
 
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1153,8 +1153,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     module.in <= UInt(1)
 
   ; CHECK-LABEL: module private @RefsChild(
-  ; CHECK-SAME: out %r: !firrtl.ref<uint<1>>
-  ; CHECK-SAME: out %rw: !firrtl.ref<uint<1>>
+  ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>
+  ; CHECK-SAME: out %rw: !firrtl.probe<uint<1>>
   module RefsChild :
     input in : UInt<1>
     output r : Probe<UInt<1>>
@@ -1177,7 +1177,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output out : UInt<1>
     output out2 : UInt<1>
     output out3 : UInt<3>
-    ; CHECK-SAME: out %agg_out: !firrtl.ref<bundle<a: uint<1>, b: uint>>
+    ; CHECK-SAME: out %agg_out: !firrtl.probe<bundle<a: uint<1>, b: uint>>
     output agg_out : Probe<{a: UInt<1>, b: UInt}>
 
     ; CHECK-NEXT: %[[RC_IN:.+]], %[[RC_R:.+]], %[[RC_RW:.+]] = firrtl.instance rc
@@ -1232,7 +1232,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     out <= and(read(probe(in)), UInt(1))
 
   ; CHECK-LABEL: extmodule private @RefExt(
-  ; CHECK-SAME:  in in: !firrtl.uint<1>, out r: !firrtl.ref<uint<1>> 
+  ; CHECK-SAME:  in in: !firrtl.uint<1>, out r: !firrtl.probe<uint<1>> 
   ; CHECK-SAME: internalPaths = ["in"]
   extmodule RefExt :
     input in : UInt<1>
@@ -1241,9 +1241,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: extmodule private @RefExtMore(
   ; CHECK-SAME:  in in: !firrtl.uint<1>
-  ; CHECK-SAME: out r: !firrtl.ref<uint<1>> 
+  ; CHECK-SAME: out r: !firrtl.probe<uint<1>> 
   ; CHECK-SAME: out data: !firrtl.uint<3> 
-  ; CHECK-SAME: out r2: !firrtl.ref<vector<bundle<a: uint<3>>, 3>>
+  ; CHECK-SAME: out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>
   ; CHECK-SAME: internalPaths = ["path.to.internal.signal", "in"]
   extmodule RefExtMore :
     input in : UInt<1>

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -190,3 +190,13 @@ firrtl.circuit "UseRefsWithSinkFlow" {
     firrtl.connect %zz, %oc_y : !firrtl.uint<1>, !firrtl.uint
   }
 }
+
+// -----
+
+firrtl.circuit "ProbeAndRWProbe" {
+  // Dead, just check it parses.
+  firrtl.module private @Probes(in %ro : !firrtl.probe<uint<1>>, in %rw : !firrtl.rwprobe<uint<2>>) { }
+  firrtl.module @ProbeAndRWProbe() {
+  }
+}
+

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -4,16 +4,16 @@
 
 // Simple 1 level read from wire.
 firrtl.circuit "xmr" {
-  firrtl.module private @Test(out %x: !firrtl.ref<uint<2>>) {
+  firrtl.module private @Test(out %x: !firrtl.probe<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %zero = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.strictconnect %w, %zero : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
-    firrtl.ref.define %x, %1 : !firrtl.ref<uint<2>>
+    firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
   }
   firrtl.module @xmr() {
-    %test_x = firrtl.instance test @Test(out x: !firrtl.ref<uint<2>>)
-    %x = firrtl.ref.resolve %test_x : !firrtl.ref<uint<2>>
+    %test_x = firrtl.instance test @Test(out x: !firrtl.probe<uint<2>>)
+    %x = firrtl.ref.resolve %test_x : !firrtl.probe<uint<2>>
   }
 }
 
@@ -21,15 +21,15 @@ firrtl.circuit "xmr" {
 
 // Simple 1 level read from constant.
 firrtl.circuit "SimpleRead" {
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
   firrtl.module @SimpleRead() {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -38,19 +38,19 @@ firrtl.circuit "SimpleRead" {
 
 // Forward module port to instance
 firrtl.circuit "ForwardToInstance" {
-  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @Bar2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %bar_2 : !firrtl.ref<uint<1>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>
   }
   firrtl.module @ForwardToInstance() {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -59,24 +59,24 @@ firrtl.circuit "ForwardToInstance" {
 
 // Multiple readers, for a single remote value.
 firrtl.circuit "ForwardToInstance" {
-  firrtl.module @Bar2(out %_a: !firrtl.ref<uint<1>>) {
+  firrtl.module @Bar2(out %_a: !firrtl.probe<uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
-    firrtl.ref.define %_a, %1    : !firrtl.ref<uint<1>>
+    firrtl.ref.define %_a, %1    : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Bar(out %_a: !firrtl.ref<uint<1>>) {
-    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.ref<uint<1>>)
-    firrtl.ref.define %_a, %bar_2 : !firrtl.ref<uint<1>>
+  firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
+    %bar_2 = firrtl.instance bar @Bar2(out _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %_a, %bar_2 : !firrtl.probe<uint<1>>
     // Reader 1
-    %0 = firrtl.ref.resolve %bar_2 : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_2 : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @ForwardToInstance() {
-    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.ref<uint<1>>)
+    %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     // Reader 2
-    %0 = firrtl.ref.resolve %bar_a : !firrtl.ref<uint<1>>
+    %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -85,24 +85,24 @@ firrtl.circuit "ForwardToInstance" {
 
 // Two references passed by value.
 firrtl.circuit "DUT" {
-  firrtl.module private @Submodule (out %ref_out1: !firrtl.ref<uint<1>>, out %ref_out2: !firrtl.ref<uint<4>>) {
+  firrtl.module private @Submodule (out %ref_out1: !firrtl.probe<uint<1>>, out %ref_out2: !firrtl.probe<uint<4>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %w_data1 = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %w_data1, %zero : !firrtl.uint<1>
     %1 = firrtl.ref.send %w_data1 : !firrtl.uint<1>
-    firrtl.ref.define %ref_out1, %1 : !firrtl.ref<uint<1>>
+    firrtl.ref.define %ref_out1, %1 : !firrtl.probe<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
     %zero4 = firrtl.constant 0 : !firrtl.uint<4>
     firrtl.strictconnect %w_data2, %zero4 : !firrtl.uint<4>
     %2 = firrtl.ref.send %w_data2 : !firrtl.uint<4>
-    firrtl.ref.define %ref_out2, %2 : !firrtl.ref<uint<4>>
+    firrtl.ref.define %ref_out2, %2 : !firrtl.probe<uint<4>>
   }
   firrtl.module @DUT() {
-    %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.ref<uint<1>>, out ref_out2: !firrtl.ref<uint<4>>)
+    %view_out1, %view_out2 = firrtl.instance sub @Submodule(out ref_out1: !firrtl.probe<uint<1>>, out ref_out2: !firrtl.probe<uint<4>>)
     %view_in1, %view_in2 = firrtl.instance MyView_companion @MyView_companion(in ref_in1: !firrtl.uint<1>, in ref_in2: !firrtl.uint<4>)
 
-    %1 = firrtl.ref.resolve %view_out1 : !firrtl.ref<uint<1>>
-    %2 = firrtl.ref.resolve %view_out2 : !firrtl.ref<uint<4>>
+    %1 = firrtl.ref.resolve %view_out1 : !firrtl.probe<uint<1>>
+    %2 = firrtl.ref.resolve %view_out2 : !firrtl.probe<uint<4>>
     firrtl.strictconnect %view_in1, %1 : !firrtl.uint<1>
     firrtl.strictconnect %view_in2, %2 : !firrtl.uint<4>
   }
@@ -128,13 +128,13 @@ firrtl.circuit "RefTypeVector" {
     %zero = firrtl.constant 0 : !firrtl.uint<4>
     %z = firrtl.bitcast %zero : (!firrtl.uint<4>) -> !firrtl.vector<uint<1>,4>
     %1 = firrtl.ref.send %z : !firrtl.vector<uint<1>,4>
-    %10 = firrtl.ref.sub %1[0] : !firrtl.ref<vector<uint<1>,4>>
-    %11 = firrtl.ref.sub %1[1] : !firrtl.ref<vector<uint<1>,4>>
-    %a = firrtl.ref.resolve %10 : !firrtl.ref<uint<1>>
-    %b = firrtl.ref.resolve %11 : !firrtl.ref<uint<1>>
+    %10 = firrtl.ref.sub %1[0] : !firrtl.probe<vector<uint<1>,4>>
+    %11 = firrtl.ref.sub %1[1] : !firrtl.probe<vector<uint<1>,4>>
+    %a = firrtl.ref.resolve %10 : !firrtl.probe<uint<1>>
+    %b = firrtl.ref.resolve %11 : !firrtl.probe<uint<1>>
     %b1 = firrtl.ref.send %bundle : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
-    %12 = firrtl.ref.sub %b1[1] : !firrtl.ref<bundle<a: uint<1>, b: uint<2>>>
-    %rb = firrtl.ref.resolve %12 : !firrtl.ref<uint<2>>
+    %12 = firrtl.ref.sub %b1[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    %rb = firrtl.ref.resolve %12 : !firrtl.probe<uint<2>>
     %bundle_b = firrtl.subfield %bundle[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
     %zero2 = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.strictconnect %bundle_b, %zero2 : !firrtl.uint<2>
@@ -145,19 +145,19 @@ firrtl.circuit "RefTypeVector" {
 
 // https://github.com/llvm/circt/issues/3715
 firrtl.circuit "Issue3715" {
-  firrtl.module private @Test(in %p: !firrtl.uint<1>, out %x: !firrtl.ref<uint<2>>) {
+  firrtl.module private @Test(in %p: !firrtl.uint<1>, out %x: !firrtl.probe<uint<2>>) {
     firrtl.when %p : !firrtl.uint<1> {
       %zero = firrtl.constant 1 : !firrtl.uint<2>
       %w = firrtl.wire : !firrtl.uint<2>
       %1 = firrtl.ref.send %w : !firrtl.uint<2>
-      firrtl.ref.define %x, %1 : !firrtl.ref<uint<2>>
+      firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
       firrtl.strictconnect %w, %zero : !firrtl.uint<2>
     }
   }
   firrtl.module @Issue3715(in %p: !firrtl.uint<1>) {
-    %test_in, %test_x = firrtl.instance test @Test(in p: !firrtl.uint<1>, out x: !firrtl.ref<uint<2>>)
+    %test_in, %test_x = firrtl.instance test @Test(in p: !firrtl.uint<1>, out x: !firrtl.probe<uint<2>>)
     firrtl.strictconnect %test_in, %p : !firrtl.uint<1>
-    %x = firrtl.ref.resolve %test_x : !firrtl.ref<uint<2>>
+    %x = firrtl.ref.resolve %test_x : !firrtl.probe<uint<2>>
   }
 }
 
@@ -167,25 +167,25 @@ firrtl.circuit "Issue3715" {
 // https://github.com/llvm/circt/issues/3713
 
 firrtl.circuit "UseRefsWithSinkFlow" {
-  firrtl.module private @InChild(in %p: !firrtl.ref<uint<1>>) {
+  firrtl.module private @InChild(in %p: !firrtl.probe<uint<1>>) {
   }
-  firrtl.module private @OutChild(in %x: !firrtl.uint, out %y: !firrtl.uint, out %p: !firrtl.ref<uint>) {
+  firrtl.module private @OutChild(in %x: !firrtl.uint, out %y: !firrtl.uint, out %p: !firrtl.probe<uint>) {
     %0 = firrtl.ref.send %x : !firrtl.uint
-    firrtl.ref.define %p, %0 : !firrtl.ref<uint>
-    %1 = firrtl.ref.resolve %p : !firrtl.ref<uint>
+    firrtl.ref.define %p, %0 : !firrtl.probe<uint>
+    %1 = firrtl.ref.resolve %p : !firrtl.probe<uint>
     firrtl.connect %y, %1 : !firrtl.uint, !firrtl.uint
   }
-  firrtl.module @UseRefsWithSinkFlow(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %zz: !firrtl.uint<1>, out %p: !firrtl.ref<uint<1>>) {
+  firrtl.module @UseRefsWithSinkFlow(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %zz: !firrtl.uint<1>, out %p: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.send %x : !firrtl.uint<1>
-    firrtl.ref.define %p, %0 : !firrtl.ref<uint<1>>
-    %1 = firrtl.ref.resolve %p : !firrtl.ref<uint<1>>
+    firrtl.ref.define %p, %0 : !firrtl.probe<uint<1>>
+    %1 = firrtl.ref.resolve %p : !firrtl.probe<uint<1>>
     firrtl.strictconnect %y, %1 : !firrtl.uint<1>
-    %ic_p = firrtl.instance ic interesting_name @InChild(in p: !firrtl.ref<uint<1>>)
+    %ic_p = firrtl.instance ic interesting_name @InChild(in p: !firrtl.probe<uint<1>>)
     %2 = firrtl.ref.send %x : !firrtl.uint<1>
-    firrtl.ref.define %ic_p, %2 : !firrtl.ref<uint<1>>
-    %3 = firrtl.ref.resolve %ic_p : !firrtl.ref<uint<1>>
+    firrtl.ref.define %ic_p, %2 : !firrtl.probe<uint<1>>
+    %3 = firrtl.ref.resolve %ic_p : !firrtl.probe<uint<1>>
     firrtl.strictconnect %z, %3 : !firrtl.uint<1>
-    %oc_x, %oc_y, %oc_p = firrtl.instance oc interesting_name @OutChild(in x: !firrtl.uint, out y: !firrtl.uint, out p: !firrtl.ref<uint>)
+    %oc_x, %oc_y, %oc_p = firrtl.instance oc interesting_name @OutChild(in x: !firrtl.uint, out y: !firrtl.uint, out p: !firrtl.probe<uint>)
     firrtl.connect %oc_x, %x : !firrtl.uint, !firrtl.uint<1>
     firrtl.connect %zz, %oc_y : !firrtl.uint<1>, !firrtl.uint
   }

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -690,29 +690,29 @@ firrtl.circuit "Test" {
   //===--------------------------------------------------------------------===//
 
   // CHECK-LABEL @RefSender
-  firrtl.module @RefSender(out %port: !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>) {
+  firrtl.module @RefSender(out %port: !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>) {
    // CHECK: %w = firrtl.wire : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
     // CHECK: %0 = firrtl.ref.send %w : !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
-    // CHECK: firrtl.ref.define %port, %0 : !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
+    // CHECK: firrtl.ref.define %port, %0 : !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
     %w = firrtl.wire : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
     %ref = firrtl.ref.send %w : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
-    firrtl.ref.define %port, %ref : !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
+    firrtl.ref.define %port, %ref : !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
   }
 
   firrtl.module @RefResolver() {
-    // CHECK: %sender_port = firrtl.instance sender @RefSender(out port: !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>)
-    // CHECK: %0 = firrtl.ref.sub %sender_port[1] : !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
-    // CHECK: %1 = firrtl.ref.sub %0[1] : !firrtl.ref<vector<uint<8>, 2>>
-    // CHECK: %2 = firrtl.ref.sub %sender_port[0] : !firrtl.ref<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
-    // CHECK: %3 = firrtl.ref.sub %2[1] : !firrtl.ref<vector<uint<4>, 2>>
-    // CHECK: %4 = firrtl.ref.resolve %3 : !firrtl.ref<uint<4>>
-    // CHECK: %5 = firrtl.ref.resolve %1 : !firrtl.ref<uint<8>>
+    // CHECK: %sender_port = firrtl.instance sender @RefSender(out port: !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>)
+    // CHECK: %0 = firrtl.ref.sub %sender_port[1] : !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
+    // CHECK: %1 = firrtl.ref.sub %0[1] : !firrtl.probe<vector<uint<8>, 2>>
+    // CHECK: %2 = firrtl.ref.sub %sender_port[0] : !firrtl.probe<bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>>
+    // CHECK: %3 = firrtl.ref.sub %2[1] : !firrtl.probe<vector<uint<4>, 2>>
+    // CHECK: %4 = firrtl.ref.resolve %3 : !firrtl.probe<uint<4>>
+    // CHECK: %5 = firrtl.ref.resolve %1 : !firrtl.probe<uint<8>>
     // CHECK: %6 = firrtl.bundlecreate %4, %5 : (!firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.bundle<a: uint<4>, b: uint<8>>
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: uint<4>, b: uint<8>>
     // CHECK: firrtl.strictconnect %w, %6 : !firrtl.bundle<a: uint<4>, b: uint<8>>
-    %vector_ref = firrtl.instance sender @RefSender(out port: !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>)
-    %bundle_ref = firrtl.ref.sub     %vector_ref[1] : !firrtl.ref<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
-    %bundle_val = firrtl.ref.resolve %bundle_ref    : !firrtl.ref<bundle<a: uint<4>, b: uint<8>>>
+    %vector_ref = firrtl.instance sender @RefSender(out port: !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>)
+    %bundle_ref = firrtl.ref.sub     %vector_ref[1] : !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
+    %bundle_val = firrtl.ref.resolve %bundle_ref    : !firrtl.probe<bundle<a: uint<4>, b: uint<8>>>
     %w = firrtl.wire: !firrtl.bundle<a: uint<4>, b: uint<8>>
     firrtl.strictconnect %w, %bundle_val : !firrtl.bundle<a: uint<4>, b: uint<8>>
   }


### PR DESCRIPTION
On the path to supporting forcing declarations, we want to be able to differentiate whether a reference is read-only or if it can be used with forcing.
To this end, extend `firrtl.ref` with a bit indicating the reference kind.

Default kind is `probe` which is basically what `firrtl.ref` is for today: read-only view of the data, and produced by `ref.send`.

Nothing presently will create the forceable (rwprobe) variant yet.