### PR TITLE
[FIRRTL] Allow ref.sub of rwprobe while allowing LowerTypes of forceables.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4137,9 +4137,10 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
   // TODO: Determine ref.sub + rwprobe behavior, test.
   // Probably best to demote to non-rw, but that has implications
   // for any LowerTypes behavior being relied on.
+  // Allow for now, as need to LowerTypes things generally.
   if (auto vectorType = inType.dyn_cast<FVectorType>()) {
     if (fieldIdx < vectorType.getNumElements())
-      return RefType::get(vectorType.getElementType());
+      return RefType::get(vectorType.getElementType(), refType.getForceable());
     return emitInferRetTypeError(loc, "out of range index '", fieldIdx,
                                  "' in RefType of vector type ", refType);
   }
@@ -4149,7 +4150,8 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                    "subfield element index is greater than "
                                    "the number of fields in the bundle type");
     }
-    return RefType::get(bundleType.getElement(fieldIdx).type);
+    return RefType::get(bundleType.getElement(fieldIdx).type,
+                        refType.getForceable());
   }
 
   return emitInferRetTypeError(

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1304,9 +1304,8 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
       for (const auto &field : fieldTypes) {
         newDirs.push_back(direction::get((unsigned)oldDir ^ field.isOutput));
         newNames.push_back(builder->getStringAttr(oldName + field.suffix));
-        resultTypes.push_back(srcType.isa<RefType>()
-                                  ? FIRRTLType(RefType::get(field.type))
-                                  : FIRRTLType(field.type));
+        resultTypes.push_back(
+            mapBaseType(srcType, [&](auto base) { return field.type; }));
         auto annos = filterAnnotations(
             context, oldPortAnno[i].dyn_cast_or_null<ArrayAttr>(), srcType,
             field);

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1158,6 +1158,19 @@ firrtl.module private @is1436_FOO() {
     firrtl.strictconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>
     // CHECK-NEXT: }
   }
+  // Check how rwprobe's of aggregates in instances are handled.
+  // Temporary until no longer need to lower these.
+  // CHECK-LABEL: firrtl.module private @InstWithRWProbeOfAgg
+  firrtl.module private @InstWithRWProbeOfAgg() {
+    // CHECK-NOT: firrtl.probe
+    // CHECK: probe: !firrtl.probe<uint<2>>)
+    %inst_vec_ref, %inst_vec, %inst_bov_ref, %inst_bov, %inst_probe = firrtl.instance inst @RefTypeBV_RW(
+      out vec_ref: !firrtl.rwprobe<vector<uint<1>,2>>,
+      out vec: !firrtl.vector<uint<1>,2>,
+      out bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>,
+      out bov: !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>,
+      out probe: !firrtl.probe<uint<2>>)
+  }
 
   // CHECK-LABEL: firrtl.module private @ForeignTypes
   firrtl.module private @ForeignTypes() {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1132,18 +1132,18 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT: firrtl.strictconnect %vec_0, %[[v_0]]
     // CHECK-NEXT: firrtl.strictconnect %vec_1, %[[v_1]]
     %x_ref_a = firrtl.ref.sub %x_ref[0] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
-    %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.probe<vector<uint<1>,2>>
+    %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.rwprobe<vector<uint<1>,2>>
     firrtl.strictconnect %vec, %x_a : !firrtl.vector<uint<1>,2>
 
     // Check chained ref.sub's work.
     // CHECK-NEXT: firrtl.ref.resolve %[[X_A_1_REF]]
-    %x_ref_a_1 = firrtl.ref.sub %x_ref_a[1] : !firrtl.probe<vector<uint<1>,2>>
-    %x_a_1 = firrtl.ref.resolve %x_ref_a_1 : !firrtl.probe<uint<1>>
+    %x_ref_a_1 = firrtl.ref.sub %x_ref_a[1] : !firrtl.rwprobe<vector<uint<1>,2>>
+    %x_a_1 = firrtl.ref.resolve %x_ref_a_1 : !firrtl.rwprobe<uint<1>>
 
     // Ref to flipped field.
     // CHECK-NEXT: firrtl.ref.resolve %[[X_B_REF]]
     %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
-    %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.probe<uint<2>>
+    %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.rwprobe<uint<2>>
     // TODO: Handle rwprobe --> probe define, enable this.
     // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>
 


### PR DESCRIPTION
Still reject this in the input, but as long as we require fully splitting up references we need a way to (temporarily) represent a sub-element of a `rwprobe`.

Allow this for now.

This is okay as long as the entire reference "chain" is "lowered"/expanded.