### PR TITLE
[FIRRTL][NFC] Use getResult() for primary Value of declaration ops.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1229,8 +1229,10 @@ bool HandshakeBuilder::visitHandshake(SyncOp op) {
   // Create wires that will be used to connect the join and the fork logic
   auto bitType = UIntType::get(op->getContext(), 1);
   ValueVector connector;
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allValid"));
-  connector.push_back(rewriter.create<WireOp>(insertLoc, bitType, "allReady"));
+  connector.push_back(
+      rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult());
+  connector.push_back(
+      rewriter.create<WireOp>(insertLoc, bitType, "allReady").getResult());
 
   // Collect all input ports.
   SmallVector<ValueVector *, 4> inputs;
@@ -1386,7 +1388,8 @@ bool HandshakeBuilder::visitHandshake(handshake::SelectOp op) {
   rewriter.create<ConnectOp>(insertLoc, resultData, muxedData);
 
   // 'and' the arg valids and select valid
-  Value allValid = rewriter.create<WireOp>(insertLoc, bitType, "allValid");
+  Value allValid =
+      rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult();
   buildReductionTree<AndPrimOp>({trueValid, falseValid, selectValid}, allValid);
 
   // Connect that to the result valid.
@@ -1444,10 +1447,11 @@ bool HandshakeBuilder::visitHandshake(MergeOp op) {
       createConstantOp(indexType, APInt(numInputs, 0), insertLoc, rewriter);
 
   // Declare wire for arbitration winner.
-  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win");
+  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win").getResult();
 
   // Declare wires for if each output is done.
-  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone");
+  auto resultDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
 
   // Create predicates to assert if the win wire holds a valid index.
   auto hasWinnerCondition = rewriter.create<OrRPrimOp>(insertLoc, bitType, win);
@@ -1537,26 +1541,35 @@ bool HandshakeBuilder::visitHandshake(ControlMergeOp op) {
   auto falseConst = createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
 
   // Declare register for storing arbitration winner.
-  auto won = rewriter.create<RegResetOp>(insertLoc, indexType, clock, reset,
-                                         noWinner, "won");
+  auto won = rewriter
+                 .create<RegResetOp>(insertLoc, indexType, clock, reset,
+                                     noWinner, "won")
+                 .getResult();
 
   // Declare wire for arbitration winner.
-  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win");
+  auto win = rewriter.create<WireOp>(insertLoc, indexType, "win").getResult();
 
   // Declare wire for whether the circuit just fired and emitted both outputs.
-  auto fired = rewriter.create<WireOp>(insertLoc, bitType, "fired");
+  auto fired = rewriter.create<WireOp>(insertLoc, bitType, "fired").getResult();
 
   // Declare registers for storing if each output has been emitted.
-  auto resultEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "resultEmitted");
+  auto resultEmitted = rewriter
+                           .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                               falseConst, "resultEmitted")
+                           .getResult();
 
-  auto controlEmitted = rewriter.create<RegResetOp>(
-      insertLoc, bitType, clock, reset, falseConst, "controlEmitted");
+  auto controlEmitted =
+      rewriter
+          .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                              "controlEmitted")
+          .getResult();
 
   // Declare wires for if each output is done.
-  auto resultDone = rewriter.create<WireOp>(insertLoc, bitType, "resultDone");
+  auto resultDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "resultDone").getResult();
 
-  auto controlDone = rewriter.create<WireOp>(insertLoc, bitType, "controlDone");
+  auto controlDone =
+      rewriter.create<WireOp>(insertLoc, bitType, "controlDone").getResult();
 
   // Create predicates to assert if the win wire or won register hold a valid
   // index.
@@ -1802,13 +1815,14 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
   for (unsigned i = 0; i < resultNum; ++i) {
     auto doneWire =
         rewriter.create<WireOp>(insertLoc, bitType, "done" + std::to_string(i));
-    doneWires.push_back(doneWire);
+    doneWires.push_back(doneWire.getResult());
   }
 
   // Create an AndPrimOp chain for generating the ready signal. Only if all
   // result ports are handshaked (done), the argument port is ready to accept
   // the next token.
-  Value allDoneWire = rewriter.create<WireOp>(insertLoc, bitType, "allDone");
+  Value allDoneWire =
+      rewriter.create<WireOp>(insertLoc, bitType, "allDone").getResult();
   buildReductionTree<AndPrimOp>(doneWires, allDoneWire);
 
   // Connect the allDoneWire to the input ready.
@@ -1816,7 +1830,7 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
   // Create a notAllDoneWire for later use.
   auto notAllDoneWire =
