### PR TITLE
[FIRRTL] Add optional forceable ref result to FIRRTL decls.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -380,13 +380,7 @@ def CatDoubleConst : Pat <
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegResetWithZeroReset : Pat<
-  (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym),
-  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym), [(ZeroConstantOp $reset)]>;
-
-// regreset(clock, constant_one, resetValue) -> node(resetValue)
-def RegResetWithOneReset : Pat<
-  (RegResetOp:$reg $clock, $reset, $resetVal, $name, $nameKind, $annotations, $inner_sym),
-  (DropWrite $reg, (NodeOp $resetVal, $name, $nameKind, $annotations, $inner_sym)),
-  [(OneConstantOp $reset)]>;
+  (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym, $forceable),
+  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym, $forceable), [(ZeroConstantOp $reset)]>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -287,7 +287,49 @@ def RegOp : ReferableDeclOp<"reg", [Forceable]> {
         UnitAttr:$forceable);
   let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
+  let skipDefaultBuilders = true;
   let builders = [
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::mlir::ValueRange":$operands,
+                   CArg<"::llvm::ArrayRef<::mlir::NamedAttribute>","{}">:$attributes), [{
+      assert(operands.size() == 1u && "mismatched number of parameters");
+      odsState.addOperands(operands);
+      odsState.addAttributes(attributes);
+      assert(resultTypes.size() >= 1u && "mismatched number of return types");
+      odsState.addTypes(resultTypes);
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                   "::mlir::Value":$clockVal,
+                   "::mlir::StringAttr":$name,
+                   "::circt::firrtl::NameKindEnumAttr":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "::circt::hw::InnerSymAttr":$inner_sym,
+                   "::mlir::UnitAttr":$forceable), [{
+      $_state.addOperands(clockVal);
+      $_state.addAttribute(getNameAttrName($_state.name), name);
+      $_state.addAttribute(getNameKindAttrName($_state.name), nameKind);
+      $_state.addAttribute(getAnnotationsAttrName($_state.name), annotations);
+      if (inner_sym) {
+        $_state.addAttribute(getInnerSymAttrName($_state.name), inner_sym);
+      }
+      $_state.addTypes(elementType);
+      if (forceable) {
+        $_state.addAttribute(getForceableAttrName($_state.name), forceable);
+        $_state.addTypes(detail::getForceableResultType(true, elementType));
+      }
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                   "::mlir::Value":$clockVal,
+                   "::llvm::StringRef":$name,
+                   "::circt::firrtl::NameKindEnum":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "::circt::hw::InnerSymAttr":$inner_sym,
+                   "bool":$forceable), [{
+      return build($_builder, $_state, elementType, clockVal,
+                   $_builder.getStringAttr(name),
+                   ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
+                   annotations, inner_sym,
+                   forceable ? $_builder.getUnitAttr() : nullptr);
+    }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
@@ -295,8 +337,7 @@ def RegOp : ReferableDeclOp<"reg", [Forceable]> {
                    CArg<"StringAttr", "StringAttr()">:$inner_sym,
                    CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
-                   clockVal, name, nameKind,
+                   clockVal, $_builder.getStringAttr(name), nameKind,
                    $_builder.getArrayAttr(annotations),
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
                    forceable);
@@ -306,8 +347,7 @@ def RegOp : ReferableDeclOp<"reg", [Forceable]> {
                    "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym,
                    CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
-                   clockVal, name, nameKind, annotation,
+                   clockVal, $_builder.getStringAttr(name), nameKind, annotation,
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
                    forceable);
     }]>
@@ -339,7 +379,39 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
         UnitAttr:$forceable);
   let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
+  let skipDefaultBuilders = true;
   let builders = [
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::mlir::ValueRange":$operands,
+                   CArg<"::llvm::ArrayRef<::mlir::NamedAttribute>","{}">:$attributes), [{
+      assert(operands.size() == 3u && "mismatched number of parameters");
+      odsState.addOperands(operands);
+      odsState.addAttributes(attributes);
+      assert(resultTypes.size() >= 1u && "mismatched number of return types");
+      odsState.addTypes(resultTypes);
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                   "::mlir::Value":$clockVal,
+                   "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
+                   "::mlir::StringAttr":$name,
+                   "::circt::firrtl::NameKindEnumAttr":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "::circt::hw::InnerSymAttr":$inner_sym,
+                   "::mlir::UnitAttr":$forceable), [{
+      $_state.addOperands(clockVal);
+      odsState.addOperands(resetSignal);
+      odsState.addOperands(resetValue);
+      $_state.addAttribute(getNameAttrName($_state.name), name);
+      $_state.addAttribute(getNameKindAttrName($_state.name), nameKind);
+      $_state.addAttribute(getAnnotationsAttrName($_state.name), annotations);
+      if (inner_sym) {
+        $_state.addAttribute(getInnerSymAttrName($_state.name), inner_sym);
+      }
+      $_state.addTypes(elementType);
+      if (forceable) {
+        $_state.addAttribute(getForceableAttrName($_state.name), forceable);
+        $_state.addTypes(detail::getForceableResultType(true, elementType));
+      }
+    }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
                    CArg<"StringRef", "{}">:$name,
@@ -348,12 +420,12 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
                    CArg<"StringAttr", "StringAttr()">:$inner_sym,
                    CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
                    clockVal, resetSignal, resetValue,
-                   name, nameKind,
+                   $_builder.getStringAttr(name),
+                   ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
                    $_builder.getArrayAttr(annotations),
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
-                   forceable);
+                   forceable ? $_builder.getUnitAttr() : nullptr);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
@@ -361,11 +433,12 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
                     "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym,
                     CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
                    clockVal, resetSignal, resetValue,
-                   name, nameKind, annotation,
+                   $_builder.getStringAttr(name),
+                   ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
+                   annotation,
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
-                   forceable);
+                   forceable ? $_builder.getUnitAttr() : nullptr);
     }]>
   ];
 
