### PR TITLE
[CombFolds] Don't flatten operands when operand has a name hint.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -134,6 +134,10 @@ static bool tryFlatteningOperands(Operation *op, PatternRewriter &rewriter) {
     if (flattenOp == op)
       continue;
 
+    // Don't flatten if the operand has a name hint.
+    if (flattenOp->hasAttrOfType<StringAttr>("sv.namehint"))
+      continue;
+
     // Don't duplicate logic when it has multiple uses.
     if (!inputs[i].hasOneUse()) {
       // We can fold a multi-use binary operation into this one if this allows a

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1303,6 +1303,24 @@ hw.module @flatten_multi_use_and(%arg0: i8, %arg1: i8, %arg2: i8)
   hw.output %0, %1 : i8, i8
 }
 
+// CHECK-LABEL: @flatten_and_no_name_hint
+hw.module @flatten_and_no_name_hint(%arg0: i8, %arg1: i8, %arg2: i8) -> (o1: i8) {
+  // CHECK: comb.and
+  // CHECK-NOT: comb.and
+  %0 = comb.and %arg0, %arg1 : i8
+  %1 = comb.and %0, %arg2 : i8
+  hw.output %1 : i8
+}
+
+// CHECK-LABEL: @flatten_and_name_hint
+hw.module @flatten_and_name_hint(%arg0: i8, %arg1: i8, %arg2: i8) -> (o1: i8) {
+  // CHECK: comb.and
+  %0 = comb.and %arg0, %arg1 {sv.namehint = "myname"} : i8
+  // CHECK: comb.and
+  %1 = comb.and %0, %arg2 : i8
+  hw.output %1 : i8
+}
+
 // CHECK-LABEL: hw.module @muxCommonOp(
 // This handles various cases of mux(cond, someop(...), someop(...)).
 hw.module @muxCommonOp(%cond: i1,


### PR DESCRIPTION
This updates `tryFlatteningOperands` to check if an operand has a name hint, and not flatten it if so. This weakens the optimizations in the presence of name hints, which could lead to some missed opportunities for constant propagation, etc. However, the optimizations are mostly aesthetic at this level, and this might be a worthwhile tradeoff for preserving names when requested.