### PR TITLE
[HW] Update getters in HWOpInterfaces to prefixed style

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -31,7 +31,7 @@ class ReferableDeclOp<string mnemonic, list<Trait> traits = []> :
 
 def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firrtl::WhenOp">,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-    DeclareOpInterfaceMethods<HWInstanceLike, ["instanceName", "instanceNameAttr"]>]> {
+    DeclareOpInterfaceMethods<HWInstanceLike>]> {
   let summary = "Instantiate an instance of a module";
   let description = [{
     This represents an instance of a module.  The results are the modules inputs

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -173,14 +173,6 @@ def HWInstanceOp : FSMOp<"hw_instance", [
     FlatSymbolRefAttr getModuleNameAttr() {
       return getMachineAttr();
     }
-
-    // HWInstanceLike interface
-    StringRef getInstanceName() {
-      return getSymName();
-    }
-    StringAttr getInstanceNameAttr() {
-      return getSymNameAttr();
-    }
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -28,12 +28,12 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     }]>,
 
     InterfaceMethod<"Get the module name",
-    "::llvm::StringRef", "moduleName", (ins),
+    "::llvm::StringRef", "getModuleName", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getName(); }]>,
 
     InterfaceMethod<"Get the module name",
-    "::mlir::StringAttr", "moduleNameAttr", (ins),
+    "::mlir::StringAttr", "getModuleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
 
@@ -159,29 +159,23 @@ def HWInstanceLike : OpInterface<"HWInstanceLike"> {
 
   let methods = [
     InterfaceMethod<"Get the name of the instance",
-    "::llvm::StringRef", "instanceName", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getInstanceName(); }]>,
+    "::llvm::StringRef", "getInstanceName", (ins)>,
 
     InterfaceMethod<"Get the name of the instance",
-    "::mlir::StringAttr", "instanceNameAttr", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getInstanceNameAttr(); }]>,
+    "::mlir::StringAttr", "getInstanceNameAttr", (ins)>,
 
     InterfaceMethod<"Get the name of the instantiated module",
-    "::llvm::StringRef", "referencedModuleName", (ins),
+    "::llvm::StringRef", "getReferencedModuleName", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
 
     InterfaceMethod<"Get the name of the instantiated module",
-    "::mlir::StringAttr", "referencedModuleNameAttr", (ins),
+    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
 
     InterfaceMethod<"Get the referenced module",
