### PR TITLE
[FIRRTL][FIRRTLFolds] Drop forceable if unused.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -113,6 +113,9 @@ namespace detail {
 RefType getForceableResultType(bool forceable, Type type);
 /// Verify a Forceable op.
 LogicalResult verifyForceableOp(Forceable op);
+/// Replace a Forceable op with equivalent, changing whether forceable.
+/// No-op if already has specified forceability.
+Forceable replaceWithNewForceability(Forceable op, bool forceable);
 } // end namespace detail
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -446,6 +446,10 @@ def Forceable : OpInterface<"Forceable"> {
     InterfaceMethod<"Return reference result, or null if not active.",
     "mlir::TypedValue<RefType>", "getDataRef", (ins), [{}], /*defaultImplementation=*/[{
       return llvm::cast_or_null<mlir::TypedValue<RefType>>($_op.getRef());
+    }]>,
+    InterfaceMethod<"Mark operation as forceable (or not), replacing this op as needed.",
+    "Forceable", "markForceable", (ins "bool":$forceable), [{}], /*defaultImplementation=*/[{
+      return detail::replaceWithNewForceability($_op, forceable);
     }]>
   ];
   let extraClassDeclaration = [{

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1817,15 +1817,13 @@ struct NodeBypass : public mlir::RewritePattern {
 
 template <typename OpTy>
 static LogicalResult demoteForceableIfUnused(OpTy op,
-                                                  PatternRewriter &rewriter) {
+                                             PatternRewriter &rewriter) {
   if (!op.isForceable() || !op.getDataRef().use_empty())
     return failure();
 
   op.markForceable(false);
   return success();
 }
-
-
 
 // Interesting names and symbols and don't touch force nodes to stick around.
 LogicalResult NodeOp::fold(FoldAdaptor adaptor,

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -131,13 +131,15 @@ LogicalResult circt::firrtl::detail::verifyForceableOp(Forceable op) {
   return success();
 }
 
-Forceable circt::firrtl::detail::replaceWithNewForceability(Forceable op, bool forceable){
+Forceable circt::firrtl::detail::replaceWithNewForceability(Forceable op,
+                                                            bool forceable) {
   if (forceable == op.isForceable())
     return op;
 
   assert(op->getNumRegions() == 0);
 
-  // Create copy of this operation with/without the forceable marker + result type.
+  // Create copy of this operation with/without the forceable marker + result
+  // type.
   OpBuilder b(op.getContext());
 
   // Grab the current operation's results and attributes.
@@ -149,12 +151,14 @@ Forceable circt::firrtl::detail::replaceWithNewForceability(Forceable op, bool f
   if (forceable)
     resultTypes.push_back(refType);
   else {
-    assert(resultTypes.back() == refType && "expected forceable type as last result");
+    assert(resultTypes.back() == refType &&
+           "expected forceable type as last result");
     resultTypes.pop_back();
   }
 
   // Add/remove the forceable marker.
-  auto forceableMarker = b.getNamedAttr(op.getForceableAttrName(), b.getUnitAttr());
+  auto forceableMarker =
+      b.getNamedAttr(op.getForceableAttrName(), b.getUnitAttr());
   if (forceable)
     attributes.push_back(forceableMarker);
   else {

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -131,4 +131,51 @@ LogicalResult circt::firrtl::detail::verifyForceableOp(Forceable op) {
   return success();
 }
 
+Forceable circt::firrtl::detail::replaceWithNewForceability(Forceable op, bool forceable){
+  if (forceable == op.isForceable())
+    return op;
+
+  assert(op->getNumRegions() == 0);
+
+  // Create copy of this operation with/without the forceable marker + result type.
+  OpBuilder b(op.getContext());
+
+  // Grab the current operation's results and attributes.
+  SmallVector<Type, 8> resultTypes(op->getResultTypes());
+  SmallVector<NamedAttribute, 16> attributes(op->getAttrs());
+
+  // Add/remove the optional ref result.
+  auto refType = firrtl::detail::getForceableResultType(true, op.getDataType());
+  if (forceable)
+    resultTypes.push_back(refType);
+  else {
+    assert(resultTypes.back() == refType && "expected forceable type as last result");
+    resultTypes.pop_back();
+  }
+
+  // Add/remove the forceable marker.
+  auto forceableMarker = b.getNamedAttr(op.getForceableAttrName(), b.getUnitAttr());
+  if (forceable)
+    attributes.push_back(forceableMarker);
+  else {
+    llvm::erase_value(attributes, forceableMarker);
+    assert(attributes.size() != op->getAttrs().size());
+  }
+
+  // Create the replacement operation.
+  OperationState state(op.getLoc(), op->getName(), op->getOperands(),
+                       resultTypes, attributes, op->getSuccessors());
+  b.setInsertionPoint(op);
+  auto *replace = b.create(state);
+
+  // Dropping forceability (!forceable) -> no uses of forceable ref handle.
+  assert(forceable || op.getDataRef().use_empty());
+
+  // Replace results.
+  for (auto result : llvm::drop_end(op->getResults(), forceable ? 0 : 1))
+    result.replaceAllUsesWith(replace->getResult(result.getResultNumber()));
+  op->erase();
+  return cast<Forceable>(replace);
+}
+
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp.inc"

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2824,4 +2824,15 @@ firrtl.module @AggregateCreate(in %vector_in: !firrtl.vector<uint<1>, 2>,
   // CHECK-NEXT: firrtl.strictconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>, b: uint<1>>
 }
 
+
+// CHECK-LABEL: firrtl.module private @RWProbeUnused
+firrtl.module private @RWProbeUnused(in %in: !firrtl.uint<4>, in %clk: !firrtl.clock, out %out: !firrtl.uint) {
+  // CHECK-NOT: forceable
+  %n, %n_ref = firrtl.node interesting_name %in forceable : !firrtl.uint<4>
+  %w, %w_ref = firrtl.wire interesting_name forceable : !firrtl.uint, !firrtl.rwprobe<uint>
+  firrtl.connect %w, %n : !firrtl.uint, !firrtl.uint<4>
+  %r, %r_ref = firrtl.reg interesting_name %clk forceable : !firrtl.clock, !firrtl.uint, !firrtl.rwprobe<uint>
+  firrtl.connect %r, %w : !firrtl.uint, !firrtl.uint
+  firrtl.connect %out, %r : !firrtl.uint, !firrtl.uint
+}
 }


### PR DESCRIPTION
Add canonicalizer to forceable declarations demoting to non-forceable if rwprobe ref result is unused.

Add method to `Forceable` for rewriting the op to add/remove forceability.