### PR TITLE
[FIRRTL] Fix replaceWithNewForceability to use PatternRewriter.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -25,6 +25,10 @@
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+namespace mlir {
+class PatternRewriter;
+} // end namespace mlir
+
 namespace circt {
 namespace firrtl {
 
@@ -115,7 +119,9 @@ RefType getForceableResultType(bool forceable, Type type);
 LogicalResult verifyForceableOp(Forceable op);
 /// Replace a Forceable op with equivalent, changing whether forceable.
 /// No-op if already has specified forceability.
-Forceable replaceWithNewForceability(Forceable op, bool forceable);
+Forceable
+replaceWithNewForceability(Forceable op, bool forceable,
+                           ::mlir::PatternRewriter *rewriter = nullptr);
 } // end namespace detail
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -447,10 +447,6 @@ def Forceable : OpInterface<"Forceable"> {
     "mlir::TypedValue<RefType>", "getDataRef", (ins), [{}], /*defaultImplementation=*/[{
       return llvm::cast_or_null<mlir::TypedValue<RefType>>($_op.getRef());
     }]>,
-    InterfaceMethod<"Mark operation as forceable (or not), replacing this op as needed.",
-    "Forceable", "markForceable", (ins "bool":$forceable), [{}], /*defaultImplementation=*/[{
-      return detail::replaceWithNewForceability($_op, forceable);
-    }]>
   ];
   let extraClassDeclaration = [{
     /// Attribute name for 'forceable' tracking.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1821,7 +1821,7 @@ static LogicalResult demoteForceableIfUnused(OpTy op,
   if (!op.isForceable() || !op.getDataRef().use_empty())
     return failure();
 
-  op.markForceable(false);
+  firrtl::detail::replaceWithNewForceability(op, false, &rewriter);
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
 


### PR DESCRIPTION
Drop interface method for this until a good design there is found.

Not using the rewriter may cause crashes or other behavior, so fixing this for now
and can find how/if to put this back on the Forceable interface in the future.