### PR TITLE
[FIRRTL][Dedup] Change port renaming strategy

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1155,13 +1155,12 @@ private:
 /// This fixes up connects when the field names of a bundle type changes.  It
 /// finds all fields which were previously bulk connected and legalizes it
 /// into a connect for each field.
-template <typename T>
 void fixupConnect(ImplicitLocOpBuilder &builder, Value dst, Value src) {
   // If the types already match we can emit a connect.
   auto dstType = dst.getType();
   auto srcType = src.getType();
   if (dstType == srcType) {
-    builder.create<T>(dst, src);
+    builder.create<StrictConnectOp>(dst, src);
     return;
   }
   // It must be a bundle type and the field name has changed. We have to
@@ -1175,50 +1174,7 @@ void fixupConnect(ImplicitLocOpBuilder &builder, Value dst, Value src) {
       std::swap(srcBundle, dstBundle);
       std::swap(srcField, dstField);
     }
-    fixupConnect<T>(builder, dstField, srcField);
-  }
-}
-
-/// Replaces a ConnectOp or StrictConnectOp with new bundle types.
-template <typename T>
-void fixupConnect(T connect) {
-  ImplicitLocOpBuilder builder(connect.getLoc(), connect);
-  fixupConnect<T>(builder, connect.getDest(), connect.getSrc());
-  connect->erase();
-}
-
-/// When we replace a bundle type with a similar bundle with different field
-/// names, we have to rewrite all the code to use the new field names. This
-/// mostly affects subfield result types and any bulk connects.
-void fixupReferences(Value oldValue, Type newType) {
-  SmallVector<std::pair<Value, Type>> workList;
-  workList.emplace_back(oldValue, newType);
-  while (!workList.empty()) {
-    auto [oldValue, newType] = workList.pop_back_val();
-    auto oldType = oldValue.getType();
-    // If the two types are identical, we don't need to do anything, otherwise
-    // update the type in place.
-    if (oldType == newType)
-      continue;
-    oldValue.setType(newType);
-    for (auto *op : llvm::make_early_inc_range(oldValue.getUsers())) {
-      if (auto subfield = dyn_cast<SubfieldOp>(op)) {
-        // Rewrite a subfield op to return the correct type.
-        auto index = subfield.getFieldIndex();
-        auto result = subfield.getResult();
-        auto newResultType = newType.cast<BundleType>().getElementType(index);
-        workList.emplace_back(result, newResultType);
-        continue;
-      }
-      if (auto connect = dyn_cast<ConnectOp>(op)) {
-        fixupConnect<ConnectOp>(connect);
-        continue;
-      }
-      if (auto strict = dyn_cast<StrictConnectOp>(op)) {
-        fixupConnect<StrictConnectOp>(strict);
-        continue;
-      }
-    }
+    fixupConnect(builder, dstField, srcField);
   }
 }
 
