### PR TITLE
[FIRRTL][LowerXMR] Treat forceable ref result as ref origin.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -194,6 +194,12 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             resolveOps.push_back(resolve);
             return success();
           })
+          .Case<Forceable>([&](Forceable op) {
+            if (!op.isForceable() || op.getDataRef().use_empty())
+              return success();
+            addReachingSendsEntry(op.getDataRef(), getInnerRefTo(op));
+            return success();
+          })
           .Default([&](auto) { return success(); });
     };
 


### PR DESCRIPTION
Support read of a rwprobe, add test.