-    "::mlir::Operation *", "getReferencedModule", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{}]>,
+    "::mlir::Operation *", "getReferencedModule", (ins)>,
   ];
 }
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -515,16 +515,6 @@ def InstanceOp : HWOp<"instance", [
     /// invalid IR.
     Operation *getReferencedModule(const HWSymbolCache *cache);
 
-    /// Get the instances's name.
-    StringAttr getName() {
-      return getInstanceNameAttr();
-    }
-
-    /// Set the instance's name.
-    void setName(StringAttr name) {
-      setInstanceNameAttr(name);
-    }
-
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/InstanceGraphBase.h
+++ b/include/circt/Dialect/HW/InstanceGraphBase.h
@@ -269,7 +269,8 @@ template <typename T>
 inline static T &formatInstancePath(T &into, const InstancePath &path) {
   into << "$root";
   for (auto inst : path)
-    into << "/" << inst.instanceName() << ":" << inst.referencedModuleName();
+    into << "/" << inst.getInstanceName() << ":"
+         << inst.getReferencedModuleName();
   return into;
 }
 
@@ -381,7 +382,7 @@ struct llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>
   static std::string getNodeLabel(circt::hw::InstanceGraphNode *node,
                                   circt::hw::InstanceGraphBase *) {
     // The name of the graph node is the module name.
-    return node->getModule().moduleName().str();
+    return node->getModule().getModuleName().str();
   }
 
   template <typename Iterator>
@@ -391,7 +392,7 @@ struct llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>
     // Set an edge label that is the name of the instance.
     auto *instanceRecord = *it.getCurrent();
     auto instanceOp = instanceRecord->getInstance();
-    return ("label=" + instanceOp.instanceName()).str();
+    return ("label=" + instanceOp.getInstanceName()).str();
   }
 };
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -33,14 +33,6 @@ def InstanceOp : MSFTOp<"instance", [
     // determined.
     StringAttr getResultName(size_t i);
 
-    /// Instance name is the same as the symbol name. This may change in the
-    /// future.
-    StringRef instanceName() {
-      return getSymName();
-    }
-    StringAttr instanceNameAttr() {
-      return getSymNameAttr();
-    }
     /// Check that the operands and results match the module specified.
     LogicalResult verifySignatureMatch(const circt::hw::ModulePortInfo&);
 

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -130,9 +130,6 @@ def InstanceDeclOp : SystemCOp<"instance.decl", [
       return getInstanceHandle().getType().cast<systemc::ModuleType>();
     }
 
-    StringRef getInstanceName() { return getName(); }
-    StringAttr getInstanceNameAttr() { return getNameAttr(); }
-
     /// Lookup the module for the symbol. This returns null on invalid IR.
     Operation *getReferencedModule(const hw::HWSymbolCache *cache);
 

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -198,7 +198,7 @@ void InferTopModulePass::runOnOperation() {
 
   llvm::SmallVector<Attribute, 4> attrs;
   for (auto *node : *res)
-    attrs.push_back(node->getModule().moduleNameAttr());
+    attrs.push_back(node->getModule().getModuleNameAttr());
 
   analysis.getParent()->setAttr("test.top",
                                 ArrayAttr::get(&getContext(), attrs));

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -89,7 +89,7 @@ LogicalResult Converter::runOnModule(HWModuleOp module) {
   if (module.getBodyBlock()->without_terminator().empty() &&
       isa<hw::OutputOp>(module.getBodyBlock()->getTerminator()))
     return success();
-  LLVM_DEBUG(llvm::dbgs() << "Analyzing " << module.moduleNameAttr() << " ("
+  LLVM_DEBUG(llvm::dbgs() << "Analyzing " << module.getModuleNameAttr() << " ("
                           << arcBreakers.size() << " breakers)\n");
 
   // For each operation, figure out the set of breaker ops it contributes to,
@@ -236,7 +236,7 @@ void Converter::extractArcs(HWModuleOp module) {
     auto defOp = builder.create<DefineOp>(
         lastOp->getLoc(),
         builder.getStringAttr(
-            globalNamespace.newName(module.moduleName() + "_arc")),
+            globalNamespace.newName(module.getModuleName() + "_arc")),
         builder.getFunctionType(inputTypes, outputTypes));
     defOp.getBody().push_back(block.release());
 
@@ -357,7 +357,7 @@ void Converter::absorbRegs(HWModuleOp module) {
     auto defOp =
         builder.create<DefineOp>(loc,
                                  builder.getStringAttr(globalNamespace.newName(
-                                     module.moduleName() + "_arc")),
+                                     module.getModuleName() + "_arc")),
                                  builder.getFunctionType(types, types));
     defOp.getBody().push_back(block.release());
 

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -66,7 +66,7 @@ static void spillWiresForInstanceInputs(InstanceOp op) {
   Block *block = op->getParentOfType<HWModuleOp>().getBodyBlock();
   auto builder = ImplicitLocOpBuilder::atBlockBegin(op.getLoc(), block);
 
-  SmallString<32> nameTmp{"_", op.instanceName(), "_"};
+  SmallString<32> nameTmp{"_", op.getInstanceName(), "_"};
   auto namePrefixSize = nameTmp.size();
 
   size_t nextOpNo = 0;
@@ -97,7 +97,7 @@ static void lowerInstanceResults(InstanceOp op) {
   Block *block = op->getParentOfType<HWModuleOp>().getBodyBlock();
   auto builder = ImplicitLocOpBuilder::atBlockBegin(op.getLoc(), block);
 
-  SmallString<32> nameTmp{"_", op.instanceName(), "_"};
+  SmallString<32> nameTmp{"_", op.getInstanceName(), "_"};
   auto namePrefixSize = nameTmp.size();
 
   size_t nextResultNo = 0;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1144,8 +1144,8 @@ FIRRTLModuleLowering::lowerMemModule(FMemModuleOp oldModule,
   // Build the new hw.module op.
   auto builder = OpBuilder::atBlockEnd(topLevelModule);
   auto newModule = builder.create<hw::HWModuleExternOp>(
-      oldModule.getLoc(), oldModule.moduleNameAttr(), ports,
-      oldModule.moduleNameAttr());
+      oldModule.getLoc(), oldModule.getModuleNameAttr(), ports,
+      oldModule.getModuleNameAttr());
   loweringState.processRemainingAnnotations(oldModule,
                                             AnnotationSet(oldModule));
   return newModule;

--- a/lib/Conversion/HWToLLHD/HWToLLHD.cpp
+++ b/lib/Conversion/HWToLLHD/HWToLLHD.cpp
@@ -179,7 +179,7 @@ struct ConvertInstance : public OpConversionPattern<InstanceOp> {
         });
 
       auto init = rewriter.create<ConstantOp>(arg.getLoc(), argType, 0);
-      SmallString<8> sigName(instance.instanceName());
+      SmallString<8> sigName(instance.getInstanceName());
       sigName += "_arg_";
       sigName += std::to_string(argIdx++);
       auto sig = rewriter.createOrFold<SigOp>(
@@ -230,7 +230,7 @@ struct ConvertInstance : public OpConversionPattern<InstanceOp> {
       // See github.com/llvm/circt/pull/988 for a discussion.
       if (!sig) {
         auto init = rewriter.create<ConstantOp>(loc, resultType, 0);
-        SmallString<8> sigName(instance.instanceName());
+        SmallString<8> sigName(instance.getInstanceName());
         sigName += "_result_";
         sigName += std::to_string(result.getResultNumber());
         sig = rewriter.createOrFold<SigOp>(loc, SigType::get(resultType),
@@ -255,7 +255,7 @@ struct ConvertInstance : public OpConversionPattern<InstanceOp> {
     // Create the LLHD instance from the operands and results. Then mark the
     // original instance for replacement with the new values probed from the
     // signals attached to the LLHD instance.
-    rewriter.create<InstOp>(instance.getLoc(), instance.instanceName(),
+    rewriter.create<InstOp>(instance.getLoc(), instance.getInstanceName(),
                             instance.getModuleName(), arguments, resultSigs);
     rewriter.replaceOp(instance, resultValues);
 

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -1841,7 +1841,7 @@ public:
           SymbolTable::lookupSymbolIn(parentOp, predecl.getValue());
       if (predeclModule) {
         if (failed(SymbolTable::replaceAllSymbolUses(
-                predeclModule, hwModule.moduleNameAttr(), parentOp)))
+                predeclModule, hwModule.getModuleNameAttr(), parentOp)))
           return failure();
         rewriter.eraseOp(predeclModule);
       }

--- a/lib/Dialect/Arc/Transforms/InferMemories.cpp
+++ b/lib/Dialect/Arc/Transforms/InferMemories.cpp
@@ -45,7 +45,7 @@ void InferMemoriesPass::runOnOperation() {
   for (auto genOp : module.getOps<hw::HWModuleGeneratedOp>()) {
     if (!schemaNames.contains(genOp.getGeneratorKindAttr().getAttr()))
       continue;
-    memoryParams[genOp.moduleNameAttr()] = genOp->getAttrDictionary();
+    memoryParams[genOp.getModuleNameAttr()] = genOp->getAttrDictionary();
     opsToDelete.push_back(genOp);
   }
   LLVM_DEBUG(llvm::dbgs() << "Found " << memoryParams.size()
@@ -79,7 +79,7 @@ void InferMemoriesPass::runOnOperation() {
     auto wordType = builder.getIntegerType(width);
     auto memType = MemoryType::get(&getContext(), depth, wordType, {});
     auto memOp = builder.create<MemoryOp>(memType);
-    if (!instOp.instanceName().empty())
+    if (!instOp.getInstanceName().empty())
       memOp->setAttr("name", instOp.getInstanceNameAttr());
 
     unsigned argIdx = 0;

--- a/lib/Dialect/Arc/Transforms/InlineModules.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineModules.cpp
@@ -112,13 +112,13 @@ void InlineModulesPass::runOnOperation() {
 
         bool isLastModuleUse = --numUsesLeft == 0;
 
-        PrefixingInliner inliner(&getContext(), inst.instanceName());
+        PrefixingInliner inliner(&getContext(), inst.getInstanceName());
         if (failed(mlir::inlineRegion(inliner, &module.getBody(), inst,
                                       inst.getOperands(), inst.getResults(),
                                       std::nullopt, !isLastModuleUse))) {
           inst.emitError("failed to inline '")
-              << module.moduleName() << "' into instance '"
-              << inst.instanceName() << "'";
+              << module.getModuleName() << "' into instance '"
+              << inst.getInstanceName() << "'";
           return signalPassFailure();
         }
 

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -593,7 +593,7 @@ void LowerStatePass::runOnOperation() {
 }
 
 LogicalResult LowerStatePass::runOnModule(HWModuleOp moduleOp) {
-  LLVM_DEBUG(llvm::dbgs() << "Lowering state in `" << moduleOp.moduleName()
+  LLVM_DEBUG(llvm::dbgs() << "Lowering state in `" << moduleOp.getModuleName()
                           << "`\n");
   ModuleLowering lowering(moduleOp, stats);
   lowering.addStorageArg();
@@ -630,7 +630,7 @@ LogicalResult LowerStatePass::runOnModule(HWModuleOp moduleOp) {
   moduleOp.getBodyBlock()->getTerminator()->erase();
   ImplicitLocOpBuilder builder(moduleOp.getLoc(), moduleOp);
   auto modelOp =
-      builder.create<ModelOp>(moduleOp.getLoc(), moduleOp.moduleNameAttr());
+      builder.create<ModelOp>(moduleOp.getLoc(), moduleOp.getModuleNameAttr());
   modelOp.getBody().takeBody(moduleOp.getBody());
   moduleOp->erase();
   return success();

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -47,7 +47,7 @@ void StripSVPass::runOnOperation() {
       if (extModOp.getArgNames() != expectedClockGateInputs ||
           extModOp.getResultNames() != expectedClockGateOutputs) {
         extModOp.emitError("clock gate module `")
-            << extModOp.moduleName() << "` has incompatible port names "
+            << extModOp.getModuleName() << "` has incompatible port names "
             << extModOp.getArgNamesAttr() << " -> "
             << extModOp.getResultNamesAttr();
         return signalPassFailure();
@@ -56,14 +56,14 @@ void StripSVPass::runOnOperation() {
               ArrayRef<Type>{i1Type, i1Type, i1Type} ||
           extModOp.getResultTypes() != ArrayRef<Type>{i1Type}) {
         extModOp.emitError("clock gate module `")
-            << extModOp.moduleName() << "` has incompatible port types "
+            << extModOp.getModuleName() << "` has incompatible port types "
             << extModOp.getArgumentTypes() << " -> "
             << extModOp.getResultTypes();
         return signalPassFailure();
       }
-      clockGateModuleNames.insert(extModOp.moduleNameAttr());
+      clockGateModuleNames.insert(extModOp.getModuleNameAttr());
     } else {
-      externModuleNames.insert(extModOp.moduleNameAttr());
+      externModuleNames.insert(extModOp.getModuleNameAttr());
     }
     opsToDelete.push_back(extModOp);
   }

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -1237,7 +1237,7 @@ static StringRef getOperandName(Value operand) {
   } else {
     auto srcOp = operand.getDefiningOp();
     if (auto instOp = dyn_cast<InstanceOp>(srcOp))
-      return instOp.instanceName();
+      return instOp.getInstanceName();
 
     if (auto srcName = srcOp->getAttrOfType<StringAttr>("name"))
       return srcName.getValue();
@@ -1256,8 +1256,8 @@ static std::string &constructInstanceName(Value operand, InterfaceOp iface,
   if (operand.hasOneUse()) {
     Operation *dstOp = *operand.getUsers().begin();
     if (auto instOp = dyn_cast<InstanceOp>(dstOp))
-      s << "To" << llvm::toUpper(instOp.instanceName()[0])
-        << instOp.instanceName().substr(1);
+      s << "To" << llvm::toUpper(instOp.getInstanceName()[0])
+        << instOp.getInstanceName().substr(1);
     else if (auto dstName = dstOp->getAttrOfType<StringAttr>("name"))
       s << "To" << dstName.getValue();
   }
@@ -2063,7 +2063,7 @@ void ESIEmitCollateralPass::emitServiceJSON() {
         hw::HWModuleLike hwmod = nameMdPair.first;
         auto &mdOps = nameMdPair.second;
         j.object([&] {
-          j.attribute("symbol", hwmod.moduleName());
+          j.attribute("symbol", hwmod.getModuleName());
           j.attributeArray("services", [&] {
             for (ServiceHierarchyMetadataOp metadata : mdOps) {
               j.object([&] {

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -413,10 +413,10 @@ void ESIConnectServicesPass::copyMetadata(hw::HWModuleLike mod) {
 
   for (auto inst : moduleInstantiations[mod]) {
     OpBuilder b(inst);
-    auto instName = b.getStringAttr(inst.instanceName());
+    auto instName = inst.getInstanceNameAttr();
     for (auto metadata : metadataOps) {
       SmallVector<Attribute, 4> path;
-      path.push_back(hw::InnerRefAttr::get(mod.moduleNameAttr(), instName));
+      path.push_back(hw::InnerRefAttr::get(mod.getModuleNameAttr(), instName));
       for (auto attr : metadata.getServerNamePathAttr())
         path.push_back(attr);
 
@@ -627,7 +627,7 @@ LogicalResult ESIConnectServicesPass::surfaceReqs(
     for (auto [toClient, newPort] : llvm::zip(toClientReqs, newInputs)) {
       auto instToClient = cast<RequestToClientConnectionOp>(b.clone(*toClient));
       instToClient.setClientNamePathAttr(prependNamePart(
-          instToClient.getClientNamePath(), inst.instanceName()));
+          instToClient.getClientNamePath(), inst.getInstanceName()));
       newOperands.push_back(instToClient.getToClient());
     }
 
@@ -662,7 +662,7 @@ LogicalResult ESIConnectServicesPass::surfaceReqs(
     for (auto [toServer, newPort] : llvm::zip(toServerReqs, newOutputs)) {
       auto instToServer = cast<RequestToServerConnectionOp>(b.clone(*toServer));
       instToServer.setClientNamePathAttr(prependNamePart(
-          instToServer.getClientNamePath(), inst.instanceName()));
+          instToServer.getClientNamePath(), inst.getInstanceName()));
       instToServer->setOperand(0, newHWInst->getResult(outputCounter++));
     }
   }

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -701,7 +701,7 @@ LogicalResult circt::firrtl::extractDUT(const FModuleOp mod, FModuleOp &dut) {
   if (dut) {
     auto diag = emitError(mod->getLoc())
                 << "is marked with a '" << dutAnnoClass << "', but '"
-                << dut.moduleName()
+                << dut.getModuleName()
                 << "' also had such an annotation (this should "
                    "be impossible!)";
     diag.attachNote(dut.getLoc()) << "the first DUT was found here";

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1609,9 +1609,9 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-StringRef InstanceOp::instanceName() { return getName(); }
+StringRef InstanceOp::getInstanceName() { return getName(); }
 
-StringAttr InstanceOp::instanceNameAttr() { return getNameAttr(); }
+StringAttr InstanceOp::getInstanceNameAttr() { return getNameAttr(); }
 
 void InstanceOp::print(OpAsmPrinter &p) {
   // Print the instance name.

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -305,7 +305,7 @@ void AddSeqMemPortsPass::createOutputFile(hw::HWModuleLike module) {
 
   // The current sram we are processing.
   unsigned sramIndex = 0;
-  auto dutSymbol = FlatSymbolRefAttr::get(module.moduleNameAttr());
+  auto dutSymbol = FlatSymbolRefAttr::get(module.getModuleNameAttr());
   auto &instancePaths = memInfoMap[module].instancePaths;
   for (auto instancePath : instancePaths) {
     os << sramIndex++ << " -> ";

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -157,7 +157,7 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
             auto parentModule = inst->getParentOfType<FModuleOp>();
             if (dutMod == parentModule)
               hierName = parentModule.getName().str();
-            hierName = (Twine(hierName) + "." + inst.instanceName()).str();
+            hierName = (Twine(hierName) + "." + inst.getInstanceName()).str();
           }
           hierNames.push_back(hierName);
           // Only include the memory path if it is under the DUT or we are in a

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -745,7 +745,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   };
   // Add the path up to where the NLA starts.
   for (auto inst : paths[0])
-    addToPath(inst, inst.instanceNameAttr());
+    addToPath(inst, inst.getInstanceNameAttr());
   // Add the path from the NLA to the op.
   if (tracker.nla) {
     auto path = tracker.nla.getNamepath().getValue();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1657,7 +1657,7 @@ void GrandCentralPass::runOnOperation() {
       llvm::dbgs() << "  <none>\n";
     llvm::dbgs() << "DUT: ";
     if (dut)
-      llvm::dbgs() << dut.moduleName() << "\n";
+      llvm::dbgs() << dut.getModuleName() << "\n";
     else
       llvm::dbgs() << "<none>\n";
     llvm::dbgs()
@@ -1922,10 +1922,11 @@ void GrandCentralPass::runOnOperation() {
                   instancePaths->instanceGraph.lookup(op);
 
               LLVM_DEBUG({
-                llvm::dbgs() << "Found companion module: "
-                             << companionNode->getModule().moduleName() << "\n"
-                             << "  submodules exclusively instantiated "
-                                "(including companion):\n";
+                llvm::dbgs()
+                    << "Found companion module: "
+                    << companionNode->getModule().getModuleName() << "\n"
+                    << "  submodules exclusively instantiated "
+                       "(including companion):\n";
               });
 
               for (auto &node : llvm::depth_first(companionNode)) {

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -413,7 +413,7 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
     return;
 
   InstanceGraphNode *instanceGraphNode =
-      instanceGraph->lookup(module.moduleNameAttr());
+      instanceGraph->lookup(module.getModuleNameAttr());
   LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
                           << "\n");
 
@@ -622,7 +622,7 @@ void IMDeadCodeElimPass::eraseEmptyModule(FModuleOp module) {
   LLVM_DEBUG(llvm::dbgs() << "Erase " << module.getName() << "\n");
 
   InstanceGraphNode *instanceGraphNode =
-      instanceGraph->lookup(module.moduleNameAttr());
+      instanceGraph->lookup(module.getModuleNameAttr());
 
   SmallVector<Location> instancesWithSymbols;
   for (auto *use : llvm::make_early_inc_range(instanceGraphNode->uses())) {

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -50,7 +50,7 @@ static void addHierarchy(hw::HierPathOp path, FModuleOp dut,
   newNamepath.reserve(namepath.size() + 1);
   while (path.modPart(nlaIdx) != dut.getNameAttr())
     newNamepath.push_back(namepath[nlaIdx++]);
-  newNamepath.push_back(hw::InnerRefAttr::get(dut.moduleNameAttr(),
+  newNamepath.push_back(hw::InnerRefAttr::get(dut.getModuleNameAttr(),
                                               getInnerSymName(wrapperInst)));
 
   // Add the extra level of hierarchy.
@@ -132,7 +132,7 @@ void InjectDUTHierarchy::runOnOperation() {
     if (dut) {
       auto diag = emitError(mod.getLoc())
                   << "is marked with a '" << dutAnnoClass << "', but '"
-                  << dut.moduleName()
+                  << dut.getModuleName()
                   << "' also had such an annotation (this should "
                      "be impossible!)";
       diag.attachNote(dut.getLoc()) << "the first DUT was found here";
@@ -191,9 +191,9 @@ void InjectDUTHierarchy::runOnOperation() {
   b.setInsertionPointToStart(dut.getBodyBlock());
   ModuleNamespace dutNS(dut);
   auto wrapperInst = b.create<InstanceOp>(
-      b.getUnknownLoc(), wrapper, wrapper.moduleName(),
+      b.getUnknownLoc(), wrapper, wrapper.getModuleName(),
       NameKindEnum::DroppableName, ArrayRef<Attribute>{}, ArrayRef<Attribute>{},
-      false, b.getStringAttr(dutNS.newName(wrapper.moduleName())));
+      false, b.getStringAttr(dutNS.newName(wrapper.getModuleName())));
   for (const auto &pair : llvm::enumerate(wrapperInst.getResults())) {
     Value lhs = dut.getArgument(pair.index());
     Value rhs = pair.value();

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -837,15 +837,15 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     }
 
     LLVM_DEBUG({
-      llvm::dbgs() << "    LCA: " << lca.moduleName() << "\n"
+      llvm::dbgs() << "    LCA: " << lca.getModuleName() << "\n"
                    << "    sourcePaths:\n";
       for (auto inst : sourcePaths[0])
-        llvm::dbgs() << "      - " << inst.instanceName() << " of "
-                     << inst.referencedModuleName() << "\n";
+        llvm::dbgs() << "      - " << inst.getInstanceName() << " of "
+                     << inst.getReferencedModuleName() << "\n";
       llvm::dbgs() << "    sinkPaths:\n";
       for (auto inst : sinkPaths[0])
-        llvm::dbgs() << "      - " << inst.instanceName() << " of "
-                     << inst.referencedModuleName() << "\n";
+        llvm::dbgs() << "      - " << inst.getInstanceName() << " of "
+                     << inst.getReferencedModuleName() << "\n";
     });
 
     // Pre-populate the connectionMap of the module with the source and sink.
@@ -923,7 +923,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
         }
         moduleModifications[mod].portsToAdd.push_back(
             {index, {StringAttr::get(context, name), tpe, dir}});
-        instName = inst.instanceName();
+        instName = inst.getInstanceName();
       }
     };
 
@@ -943,7 +943,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
 
     auto modifications = moduleModifications[fmodule];
     LLVM_DEBUG({
-      llvm::dbgs() << "  - module: " << fmodule.moduleName() << "\n";
+      llvm::dbgs() << "  - module: " << fmodule.getModuleName() << "\n";
       llvm::dbgs() << "    ports:\n";
       for (auto [index, port] : modifications.portsToAdd) {
         llvm::dbgs() << "      - name: " << port.getName() << "\n"

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -233,7 +233,7 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   b.setInsertionPointToStart(wrapper.getBodyBlock());
 
   auto memInst =
-      b.create<InstanceOp>(mem->getLoc(), memModule, memModule.moduleName(),
+      b.create<InstanceOp>(mem->getLoc(), memModule, memModule.getModuleName(),
                            mem.getNameKind(), mem.getAnnotations().getValue());
 
   // Wire all the ports together.
@@ -253,8 +253,8 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   // module op, so we have to fix up the NLA to have the module as the leaf
   // element.
 
-  auto leafSym = memModule.moduleNameAttr();
-  auto leafAttr = FlatSymbolRefAttr::get(wrapper.moduleNameAttr());
+  auto leafSym = memModule.getModuleNameAttr();
+  auto leafAttr = FlatSymbolRefAttr::get(wrapper.getModuleNameAttr());
 
   // NLAs that we have already processed.
   llvm::SmallDenseMap<StringAttr, StringAttr> processedNLAs;

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -204,7 +204,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       if (!module)
         continue;
       LLVM_DEBUG(llvm::dbgs()
-                 << "Traversing module:" << module.moduleNameAttr() << "\n");
+                 << "Traversing module:" << module.getModuleNameAttr() << "\n");
       for (Operation &op : module.getBodyBlock()->getOperations())
         if (transferFunc(op).failed())
           return signalPassFailure();

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -206,7 +206,7 @@ void WireDFTPass::runOnOperation() {
       instanceGraph.lookup(dut), [&](InstanceRecord *node) {
         auto module = node->getTarget()->getModule();
         // If this is a clock gate, record the module and return true.
-        if (module.moduleName().startswith("EICG_wrapper")) {
+        if (module.getModuleName().startswith("EICG_wrapper")) {
           clockGates.insert(node);
           return true;
         }

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -240,6 +240,11 @@ LogicalResult TriggerOp::verify() { return verifyCallerTypes(*this); }
 // HWInstanceOp
 //===----------------------------------------------------------------------===//
 
+// HWInstanceLike interface
+StringRef HWInstanceOp::getInstanceName() { return getSymName(); }
+
+StringAttr HWInstanceOp::getInstanceNameAttr() { return getSymNameAttr(); }
+
 Operation *HWInstanceOp::getReferencedModule() { return getMachineOp(); }
 
 /// Lookup the machine for the symbol.  This returns null on invalid IR.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1618,7 +1618,7 @@ void InstanceOp::setResultName(size_t i, StringAttr name) {
 /// Suggest a name for each result value based on the saved result names
 /// attribute.
 void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  instance_like_impl::getAsmResultNames(setNameFn, instanceName(),
+  instance_like_impl::getAsmResultNames(setNameFn, getInstanceName(),
                                         getResultNames(), getResults());
 }
 
@@ -3069,7 +3069,7 @@ LogicalResult HierPathOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
       return emitOpError() << " module: " << innerRef.getModule()
                            << " does not contain any instance with symbol: "
                            << innerRef.getName();
-    expectedModuleName = instOp.referencedModuleNameAttr();
+    expectedModuleName = instOp.getReferencedModuleNameAttr();
   }
   // The instance path has been verified. Now verify the last element.
   auto leafRef = getNamepath()[getNamepath().size() - 1];

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -382,6 +382,11 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
+/// Instance name is the same as the symbol name. This may change in the
+/// future.
+StringRef InstanceOp::getInstanceName() { return getSymName(); }
+StringAttr InstanceOp::getInstanceNameAttr() { return getSymNameAttr(); }
+
 /// Lookup the module or extmodule for the symbol.  This returns null on
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
@@ -401,7 +406,7 @@ StringAttr InstanceOp::getResultName(size_t idx) {
 /// attribute.
 void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // Provide default names for instance results.
-  std::string name = instanceName().str() + ".";
+  std::string name = getInstanceName().str() + ".";
   size_t baseNameLen = name.size();
 
   for (size_t i = 0, e = getNumResults(); i != e; ++i) {

--- a/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
@@ -95,14 +95,14 @@ InstanceOpLowering::matchAndRewrite(InstanceOp msftInst, OpAdaptor adaptor,
       // mod is the top level.
       std::string instHier;
       llvm::raw_string_ostream(instHier)
-          << mod.moduleName() << "." << msftInst.instanceName();
+          << mod.getModuleName() << "." << msftInst.getInstanceName();
       paramValues = rewriter.getArrayAttr({hw::ParamDeclAttr::get(
           "__INST_HIER", rewriter.getStringAttr(instHier))});
     }
   }
 
   auto hwInst = rewriter.create<hw::InstanceOp>(
-      msftInst.getLoc(), referencedModule, msftInst.instanceNameAttr(),
+      msftInst.getLoc(), referencedModule, msftInst.getInstanceNameAttr(),
       SmallVector<Value>(adaptor.getOperands().begin(),
                          adaptor.getOperands().end()),
       paramValues, msftInst.getSymNameAttr());

--- a/lib/Dialect/MSFT/Transforms/PassCommon.cpp
+++ b/lib/Dialect/MSFT/Transforms/PassCommon.cpp
@@ -100,7 +100,7 @@ void PassCommon::getAndSortModulesVisitor(
 
   mod.walk([&](hw::HWInstanceLike inst) {
     Operation *modOp =
-        topLevelSyms.getDefinition(inst.referencedModuleNameAttr());
+        topLevelSyms.getDefinition(inst.getReferencedModuleNameAttr());
     assert(modOp);
     moduleInstantiations[modOp].push_back(inst);
     if (auto modLike = dyn_cast<hw::HWModuleLike>(modOp))

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -45,7 +45,7 @@ static void printHierarchy(hw::InstanceOp &inst, SymbolTable &symbolTable,
   auto moduleOp = symbolTable.lookup(inst.getModuleNameAttr().getValue());
 
   j.object([&] {
-    j.attribute("instance_name", inst.instanceName());
+    j.attribute("instance_name", inst.getInstanceName());
     j.attribute("module_name", hw::getVerilogModuleName(moduleOp));
     j.attributeArray("instances", [&] {
       // Only recurse on module ops, not extern or generated ops, whose internal

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -525,7 +525,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
           boundModule, boundModule.getName(), ArrayRef<Value>());
       boundInstance->setAttr("inner_sym",
                              b.getStringAttr(moduleNamespace.newName(
-                                 boundInstance.getName().getValue())));
+                                 boundInstance.getInstanceName())));
       boundInstance->setAttr("doNotPrint", b.getBoolAttr(true));
 
       // Bind the new module.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -536,7 +536,7 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
             sv::BindOp bind = it->second;
             auto oldInnerRef = bind.getInstanceAttr();
             auto newInnerRef = hw::InnerRefAttr::get(
-                instParent.moduleNameAttr(), oldInnerRef.getName());
+                instParent.getModuleNameAttr(), oldInnerRef.getName());
             bind.setInstanceAttr(newInnerRef);
           }
         }

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -448,6 +448,9 @@ void InstanceDeclOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getInstanceHandle(), getName());
 }
 
+StringRef InstanceDeclOp::getInstanceName() { return getName(); }
+StringAttr InstanceDeclOp::getInstanceNameAttr() { return getNameAttr(); }
+
 Operation *InstanceDeclOp::getReferencedModule(const hw::HWSymbolCache *cache) {
   if (cache)
     if (auto *result = cache->getDefinition(getModuleNameAttr()))

--- a/unittests/Dialect/HW/InstanceGraphTest.cpp
+++ b/unittests/Dialect/HW/InstanceGraphTest.cpp
@@ -64,13 +64,13 @@ TEST(InstanceGraphTest, PostOrderTraversal) {
   auto range = llvm::post_order(&graph);
 
   auto it = range.begin();
-  ASSERT_EQ("Cat", it->getModule().moduleName());
+  ASSERT_EQ("Cat", it->getModule().getModuleName());
   ++it;
-  ASSERT_EQ("Bear", it->getModule().moduleName());
+  ASSERT_EQ("Bear", it->getModule().getModuleName());
   ++it;
-  ASSERT_EQ("Alligator", it->getModule().moduleName());
+  ASSERT_EQ("Alligator", it->getModule().getModuleName());
   ++it;
-  ASSERT_EQ("Top", it->getModule().moduleName());
+  ASSERT_EQ("Top", it->getModule().getModuleName());
   ++it;
   ASSERT_EQ(graph.getTopLevelNode(), *it);
   ++it;


### PR DESCRIPTION
Shall we update the getter functions in the `HWOpInterfaces` to be consistent with the prefixed getter style?