@@ -396,8 +469,47 @@ def WireOp : ReferableDeclOp<"wire", [Forceable]> {
   let results = (outs AnyType:$result, Optional<RefType>:$ref);
 
   let hasCanonicalizer = true;
+  let skipDefaultBuilders = true;
 
   let builders = [
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::mlir::ValueRange":$operands,
+                   CArg<"::llvm::ArrayRef<::mlir::NamedAttribute>","{}">:$attributes), [{
+      assert(operands.size() == 0u && "mismatched number of parameters");
+      odsState.addOperands(operands);
+      odsState.addAttributes(attributes);
+      assert(resultTypes.size() >= 1u && "mismatched number of return types");
+      odsState.addTypes(resultTypes);
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                   "::mlir::StringAttr":$name,
+                   "::circt::firrtl::NameKindEnumAttr":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "::circt::hw::InnerSymAttr":$inner_sym,
+                   "::mlir::UnitAttr":$forceable), [{
+      $_state.addAttribute(getNameAttrName($_state.name), name);
+      $_state.addAttribute(getNameKindAttrName($_state.name), nameKind);
+      $_state.addAttribute(getAnnotationsAttrName($_state.name), annotations);
+      if (inner_sym) {
+        $_state.addAttribute(getInnerSymAttrName($_state.name), inner_sym);
+      }
+      $_state.addTypes(elementType);
+      if (forceable) {
+        $_state.addAttribute(getForceableAttrName($_state.name), forceable);
+        $_state.addTypes(detail::getForceableResultType(true, elementType));
+      }
+    }]>,
+    OpBuilder<(ins "::mlir::Type":$elementType,
+                   "::llvm::StringRef":$name,
+                   "::circt::firrtl::NameKindEnum":$nameKind,
+                   "::mlir::ArrayAttr":$annotations,
+                   "::circt::hw::InnerSymAttr":$inner_sym,
+                   "bool":$forceable), [{
+      return build($_builder, $_state, elementType,
+                   $_builder.getStringAttr(name),
+                   ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
+                   annotations, inner_sym,
+                   forceable ? $_builder.getUnitAttr() : nullptr);
+    }]>,
     OpBuilder<(ins "::mlir::Type":$elementType,
                       CArg<"StringRef", "{}">:$name,
                       CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
@@ -405,7 +517,6 @@ def WireOp : ReferableDeclOp<"wire", [Forceable]> {
                       CArg<"StringAttr", "StringAttr()">:$inner_sym,
                       CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
                    name, nameKind,
                    $_builder.getArrayAttr(annotations),
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
@@ -416,7 +527,6 @@ def WireOp : ReferableDeclOp<"wire", [Forceable]> {
                    CArg<"StringAttr", "StringAttr()">:$inner_sym,
                    CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType,
-                   detail::getForceableResultType(forceable, elementType),
                    name, nameKind, annotations,
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
                    forceable);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -238,23 +238,23 @@ def NodeOp : ReferableDeclOp<"node", [
   let results = (outs FIRRTLBaseType:$result, Optional<RefType>:$ref);
 
   let builders = [
-    OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
-                  CArg<"StringRef", "{}">:$name,
-                  CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
-                  CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                  CArg<"StringAttr", "StringAttr()">:$inner_sym,
-                  CArg<"bool", "false">:$forceable), [{
-      return build($_builder, $_state, elementType, input, name, nameKind,
+    OpBuilder<(ins "::mlir::Value":$input,
+                   CArg<"StringRef", "{}">:$name,
+                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
+                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                   CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, input, name, nameKind,
                    $_builder.getArrayAttr(annotations),
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
                    forceable);
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
+    OpBuilder<(ins "::mlir::Value":$input,
                   "StringRef":$name, "NameKindEnum":$nameKind,
                   "::mlir::ArrayAttr":$annotations,
                   CArg<"StringAttr", "StringAttr()">:$inner_sym,
                   CArg<"bool", "false">:$forceable), [{
-      return build($_builder, $_state, elementType, input, name, nameKind,
+      return build($_builder, $_state, input, name, nameKind,
                    annotations,
                    inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
                    forceable);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -214,8 +214,10 @@ def MemOp : ReferableDeclOp<"mem"> {
   }];
 }
 
-def NodeOp : ReferableDeclOp<"node",
-      [SameOperandsAndResultType, InferTypeOpInterface]> {
+def NodeOp : ReferableDeclOp<"node", [
+      AllTypesMatch<["input","result"]>,
+      DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+      Forceable]> {
   let summary = "No-op to name a value";
   let description = [{
     A node is simply a named intermediate value in a circuit. The node must
@@ -231,39 +233,44 @@ def NodeOp : ReferableDeclOp<"node",
   let arguments = (ins PassiveType:$input, StrAttr:$name,
                        NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLBaseType:$result);
+                       OptionalAttr<InnerSymAttr>:$inner_sym,
+                       UnitAttr:$forceable); // ReferenceKinds
+  let results = (outs FIRRTLBaseType:$result, Optional<RefType>:$ref);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
                   CArg<"StringRef", "{}">:$name,
                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                  CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
+                  CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                  CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType, input, name, nameKind,
                    $_builder.getArrayAttr(annotations),
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$input,
                   "StringRef":$name, "NameKindEnum":$nameKind,
                   "::mlir::ArrayAttr":$annotations,
-                  CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
+                  CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                  CArg<"bool", "false">:$forceable), [{
       return build($_builder, $_state, elementType, input, name, nameKind,
                    annotations,
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>
   ];
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    $input `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` qualified(type($input))
+    $input (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` qualified(type($input))
   }];
 
   let hasCanonicalizer = true;
   let hasFolder = 1;
 }
 
-def RegOp : ReferableDeclOp<"reg"> {
+def RegOp : ReferableDeclOp<"reg", [Forceable]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
@@ -276,36 +283,45 @@ def RegOp : ReferableDeclOp<"reg"> {
   let arguments = (
     ins ClockType:$clockVal, StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
-        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs AnyRegisterType:$result);
+        OptionalAttr<InnerSymAttr>:$inner_sym,
+        UnitAttr:$forceable);
+  let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
-                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
-      return build($_builder, $_state, elementType, clockVal, name,
-                   nameKind, $_builder.getArrayAttr(annotations),
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                   CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   clockVal, name, nameKind,
+                   $_builder.getArrayAttr(annotations),
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "StringRef":$name, "NameKindEnum":$nameKind,
-                   "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym), [{
-      return build($_builder, $_state, elementType, clockVal, name,
-                   nameKind, annotation,
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym,
+                   CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   clockVal, name, nameKind, annotation,
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>
   ];
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` type($clockVal) `,` qualified(type($result))
+    operands (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` type($clockVal) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
+
   }];
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : ReferableDeclOp<"regreset"> {
+def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:
@@ -319,8 +335,9 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
         AnyRegisterType:$resetValue,
         StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
-        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs AnyRegisterType:$result);
+        OptionalAttr<InnerSymAttr>:$inner_sym,
+        UnitAttr:$forceable);
+  let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
@@ -328,33 +345,42 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
                    CArg<"StringRef", "{}">:$name,
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
-                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
-      return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, name, nameKind,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                   CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   clockVal, resetSignal, resetValue,
+                   name, nameKind,
                    $_builder.getArrayAttr(annotations),
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
                    "StringRef":$name, "NameKindEnum":$nameKind,
-                    "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym), [{
-      return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, name, nameKind, annotation,
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                    "::mlir::ArrayAttr":$annotation, "StringAttr":$inner_sym,
+                    CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   clockVal, resetSignal, resetValue,
+                   name, nameKind, annotation,
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>
   ];
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands `` custom<FIRRTLImplicitSSAName>(attr-dict)
-    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
+    operands (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict)
+    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
+
   }];
 
   let hasCanonicalizer = true;
   let hasVerifier = 1;
 }
 
-def WireOp : ReferableDeclOp<"wire"> {
+def WireOp : ReferableDeclOp<"wire", [Forceable]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a new wire:
@@ -365,8 +391,9 @@ def WireOp : ReferableDeclOp<"wire"> {
 
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs AnyType:$result);
+                       OptionalAttr<InnerSymAttr>:$inner_sym,
+                       UnitAttr:$forceable); // ReferenceKinds
+  let results = (outs AnyType:$result, Optional<RefType>:$ref);
 
   let hasCanonicalizer = true;
 
@@ -375,23 +402,31 @@ def WireOp : ReferableDeclOp<"wire"> {
                       CArg<"StringRef", "{}">:$name,
                       CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                       CArg<"ArrayRef<Attribute>","{}">:$annotations,
-                      CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
-      return build($_builder, $_state, elementType, name, nameKind,
+                      CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                      CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   name, nameKind,
                    $_builder.getArrayAttr(annotations),
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "StringRef":$name,
                    "NameKindEnum":$nameKind, "::mlir::ArrayAttr":$annotations,
-                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
-      return build($_builder, $_state, elementType, name, nameKind, annotations,
-                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr());
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym,
+                   CArg<"bool", "false">:$forceable), [{
+      return build($_builder, $_state, elementType,
+                   detail::getForceableResultType(forceable, elementType),
+                   name, nameKind, annotations,
+                   inner_sym ? hw::InnerSymAttr::get(inner_sym) : hw::InnerSymAttr(),
+                   forceable);
     }]>
   ];
 
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind) ``
-    custom<FIRRTLImplicitSSAName>(attr-dict) `:`
-    qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
+    (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict) `:`
+    qualified(type($result)) (`,` qualified(type($ref))^)?
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -783,20 +783,6 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-// Constraints on RefOps
-//===----------------------------------------------------------------------===//
-
-class RefTypeConstraint<string ref, string base>
-  : TypesMatchWith<"reference base type should match",
-                   ref, base,
-                   "$_self.cast<RefType>().getType()">;
-
-class RefResultTypeConstraint<string base, string ref>
-  : TypesMatchWith<"reference base type should match",
-                   base, ref,
-                   "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
-
-//===----------------------------------------------------------------------===//
 // RefOps
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -29,6 +29,7 @@ namespace circt {
 namespace firrtl {
 
 class FIRRTLType;
+class Forceable;
 
 /// This holds the name and type that describes the module's ports.
 struct PortInfo {
@@ -106,6 +107,13 @@ enum class ConnectBehaviorKind {
 
 /// Verification hook for verifying module like operations.
 LogicalResult verifyModuleLikeOpInterface(FModuleLike module);
+
+namespace detail {
+/// Return null or forceable reference result type.
+RefType getForceableResultType(bool forceable, Type type);
+/// Verify a Forceable op.
+LogicalResult verifyForceableOp(Forceable op);
+} // end namespace detail
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -419,4 +419,40 @@ def FNamableOp : OpInterface<"FNamableOp"> {
   ];
 }
 
+def Forceable : OpInterface<"Forceable"> {
+  let cppNamespace = "circt::firrtl";
+  let description = [{
+    Interaction with declarations of forceable hardware components,
+    and managing references to them.
+  }];
+
+  let methods = [
+    InterfaceMethod<"Return true if the operation is forceable.",
+    "bool", "isForceable", (ins), [{}], /*defaultImplementation=*/[{
+      return $_op.getForceable();
+    }]>,
+    InterfaceMethod<"Return data value that will be targeted.",
+    "mlir::TypedValue<FIRRTLBaseType>", "getData", (ins), [{}], /*defaultImplementation=*/[{
+      return llvm::cast<mlir::TypedValue<FIRRTLBaseType>>($_op.getDataRaw());
+    }]>,
+    InterfaceMethod<"Return raw data value that will be targeted.",
+    "Value", "getDataRaw", (ins), [{}], /*defaultImplementation=*/[{
+      return $_op.getResult();
+    }]>,
+    InterfaceMethod<"Return data type that will be referenced.",
+    "FIRRTLBaseType", "getDataType", (ins), [{}], /*defaultImplementation=*/[{
+      return cast<FIRRTLBaseType>($_op.getDataRaw().getType());
+    }]>,
+    InterfaceMethod<"Return reference result, or null if not active.",
+    "mlir::TypedValue<RefType>", "getDataRef", (ins), [{}], /*defaultImplementation=*/[{
+      return llvm::cast_or_null<mlir::TypedValue<RefType>>($_op.getRef());
+    }]>
+  ];
+  let extraClassDeclaration = [{
+    /// Attribute name for 'forceable' tracking.
+    static StringRef getForceableAttrName() { return "forceable"; }
+  }];
+  let verify = [{ return detail::verifyForceableOp($_op); }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -141,4 +141,18 @@ def OneBitCastableType : AnyTypeOf<
   "1-bit uint/sint/analog, reset, asyncreset, or clock",
                                   "::circt::firrtl::FIRRTLBaseType">;
 
+//===----------------------------------------------------------------------===//
+// Constraints on RefOps
+//===----------------------------------------------------------------------===//
+
+class RefTypeConstraint<string ref, string base>
+  : TypesMatchWith<"reference base type should match",
+                   ref, base,
+                   "$_self.cast<RefType>().getType()">;
+
+class RefResultTypeConstraint<string base, string ref>
+  : TypesMatchWith<"reference base type should match",
+                   base, ref,
+                   "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1393,8 +1393,10 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
     // We lower zero width inout and outputs to a wire that isn't connected to
     // anything outside the module.  Inputs are lowered to zero.
     if (isZeroWidth && port.isInput()) {
-      Value newArg = bodyBuilder.create<WireOp>(
-          port.type, "." + port.getName().str() + ".0width_input").getResult();
+      Value newArg = bodyBuilder
+                         .create<WireOp>(port.type, "." + port.getName().str() +
+                                                        ".0width_input")
+                         .getResult();
       oldArg.replaceAllUsesWith(newArg);
       continue;
     }
@@ -1409,8 +1411,10 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
 
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
-    Value newArg = bodyBuilder.create<WireOp>(
-        port.type, "." + port.getName().str() + ".output").getResult();
+    Value newArg =
+        bodyBuilder
+            .create<WireOp>(port.type, "." + port.getName().str() + ".output")
+            .getResult();
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg);
 
@@ -2776,8 +2780,8 @@ LogicalResult FIRRTLLowering::visitDecl(VerbatimWireOp op) {
 LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   auto operand = getLoweredValue(op.getInput());
   if (!operand)
-    return handleZeroBit(op.getInput(),
-                         [&]() { return setLowering(op.getResult(), Value()); });
+    return handleZeroBit(
+        op.getInput(), [&]() { return setLowering(op.getResult(), Value()); });
 
   // Node operations are logical noops, but may carry annotations or be
   // referred to through an inner name. If a don't touch is present, ensure

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1394,7 +1394,7 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
     // anything outside the module.  Inputs are lowered to zero.
     if (isZeroWidth && port.isInput()) {
       Value newArg = bodyBuilder.create<WireOp>(
-          port.type, "." + port.getName().str() + ".0width_input");
+          port.type, "." + port.getName().str() + ".0width_input").getResult();
       oldArg.replaceAllUsesWith(newArg);
       continue;
     }
@@ -1410,7 +1410,7 @@ FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
     Value newArg = bodyBuilder.create<WireOp>(
-        port.type, "." + port.getName().str() + ".output");
+        port.type, "." + port.getName().str() + ".output").getResult();
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg);
 
@@ -2715,17 +2715,18 @@ LogicalResult FIRRTLLowering::visitExpr(AggregateConstantOp op) {
 LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
   // Foreign types lower to a backedge that needs to be resolved by a later
   // connect op.
-  if (!op.getType().isa<FIRRTLType>()) {
-    createBackedge(op, op.getType());
+  auto origResultType = op.getResult().getType();
+  if (!origResultType.isa<FIRRTLType>()) {
+    createBackedge(op.getResult(), origResultType);
     return success();
   }
 
-  auto resultType = lowerType(op.getResult().getType());
+  auto resultType = lowerType(origResultType);
   if (!resultType)
     return failure();
 
   if (resultType.isInteger(0))
-    return setLowering(op, Value());
+    return setLowering(op.getResult(), Value());
 
   // Name attr is required on sv.wire but optional on firrtl.wire.
   StringAttr symName = getInnerSymName(op);
@@ -2776,7 +2777,7 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   auto operand = getLoweredValue(op.getInput());
   if (!operand)
     return handleZeroBit(op.getInput(),
-                         [&]() { return setLowering(op, Value()); });
+                         [&]() { return setLowering(op.getResult(), Value()); });
 
   // Node operations are logical noops, but may carry annotations or be
   // referred to through an inner name. If a don't touch is present, ensure
@@ -2800,7 +2801,7 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   if (symName)
     operand = builder.create<hw::WireOp>(operand, name, symName);
 
-  return setLowering(op, operand);
+  return setLowering(op.getResult(), operand);
 }
 
 LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
@@ -2808,7 +2809,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   if (!resultType)
     return failure();
   if (resultType.isInteger(0))
-    return setLowering(op, Value());
+    return setLowering(op.getResult(), Value());
 
   Value clockVal = getLoweredValue(op.getClockVal());
   if (!clockVal)
@@ -2836,7 +2837,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
 
   inputEdge.setValue(reg);
   circuitState.used_RANDOMIZE_REG_INIT = 1;
-  (void)setLowering(op, reg);
+  (void)setLowering(op.getResult(), reg);
   return success();
 }
 
@@ -2845,13 +2846,13 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   if (!resultType)
     return failure();
   if (resultType.isInteger(0))
-    return setLowering(op, Value());
+    return setLowering(op.getResult(), Value());
 
   Value clockVal = getLoweredValue(op.getClockVal());
   Value resetSignal = getLoweredValue(op.getResetSignal());
   // Reset values may be narrower than the register.  Extend appropriately.
   Value resetValue = getLoweredAndExtOrTruncValue(
-      op.getResetValue(), op.getType().cast<FIRRTLBaseType>());
+      op.getResetValue(), op.getResult().getType().cast<FIRRTLBaseType>());
 
   if (!clockVal || !resetSignal || !resetValue)
     return failure();
@@ -2879,7 +2880,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
 
   inputEdge.setValue(reg);
   circuitState.used_RANDOMIZE_REG_INIT = 1;
-  (void)setLowering(op, reg);
+  (void)setLowering(op.getResult(), reg);
 
   return success();
 }

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1229,8 +1229,8 @@ bool HandshakeBuilder::visitHandshake(SyncOp op) {
   // Create wires that will be used to connect the join and the fork logic
   auto bitType = UIntType::get(op->getContext(), 1);
   ValueVector connector;
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allValid"));
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allReady"));
+  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult());
+  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allReady").getResult());
 
   // Collect all input ports.
   SmallVector<ValueVector *, 4> inputs;
@@ -1386,7 +1386,7 @@ bool HandshakeBuilder::visitHandshake(handshake::SelectOp op) {
   rewriter.create<ConnectOp>(insertLoc, resultData, muxedData);
 
   // 'and' the arg valids and select valid
-  Value allValid = rewriter.create<WireOp>(insertLoc, bitType, "allValid");
+  Value allValid = rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult();
   buildReductionTree<AndPrimOp>({trueValid, falseValid, selectValid}, allValid);
 
   // Connect that to the result valid.
@@ -1444,10 +1444,11 @@ bool HandshakeBuilder::visitHandshake(MergeOp op) {
       createConstantOp(indexType, APInt(numInputs, 0), insertLoc, rewriter);
 
   // Declare wire for arbitration winner.
-  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win");
+  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win").getResult();
 
   // Declare wires for if each output is done.
-  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone");
+  auto resultDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
 
   // Create predicates to assert if the win wire holds a valid index.
   auto hasWinnerCondition = rewriter.create<OrRPrimOp>(insertLoc, bitType, win);
@@ -1538,25 +1539,25 @@ bool HandshakeBuilder::visitHandshake(ControlMergeOp op) {
 
   // Declare register for storing arbitration winner.
   auto won = rewriter.create<RegResetOp>(insertLoc, indexType, clock, reset,
-                                         noWinner, "won");
+                                         noWinner, "won").getResult();
 
   // Declare wire for arbitration winner.
-  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win");
+  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win").getResult();
 
   // Declare wire for whether the circuit just fired and emitted both outputs.
-  auto fired = rewriter.create<WireOp>(insertLoc, bitType, "fired");
+  auto fired = rewriter.create<WireOp>(insertLoc, bitType, "fired").getResult();
 
   // Declare registers for storing if each output has been emitted.
   auto resultEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "resultEmitted");
+      insertLoc, bitType, clock, reset, falseConst, "resultEmitted").getResult();
 
   auto controlEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "controlEmitted");
+      insertLoc, bitType, clock, reset, falseConst, "controlEmitted").getResult();
 
   // Declare wires for if each output is done.
-  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone");
+  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
 
-  auto controlDone = rewriter.create<WireOp>(insertLoc, bitType, "controlDone");
+  auto controlDone = rewriter.create<WireOp>(insertLoc, bitType, "controlDone").getResult();
 
   // Create predicates to assert if the win wire or won register hold a valid
   // index.
@@ -1802,13 +1803,13 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
   for (unsigned i = 0; i < resultNum; ++i) {
     auto doneWire =
         rewriter.create<WireOp>(insertLoc, bitType, "done" + std::to_string(i));
-    doneWires.push_back(doneWire);
+    doneWires.push_back(doneWire.getResult());
   }
 
   // Create an AndPrimOp chain for generating the ready signal. Only if all
   // result ports are handshaked (done), the argument port is ready to accept
   // the next token.
-  Value allDoneWire = rewriter.create<WireOp>(insertLoc, bitType, "allDone");
+  Value allDoneWire = rewriter.create<WireOp>(insertLoc, bitType, "allDone").getResult();
   buildReductionTree<AndPrimOp>(doneWires, allDoneWire);
 
   // Connect the allDoneWire to the input ready.
@@ -1816,7 +1817,7 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
   // Create a notAllDoneWire for later use.
   auto notAllDoneWire =
-      rewriter.create<WireOp>(insertLoc, bitType, "notAllDone");
+      rewriter.create<WireOp>(insertLoc, bitType, "notAllDone").getResult();
   rewriter.create<ConnectOp>(
       insertLoc, notAllDoneWire,
       rewriter.create<NotPrimOp>(insertLoc, bitType, allDoneWire));
@@ -1843,7 +1844,7 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
     // Create a emitted register.
     auto emtdReg =
         rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                    falseConst, "emtd" + std::to_string(idx));
+                                    falseConst, "emtd" + std::to_string(idx)).getResult();
 
     // Connect the emitted register with {doneWire && notallDoneWire}. Only if
     // notallDone, the emtdReg will be set to the value of doneWire. Otherwise,
@@ -1853,8 +1854,10 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
     rewriter.create<ConnectOp>(insertLoc, emtdReg, emtd);
 
     // Create a notEmtdWire for later use.
-    auto notEmtdWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                               "notEmtd" + std::to_string(idx));
+    auto notEmtdWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType, "notEmtd" + std::to_string(idx))
+            .getResult();
     rewriter.create<ConnectOp>(
         insertLoc, notEmtdWire,
         rewriter.create<NotPrimOp>(insertLoc, bitType, emtdReg));
@@ -1867,8 +1870,11 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
     // Create validReady wire signal, which indicates a successful handshake in
     // the current clock cycle.
-    auto validReadyWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "validReady" + std::to_string(idx));
+    auto validReadyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "validReady" + std::to_string(idx))
+            .getResult();
     rewriter.create<ConnectOp>(
         insertLoc, validReadyWire,
         rewriter.create<AndPrimOp>(insertLoc, bitType, resultReady, valid));
@@ -1938,10 +1944,10 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
 
   // Create a wire and connect it to the register for the ready buffer.
   auto readyRegWire =
-      rewriter.create<WireOp>(insertLoc, bitType, "readyRegWire");
+      rewriter.create<WireOp>(insertLoc, bitType, "readyRegWire").getResult();
 
-  auto readyReg = rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                              falseConst, "readyReg");
+  Value readyReg = rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                              falseConst, "readyReg").getResult();
   rewriter.create<ConnectOp>(insertLoc, readyReg, readyRegWire);
 
   // Create the logic to drive the successor valid and potentially data.
@@ -1975,12 +1981,12 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
   if (predData) {
     auto dataType = predData.getType().cast<FIRRTLBaseType>();
     auto ctrlDataRegWire =
-        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire");
+        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire").getResult();
 
     auto ctrlZeroConst = createZeroDataConst(dataType, insertLoc, rewriter);
 
     auto ctrlDataReg = rewriter.create<RegResetOp>(
-        insertLoc, dataType, clock, reset, ctrlZeroConst, "ctrlDataReg");
+        insertLoc, dataType, clock, reset, ctrlZeroConst, "ctrlDataReg").getResult();
 
     rewriter.create<ConnectOp>(insertLoc, ctrlDataReg, ctrlDataRegWire);
 
@@ -2123,17 +2129,18 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
   auto oneConst =
       createConstantOp(bitType, APInt(1, 1), builder.getLoc(), builder);
 
-  auto readEn = builder.create<WireOp>(bitType, "read_en");
-  auto writeEn = builder.create<WireOp>(bitType, "write_en");
+  auto readEn = builder.create<WireOp>(bitType, "read_en").getResult();
+  auto writeEn = builder.create<WireOp>(bitType, "write_en").getResult();
   auto tail =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg");
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg").getResult();
   auto head =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg");
-  auto full = builder.create<WireOp>(bitType, "full");
-  auto empty = builder.create<WireOp>(bitType, "empty");
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg").getResult();
+  auto full = builder.create<WireOp>(bitType, "full").getResult();
+  auto empty = builder.create<WireOp>(bitType, "empty").getResult();
   auto notEmpty = builder.create<NotPrimOp>(empty);
   auto count =
-      builder.create<RegResetOp>(depthType, clk, rst, zeroConst, "count_reg");
+      builder.create<RegResetOp>(depthType, clk, rst, zeroConst, "count_reg")
+          .getResult();
 
   // Function for truncating results to a given types' width.
   auto trunc = [&](Value v, FIRRTLBaseType toType) {
@@ -2300,16 +2307,16 @@ bool HandshakeBuilder::buildFIFOBufferLogic(int64_t numStage,
   auto outputReady = outputSubfields[1];
 
   auto bitType = UIntType::get(builder.getContext(), 1);
-  auto muxSelWire = builder.create<WireOp>(insertLoc, bitType, "muxSelWire");
-  auto fifoValid = builder.create<WireOp>(insertLoc, bitType, "fifoValid");
-  auto fifoPValid = builder.create<WireOp>(insertLoc, bitType, "fifoPValid");
-  auto fifoReady = builder.create<WireOp>(insertLoc, bitType, "fifoReady");
-  auto fifoNReady = builder.create<WireOp>(insertLoc, bitType, "fifoNReady");
+  auto muxSelWire = builder.create<WireOp>(insertLoc, bitType, "muxSelWire").getResult();
+  auto fifoValid = builder.create<WireOp>(insertLoc, bitType, "fifoValid").getResult();
+  auto fifoPValid = builder.create<WireOp>(insertLoc, bitType, "fifoPValid").getResult();
+  auto fifoReady = builder.create<WireOp>(insertLoc, bitType, "fifoReady").getResult();
+  auto fifoNReady = builder.create<WireOp>(insertLoc, bitType, "fifoNReady").getResult();
   Value fifoIn = nullptr;
   Value fifoOut = nullptr;
   if (!isControl) {
-    fifoIn = builder.create<WireOp>(insertLoc, dataType, "fifoIn");
-    fifoOut = builder.create<WireOp>(insertLoc, dataType, "fifoOut");
+    fifoIn = builder.create<WireOp>(insertLoc, dataType, "fifoIn").getResult();
+    fifoOut = builder.create<WireOp>(insertLoc, dataType, "fifoOut").getResult();
   }
 
   // Connect output valid and ready signals.
@@ -2429,12 +2436,12 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
 
     // Create wires for ready signal from the success buffer stage.
     auto readyWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                             "readyWire" + std::to_string(i));
+                                             "readyWire" + std::to_string(i)).getResult();
 
     // Create a register for valid signal.
     auto validReg = rewriter.create<RegResetOp>(
         insertLoc, bitType, clock, reset,
-        isInitialized ? trueConst : falseConst, "validReg" + std::to_string(i));
+        isInitialized ? trueConst : falseConst, "validReg" + std::to_string(i)).getResult();
 
     // Create registers for data signal.
     Value dataReg = nullptr;
@@ -2449,21 +2456,21 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
       }
       dataReg =
           rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
-                                      initValue, "dataReg" + std::to_string(i));
+                                      initValue, "dataReg" + std::to_string(i)).getResult();
     }
 
     // Create wires for valid, ready and data signal coming from the control
     // buffer stage.
     auto ctrlValidWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlValidWire" + std::to_string(i));
+        insertLoc, bitType, "ctrlValidWire" + std::to_string(i)).getResult();
 
     auto ctrlReadyWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlReadyWire" + std::to_string(i));
+        insertLoc, bitType, "ctrlReadyWire" + std::to_string(i)).getResult();
 
     Value ctrlDataWire;
     if (!isControl)
       ctrlDataWire = rewriter.create<WireOp>(
-          insertLoc, dataType, "ctrlDataWire" + std::to_string(i));
+          insertLoc, dataType, "ctrlDataWire" + std::to_string(i)).getResult();
 
     // Build the current stage of the buffer.
     buildDataBufferLogic(currentValid, validReg, currentReady, readyWire,
@@ -2745,7 +2752,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     auto falseConst =
         createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
     auto writeValidBuffer = rewriter.create<RegResetOp>(
-        insertLoc, bitType, clock, reset, falseConst, "writeValidBuffer");
+        insertLoc, bitType, clock, reset, falseConst, "writeValidBuffer").getResult();
 
     // Connect the write valid buffer to the store control valid.
     rewriter.create<ConnectOp>(insertLoc, storeControlValid, writeValidBuffer);
@@ -2753,7 +2760,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Create the logic for when both the buffered write valid signal and the
     // store complete ready signal are asserted.
     Value storeCompleted =
-        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted");
+        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted").getResult();
     ValueVector storeCompletedVector({Value(), storeCompleted});
     buildAllReadyLogic({&storeCompletedVector}, &storeControl,
                        writeValidBuffer);
@@ -2774,7 +2781,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     SmallVector<Value, 2> storeValids;
     extractValues({&storeAddr, &storeData}, 0, storeValids);
     Value writeValid =
-        rewriter.create<WireOp>(insertLoc, bitType, "writeValid");
+        rewriter.create<WireOp>(insertLoc, bitType, "writeValid").getResult();
     buildReductionTree<AndPrimOp>(storeValids, writeValid);
 
     // Create a mux that drives the buffer input. If the emptyOrComplete signal
@@ -2833,7 +2840,7 @@ bool HandshakeBuilder::visitHandshake(handshake::StoreOp op) {
   auto bitType = UIntType::get(rewriter.getContext(), 1);
 
   // Create a wire that will be asserted when all inputs are valid.
-  auto inputsValid = rewriter.create<WireOp>(insertLoc, bitType, "inputsValid");
+  auto inputsValid = rewriter.create<WireOp>(insertLoc, bitType, "inputsValid").getResult();
 
   // Create a gate that will be asserted when all outputs are ready.
   auto outputsReady = rewriter.create<AndPrimOp>(

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1229,8 +1229,10 @@ bool HandshakeBuilder::visitHandshake(SyncOp op) {
   // Create wires that will be used to connect the join and the fork logic
   auto bitType = UIntType::get(op->getContext(), 1);
   ValueVector connector;
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult());
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allReady").getResult());
+  connector.push_back(
+      rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult());
+  connector.push_back(
+      rewriter.create<WireOp>(insertLoc, bitType, "allReady").getResult());
 
   // Collect all input ports.
   SmallVector<ValueVector *, 4> inputs;
@@ -1386,7 +1388,8 @@ bool HandshakeBuilder::visitHandshake(handshake::SelectOp op) {
   rewriter.create<ConnectOp>(insertLoc, resultData, muxedData);
 
   // 'and' the arg valids and select valid
-  Value allValid = rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult();
+  Value allValid =
+      rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult();
   buildReductionTree<AndPrimOp>({trueValid, falseValid, selectValid}, allValid);
 
   // Connect that to the result valid.
@@ -1538,8 +1541,10 @@ bool HandshakeBuilder::visitHandshake(ControlMergeOp op) {
   auto falseConst = createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
 
   // Declare register for storing arbitration winner.
-  auto won = rewriter.create<RegResetOp>(insertLoc, indexType, clock, reset,
-                                         noWinner, "won").getResult();
+  auto won = rewriter
+                 .create<RegResetOp>(insertLoc, indexType, clock, reset,
+                                     noWinner, "won")
+                 .getResult();
 
   // Declare wire for arbitration winner.
   auto win = rewriter.create<WireOp>(insertLoc, indexType, "win").getResult();
@@ -1548,16 +1553,23 @@ bool HandshakeBuilder::visitHandshake(ControlMergeOp op) {
   auto fired = rewriter.create<WireOp>(insertLoc, bitType, "fired").getResult();
 
   // Declare registers for storing if each output has been emitted.
-  auto resultEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "resultEmitted").getResult();
+  auto resultEmitted = rewriter
+                           .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                               falseConst, "resultEmitted")
+                           .getResult();
 
-  auto controlEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "controlEmitted").getResult();
+  auto controlEmitted =
+      rewriter
+          .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                              "controlEmitted")
+          .getResult();
 
   // Declare wires for if each output is done.
-  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
+  auto resultDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
 
-  auto controlDone = rewriter.create<WireOp>(insertLoc, bitType, "controlDone").getResult();
+  auto controlDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "controlDone").getResult();
 
   // Create predicates to assert if the win wire or won register hold a valid
   // index.
@@ -1809,7 +1821,8 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
   // Create an AndPrimOp chain for generating the ready signal. Only if all
   // result ports are handshaked (done), the argument port is ready to accept
   // the next token.
-  Value allDoneWire = rewriter.create<WireOp>(insertLoc, bitType, "allDone").getResult();
+  Value allDoneWire =
+      rewriter.create<WireOp>(insertLoc, bitType, "allDone").getResult();
   buildReductionTree<AndPrimOp>(doneWires, allDoneWire);
 
   // Connect the allDoneWire to the input ready.
@@ -1843,8 +1856,10 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
     // Create a emitted register.
     auto emtdReg =
-        rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                    falseConst, "emtd" + std::to_string(idx)).getResult();
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                                "emtd" + std::to_string(idx))
+            .getResult();
 
     // Connect the emitted register with {doneWire && notallDoneWire}. Only if
     // notallDone, the emtdReg will be set to the value of doneWire. Otherwise,
@@ -1946,8 +1961,10 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
   auto readyRegWire =
       rewriter.create<WireOp>(insertLoc, bitType, "readyRegWire").getResult();
 
-  Value readyReg = rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                              falseConst, "readyReg").getResult();
+  Value readyReg = rewriter
+                       .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                           falseConst, "readyReg")
+                       .getResult();
   rewriter.create<ConnectOp>(insertLoc, readyReg, readyRegWire);
 
   // Create the logic to drive the successor valid and potentially data.
@@ -1981,12 +1998,16 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
   if (predData) {
     auto dataType = predData.getType().cast<FIRRTLBaseType>();
     auto ctrlDataRegWire =
-        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire").getResult();
+        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire")
+            .getResult();
 
     auto ctrlZeroConst = createZeroDataConst(dataType, insertLoc, rewriter);
 
-    auto ctrlDataReg = rewriter.create<RegResetOp>(
-        insertLoc, dataType, clock, reset, ctrlZeroConst, "ctrlDataReg").getResult();
+    auto ctrlDataReg =
+        rewriter
+            .create<RegResetOp>(insertLoc, dataType, clock, reset,
+                                ctrlZeroConst, "ctrlDataReg")
+            .getResult();
 
     rewriter.create<ConnectOp>(insertLoc, ctrlDataReg, ctrlDataRegWire);
 
@@ -2132,9 +2153,11 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
   auto readEn = builder.create<WireOp>(bitType, "read_en").getResult();
   auto writeEn = builder.create<WireOp>(bitType, "write_en").getResult();
   auto tail =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg").getResult();
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg")
+          .getResult();
   auto head =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg").getResult();
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg")
+          .getResult();
   auto full = builder.create<WireOp>(bitType, "full").getResult();
   auto empty = builder.create<WireOp>(bitType, "empty").getResult();
   auto notEmpty = builder.create<NotPrimOp>(empty);
@@ -2307,16 +2330,22 @@ bool HandshakeBuilder::buildFIFOBufferLogic(int64_t numStage,
   auto outputReady = outputSubfields[1];
 
   auto bitType = UIntType::get(builder.getContext(), 1);
-  auto muxSelWire = builder.create<WireOp>(insertLoc, bitType, "muxSelWire").getResult();
-  auto fifoValid = builder.create<WireOp>(insertLoc, bitType, "fifoValid").getResult();
-  auto fifoPValid = builder.create<WireOp>(insertLoc, bitType, "fifoPValid").getResult();
-  auto fifoReady = builder.create<WireOp>(insertLoc, bitType, "fifoReady").getResult();
-  auto fifoNReady = builder.create<WireOp>(insertLoc, bitType, "fifoNReady").getResult();
+  auto muxSelWire =
+      builder.create<WireOp>(insertLoc, bitType, "muxSelWire").getResult();
+  auto fifoValid =
+      builder.create<WireOp>(insertLoc, bitType, "fifoValid").getResult();
+  auto fifoPValid =
+      builder.create<WireOp>(insertLoc, bitType, "fifoPValid").getResult();
+  auto fifoReady =
+      builder.create<WireOp>(insertLoc, bitType, "fifoReady").getResult();
+  auto fifoNReady =
+      builder.create<WireOp>(insertLoc, bitType, "fifoNReady").getResult();
   Value fifoIn = nullptr;
   Value fifoOut = nullptr;
   if (!isControl) {
     fifoIn = builder.create<WireOp>(insertLoc, dataType, "fifoIn").getResult();
-    fifoOut = builder.create<WireOp>(insertLoc, dataType, "fifoOut").getResult();
+    fifoOut =
+        builder.create<WireOp>(insertLoc, dataType, "fifoOut").getResult();
   }
 
   // Connect output valid and ready signals.
@@ -2435,13 +2464,18 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
     bool isInitialized = initValues.size() > i;
 
     // Create wires for ready signal from the success buffer stage.
-    auto readyWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                             "readyWire" + std::to_string(i)).getResult();
+    auto readyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType, "readyWire" + std::to_string(i))
+            .getResult();
 
     // Create a register for valid signal.
-    auto validReg = rewriter.create<RegResetOp>(
-        insertLoc, bitType, clock, reset,
-        isInitialized ? trueConst : falseConst, "validReg" + std::to_string(i)).getResult();
+    auto validReg =
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                isInitialized ? trueConst : falseConst,
+                                "validReg" + std::to_string(i))
+            .getResult();
 
     // Create registers for data signal.
     Value dataReg = nullptr;
@@ -2455,22 +2489,32 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
             insertLoc, rewriter);
       }
       dataReg =
-          rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
-                                      initValue, "dataReg" + std::to_string(i)).getResult();
+          rewriter
+              .create<RegResetOp>(insertLoc, dataType, clock, reset, initValue,
+                                  "dataReg" + std::to_string(i))
+              .getResult();
     }
 
     // Create wires for valid, ready and data signal coming from the control
     // buffer stage.
-    auto ctrlValidWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlValidWire" + std::to_string(i)).getResult();
+    auto ctrlValidWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "ctrlValidWire" + std::to_string(i))
+            .getResult();
 
-    auto ctrlReadyWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlReadyWire" + std::to_string(i)).getResult();
+    auto ctrlReadyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "ctrlReadyWire" + std::to_string(i))
+            .getResult();
 
     Value ctrlDataWire;
     if (!isControl)
-      ctrlDataWire = rewriter.create<WireOp>(
-          insertLoc, dataType, "ctrlDataWire" + std::to_string(i)).getResult();
+      ctrlDataWire = rewriter
+                         .create<WireOp>(insertLoc, dataType,
+                                         "ctrlDataWire" + std::to_string(i))
+                         .getResult();
 
     // Build the current stage of the buffer.
     buildDataBufferLogic(currentValid, validReg, currentReady, readyWire,
@@ -2751,8 +2795,11 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // latency of 1.
     auto falseConst =
         createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
-    auto writeValidBuffer = rewriter.create<RegResetOp>(
-        insertLoc, bitType, clock, reset, falseConst, "writeValidBuffer").getResult();
+    auto writeValidBuffer =
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                                "writeValidBuffer")
+            .getResult();
 
     // Connect the write valid buffer to the store control valid.
     rewriter.create<ConnectOp>(insertLoc, storeControlValid, writeValidBuffer);
@@ -2760,7 +2807,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Create the logic for when both the buffered write valid signal and the
     // store complete ready signal are asserted.
     Value storeCompleted =
-        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted").getResult();
+        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted")
+            .getResult();
     ValueVector storeCompletedVector({Value(), storeCompleted});
     buildAllReadyLogic({&storeCompletedVector}, &storeControl,
                        writeValidBuffer);
@@ -2840,7 +2888,8 @@ bool HandshakeBuilder::visitHandshake(handshake::StoreOp op) {
   auto bitType = UIntType::get(rewriter.getContext(), 1);
 
   // Create a wire that will be asserted when all inputs are valid.
-  auto inputsValid = rewriter.create<WireOp>(insertLoc, bitType, "inputsValid").getResult();
+  auto inputsValid =
+      rewriter.create<WireOp>(insertLoc, bitType, "inputsValid").getResult();
 
   // Create a gate that will be asserted when all outputs are ready.
   auto outputsReady = rewriter.create<AndPrimOp>(

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -360,25 +360,25 @@ void Emitter::emitStatement(WhenOp op, bool noIndent) {
 }
 
 void Emitter::emitStatement(WireOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "wire " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   emitLocationAndNewLine(op);
 }
 
 void Emitter::emitStatement(RegOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "reg " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   os << ", ";
   emitExpression(op.getClockVal());
   emitLocationAndNewLine(op);
 }
 
 void Emitter::emitStatement(RegResetOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "reg " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   os << ", ";
   emitExpression(op.getClockVal());
   os << " with :\n";
@@ -391,7 +391,7 @@ void Emitter::emitStatement(RegResetOp op) {
 }
 
 void Emitter::emitStatement(NodeOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "node " << op.getName() << " = ";
   emitExpression(op.getInput());
   emitLocationAndNewLine(op);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -663,7 +663,7 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
       auto addWireWithCast = [&](auto createCast) {
         auto wire = sinkBuilder.create<WireOp>(
             valType,
-            state.getNamespace(wireModule).newName(tapName.getValue()));
+            state.getNamespace(wireModule).newName(tapName.getValue())).getResult();
         sinkBuilder.create<ConnectOp>(sink, createCast(wire));
         sink = wire;
       };

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -661,9 +661,12 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
         valType.getWidthlessType() != wireType.getWidthlessType()) {
       // Helper: create a wire, cast it with callback, connect cast to sink.
       auto addWireWithCast = [&](auto createCast) {
-        auto wire = sinkBuilder.create<WireOp>(
-            valType,
-            state.getNamespace(wireModule).newName(tapName.getValue())).getResult();
+        auto wire =
+            sinkBuilder
+                .create<WireOp>(
+                    valType,
+                    state.getNamespace(wireModule).newName(tapName.getValue()))
+                .getResult();
         sinkBuilder.create<ConnectOp>(sink, createCast(wire));
         sink = wire;
       };

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -615,8 +615,7 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
                                                       lastInst->getBlock());
       builder.setInsertionPointAfter(lastInst);
       // Instance port cannot be used as an annotation target, so use a NodeOp.
-      auto node = builder.create<NodeOp>(lastInst.getType(portNo),
-                                         lastInst.getResult(portNo));
+      auto node = builder.create<NodeOp>(lastInst.getResult(portNo));
       AnnotationSet::addDontTouch(node);
       srcTarget->ref = AnnoTarget(circt::firrtl::detail::AnnoTargetImpl(node));
     }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2910,8 +2910,8 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
     SmallVector<NamedAttribute, 2> attrs(reg->getDialectAttrs());
     auto newReg = replaceOpWithNewOpAndCopyName<RegResetOp>(
         rewriter, reg, reg.getResult().getType(), reg.getClockVal(),
-        mux.getSel(), mux.getHigh(), reg.getName(), reg.getNameKind(),
-        reg.getAnnotations(), reg.getInnerSymAttr());
+        mux.getSel(), mux.getHigh(), reg.getNameAttr(), reg.getNameKindAttr(),
+        reg.getAnnotationsAttr(), reg.getInnerSymAttr(), reg.getForceableAttr());
     newReg->setDialectAttrs(attrs);
   }
   auto pt = rewriter.saveInsertionPoint();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2911,7 +2911,8 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
     auto newReg = replaceOpWithNewOpAndCopyName<RegResetOp>(
         rewriter, reg, reg.getResult().getType(), reg.getClockVal(),
         mux.getSel(), mux.getHigh(), reg.getNameAttr(), reg.getNameKindAttr(),
-        reg.getAnnotationsAttr(), reg.getInnerSymAttr(), reg.getForceableAttr());
+        reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
+        reg.getForceableAttr());
     newReg->setDialectAttrs(attrs);
   }
   auto pt = rewriter.saveInsertionPoint();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1815,7 +1815,8 @@ struct NodeBypass : public mlir::RewritePattern {
 } // namespace
 
 // Interesting names and symbols and don't touch force nodes to stick around.
-LogicalResult NodeOp::fold(FoldAdaptor adaptor, SmallVectorImpl<OpFoldResult>& results) {
+LogicalResult NodeOp::fold(FoldAdaptor adaptor,
+                           SmallVectorImpl<OpFoldResult> &results) {
   if (!hasDroppableName())
     return failure();
   if (hasDontTouch(getResult())) // handles inner symbols
@@ -2078,7 +2079,8 @@ static bool isDefinedByOneConstantOp(Value v) {
   return false;
 }
 
-static LogicalResult canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
+static LogicalResult
+canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
   if (!isDefinedByOneConstantOp(reg.getResetSignal()))
     return failure();
 
@@ -2412,7 +2414,8 @@ struct FoldReadWritePorts : public mlir::RewritePattern {
       if (deadReads[i]) {
         // Create a wire to replace the old result. Wire the sub-fields of the
         // old result to the relevant sub-fields of the write port.
-        auto wire = rewriter.create<WireOp>(result.getLoc(), result.getType()).getResult();
+        auto wire = rewriter.create<WireOp>(result.getLoc(), result.getType())
+                        .getResult();
         result.replaceAllUsesWith(wire);
 
         auto connect = [&](Value to, StringRef toName, Value from,
@@ -2715,7 +2718,8 @@ struct FoldRegMems : public mlir::RewritePattern {
     // Create a new register to store the data.
     auto ty = mem.getDataType();
     rewriter.setInsertionPointAfterValue(clock);
-    auto reg = rewriter.create<RegOp>(mem.getLoc(), ty, clock, mem.getName()).getResult();
+    auto reg = rewriter.create<RegOp>(mem.getLoc(), ty, clock, mem.getName())
+                   .getResult();
 
     // Helper to insert a given number of pipeline stages through registers.
     auto pipeline = [&](Value value, Value clock, const Twine &name,
@@ -2727,8 +2731,10 @@ struct FoldRegMems : public mlir::RewritePattern {
           os << mem.getName() << "_" << name << "_" << i;
         }
 
-        auto reg = rewriter.create<RegOp>(mem.getLoc(), value.getType(), clock,
-                                          rewriter.getStringAttr(regName)).getResult();
+        auto reg = rewriter
+                       .create<RegOp>(mem.getLoc(), value.getType(), clock,
+                                      rewriter.getStringAttr(regName))
+                       .getResult();
         rewriter.create<StrictConnectOp>(value.getLoc(), reg, value);
         value = reg;
       }
@@ -2903,9 +2909,9 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   if (!constReg) {
     SmallVector<NamedAttribute, 2> attrs(reg->getDialectAttrs());
     auto newReg = replaceOpWithNewOpAndCopyName<RegResetOp>(
-        rewriter, reg, reg.getResult().getType(), reg.getClockVal(), mux.getSel(),
-        mux.getHigh(), reg.getName(), reg.getNameKind(), reg.getAnnotations(),
-        reg.getInnerSymAttr());
+        rewriter, reg, reg.getResult().getType(), reg.getClockVal(),
+        mux.getSel(), mux.getHigh(), reg.getName(), reg.getNameKind(),
+        reg.getAnnotations(), reg.getInnerSymAttr());
     newReg->setDialectAttrs(attrs);
   }
   auto pt = rewriter.saveInsertionPoint();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1628,7 +1628,8 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   if (!isa<WireOp>(connectedDecl) && !isa<RegOp>(connectedDecl))
     return failure();
   if (hasDontTouch(connectedDecl) || !AnnotationSet(connectedDecl).empty() ||
-      !hasDroppableName(connectedDecl))
+      !hasDroppableName(connectedDecl) ||
+      cast<Forceable>(connectedDecl).isForceable())
     return failure();
 
   // Only forward if the types exactly match and there is one connect.
@@ -1752,7 +1753,8 @@ LogicalResult AttachOp::canonicalize(AttachOp op, PatternRewriter &rewriter) {
     // TODO: May need to be sensitive to "don't touch" or other
     // annotations.
     if (auto wire = dyn_cast_or_null<WireOp>(operand.getDefiningOp())) {
-      if (!hasDontTouch(wire.getOperation()) && wire->hasOneUse()) {
+      if (!hasDontTouch(wire.getOperation()) && wire->hasOneUse() &&
+          !wire.isForceable()) {
         SmallVector<Value> newOperands;
         for (auto newOperand : op.getOperands())
           if (newOperand != operand) // Don't the add wire.
@@ -1779,7 +1781,7 @@ struct FoldNodeName : public mlir::RewritePattern {
     auto node = cast<NodeOp>(op);
     auto name = node.getNameAttr();
     if (!node.hasDroppableName() || node.getInnerSym() ||
-        !node.getAnnotations().empty())
+        !node.getAnnotations().empty() || node.isForceable())
       return failure();
     auto *newOp = node.getInput().getDefiningOp();
     // Best effort
@@ -1802,10 +1804,10 @@ struct NodeBypass : public mlir::RewritePattern {
                                 PatternRewriter &rewriter) const override {
     auto node = cast<NodeOp>(op);
     if (node.getInnerSym() || !node.getAnnotations().empty() ||
-        node.use_empty())
+        node.use_empty() || node.isForceable())
       return failure();
     rewriter.startRootUpdate(node);
-    node.replaceAllUsesWith(node.getInput());
+    node.getResult().replaceAllUsesWith(node.getInput());
     rewriter.finalizeRootUpdate(node);
     return success();
   }
@@ -1813,14 +1815,20 @@ struct NodeBypass : public mlir::RewritePattern {
 } // namespace
 
 // Interesting names and symbols and don't touch force nodes to stick around.
-OpFoldResult NodeOp::fold(FoldAdaptor adaptor) {
+LogicalResult NodeOp::fold(FoldAdaptor adaptor, SmallVectorImpl<OpFoldResult>& results) {
   if (!hasDroppableName())
-    return {};
+    return failure();
   if (hasDontTouch(getResult())) // handles inner symbols
-    return {};
+    return failure();
   if (getAnnotationsAttr() && !getAnnotationsAttr().empty())
-    return {};
-  return adaptor.getInput();
+    return failure();
+  if (isForceable())
+    return failure();
+  if (!adaptor.getInput())
+    return failure();
+
+  results.push_back(adaptor.getInput());
+  return success();
 }
 
 void NodeOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2017,7 +2025,7 @@ struct FoldResetMux : public mlir::RewritePattern {
     auto reset =
         dyn_cast_or_null<ConstantOp>(reg.getResetValue().getDefiningOp());
     if (!reset || hasDontTouch(reg.getOperation()) ||
-        !reg.getAnnotations().empty())
+        !reg.getAnnotations().empty() || reg.isForceable())
       return failure();
     // Find the one true connect, or bail
     auto con = getSingleConnectUserOf(reg.getResult());
@@ -2041,7 +2049,7 @@ struct FoldResetMux : public mlir::RewritePattern {
       return failure();
 
     // Check all types should be typed by now
-    auto regTy = reg.getType();
+    auto regTy = reg.getResult().getType();
     if (con.getDest().getType() != regTy || con.getSrc().getType() != regTy ||
         mux.getHigh().getType() != regTy || mux.getLow().getType() != regTy ||
         regTy.getBitWidthOrSentinel() < 0)
@@ -2062,10 +2070,30 @@ struct FoldResetMux : public mlir::RewritePattern {
 };
 } // namespace
 
+static bool isDefinedByOneConstantOp(Value v) {
+  if (auto c = v.getDefiningOp<ConstantOp>())
+    return c.getValue().isOne();
+  if (auto sc = v.getDefiningOp<SpecialConstantOp>())
+    return sc.getValue();
+  return false;
+}
+
+static LogicalResult canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
+  if (!isDefinedByOneConstantOp(reg.getResetSignal()))
+    return failure();
+
+  // Ignore 'passthrough'.
+  (void)dropWrite(rewriter, reg->getResult(0), {});
+  replaceOpWithNewOpAndCopyName<NodeOp>(
+      rewriter, reg, reg.getResetValue(), reg.getNameAttr(), reg.getNameKind(),
+      reg.getAnnotationsAttr(), reg.getInnerSymAttr(), reg.getForceable());
+  return success();
+}
+
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::RegResetWithZeroReset,
-                 patterns::RegResetWithOneReset, FoldResetMux>(context);
+  results.add<patterns::RegResetWithZeroReset, FoldResetMux>(context);
+  results.add(canonicalizeRegResetWithOneReset);
 }
 
 // Returns the value connected to a port, if there is only one.
@@ -2151,7 +2179,7 @@ static void erasePort(PatternRewriter &rewriter, Value port) {
     if (!subfield) {
       auto ty = port.getType();
       auto reg = rewriter.create<RegOp>(port.getLoc(), ty, getClock());
-      port.replaceAllUsesWith(reg);
+      port.replaceAllUsesWith(reg.getResult());
       return;
     }
   }
@@ -2177,8 +2205,8 @@ static void erasePort(PatternRewriter &rewriter, Value port) {
     // Replace read values with a register that is never written, handing off
     // the canonicalization of such a register to another canonicalizer.
     auto ty = access.getType();
-    Value reg = rewriter.create<RegOp>(access.getLoc(), ty, getClock());
-    rewriter.replaceOp(access, reg);
+    auto reg = rewriter.create<RegOp>(access.getLoc(), ty, getClock());
+    rewriter.replaceOp(access, reg.getResult());
   }
   assert(port.use_empty() && "port should have no remaining uses");
 }
@@ -2384,7 +2412,7 @@ struct FoldReadWritePorts : public mlir::RewritePattern {
       if (deadReads[i]) {
         // Create a wire to replace the old result. Wire the sub-fields of the
         // old result to the relevant sub-fields of the write port.
-        auto wire = rewriter.create<WireOp>(result.getLoc(), result.getType());
+        auto wire = rewriter.create<WireOp>(result.getLoc(), result.getType()).getResult();
         result.replaceAllUsesWith(wire);
 
         auto connect = [&](Value to, StringRef toName, Value from,
@@ -2687,7 +2715,7 @@ struct FoldRegMems : public mlir::RewritePattern {
     // Create a new register to store the data.
     auto ty = mem.getDataType();
     rewriter.setInsertionPointAfterValue(clock);
-    auto reg = rewriter.create<RegOp>(mem.getLoc(), ty, clock, mem.getName());
+    auto reg = rewriter.create<RegOp>(mem.getLoc(), ty, clock, mem.getName()).getResult();
 
     // Helper to insert a given number of pipeline stages through registers.
     auto pipeline = [&](Value value, Value clock, const Twine &name,
@@ -2700,7 +2728,7 @@ struct FoldRegMems : public mlir::RewritePattern {
         }
 
         auto reg = rewriter.create<RegOp>(mem.getLoc(), value.getType(), clock,
-                                          rewriter.getStringAttr(regName));
+                                          rewriter.getStringAttr(regName)).getResult();
         rewriter.create<StrictConnectOp>(value.getLoc(), reg, value);
         value = reg;
       }
@@ -2860,7 +2888,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
     return failure();
 
   // Check all types should be typed by now
-  auto regTy = reg.getType();
+  auto regTy = reg.getResult().getType();
   if (con.getDest().getType() != regTy || con.getSrc().getType() != regTy ||
       mux.getHigh().getType() != regTy || mux.getLow().getType() != regTy ||
       regTy.getBitWidthOrSentinel() < 0)
@@ -2875,7 +2903,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   if (!constReg) {
     SmallVector<NamedAttribute, 2> attrs(reg->getDialectAttrs());
     auto newReg = replaceOpWithNewOpAndCopyName<RegResetOp>(
-        rewriter, reg, reg.getType(), reg.getClockVal(), mux.getSel(),
+        rewriter, reg, reg.getResult().getType(), reg.getClockVal(), mux.getSel(),
         mux.getHigh(), reg.getName(), reg.getNameKind(), reg.getAnnotations(),
         reg.getInnerSymAttr());
     newReg->setDialectAttrs(attrs);
@@ -2889,7 +2917,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
 }
 
 LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
-  if (!hasDontTouch(op.getOperation()) &&
+  if (!hasDontTouch(op.getOperation()) && !op.isForceable() &&
       succeeded(foldHiddenReset(op, rewriter)))
     return success();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2187,13 +2187,18 @@ void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // Construct name of the module which will be used for the memory definition.
 StringAttr FirMemory::getFirMemoryName() const { return modName; }
 
+/// Helper for naming forceable declarations (and their optional ref result).
+static void forceableAsmResultNames(Forceable op, StringRef name,
+                                    OpAsmSetValueNameFn setNameFn) {
+  if (name.empty())
+    return;
+  setNameFn(op.getDataRaw(), name);
+  if (op.isForceable())
+    setNameFn(op.getDataRef(), (name + "_ref").str());
+}
+
 void NodeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  StringRef name = getName();
-  if (!name.empty()) {
-    setNameFn(getResult(), name);
-    if (getForceable())
-      setNameFn(getRef(), (name + "_ref").str());
-  }
+  return forceableAsmResultNames(*this, getName(), setNameFn);
 }
 
 LogicalResult NodeOp::inferReturnTypes(
@@ -2212,7 +2217,7 @@ LogicalResult NodeOp::inferReturnTypes(
 }
 
 void RegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  setNameFn(getResult(), getName());
+  return forceableAsmResultNames(*this, getName(), setNameFn);
 }
 
 LogicalResult RegResetOp::verify() {
@@ -2230,11 +2235,11 @@ LogicalResult RegResetOp::verify() {
 }
 
 void RegResetOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  setNameFn(getResult(), getName());
+  return forceableAsmResultNames(*this, getName(), setNameFn);
 }
 
 void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  setNameFn(getResult(), getName());
+  return forceableAsmResultNames(*this, getName(), setNameFn);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3952,8 +3952,7 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
     if (fieldIdx < vectorType.getNumElements())
       return RefType::get(vectorType.getElementType());
     return emitInferRetTypeError(loc, "out of range index '", fieldIdx,
-                                 "' in RefType of vector type ",
-                                 refType);
+                                 "' in RefType of vector type ", refType);
   }
   if (auto bundleType = inType.dyn_cast<BundleType>()) {
     if (fieldIdx >= bundleType.getNumElements()) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3917,18 +3917,22 @@ void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                      ArrayRef<NamedAttribute> attrs,
                                      std::optional<Location> loc) {
-  // TODO: Don't cast without checking, we're careful to check in all the
-  // others.
-  auto inType = operands[0].getType().cast<RefType>().getType();
+  auto refType = operands[0].getType().dyn_cast<RefType>();
+  if (!refType)
+    return emitInferRetTypeError(loc, "input must be of reference type");
+  auto inType = refType.getType();
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
 
+  // TODO: Determine ref.sub + rwprobe behavior, test.
+  // Probably best to demote to non-rw, but that has implications
+  // for any LowerTypes behavior being relied on.
   if (auto vectorType = inType.dyn_cast<FVectorType>()) {
     if (fieldIdx < vectorType.getNumElements())
       return RefType::get(vectorType.getElementType());
     return emitInferRetTypeError(loc, "out of range index '", fieldIdx,
                                  "' in RefType of vector type ",
-                                 operands[0].getType());
+                                 refType);
   }
   if (auto bundleType = inType.dyn_cast<BundleType>()) {
     if (fieldIdx >= bundleType.getNumElements()) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2830,9 +2830,8 @@ ParseResult FIRStmtParser::parseNode() {
 
   auto annotations = getConstants().emptyArrayAttr;
   StringAttr sym = {};
-  auto result =
-      builder.create<NodeOp>(initializer.getType(), initializer, id,
-                             NameKindEnum::InterestingName, annotations, sym);
+  auto result = builder.create<NodeOp>(
+      initializer, id, NameKindEnum::InterestingName, annotations, sym);
   return moduleContext.addSymbolEntry(id, result.getResult(),
                                       startTok.getLoc());
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2857,9 +2857,8 @@ ParseResult FIRStmtParser::parseWire() {
   auto annotations = getConstants().emptyArrayAttr;
   StringAttr sym = {};
 
-  auto result = builder.create<WireOp>(
-      type, id, NameKindEnum::InterestingName, annotations,
-      sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
+  auto result = builder.create<WireOp>(type, id, NameKindEnum::InterestingName,
+                                       annotations, sym);
   return moduleContext.addSymbolEntry(id, result.getResult(),
                                       startTok.getLoc());
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2833,7 +2833,7 @@ ParseResult FIRStmtParser::parseNode() {
   auto result =
       builder.create<NodeOp>(initializer.getType(), initializer, id,
                              NameKindEnum::InterestingName, annotations, sym);
-  return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
+  return moduleContext.addSymbolEntry(id, result.getResult(), startTok.getLoc());
 }
 
 /// wire ::= 'wire' id ':' type info?
@@ -2860,7 +2860,7 @@ ParseResult FIRStmtParser::parseWire() {
   auto result = builder.create<WireOp>(
       type, id, NameKindEnum::InterestingName, annotations,
       sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
-  return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
+  return moduleContext.addSymbolEntry(id, result.getResult(), startTok.getLoc());
 }
 
 /// register    ::= 'reg' id ':' type exp ('with' ':' reset_block)? info?
@@ -2951,10 +2951,10 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   if (resetSignal)
     result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
                                         id, NameKindEnum::InterestingName,
-                                        annotations, sym);
+                                        annotations, sym).getResult();
   else
     result = builder.create<RegOp>(
-        type, clock, id, NameKindEnum::InterestingName, annotations, sym);
+        type, clock, id, NameKindEnum::InterestingName, annotations, sym).getResult();
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2833,7 +2833,8 @@ ParseResult FIRStmtParser::parseNode() {
   auto result =
       builder.create<NodeOp>(initializer.getType(), initializer, id,
                              NameKindEnum::InterestingName, annotations, sym);
-  return moduleContext.addSymbolEntry(id, result.getResult(), startTok.getLoc());
+  return moduleContext.addSymbolEntry(id, result.getResult(),
+                                      startTok.getLoc());
 }
 
 /// wire ::= 'wire' id ':' type info?
@@ -2860,7 +2861,8 @@ ParseResult FIRStmtParser::parseWire() {
   auto result = builder.create<WireOp>(
       type, id, NameKindEnum::InterestingName, annotations,
       sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
-  return moduleContext.addSymbolEntry(id, result.getResult(), startTok.getLoc());
+  return moduleContext.addSymbolEntry(id, result.getResult(),
+                                      startTok.getLoc());
 }
 
 /// register    ::= 'reg' id ':' type exp ('with' ':' reset_block)? info?
@@ -2949,12 +2951,16 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   Value result;
   StringAttr sym = {};
   if (resetSignal)
-    result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
-                                        id, NameKindEnum::InterestingName,
-                                        annotations, sym).getResult();
+    result =
+        builder
+            .create<RegResetOp>(type, clock, resetSignal, resetValue, id,
+                                NameKindEnum::InterestingName, annotations, sym)
+            .getResult();
   else
-    result = builder.create<RegOp>(
-        type, clock, id, NameKindEnum::InterestingName, annotations, sym).getResult();
+    result = builder
+                 .create<RegOp>(type, clock, id, NameKindEnum::InterestingName,
+                                annotations, sym)
+                 .getResult();
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -253,7 +253,7 @@ public:
           // Wire is added to the worklist
           .Case<WireOp>([&](WireOp wire) {
             worklist.push_back(wire.getResult());
-            if (!wire.getType().cast<FIRRTLBaseType>().isGround())
+            if (!wire.getResult().getType().cast<FIRRTLBaseType>().isGround())
               setValRefsTo(wire.getResult(), FieldRef(wire.getResult(), 0));
           })
           // All sub elements are added to the worklist.

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1197,7 +1197,8 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
           continue;
         // If the type changed we transform it back to the old type with an
         // intermediate wire.
-        auto wire = builder.create<WireOp>(oldType, inst.getPortName(i));
+        auto wire =
+            builder.create<WireOp>(oldType, inst.getPortName(i)).getResult();
         result.replaceAllUsesWith(wire);
         result.setType(newType);
         if (inst.getPortDirection(i) == Direction::Out)

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -118,10 +118,12 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       for (size_t index = 0, rend = memOp.getNumResults(); index < rend;
            ++index) {
         auto result = memOp.getResult(index);
-        auto wire = builder.create<WireOp>(
-            result.getType(),
-            (memOp.getName() + "_" + memOp.getPortName(index).getValue())
-                .str()).getResult();
+        auto wire = builder
+                        .create<WireOp>(result.getType(),
+                                        (memOp.getName() + "_" +
+                                         memOp.getPortName(index).getValue())
+                                            .str())
+                        .getResult();
         result.replaceAllUsesWith(wire);
         result = wire;
         auto newResult = flatMem.getResult(index);

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -121,8 +121,8 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
         auto wire = builder.create<WireOp>(
             result.getType(),
             (memOp.getName() + "_" + memOp.getPortName(index).getValue())
-                .str());
-        result.replaceAllUsesWith(wire.getResult());
+                .str()).getResult();
+        result.replaceAllUsesWith(wire);
         result = wire;
         auto newResult = flatMem.getResult(index);
         auto rType = result.getType().cast<BundleType>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1075,7 +1075,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
 
     // Append this new Wiring Problem to the ApplyState.  The Wiring Problem
     // will be resolved to bore RefType ports before LowerAnnotations finishes.
-    state.wiringProblems.push_back({*source, sink, (path + "__bore").str(),
+    state.wiringProblems.push_back({*source, sink.getResult(), (path + "__bore").str(),
                                     WiringProblem::RefTypeUsage::Prefer});
 
     return DictionaryAttr::getWithSorted(context, elementIface);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1075,7 +1075,8 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
 
     // Append this new Wiring Problem to the ApplyState.  The Wiring Problem
     // will be resolved to bore RefType ports before LowerAnnotations finishes.
-    state.wiringProblems.push_back({*source, sink.getResult(), (path + "__bore").str(),
+    state.wiringProblems.push_back({*source, sink.getResult(),
+                                    (path + "__bore").str(),
                                     WiringProblem::RefTypeUsage::Prefer});
 
     return DictionaryAttr::getWithSorted(context, elementIface);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -481,12 +481,12 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
 }
 
 void IMConstPropPass::markWireOp(WireOp wire) {
-  auto type = wire.getType().dyn_cast<FIRRTLType>();
+  auto type = wire.getResult().getType().dyn_cast<FIRRTLType>();
   if (!type)
-    return markOverdefined(wire);
+    return markOverdefined(wire.getResult());
 
   if (hasDontTouch(wire.getResult()))
-    return markOverdefined(wire);
+    return markOverdefined(wire.getResult());
 
   // Otherwise, this starts out as unknown and is upgraded by connects.
 }
@@ -665,7 +665,7 @@ void IMConstPropPass::visitNode(NodeOp node) {
   // propagate values.
   if (hasDontTouch(node.getResult()) ||
       (node.getAnnotationsAttr() && !node.getAnnotationsAttr().empty()))
-    return markOverdefined(node);
+    return markOverdefined(node.getResult());
 
   return mergeLatticeValue(node.getResult(), node.getInput());
 }

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -31,6 +31,10 @@ static bool isDeletableDeclaration(Operation *op) {
   if (auto name = dyn_cast<FNamableOp>(op))
     if (!name.hasDroppableName())
       return false;
+  // TODO: If uses are DCE'd, can delete this.
+  if (auto fop = dyn_cast<Forceable>(op))
+    if (fop.isForceable())
+      return false;
   return !hasDontTouch(op);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -517,7 +517,7 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
 
       // Ok, this port is used only within its defined module. So we can replace
       // the port with a wire.
-      WireOp wire = builder.create<WireOp>(argument.getType());
+      auto wire = builder.create<WireOp>(argument.getType()).getResult();
 
       // Since `liveSet` contains the port, we have to erase it from the set.
       liveValues.erase(argument);

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -154,10 +154,14 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
       auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
       // Temp wires to replace the original memory connects.
-      auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr").getResult();
-      auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr").getResult();
-      auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable").getResult();
-      auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable").getResult();
+      auto rAddr =
+          builder.create<WireOp>(addr.getType(), "readAddr").getResult();
+      auto wAddr =
+          builder.create<WireOp>(addr.getType(), "writeAddr").getResult();
+      auto wEnWire =
+          builder.create<WireOp>(enb.getType(), "writeEnable").getResult();
+      auto rEnWire =
+          builder.create<WireOp>(enb.getType(), "readEnable").getResult();
       auto writeClock =
           builder.create<WireOp>(ClockType::get(enb.getContext())).getResult();
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -154,12 +154,12 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
       auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
       // Temp wires to replace the original memory connects.
-      auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr");
-      auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
-      auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
-      auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
+      auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr").getResult();
+      auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr").getResult();
+      auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable").getResult();
+      auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable").getResult();
       auto writeClock =
-          builder.create<WireOp>(ClockType::get(enb.getContext()));
+          builder.create<WireOp>(ClockType::get(enb.getContext())).getResult();
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
       builder.create<StrictConnectOp>(
           addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1602,8 +1602,8 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
         ImplicitLocOpBuilder builder(nodeOp.getLoc(), nodeOp);
         auto wireOp = builder.create<WireOp>(
             nodeOp.getResult().getType(), nodeOp.getNameAttr(),
-            nodeOp.getNameKind(), nodeOp.getAnnotationsAttr(),
-            nodeOp.getInnerSymAttr());
+            nodeOp.getNameKindAttr(), nodeOp.getAnnotationsAttr(),
+            nodeOp.getInnerSymAttr(), nodeOp.getForceableAttr());
         builder.create<StrictConnectOp>(wireOp.getResult(), nodeOp.getInput());
         nodeOp->replaceAllUsesWith(wireOp);
         nodeOp.erase();

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -134,20 +134,20 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLBaseType type,
             auto wireOp = builder.create<WireOp>(type);
             for (auto field : llvm::enumerate(type)) {
               auto zero = createZeroValue(builder, field.value().type, cache);
-              auto acc = builder.create<SubfieldOp>(field.value().type, wireOp,
+              auto acc = builder.create<SubfieldOp>(field.value().type, wireOp.getResult(),
                                                     field.index());
               builder.create<StrictConnectOp>(acc, zero);
             }
-            return wireOp;
+            return wireOp.getResult();
           })
           .Case<FVectorType>([&](auto type) {
             auto wireOp = builder.create<WireOp>(type);
             auto zero = createZeroValue(builder, type.getElementType(), cache);
             for (unsigned i = 0, e = type.getNumElements(); i < e; ++i) {
-              auto acc = builder.create<SubindexOp>(zero.getType(), wireOp, i);
+              auto acc = builder.create<SubindexOp>(zero.getType(), wireOp.getResult(), i);
               builder.create<StrictConnectOp>(acc, zero);
             }
-            return wireOp;
+            return wireOp.getResult();
           })
           .Case<ResetType, AnalogType>(
               [&](auto type) { return builder.create<InvalidValueOp>(type); })
@@ -1600,14 +1600,14 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
                    << "- Promoting node to wire for move: " << nodeOp << "\n");
         ImplicitLocOpBuilder builder(nodeOp.getLoc(), nodeOp);
         auto wireOp = builder.create<WireOp>(
-            nodeOp.getType(), nodeOp.getNameAttr(), nodeOp.getNameKind(),
+            nodeOp.getResult().getType(), nodeOp.getNameAttr(), nodeOp.getNameKind(),
             nodeOp.getAnnotationsAttr(), nodeOp.getInnerSymAttr());
-        builder.create<StrictConnectOp>(wireOp, nodeOp.getInput());
+        builder.create<StrictConnectOp>(wireOp.getResult(), nodeOp.getInput());
         nodeOp->replaceAllUsesWith(wireOp);
         nodeOp.erase();
         resetOp = wireOp;
-        actualReset = wireOp;
-        domain.existingValue = wireOp;
+        actualReset = wireOp.getResult();
+        domain.existingValue = wireOp.getResult();
       }
 
       // Determine the block into which the reset declaration needs to be moved.
@@ -1714,12 +1714,14 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
       return;
 
     LLVM_DEBUG(llvm::dbgs() << "- Adding async reset to " << regOp << "\n");
-    auto zero = createZeroValue(builder, regOp.getType());
+    auto zero = createZeroValue(builder, regOp.getResult().getType());
     auto newRegOp = builder.create<RegResetOp>(
-        regOp.getType(), regOp.getClockVal(), actualReset, zero,
+        regOp.getResult().getType(), regOp.getClockVal(), actualReset, zero,
         regOp.getNameAttr(), regOp.getNameKindAttr(), regOp.getAnnotations(),
-        regOp.getInnerSymAttr());
-    regOp.getResult().replaceAllUsesWith(newRegOp);
+        regOp.getInnerSymAttr(), regOp.getForceableAttr());
+    regOp.getResult().replaceAllUsesWith(newRegOp.getResult());
+    if (regOp.getForceable())
+      regOp.getRef().replaceAllUsesWith(newRegOp.getRef());
     regOp->erase();
     return;
   }
@@ -1744,14 +1746,14 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     // If we arrive here, the register has a sync reset. In order to add an
     // async reset, we have to move the sync reset into a mux in front of the
     // register.
-    insertResetMux(builder, regOp, reset, value);
-    builder.setInsertionPointAfterValue(regOp);
-    auto mux = builder.create<MuxPrimOp>(reset, value, regOp);
-    builder.create<ConnectOp>(regOp, mux);
+    insertResetMux(builder, regOp.getResult(), reset, value);
+    builder.setInsertionPointAfterValue(regOp.getResult());
+    auto mux = builder.create<MuxPrimOp>(reset, value, regOp.getResult());
+    builder.create<ConnectOp>(regOp.getResult(), mux);
 
     // Replace the existing reset with the async reset.
     builder.setInsertionPoint(regOp);
-    auto zero = createZeroValue(builder, regOp.getType());
+    auto zero = createZeroValue(builder, regOp.getResult().getType());
     regOp.getResetSignalMutable().assign(actualReset);
     regOp.getResetValueMutable().assign(zero);
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -134,8 +134,8 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLBaseType type,
             auto wireOp = builder.create<WireOp>(type);
             for (auto field : llvm::enumerate(type)) {
               auto zero = createZeroValue(builder, field.value().type, cache);
-              auto acc = builder.create<SubfieldOp>(field.value().type, wireOp.getResult(),
-                                                    field.index());
+              auto acc = builder.create<SubfieldOp>(
+                  field.value().type, wireOp.getResult(), field.index());
               builder.create<StrictConnectOp>(acc, zero);
             }
             return wireOp.getResult();
@@ -144,7 +144,8 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLBaseType type,
             auto wireOp = builder.create<WireOp>(type);
             auto zero = createZeroValue(builder, type.getElementType(), cache);
             for (unsigned i = 0, e = type.getNumElements(); i < e; ++i) {
-              auto acc = builder.create<SubindexOp>(zero.getType(), wireOp.getResult(), i);
+              auto acc = builder.create<SubindexOp>(zero.getType(),
+                                                    wireOp.getResult(), i);
               builder.create<StrictConnectOp>(acc, zero);
             }
             return wireOp.getResult();
@@ -1600,8 +1601,9 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
                    << "- Promoting node to wire for move: " << nodeOp << "\n");
         ImplicitLocOpBuilder builder(nodeOp.getLoc(), nodeOp);
         auto wireOp = builder.create<WireOp>(
-            nodeOp.getResult().getType(), nodeOp.getNameAttr(), nodeOp.getNameKind(),
-            nodeOp.getAnnotationsAttr(), nodeOp.getInnerSymAttr());
+            nodeOp.getResult().getType(), nodeOp.getNameAttr(),
+            nodeOp.getNameKind(), nodeOp.getAnnotationsAttr(),
+            nodeOp.getInnerSymAttr());
         builder.create<StrictConnectOp>(wireOp.getResult(), nodeOp.getInput());
         nodeOp->replaceAllUsesWith(wireOp);
         nodeOp.erase();

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1336,7 +1336,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       .Case<NodeOp>([&](auto op) {
         // Nodes have the same type as their input.
         unifyTypes(FieldRef(op.getResult(), 0), FieldRef(op.getInput(), 0),
-                   op.getType());
+                   op.getResult().getType());
       })
 
       // Aggregate Values

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1611,6 +1611,12 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         mappingFailed = true;
       });
 
+  // Forceable declarations should have the ref constrained to data result.
+  if (auto fop = dyn_cast<Forceable>(op); fop && fop.isForceable()) {
+    declareVars(fop.getDataRef(), fop.getLoc());
+    constrainTypes(fop.getDataRef(), fop.getDataRaw());
+  }
+
   return failure(mappingFailed);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -728,7 +728,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     // If the sink is a wire with no users, then convert this to a node.
     auto destOp = dyn_cast_or_null<WireOp>(dest.getDefiningOp());
     if (destOp && dest.getUses().empty()) {
-      builder.create<NodeOp>(src.getType(), src, destOp.getName())
+      builder.create<NodeOp>(src, destOp.getName())
           .setAnnotationsAttr(destOp.getAnnotations());
       opsToErase.push_back(destOp);
       return success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -128,7 +128,7 @@ static bool lowerCirctSizeof(InstancePathCache &instancePathCache,
   for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
     auto inst = cast<InstanceOp>(use->getInstance().getOperation());
     ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-    auto inputWire = builder.create<WireOp>(ports[0].type);
+    auto inputWire = builder.create<WireOp>(ports[0].type).getResult();
     inst.getResult(0).replaceAllUsesWith(inputWire);
     auto size = builder.create<SizeOfIntrinsicOp>(inputWire);
     inst.getResult(1).replaceAllUsesWith(size);
@@ -149,7 +149,7 @@ static bool lowerCirctIsX(InstancePathCache &instancePathCache,
   for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
     auto inst = cast<InstanceOp>(use->getInstance().getOperation());
     ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-    auto inputWire = builder.create<WireOp>(ports[0].type);
+    auto inputWire = builder.create<WireOp>(ports[0].type).getResult();
     inst.getResult(0).replaceAllUsesWith(inputWire);
     auto size = builder.create<IsXIntrinsicOp>(inputWire);
     inst.getResult(1).replaceAllUsesWith(size);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -910,7 +910,7 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
     newMemories.push_back(cloneMemWithNewType(builder, op, field));
   // Hook up the new memories to the wires the old memory was replaced with.
   for (size_t index = 0, rend = op.getNumResults(); index < rend; ++index) {
-    auto result = oldPorts[index];
+    auto result = oldPorts[index].getResult();
     auto rType = result.getType().cast<BundleType>();
     for (size_t fieldIndex = 0, fend = rType.getNumElements();
          fieldIndex != fend; ++fieldIndex) {
@@ -1098,7 +1098,7 @@ bool TypeLoweringVisitor::visitDecl(WireOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     return builder->create<WireOp>(field.type, "", NameKindEnum::DroppableName,
-                                   attrs, StringAttr{});
+                                   attrs, StringAttr{}).getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1109,7 +1109,7 @@ bool TypeLoweringVisitor::visitDecl(RegOp op) {
                    ArrayAttr attrs) -> Value {
     return builder->create<RegOp>(field.type, op.getClockVal(), "",
                                   NameKindEnum::DroppableName, attrs,
-                                  StringAttr{});
+                                  StringAttr{}).getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1121,7 +1121,7 @@ bool TypeLoweringVisitor::visitDecl(RegResetOp op) {
     auto resetVal = getSubWhatever(op.getResetValue(), field.index);
     return builder->create<RegResetOp>(
         field.type, op.getClockVal(), op.getResetSignal(), resetVal, "",
-        NameKindEnum::DroppableName, attrs, StringAttr{});
+        NameKindEnum::DroppableName, attrs, StringAttr{}).getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1133,7 +1133,7 @@ bool TypeLoweringVisitor::visitDecl(NodeOp op) {
     auto input = getSubWhatever(op.getInput(), field.index);
     return builder->create<NodeOp>(field.type, input, "",
                                    NameKindEnum::DroppableName, attrs,
-                                   StringAttr{});
+                                   StringAttr{}).getResult();
   };
   return lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1097,8 +1097,10 @@ bool TypeLoweringVisitor::visitDecl(FModuleOp module) {
 bool TypeLoweringVisitor::visitDecl(WireOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
-    return builder->create<WireOp>(field.type, "", NameKindEnum::DroppableName,
-                                   attrs, StringAttr{}).getResult();
+    return builder
+        ->create<WireOp>(field.type, "", NameKindEnum::DroppableName, attrs,
+                         StringAttr{})
+        .getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1107,9 +1109,10 @@ bool TypeLoweringVisitor::visitDecl(WireOp op) {
 bool TypeLoweringVisitor::visitDecl(RegOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
-    return builder->create<RegOp>(field.type, op.getClockVal(), "",
-                                  NameKindEnum::DroppableName, attrs,
-                                  StringAttr{}).getResult();
+    return builder
+        ->create<RegOp>(field.type, op.getClockVal(), "",
+                        NameKindEnum::DroppableName, attrs, StringAttr{})
+        .getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1119,9 +1122,11 @@ bool TypeLoweringVisitor::visitDecl(RegResetOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto resetVal = getSubWhatever(op.getResetValue(), field.index);
-    return builder->create<RegResetOp>(
-        field.type, op.getClockVal(), op.getResetSignal(), resetVal, "",
-        NameKindEnum::DroppableName, attrs, StringAttr{}).getResult();
+    return builder
+        ->create<RegResetOp>(field.type, op.getClockVal(), op.getResetSignal(),
+                             resetVal, "", NameKindEnum::DroppableName, attrs,
+                             StringAttr{})
+        .getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1131,9 +1136,10 @@ bool TypeLoweringVisitor::visitDecl(NodeOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto input = getSubWhatever(op.getInput(), field.index);
-    return builder->create<NodeOp>(field.type, input, "",
-                                   NameKindEnum::DroppableName, attrs,
-                                   StringAttr{}).getResult();
+    return builder
+        ->create<NodeOp>(field.type, input, "", NameKindEnum::DroppableName,
+                         attrs, StringAttr{})
+        .getResult();
   };
   return lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -408,6 +408,10 @@ private:
   bool lowerProducer(
       Operation *op,
       llvm::function_ref<Value(const FlatBundleFieldEntry &, ArrayAttr)> clone);
+  bool lowerForceable(
+      Forceable op,
+      llvm::function_ref<Forceable(const FlatBundleFieldEntry &, ArrayAttr)>
+          clone);
   /// Copy annotations from \p annotations to \p loweredAttrs, except
   /// annotations with "target" key, that do not match the field suffix.
   ArrayAttr filterAnnotations(MLIRContext *ctxt, ArrayAttr annotations,
@@ -572,10 +576,13 @@ bool TypeLoweringVisitor::lowerProducer(
 
   // FIXME: Don't presereve aggregates on RefType operations for now. This is
   // workaround for MemTap which causes type mismatches (issue 4479).
-  if (!peelType(srcType, fieldTypes,
-                isa<RefResolveOp, RefSendOp, RefSubOp>(op)
-                    ? PreserveAggregate::None
-                    : aggregatePreservationMode))
+  auto preserveMode = aggregatePreservationMode;
+  if (isa<RefResolveOp, RefSendOp, RefSubOp>(op))
+    preserveMode = PreserveAggregate::None;
+  // Because of the above, also insist on splitting force targets.
+  if (auto fop = dyn_cast<Forceable>(op); fop && fop.isForceable())
+    preserveMode = PreserveAggregate::None;
+  if (!peelType(srcType, fieldTypes, preserveMode))
     return false;
 
   // If an aggregate value has a symbol, emit errors.
@@ -589,7 +596,6 @@ bool TypeLoweringVisitor::lowerProducer(
   SmallVector<Value> lowered;
   // Loop over the leaf aggregates.
   SmallString<16> loweredName;
-  SmallString<16> loweredSymName;
   auto nameKindAttr = op->getAttrOfType<NameKindEnumAttr>(cache.nameKindAttr);
 
   if (auto nameAttr = op->getAttrOfType<StringAttr>(cache.nameAttr))
@@ -620,6 +626,28 @@ bool TypeLoweringVisitor::lowerProducer(
   }
 
   processUsers(op->getResult(0), lowered);
+  return true;
+}
+
+bool TypeLoweringVisitor::lowerForceable(
+    Forceable op,
+    llvm::function_ref<Forceable(const FlatBundleFieldEntry &, ArrayAttr)>
+        clone) {
+  // Lower primary result value as usual, but save refs for rewriting them too.
+  // Makes assumptions about lowerProducer's behavior.
+  SmallVector<Value> loweredRefs;
+  auto cloneAndSave = [&](auto entry, auto attrs) -> Value {
+    auto f = clone(entry, attrs);
+    assert(f.isForceable() == op.isForceable());
+    if (f.isForceable())
+      loweredRefs.push_back(f.getDataRef());
+    return f.getDataRaw();
+  };
+  if (!lowerProducer(op, cloneAndSave))
+    return false;
+
+  if (op.isForceable())
+    processUsers(op.getDataRef(), loweredRefs);
   return true;
 }
 
@@ -689,9 +717,7 @@ TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
                             unsigned insertPtOffset, FIRRTLType srcType,
                             FlatBundleFieldEntry field, PortInfo &oldArg) {
   Value newValue;
-  FIRRTLType fieldType = srcType.isa<RefType>()
-                             ? FIRRTLType(RefType::get(field.type))
-                             : field.type;
+  FIRRTLType fieldType = mapBaseType(srcType, [&](auto) { return field.type; });
   if (auto mod = dyn_cast<FModuleOp>(module)) {
     Block *body = mod.getBodyBlock();
     // Append the new argument.
@@ -1096,52 +1122,45 @@ bool TypeLoweringVisitor::visitDecl(FModuleOp module) {
 /// Lower a wire op with a bundle to multiple non-bundled wires.
 bool TypeLoweringVisitor::visitDecl(WireOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
-                   ArrayAttr attrs) -> Value {
-    return builder
-        ->create<WireOp>(field.type, "", NameKindEnum::DroppableName, attrs,
-                         StringAttr{})
-        .getResult();
+                   ArrayAttr attrs) -> Forceable {
+    return builder->create<WireOp>(field.type, "", NameKindEnum::DroppableName,
+                                   attrs, StringAttr{}, op.isForceable());
   };
-  return lowerProducer(op, clone);
+  return lowerForceable(op, clone);
 }
 
 /// Lower a reg op with a bundle to multiple non-bundled regs.
 bool TypeLoweringVisitor::visitDecl(RegOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
-                   ArrayAttr attrs) -> Value {
-    return builder
-        ->create<RegOp>(field.type, op.getClockVal(), "",
-                        NameKindEnum::DroppableName, attrs, StringAttr{})
-        .getResult();
+                   ArrayAttr attrs) -> Forceable {
+    return builder->create<RegOp>(field.type, op.getClockVal(), "",
+                                  NameKindEnum::DroppableName, attrs,
+                                  StringAttr{}, op.isForceable());
   };
-  return lowerProducer(op, clone);
+  return lowerForceable(op, clone);
 }
 
 /// Lower a reg op with a bundle to multiple non-bundled regs.
 bool TypeLoweringVisitor::visitDecl(RegResetOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
-                   ArrayAttr attrs) -> Value {
+                   ArrayAttr attrs) -> Forceable {
     auto resetVal = getSubWhatever(op.getResetValue(), field.index);
-    return builder
-        ->create<RegResetOp>(field.type, op.getClockVal(), op.getResetSignal(),
-                             resetVal, "", NameKindEnum::DroppableName, attrs,
-                             StringAttr{})
-        .getResult();
+    return builder->create<RegResetOp>(
+        field.type, op.getClockVal(), op.getResetSignal(), resetVal, "",
+        NameKindEnum::DroppableName, attrs, StringAttr{}, op.isForceable());
   };
-  return lowerProducer(op, clone);
+  return lowerForceable(op, clone);
 }
 
 /// Lower a wire op with a bundle to multiple non-bundled wires.
 bool TypeLoweringVisitor::visitDecl(NodeOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
-                   ArrayAttr attrs) -> Value {
+                   ArrayAttr attrs) -> Forceable {
     auto input = getSubWhatever(op.getInput(), field.index);
-    return builder
-        ->create<NodeOp>(field.type, input, "", NameKindEnum::DroppableName,
-                         attrs, StringAttr{})
-        .getResult();
+    return builder->create<NodeOp>(input, "", NameKindEnum::DroppableName,
+                                   attrs, StringAttr{}, op.isForceable());
   };
-  return lowerProducer(op, clone);
+  return lowerForceable(op, clone);
 }
 
 /// Lower an InvalidValue op with a bundle to multiple non-bundled InvalidOps.

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -109,7 +109,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                   nameKind = NameKindEnum::InterestingName;
                 }
                 xmrDef = b.create<NodeOp>(xmrDef.getType(), xmrDef, opName,
-                                          nameKind);
+                                          nameKind).getResult();
               }
             }
             // Create a new entry for this RefSendOp. The path is currently

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -108,8 +108,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                   opName = name.getValue();
                   nameKind = NameKindEnum::InterestingName;
                 }
-                xmrDef = b.create<NodeOp>(xmrDef.getType(), xmrDef, opName,
-                                          nameKind).getResult();
+                xmrDef =
+                    b.create<NodeOp>(xmrDef.getType(), xmrDef, opName, nameKind)
+                        .getResult();
               }
             }
             // Create a new entry for this RefSendOp. The path is currently

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -108,9 +108,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                   opName = name.getValue();
                   nameKind = NameKindEnum::InterestingName;
                 }
-                xmrDef =
-                    b.create<NodeOp>(xmrDef.getType(), xmrDef, opName, nameKind)
-                        .getResult();
+                xmrDef = b.create<NodeOp>(xmrDef, opName, nameKind).getResult();
               }
             }
             // Create a new entry for this RefSendOp. The path is currently

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -353,8 +353,10 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     auto vecType = op.getResult().getType().cast<FVectorType>();
     for (auto anno : annos) {
       if (anno.isClass(memTapSourceClass)) {
-        for (size_t i = 0,
-                    e = op.getResult().getType().cast<FVectorType>().getNumElements();
+        for (size_t i = 0, e = op.getResult()
+                                   .getType()
+                                   .cast<FVectorType>()
+                                   .getNumElements();
              i != e; ++i) {
           NamedAttrList newAnno;
           newAnno.append("class", anno.getMember("class"));
@@ -421,7 +423,8 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
         generateRead(firMem, clk, adr, enb, dta, regOfVec.getResult(), builder);
       } else if (portKind == MemOp::PortKind::Write) {
         auto mask = getMask(builder, result);
-        generateWrite(firMem, clk, adr, enb, mask, dta, regOfVec.getResult(), builder);
+        generateWrite(firMem, clk, adr, enb, mask, dta, regOfVec.getResult(),
+                      builder);
       } else {
         auto wmode = getWmode(builder, result);
         auto wDta = getData(builder, result, true);

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -95,7 +95,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
       return pipeInput;
 
     while (stages--) {
-      auto reg = b.create<RegOp>(pipeInput.getType(), clock, name);
+      auto reg = b.create<RegOp>(pipeInput.getType(), clock, name).getResult();
       if (gate) {
         b.create<WhenOp>(gate, /*withElseRegion*/ false,
                          [&]() { b.create<StrictConnectOp>(reg, pipeInput); });
@@ -350,11 +350,11 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
                          ImplicitLocOpBuilder &builder) {
     AnnotationSet annos(attr);
     SmallVector<Attribute> regAnnotations;
-    auto vecType = op.getType().cast<FVectorType>();
+    auto vecType = op.getResult().getType().cast<FVectorType>();
     for (auto anno : annos) {
       if (anno.isClass(memTapSourceClass)) {
         for (size_t i = 0,
-                    e = op.getType().cast<FVectorType>().getNumElements();
+                    e = op.getResult().getType().cast<FVectorType>().getNumElements();
              i != e; ++i) {
           NamedAttrList newAnno;
           newAnno.append("class", anno.getMember("class"));
@@ -398,7 +398,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
           (memOp.getName() + "_" + memOp.getPortName(index).getValue()).str(),
           memOp.getNameKind());
       result.replaceAllUsesWith(wire.getResult());
-      result = wire;
+      result = wire.getResult();
       // Create an access to all the common subfields.
       auto adr = getAddr(builder, result);
       auto enb = getEnable(builder, result);
@@ -418,16 +418,16 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
       }
       auto portKind = memOp.getPortKind(index);
       if (portKind == MemOp::PortKind::Read) {
-        generateRead(firMem, clk, adr, enb, dta, regOfVec, builder);
+        generateRead(firMem, clk, adr, enb, dta, regOfVec.getResult(), builder);
       } else if (portKind == MemOp::PortKind::Write) {
         auto mask = getMask(builder, result);
-        generateWrite(firMem, clk, adr, enb, mask, dta, regOfVec, builder);
+        generateWrite(firMem, clk, adr, enb, mask, dta, regOfVec.getResult(), builder);
       } else {
         auto wmode = getWmode(builder, result);
         auto wDta = getData(builder, result, true);
         auto mask = getMask(builder, result);
         generateReadWrite(firMem, clk, adr, enb, mask, wDta, dta, wmode,
-                          regOfVec, builder);
+                          regOfVec.getResult(), builder);
       }
     }
     // If a valid register is created, then replace all the debug port users
@@ -435,7 +435,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     // RefSend on the register.
     if (regOfVec)
       for (auto r : debugPorts)
-        r.replaceAllUsesWith(builder.create<RefSendOp>(regOfVec));
+        r.replaceAllUsesWith(builder.create<RefSendOp>(regOfVec.getResult()));
   }
 
 private:

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -801,10 +801,13 @@ void Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b, IRMapping &mapper,
     Value wire =
         TypeSwitch<FIRRTLType, Value>(type)
             .Case<FIRRTLBaseType>([&](auto base) {
-              return b.create<WireOp>(
-                  target.getLoc(), base, (prefix + portInfo[i].getName()).str(),
-                  NameKindEnum::DroppableName,
-                  ArrayAttr::get(context, newAnnotations), newSym).getResult();
+              return b
+                  .create<WireOp>(target.getLoc(), base,
+                                  (prefix + portInfo[i].getName()).str(),
+                                  NameKindEnum::DroppableName,
+                                  ArrayAttr::get(context, newAnnotations),
+                                  newSym)
+                  .getResult();
             })
             .Case<RefType>([&](auto refty) {
               // Symbols and annotations are not allowed, warn if dropping.

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -804,7 +804,7 @@ void Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b, IRMapping &mapper,
               return b.create<WireOp>(
                   target.getLoc(), base, (prefix + portInfo[i].getName()).str(),
                   NameKindEnum::DroppableName,
-                  ArrayAttr::get(context, newAnnotations), newSym);
+                  ArrayAttr::get(context, newAnnotations), newSym).getResult();
             })
             .Case<RefType>([&](auto refty) {
               // Symbols and annotations are not allowed, warn if dropping.

--- a/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
@@ -24,7 +24,7 @@ using namespace firrtl;
 // Instantiated for RegOp and RegResetOp
 template <typename T>
 static bool canErase(T op) {
-  return !(hasDontTouch(op.getResult()) ||
+  return !(hasDontTouch(op.getResult()) || op.isForceable() ||
            (op.getAnnotationsAttr() && !op.getAnnotationsAttr().empty()));
 }
 
@@ -55,10 +55,10 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
     return;
 
   // Register is only written by itself, replace with invalid.
-  if (con.getSrc() == reg) {
+  if (con.getSrc() == reg.getResult()) {
     auto inv =
-        OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(), reg.getType());
-    reg.replaceAllUsesWith(inv.getResult());
+        OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(), reg.getResult().getType());
+    reg.getResult().replaceAllUsesWith(inv.getResult());
     toErase.push_back(reg);
     toErase.push_back(con);
     return;
@@ -73,7 +73,7 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
       // Simple constants we can move safely
       auto *fmodb = con->getParentOfType<FModuleOp>().getBodyBlock();
       cst->moveBefore(fmodb, fmodb->begin());
-      reg.replaceAllUsesWith(cst.getResult());
+      reg.getResult().replaceAllUsesWith(cst.getResult());
       toErase.push_back(con);
     } else {
       bool dominatesAll = true;
@@ -87,12 +87,12 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
       }
       if (dominatesAll) {
         // Dominance is fine, just replace the op.
-        reg.replaceAllUsesWith(con.getSrc());
+        reg.getResult().replaceAllUsesWith(con.getSrc());
         toErase.push_back(con);
       } else {
         auto bounce =
-            OpBuilder(reg).create<WireOp>(reg.getLoc(), reg.getType());
-        reg.replaceAllUsesWith(bounce.getResult());
+            OpBuilder(reg).create<WireOp>(reg.getLoc(), reg.getResult().getType());
+        reg.replaceAllUsesWith(bounce);
       }
     }
     toErase.push_back(reg);
@@ -110,10 +110,10 @@ void RegisterOptimizerPass::checkRegReset(mlir::DominanceInfo &dom,
     return;
 
   // Register is only written by itself, and reset with a constant.
-  if (reg.getResetValue().getType() == reg.getType()) {
-    if (con.getSrc() == reg && isConstant(reg.getResetValue())) {
+  if (reg.getResetValue().getType() == reg.getResult().getType()) {
+    if (con.getSrc() == reg.getResult() && isConstant(reg.getResetValue())) {
       // constant obviously dominates the register.
-      reg.replaceAllUsesWith(reg.getResetValue());
+      reg.getResult().replaceAllUsesWith(reg.getResetValue());
       toErase.push_back(reg);
       toErase.push_back(con);
       return;
@@ -122,7 +122,7 @@ void RegisterOptimizerPass::checkRegReset(mlir::DominanceInfo &dom,
     if (con.getSrc() == reg.getResetValue() &&
         isConstant(reg.getResetValue())) {
       // constant obviously dominates the register.
-      reg.replaceAllUsesWith(reg.getResetValue());
+      reg.getResult().replaceAllUsesWith(reg.getResetValue());
       toErase.push_back(reg);
       toErase.push_back(con);
       return;

--- a/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
@@ -56,8 +56,8 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
 
   // Register is only written by itself, replace with invalid.
   if (con.getSrc() == reg.getResult()) {
-    auto inv =
-        OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(), reg.getResult().getType());
+    auto inv = OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(),
+                                                     reg.getResult().getType());
     reg.getResult().replaceAllUsesWith(inv.getResult());
     toErase.push_back(reg);
     toErase.push_back(con);
@@ -90,8 +90,8 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
         reg.getResult().replaceAllUsesWith(con.getSrc());
         toErase.push_back(con);
       } else {
-        auto bounce =
-            OpBuilder(reg).create<WireOp>(reg.getLoc(), reg.getResult().getType());
+        auto bounce = OpBuilder(reg).create<WireOp>(reg.getLoc(),
+                                                    reg.getResult().getType());
         reg.replaceAllUsesWith(bounce);
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -96,7 +96,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
         auto builder = ImplicitLocOpBuilder::atBlockBegin(
             arg.getLoc(), module.getBodyBlock());
         auto wire = builder.create<WireOp>(arg.getType());
-        arg.replaceAllUsesWith(wire);
+        arg.replaceAllUsesWith(wire.getResult());
         outputPortConstants.push_back(std::nullopt);
       } else if (arg.hasOneUse()) {
         // If the port has a single use, check the port is only connected to
@@ -162,7 +162,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
           return false;
         });
 
-        result.replaceUsesWithIf(wire, [&](OpOperand &op) -> bool {
+        result.replaceUsesWithIf(wire.getResult(), [&](OpOperand &op) -> bool {
           // Connects can be deleted directly.
           if (onlyWritten && isa<FConnectLike>(op.getOwner())) {
             op.getOwner()->erase();

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -62,8 +62,8 @@ void SFCCompatPass::runOnOperation() {
                     })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
-          reg.getResult().getType(), reg.getClockVal(), reg.getName(), reg.getNameKind(),
-          reg.getAnnotations(), reg.getInnerSymAttr());
+          reg.getResult().getType(), reg.getClockVal(), reg.getName(),
+          reg.getNameKind(), reg.getAnnotations(), reg.getInnerSymAttr());
       reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -62,9 +62,9 @@ void SFCCompatPass::runOnOperation() {
                     })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
-          reg.getType(), reg.getClockVal(), reg.getName(), reg.getNameKind(),
+          reg.getResult().getType(), reg.getClockVal(), reg.getName(), reg.getNameKind(),
           reg.getAnnotations(), reg.getInnerSymAttr());
-      reg.replaceAllUsesWith(newReg.getResult());
+      reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -63,8 +63,8 @@ void SFCCompatPass::runOnOperation() {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
           reg.getResult().getType(), reg.getClockVal(), reg.getNameAttr(),
-          reg.getNameKindAttr(), reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
-          reg.getForceableAttr());
+          reg.getNameKindAttr(), reg.getAnnotationsAttr(),
+          reg.getInnerSymAttr(), reg.getForceableAttr());
       reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -62,8 +62,9 @@ void SFCCompatPass::runOnOperation() {
                     })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
       RegOp newReg = builder.create<RegOp>(
-          reg.getResult().getType(), reg.getClockVal(), reg.getName(),
-          reg.getNameKind(), reg.getAnnotations(), reg.getInnerSymAttr());
+          reg.getResult().getType(), reg.getClockVal(), reg.getNameAttr(),
+          reg.getNameKindAttr(), reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
+          reg.getForceableAttr());
       reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2035,7 +2035,7 @@ firrtl.module @MuxShorten(
 
 
 // CHECK-LABEL: firrtl.module @RegresetToReg
-firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>) {
+firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>, out %bar2_ref : !firrtl.rwprobe<uint<1>>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
@@ -2043,7 +2043,8 @@ firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<
   // CHECK: %bar1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %foo2, %dummy : !firrtl.uint<1>
   %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %bar2, %bar2_f = firrtl.regreset %clock, %one_asyncreset, %dummy forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
+  firrtl.ref.define %bar2_ref, %bar2_f : !firrtl.rwprobe<uint<1>>
 
   firrtl.strictconnect %bar2, %bar1 : !firrtl.uint<1> // Force a use to trigger a crash on a sink replacement
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1148,3 +1148,30 @@ firrtl.circuit "AnalogDifferentWidths" {
     firrtl.attach %a, %b : !firrtl.analog<1>, !firrtl.analog<2>
   }
 }
+
+// -----
+
+firrtl.circuit "ForceableWithoutRefResult" {
+  firrtl.module @ForceableWithoutRefResult() {
+    // expected-error @below {{op must have ref result iff marked forceable}}
+    %w = firrtl.wire forceable : !firrtl.uint<2>
+  }
+}
+
+// -----
+
+firrtl.circuit "RefResultButNotForceable" {
+  firrtl.module @RefResultButNotForceable() {
+    // expected-error @below {{op must have ref result iff marked forceable}}
+    %w, %w_f = firrtl.wire : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+  }
+}
+
+// -----
+
+firrtl.circuit "ForceableTypeMismatch" {
+  firrtl.module @ForceableTypeMismatch() {
+    // expected-error @below {{reference result of incorrect type, found}}
+    %w, %w_f = firrtl.wire forceable : !firrtl.uint, !firrtl.rwprobe<uint<2>>
+  }
+}

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -527,6 +527,28 @@ firrtl.circuit "ForwardRef" {
 
 // -----
 
+// Don't prop through a rwprobe ref.
+
+// CHECK-LABEL: "SendThroughRWProbe"
+firrtl.circuit "SendThroughRWProbe" {
+  // CHECK-LABEL: firrtl.module private @Bar
+  firrtl.module private @Bar(out %rw: !firrtl.rwprobe<uint<1>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK: firrtl.node
+    // CHECK-SAME: forceable
+    %n, %n_ref = firrtl.node %zero forceable : !firrtl.uint<1>
+    firrtl.ref.define %rw, %n_ref : !firrtl.rwprobe<uint<1>>
+  }
+  // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  firrtl.module @SendThroughRWProbe(out %a: !firrtl.uint<1>) {
+    %bar_rw = firrtl.instance bar @Bar(out rw: !firrtl.rwprobe<uint<1>>)
+    %0 = firrtl.ref.resolve %bar_rw : !firrtl.rwprobe<uint<1>>
+    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
 // Verbatim expressions should not be optimized away.
 firrtl.circuit "Verbatim"  {
   firrtl.module @Verbatim() {

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -631,6 +631,23 @@ firrtl.circuit "UnmovableNodeShouldDominate" {
 
 // -----
 
+// Same test as above, ensure works w/forceable node.
+firrtl.circuit "UnmovableForceableNodeShouldDominate" {
+  // CHECK-LABEL: firrtl.module @UnmovableForceableNodeShouldDominate
+  firrtl.module @UnmovableForceableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
+    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %localReset, %ref = firrtl.node sym @theReset %0 forceable {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // CHECK-NEXT: %localReset, %{{.+}} = firrtl.wire sym @theReset
+    // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT: firrtl.strictconnect %localReset, %0
+  }
+}
+
+// -----
+
 // Move of local async resets should work across blocks.
 firrtl.circuit "MoveAcrossBlocks1" {
   // CHECK-LABEL: firrtl.module @MoveAcrossBlocks1

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1106,6 +1106,59 @@ firrtl.module private @is1436_FOO() {
     // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>
   }
 
+  // CHECK-LABEL: firrtl.module private @RefTypeBV_RW
+  firrtl.module private @RefTypeBV_RW(
+    out %vec_ref: !firrtl.rwprobe<vector<uint<1>,2>>,
+    out %vec: !firrtl.vector<uint<1>,2>,
+    out %bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>,
+    out %bov: !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>,
+    out %probe: !firrtl.probe<uint<2>>
+  ) {
+    // Forceable declaration expanded into ground elements.
+    // CHECK-NEXT: %{{.+}}, %[[X_A_0_REF:.+]] = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
+    // CHECK-NEXT: %{{.+}}, %[[X_A_1_REF:.+]] = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
+    // CHECK-NEXT: %{{.+}}, %[[X_B_REF:.+]] = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    %x, %x_ref = firrtl.wire forceable : !firrtl.bundle<a: vector<uint<1>, 2>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+
+    // Define using forceable ref expanded.
+    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_A_0_REF]] : !firrtl.rwprobe<uint<1>>
+    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_A_1_REF]] : !firrtl.rwprobe<uint<1>>
+    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_B_REF]] : !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+
+    // Update ref.sub uses.
+    // CHECK-NEXT: %[[v_0:.+]] = firrtl.ref.resolve %[[X_A_0_REF]]
+    // CHECK-NEXT: %[[v_1:.+]] = firrtl.ref.resolve %[[X_A_1_REF]]
+    // CHECK-NEXT: firrtl.strictconnect %vec_0, %[[v_0]]
+    // CHECK-NEXT: firrtl.strictconnect %vec_1, %[[v_1]]
+    %x_ref_a = firrtl.ref.sub %x_ref[0] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.probe<vector<uint<1>,2>>
+    firrtl.strictconnect %vec, %x_a : !firrtl.vector<uint<1>,2>
+
+    // Check chained ref.sub's work.
+    // CHECK-NEXT: firrtl.ref.resolve %[[X_A_1_REF]]
+    %x_ref_a_1 = firrtl.ref.sub %x_ref_a[1] : !firrtl.probe<vector<uint<1>,2>>
+    %x_a_1 = firrtl.ref.resolve %x_ref_a_1 : !firrtl.probe<uint<1>>
+
+    // Ref to flipped field.
+    // CHECK-NEXT: firrtl.ref.resolve %[[X_B_REF]]
+    %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.probe<uint<2>>
+    // TODO: Handle rwprobe --> probe define, enable this.
+    // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>
+
+    // Check resolve is fully expanded.
+    // CHECK-NEXT: %[[READ_A_0:.+]] = firrtl.ref.resolve %[[X_A_0_REF]]
+    // CHECK-NEXT: %[[READ_A_1:.+]] = firrtl.ref.resolve %[[X_A_1_REF]]
+    // CHECK-NEXT: %[[READ_B:.+]] = firrtl.ref.resolve %[[X_B_REF]]
+    // CHECK-NEXT: firrtl.strictconnect %bov_a_0, %[[READ_A_0]]
+    // CHECK-NEXT: firrtl.strictconnect %bov_a_1, %[[READ_A_1]]
+    // CHECK-NEXT: firrtl.strictconnect %bov_b, %[[READ_B]]
+    %x_read = firrtl.ref.resolve %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    firrtl.strictconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>
+    // CHECK-NEXT: }
+  }
+
   // CHECK-LABEL: firrtl.module private @ForeignTypes
   firrtl.module private @ForeignTypes() {
     // CHECK-NEXT: firrtl.wire : index

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -split-input-file
+// RUN: circt-opt %s -split-input-file | circt-opt -split-input-file
 // RUN: firtool %s -split-input-file
 // These tests are just for demonstrating RefOps, and expected to not error.
 

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -209,7 +209,7 @@ firrtl.circuit "Forceable" {
     in %reset : !firrtl.uint<1>,
     in %value : !firrtl.uint<2>,
     out %node_ref : !firrtl.rwprobe<uint<2>>,
-    out %wire_ref : !firrtl.rwprobe<uint<2>>,
+    out %wire_ref : !firrtl.rwprobe<uint>,
     out %reg_ref : !firrtl.rwprobe<uint<2>>,
     out %regreset_ref : !firrtl.rwprobe<uint<2>>) {
 
@@ -217,9 +217,9 @@ firrtl.circuit "Forceable" {
     firrtl.ref.define %node_ref, %n_f : !firrtl.rwprobe<uint<2>>
 
     // TODO: infer ref result existence + type based on "forceable" or other ref-kind(s) indicator.
-    %w, %w_f = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    firrtl.ref.define %wire_ref, %w_f : !firrtl.rwprobe<uint<2>>
-    firrtl.strictconnect %w, %value : !firrtl.uint<2>
+    %w, %w_f = firrtl.wire forceable : !firrtl.uint, !firrtl.rwprobe<uint>
+    firrtl.ref.define %wire_ref, %w_f : !firrtl.rwprobe<uint>
+    firrtl.connect %w, %value : !firrtl.uint, !firrtl.uint<2>
 
     %reg, %reg_f = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     firrtl.ref.define %reg_ref, %reg_f : !firrtl.rwprobe<uint<2>>

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -200,3 +200,32 @@ firrtl.circuit "ProbeAndRWProbe" {
   }
 }
 
+// -----
+
+firrtl.circuit "Forceable" {
+  // Check forceable declarations
+  firrtl.module @Forceable(
+    in %clock : !firrtl.clock,
+    in %reset : !firrtl.uint<1>,
+    in %value : !firrtl.uint<2>,
+    out %node_ref : !firrtl.rwprobe<uint<2>>,
+    out %wire_ref : !firrtl.rwprobe<uint<2>>,
+    out %reg_ref : !firrtl.rwprobe<uint<2>>,
+    out %regreset_ref : !firrtl.rwprobe<uint<2>>) {
+
+    %n, %n_f = firrtl.node %value forceable : !firrtl.uint<2>
+    firrtl.ref.define %node_ref, %n_f : !firrtl.rwprobe<uint<2>>
+
+    // TODO: infer ref result existence + type based on "forceable" or other ref-kind(s) indicator.
+    %w, %w_f = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %wire_ref, %w_f : !firrtl.rwprobe<uint<2>>
+    firrtl.strictconnect %w, %value : !firrtl.uint<2>
+
+    %reg, %reg_f = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %reg_ref, %reg_f : !firrtl.rwprobe<uint<2>>
+
+    %regreset, %regreset_f = firrtl.regreset %clock, %reset, %value forceable : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %regreset_ref, %regreset_f : !firrtl.rwprobe<uint<2>>
+  }
+}
+

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -424,7 +424,7 @@ struct InstanceStubber : public Reduction {
                                         instOp.getPortNameStr(i));
       auto wire = builder.create<firrtl::WireOp>(
           result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{});
+          instOp.getPortAnnotation(i), StringAttr{}).getResult();
       invalidateOutputs(builder, wire, invalidCache,
                         instOp.getPortDirection(i) == firrtl::Direction::In);
       result.replaceAllUsesWith(wire);
@@ -472,7 +472,7 @@ struct MemoryStubber : public Reduction {
                                         memOp.getPortNameStr(i));
       auto wire = builder.create<firrtl::WireOp>(
           result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          memOp.getPortAnnotation(i), StringAttr{});
+          memOp.getPortAnnotation(i), StringAttr{}).getResult();
       invalidateOutputs(builder, wire, invalidCache, true);
       result.replaceAllUsesWith(wire);
 
@@ -759,7 +759,7 @@ struct ExtmoduleInstanceRemover : public Reduction {
     SmallVector<Value> replacementWires;
     for (firrtl::PortInfo info : portInfo) {
       auto wire = builder.create<firrtl::WireOp>(
-          info.type, (Twine(instOp.getName()) + "_" + info.getName()).str());
+          info.type, (Twine(instOp.getName()) + "_" + info.getName()).str()).getResult();
       if (info.isOutput()) {
         auto inv = builder.create<firrtl::InvalidValueOp>(info.type);
         builder.create<firrtl::ConnectOp>(wire, inv);
@@ -871,14 +871,14 @@ struct ConnectSourceOperandForwarder : public Reduction {
     Value newDest;
     if (auto wire = dyn_cast<firrtl::WireOp>(destOp))
       newDest = builder.create<firrtl::WireOp>(forwardedOperand.getType(),
-                                               wire.getName());
+                                               wire.getName()).getResult();
     else {
       auto regName = destOp->getAttrOfType<StringAttr>("name");
       // We can promote the register into a wire but we wouldn't do here because
       // the error might be caused by the register.
       auto clock = destOp->getOperand(0);
       newDest = builder.create<firrtl::RegOp>(forwardedOperand.getType(), clock,
-                                              regName ? regName.str() : "");
+                                              regName ? regName.str() : "").getResult();
     }
 
     // Create new connection between a new wire and the forwarded operand.
@@ -1001,7 +1001,7 @@ struct EagerInliner : public Reduction {
                                         instOp.getPortNameStr(i));
       auto wire = builder.create<firrtl::WireOp>(
           result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{});
+          instOp.getPortAnnotation(i), StringAttr{}).getResult();
       result.replaceAllUsesWith(wire);
       argReplacements.push_back(wire);
     }

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -422,9 +422,12 @@ struct InstanceStubber : public Reduction {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{}).getResult();
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      instOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       invalidateOutputs(builder, wire, invalidCache,
                         instOp.getPortDirection(i) == firrtl::Direction::In);
       result.replaceAllUsesWith(wire);
@@ -470,9 +473,12 @@ struct MemoryStubber : public Reduction {
       auto result = memOp.getResult(i);
       auto name = builder.getStringAttr(Twine(memOp.getName()) + "_" +
                                         memOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          memOp.getPortAnnotation(i), StringAttr{}).getResult();
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      memOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       invalidateOutputs(builder, wire, invalidCache, true);
       result.replaceAllUsesWith(wire);
 
@@ -758,8 +764,12 @@ struct ExtmoduleInstanceRemover : public Reduction {
     ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
     SmallVector<Value> replacementWires;
     for (firrtl::PortInfo info : portInfo) {
-      auto wire = builder.create<firrtl::WireOp>(
-          info.type, (Twine(instOp.getName()) + "_" + info.getName()).str()).getResult();
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(
+                  info.type,
+                  (Twine(instOp.getName()) + "_" + info.getName()).str())
+              .getResult();
       if (info.isOutput()) {
         auto inv = builder.create<firrtl::InvalidValueOp>(info.type);
         builder.create<firrtl::ConnectOp>(wire, inv);
@@ -870,15 +880,19 @@ struct ConnectSourceOperandForwarder : public Reduction {
     ImplicitLocOpBuilder builder(destOp->getLoc(), destOp);
     Value newDest;
     if (auto wire = dyn_cast<firrtl::WireOp>(destOp))
-      newDest = builder.create<firrtl::WireOp>(forwardedOperand.getType(),
-                                               wire.getName()).getResult();
+      newDest = builder
+                    .create<firrtl::WireOp>(forwardedOperand.getType(),
+                                            wire.getName())
+                    .getResult();
     else {
       auto regName = destOp->getAttrOfType<StringAttr>("name");
       // We can promote the register into a wire but we wouldn't do here because
       // the error might be caused by the register.
       auto clock = destOp->getOperand(0);
-      newDest = builder.create<firrtl::RegOp>(forwardedOperand.getType(), clock,
-                                              regName ? regName.str() : "").getResult();
+      newDest = builder
+                    .create<firrtl::RegOp>(forwardedOperand.getType(), clock,
+                                           regName ? regName.str() : "")
+                    .getResult();
     }
 
     // Create new connection between a new wire and the forwarded operand.
@@ -999,9 +1013,12 @@ struct EagerInliner : public Reduction {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{}).getResult();
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      instOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       result.replaceAllUsesWith(wire);
       argReplacements.push_back(wire);
     }


### PR DESCRIPTION
Add ability to get rwprobe references as optional result on supported FIRRTL declarations.
Declarations also track whether they're "forceable" for inspection in analyses/transforms/canonicalizers.

These are not yet produced outside manually crafted IR.