### PR TITLE
[FIRRTL][IMCP] Clear more state to avoid bugs w/pass obj reuse.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -365,6 +365,9 @@ void IMConstPropPass::runOnOperation() {
   instanceGraph = nullptr;
   latticeValues.clear();
   executableBlocks.clear();
+  assert(changedLatticeValueWorklist.empty());
+  fieldRefToUsers.clear();
+  valueToFieldRef.clear();
   resultPortToInstanceResultMapping.clear();
 }
 


### PR DESCRIPTION
This aligns with backtraces produced for recent occasional CI
failure in circt-reduce on trivial.mlir, such as in [1],
which this hopefully resolves.

[1] https://github.com/llvm/circt/actions/runs/4618772832/jobs/8166656654?pr=4879