### PR TITLE
[HW][FIRRTL] Let ops specify inner symbol behavior.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -25,8 +25,9 @@ include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 class ReferableDeclOp<string mnemonic, list<Trait> traits = []> :
-  FIRRTLOp<mnemonic, traits # [HasCustomSSAName, InnerSymbol, FNamableOp]> {
-
+  FIRRTLOp<mnemonic, traits # [HasCustomSSAName,
+                               DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>,
+                               FNamableOp]> {
 }
 
 def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firrtl::WhenOp">,

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -265,6 +265,9 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
               circt::hw::InnerSymbolTable::getInnerSymbolAttrName());
       }]
     >,
+    // Ask an operation if per-field symbols are allowed.
+    // Defaults to indicating they're allowed iff there's a defined target result,
+    // but let operations answer this differently if for some reason that makes sense.
     StaticInterfaceMethod<"Returns whether per-field symbols are supported for this operation type.",
       "bool", "supportsPerFieldSymbols", (ins), [{}], /*defaultImplementation=*/[{
        return ConcreteOp::getTargetResultIndex().has_value();

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -265,6 +265,19 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
               circt::hw::InnerSymbolTable::getInnerSymbolAttrName());
       }]
     >,
+    StaticInterfaceMethod<"Returns whether per-field symbols are supported for this operation type.",
+      "bool", "supportsPerFieldSymbols", (ins), [{}], /*defaultImplementation=*/[{
+       return ConcreteOp::getTargetResultIndex().has_value();
+    }]>,
+    StaticInterfaceMethod<"Returns the index of the result the innner symbol targets, if applicable.  Per-field symbols are resolved into this.",
+      "std::optional<size_t>", "getTargetResultIndex">,
+    InterfaceMethod<"Returns the result the innner symbol targets, if applicable.  Per-field symbols are resolved into this.",
+      "OpResult", "getTargetResult", (ins), [{}], /*defaultImplementation=*/[{
+        auto idx = ConcreteOp::getTargetResultIndex();
+        if (!idx)
+          return {};
+        return $_op->getResult(*idx);
+      }]>,
   ];
 
   let verify = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2189,7 +2189,7 @@ void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   }
 }
 
-std::optional<size_t> MemOp::getTargetResultIndex() { return 0; }
+std::optional<size_t> MemOp::getTargetResultIndex() { return std::nullopt; }
 
 // Construct name of the module which will be used for the memory definition.
 StringAttr FirMemory::getFirMemoryName() const { return modName; }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1722,6 +1722,11 @@ void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   }
 }
 
+std::optional<size_t> InstanceOp::getTargetResultIndex() {
+  // Inner symbols on instance operations target the op not any result.
+  return std::nullopt;
+}
+
 void MemOp::build(OpBuilder &builder, OperationState &result,
                   TypeRange resultTypes, uint32_t readLatency,
                   uint32_t writeLatency, uint64_t depth, RUWAttr ruw,
@@ -2184,6 +2189,8 @@ void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   }
 }
 
+std::optional<size_t> MemOp::getTargetResultIndex() { return 0; }
+
 // Construct name of the module which will be used for the memory definition.
 StringAttr FirMemory::getFirMemoryName() const { return modName; }
 
@@ -2216,9 +2223,13 @@ LogicalResult NodeOp::inferReturnTypes(
   return success();
 }
 
+std::optional<size_t> NodeOp::getTargetResultIndex() { return 0; }
+
 void RegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   return forceableAsmResultNames(*this, getName(), setNameFn);
 }
+
+std::optional<size_t> RegOp::getTargetResultIndex() { return 0; }
 
 LogicalResult RegResetOp::verify() {
   auto reset = getResetValue();
@@ -2234,6 +2245,8 @@ LogicalResult RegResetOp::verify() {
   return success();
 }
 
+std::optional<size_t> RegResetOp::getTargetResultIndex() { return 0; }
+
 void RegResetOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   return forceableAsmResultNames(*this, getName(), setNameFn);
 }
@@ -2241,6 +2254,8 @@ void RegResetOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   return forceableAsmResultNames(*this, getName(), setNameFn);
 }
+
+std::optional<size_t> WireOp::getTargetResultIndex() { return 0; }
 
 //===----------------------------------------------------------------------===//
 // Statements

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2189,7 +2189,10 @@ void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   }
 }
 
-std::optional<size_t> MemOp::getTargetResultIndex() { return std::nullopt; }
+std::optional<size_t> MemOp::getTargetResultIndex() {
+  // Inner symbols on memory operations target the op not any result.
+  return std::nullopt;
+}
 
 // Construct name of the module which will be used for the memory definition.
 StringAttr FirMemory::getFirMemoryName() const { return modName; }

