### PR TITLE
[FIRRTL][FIRParser] Parse RWProbe<T> and rwprobe().

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -701,9 +701,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
         parseToken(FIRToken::greater, "expected '>' in reference type"))
       return failure();
 
-    if (kind == FIRToken::kw_RWProbe)
-      emitWarning(translateLocation(loc),
-                  "RWProbe not yet supported, converting to Probe");
+    bool forceable = kind == FIRToken::kw_RWProbe;
 
     auto innerType = dyn_cast<FIRRTLBaseType>(type);
     if (!innerType) // TODO: "innerType.containsReference()"
@@ -712,7 +710,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     if (!innerType.isPassive())
       return emitError(loc, "probe inner type must be passive");
 
-    result = RefType::get(innerType);
+    result = RefType::get(innerType, forceable);
     break;
   }
 
@@ -2458,6 +2456,7 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
           staticRef.getDefiningOp()))
     return emitError(startTok.getLoc(), "cannot probe memories or their ports");
 
+  // TODO: RWProbe<T>.  rework ref.send, not good for force.
   result = builder.create<RefSendOp>(staticRef);
 
   return success();

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1157,19 +1157,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: module private @RefsChild(
   ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>
-  ; CHECK-SAME: out %rw: !firrtl.probe<uint<1>>
+  ; CHECK-SAME: out %rw: !firrtl.rwprobe<uint<1>>
   module RefsChild :
     input in : UInt<1>
     output r : Probe<UInt<1>>
     output rw : RWProbe<UInt<1>>
 
-    ; CHECK-NEXT: %[[NODE:.+]] = firrtl.node
+    ; CHECK-NEXT: %[[NODE:.+]], %[[NODE_RWREF:.+]] = firrtl.node
+    ; CHECK-SAME: forceable
     node n = in
     ; CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %[[NODE]]
     ; CHECK-NEXT: ref.define %r, %[[REF]]
     define r = probe(n)
-    ; CHECK-NEXT: %[[RWREF:.+]] = firrtl.ref.send %[[NODE]]
-    ; CHECK-NEXT: ref.define %rw, %[[RWREF]]
+    ; CHECK-NOT: ref.send
+    ; CHECK-NEXT: ref.define %rw, %[[NODE_RWREF]]
     define rw = rwprobe(n)
 
   ; CHECK-LABEL: module private @Refs(
@@ -1190,6 +1191,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: ref.define %r, %[[OUTREF]]
     define r = probe(out)
     ; CHECK-NEXT: ref.define %rw, %[[RC_RW]]
+    ; CHECK-SAME: rwprobe
     define rw = rc.rw
 
     ; CHECK-NEXT: %[[READ_RC_R:.+]] = firrtl.ref.resolve %[[RC_R]]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1161,7 +1161,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module RefsChild :
     input in : UInt<1>
     output r : Probe<UInt<1>>
-    output rw : RWProbe<UInt<1>> ; expected-warning {{RWProbe not yet supported}}
+    output rw : RWProbe<UInt<1>>
 
     ; CHECK-NEXT: %[[NODE:.+]] = firrtl.node
     node n = in
@@ -1176,7 +1176,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module Refs :
     input in : UInt<1>
     output r : Probe<UInt<1>>
-    output rw : RWProbe<UInt<1>> ; expected-warning {{RWProbe not yet supported}}
+    output rw : RWProbe<UInt<1>>
     output out : UInt<1>
     output out2 : UInt<1>
     output out3 : UInt<3>


### PR DESCRIPTION
With the IR pieces in place, add parsing support instead of faking it.

* Parse RWProbe into firrtl.rwprobe<T> .
* Add `rwprobe()` support leveraging `Forceable`.

Eagerly create declarations with the rwprobe ref result enabled,
to ensure it's available if it's needed.
Cleanup any declarations not forced (most of them) after parsing.