### PR TITLE
[Arc] Memory ops: optional enables and folders

### DIFF
--- a/include/circt/Dialect/Arc/ArcDialect.td
+++ b/include/circt/Dialect/Arc/ArcDialect.td
@@ -18,6 +18,7 @@ def ArcDialect : Dialect {
   }];
   let cppNamespace = "circt::arc";
 
+  let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -260,22 +260,25 @@ class MemoryAndDataTypesMatch<string mem, string data> : TypesMatchWith<
 
 def MemoryReadPortOp : ArcOp<"memory_read_port", [
   MemoryEffects<[MemRead]>,
-  MemoryAndDataTypesMatch<"memory", "data">
+  MemoryAndDataTypesMatch<"memory", "data">,
+  AttrSizedOperandSegments
 ]> {
   let summary = "Read port from a memory";
   let arguments = (ins
     MemoryType:$memory,
     AnyInteger:$address,
     Optional<I1>:$clock,
-    I1:$enable
+    Optional<I1>:$enable
   );
   let results = (outs AnyInteger:$data);
+
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` $enable ( `clock` $clock^ )?
+    $memory `[` $address `]` (`if` $enable^)? (`clock` $clock^)?
     attr-dict `:` type($memory) `,` type($address)
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def MemoryWritePortOp : ArcOp<"memory_write_port", [
@@ -288,17 +291,20 @@ def MemoryWritePortOp : ArcOp<"memory_write_port", [
     MemoryType:$memory,
     AnyInteger:$address,
     Optional<I1>:$clock,
-    I1:$enable,
+    Optional<I1>:$enable,
     AnyInteger:$data,
     Optional<AnyInteger>:$mask
   );
+
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` $enable `,` $data
-    ( `mask` `(` $mask^ `:` type($mask) `)`)? (`clock` $clock^)?
+    $memory `[` $address `]` `,` $data (`mask` `(` $mask^ `:` type($mask) `)`)?
+    (`if` $enable^)? (`clock` $clock^)?
     attr-dict `:` type($memory) `,` type($address)
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 def MemoryReadOp : ArcOp<"memory_read", [
@@ -311,6 +317,7 @@ def MemoryReadOp : ArcOp<"memory_read", [
     AnyInteger:$address
   );
   let results = (outs AnyInteger:$data);
+
   let assemblyFormat = [{
     $memory `[` $address `]` attr-dict `:` type($memory) `,` type($address)
   }];
@@ -324,13 +331,17 @@ def MemoryWriteOp : ArcOp<"memory_write", [
   let arguments = (ins
     MemoryType:$memory,
     AnyInteger:$address,
-    I1:$enable,
+    Optional<I1>:$enable,
     AnyInteger:$data
   );
+
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` $enable `,` $data
+    $memory `[` $address `]` `,` $data (`if` $enable^)?
     attr-dict `:` type($memory) `,` type($address)
   }];
+
+  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -259,8 +259,10 @@ struct MemoryWriteOpLowering : public OpConversionPattern<arc::MemoryWriteOp> {
     auto access = prepareMemoryAccess(
         op.getLoc(), adaptor.getMemory(), adaptor.getAddress(),
         op.getMemory().getType().cast<MemoryType>(), rewriter);
-    auto enable = rewriter.create<LLVM::AndOp>(op.getLoc(), adaptor.getEnable(),
-                                               access.withinBounds);
+    auto enable = access.withinBounds;
+    if (adaptor.getEnable())
+      enable = rewriter.create<LLVM::AndOp>(op.getLoc(), adaptor.getEnable(),
+                                            enable);
 
     // Only attempt to write the memory if the address is within bounds.
     rewriter.replaceOpWithNewOp<scf::IfOp>(

--- a/lib/Dialect/Arc/ArcDialect.cpp
+++ b/lib/Dialect/Arc/ArcDialect.cpp
@@ -9,6 +9,7 @@
 #include "circt/Dialect/Arc/ArcDialect.h"
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/Arc/ArcTypes.h"
+#include "circt/Dialect/HW/HWOps.h"
 
 using namespace circt;
 using namespace arc;
@@ -19,6 +20,31 @@ void ArcDialect::initialize() {
 #define GET_OP_LIST
 #include "circt/Dialect/Arc/Arc.cpp.inc"
       >();
+}
+
+/// Registered hook to materialize a single constant operation from a given
+/// attribute value with the desired resultant type. This method should use
+/// the provided builder to create the operation without changing the
+/// insertion position. The generated operation is expected to be constant
+/// like, i.e. single result, zero operands, non side-effecting, etc. On
+/// success, this hook should return the value generated to represent the
+/// constant value. Otherwise, it should return null on failure.
+Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
+                                           Type type, Location loc) {
+  // Integer constants.
+  if (auto intType = type.dyn_cast<IntegerType>())
+    if (auto attrValue = value.dyn_cast<IntegerAttr>())
+      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+
+  // Parameter expressions materialize into hw.param.value.
+  auto *parentOp = builder.getBlock()->getParentOp();
+  auto curModule = dyn_cast<hw::HWModuleOp>(parentOp);
+  if (!curModule)
+    curModule = parentOp->getParentOfType<hw::HWModuleOp>();
+  if (curModule && isValidParameterExpression(value, curModule))
+    return builder.create<hw::ParamValueOp>(loc, type, value);
+
+  return nullptr;
 }
 
 #include "circt/Dialect/Arc/ArcDialect.cpp.inc"

--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -7,11 +7,32 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 using namespace circt;
 using namespace arc;
 using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+static bool isAlways(Attribute attr, bool expected) {
+  if (auto enable = dyn_cast_or_null<IntegerAttr>(attr))
+    return enable.getValue().getBoolValue() == expected;
+  return false;
+}
+
+static bool isAlways(Value value, bool expected) {
+  if (!value)
+    return false;
+
+  if (auto constOp = value.getDefiningOp<hw::ConstantOp>())
+    return constOp.getValue().getBoolValue() == expected;
+
+  return false;
+}
 
 //===----------------------------------------------------------------------===//
 // StateOp
@@ -25,5 +46,56 @@ LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
     return success();
   }
 
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// MemoryReadPortOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult MemoryReadPortOp::fold(FoldAdaptor adaptor) {
+  // The result is undefined in this case, but we just return 0.
+  if (isAlways(adaptor.getEnable(), false))
+    return IntegerAttr::get(getType(), 0);
+
+  if (isAlways(adaptor.getEnable(), true))
+    return this->getEnableMutable().clear(), this->getResult();
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// MemoryWritePortOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MemoryWritePortOp::fold(FoldAdaptor adaptor,
+                                      SmallVectorImpl<OpFoldResult> &results) {
+  if (isAlways(adaptor.getEnable(), true))
+    return getEnableMutable().clear(), success();
+  return failure();
+}
+
+LogicalResult MemoryWritePortOp::canonicalize(MemoryWritePortOp op,
+                                              PatternRewriter &rewriter) {
+  if (isAlways(op.getEnable(), false))
+    return rewriter.eraseOp(op), success();
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// MemoryWriteOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MemoryWriteOp::fold(FoldAdaptor adaptor,
+                                  SmallVectorImpl<OpFoldResult> &results) {
+  if (isAlways(adaptor.getEnable(), true))
+    return getEnableMutable().clear(), success();
+  return failure();
+}
+
+LogicalResult MemoryWriteOp::canonicalize(MemoryWriteOp op,
+                                          PatternRewriter &rewriter) {
+  if (isAlways(op.getEnable(), false))
+    return rewriter.eraseOp(op), success();
   return failure();
 }

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_dialect_library(CIRCTArc
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTHW
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -121,13 +121,24 @@ func.func @MemoryUpdates(%arg0: !arc.storage<24>, %enable: i1) {
   // CHECK-NEXT: [[BB_RESUME]]([[LOADED:%.+]]: i42):
   // CHECK:        [[ADDED:%.+]] = llvm.add [[LOADED]], [[LOADED]]
 
-  arc.memory_write %0[%c3_i19], %enable, %2 : <4 x i42, 6>, i19
+  arc.memory_write %0[%c3_i19], %2 if %enable : <4 x i42, 6>, i19
   // CHECK-NEXT:   [[ADDR:%.+]] = llvm.zext [[THREE]] : i19 to i20
   // CHECK-NEXT:   [[FOUR:%.+]] = llvm.mlir.constant(4
   // CHECK-NEXT:   [[INBOUNDS:%.+]] = llvm.icmp "ult" [[ADDR]], [[FOUR]]
   // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i48>, i20) -> !llvm.ptr<i42>
   // CHECK-NEXT:   [[COND:%.+]] = llvm.and %arg1, [[INBOUNDS]]
   // CHECK-NEXT:   llvm.cond_br [[COND]], [[BB_STORE:\^.+]], [[BB_RESUME:\^.+]]
+  // CHECK-NEXT: [[BB_STORE]]:
+  // CHECK-NEXT:   llvm.store [[ADDED]], [[GEP]]
+  // CHECK-NEXT:   llvm.br [[BB_RESUME]]
+  // CHECK-NEXT: [[BB_RESUME]]:
+
+  arc.memory_write %0[%c3_i19], %2 : <4 x i42, 6>, i19
+  // CHECK-NEXT:   [[ADDR:%.+]] = llvm.zext [[THREE]] : i19 to i20
+  // CHECK-NEXT:   [[FOUR:%.+]] = llvm.mlir.constant(4
+  // CHECK-NEXT:   [[INBOUNDS:%.+]] = llvm.icmp "ult" [[ADDR]], [[FOUR]]
+  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i48>, i20) -> !llvm.ptr<i42>
+  // CHECK-NEXT:   llvm.cond_br [[INBOUNDS]], [[BB_STORE:\^.+]], [[BB_RESUME:\^.+]]
   // CHECK-NEXT: [[BB_STORE]]:
   // CHECK-NEXT:   llvm.store [[ADDED]], [[GEP]]
   // CHECK-NEXT:   llvm.br [[BB_RESUME]]

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -177,7 +177,7 @@ arc.define @lutSideEffects () -> i32 {
     %true = hw.constant true
     // expected-note @+1 {{first operation with side-effects here}}
     %1 = arc.memory !arc.memory<20 x i32>
-    %2 = arc.memory_read_port %1[%true], %true clock %true : !arc.memory<20 x i32>, i1
+    %2 = arc.memory_read_port %1[%true] clock %true : !arc.memory<20 x i32>, i1
     arc.output %2 : i32
   }
   arc.output %0 : i32
@@ -266,7 +266,7 @@ hw.module @memoryReadPortOpInsideClockDomain(%clk: i1) {
     %mem = arc.memory <4 x i32>
     %c0_i32 = hw.constant 0 : i32
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    %0 = arc.memory_read_port %mem[%c0_i32], %arg0 clock %arg0 : !arc.memory<4 x i32>, i32
+    %0 = arc.memory_read_port %mem[%c0_i32] if %arg0 clock %arg0 : !arc.memory<4 x i32>, i32
     arc.output
   }
 }
@@ -279,7 +279,7 @@ hw.module @memoryWritePortOpInsideClockDomain(%clk: i1) {
     %mem = arc.memory <4 x i32>
     %c0_i32 = hw.constant 0 : i32
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    arc.memory_write_port %mem[%c0_i32], %arg0, %c0_i32 clock %arg0 : !arc.memory<4 x i32>, i32
+    arc.memory_write_port %mem[%c0_i32], %c0_i32 if %arg0 clock %arg0 : !arc.memory<4 x i32>, i32
     arc.output
   }
 }
@@ -290,7 +290,7 @@ hw.module @memoryReadPortOpOutsideClockDomain(%en: i1) {
   %mem = arc.memory <4 x i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{outside a clock domain requires a clock}}
-  %0 = arc.memory_read_port %mem[%c0_i32], %en : !arc.memory<4 x i32>, i32
+  %0 = arc.memory_read_port %mem[%c0_i32] if %en : !arc.memory<4 x i32>, i32
 }
 
 // -----
@@ -299,5 +299,5 @@ hw.module @memoryWritePortOpOutsideClockDomain(%en: i1) {
   %mem = arc.memory <4 x i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{outside a clock domain requires a clock}}
-  arc.memory_write_port %mem[%c0_i32], %en, %c0_i32 : !arc.memory<4 x i32>, i32
+  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en : !arc.memory<4 x i32>, i32
 }

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -113,10 +113,15 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
   // CHECK: [[MEM:%.+]] = arc.memory <4 x i32>
   %mem = arc.memory <4 x i32>
 
-  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32], %en clock %clk : <4 x i32>, i32
-  %0 = arc.memory_read_port %mem[%c0_i32], %en clock %clk : <4 x i32>, i32
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %en, %c0_i32 clock %clk : <4 x i32>, i32
-  arc.memory_write_port %mem[%c0_i32], %en, %c0_i32 clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] if %en clock %clk : <4 x i32>, i32
+  %0 = arc.memory_read_port %mem[%c0_i32] if %en clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 if %en clock %clk : <4 x i32>, i32
+  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en clock %clk : <4 x i32>, i32
+
+  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] clock %clk : <4 x i32>, i32
+  %1 = arc.memory_read_port %mem[%c0_i32] clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 clock %clk : <4 x i32>, i32
+  arc.memory_write_port %mem[%c0_i32], %c0_i32 clock %clk : <4 x i32>, i32
 
   // CHECK-NEXT: arc.clock_domain
   arc.clock_domain (%clk) clock %clk : (i1) -> () {
@@ -124,14 +129,22 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
     %c1_i32 = hw.constant 1 : i32
     // CHECK: [[MEM2:%.+]] = arc.memory <4 x i32>
     %mem2 = arc.memory <4 x i32>
-    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32], %arg0 : <4 x i32>, i32
-    %1 = arc.memory_read_port %mem2[%c1_i32], %arg0 : <4 x i32>, i32
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %arg0, %c1_i32 : <4 x i32>, i32
-    arc.memory_write_port %mem2[%c1_i32], %arg0, %c1_i32 : <4 x i32>, i32
+    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] if %arg0 : <4 x i32>, i32
+    %2 = arc.memory_read_port %mem2[%c1_i32] if %arg0 : <4 x i32>, i32
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 if %arg0 : <4 x i32>, i32
+    arc.memory_write_port %mem2[%c1_i32], %c1_i32 if %arg0 : <4 x i32>, i32
+
+    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32>, i32
+    %3 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32>, i32
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 : <4 x i32>, i32
+    arc.memory_write_port %mem2[%c1_i32], %c1_i32 : <4 x i32>, i32
   }
 
   // CHECK: %{{.+}} = arc.memory_read [[MEM]][%c0_i32] : <4 x i32>, i32
-  %1 = arc.memory_read %mem[%c0_i32] : <4 x i32>, i32
-  // CHECK-NEXT: arc.memory_write [[MEM]][%c0_i32], %en, %c0_i32 : <4 x i32>, i32
-  arc.memory_write %mem[%c0_i32], %en, %c0_i32 : <4 x i32>, i32
+  %2 = arc.memory_read %mem[%c0_i32] : <4 x i32>, i32
+  // CHECK-NEXT: arc.memory_write [[MEM]][%c0_i32], %c0_i32 if %en : <4 x i32>, i32
+  arc.memory_write %mem[%c0_i32], %c0_i32 if %en : <4 x i32>, i32
+
+  // CHECK-NEXT: arc.memory_write [[MEM]][%c0_i32], %c0_i32 : <4 x i32>, i32
+  arc.memory_write %mem[%c0_i32], %c0_i32 : <4 x i32>, i32
 }

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -26,3 +26,22 @@ hw.module @clockDomainDCE(%clk: i1) {
     arc.output
   }
 }
+
+// CHECK-LABEL: hw.module @memoryOps
+hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32>, %addr: i32, %data: i32) -> (out0: i32, out1: i32) {
+  %true = hw.constant true
+  // CHECK: [[RD:%.+]] = arc.memory_read_port %mem[%addr] clock %clk : <4 x i32>, i32
+  %0 = arc.memory_read_port %mem[%addr] if %true clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: arc.memory_write_port %mem[%addr], %data clock %clk : <4 x i32>, i32
+  arc.memory_write_port %mem[%addr], %data if %true clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: arc.memory_write %mem[%addr], %data : <4 x i32>, i32
+  arc.memory_write %mem[%addr], %data if %true : <4 x i32>, i32
+
+  %false = hw.constant false
+  %1 = arc.memory_read_port %mem[%addr] if %false clock %clk : <4 x i32>, i32
+  arc.memory_write_port %mem[%addr], %data if %false clock %clk : <4 x i32>, i32
+  arc.memory_write %mem[%addr], %data if %false : <4 x i32>, i32
+
+  // CHECK-NEXT: hw.output [[RD]], %c0_i32
+  hw.output %0, %1 : i32, i32
+}

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -7,7 +7,7 @@ hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numW
 hw.module @TestWOMemory(%clock: i1, %addr: i10, %enable: i1, %data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %enable, %data clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data if %enable clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i8) -> ()
 }
@@ -25,7 +25,7 @@ hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16,
   // CHECK-NEXT: [[MASK_BIT1:%.+]] = comb.extract %mask from 1 : (i2) -> i1
   // CHECK-NEXT: [[MASK_BYTE1:%.+]] = comb.replicate [[MASK_BIT1]] : (i1) -> i8
   // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE0]], [[MASK_BYTE1]]
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %enable, %data mask([[MASK]] : i16) clock %clock : <1024 x i16>, i10
+  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data mask([[MASK]] : i16) if %enable clock %clock : <1024 x i16>, i10
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
 }
@@ -38,7 +38,7 @@ hw.module.generated @WOMemoryWithMask, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0
 hw.module @TestROMemory(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr], %enable clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] if %enable clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: hw.output [[RDATA]]
   %0 = hw.instance "foo" @ROMemory(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
   hw.output %0 : i8
@@ -52,7 +52,7 @@ hw.module.generated @ROMemory, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1
 hw.module @TestROMemoryWithLatency(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: [[D0:%.+]] = arc.memory_read_port [[FOO]][%addr], %enable clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[D0:%.+]] = arc.memory_read_port [[FOO]][%addr] if %enable clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: [[D1:%.+]] = seq.compreg {{.+}} [[D0]], %clock
   // CHECK-NEXT: [[D2:%.+]] = seq.compreg {{.+}} [[D1]], %clock
   // CHECK-NEXT: [[D3:%.+]] = seq.compreg {{.+}} [[D2]], %clock
@@ -72,9 +72,9 @@ hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata:
   // CHECK-NEXT: hw.constant true
   // CHECK-NEXT: [[WMODE_INV:%.+]] = comb.xor %wmode, %true
   // CHECK-NEXT: [[RENABLE:%.+]] = comb.and %enable, [[WMODE_INV]]
-  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr], [[RENABLE]] clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] if [[RENABLE]] clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], [[WENABLE]], %wdata clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %wdata if [[WENABLE]] clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: hw.output [[RDATA]]
   %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
   hw.output %0 : i8


### PR DESCRIPTION
Make the enables of the MemoryReadPortOp, MemoryWritePortOp, and MemoryWriteOp optional. Its absence means a constant true enable. Add folders to remove the operand when it is constant true as well as remove the entire operation when the enable is constant false as the writes do not ever happen in this case and the read returns an undefined value.