@@ -1229,9 +1185,26 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
   for (auto *node : instanceGraph) {
     auto module = cast<FModuleLike>(*node->getModule());
     for (auto *instRec : node->uses()) {
-      auto inst = instRec->getInstance();
-      for (unsigned i = 0, e = getNumPorts(module); i < e; ++i)
-        fixupReferences(inst->getResult(i), module.getPortType(i));
+      auto inst = cast<InstanceOp>(instRec->getInstance());
+      ImplicitLocOpBuilder builder(inst.getLoc(), inst->getContext());
+      builder.setInsertionPointAfter(inst);
+      for (unsigned i = 0, e = getNumPorts(module); i < e; ++i) {
+        auto result = inst.getResult(i);
+        auto newType = module.getPortType(i);
+        auto oldType = result.getType();
+        // If the type has not changed, we don't have to fix up anything.
+        if (newType == oldType)
+          continue;
+        // If the type changed we transform it back to the old type with an
+        // intermediate wire.
+        auto wire = builder.create<WireOp>(oldType, inst.getPortName(i));
+        result.replaceAllUsesWith(wire);
+        result.setType(newType);
+        if (inst.getPortDirection(i) == Direction::Out)
+          fixupConnect(builder, wire, result);
+        else
+          fixupConnect(builder, result, wire);
+      }
     }
   }
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -482,20 +482,58 @@ firrtl.circuit "Bundle" {
   firrtl.module @Bundle() {
     // CHECK: firrtl.instance bundle0  @Bundle0
     %a = firrtl.instance bundle0 @Bundle0(out a: !firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>)
+
     // CHECK: firrtl.instance bundle1  @Bundle0
+    // CHECK: %a = firrtl.wire : !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>
+    // CHECK: [[A_F:%.+]] = firrtl.subfield %a[f]
+    // CHECK: [[A_B:%.+]] = firrtl.subfield %bundle1_a[b]
+    // CHECK: [[A_F_G:%.+]] = firrtl.subfield %0[g]
+    // CHECK: [[A_B_C:%.+]] = firrtl.subfield %1[c]
+    // CHECK: firrtl.strictconnect [[A_B_C]], [[A_F_G]]
+    // CHECK: [[A_F_H:%.+]] = firrtl.subfield [[A_F]][h]
+    // CHECK: [[A_B_D:%.+]] = firrtl.subfield [[A_B]][d]
+    // CHECK: firrtl.strictconnect [[A_F_H]], [[A_B_D]]
     %e = firrtl.instance bundle1 @Bundle1(out e: !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>)
 
     // CHECK: [[B:%.+]] = firrtl.subfield %bundle0_a[b]
     %b = firrtl.subfield %a[b] : !firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>
-    // CHECK: [[F:%.+]] = firrtl.subfield %bundle1_a[b]
+
+    // CHECK: [[F:%.+]] = firrtl.subfield %a[f]
     %f = firrtl.subfield %e[f] : !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>
 
     // Check that we properly fixup connects when the field names change.
     %w0 = firrtl.wire : !firrtl.bundle<g flip: uint<1>, h: uint<1>>
-    // CHECK: [[W0_G:%.+]] = firrtl.subfield %w0[g]
-    // CHECK: [[F_G:%.+]] = firrtl.subfield [[F]][c]
-    // CHECK: firrtl.connect [[F_G]], [[W0_G]]
+
+    // CHECK: firrtl.connect %w0, [[F]]
     firrtl.connect %w0, %f : !firrtl.bundle<g flip: uint<1>, h: uint<1>>, !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "MuxBundle"
+firrtl.circuit "MuxBundle" {
+  firrtl.module @Bar0(out %o: !firrtl.bundle<a: uint<1>>) {
+    %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>>
+    firrtl.strictconnect %o, %invalid : !firrtl.bundle<a: uint<1>>
+  }
+  firrtl.module @Bar1(out %o: !firrtl.bundle<b: uint<1>>) {
+    %invalid = firrtl.invalidvalue : !firrtl.bundle<b: uint<1>>
+    firrtl.strictconnect %o, %invalid : !firrtl.bundle<b: uint<1>>
+  }
+  firrtl.module @MuxBundle(in %p: !firrtl.uint<1>, in %l: !firrtl.bundle<b: uint<1>>, out %o: !firrtl.bundle<b: uint<1>>) attributes {convention = #firrtl<convention scalarized>} {
+    // CHECK: %bar0_o = firrtl.instance bar0 @Bar0(out o: !firrtl.bundle<a: uint<1>>)
+    %bar0_o = firrtl.instance bar0 @Bar0(out o: !firrtl.bundle<a: uint<1>>)
+
+    // CHECK: %bar1_o = firrtl.instance bar1 @Bar0(out o: !firrtl.bundle<a: uint<1>>)
+    // CHECK: [[WIRE:%.+]] = firrtl.wire {name = "o"} : !firrtl.bundle<b: uint<1>>
+    // CHECK: [[WIRE_B:%.+]] = firrtl.subfield [[WIRE]][b]
+    // CHECK: [[PORT_A:%.+]] = firrtl.subfield %bar1_o[a]
+    // CHECK: firrtl.strictconnect [[WIRE_B]], [[PORT_A]]
+    %bar1_o = firrtl.instance bar1 @Bar1(out o: !firrtl.bundle<b: uint<1>>)
+
+    // CHECK: %2 = firrtl.mux(%p, [[WIRE]], %l)
+    // CHECK: firrtl.strictconnect %o, %2 : !firrtl.bundle<b: uint<1>>
+    %0 = firrtl.mux(%p, %bar1_o, %l) : (!firrtl.uint<1>, !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>) -> !firrtl.bundle<b: uint<1>>
+    firrtl.strictconnect %o, %0 : !firrtl.bundle<b: uint<1>>
   }
 }
 


### PR DESCRIPTION
When we determine if two modules can be merged we ignore the names of fields in bundle types.  When we merge two modules with different bundle field names, this results in the type of instance results changing.  We used to run a procedure to fix up subfield and connect operations on instance results, but this missed some other operations which work with bundle types. We now convert from the new type back to the old type using an intermediate wire.