### PR TITLE
[HW][IST] Drop debug printing from InnerSymbolTable.

### DIFF
--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -15,8 +15,6 @@
 #include "mlir/IR/Threading.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "ist"
-
 using namespace circt;
 using namespace hw;
 
@@ -63,12 +61,7 @@ FailureOr<InnerSymbolTable> InnerSymbolTable::get(Operation *op) {
 
 LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
                                             InnerSymCallbackFn callback) {
-  using llvm::dbgs;
-  LLVM_DEBUG(dbgs() << "===----- InnerSymbolTable -----===\n";
-             dbgs() << "Walking inner symbols for @"
-                    << SymbolTable::getSymbolName(op) << "\n");
   auto walkSym = [&](StringAttr name, const InnerSymTarget &target) {
-    LLVM_DEBUG(dbgs() << " - @" << name << " -> " << target << "\n");
     assert(name && !name.getValue().empty());
     return callback(name, target);
   };


### PR DESCRIPTION
A line is printed for every encountered symbol + its target, often from IST's constructed in parallel producing a lot of essentially unreadable debug information that rarely is useful.

Given IST's use in verification, this also means `-debug` quickly becomes very noisy (between passes or when printing IR).

Drop for now, can add a dump() and/or PrintISTPass in the future.