### PR TITLE
[FIRRTL] Replace BoolAttr with bool in MemoryInitAttr; NFC

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -181,10 +181,10 @@ def MemoryInitAttr : AttrDef<FIRRTLDialect, "MemoryInit"> {
     "firrtl.annotations.LoadMemoryFromFile" and
     "firrtl.annotations.MemoryFileInlineAnnotation".
   }];
-  let parameters = (
-    ins "::mlir::StringAttr":$filename,
-        "::mlir::BoolAttr":$isBinary,
-        "::mlir::BoolAttr":$isInline
+  let parameters = (ins
+    "::mlir::StringAttr":$filename,
+    "bool":$isBinary,
+    "bool":$isInline
   );
  let assemblyFormat = "`<` $filename `,` $isBinary `,` $isInline `>`";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -206,8 +206,7 @@ struct FirMemory {
         numReadPorts, numWritePorts, numReadWritePorts, dataWidth, depth,
         readLatency, writeLatency, maskBits, readUnderWrite, writeUnderWrite,
         writeClockIDs, groupID, init ? init.getFilename().getValue() : "",
-        init ? init.getIsBinary().getValue() : false,
-        init ? init.getIsInline().getValue() : false);
+        init ? init.getIsBinary() : false, init ? init.getIsInline() : false);
   }
   bool operator<(const FirMemory &rhs) const {
     return getTuple() < rhs.getTuple();

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -746,10 +746,12 @@ void FIRRTLModuleLowering::lowerMemoryDecls(ArrayRef<FirMemory> mems,
         b.getNamedAttr("writeClockIDs", b.getI32ArrayAttr(mem.writeClockIDs)),
         b.getNamedAttr("initFilename",
                        mem.init ? mem.init.getFilename() : b.getStringAttr("")),
-        b.getNamedAttr("initIsBinary", mem.init ? mem.init.getIsBinary()
-                                                : b.getBoolAttr(false)),
-        b.getNamedAttr("initIsInline", mem.init ? mem.init.getIsInline()
-                                                : b.getBoolAttr(false))};
+        b.getNamedAttr(
+            "initIsBinary",
+            b.getBoolAttr(mem.init ? mem.init.getIsBinary() : false)),
+        b.getNamedAttr(
+            "initIsInline",
+            b.getBoolAttr(mem.init ? mem.init.getIsInline() : false))};
 
     // Make the global module for the memory
     // Set a name for the memory wrapper module, the combMem is an arbitrary

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2152,9 +2152,9 @@ FirMemory MemOp::getSummary() {
             (c >= '0' && c <= '9'))
           initStr.push_back(c);
       initStr.push_back('_');
-      initStr.push_back(init.getIsBinary().getValue() ? 't' : 'f');
+      initStr.push_back(init.getIsBinary() ? 't' : 'f');
       initStr.push_back('_');
-      initStr.push_back(init.getIsInline().getValue() ? 't' : 'f');
+      initStr.push_back(init.getIsInline() ? 't' : 'f');
     }
     modName = StringAttr::get(
         op->getContext(),

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -397,11 +397,8 @@ static LogicalResult applyLoadMemoryAnno(const AnnoPathValue &target,
     return failure();
   }
 
-  op->setAttr("init",
-              MemoryInitAttr::get(
-                  op->getContext(), filename,
-                  BoolAttr::get(op->getContext(), hexOrBinaryValue == "b"),
-                  BoolAttr::get(op->getContext(), isInline)));
+  op->setAttr("init", MemoryInitAttr::get(op->getContext(), filename,
+                                          hexOrBinaryValue == "b", isInline));
 
   return success();
 }


### PR DESCRIPTION
No need to carry `BoolAttr`s in `MemoryInitAttr`. Replace them with plain old booleans.