--- a/lib/Dialect/HW/HWOpInterfaces.cpp
+++ b/lib/Dialect/HW/HWOpInterfaces.cpp
@@ -40,6 +40,7 @@ LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
   auto result = op.getTargetResult();
   // If op supports per-field symbols, but does not have a target result,
   // its up to the operation to verify itself.
+  // (there are no uses for this presently, but be open to this anyway.)
   if (!result)
     return success();
   auto resultType = result.getType().dyn_cast<hw::FieldIDTypeInterface>();

--- a/lib/Dialect/HW/HWOpInterfaces.cpp
+++ b/lib/Dialect/HW/HWOpInterfaces.cpp
@@ -27,20 +27,24 @@ LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
   // If does not have any inner sym then ignore.
   if (!innerSym)
     return success();
-  if (isa<InstanceOp>(&op) || op->getNumResults() != 1) {
+
+  if (!op.supportsPerFieldSymbols()) {
     // The inner sym can only be specified on fieldID=0.
     if (innerSym.size() > 1 || !innerSym.getSymName()) {
-      op->emitOpError("cannot assign symbols to non-zero field id, for ops "
-                      "with zero or multiple results");
+      op->emitOpError("does not support per-field inner symbols");
       return failure();
     }
     return success();
   }
 
-  auto resultType =
-      op->getResultTypes()[0].dyn_cast<hw::FieldIDTypeInterface>();
+  auto result = op.getTargetResult();
+  // If op supports per-field symbols, but does not have a target result,
+  // its up to the operation to verify itself.
+  if (!result)
+    return success();
+  auto resultType = result.getType().dyn_cast<hw::FieldIDTypeInterface>();
   // If this type doesn't implement the FieldIDTypeInterface, then there is
-  // nothing additional to check.
+  // nothing additional we can check.
   if (!resultType)
     return success();
   auto maxFields = resultType.getMaxFieldID();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -910,7 +910,7 @@ firrtl.circuit "Parent" {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
   }
   firrtl.module @Parent() {
-    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with zero or multiple results}}
+    // expected-error @below {{'firrtl.instance' op does not support per-field inner symbols}}
     firrtl.instance child sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Child()
   }
 }
@@ -930,7 +930,7 @@ firrtl.circuit "Foo"   {
   firrtl.module @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>, out %c: !firrtl.uint<1>) {
   }
   firrtl.module @Foo() {
-    // expected-error @+1 {{cannot assign symbols to non-zero field id, for ops with zero or multiple results}}
+    // expected-error @+1 {{'firrtl.instance' op does not support per-field inner symbols}}
     %bar_a, %bar_b, %bar_c = firrtl.instance bar sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] @Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [{circt.fieldID = 1 : i32, two}], out c: !firrtl.uint<1> [{four}])
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -919,8 +919,8 @@ firrtl.circuit "Parent" {
 
 firrtl.circuit "Foo" {
   firrtl.module @Foo() {
-  // expected-error @+1 {{field id:'1' is greater than the maximum field id:'0'}}
-    %m = firrtl.mem sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] Undefined {depth = 32 : i64, name = "m", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<>
+  // expected-error @below {{'firrtl.mem' op does not support per-field inner symbols}}
+    %m = firrtl.mem sym [<@x,1,public>,<@y,2,public>] Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
   }
 }
 

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -190,8 +190,8 @@ firrtl.module @InnerSymAttr() {
   // CHECK: %w1 = firrtl.wire sym @w1
   %w2 = firrtl.wire sym [<@w2,0,private>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
   // CHECK: %w2 = firrtl.wire sym [<@w2,0,private>]
-  %w3 = firrtl.wire sym [<@w3,2,public>,<@x2,1,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
-  // CHECK: %w3 = firrtl.wire sym [<@syh2,0,public>, <@x2,1,private>, <@w3,2,public>]
+  %w3, %w3_ref = firrtl.wire sym [<@w3,2,public>,<@x2,1,private>,<@syh2,0,public>] forceable : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>, !firrtl.rwprobe<bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>>
+  // CHECK: %w3, %w3_ref = firrtl.wire sym [<@syh2,0,public>, <@x2,1,private>, <@w3,2,public>]
 }
 
 // CHECK-LABEL: firrtl.module @EnumTest


### PR DESCRIPTION
* Which result, if any, do inner symbols target?
* Are per-field symbols sensible for this operation kind?

No longer need to know this information in the verifier or passes, query through the interface.

Fixes per-field inner symbol support on forceable declarations.

Fixes #4873 .