-      rewriter.create<WireOp>(insertLoc, bitType, "notAllDone");
+      rewriter.create<WireOp>(insertLoc, bitType, "notAllDone").getResult();
   rewriter.create<ConnectOp>(
       insertLoc, notAllDoneWire,
       rewriter.create<NotPrimOp>(insertLoc, bitType, allDoneWire));
@@ -1842,8 +1856,10 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
     // Create a emitted register.
     auto emtdReg =
-        rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                    falseConst, "emtd" + std::to_string(idx));
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                                "emtd" + std::to_string(idx))
+            .getResult();
 
     // Connect the emitted register with {doneWire && notallDoneWire}. Only if
     // notallDone, the emtdReg will be set to the value of doneWire. Otherwise,
@@ -1853,8 +1869,10 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
     rewriter.create<ConnectOp>(insertLoc, emtdReg, emtd);
 
     // Create a notEmtdWire for later use.
-    auto notEmtdWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                               "notEmtd" + std::to_string(idx));
+    auto notEmtdWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType, "notEmtd" + std::to_string(idx))
+            .getResult();
     rewriter.create<ConnectOp>(
         insertLoc, notEmtdWire,
         rewriter.create<NotPrimOp>(insertLoc, bitType, emtdReg));
@@ -1867,8 +1885,11 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
 
     // Create validReady wire signal, which indicates a successful handshake in
     // the current clock cycle.
-    auto validReadyWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "validReady" + std::to_string(idx));
+    auto validReadyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "validReady" + std::to_string(idx))
+            .getResult();
     rewriter.create<ConnectOp>(
         insertLoc, validReadyWire,
         rewriter.create<AndPrimOp>(insertLoc, bitType, resultReady, valid));
@@ -1938,10 +1959,12 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
 
   // Create a wire and connect it to the register for the ready buffer.
   auto readyRegWire =
-      rewriter.create<WireOp>(insertLoc, bitType, "readyRegWire");
+      rewriter.create<WireOp>(insertLoc, bitType, "readyRegWire").getResult();
 
-  auto readyReg = rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                              falseConst, "readyReg");
+  Value readyReg = rewriter
+                       .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                           falseConst, "readyReg")
+                       .getResult();
   rewriter.create<ConnectOp>(insertLoc, readyReg, readyRegWire);
 
   // Create the logic to drive the successor valid and potentially data.
