### PR TITLE
[ModuleInliner] Retop with correct recursive parent

### DIFF
--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1158,7 +1158,7 @@ firrtl.circuit "DidNotContainSymbol" {
   firrtl.module @DidNotContainSymbol() {
     firrtl.instance bar2 sym @w @Bar2()
   }
-	// CHECK-LABEL: firrtl.module @DidNotContainSymbol() {
+  // CHECK-LABEL: firrtl.module @DidNotContainSymbol() {
   // CHECK-NEXT:     %bar2_no_bar3_w = firrtl.wire sym @w_0 {annotations = [{class = "test0"}]} : !firrtl.uint<8>
   // CHECK-NEXT:  }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1142,7 +1142,7 @@ firrtl.circuit "Bug4882Rename"  {
 
 // -----
 
-// Issue #4920 fixes a bug, the recursive inlining should consider the correct retop for NLAs.
+// Issue #4920, the recursive inlining should consider the correct retop for NLAs.
 
 firrtl.circuit "DidNotContainSymbol" {
   hw.hierpath private @path [@Bar1::@w, @Bar3]
@@ -1161,4 +1161,32 @@ firrtl.circuit "DidNotContainSymbol" {
   // CHECK-LABEL: firrtl.module @DidNotContainSymbol() {
   // CHECK-NEXT:     %bar2_no_bar3_w = firrtl.wire sym @w_0 {annotations = [{class = "test0"}]} : !firrtl.uint<8>
   // CHECK-NEXT:  }
+}
+
+// -----
+
+// Issue #4915, the NLAs should be updated with renamed extern module instance.
+
+firrtl.circuit "SimTop" {
+  hw.hierpath private @nla_61 [@Rob::@difftest_3, @DifftestLoadEvent]
+  // CHECK: hw.hierpath private @nla_61 [@SimTop::@difftest_3_0, @DifftestLoadEvent]
+  hw.hierpath private @nla_60 [@Rob::@difftest_2, @DifftestLoadEvent]
+  // CHECK: hw.hierpath private @nla_60 [@SimTop::@difftest_2, @DifftestLoadEvent]
+  firrtl.extmodule private @DifftestIntWriteback()
+  firrtl.extmodule private @DifftestLoadEvent() attributes {annotations = [{circt.nonlocal = @nla_60, class = "B"}, {circt.nonlocal = @nla_61, class = "B"}]}
+	// CHECK: firrtl.extmodule private @DifftestLoadEvent() attributes {annotations = [{circt.nonlocal = @nla_60, class = "B"}, {circt.nonlocal = @nla_61, class = "B"}]}
+  firrtl.module private @Rob() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance difftest_2 sym @difftest_2 @DifftestLoadEvent()
+    firrtl.instance difftest_3 sym @difftest_3 @DifftestLoadEvent()
+  }
+  firrtl.module private @CtrlBlock() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance rob @Rob()
+  }
+  firrtl.module @SimTop() {
+    firrtl.instance difftest_3 sym @difftest_3 @DifftestIntWriteback()
+    firrtl.instance ctrlBlock @CtrlBlock()
+    // CHECK:  firrtl.instance difftest_3 sym @difftest_3 @DifftestIntWriteback()
+    // CHECK:  firrtl.instance ctrlBlock_rob_difftest_2 sym @difftest_2 @DifftestLoadEvent()
+    // CHECK:  firrtl.instance ctrlBlock_rob_difftest_3 sym @difftest_3_0 @DifftestLoadEvent()
+  }
 }


### PR DESCRIPTION
This fixes a bug with updating the NLA, when modules are recursively inlined to a single parent.
The NLA was being  updated with respect to a temporary and stale parent, the `retop` must be
called with the original parent.
Fixes #4920, #4915