@@ -1975,12 +1998,16 @@ void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
   if (predData) {
     auto dataType = predData.getType().cast<FIRRTLBaseType>();
     auto ctrlDataRegWire =
-        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire");
+        rewriter.create<WireOp>(insertLoc, dataType, "ctrlDataRegWire")
+            .getResult();
 
     auto ctrlZeroConst = createZeroDataConst(dataType, insertLoc, rewriter);
 
-    auto ctrlDataReg = rewriter.create<RegResetOp>(
-        insertLoc, dataType, clock, reset, ctrlZeroConst, "ctrlDataReg");
+    auto ctrlDataReg =
+        rewriter
+            .create<RegResetOp>(insertLoc, dataType, clock, reset,
+                                ctrlZeroConst, "ctrlDataReg")
+            .getResult();
 
     rewriter.create<ConnectOp>(insertLoc, ctrlDataReg, ctrlDataRegWire);
 
@@ -2123,17 +2150,20 @@ FModuleOp buildInnerFIFO(CircuitOp circuit, StringRef moduleName,
   auto oneConst =
       createConstantOp(bitType, APInt(1, 1), builder.getLoc(), builder);
 
-  auto readEn = builder.create<WireOp>(bitType, "read_en");
-  auto writeEn = builder.create<WireOp>(bitType, "write_en");
+  auto readEn = builder.create<WireOp>(bitType, "read_en").getResult();
+  auto writeEn = builder.create<WireOp>(bitType, "write_en").getResult();
   auto tail =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg");
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "tail_reg")
+          .getResult();
   auto head =
-      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg");
-  auto full = builder.create<WireOp>(bitType, "full");
-  auto empty = builder.create<WireOp>(bitType, "empty");
+      builder.create<RegResetOp>(depthPtrType, clk, rst, zeroConst, "head_reg")
+          .getResult();
+  auto full = builder.create<WireOp>(bitType, "full").getResult();
+  auto empty = builder.create<WireOp>(bitType, "empty").getResult();
   auto notEmpty = builder.create<NotPrimOp>(empty);
   auto count =
-      builder.create<RegResetOp>(depthType, clk, rst, zeroConst, "count_reg");
+      builder.create<RegResetOp>(depthType, clk, rst, zeroConst, "count_reg")
+          .getResult();
 
   // Function for truncating results to a given types' width.
   auto trunc = [&](Value v, FIRRTLBaseType toType) {
@@ -2300,16 +2330,22 @@ bool HandshakeBuilder::buildFIFOBufferLogic(int64_t numStage,
   auto outputReady = outputSubfields[1];
 
   auto bitType = UIntType::get(builder.getContext(), 1);
-  auto muxSelWire = builder.create<WireOp>(insertLoc, bitType, "muxSelWire");
-  auto fifoValid = builder.create<WireOp>(insertLoc, bitType, "fifoValid");
-  auto fifoPValid = builder.create<WireOp>(insertLoc, bitType, "fifoPValid");
-  auto fifoReady = builder.create<WireOp>(insertLoc, bitType, "fifoReady");
-  auto fifoNReady = builder.create<WireOp>(insertLoc, bitType, "fifoNReady");
+  auto muxSelWire =
+      builder.create<WireOp>(insertLoc, bitType, "muxSelWire").getResult();
+  auto fifoValid =
+      builder.create<WireOp>(insertLoc, bitType, "fifoValid").getResult();
+  auto fifoPValid =
+      builder.create<WireOp>(insertLoc, bitType, "fifoPValid").getResult();
+  auto fifoReady =
+      builder.create<WireOp>(insertLoc, bitType, "fifoReady").getResult();
+  auto fifoNReady =
+      builder.create<WireOp>(insertLoc, bitType, "fifoNReady").getResult();
   Value fifoIn = nullptr;
   Value fifoOut = nullptr;
   if (!isControl) {
-    fifoIn = builder.create<WireOp>(insertLoc, dataType, "fifoIn");
-    fifoOut = builder.create<WireOp>(insertLoc, dataType, "fifoOut");
+    fifoIn = builder.create<WireOp>(insertLoc, dataType, "fifoIn").getResult();
+    fifoOut =
+        builder.create<WireOp>(insertLoc, dataType, "fifoOut").getResult();
   }
 
   // Connect output valid and ready signals.
@@ -2428,13 +2464,18 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
     bool isInitialized = initValues.size() > i;
 
     // Create wires for ready signal from the success buffer stage.
-    auto readyWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                             "readyWire" + std::to_string(i));
+    auto readyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType, "readyWire" + std::to_string(i))
+            .getResult();
 
     // Create a register for valid signal.
-    auto validReg = rewriter.create<RegResetOp>(
-        insertLoc, bitType, clock, reset,
-        isInitialized ? trueConst : falseConst, "validReg" + std::to_string(i));
+    auto validReg =
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                isInitialized ? trueConst : falseConst,
+                                "validReg" + std::to_string(i))
+            .getResult();
 
     // Create registers for data signal.
     Value dataReg = nullptr;
@@ -2448,22 +2489,32 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
             insertLoc, rewriter);
       }
       dataReg =
-          rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
-                                      initValue, "dataReg" + std::to_string(i));
+          rewriter
+              .create<RegResetOp>(insertLoc, dataType, clock, reset, initValue,
+                                  "dataReg" + std::to_string(i))
+              .getResult();
     }
 
     // Create wires for valid, ready and data signal coming from the control
     // buffer stage.
-    auto ctrlValidWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlValidWire" + std::to_string(i));
+    auto ctrlValidWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "ctrlValidWire" + std::to_string(i))
+            .getResult();
 
-    auto ctrlReadyWire = rewriter.create<WireOp>(
-        insertLoc, bitType, "ctrlReadyWire" + std::to_string(i));
+    auto ctrlReadyWire =
+        rewriter
+            .create<WireOp>(insertLoc, bitType,
+                            "ctrlReadyWire" + std::to_string(i))
+            .getResult();
 
     Value ctrlDataWire;
     if (!isControl)
-      ctrlDataWire = rewriter.create<WireOp>(
-          insertLoc, dataType, "ctrlDataWire" + std::to_string(i));
+      ctrlDataWire = rewriter
+                         .create<WireOp>(insertLoc, dataType,
+                                         "ctrlDataWire" + std::to_string(i))
+                         .getResult();
 
     // Build the current stage of the buffer.
     buildDataBufferLogic(currentValid, validReg, currentReady, readyWire,
@@ -2744,8 +2795,11 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // latency of 1.
     auto falseConst =
         createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
-    auto writeValidBuffer = rewriter.create<RegResetOp>(
-        insertLoc, bitType, clock, reset, falseConst, "writeValidBuffer");
+    auto writeValidBuffer =
+        rewriter
+            .create<RegResetOp>(insertLoc, bitType, clock, reset, falseConst,
+                                "writeValidBuffer")
+            .getResult();
 
     // Connect the write valid buffer to the store control valid.
     rewriter.create<ConnectOp>(insertLoc, storeControlValid, writeValidBuffer);
@@ -2753,7 +2807,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Create the logic for when both the buffered write valid signal and the
     // store complete ready signal are asserted.
     Value storeCompleted =
-        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted");
+        rewriter.create<WireOp>(insertLoc, bitType, "storeCompleted")
+            .getResult();
     ValueVector storeCompletedVector({Value(), storeCompleted});
     buildAllReadyLogic({&storeCompletedVector}, &storeControl,
                        writeValidBuffer);
@@ -2774,7 +2829,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     SmallVector<Value, 2> storeValids;
     extractValues({&storeAddr, &storeData}, 0, storeValids);
     Value writeValid =
-        rewriter.create<WireOp>(insertLoc, bitType, "writeValid");
+        rewriter.create<WireOp>(insertLoc, bitType, "writeValid").getResult();
     buildReductionTree<AndPrimOp>(storeValids, writeValid);
 
     // Create a mux that drives the buffer input. If the emptyOrComplete signal
@@ -2833,7 +2888,8 @@ bool HandshakeBuilder::visitHandshake(handshake::StoreOp op) {
   auto bitType = UIntType::get(rewriter.getContext(), 1);
 
   // Create a wire that will be asserted when all inputs are valid.
-  auto inputsValid = rewriter.create<WireOp>(insertLoc, bitType, "inputsValid");
+  auto inputsValid =
+      rewriter.create<WireOp>(insertLoc, bitType, "inputsValid").getResult();
 
   // Create a gate that will be asserted when all outputs are ready.
   auto outputsReady = rewriter.create<AndPrimOp>(

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -360,25 +360,25 @@ void Emitter::emitStatement(WhenOp op, bool noIndent) {
 }
 
 void Emitter::emitStatement(WireOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "wire " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   emitLocationAndNewLine(op);
 }
 
 void Emitter::emitStatement(RegOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "reg " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   os << ", ";
   emitExpression(op.getClockVal());
   emitLocationAndNewLine(op);
 }
 
 void Emitter::emitStatement(RegResetOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "reg " << op.getName() << " : ";
-  emitType(op.getType());
+  emitType(op.getResult().getType());
   os << ", ";
   emitExpression(op.getClockVal());
   os << " with :\n";
@@ -391,7 +391,7 @@ void Emitter::emitStatement(RegResetOp op) {
 }
 
 void Emitter::emitStatement(NodeOp op) {
-  addValueName(op, op.getNameAttr());
+  addValueName(op.getResult(), op.getNameAttr());
   indent() << "node " << op.getName() << " = ";
   emitExpression(op.getInput());
   emitLocationAndNewLine(op);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -661,9 +661,12 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
         valType.getWidthlessType() != wireType.getWidthlessType()) {
       // Helper: create a wire, cast it with callback, connect cast to sink.
       auto addWireWithCast = [&](auto createCast) {
-        auto wire = sinkBuilder.create<WireOp>(
-            valType,
-            state.getNamespace(wireModule).newName(tapName.getValue()));
+        auto wire =
+            sinkBuilder
+                .create<WireOp>(
+                    valType,
+                    state.getNamespace(wireModule).newName(tapName.getValue()))
+                .getResult();
         sinkBuilder.create<ConnectOp>(sink, createCast(wire));
         sink = wire;
       };

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2833,7 +2833,8 @@ ParseResult FIRStmtParser::parseNode() {
   auto result =
       builder.create<NodeOp>(initializer.getType(), initializer, id,
                              NameKindEnum::InterestingName, annotations, sym);
-  return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
+  return moduleContext.addSymbolEntry(id, result.getResult(),
+                                      startTok.getLoc());
 }
 
 /// wire ::= 'wire' id ':' type info?
@@ -2857,10 +2858,10 @@ ParseResult FIRStmtParser::parseWire() {
   auto annotations = getConstants().emptyArrayAttr;
   StringAttr sym = {};
 
-  auto result = builder.create<WireOp>(
-      type, id, NameKindEnum::InterestingName, annotations,
-      sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
-  return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
+  auto result = builder.create<WireOp>(type, id, NameKindEnum::InterestingName,
+                                       annotations, sym);
+  return moduleContext.addSymbolEntry(id, result.getResult(),
+                                      startTok.getLoc());
 }
 
 /// register    ::= 'reg' id ':' type exp ('with' ':' reset_block)? info?
@@ -2949,12 +2950,16 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   Value result;
   StringAttr sym = {};
   if (resetSignal)
-    result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
-                                        id, NameKindEnum::InterestingName,
-                                        annotations, sym);
+    result =
+        builder
+            .create<RegResetOp>(type, clock, resetSignal, resetValue, id,
+                                NameKindEnum::InterestingName, annotations, sym)
+            .getResult();
   else
-    result = builder.create<RegOp>(
-        type, clock, id, NameKindEnum::InterestingName, annotations, sym);
+    result = builder
+                 .create<RegOp>(type, clock, id, NameKindEnum::InterestingName,
+                                annotations, sym)
+                 .getResult();
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -253,7 +253,7 @@ public:
           // Wire is added to the worklist
           .Case<WireOp>([&](WireOp wire) {
             worklist.push_back(wire.getResult());
-            if (!wire.getType().cast<FIRRTLBaseType>().isGround())
+            if (!wire.getResult().getType().cast<FIRRTLBaseType>().isGround())
               setValRefsTo(wire.getResult(), FieldRef(wire.getResult(), 0));
           })
           // All sub elements are added to the worklist.

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1197,7 +1197,8 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
           continue;
         // If the type changed we transform it back to the old type with an
         // intermediate wire.
-        auto wire = builder.create<WireOp>(oldType, inst.getPortName(i));
+        auto wire =
+            builder.create<WireOp>(oldType, inst.getPortName(i)).getResult();
         result.replaceAllUsesWith(wire);
         result.setType(newType);
         if (inst.getPortDirection(i) == Direction::Out)

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -118,11 +118,13 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
       for (size_t index = 0, rend = memOp.getNumResults(); index < rend;
            ++index) {
         auto result = memOp.getResult(index);
-        auto wire = builder.create<WireOp>(
-            result.getType(),
-            (memOp.getName() + "_" + memOp.getPortName(index).getValue())
-                .str());
-        result.replaceAllUsesWith(wire.getResult());
+        auto wire = builder
+                        .create<WireOp>(result.getType(),
+                                        (memOp.getName() + "_" +
+                                         memOp.getPortName(index).getValue())
+                                            .str())
+                        .getResult();
+        result.replaceAllUsesWith(wire);
         result = wire;
         auto newResult = flatMem.getResult(index);
         auto rType = result.getType().cast<BundleType>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1075,7 +1075,8 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
 
     // Append this new Wiring Problem to the ApplyState.  The Wiring Problem
     // will be resolved to bore RefType ports before LowerAnnotations finishes.
-    state.wiringProblems.push_back({*source, sink, (path + "__bore").str(),
+    state.wiringProblems.push_back({*source, sink.getResult(),
+                                    (path + "__bore").str(),
                                     WiringProblem::RefTypeUsage::Prefer});
 
     return DictionaryAttr::getWithSorted(context, elementIface);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -481,12 +481,12 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
 }
 
 void IMConstPropPass::markWireOp(WireOp wire) {
-  auto type = wire.getType().dyn_cast<FIRRTLType>();
+  auto type = wire.getResult().getType().dyn_cast<FIRRTLType>();
   if (!type)
-    return markOverdefined(wire);
+    return markOverdefined(wire.getResult());
 
   if (hasDontTouch(wire.getResult()))
-    return markOverdefined(wire);
+    return markOverdefined(wire.getResult());
 
   // Otherwise, this starts out as unknown and is upgraded by connects.
 }
@@ -665,7 +665,7 @@ void IMConstPropPass::visitNode(NodeOp node) {
   // propagate values.
   if (hasDontTouch(node.getResult()) ||
       (node.getAnnotationsAttr() && !node.getAnnotationsAttr().empty()))
-    return markOverdefined(node);
+    return markOverdefined(node.getResult());
 
   return mergeLatticeValue(node.getResult(), node.getInput());
 }

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -517,7 +517,7 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
 
       // Ok, this port is used only within its defined module. So we can replace
       // the port with a wire.
-      WireOp wire = builder.create<WireOp>(argument.getType());
+      auto wire = builder.create<WireOp>(argument.getType()).getResult();
 
       // Since `liveSet` contains the port, we have to erase it from the set.
       liveValues.erase(argument);

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -154,12 +154,16 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
       auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
       // Temp wires to replace the original memory connects.
-      auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr");
-      auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
-      auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
-      auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
+      auto rAddr =
+          builder.create<WireOp>(addr.getType(), "readAddr").getResult();
+      auto wAddr =
+          builder.create<WireOp>(addr.getType(), "writeAddr").getResult();
+      auto wEnWire =
+          builder.create<WireOp>(enb.getType(), "writeEnable").getResult();
+      auto rEnWire =
+          builder.create<WireOp>(enb.getType(), "readEnable").getResult();
       auto writeClock =
-          builder.create<WireOp>(ClockType::get(enb.getContext()));
+          builder.create<WireOp>(ClockType::get(enb.getContext())).getResult();
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
       builder.create<StrictConnectOp>(
           addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -134,20 +134,21 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLBaseType type,
             auto wireOp = builder.create<WireOp>(type);
             for (auto field : llvm::enumerate(type)) {
               auto zero = createZeroValue(builder, field.value().type, cache);
-              auto acc = builder.create<SubfieldOp>(field.value().type, wireOp,
-                                                    field.index());
+              auto acc = builder.create<SubfieldOp>(
+                  field.value().type, wireOp.getResult(), field.index());
               builder.create<StrictConnectOp>(acc, zero);
             }
-            return wireOp;
+            return wireOp.getResult();
           })
           .Case<FVectorType>([&](auto type) {
             auto wireOp = builder.create<WireOp>(type);
             auto zero = createZeroValue(builder, type.getElementType(), cache);
             for (unsigned i = 0, e = type.getNumElements(); i < e; ++i) {
-              auto acc = builder.create<SubindexOp>(zero.getType(), wireOp, i);
+              auto acc = builder.create<SubindexOp>(zero.getType(),
+                                                    wireOp.getResult(), i);
               builder.create<StrictConnectOp>(acc, zero);
             }
-            return wireOp;
+            return wireOp.getResult();
           })
           .Case<ResetType, AnalogType>(
               [&](auto type) { return builder.create<InvalidValueOp>(type); })
@@ -1602,12 +1603,12 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
         auto wireOp = builder.create<WireOp>(
             nodeOp.getType(), nodeOp.getNameAttr(), nodeOp.getNameKind(),
             nodeOp.getAnnotationsAttr(), nodeOp.getInnerSymAttr());
-        builder.create<StrictConnectOp>(wireOp, nodeOp.getInput());
+        builder.create<StrictConnectOp>(wireOp.getResult(), nodeOp.getInput());
         nodeOp->replaceAllUsesWith(wireOp);
         nodeOp.erase();
         resetOp = wireOp;
-        actualReset = wireOp;
-        domain.existingValue = wireOp;
+        actualReset = wireOp.getResult();
+        domain.existingValue = wireOp.getResult();
       }
 
       // Determine the block into which the reset declaration needs to be moved.
@@ -1714,12 +1715,12 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
       return;
 
     LLVM_DEBUG(llvm::dbgs() << "- Adding async reset to " << regOp << "\n");
-    auto zero = createZeroValue(builder, regOp.getType());
+    auto zero = createZeroValue(builder, regOp.getResult().getType());
     auto newRegOp = builder.create<RegResetOp>(
-        regOp.getType(), regOp.getClockVal(), actualReset, zero,
+        regOp.getResult().getType(), regOp.getClockVal(), actualReset, zero,
         regOp.getNameAttr(), regOp.getNameKindAttr(), regOp.getAnnotations(),
         regOp.getInnerSymAttr());
-    regOp.getResult().replaceAllUsesWith(newRegOp);
+    regOp.getResult().replaceAllUsesWith(newRegOp.getResult());
     regOp->erase();
     return;
   }
@@ -1744,14 +1745,14 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     // If we arrive here, the register has a sync reset. In order to add an
     // async reset, we have to move the sync reset into a mux in front of the
     // register.
-    insertResetMux(builder, regOp, reset, value);
-    builder.setInsertionPointAfterValue(regOp);
-    auto mux = builder.create<MuxPrimOp>(reset, value, regOp);
-    builder.create<ConnectOp>(regOp, mux);
+    insertResetMux(builder, regOp.getResult(), reset, value);
+    builder.setInsertionPointAfterValue(regOp.getResult());
+    auto mux = builder.create<MuxPrimOp>(reset, value, regOp.getResult());
+    builder.create<ConnectOp>(regOp.getResult(), mux);
 
     // Replace the existing reset with the async reset.
     builder.setInsertionPoint(regOp);
-    auto zero = createZeroValue(builder, regOp.getType());
+    auto zero = createZeroValue(builder, regOp.getResult().getType());
     regOp.getResetSignalMutable().assign(actualReset);
     regOp.getResetValueMutable().assign(zero);
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1336,7 +1336,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       .Case<NodeOp>([&](auto op) {
         // Nodes have the same type as their input.
         unifyTypes(FieldRef(op.getResult(), 0), FieldRef(op.getInput(), 0),
-                   op.getType());
+                   op.getResult().getType());
       })
 
       // Aggregate Values

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -128,7 +128,7 @@ static bool lowerCirctSizeof(InstancePathCache &instancePathCache,
   for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
     auto inst = cast<InstanceOp>(use->getInstance().getOperation());
     ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-    auto inputWire = builder.create<WireOp>(ports[0].type);
+    auto inputWire = builder.create<WireOp>(ports[0].type).getResult();
     inst.getResult(0).replaceAllUsesWith(inputWire);
     auto size = builder.create<SizeOfIntrinsicOp>(inputWire);
     inst.getResult(1).replaceAllUsesWith(size);
@@ -149,7 +149,7 @@ static bool lowerCirctIsX(InstancePathCache &instancePathCache,
   for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
     auto inst = cast<InstanceOp>(use->getInstance().getOperation());
     ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-    auto inputWire = builder.create<WireOp>(ports[0].type);
+    auto inputWire = builder.create<WireOp>(ports[0].type).getResult();
     inst.getResult(0).replaceAllUsesWith(inputWire);
     auto size = builder.create<IsXIntrinsicOp>(inputWire);
     inst.getResult(1).replaceAllUsesWith(size);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -910,7 +910,7 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
     newMemories.push_back(cloneMemWithNewType(builder, op, field));
   // Hook up the new memories to the wires the old memory was replaced with.
   for (size_t index = 0, rend = op.getNumResults(); index < rend; ++index) {
-    auto result = oldPorts[index];
+    auto result = oldPorts[index].getResult();
     auto rType = result.getType().cast<BundleType>();
     for (size_t fieldIndex = 0, fend = rType.getNumElements();
          fieldIndex != fend; ++fieldIndex) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -108,8 +108,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
                   opName = name.getValue();
                   nameKind = NameKindEnum::InterestingName;
                 }
-                xmrDef = b.create<NodeOp>(xmrDef.getType(), xmrDef, opName,
-                                          nameKind);
+                xmrDef =
+                    b.create<NodeOp>(xmrDef.getType(), xmrDef, opName, nameKind)
+                        .getResult();
               }
             }
             // Create a new entry for this RefSendOp. The path is currently

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -801,10 +801,13 @@ void Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b, IRMapping &mapper,
     Value wire =
         TypeSwitch<FIRRTLType, Value>(type)
             .Case<FIRRTLBaseType>([&](auto base) {
-              return b.create<WireOp>(
-                  target.getLoc(), base, (prefix + portInfo[i].getName()).str(),
-                  NameKindEnum::DroppableName,
-                  ArrayAttr::get(context, newAnnotations), newSym);
+              return b
+                  .create<WireOp>(target.getLoc(), base,
+                                  (prefix + portInfo[i].getName()).str(),
+                                  NameKindEnum::DroppableName,
+                                  ArrayAttr::get(context, newAnnotations),
+                                  newSym)
+                  .getResult();
             })
             .Case<RefType>([&](auto refty) {
               // Symbols and annotations are not allowed, warn if dropping.

--- a/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
@@ -55,10 +55,10 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
     return;
 
   // Register is only written by itself, replace with invalid.
-  if (con.getSrc() == reg) {
-    auto inv =
-        OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(), reg.getType());
-    reg.replaceAllUsesWith(inv.getResult());
+  if (con.getSrc() == reg.getResult()) {
+    auto inv = OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(),
+                                                     reg.getResult().getType());
+    reg.getResult().replaceAllUsesWith(inv.getResult());
     toErase.push_back(reg);
     toErase.push_back(con);
     return;
@@ -73,7 +73,7 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
       // Simple constants we can move safely
       auto *fmodb = con->getParentOfType<FModuleOp>().getBodyBlock();
       cst->moveBefore(fmodb, fmodb->begin());
-      reg.replaceAllUsesWith(cst.getResult());
+      reg.getResult().replaceAllUsesWith(cst.getResult());
       toErase.push_back(con);
     } else {
       bool dominatesAll = true;
@@ -87,11 +87,11 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
       }
       if (dominatesAll) {
         // Dominance is fine, just replace the op.
-        reg.replaceAllUsesWith(con.getSrc());
+        reg.getResult().replaceAllUsesWith(con.getSrc());
         toErase.push_back(con);
       } else {
-        auto bounce =
-            OpBuilder(reg).create<WireOp>(reg.getLoc(), reg.getType());
+        auto bounce = OpBuilder(reg).create<WireOp>(reg.getLoc(),
+                                                    reg.getResult().getType());
         reg.replaceAllUsesWith(bounce.getResult());
       }
     }
@@ -110,10 +110,10 @@ void RegisterOptimizerPass::checkRegReset(mlir::DominanceInfo &dom,
     return;
 
   // Register is only written by itself, and reset with a constant.
-  if (reg.getResetValue().getType() == reg.getType()) {
-    if (con.getSrc() == reg && isConstant(reg.getResetValue())) {
+  if (reg.getResetValue().getType() == reg.getResult().getType()) {
+    if (con.getSrc() == reg.getResult() && isConstant(reg.getResetValue())) {
       // constant obviously dominates the register.
-      reg.replaceAllUsesWith(reg.getResetValue());
+      reg.getResult().replaceAllUsesWith(reg.getResetValue());
       toErase.push_back(reg);
       toErase.push_back(con);
       return;
@@ -122,7 +122,7 @@ void RegisterOptimizerPass::checkRegReset(mlir::DominanceInfo &dom,
     if (con.getSrc() == reg.getResetValue() &&
         isConstant(reg.getResetValue())) {
       // constant obviously dominates the register.
-      reg.replaceAllUsesWith(reg.getResetValue());
+      reg.getResult().replaceAllUsesWith(reg.getResetValue());
       toErase.push_back(reg);
       toErase.push_back(con);
       return;

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -96,7 +96,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
         auto builder = ImplicitLocOpBuilder::atBlockBegin(
             arg.getLoc(), module.getBodyBlock());
         auto wire = builder.create<WireOp>(arg.getType());
-        arg.replaceAllUsesWith(wire);
+        arg.replaceAllUsesWith(wire.getResult());
         outputPortConstants.push_back(std::nullopt);
       } else if (arg.hasOneUse()) {
         // If the port has a single use, check the port is only connected to
@@ -162,7 +162,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
           return false;
         });
 
-        result.replaceUsesWithIf(wire, [&](OpOperand &op) -> bool {
+        result.replaceUsesWithIf(wire.getResult(), [&](OpOperand &op) -> bool {
           // Connects can be deleted directly.
           if (onlyWritten && isa<FConnectLike>(op.getOwner())) {
             op.getOwner()->erase();

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -422,9 +422,12 @@ struct InstanceStubber : public Reduction {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{});
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      instOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       invalidateOutputs(builder, wire, invalidCache,
                         instOp.getPortDirection(i) == firrtl::Direction::In);
       result.replaceAllUsesWith(wire);
@@ -470,9 +473,12 @@ struct MemoryStubber : public Reduction {
       auto result = memOp.getResult(i);
       auto name = builder.getStringAttr(Twine(memOp.getName()) + "_" +
                                         memOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          memOp.getPortAnnotation(i), StringAttr{});
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      memOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       invalidateOutputs(builder, wire, invalidCache, true);
       result.replaceAllUsesWith(wire);
 
@@ -758,8 +764,12 @@ struct ExtmoduleInstanceRemover : public Reduction {
     ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
     SmallVector<Value> replacementWires;
     for (firrtl::PortInfo info : portInfo) {
-      auto wire = builder.create<firrtl::WireOp>(
-          info.type, (Twine(instOp.getName()) + "_" + info.getName()).str());
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(
+                  info.type,
+                  (Twine(instOp.getName()) + "_" + info.getName()).str())
+              .getResult();
       if (info.isOutput()) {
         auto inv = builder.create<firrtl::InvalidValueOp>(info.type);
         builder.create<firrtl::ConnectOp>(wire, inv);
@@ -870,15 +880,19 @@ struct ConnectSourceOperandForwarder : public Reduction {
     ImplicitLocOpBuilder builder(destOp->getLoc(), destOp);
     Value newDest;
     if (auto wire = dyn_cast<firrtl::WireOp>(destOp))
-      newDest = builder.create<firrtl::WireOp>(forwardedOperand.getType(),
-                                               wire.getName());
+      newDest = builder
+                    .create<firrtl::WireOp>(forwardedOperand.getType(),
+                                            wire.getName())
+                    .getResult();
     else {
       auto regName = destOp->getAttrOfType<StringAttr>("name");
       // We can promote the register into a wire but we wouldn't do here because
       // the error might be caused by the register.
       auto clock = destOp->getOperand(0);
-      newDest = builder.create<firrtl::RegOp>(forwardedOperand.getType(), clock,
-                                              regName ? regName.str() : "");
+      newDest = builder
+                    .create<firrtl::RegOp>(forwardedOperand.getType(), clock,
+                                           regName ? regName.str() : "")
+                    .getResult();
     }
 
     // Create new connection between a new wire and the forwarded operand.
@@ -999,9 +1013,12 @@ struct EagerInliner : public Reduction {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire = builder.create<firrtl::WireOp>(
-          result.getType(), name, firrtl::NameKindEnum::DroppableName,
-          instOp.getPortAnnotation(i), StringAttr{});
+      auto wire =
+          builder
+              .create<firrtl::WireOp>(result.getType(), name,
+                                      firrtl::NameKindEnum::DroppableName,
+                                      instOp.getPortAnnotation(i), StringAttr{})
+              .getResult();
       result.replaceAllUsesWith(wire);
       argReplacements.push_back(wire);
     }


### PR DESCRIPTION
Be explicit about the result used, instead of implicit conversion to Value for single-result declarations.

In preparation for making these optionally have more than one result.