### PR TITLE
[FIRRTL] Support mixed const operands in firrtl ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -41,8 +41,12 @@ def GetDroppableNameAttr : NativeCodeCall<
 def NonEmptyAttr : Constraint<CPred<"!$0.getValue().empty()">>;
 def NullAttr : Constraint<CPred<"!$0">>;
 
-// Constraint that enforces equal types
-def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
+// Constraint that enforces types are equal except for constness
+def MixedConstTypes : Constraint<CPred<[{
+  $0.getType() == $1.getType() ||
+  ($0.getType().isa<FIRRTLBaseType>() && $1.getType().isa<FIRRTLBaseType>() &&
+   mixedConstTypes($0.getType().cast<FIRRTLBaseType>(), $1.getType().cast<FIRRTLBaseType>()))
+}]>>;
 
 // Constraint that enforces int types
 def IntTypes : Constraint<CPred<"$0.isa<IntType>()">>;
@@ -53,8 +57,11 @@ def SIntTypes : Constraint<CPred<"$0.isa<SIntType>()">>;
 // Constraint that enforces uint types
 def UIntTypes : Constraint<CPred<"$0.isa<UIntType>()">>;
 
-// Constraint that enforces types mismatches
-def mismatchTypes : Constraint<CPred<"$0.getType() != $1.getType()">>;
+// Constraint that enforces type width mismatches
+def MismatchWidth : Constraint<CPred<[{
+  !$0.getType().isa<FIRRTLBaseType>() || !$1.getType().isa<FIRRTLBaseType>() ||
+  $0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel() != $1.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel()
+}]>>;
 
 // Constraint that enforces types of known width
 def KnownWidth : Constraint<CPred<[{
@@ -84,6 +91,8 @@ def AllOneConstantOp : Constraint<CPred<"$0.getDefiningOp<ConstantOp>() && $0.ge
 // Delta between type widths
 def TypeWidthAdjust32 : NativeCodeCall<
   "$_builder.getI32IntegerAttr($0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel() - $1.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel())">;
+
+def NonConstType : Constraint<CPred<"!isConst($0.getType())">>;
 
 /// Drop the writer to the first argument and passthrough the second
 def DropWrite : NativeCodeCall<"dropWrite($_builder, $0, $1)">;
@@ -127,14 +136,14 @@ def NotNot : Pat <
 def ConnectSameType : Pat<
   (ConnectOp $dst, $src),
   (StrictConnectOp $dst, $src),
-  [(EqualTypes $dst, $src), (KnownWidth $dst)]>;
+  [(MixedConstTypes $dst, $src), (KnownWidth $dst)]>;
 
 // connect(a:t1,b:(t2<t1) -> strictconnect(a,(pad b))
 def ConnectExtension : Pat<
   (ConnectOp $dst, $src),
   (StrictConnectOp $dst, (PadPrimOp $src,
     (NativeCodeCall<"$0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel()"> $dst))),
-  [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src), (mismatchTypes $src, $dst)]>;
+  [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src), (MismatchWidth $src, $dst)]>;
 
 def LimitConstant32 : NativeCodeCall<
   "$_builder.getI32IntegerAttr($0.getValue().getLimitedValue(1ULL << 31))">;
@@ -162,19 +171,19 @@ def extendAnd : Pat <
   (AndPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (AndPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                  (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (MismatchWidth $lhs, $rhs)]>;
 
 def extendOr : Pat <
   (OrPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (OrPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                 (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (MismatchWidth $lhs, $rhs)]>;
 
 def extendXor : Pat <
   (XorPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (XorPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                  (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (MismatchWidth $lhs, $rhs)]>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Move constants to the right
@@ -268,7 +277,7 @@ def AndOfZero : Pat <
 def AndOfAllOne : Pat <
   (AndPrimOp:$old $x, (ConstantOp:$ocst $cst)),
   (MoveNameHint $old, (AsUIntPrimOp (PadPrimOp $x, (TypeWidth32 $old)))),
-  [(KnownWidth $x), (EqualTypes $x, $ocst), (AllOneConstantOp $ocst)]>;
+  [(KnownWidth $x), (MixedConstTypes $x, $ocst), (AllOneConstantOp $ocst)]>;
 
 /// and(x,x) -> x, fold can't handle all cases
 def AndOfSelf : Pat <
@@ -280,7 +289,7 @@ def AndOfSelf : Pat <
 def AndOfPad : Pat <
   (AndPrimOp:$old (either $x, (PadPrimOp:$pad $y, $n))),
   (MoveNameHint $old, (PadPrimOp (AndPrimOp (TailPrimOp $x, (TypeWidthAdjust32 $x, $y)), $y), $n)),
-  [(KnownWidth $x), (UIntType $x), (EqualTypes $x, $pad)]>;
+  [(KnownWidth $x), (UIntType $x), (MixedConstTypes $x, $pad)]>;
 
 // or(x, 0) -> x, fold can't handle all cases
 def OrOfZero : Pat <
@@ -292,7 +301,7 @@ def OrOfZero : Pat <
 def OrOfAllOne : Pat <
   (OrPrimOp:$old $x, (ConstantOp:$ocst $cst)),
   (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), $0.getType().cast<IntType>(), getIntOnesAttr($0.getType()))"> $old),
-  [(KnownWidth $x), (EqualTypes $x, $ocst), (AllOneConstantOp $ocst)]>;
+  [(KnownWidth $x), (MixedConstTypes $x, $ocst), (AllOneConstantOp $ocst)]>;
 
 /// or(x,x) -> x, fold can't handle all cases
 def OrOfSelf : Pat <
@@ -305,7 +314,7 @@ def OrOfPad : Pat <
   (OrPrimOp:$old $x, (PadPrimOp:$pad $y, $n)),
   (MoveNameHint $old, (CatPrimOp (HeadPrimOp $x, (TypeWidthAdjust32 $x, $y)),
                                  (OrPrimOp (TailPrimOp $x, (TypeWidthAdjust32 $x, $y)), $y))),
-  [(KnownWidth $x), (UIntType $x), (EqualTypes $x, $pad)]>;
+  [(KnownWidth $x), (UIntType $x), (MixedConstTypes $x, $pad)]>;
 
 // xor(x, 0) -> x, fold can't handle all cases
 def XorOfZero : Pat <
@@ -324,7 +333,7 @@ def XorOfPad : Pat <
   (XorPrimOp:$old $x, (PadPrimOp:$pad $y, $n)),
   (MoveNameHint $old, (CatPrimOp (HeadPrimOp $x, (TypeWidthAdjust32 $x, $y)),
                                  (XorPrimOp (TailPrimOp $x, (TypeWidthAdjust32 $x, $y)), $y))),
-  [(KnownWidth $x), (UIntType $x), (EqualTypes $x, $pad)]>;
+  [(KnownWidth $x), (UIntType $x), (MixedConstTypes $x, $pad)]>;
 
 // bits(bits(x, ...), ...) -> bits(x, ...)
 def BitsOfBits : Pat<
@@ -345,7 +354,7 @@ def SubaccessOfConstant : Pat<
 def MuxNot : Pat<
   (MuxPrimOp:$old $cond, (ConstantOp:$zcst $_), (ConstantOp:$ocst $_)),
   (MoveNameHint $old, (NotPrimOp $cond)), [
-    (EqualTypes $cond, $zcst), (EqualTypes $cond, $ocst),
+    (MixedConstTypes $cond, $zcst), (MixedConstTypes $cond, $ocst),
     (ZeroConstantOp $zcst) , (OneConstantOp $ocst)
   ]>;
 
@@ -353,25 +362,25 @@ def MuxNot : Pat<
 def MuxSameTrue : Pat <
   (MuxPrimOp:$old $cond1, $t, (MuxPrimOp $cond2, $t, $f)),
   (MoveNameHint $old, (MuxPrimOp (OrPrimOp $cond1, $cond2), $t, $f)),
-  [(EqualTypes $t, $f), (KnownWidth $t)]>;
+  [(MixedConstTypes $t, $f), (KnownWidth $t)]>;
 
 // mux(cond1, mux(cond2, t, f), f) -> mux(and(cond1, cond2), t, f)
 def MuxSameFalse : Pat <
   (MuxPrimOp:$old $cond1, (MuxPrimOp $cond2, $t, $f), $f),
   (MoveNameHint $old, (MuxPrimOp (AndPrimOp $cond1, $cond2), $t, $f)),
-  [(EqualTypes $t, $f), (KnownWidth $f)]>;
+  [(MixedConstTypes $t, $f), (KnownWidth $f)]>;
 
 // mux(cond, (Concat a, b), (Concat a, c)) -> Concat(a, mux(cond, b, c))
 def NarrowMuxLHS : Pat <
   (MuxPrimOp:$old $cond, (CatPrimOp:$lhs $a, $b), (CatPrimOp:$rhs $a, $c)),
   (MoveNameHint $old, (CatPrimOp $a, (MuxPrimOp $cond, $b, $c))),
-  [(EqualTypes $lhs, $rhs), (KnownWidth $lhs)]>;
+  [(MixedConstTypes $lhs, $rhs), (KnownWidth $lhs)]>;
 
 // mux(cond, (Concat a, b), (Concat c, b)) -> Concat(mux(cond, a, c), b)
 def NarrowMuxRHS : Pat <
   (MuxPrimOp:$old $cond, (CatPrimOp:$lhs $a, $b), (CatPrimOp:$rhs $c, $b)),
   (MoveNameHint $old, (CatPrimOp (MuxPrimOp $cond, $a, $c), $b)),
-  [(EqualTypes $lhs, $rhs), (KnownWidth $lhs)]>;
+  [(MixedConstTypes $lhs, $rhs), (KnownWidth $lhs)]>;
 
 def CatDoubleConst : Pat <
   (CatPrimOp:$old $cst1, (CatPrimOp $cst2, $v)),

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -92,8 +92,6 @@ def AllOneConstantOp : Constraint<CPred<"$0.getDefiningOp<ConstantOp>() && $0.ge
 def TypeWidthAdjust32 : NativeCodeCall<
   "$_builder.getI32IntegerAttr($0.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel() - $1.getType().cast<FIRRTLBaseType>().getBitWidthOrSentinel())">;
 
-def NonConstType : Constraint<CPred<"!isConst($0.getType())">>;
-
 /// Drop the writer to the first argument and passthrough the second
 def DropWrite : NativeCodeCall<"dropWrite($_builder, $0, $1)">;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -87,7 +87,7 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>
   ];
 
-  let extraClassDeclaration = [{
+  let firrtlExtraClassDeclaration = [{
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
     FModuleLike getReferencedModule(SymbolTable& symtbl);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -373,7 +373,7 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
 
   let arguments = (
     ins ClockType:$clockVal, AnyResetType:$resetSignal,
-        AnyRegisterType:$resetValue,
+        FIRRTLBaseType:$resetValue,
         StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
         OptionalAttr<InnerSymAttr>:$inner_sym,

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
@@ -30,6 +30,7 @@ def FIRRTLDialect : Dialect {
     page](https://github.com/freechipsproject/firrtl).
   }];
 
+  let hasCanonicalizer = 1;
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 1;

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
@@ -52,6 +52,79 @@ def FIRRTLDialect : Dialect {
 
 // Base class for the operation in this dialect.
 class FIRRTLOp<string mnemonic, list<Trait> traits = []> :
-    Op<FIRRTLDialect, mnemonic, traits>;
+    Op<FIRRTLDialect, mnemonic, traits> {
+  
+  // Because FIRRTL hardware types can be 'const', folding an op can change
+  // it's type from a non-'const' to a 'const' type. 
+  // To accomodate this, ops with `hasFolder` automatically generate their
+  // `fold` functions to call a `constFold` function. `constFold` handles
+  // folding logic as normal. `fold` automatically handles type changes
+  // to 'const'.
+  
+  // If the op `hasFolder`, generate a `constFold` prototype 
+  // based on the number of results.
+  code constFoldDecl = !if(hasFolder, !if(!eq(!size(results), 1), 
+    [{
+      OpFoldResult constFold(FoldAdaptor adaptor);
+    }],
+    [{
+      LogicalResult constFold(FoldAdaptor adaptor, 
+                              SmallVectorImpl<OpFoldResult> &results);
+    }]
+  ), "");
+
+  // If the op `hasFolder`, generate a `fold` implementation that calls
+  // `constFold` and handles type changes.
+  code constFoldDef = !if(hasFolder, !if(!eq(!size(results), 1), 
+    [{    
+      OpFoldResult $cppClass::fold(FoldAdaptor adaptor) {
+        auto result = this->constFold(adaptor);
+        if (result) {
+          if (auto value = result.dyn_cast<Value>()) {
+            assert(mixedConstTypes((*this)->getResultTypes()[0].cast<FIRRTLBaseType>(),
+                                   value.getType().cast<FIRRTLBaseType>()) 
+                  && "result type can only differ by constness");
+            (*this)->getResult(0).setType(value.getType());
+          } else {
+            // TODO: Uncomment once constant ops return const types
+            // if (auto resultType =
+            // (*this)->getResultTypes()[0].dyn_cast<FIRRTLBaseType>())
+            //   (*this)->getResult(0).setType(resultType.getConstType(true));
+          }
+        }
+        return result;
+      }
+    }],
+    [{    
+      LogicalResult $cppClass::fold(FoldAdaptor adaptor,
+                                    SmallVectorImpl<OpFoldResult> &results) {
+        if (failed(this->constFold(adaptor, results)))
+          return failure();
+
+        for (size_t i = 0, e = results.size(); i != e; ++i) {
+          if (auto value = results[i].dyn_cast<Value>()) {
+            assert(mixedConstTypes((*this)->getResultTypes()[i].cast<FIRRTLBaseType>(),
+                                   value.getType().cast<FIRRTLBaseType>()) 
+                  && "result type can only differ by constness");
+            (*this)->getResult(i).setType(value.getType());
+          } else if (results[i]) {
+            // TODO: Uncomment once constant ops return const types
+            // if (auto resultType =
+            // (*this)->getResultTypes()[i].dyn_cast<FIRRTLBaseType>();
+            //     resultType && result)
+            //   (*this)->getResult(i).setType(resultType.getConstType(true));
+          }
+        }
+        return success();
+      }
+    }]
+  ), "");
+
+  // Additional class declarations to emit
+  code firrtlExtraClassDeclaration = "";
+
+  let extraClassDeclaration = constFoldDecl # firrtlExtraClassDeclaration;
+  let extraClassDefinition = constFoldDef;
+}
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLDIALECT_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
@@ -60,6 +60,15 @@ class FIRRTLOp<string mnemonic, list<Trait> traits = []> :
   // `fold` functions to call a `constFold` function. `constFold` handles
   // folding logic as normal. `fold` automatically handles type changes
   // to 'const'.
+  //
+  // This type change is needed for folding both values and attributes:
+  // - MLIR's canonicalizer checks that folded values have types identical 
+  //   to the types of the op results they are replacing. 
+  //   Updating the op result type allows that check to pass. 
+  // - MLIR's canonicalizer calls `materializeConstant` on folded attributes. 
+  //   Updating the op result type ensures that `materializeConstant` is 
+  //   provided a 'const' type for constant ops and that the canonicalizer's 
+  //   internal bookkeeping of cached constants is consistent.
   
   // If the op `hasFolder`, generate a `constFold` prototype 
   // based on the number of results.

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -54,11 +54,8 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
     return $_impl(operands, attrs, loc);
   } }]));
 
-  // Additional class declarations to emit alongside the type inference.
-  code firrtlExtraClassDeclaration = "";
-
   let extraClassDeclaration = firrtlExtraClassDeclaration # inferTypeDecl #
-      parseValidatorDecl # [{
+      parseValidatorDecl # constFoldDecl # [{
     /// Infer the return types of this operation. This is called by the
     /// `InferTypeOpInterface`. We simply forward to a narrower
     /// operation-specific implementation which is sufficient for FIRRTL ops.
@@ -140,7 +137,7 @@ def AggregateConstantOp : FIRRTLOp<"aggregateconstant", [Pure, ConstantLike]> {
     ```
   }];
 
-  let extraClassDeclaration = [{
+  let firrtlExtraClassDeclaration = [{
     Attribute getAttributeFromFieldID(uint64_t fieldID);
   }];
 
@@ -214,7 +211,7 @@ def FEnumCreateOp : FIRRTLOp<"enumcreate"> {
     }]>
   ];
 
-  let extraClassDeclaration = [{
+  let firrtlExtraClassDeclaration = [{
     /// Return the name of the accessed field.
     StringRef getFieldName() {
       return getResult().getType().getElementName(getFieldIndex());

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -55,6 +55,9 @@ bool isConstant(Value value);
 /// constant values
 bool isConst(Type type);
 
+// Returns true if the provided types are equal except for constness
+bool mixedConstTypes(FIRRTLBaseType a, FIRRTLBaseType b);
+
 /// Returns true if the value results from an expression with duplex flow.
 /// Duplex values have special treatment in bundle connect operations, and
 /// their flip orientation is not used to determine the direction of each

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -55,7 +55,7 @@ bool isConstant(Value value);
 /// constant values
 bool isConst(Type type);
 
-// Returns true if the provided types are equal except for constness
+/// Returns true if the provided types are equal except for constness
 bool mixedConstTypes(FIRRTLBaseType a, FIRRTLBaseType b);
 
 /// Returns true if the value results from an expression with duplex flow.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -50,7 +50,7 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasCanonicalizer = true;
 }
 
-def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]> {
+def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
   let summary = "Connect two signals";
   let description =  [{
     Connect two values with strict constraints:
@@ -67,7 +67,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
   let hasVerifier = 1;
 
   let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(qualified(type($dest)), qualified(type($src)))";
 }
 
 def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -67,7 +67,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
   let hasVerifier = 1;
 
   let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(qualified(type($dest)), qualified(type($src)))";
+    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(type($dest), type($src))";
 }
 
 def RefDefineOp : FIRRTLOp<"ref.define", [FConnectLike]> {
@@ -91,7 +91,7 @@ def RefDefineOp : FIRRTLOp<"ref.define", [FConnectLike]> {
   let hasVerifier = 1;
 
   let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(qualified(type($dest)), qualified(type($src)))";
+    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(type($dest), type($src))";
 
   let extraClassDeclaration = [{
     static ConnectBehaviorKind getConnectBehaviorKind() {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -70,7 +70,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
     "$dest `,` $src  attr-dict `:` custom<ConstDecay>(qualified(type($dest)), qualified(type($src)))";
 }
 
-def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
+def RefDefineOp : FIRRTLOp<"ref.define", [FConnectLike]> {
   let summary = "FIRRTL Define References";
   let description = [{
     Define a target reference to the source reference:
@@ -91,7 +91,7 @@ def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
   let hasVerifier = 1;
 
   let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+    "$dest `,` $src  attr-dict `:` custom<ConstDecay>(qualified(type($dest)), qualified(type($src)))";
 
   let extraClassDeclaration = [{
     static ConnectBehaviorKind getConnectBehaviorKind() {

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -183,15 +183,19 @@ public:
 /// definition of type equivalence in the FIRRTL spec.  If the types being
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
-/// If `strict` is `true`, `srcFType` must be identical `destFType` except that
-/// 'const' sources can be connected to non-'const' sinks.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
-                        bool srcOuterTypeIsConst = false, bool strict = false);
+                        bool srcOuterTypeIsConst = false);
+
+/// Returns whether the two types are strictly equivalent.  `srcFType` must be
+/// identical `destFType` except that 'const' sources can be connected to
+/// non-'const' sinks.
+bool areTypesStrictlyEquivalent(FIRRTLType destFType, FIRRTLType srcFType,
+                                bool srcOuterTypeIsConst = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types
-/// (the types with any flips pushed to the leaves) must match.  This allows for
-/// types with flips in different positions to be equivalent.
+/// (the types with any flips pushed to the leaves) must match.  This allows
+/// for types with flips in different positions to be equivalent.
 bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
                               bool destFlip = false, bool srcFlip = false,
                               bool srcOuterTypeIsConst = false);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -81,7 +81,7 @@ public:
 
   /// Returns true if this is a non-const "passive" that which is not analog.
   bool isRegisterType() {
-    return isPassive() && !containsAnalog() && !isConst();
+    return isPassive() && !containsAnalog() && !hasConst();
   }
 
   /// Return true if this is a 'ground' type, aka a non-aggregate type.
@@ -94,6 +94,9 @@ public:
   /// Returns true if this is a 'const' type that can only hold compile-time
   /// constant values
   bool isConst();
+
+  /// Returns true if this is or contains a 'const' type
+  bool hasConst() { return isConst() || getPurelyNonConstType() != *this; }
 
   /// Return true if this is or contains an Analog type.
   bool containsAnalog() { return getRecursiveTypeProperties().containsAnalog; }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -79,8 +79,10 @@ public:
   /// types recursively within itself.
   bool isPassive() const { return getRecursiveTypeProperties().isPassive; }
 
-  /// Returns true if this is a "passive" that which is not analog.
-  bool isRegisterType() { return isPassive() && !containsAnalog(); }
+  /// Returns true if this is a non-const "passive" that which is not analog.
+  bool isRegisterType() {
+    return isPassive() && !containsAnalog() && !isConst();
+  }
 
   /// Return true if this is a 'ground' type, aka a non-aggregate type.
   bool isGround();
@@ -120,6 +122,10 @@ public:
 
   /// Return a 'const' or non-'const' version of this type.
   FIRRTLBaseType getConstType(bool isConst);
+
+  /// Return a non-'const' version of this type with any 'const' types
+  /// recursively set to non-'const'.
+  FIRRTLBaseType getPurelyNonConstType();
 
   /// Return this type with all ground types replaced with UInt<1>.  This is
   /// used for `mem` operations.
@@ -177,8 +183,10 @@ public:
 /// definition of type equivalence in the FIRRTL spec.  If the types being
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
+/// If `strict` is `true`, `srcFType` must be identical `destFType` except that
+/// 'const' sources can be connected to non-'const' sinks.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
-                        bool srcOuterTypeIsConst = false);
+                        bool srcOuterTypeIsConst = false, bool strict = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -133,7 +133,7 @@ def AnyResetType : FIRRTLDialectType<
 def AnyRegisterType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "$_self.cast<FIRRTLBaseType>().isRegisterType()">,
-    "a passive base type that does not contain analog",
+    "a passive non-'const' base type that does not contain analog",
     "::circt::firrtl::FIRRTLBaseType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -168,6 +168,10 @@ def FVectorTypeImpl : FIRRTLImplType<"FVector", [FieldIDTypeInterface]> {
     /// Return a 'const' or non-'const' version of this type.
     FVectorType getConstType(bool isConst);
 
+    /// Return a non-'const' version of this type with any 'const' types
+    /// recursively set to non-'const'.
+    FVectorType getPurelyNonConstType();
+
     /// Get an integer ID for the field. Field IDs start at 1, and are assigned
     /// to each field in a vector in a recursive depth-first walk of all
     /// elements. A field ID of 0 is used to reference the vector itself.
@@ -262,6 +266,10 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
 
     /// Return a 'const' or non-'const' version of this type.
     BundleType getConstType(bool isConst);
+
+    /// Return a non-'const' version of this type with any 'const' types
+    /// recursively set to non-'const'.
+    BundleType getPurelyNonConstType();
 
     /// Get an integer ID for the field. Field IDs start at 1, and are assigned
     /// to each field in a bundle in a recursive pre-order walk of all fields,

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -345,6 +345,10 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
 
     FEnumType getConstType(bool isConst);
 
+    /// Return a non-'const' version of this type with any 'const' types
+    /// recursively set to non-'const'.
+    FEnumType getPurelyNonConstType();
+
     /// Look up an element's index by name.  This returns None on failure.
     std::optional<unsigned> getElementIndex(StringAttr name);
     std::optional<unsigned> getElementIndex(StringRef name);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -182,34 +182,6 @@ static bool isConstantZero(Attribute operand) {
   return false;
 }
 
-/// Return the result attribute, updating `op`'s result type to be a 'const'
-/// version of itself. This ensures that `materializeConstant` is provided a
-/// 'const' type for constant ops.
-/// TODO: Updating the result type is not actually implemented, constant ops
-/// need to be updated to use const types first.
-static Attribute foldResult(Operation *op, Attribute result,
-                            unsigned index = 0) {
-  // TODO: Uncomment once constant ops return const types
-  // if (auto resultType =
-  // op->getResultTypes()[index].dyn_cast<FIRRTLBaseType>();
-  //     resultType && result)
-  //   op->getResult(index).setType(resultType.getConstType(true));
-  return result;
-}
-
-/// Return the result value, updating `op`'s result type to be a the type of the
-/// value. The value and op result types can only differ by constness.
-/// MLIR's canonicalizer checks that folded values have types identical to the
-/// types of the op results they are replacing. Updating the op result type here
-/// allows that check to pass.
-static Value foldResult(Operation *op, Value result, unsigned index = 0) {
-  assert(mixedConstTypes(op->getResultTypes()[index].cast<FIRRTLBaseType>(),
-                         result.getType().cast<FIRRTLBaseType>()) &&
-         "result type can only differ by constness");
-  op->getResult(index).setType(result.getType());
-  return result;
-}
-
 /// This is the policy for folding, which depends on the sort of operator we're
 /// processing.
 enum class BinOpKind {
@@ -236,8 +208,7 @@ static Attribute constFoldFIRRTLBinaryOp(
 
   // Any binary op returning i0 is 0.
   if (resultType.getWidthOrSentinel() == 0)
-    return foldResult(
-        op, getIntAttr(resultType, APInt(0, 0, resultType.isSigned())));
+    return getIntAttr(resultType, APInt(0, 0, resultType.isSigned()));
 
   // Determine the operand widths. This is either dictated by the operand type,
   // or if that type is an unsized integer, by the actual bits necessary to
@@ -285,7 +256,7 @@ static Attribute constFoldFIRRTLBinaryOp(
 
   assert((unsigned)resultType.getWidthOrSentinel() ==
          resultValue.getBitWidth());
-  return foldResult(op, getIntAttr(resultType, resultValue));
+  return getIntAttr(resultType, resultValue);
 }
 
 /// Applies the canonicalization function `canonicalize` to the given operation.
@@ -374,17 +345,17 @@ static APInt getMaxSignedValue(unsigned bitWidth) {
 // Fold Hooks
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
+OpFoldResult ConstantOp::constFold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getValueAttr();
 }
 
-OpFoldResult SpecialConstantOp::fold(FoldAdaptor adaptor) {
+OpFoldResult SpecialConstantOp::constFold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getValueAttr();
 }
 
-OpFoldResult AggregateConstantOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AggregateConstantOp::constFold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getFieldsAttr();
 }
@@ -393,7 +364,7 @@ OpFoldResult AggregateConstantOp::fold(FoldAdaptor adaptor) {
 // Binary Operators
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AddPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AddPrimOp::constFold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
       [=](const APSInt &a, const APSInt &b) { return a + b; });
@@ -405,7 +376,7 @@ void AddPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                  patterns::AddOfSelf, patterns::AddOfPad>(context);
 }
 
-OpFoldResult SubPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult SubPrimOp::constFold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
       [=](const APSInt &a, const APSInt &b) { return a - b; });
@@ -418,7 +389,7 @@ void SubPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                  patterns::SubOfPadL, patterns::SubOfPadR>(context);
 }
 
-OpFoldResult MulPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult MulPrimOp::constFold(FoldAdaptor adaptor) {
   // mul(x, 0) -> 0
   //
   // This is legal because it aligns with the Scala FIRRTL Compiler
@@ -426,14 +397,14 @@ OpFoldResult MulPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // multiplication this way and will emit "x * 0".
   if (isConstantZero(adaptor.getRhs()) || isConstantZero(adaptor.getLhs()))
-    return foldResult(*this, getIntZerosAttr(getType()));
+    return getIntZerosAttr(getType());
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
       [=](const APSInt &a, const APSInt &b) { return a * b; });
 }
 
-OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult DivPrimOp::constFold(FoldAdaptor adaptor) {
   /// div(x, x) -> 1
   ///
   /// Division by zero is undefined in the FIRRTL specification.  This fold
@@ -446,7 +417,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
       width = 2;
     // Only fold if we have at least 1 bit of width to represent the `1` value.
     if (width != 0)
-      return foldResult(*this, getIntAttr(getType(), APInt(width, 1)));
+      return getIntAttr(getType(), APInt(width, 1));
   }
 
   // div(0, x) -> 0
@@ -456,7 +427,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // division this way and will emit "0 / x".
   if (isConstantZero(adaptor.getLhs()) && !isConstantZero(adaptor.getRhs()))
-    return foldResult(*this, getIntZerosAttr(getType()));
+    return getIntZerosAttr(getType());
 
   /// div(x, 1) -> x : (uint, uint) -> uint
   ///
@@ -466,7 +437,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
   if (auto rhsCst = adaptor.getRhs().dyn_cast_or_null<IntegerAttr>())
     if (rhsCst.getValue().isOne() &&
         mixedConstTypes(getLhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
@@ -477,7 +448,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
       });
 }
 
-OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult RemPrimOp::constFold(FoldAdaptor adaptor) {
   // rem(x, x) -> 0
   //
   // Division by zero is undefined in the FIRRTL specification.  This fold
@@ -485,7 +456,7 @@ OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
   // this should supersede any division with invalid or zero.  Remainder of
   // division of invalid by invalid should be zero.
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntZerosAttr(getType()));
+    return getIntZerosAttr(getType());
 
   // rem(0, x) -> 0
   //
@@ -494,7 +465,7 @@ OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // division this way and will emit "0 % x".
   if (isConstantZero(adaptor.getLhs()))
-    return foldResult(*this, getIntZerosAttr(getType()));
+    return getIntZerosAttr(getType());
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
@@ -505,19 +476,19 @@ OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
       });
 }
 
-OpFoldResult DShlPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult DShlPrimOp::constFold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
       [=](const APSInt &a, const APSInt &b) -> APInt { return a.shl(b); });
 }
 
-OpFoldResult DShlwPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult DShlwPrimOp::constFold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
       [=](const APSInt &a, const APSInt &b) -> APInt { return a.shl(b); });
 }
 
-OpFoldResult DShrPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult DShrPrimOp::constFold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
       [=](const APSInt &a, const APSInt &b) -> APInt {
@@ -527,32 +498,32 @@ OpFoldResult DShrPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 // TODO: Move to DRR.
-OpFoldResult AndPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AndPrimOp::constFold(FoldAdaptor adaptor) {
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// and(x, 0) -> 0, 0 is largest or is implicit zero extended
     if (rhsCst->isZero())
-      return foldResult(*this, getIntZerosAttr(getType()));
+      return getIntZerosAttr(getType());
 
     /// and(x, -1) -> x
     if (rhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
         mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
   }
 
   if (auto lhsCst = getConstant(adaptor.getLhs())) {
     /// and(0, x) -> 0, 0 is largest or is implicit zero extended
     if (lhsCst->isZero())
-      return foldResult(*this, getIntZerosAttr(getType()));
+      return getIntZerosAttr(getType());
 
     /// and(-1, x) -> x
     if (lhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
         mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getRhs());
+      return getRhs();
   }
 
   /// and(x, x) -> x
   if (getLhs() == getRhs() && mixedConstTypes(getRhs().getType(), getType()))
-    return foldResult(*this, getRhs());
+    return getRhs();
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -567,32 +538,32 @@ void AndPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
           context);
 }
 
-OpFoldResult OrPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult OrPrimOp::constFold(FoldAdaptor adaptor) {
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// or(x, 0) -> x
     if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
 
     /// or(x, -1) -> -1
     if (rhsCst->isAllOnes() && mixedConstTypes(getRhs().getType(), getType()) &&
         mixedConstTypes(getLhs().getType(), getType()))
-      return foldResult(*this, getRhs());
+      return getRhs();
   }
 
   if (auto lhsCst = getConstant(adaptor.getLhs())) {
     /// or(0, x) -> x
     if (lhsCst->isZero() && mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getRhs());
+      return getRhs();
 
     /// or(-1, x) -> -1
     if (lhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
         mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
   }
 
   /// or(x, x) -> x
   if (getLhs() == getRhs() && mixedConstTypes(getRhs().getType(), getType()))
-    return foldResult(*this, getRhs());
+    return getRhs();
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -606,23 +577,21 @@ void OrPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
       context);
 }
 
-OpFoldResult XorPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult XorPrimOp::constFold(FoldAdaptor adaptor) {
   /// xor(x, 0) -> x
   if (auto rhsCst = getConstant(adaptor.getRhs()))
     if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
 
   /// xor(x, 0) -> x
   if (auto lhsCst = getConstant(adaptor.getLhs()))
     if (lhsCst->isZero() && mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getRhs());
+      return getRhs();
 
   /// xor(x, x) -> 0
   if (getLhs() == getRhs())
-    return foldResult(
-        *this,
-        getIntAttr(getType(),
-                   APInt(std::max(getType().getWidthOrSentinel(), 0), 0)));
+    return getIntAttr(getType(),
+                      APInt(std::max(getType().getWidthOrSentinel(), 0), 0));
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -641,12 +610,12 @@ void LEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<patterns::LEQWithConstLHS>(context);
 }
 
-OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult LEQPrimOp::constFold(FoldAdaptor adaptor) {
   bool isUnsigned = getLhs().getType().isUnsigned();
 
   // leq(x, x) -> 1
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+    return getIntAttr(getType(), APInt(1, 1));
 
   // Comparison against constant outside type bounds.
   if (auto width = getLhs().getType().getWidth()) {
@@ -660,17 +629,17 @@ OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
       // leq(x, const) -> 0 where const < minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .slt(getMinSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // leq(x, const) -> 1 where const >= maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
 
       // leq(x, const) -> 1 where const >= maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sge(getMaxSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
     }
   }
 
@@ -686,17 +655,17 @@ void LTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<patterns::LTWithConstLHS>(context);
 }
 
-OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult LTPrimOp::constFold(FoldAdaptor adaptor) {
   bool isUnsigned = getLhs().getType().isUnsigned();
 
   // lt(x, x) -> 0
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   // lt(x, 0) -> 0 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     if (rhsCst->isZero() && getLhs().getType().isUnsigned())
-      return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+      return getIntAttr(getType(), APInt(1, 0));
   }
 
   // Comparison against constant outside type bounds.
@@ -711,17 +680,17 @@ OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
       // lt(x, const) -> 0 where const <= minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sle(getMinSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // lt(x, const) -> 1 where const > maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
 
       // lt(x, const) -> 1 where const > maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
     }
   }
 
@@ -737,17 +706,17 @@ void GEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<patterns::GEQWithConstLHS>(context);
 }
 
-OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult GEQPrimOp::constFold(FoldAdaptor adaptor) {
   bool isUnsigned = getLhs().getType().isUnsigned();
 
   // geq(x, x) -> 1
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+    return getIntAttr(getType(), APInt(1, 1));
 
   // geq(x, 0) -> 1 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     if (rhsCst->isZero() && isUnsigned)
-      return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+      return getIntAttr(getType(), APInt(1, 1));
   }
 
   // Comparison against constant outside type bounds.
@@ -759,12 +728,12 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
       // geq(x, const) -> 0 where const > maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 0 where const > maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 1 where const <= minValue of the unsigned type of x
       // Handled explicitly above.
@@ -772,7 +741,7 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
       // geq(x, const) -> 1 where const <= minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sle(getMinSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
     }
   }
 
@@ -788,12 +757,12 @@ void GTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<patterns::GTWithConstLHS>(context);
 }
 
-OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult GTPrimOp::constFold(FoldAdaptor adaptor) {
   bool isUnsigned = getLhs().getType().isUnsigned();
 
   // gt(x, x) -> 0
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   // Comparison against constant outside type bounds.
   if (auto width = getLhs().getType().getWidth()) {
@@ -804,12 +773,12 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
       // gt(x, const) -> 0 where const >= maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 0 where const >= maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sge(getMaxSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+        return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 1 where const < minValue of the unsigned type of x
       // This can never occur since const is unsigned and cannot be less than 0.
@@ -817,7 +786,7 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
       // gt(x, const) -> 1 where const < minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .slt(getMinSignedValue(*width).sext(commonWidth)))
-        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+        return getIntAttr(getType(), APInt(1, 1));
     }
   }
 
@@ -828,17 +797,17 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
       });
 }
 
-OpFoldResult EQPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult EQPrimOp::constFold(FoldAdaptor adaptor) {
   // eq(x, x) -> 1
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+    return getIntAttr(getType(), APInt(1, 1));
 
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// eq(x, 1) -> x when x is 1 bit.
     /// TODO: Support SInt<1> on the LHS etc.
     if (rhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
         mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
   }
 
   return constFoldFIRRTLBinaryOp(
@@ -880,17 +849,17 @@ LogicalResult EQPrimOp::canonicalize(EQPrimOp op, PatternRewriter &rewriter) {
       });
 }
 
-OpFoldResult NEQPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult NEQPrimOp::constFold(FoldAdaptor adaptor) {
   // neq(x, x) -> 0
   if (getLhs() == getRhs())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// neq(x, 0) -> x when x is 1 bit.
     /// TODO: Support SInt<1> on the LHS etc.
     if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()) &&
         mixedConstTypes(getRhs().getType(), getType()))
-      return foldResult(*this, getLhs());
+      return getLhs();
   }
 
   return constFoldFIRRTLBinaryOp(
@@ -936,88 +905,88 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
 // Unary Operators
 //===----------------------------------------------------------------------===//
 
-OpFoldResult SizeOfIntrinsicOp::fold(FoldAdaptor) {
+OpFoldResult SizeOfIntrinsicOp::constFold(FoldAdaptor) {
   auto base = getInput().getType();
   auto w = base.getBitWidthOrSentinel();
   if (w >= 0)
-    return foldResult(*this, getIntAttr(getType(), APInt(32, w)));
+    return getIntAttr(getType(), APInt(32, w));
   return {};
 }
 
-OpFoldResult IsXIntrinsicOp::fold(FoldAdaptor adaptor) {
+OpFoldResult IsXIntrinsicOp::constFold(FoldAdaptor adaptor) {
   // No constant can be 'x' by definition.
   if (auto cst = getConstant(adaptor.getArg()))
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
   return {};
 }
 
-OpFoldResult AsSIntPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AsSIntPrimOp::constFold(FoldAdaptor adaptor) {
   // No effect.
   if (mixedConstTypes(getInput().getType(), getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (getType().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
-      return foldResult(*this, getIntAttr(getType(), *cst));
+      return getIntAttr(getType(), *cst);
 
   return {};
 }
 
-OpFoldResult AsUIntPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AsUIntPrimOp::constFold(FoldAdaptor adaptor) {
   // No effect.
   if (mixedConstTypes(getInput().getType(), getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (getType().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
-      return foldResult(*this, getIntAttr(getType(), *cst));
+      return getIntAttr(getType(), *cst);
 
   return {};
 }
 
-OpFoldResult AsAsyncResetPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AsAsyncResetPrimOp::constFold(FoldAdaptor adaptor) {
   // No effect.
   if (mixedConstTypes(getInput().getType(), getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput()))
-    return foldResult(*this, BoolAttr::get(getContext(), cst->getBoolValue()));
+    return BoolAttr::get(getContext(), cst->getBoolValue());
 
   return {};
 }
 
-OpFoldResult AsClockPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AsClockPrimOp::constFold(FoldAdaptor adaptor) {
   // No effect.
   if (mixedConstTypes(getInput().getType(), getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput()))
-    return foldResult(*this, BoolAttr::get(getContext(), cst->getBoolValue()));
+    return BoolAttr::get(getContext(), cst->getBoolValue());
 
   return {};
 }
 
-OpFoldResult CvtPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult CvtPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
   // Signed to signed is a noop, unsigned operands prepend a zero bit.
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return foldResult(*this, getIntAttr(getType(), *cst));
+    return getIntAttr(getType(), *cst);
 
   return {};
 }
 
-OpFoldResult NegPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult NegPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
@@ -1025,19 +994,18 @@ OpFoldResult NegPrimOp::fold(FoldAdaptor adaptor) {
   // -x ---> 0-sext(x) or 0-zext(x)
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return foldResult(
-        *this, getIntAttr(getType(), APInt((*cst).getBitWidth(), 0) - *cst));
+    return getIntAttr(getType(), APInt((*cst).getBitWidth(), 0) - *cst);
 
   return {};
 }
 
-OpFoldResult NotPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult NotPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return foldResult(*this, getIntAttr(getType(), ~*cst));
+    return getIntAttr(getType(), ~*cst);
 
   return {};
 }
@@ -1047,59 +1015,58 @@ void NotPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<patterns::NotNot>(context);
 }
 
-OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult AndRPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
+    return getIntAttr(getType(), APInt(1, 1));
 
   // x == -1
   if (auto cst = getConstant(adaptor.getInput()))
-    return foldResult(*this, getIntAttr(getType(), APInt(1, cst->isAllOnes())));
+    return getIntAttr(getType(), APInt(1, cst->isAllOnes()));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast
   // here.
   if (isUInt1(getInput().getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   return {};
 }
 
-OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult OrRPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   // x != 0
   if (auto cst = getConstant(adaptor.getInput()))
-    return foldResult(*this, getIntAttr(getType(), APInt(1, !cst->isZero())));
+    return getIntAttr(getType(), APInt(1, !cst->isZero()));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast
   // here.
   if (isUInt1(getInput().getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   return {};
 }
 
-OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult XorRPrimOp::constFold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   // popcount(x) & 1
   if (auto cst = getConstant(adaptor.getInput()))
-    return foldResult(*this,
-                      getIntAttr(getType(), APInt(1, cst->popcount() & 1)));
+    return getIntAttr(getType(), APInt(1, cst->popcount() & 1));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast here.
   if (isUInt1(getInput().getType()))
-    return foldResult(*this, getInput());
+    return getInput();
 
   return {};
 }
@@ -1108,16 +1075,16 @@ OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
 // Other Operators
 //===----------------------------------------------------------------------===//
 
-OpFoldResult CatPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult CatPrimOp::constFold(FoldAdaptor adaptor) {
   // cat(x, 0-width) -> x
   // cat(0-width, x) -> x
   // Limit to unsigned (result type), as cannot insert cast here.
   if (getLhs().getType().getBitWidthOrSentinel() == 0 &&
       getRhs().getType().isUnsigned())
-    return foldResult(*this, getRhs());
+    return getRhs();
   if (getRhs().getType().getBitWidthOrSentinel() == 0 &&
       getLhs().getType().isUnsigned())
-    return foldResult(*this, getLhs());
+    return getLhs();
 
   if (!hasKnownWidthIntTypes(*this))
     return {};
@@ -1125,7 +1092,7 @@ OpFoldResult CatPrimOp::fold(FoldAdaptor adaptor) {
   // Constant fold cat.
   if (auto lhs = getConstant(adaptor.getLhs()))
     if (auto rhs = getConstant(adaptor.getRhs()))
-      return foldResult(*this, getIntAttr(getType(), lhs->concat(*rhs)));
+      return getIntAttr(getType(), lhs->concat(*rhs));
 
   return {};
 }
@@ -1172,33 +1139,32 @@ void CatPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<CatBitsBits, patterns::CatDoubleConst>(context);
 }
 
-OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {
+OpFoldResult BitCastOp::constFold(FoldAdaptor adaptor) {
   auto op = (*this);
   // BitCast is redundant if input and result types are same.
   if (mixedConstTypes(op.getType(), op.getInput().getType()))
-    return foldResult(*this, op.getInput());
+    return op.getInput();
 
   // Two consecutive BitCasts are redundant if first bitcast type is same as the
   // final result type.
   if (BitCastOp in = dyn_cast_or_null<BitCastOp>(op.getInput().getDefiningOp()))
     if (mixedConstTypes(op.getType(), in.getInput().getType()))
-      return foldResult(*this, in.getInput());
+      return in.getInput();
 
   return {};
 }
 
-OpFoldResult BitsPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult BitsPrimOp::constFold(FoldAdaptor adaptor) {
   auto inputType = getInput().getType();
   // If we are extracting the entire input, then return it.
   if (inputType == getType() && getType().hasWidth())
-    return foldResult(*this, getInput());
+    return getInput();
 
   // Constant fold.
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return foldResult(
-          *this, getIntAttr(getType(),
-                            cst->extractBits(getHi() - getLo() + 1, getLo())));
+      return getIntAttr(getType(),
+                        cst->extractBits(getHi() - getLo() + 1, getLo()));
 
   return {};
 }
@@ -1226,16 +1192,15 @@ static void replaceWithBits(Operation *op, Value value, unsigned hiBit,
   rewriter.replaceOp(op, value);
 }
 
-OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult MuxPrimOp::constFold(FoldAdaptor adaptor) {
 
   // mux : UInt<0> -> 0
   if (getType().getBitWidthOrSentinel() == 0)
-    return foldResult(
-        *this, getIntAttr(getType(), APInt(0, 0, getType().isSignedInteger())));
+    return getIntAttr(getType(), APInt(0, 0, getType().isSignedInteger()));
 
   // mux(cond, x, x) -> x
   if (getHigh() == getLow())
-    return foldResult(*this, getHigh());
+    return getHigh();
 
   // The following folds require that the result has a known width. Otherwise
   // the mux requires an additional padding operation to be inserted, which is
@@ -1246,9 +1211,9 @@ OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
   // mux(0/1, x, y) -> x or y
   if (auto cond = getConstant(adaptor.getSel())) {
     if (cond->isZero() && mixedConstTypes(getLow().getType(), getType()))
-      return foldResult(*this, getLow());
+      return getLow();
     if (!cond->isZero() && mixedConstTypes(getHigh().getType(), getType()))
-      return foldResult(*this, getHigh());
+      return getHigh();
   }
 
   // mux(cond, x, cst)
@@ -1262,7 +1227,7 @@ OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
       // mux(cond, 1, 0) -> cond
       if (highCst->isOne() && lowCst->isZero() &&
           mixedConstTypes(getType(), getSel().getType()))
-        return foldResult(*this, getSel());
+        return getSel();
 
       // TODO: x ? ~0 : 0 -> sext(x)
       // TODO: "x ? c1 : c2" -> many tricks
@@ -1414,12 +1379,12 @@ void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
               patterns::NarrowMuxRHS>(context);
 }
 
-OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult PadPrimOp::constFold(FoldAdaptor adaptor) {
   auto input = this->getInput();
 
   // pad(x) -> x  if the width doesn't change.
   if (mixedConstTypes(input.getType(), getType()))
-    return foldResult(*this, input);
+    return input;
 
   // Need to know the input width.
   auto inputType = input.getType();
@@ -1434,21 +1399,21 @@ OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
       return {};
 
     if (inputType.isSigned() && cst->getBitWidth())
-      return foldResult(*this, getIntAttr(getType(), cst->sext(destWidth)));
-    return foldResult(*this, getIntAttr(getType(), cst->zext(destWidth)));
+      return getIntAttr(getType(), cst->sext(destWidth));
+    return getIntAttr(getType(), cst->zext(destWidth));
   }
 
   return {};
 }
 
-OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult ShlPrimOp::constFold(FoldAdaptor adaptor) {
   auto input = this->getInput();
   auto inputType = input.getType();
   int shiftAmount = getAmount();
 
   // shl(x, 0) -> x
   if (shiftAmount == 0)
-    return foldResult(*this, input);
+    return input;
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput())) {
@@ -1456,33 +1421,31 @@ OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
     if (inputWidth != -1) {
       auto resultWidth = inputWidth + shiftAmount;
       shiftAmount = std::min(shiftAmount, resultWidth);
-      return foldResult(
-          *this,
-          getIntAttr(getType(), cst->zext(resultWidth).shl(shiftAmount)));
+      return getIntAttr(getType(), cst->zext(resultWidth).shl(shiftAmount));
     }
   }
   return {};
 }
 
-OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult ShrPrimOp::constFold(FoldAdaptor adaptor) {
   auto input = this->getInput();
   auto inputType = input.getType();
   int shiftAmount = getAmount();
 
   // shr(x, 0) -> x
   if (shiftAmount == 0)
-    return foldResult(*this, input);
+    return input;
 
   auto inputWidth = inputType.getWidthOrSentinel();
   if (inputWidth == -1)
     return {};
   if (inputWidth == 0)
-    return foldResult(*this, getIntZerosAttr(getType()));
+    return getIntZerosAttr(getType());
 
   // shr(x, cst) where cst is all of x's bits and x is unsigned is 0.
   // If x is signed, it is the sign bit.
   if (shiftAmount >= inputWidth && inputType.isUnsigned())
-    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
+    return getIntAttr(getType(), APInt(1, 0));
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput())) {
@@ -1492,7 +1455,7 @@ OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
     else
       value = cst->lshr(std::min(shiftAmount, inputWidth));
     auto resultWidth = std::max(inputWidth - shiftAmount, 1);
-    return foldResult(*this, getIntAttr(getType(), value.trunc(resultWidth)));
+    return getIntAttr(getType(), value.trunc(resultWidth));
   }
   return {};
 }
@@ -1533,24 +1496,20 @@ LogicalResult HeadPrimOp::canonicalize(HeadPrimOp op,
   return success();
 }
 
-OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult HeadPrimOp::constFold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput())) {
       int shiftAmount = getInput().getType().getWidthOrSentinel() - getAmount();
-      return foldResult(
-          *this,
-          getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount())));
+      return getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount()));
     }
 
   return {};
 }
 
-OpFoldResult TailPrimOp::fold(FoldAdaptor adaptor) {
+OpFoldResult TailPrimOp::constFold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return foldResult(
-          *this,
-          getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel())));
+      return getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel()));
   return {};
 }
 
@@ -1573,15 +1532,15 @@ void SubaccessOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.add<patterns::SubaccessOfConstant>(context);
 }
 
-OpFoldResult MultibitMuxOp::fold(FoldAdaptor adaptor) {
+OpFoldResult MultibitMuxOp::constFold(FoldAdaptor adaptor) {
   // If there is only one input, just return it.
   if (adaptor.getInputs().size() == 1)
-    return foldResult(*this, getOperand(1));
+    return getOperand(1);
 
   if (auto constIndex = getConstant(adaptor.getIndex())) {
     auto index = constIndex->getZExtValue();
     if (index < getInputs().size())
-      return foldResult(*this, getInputs()[getInputs().size() - 1 - index]);
+      return getInputs()[getInputs().size() - 1 - index];
   }
 
   return {};
@@ -1871,8 +1830,8 @@ static LogicalResult demoteForceableIfUnused(OpTy op,
 }
 
 // Interesting names and symbols and don't touch force nodes to stick around.
-LogicalResult NodeOp::fold(FoldAdaptor adaptor,
-                           SmallVectorImpl<OpFoldResult> &results) {
+LogicalResult NodeOp::constFold(FoldAdaptor adaptor,
+                                SmallVectorImpl<OpFoldResult> &results) {
   if (!hasDroppableName())
     return failure();
   if (hasDontTouch(getResult())) // handles inner symbols
@@ -1884,7 +1843,7 @@ LogicalResult NodeOp::fold(FoldAdaptor adaptor,
   if (!adaptor.getInput())
     return failure();
 
-  results.push_back(foldResult(*this, adaptor.getInput()));
+  results.push_back(adaptor.getInput());
   return success();
 }
 
@@ -2011,19 +1970,19 @@ void SubindexOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<SubindexAggOneShot>(context);
 }
 
-OpFoldResult SubindexOp::fold(FoldAdaptor adaptor) {
+OpFoldResult SubindexOp::constFold(FoldAdaptor adaptor) {
   auto attr = adaptor.getInput().dyn_cast_or_null<ArrayAttr>();
   if (!attr)
     return {};
-  return foldResult(*this, attr[getIndex()]);
+  return attr[getIndex()];
 }
 
-OpFoldResult SubfieldOp::fold(FoldAdaptor adaptor) {
+OpFoldResult SubfieldOp::constFold(FoldAdaptor adaptor) {
   auto attr = adaptor.getInput().dyn_cast_or_null<ArrayAttr>();
   if (!attr)
     return {};
   auto index = getFieldIndex();
-  return foldResult(*this, attr[index]);
+  return attr[index];
 }
 
 void SubfieldOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2039,7 +1998,7 @@ static Attribute collectFields(MLIRContext *context,
   return ArrayAttr::get(context, operands);
 }
 
-OpFoldResult BundleCreateOp::fold(FoldAdaptor adaptor) {
+OpFoldResult BundleCreateOp::constFold(FoldAdaptor adaptor) {
   // bundle_create(%foo["a"], %foo["b"]) -> %foo when the type of %foo is
   // bundle<a:..., b:...>.
   if (getNumOperands() > 0)
@@ -2055,10 +2014,10 @@ OpFoldResult BundleCreateOp::fold(FoldAdaptor adaptor) {
               }))
         return first.getInput();
 
-  return foldResult(*this, collectFields(getContext(), adaptor.getOperands()));
+  return collectFields(getContext(), adaptor.getOperands());
 }
 
-OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
+OpFoldResult VectorCreateOp::constFold(FoldAdaptor adaptor) {
   // vector_create(%foo[0], %foo[1]) -> %foo when the type of %foo is
   // vector<..., 2>.
   if (getNumOperands() > 0)
@@ -2073,10 +2032,10 @@ OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
               }))
         return first.getInput();
 
-  return foldResult(*this, collectFields(getContext(), adaptor.getOperands()));
+  return collectFields(getContext(), adaptor.getOperands());
 }
 
-OpFoldResult UninferredResetCastOp::fold(FoldAdaptor adaptor) {
+OpFoldResult UninferredResetCastOp::constFold(FoldAdaptor adaptor) {
   if (getOperand().getType() == getType())
     return getOperand();
   return {};

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -182,6 +182,34 @@ static bool isConstantZero(Attribute operand) {
   return false;
 }
 
+/// Return the result attribute, updating `op`'s result type to be a 'const'
+/// version of itself. This ensures that `materializeConstant` is provided a
+/// 'const' type for constant ops.
+/// TODO: Updating the result type is not actually implemented, constant ops
+/// need to be updated to use const types first.
+static Attribute foldResult(Operation *op, Attribute result,
+                            unsigned index = 0) {
+  // TODO: Uncomment once constant ops return const types
+  // if (auto resultType =
+  // op->getResultTypes()[index].dyn_cast<FIRRTLBaseType>();
+  //     resultType && result)
+  //   op->getResult(index).setType(resultType.getConstType(true));
+  return result;
+}
+
+/// Return the result value, updating `op`'s result type to be a the type of the
+/// value. The value and op result types can only differ by constness.
+/// MLIR's canonicalizer checks that folded values have types identical to the
+/// types of the op results they are replacing. Updating the op result type here
+/// allows that check to pass.
+static Value foldResult(Operation *op, Value result, unsigned index = 0) {
+  assert(mixedConstTypes(op->getResultTypes()[index].cast<FIRRTLBaseType>(),
+                         result.getType().cast<FIRRTLBaseType>()) &&
+         "result type can only differ by constness");
+  op->getResult(index).setType(result.getType());
+  return result;
+}
+
 /// This is the policy for folding, which depends on the sort of operator we're
 /// processing.
 enum class BinOpKind {
@@ -208,7 +236,8 @@ static Attribute constFoldFIRRTLBinaryOp(
 
   // Any binary op returning i0 is 0.
   if (resultType.getWidthOrSentinel() == 0)
-    return getIntAttr(resultType, APInt(0, 0, resultType.isSigned()));
+    return foldResult(
+        op, getIntAttr(resultType, APInt(0, 0, resultType.isSigned())));
 
   // Determine the operand widths. This is either dictated by the operand type,
   // or if that type is an unsized integer, by the actual bits necessary to
@@ -256,7 +285,7 @@ static Attribute constFoldFIRRTLBinaryOp(
 
   assert((unsigned)resultType.getWidthOrSentinel() ==
          resultValue.getBitWidth());
-  return getIntAttr(resultType, resultValue);
+  return foldResult(op, getIntAttr(resultType, resultValue));
 }
 
 /// Applies the canonicalization function `canonicalize` to the given operation.
@@ -317,7 +346,8 @@ static LogicalResult canonicalizePrimOp(
   else if (type.isa<UIntType>() && resultValue.getType().isa<SIntType>())
     resultValue = rewriter.create<AsUIntPrimOp>(op->getLoc(), resultValue);
 
-  assert(type == resultValue.getType() && "canonicalization changed type");
+  assert(mixedConstTypes(type, resultValue.getType().cast<FIRRTLBaseType>()) &&
+         "canonicalization changed type");
   replaceOpAndCopyName(rewriter, op, resultValue);
   return success();
 }
@@ -396,7 +426,7 @@ OpFoldResult MulPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // multiplication this way and will emit "x * 0".
   if (isConstantZero(adaptor.getRhs()) || isConstantZero(adaptor.getLhs()))
-    return getIntZerosAttr(getType());
+    return foldResult(*this, getIntZerosAttr(getType()));
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -416,7 +446,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
       width = 2;
     // Only fold if we have at least 1 bit of width to represent the `1` value.
     if (width != 0)
-      return getIntAttr(getType(), APInt(width, 1));
+      return foldResult(*this, getIntAttr(getType(), APInt(width, 1)));
   }
 
   // div(0, x) -> 0
@@ -426,7 +456,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // division this way and will emit "0 / x".
   if (isConstantZero(adaptor.getLhs()) && !isConstantZero(adaptor.getRhs()))
-    return getIntZerosAttr(getType());
+    return foldResult(*this, getIntZerosAttr(getType()));
 
   /// div(x, 1) -> x : (uint, uint) -> uint
   ///
@@ -434,8 +464,9 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
   /// be folded here because it increases the return type bitwidth by
   /// one and requires sign extension (a new op).
   if (auto rhsCst = adaptor.getRhs().dyn_cast_or_null<IntegerAttr>())
-    if (rhsCst.getValue().isOne() && getLhs().getType() == getType())
-      return getLhs();
+    if (rhsCst.getValue().isOne() &&
+        mixedConstTypes(getLhs().getType(), getType()))
+      return foldResult(*this, getLhs());
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
@@ -454,7 +485,7 @@ OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
   // this should supersede any division with invalid or zero.  Remainder of
   // division of invalid by invalid should be zero.
   if (getLhs() == getRhs())
-    return getIntZerosAttr(getType());
+    return foldResult(*this, getIntZerosAttr(getType()));
 
   // rem(0, x) -> 0
   //
@@ -463,7 +494,7 @@ OpFoldResult RemPrimOp::fold(FoldAdaptor adaptor) {
   // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
   // division this way and will emit "0 % x".
   if (isConstantZero(adaptor.getLhs()))
-    return getIntZerosAttr(getType());
+    return foldResult(*this, getIntZerosAttr(getType()));
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
@@ -500,28 +531,28 @@ OpFoldResult AndPrimOp::fold(FoldAdaptor adaptor) {
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// and(x, 0) -> 0, 0 is largest or is implicit zero extended
     if (rhsCst->isZero())
-      return getIntZerosAttr(getType());
+      return foldResult(*this, getIntZerosAttr(getType()));
 
     /// and(x, -1) -> x
-    if (rhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getLhs();
+    if (rhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
+        mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getLhs());
   }
 
   if (auto lhsCst = getConstant(adaptor.getLhs())) {
     /// and(0, x) -> 0, 0 is largest or is implicit zero extended
     if (lhsCst->isZero())
-      return getIntZerosAttr(getType());
+      return foldResult(*this, getIntZerosAttr(getType()));
 
     /// and(-1, x) -> x
-    if (lhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getRhs();
+    if (lhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
+        mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getRhs());
   }
 
   /// and(x, x) -> x
-  if (getLhs() == getRhs() && getRhs().getType() == getType())
-    return getRhs();
+  if (getLhs() == getRhs() && mixedConstTypes(getRhs().getType(), getType()))
+    return foldResult(*this, getRhs());
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -539,29 +570,29 @@ void AndPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult OrPrimOp::fold(FoldAdaptor adaptor) {
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// or(x, 0) -> x
-    if (rhsCst->isZero() && getLhs().getType() == getType())
-      return getLhs();
+    if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()))
+      return foldResult(*this, getLhs());
 
     /// or(x, -1) -> -1
-    if (rhsCst->isAllOnes() && getRhs().getType() == getType() &&
-        getLhs().getType() == getType())
-      return getRhs();
+    if (rhsCst->isAllOnes() && mixedConstTypes(getRhs().getType(), getType()) &&
+        mixedConstTypes(getLhs().getType(), getType()))
+      return foldResult(*this, getRhs());
   }
 
   if (auto lhsCst = getConstant(adaptor.getLhs())) {
     /// or(0, x) -> x
-    if (lhsCst->isZero() && getRhs().getType() == getType())
-      return getRhs();
+    if (lhsCst->isZero() && mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getRhs());
 
     /// or(-1, x) -> -1
-    if (lhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getLhs();
+    if (lhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
+        mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getLhs());
   }
 
   /// or(x, x) -> x
-  if (getLhs() == getRhs() && getRhs().getType() == getType())
-    return getRhs();
+  if (getLhs() == getRhs() && mixedConstTypes(getRhs().getType(), getType()))
+    return foldResult(*this, getRhs());
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -578,18 +609,20 @@ void OrPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult XorPrimOp::fold(FoldAdaptor adaptor) {
   /// xor(x, 0) -> x
   if (auto rhsCst = getConstant(adaptor.getRhs()))
-    if (rhsCst->isZero() && getLhs().getType() == getType())
-      return getLhs();
+    if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()))
+      return foldResult(*this, getLhs());
 
   /// xor(x, 0) -> x
   if (auto lhsCst = getConstant(adaptor.getLhs()))
-    if (lhsCst->isZero() && getRhs().getType() == getType())
-      return getRhs();
+    if (lhsCst->isZero() && mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getRhs());
 
   /// xor(x, x) -> 0
   if (getLhs() == getRhs())
-    return getIntAttr(getType(),
-                      APInt(std::max(getType().getWidthOrSentinel(), 0), 0));
+    return foldResult(
+        *this,
+        getIntAttr(getType(),
+                   APInt(std::max(getType().getWidthOrSentinel(), 0), 0)));
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -613,7 +646,7 @@ OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
 
   // leq(x, x) -> 1
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 1));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
   // Comparison against constant outside type bounds.
   if (auto width = getLhs().getType().getWidth()) {
@@ -627,17 +660,17 @@ OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
       // leq(x, const) -> 0 where const < minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .slt(getMinSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // leq(x, const) -> 1 where const >= maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
       // leq(x, const) -> 1 where const >= maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sge(getMaxSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
     }
   }
 
@@ -658,12 +691,12 @@ OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
 
   // lt(x, x) -> 0
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   // lt(x, 0) -> 0 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     if (rhsCst->isZero() && getLhs().getType().isUnsigned())
-      return getIntAttr(getType(), APInt(1, 0));
+      return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
   }
 
   // Comparison against constant outside type bounds.
@@ -678,17 +711,17 @@ OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
       // lt(x, const) -> 0 where const <= minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sle(getMinSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // lt(x, const) -> 1 where const > maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
       // lt(x, const) -> 1 where const > maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
     }
   }
 
@@ -709,12 +742,12 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
 
   // geq(x, x) -> 1
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 1));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
   // geq(x, 0) -> 1 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     if (rhsCst->isZero() && isUnsigned)
-      return getIntAttr(getType(), APInt(1, 1));
+      return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
   }
 
   // Comparison against constant outside type bounds.
@@ -726,12 +759,12 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
       // geq(x, const) -> 0 where const > maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // geq(x, const) -> 0 where const > maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // geq(x, const) -> 1 where const <= minValue of the unsigned type of x
       // Handled explicitly above.
@@ -739,7 +772,7 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
       // geq(x, const) -> 1 where const <= minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sle(getMinSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
     }
   }
 
@@ -760,7 +793,7 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
 
   // gt(x, x) -> 0
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   // Comparison against constant outside type bounds.
   if (auto width = getLhs().getType().getWidth()) {
@@ -771,12 +804,12 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
       // gt(x, const) -> 0 where const >= maxValue of the unsigned type of x
       if (isUnsigned && rhsCst->zext(commonWidth)
                             .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // gt(x, const) -> 0 where const >= maxValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .sge(getMaxSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 0));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
       // gt(x, const) -> 1 where const < minValue of the unsigned type of x
       // This can never occur since const is unsigned and cannot be less than 0.
@@ -784,7 +817,7 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
       // gt(x, const) -> 1 where const < minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(*rhsCst, commonWidth)
                              .slt(getMinSignedValue(*width).sext(commonWidth)))
-        return getIntAttr(getType(), APInt(1, 1));
+        return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
     }
   }
 
@@ -798,14 +831,14 @@ OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
 OpFoldResult EQPrimOp::fold(FoldAdaptor adaptor) {
   // eq(x, x) -> 1
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 1));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// eq(x, 1) -> x when x is 1 bit.
     /// TODO: Support SInt<1> on the LHS etc.
-    if (rhsCst->isAllOnes() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getLhs();
+    if (rhsCst->isAllOnes() && mixedConstTypes(getLhs().getType(), getType()) &&
+        mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getLhs());
   }
 
   return constFoldFIRRTLBinaryOp(
@@ -822,8 +855,9 @@ LogicalResult EQPrimOp::canonicalize(EQPrimOp op, PatternRewriter &rewriter) {
           auto width = op.getLhs().getType().getBitWidthOrSentinel();
 
           // eq(x, 0) ->  not(x) when x is 1 bit.
-          if (rhsCst->isZero() && op.getLhs().getType() == op.getType() &&
-              op.getRhs().getType() == op.getType()) {
+          if (rhsCst->isZero() &&
+              mixedConstTypes(op.getLhs().getType(), op.getType()) &&
+              mixedConstTypes(op.getRhs().getType(), op.getType())) {
             return rewriter.create<NotPrimOp>(op.getLoc(), op.getLhs())
                 .getResult();
           }
@@ -836,7 +870,7 @@ LogicalResult EQPrimOp::canonicalize(EQPrimOp op, PatternRewriter &rewriter) {
 
           // eq(x, ~0) -> andr(x) when x is >1 bit
           if (rhsCst->isAllOnes() && width > 1 &&
-              op.getLhs().getType() == op.getRhs().getType()) {
+              mixedConstTypes(op.getLhs().getType(), op.getRhs().getType())) {
             return rewriter.create<AndRPrimOp>(op.getLoc(), op.getLhs())
                 .getResult();
           }
@@ -849,14 +883,14 @@ LogicalResult EQPrimOp::canonicalize(EQPrimOp op, PatternRewriter &rewriter) {
 OpFoldResult NEQPrimOp::fold(FoldAdaptor adaptor) {
   // neq(x, x) -> 0
   if (getLhs() == getRhs())
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     /// neq(x, 0) -> x when x is 1 bit.
     /// TODO: Support SInt<1> on the LHS etc.
-    if (rhsCst->isZero() && getLhs().getType() == getType() &&
-        getRhs().getType() == getType())
-      return getLhs();
+    if (rhsCst->isZero() && mixedConstTypes(getLhs().getType(), getType()) &&
+        mixedConstTypes(getRhs().getType(), getType()))
+      return foldResult(*this, getLhs());
   }
 
   return constFoldFIRRTLBinaryOp(
@@ -873,8 +907,9 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
           auto width = op.getLhs().getType().getBitWidthOrSentinel();
 
           // neq(x, 1) -> not(x) when x is 1 bit
-          if (rhsCst->isAllOnes() && op.getLhs().getType() == op.getType() &&
-              op.getRhs().getType() == op.getType()) {
+          if (rhsCst->isAllOnes() &&
+              mixedConstTypes(op.getLhs().getType(), op.getType()) &&
+              mixedConstTypes(op.getRhs().getType(), op.getType())) {
             return rewriter.create<NotPrimOp>(op.getLoc(), op.getLhs())
                 .getResult();
           }
@@ -887,7 +922,7 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
 
           // neq(x, ~0) -> not(andr(x))) when x is >1 bit
           if (rhsCst->isAllOnes() && width > 1 &&
-              op.getLhs().getType() == op.getRhs().getType()) {
+              mixedConstTypes(op.getLhs().getType(), op.getRhs().getType())) {
             auto andrOp = rewriter.create<AndRPrimOp>(op.getLoc(), op.getLhs());
             return rewriter.create<NotPrimOp>(op.getLoc(), andrOp).getResult();
           }
@@ -905,67 +940,67 @@ OpFoldResult SizeOfIntrinsicOp::fold(FoldAdaptor) {
   auto base = getInput().getType();
   auto w = base.getBitWidthOrSentinel();
   if (w >= 0)
-    return getIntAttr(getType(), APInt(32, w));
+    return foldResult(*this, getIntAttr(getType(), APInt(32, w)));
   return {};
 }
 
 OpFoldResult IsXIntrinsicOp::fold(FoldAdaptor adaptor) {
   // No constant can be 'x' by definition.
   if (auto cst = getConstant(adaptor.getArg()))
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
   return {};
 }
 
 OpFoldResult AsSIntPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
-    return getInput();
+  if (mixedConstTypes(getInput().getType(), getType()))
+    return foldResult(*this, getInput());
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (getType().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(), *cst);
+      return foldResult(*this, getIntAttr(getType(), *cst));
 
   return {};
 }
 
 OpFoldResult AsUIntPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
-    return getInput();
+  if (mixedConstTypes(getInput().getType(), getType()))
+    return foldResult(*this, getInput());
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (getType().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(), *cst);
+      return foldResult(*this, getIntAttr(getType(), *cst));
 
   return {};
 }
 
 OpFoldResult AsAsyncResetPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
-    return getInput();
+  if (mixedConstTypes(getInput().getType(), getType()))
+    return foldResult(*this, getInput());
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput()))
-    return BoolAttr::get(getContext(), cst->getBoolValue());
+    return foldResult(*this, BoolAttr::get(getContext(), cst->getBoolValue()));
 
   return {};
 }
 
 OpFoldResult AsClockPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
-    return getInput();
+  if (mixedConstTypes(getInput().getType(), getType()))
+    return foldResult(*this, getInput());
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput()))
-    return BoolAttr::get(getContext(), cst->getBoolValue());
+    return foldResult(*this, BoolAttr::get(getContext(), cst->getBoolValue()));
 
   return {};
 }
@@ -977,7 +1012,7 @@ OpFoldResult CvtPrimOp::fold(FoldAdaptor adaptor) {
   // Signed to signed is a noop, unsigned operands prepend a zero bit.
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return getIntAttr(getType(), *cst);
+    return foldResult(*this, getIntAttr(getType(), *cst));
 
   return {};
 }
@@ -990,7 +1025,8 @@ OpFoldResult NegPrimOp::fold(FoldAdaptor adaptor) {
   // -x ---> 0-sext(x) or 0-zext(x)
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return getIntAttr(getType(), APInt((*cst).getBitWidth(), 0) - *cst);
+    return foldResult(
+        *this, getIntAttr(getType(), APInt((*cst).getBitWidth(), 0) - *cst));
 
   return {};
 }
@@ -1001,7 +1037,7 @@ OpFoldResult NotPrimOp::fold(FoldAdaptor adaptor) {
 
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
                                      getType().getWidthOrSentinel()))
-    return getIntAttr(getType(), ~*cst);
+    return foldResult(*this, getIntAttr(getType(), ~*cst));
 
   return {};
 }
@@ -1016,16 +1052,16 @@ OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return getIntAttr(getType(), APInt(1, 1));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 1)));
 
   // x == -1
   if (auto cst = getConstant(adaptor.getInput()))
-    return getIntAttr(getType(), APInt(1, cst->isAllOnes()));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, cst->isAllOnes())));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast
   // here.
   if (isUInt1(getInput().getType()))
-    return getInput();
+    return foldResult(*this, getInput());
 
   return {};
 }
@@ -1035,16 +1071,16 @@ OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   // x != 0
   if (auto cst = getConstant(adaptor.getInput()))
-    return getIntAttr(getType(), APInt(1, !cst->isZero()));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, !cst->isZero())));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast
   // here.
   if (isUInt1(getInput().getType()))
-    return getInput();
+    return foldResult(*this, getInput());
 
   return {};
 }
@@ -1054,15 +1090,16 @@ OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
     return {};
 
   if (getInput().getType().getBitWidthOrSentinel() == 0)
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   // popcount(x) & 1
   if (auto cst = getConstant(adaptor.getInput()))
-    return getIntAttr(getType(), APInt(1, cst->popcount() & 1));
+    return foldResult(*this,
+                      getIntAttr(getType(), APInt(1, cst->popcount() & 1)));
 
   // one bit is identity.  Only applies to UInt since we can't make a cast here.
   if (isUInt1(getInput().getType()))
-    return getInput();
+    return foldResult(*this, getInput());
 
   return {};
 }
@@ -1077,10 +1114,10 @@ OpFoldResult CatPrimOp::fold(FoldAdaptor adaptor) {
   // Limit to unsigned (result type), as cannot insert cast here.
   if (getLhs().getType().getBitWidthOrSentinel() == 0 &&
       getRhs().getType().isUnsigned())
-    return getRhs();
+    return foldResult(*this, getRhs());
   if (getRhs().getType().getBitWidthOrSentinel() == 0 &&
       getLhs().getType().isUnsigned())
-    return getLhs();
+    return foldResult(*this, getLhs());
 
   if (!hasKnownWidthIntTypes(*this))
     return {};
@@ -1088,7 +1125,7 @@ OpFoldResult CatPrimOp::fold(FoldAdaptor adaptor) {
   // Constant fold cat.
   if (auto lhs = getConstant(adaptor.getLhs()))
     if (auto rhs = getConstant(adaptor.getRhs()))
-      return getIntAttr(getType(), lhs->concat(*rhs));
+      return foldResult(*this, getIntAttr(getType(), lhs->concat(*rhs)));
 
   return {};
 }
@@ -1138,14 +1175,14 @@ void CatPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {
   auto op = (*this);
   // BitCast is redundant if input and result types are same.
-  if (op.getType() == op.getInput().getType())
-    return op.getInput();
+  if (mixedConstTypes(op.getType(), op.getInput().getType()))
+    return foldResult(*this, op.getInput());
 
   // Two consecutive BitCasts are redundant if first bitcast type is same as the
   // final result type.
   if (BitCastOp in = dyn_cast_or_null<BitCastOp>(op.getInput().getDefiningOp()))
-    if (op.getType() == in.getInput().getType())
-      return in.getInput();
+    if (mixedConstTypes(op.getType(), in.getInput().getType()))
+      return foldResult(*this, in.getInput());
 
   return {};
 }
@@ -1154,13 +1191,14 @@ OpFoldResult BitsPrimOp::fold(FoldAdaptor adaptor) {
   auto inputType = getInput().getType();
   // If we are extracting the entire input, then return it.
   if (inputType == getType() && getType().hasWidth())
-    return getInput();
+    return foldResult(*this, getInput());
 
   // Constant fold.
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(),
-                        cst->extractBits(getHi() - getLo() + 1, getLo()));
+      return foldResult(
+          *this, getIntAttr(getType(),
+                            cst->extractBits(getHi() - getLo() + 1, getLo())));
 
   return {};
 }
@@ -1192,11 +1230,12 @@ OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
 
   // mux : UInt<0> -> 0
   if (getType().getBitWidthOrSentinel() == 0)
-    return getIntAttr(getType(), APInt(0, 0, getType().isSignedInteger()));
+    return foldResult(
+        *this, getIntAttr(getType(), APInt(0, 0, getType().isSignedInteger())));
 
   // mux(cond, x, x) -> x
   if (getHigh() == getLow())
-    return getHigh();
+    return foldResult(*this, getHigh());
 
   // The following folds require that the result has a known width. Otherwise
   // the mux requires an additional padding operation to be inserted, which is
@@ -1206,10 +1245,10 @@ OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
 
   // mux(0/1, x, y) -> x or y
   if (auto cond = getConstant(adaptor.getSel())) {
-    if (cond->isZero() && getLow().getType() == getType())
-      return getLow();
-    if (!cond->isZero() && getHigh().getType() == getType())
-      return getHigh();
+    if (cond->isZero() && mixedConstTypes(getLow().getType(), getType()))
+      return foldResult(*this, getLow());
+    if (!cond->isZero() && mixedConstTypes(getHigh().getType(), getType()))
+      return foldResult(*this, getHigh());
   }
 
   // mux(cond, x, cst)
@@ -1222,8 +1261,8 @@ OpFoldResult MuxPrimOp::fold(FoldAdaptor adaptor) {
         return getIntAttr(getType(), *highCst);
       // mux(cond, 1, 0) -> cond
       if (highCst->isOne() && lowCst->isZero() &&
-          getType() == getSel().getType())
-        return getSel();
+          mixedConstTypes(getType(), getSel().getType()))
+        return foldResult(*this, getSel());
 
       // TODO: x ? ~0 : 0 -> sext(x)
       // TODO: "x ? c1 : c2" -> many tricks
@@ -1379,8 +1418,8 @@ OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
   auto input = this->getInput();
 
   // pad(x) -> x  if the width doesn't change.
-  if (input.getType() == getType())
-    return input;
+  if (mixedConstTypes(input.getType(), getType()))
+    return foldResult(*this, input);
 
   // Need to know the input width.
   auto inputType = input.getType();
@@ -1395,8 +1434,8 @@ OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
       return {};
 
     if (inputType.isSigned() && cst->getBitWidth())
-      return getIntAttr(getType(), cst->sext(destWidth));
-    return getIntAttr(getType(), cst->zext(destWidth));
+      return foldResult(*this, getIntAttr(getType(), cst->sext(destWidth)));
+    return foldResult(*this, getIntAttr(getType(), cst->zext(destWidth)));
   }
 
   return {};
@@ -1409,7 +1448,7 @@ OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
 
   // shl(x, 0) -> x
   if (shiftAmount == 0)
-    return input;
+    return foldResult(*this, input);
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput())) {
@@ -1417,7 +1456,9 @@ OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
     if (inputWidth != -1) {
       auto resultWidth = inputWidth + shiftAmount;
       shiftAmount = std::min(shiftAmount, resultWidth);
-      return getIntAttr(getType(), cst->zext(resultWidth).shl(shiftAmount));
+      return foldResult(
+          *this,
+          getIntAttr(getType(), cst->zext(resultWidth).shl(shiftAmount)));
     }
   }
   return {};
@@ -1430,18 +1471,18 @@ OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
 
   // shr(x, 0) -> x
   if (shiftAmount == 0)
-    return input;
+    return foldResult(*this, input);
 
   auto inputWidth = inputType.getWidthOrSentinel();
   if (inputWidth == -1)
     return {};
   if (inputWidth == 0)
-    return getIntZerosAttr(getType());
+    return foldResult(*this, getIntZerosAttr(getType()));
 
   // shr(x, cst) where cst is all of x's bits and x is unsigned is 0.
   // If x is signed, it is the sign bit.
   if (shiftAmount >= inputWidth && inputType.isUnsigned())
-    return getIntAttr(getType(), APInt(1, 0));
+    return foldResult(*this, getIntAttr(getType(), APInt(1, 0)));
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput())) {
@@ -1451,7 +1492,7 @@ OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
     else
       value = cst->lshr(std::min(shiftAmount, inputWidth));
     auto resultWidth = std::max(inputWidth - shiftAmount, 1);
-    return getIntAttr(getType(), value.trunc(resultWidth));
+    return foldResult(*this, getIntAttr(getType(), value.trunc(resultWidth)));
   }
   return {};
 }
@@ -1496,7 +1537,9 @@ OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput())) {
       int shiftAmount = getInput().getType().getWidthOrSentinel() - getAmount();
-      return getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount()));
+      return foldResult(
+          *this,
+          getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount())));
     }
 
   return {};
@@ -1505,7 +1548,9 @@ OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
 OpFoldResult TailPrimOp::fold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel()));
+      return foldResult(
+          *this,
+          getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel())));
   return {};
 }
 
@@ -1531,12 +1576,12 @@ void SubaccessOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult MultibitMuxOp::fold(FoldAdaptor adaptor) {
   // If there is only one input, just return it.
   if (adaptor.getInputs().size() == 1)
-    return getOperand(1);
+    return foldResult(*this, getOperand(1));
 
   if (auto constIndex = getConstant(adaptor.getIndex())) {
     auto index = constIndex->getZExtValue();
     if (index < getInputs().size())
-      return getInputs()[getInputs().size() - 1 - index];
+      return foldResult(*this, getInputs()[getInputs().size() - 1 - index]);
   }
 
   return {};
@@ -1839,7 +1884,7 @@ LogicalResult NodeOp::fold(FoldAdaptor adaptor,
   if (!adaptor.getInput())
     return failure();
 
-  results.push_back(adaptor.getInput());
+  results.push_back(foldResult(*this, adaptor.getInput()));
   return success();
 }
 
@@ -1970,7 +2015,7 @@ OpFoldResult SubindexOp::fold(FoldAdaptor adaptor) {
   auto attr = adaptor.getInput().dyn_cast_or_null<ArrayAttr>();
   if (!attr)
     return {};
-  return attr[getIndex()];
+  return foldResult(*this, attr[getIndex()]);
 }
 
 OpFoldResult SubfieldOp::fold(FoldAdaptor adaptor) {
@@ -1978,7 +2023,7 @@ OpFoldResult SubfieldOp::fold(FoldAdaptor adaptor) {
   if (!attr)
     return {};
   auto index = getFieldIndex();
-  return attr[index];
+  return foldResult(*this, attr[index]);
 }
 
 void SubfieldOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2010,7 +2055,7 @@ OpFoldResult BundleCreateOp::fold(FoldAdaptor adaptor) {
               }))
         return first.getInput();
 
-  return collectFields(getContext(), adaptor.getOperands());
+  return foldResult(*this, collectFields(getContext(), adaptor.getOperands()));
 }
 
 OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
@@ -2028,7 +2073,7 @@ OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
               }))
         return first.getInput();
 
-  return collectFields(getContext(), adaptor.getOperands());
+  return foldResult(*this, collectFields(getContext(), adaptor.getOperands()));
 }
 
 OpFoldResult UninferredResetCastOp::fold(FoldAdaptor adaptor) {
@@ -2080,8 +2125,12 @@ struct FoldResetMux : public mlir::RewritePattern {
 
     // Check all types should be typed by now
     auto regTy = reg.getResult().getType();
-    if (con.getDest().getType() != regTy || con.getSrc().getType() != regTy ||
-        mux.getHigh().getType() != regTy || mux.getLow().getType() != regTy ||
+    if (!mixedConstTypes(con.getDest().getType().cast<FIRRTLBaseType>(),
+                         regTy) ||
+        !mixedConstTypes(con.getSrc().getType().cast<FIRRTLBaseType>(),
+                         regTy) ||
+        !mixedConstTypes(mux.getHigh().getType(), regTy) ||
+        !mixedConstTypes(mux.getLow().getType(), regTy) ||
         regTy.getBitWidthOrSentinel() < 0)
       return failure();
 
@@ -2937,8 +2986,10 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
 
   // Check all types should be typed by now
   auto regTy = reg.getResult().getType();
-  if (con.getDest().getType() != regTy || con.getSrc().getType() != regTy ||
-      mux.getHigh().getType() != regTy || mux.getLow().getType() != regTy ||
+  if (!mixedConstTypes(con.getDest().getType().cast<FIRRTLBaseType>(), regTy) ||
+      !mixedConstTypes(con.getSrc().getType().cast<FIRRTLBaseType>(), regTy) ||
+      !mixedConstTypes(mux.getHigh().getType(), regTy) ||
+      !mixedConstTypes(mux.getLow().getType(), regTy) ||
       regTy.getBitWidthOrSentinel() < 0)
     return failure();
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2041,7 +2041,7 @@ OpFoldResult UninferredResetCastOp::constFold(FoldAdaptor adaptor) {
   return {};
 }
 
-OpFoldResult UninferredWidthCastOp::fold(FoldAdaptor adaptor) {
+OpFoldResult UninferredWidthCastOp::constFold(FoldAdaptor adaptor) {
   if (getOperand().getType() == getType() && !getType().hasUninferredWidth())
     return getOperand();
   return {};

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4473,7 +4473,9 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
   // Allow for now, as need to LowerTypes things generally.
   if (auto vectorType = inType.dyn_cast<FVectorType>()) {
     if (fieldIdx < vectorType.getNumElements())
-      return RefType::get(vectorType.getElementType(), refType.getForceable());
+      return RefType::get(
+          vectorType.getElementType().getConstType(vectorType.isConst()),
+          refType.getForceable());
     return emitInferRetTypeError(loc, "out of range index '", fieldIdx,
                                  "' in RefType of vector type ", refType);
   }
@@ -4483,8 +4485,9 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                    "subfield element index is greater than "
                                    "the number of fields in the bundle type");
     }
-    return RefType::get(bundleType.getElement(fieldIdx).type,
-                        refType.getForceable());
+    return RefType::get(
+        bundleType.getElement(fieldIdx).type.getConstType(bundleType.isConst()),
+        refType.getForceable());
   }
 
   return emitInferRetTypeError(

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2386,6 +2386,13 @@ LogicalResult StrictConnectOp::verify() {
 }
 
 LogicalResult RefDefineOp::verify() {
+  auto destBaseType = getDest().getType().getType();
+  auto srcBaseType = getSrc().getType().getType();
+  // Base types must be strictly equivalent
+  if (!areTypesEquivalent(destBaseType, srcBaseType, false, true))
+    return emitError("type mismatch between destination ")
+           << getDest().getType() << " and source " << getSrc().getType();
+
   // Check that the flows make sense.
   if (failed(checkConnectFlow(*this)))
     return failure();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3215,7 +3215,7 @@ bool firrtl::isConst(Type type) {
   return false;
 }
 
-// Returns true if the provided types are equal except for constness
+/// Returns true if the provided types are equal except for constness
 bool firrtl::mixedConstTypes(FIRRTLBaseType a, FIRRTLBaseType b) {
   return a == b || a.getPurelyNonConstType() == b.getPurelyNonConstType();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2372,7 +2372,7 @@ LogicalResult StrictConnectOp::verify() {
       return emitError("analog types may not be connected");
 
     // Types must be strictly equivalent
-    if (!areTypesEquivalent(destType, srcType, false, true))
+    if (!areTypesStrictlyEquivalent(destType, srcType))
       return typeMismatch();
   } else if (getDest().getType() != getSrc().getType()) {
     return typeMismatch();
@@ -2389,7 +2389,7 @@ LogicalResult RefDefineOp::verify() {
   auto destBaseType = getDest().getType().getType();
   auto srcBaseType = getSrc().getType().getType();
   // Base types must be strictly equivalent
-  if (!areTypesEquivalent(destBaseType, srcBaseType, false, true))
+  if (!areTypesStrictlyEquivalent(destBaseType, srcBaseType))
     return emitError("type mismatch between destination ")
            << getDest().getType() << " and source " << getSrc().getType();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2357,12 +2357,25 @@ LogicalResult ConnectOp::verify() {
 }
 
 LogicalResult StrictConnectOp::verify() {
-  if (auto type = getDest().getType().dyn_cast<FIRRTLType>()) {
-    auto baseType = type.dyn_cast<FIRRTLBaseType>();
+  auto typeMismatch = [&]() -> LogicalResult {
+    return emitError("type mismatch between destination ")
+           << getDest().getType() << " and source " << getSrc().getType();
+  };
+
+  auto destType = getDest().getType().dyn_cast<FIRRTLType>();
+  auto srcType = getSrc().getType().dyn_cast<FIRRTLType>();
+  if (destType && srcType) {
+    auto baseType = destType.dyn_cast<FIRRTLBaseType>();
 
     // Analog types cannot be connected and must be attached.
     if (baseType && baseType.containsAnalog())
       return emitError("analog types may not be connected");
+
+    // Types must be strictly equivalent
+    if (!areTypesEquivalent(destType, srcType, false, true))
+      return typeMismatch();
+  } else if (getDest().getType() != getSrc().getType()) {
+    return typeMismatch();
   }
 
   // Check that the flows make sense.
@@ -2398,6 +2411,26 @@ LogicalResult RefDefineOp::verify() {
   }
 
   return success();
+}
+
+static ParseResult parseConstDecay(OpAsmParser &parser, Type &destType,
+                                   Type &srcType) {
+  if (parser.parseType(destType))
+    return failure();
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseType(srcType))
+      return failure();
+  } else {
+    srcType = destType;
+  }
+  return success();
+}
+
+static void printConstDecay(OpAsmPrinter &p, Operation *op, Type destType,
+                            Type srcType) {
+  p << destType;
+  if (srcType != destType)
+    p << ", " << srcType;
 }
 
 void WhenOp::createElseRegion() {
@@ -3175,6 +3208,11 @@ bool firrtl::isConst(Type type) {
   return false;
 }
 
+// Returns true if the provided types are equal except for constness
+bool firrtl::mixedConstTypes(FIRRTLBaseType a, FIRRTLBaseType b) {
+  return a == b || a.getPurelyNonConstType() == b.getPurelyNonConstType();
+}
+
 FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        std::optional<Location> loc) {
@@ -3242,14 +3280,17 @@ FIRRTLType SubaccessOp::inferReturnType(ValueRange operands,
   auto inType = operands[0].getType();
   auto indexType = operands[1].getType();
 
-  if (!indexType.isa<UIntType>())
+  auto uintIndexType = indexType.dyn_cast<UIntType>();
+  if (!uintIndexType) {
     return emitInferRetTypeError(loc, "subaccess index must be UInt type, not ",
                                  indexType);
+  }
 
   if (auto vectorType = inType.dyn_cast<FVectorType>()) {
     auto elementType = vectorType.getElementType();
     return elementType.getConstType(
-        (elementType.isConst() || vectorType.isConst()) && isConst(indexType));
+        (elementType.isConst() || vectorType.isConst()) &&
+        uintIndexType.isConst());
   }
 
   return emitInferRetTypeError(loc, "subaccess requires vector operand, not ",
@@ -3267,28 +3308,57 @@ FIRRTLType TagExtractOp::inferReturnType(ValueRange operands,
 ParseResult MultibitMuxOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand index;
   SmallVector<OpAsmParser::UnresolvedOperand, 16> inputs;
-  Type indexType, elemType;
+  Type indexType, firstInputType;
+  SmallVector<Type, 4> inputTypes;
 
   if (parser.parseOperand(index) || parser.parseComma() ||
       parser.parseOperandList(inputs) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
       parser.parseType(indexType) || parser.parseComma() ||
-      parser.parseType(elemType))
+      parser.parseType(firstInputType))
     return failure();
+
+  inputTypes.push_back(firstInputType);
+
+  while (succeeded(parser.parseOptionalComma())) {
+    Type type;
+    if (parser.parseType(type))
+      return failure();
+    inputTypes.push_back(type);
+  }
 
   if (parser.resolveOperand(index, indexType, result.operands))
     return failure();
 
+  auto elemType = inputTypes[0];
+  if (isConst(elemType)) {
+    for (size_t i = 1, e = inputTypes.size(); i != e; ++i) {
+      auto inputType = inputTypes[i];
+      if (!isConst(inputType)) {
+        elemType = inputType;
+        break;
+      }
+    }
+  }
   result.addTypes(elemType);
 
-  return parser.resolveOperands(inputs, elemType, result.operands);
+  if (inputTypes.size() == 1)
+    return parser.resolveOperands(inputs, elemType, result.operands);
+  return parser.resolveOperands(inputs, inputTypes, parser.getCurrentLocation(),
+                                result.operands);
 }
 
 void MultibitMuxOp::print(OpAsmPrinter &p) {
   p << " " << getIndex() << ", ";
   p.printOperands(getInputs());
   p.printOptionalAttrDict((*this)->getAttrs());
-  p << " : " << getIndex().getType() << ", " << getType();
+  p << " : " << getIndex().getType() << ", " << getInputs()[0].getType();
+
+  bool allInputsSametype = llvm::all_equal(getInputs().getTypes());
+  if (!allInputsSametype) {
+    for (auto input : getInputs().drop_front())
+      p << ", " << input.getType();
+  }
 }
 
 FIRRTLType MultibitMuxOp::inferReturnType(ValueRange operands,
@@ -3297,13 +3367,29 @@ FIRRTLType MultibitMuxOp::inferReturnType(ValueRange operands,
   if (operands.size() < 2)
     return emitInferRetTypeError(loc, "at least one input is required");
 
-  // Check all mux inputs have the same type.
-  if (!llvm::all_of(operands.drop_front(2), [&](auto op) {
-        return operands[1].getType() == op.getType();
-      }))
-    return emitInferRetTypeError(loc, "all inputs must have the same type");
+  // Check all mux inputs have the same type ignoring constness.
+  auto firstInputType = operands[1].getType().dyn_cast<FIRRTLBaseType>();
+  if (!firstInputType)
+    return FIRRTLType();
+  bool allConst = firstInputType.isConst();
+  auto nonConstFirstInputType = firstInputType.getPurelyNonConstType();
 
-  return operands[1].getType().cast<FIRRTLType>();
+  for (auto input : operands.drop_front(2)) {
+    auto inputType = input.getType().dyn_cast<FIRRTLBaseType>();
+    if (!inputType)
+      return FIRRTLType();
+    if (inputType != firstInputType) {
+      if (inputType.getPurelyNonConstType() != nonConstFirstInputType) {
+        return emitInferRetTypeError(loc, "all inputs must have the same type");
+        if (loc)
+          mlir::emitError(*loc, "all inputs must have the same type");
+        return FIRRTLType();
+      }
+      allConst = false;
+    }
+  }
+
+  return allConst ? firstInputType : nonConstFirstInputType;
 }
 
 //===----------------------------------------------------------------------===//
@@ -3312,11 +3398,14 @@ FIRRTLType MultibitMuxOp::inferReturnType(ValueRange operands,
 
 /// If LHS and RHS are both UInt or SInt types, the return true and fill in the
 /// width of them if known.  If unknown, return -1 for the widths.
+/// The constness of the result is also returned, where if both lhs and rhs are
+/// const, then the result is const.
 ///
 /// On failure, this reports and error and returns false.  This function should
 /// not be used if you don't want an error reported.
 static bool isSameIntTypeKind(Type lhs, Type rhs, int32_t &lhsWidth,
-                              int32_t &rhsWidth, std::optional<Location> loc) {
+                              int32_t &rhsWidth, bool &isConstResult,
+                              std::optional<Location> loc) {
   // Must have two integer types with the same signedness.
   auto lhsi = lhs.dyn_cast<IntType>();
   auto rhsi = rhs.dyn_cast<IntType>();
@@ -3339,6 +3428,7 @@ static bool isSameIntTypeKind(Type lhs, Type rhs, int32_t &lhsWidth,
 
   lhsWidth = lhsi.getWidthOrSentinel();
   rhsWidth = rhsi.getWidthOrSentinel();
+  isConstResult = lhsi.isConst() && rhsi.isConst();
   return true;
 }
 
@@ -3346,9 +3436,10 @@ LogicalResult impl::verifySameOperandsIntTypeKind(Operation *op) {
   assert(op->getNumOperands() == 2 &&
          "SameOperandsIntTypeKind on non-binary op");
   int32_t lhsWidth, rhsWidth;
+  bool isConstResult;
   return success(isSameIntTypeKind(op->getOperand(0).getType(),
                                    op->getOperand(1).getType(), lhsWidth,
-                                   rhsWidth, op->getLoc()));
+                                   rhsWidth, isConstResult, op->getLoc()));
 }
 
 LogicalResult impl::validateBinaryOpArguments(ValueRange operands,
@@ -3364,77 +3455,86 @@ LogicalResult impl::validateBinaryOpArguments(ValueRange operands,
 FIRRTLType impl::inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
                                    std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   if (lhsWidth != -1 && rhsWidth != -1)
     resultWidth = std::max(lhsWidth, rhsWidth) + 1;
-  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth);
+  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth,
+                      isConstResult);
 }
 
 FIRRTLType MulPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                             std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   if (lhsWidth != -1 && rhsWidth != -1)
     resultWidth = lhsWidth + rhsWidth;
 
-  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth);
+  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth,
+                      isConstResult);
 }
 
 FIRRTLType DivPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                             std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   // For unsigned, the width is the width of the numerator on the LHS.
   if (lhs.isa<UIntType>())
-    return UIntType::get(lhs.getContext(), lhsWidth);
+    return UIntType::get(lhs.getContext(), lhsWidth, isConstResult);
 
   // For signed, the width is the width of the numerator on the LHS, plus 1.
   int32_t resultWidth = lhsWidth != -1 ? lhsWidth + 1 : -1;
-  return SIntType::get(lhs.getContext(), resultWidth);
+  return SIntType::get(lhs.getContext(), resultWidth, isConstResult);
 }
 
 FIRRTLType RemPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                             std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   if (lhsWidth != -1 && rhsWidth != -1)
     resultWidth = std::min(lhsWidth, rhsWidth);
-  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth);
+  return IntType::get(lhs.getContext(), lhs.isa<SIntType>(), resultWidth,
+                      isConstResult);
 }
 
 FIRRTLType impl::inferBitwiseResult(FIRRTLType lhs, FIRRTLType rhs,
                                     std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   if (lhsWidth != -1 && rhsWidth != -1)
     resultWidth = std::max(lhsWidth, rhsWidth);
-  return UIntType::get(lhs.getContext(), resultWidth);
+  return UIntType::get(lhs.getContext(), resultWidth, isConstResult);
 }
 
 FIRRTLType impl::inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                        std::optional<Location> loc) {
-  return UIntType::get(lhs.getContext(), 1);
+  return UIntType::get(lhs.getContext(), 1, isConst(lhs) && isConst(rhs));
 }
 
 FIRRTLType CatPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                             std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
-  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, loc))
+  bool isConstResult = false;
+  if (!isSameIntTypeKind(lhs, rhs, lhsWidth, rhsWidth, isConstResult, loc))
     return {};
 
   if (lhsWidth != -1 && rhsWidth != -1)
     resultWidth = lhsWidth + rhsWidth;
-  return UIntType::get(lhs.getContext(), resultWidth);
+  return UIntType::get(lhs.getContext(), resultWidth, isConstResult);
 }
 
 FIRRTLType DShlPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
@@ -3463,23 +3563,28 @@ FIRRTLType DShlPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                "amount exceeds maximum width");
     width = newWidth;
   }
-  return IntType::get(lhs.getContext(), lhsi.isSigned(), width);
+  return IntType::get(lhs.getContext(), lhsi.isSigned(), width,
+                      lhsi.isConst() && rhsui.isConst());
 }
 
 FIRRTLType DShlwPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                               std::optional<Location> loc) {
-  if (!lhs.isa<IntType>() || !rhs.isa<UIntType>())
+  auto lhsi = lhs.dyn_cast<IntType>();
+  auto rhsu = rhs.dyn_cast<UIntType>();
+  if (!lhsi || !rhsu)
     return emitInferRetTypeError(
         loc, "first operand should be integer, second unsigned int");
-  return lhs;
+  return lhsi.getConstType(lhsi.isConst() && rhsu.isConst());
 }
 
 FIRRTLType DShrPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
                                              std::optional<Location> loc) {
-  if (!lhs.isa<IntType>() || !rhs.isa<UIntType>())
+  auto lhsi = lhs.dyn_cast<IntType>();
+  auto rhsu = rhs.dyn_cast<UIntType>();
+  if (!lhsi || !rhsu)
     return emitInferRetTypeError(
         loc, "first operand should be integer, second unsigned int");
-  return lhs;
+  return lhsi.getConstType(lhsi.isConst() && rhsu.isConst());
 }
 
 //===----------------------------------------------------------------------===//
@@ -3499,6 +3604,7 @@ LogicalResult impl::validateUnaryOpArguments(ValueRange operands,
 FIRRTLType
 SizeOfIntrinsicOp::inferUnaryReturnType(FIRRTLType input,
                                         std::optional<Location> loc) {
+  // TODO: Should this be const?
   return UIntType::get(input.getContext(), 32);
 }
 
@@ -3510,7 +3616,7 @@ FIRRTLType AsSIntPrimOp::inferUnaryReturnType(FIRRTLType input,
   int32_t width = base.getBitWidthOrSentinel();
   if (width == -2)
     return emitInferRetTypeError(loc, "operand must be a scalar type");
-  return SIntType::get(input.getContext(), width);
+  return SIntType::get(input.getContext(), width, base.isConst());
 }
 
 FIRRTLType AsUIntPrimOp::inferUnaryReturnType(FIRRTLType input,
@@ -3521,7 +3627,7 @@ FIRRTLType AsUIntPrimOp::inferUnaryReturnType(FIRRTLType input,
   int32_t width = base.getBitWidthOrSentinel();
   if (width == -2)
     return emitInferRetTypeError(loc, "operand must be a scalar type");
-  return UIntType::get(input.getContext(), width);
+  return UIntType::get(input.getContext(), width, base.isConst());
 }
 
 FIRRTLType
@@ -3534,12 +3640,12 @@ AsAsyncResetPrimOp::inferUnaryReturnType(FIRRTLType input,
   int32_t width = base.getBitWidthOrSentinel();
   if (width == -2 || width == 0 || width > 1)
     return emitInferRetTypeError(loc, "operand must be single bit scalar type");
-  return AsyncResetType::get(input.getContext());
+  return AsyncResetType::get(input.getContext(), base.isConst());
 }
 
 FIRRTLType AsClockPrimOp::inferUnaryReturnType(FIRRTLType input,
                                                std::optional<Location> loc) {
-  return ClockType::get(input.getContext());
+  return ClockType::get(input.getContext(), isConst(input));
 }
 
 FIRRTLType CvtPrimOp::inferUnaryReturnType(FIRRTLType input,
@@ -3548,7 +3654,7 @@ FIRRTLType CvtPrimOp::inferUnaryReturnType(FIRRTLType input,
     auto width = uiType.getWidthOrSentinel();
     if (width != -1)
       ++width;
-    return SIntType::get(input.getContext(), width);
+    return SIntType::get(input.getContext(), width, uiType.isConst());
   }
 
   if (input.isa<SIntType>())
@@ -3565,7 +3671,7 @@ FIRRTLType NegPrimOp::inferUnaryReturnType(FIRRTLType input,
   int32_t width = inputi.getWidthOrSentinel();
   if (width != -1)
     ++width;
-  return SIntType::get(input.getContext(), width);
+  return SIntType::get(input.getContext(), width, inputi.isConst());
 }
 
 FIRRTLType NotPrimOp::inferUnaryReturnType(FIRRTLType input,
@@ -3573,12 +3679,13 @@ FIRRTLType NotPrimOp::inferUnaryReturnType(FIRRTLType input,
   auto inputi = input.dyn_cast<IntType>();
   if (!inputi)
     return emitInferRetTypeError(loc, "operand must have integer type");
-  return UIntType::get(input.getContext(), inputi.getWidthOrSentinel());
+  return UIntType::get(input.getContext(), inputi.getWidthOrSentinel(),
+                       inputi.isConst());
 }
 
 FIRRTLType impl::inferReductionResult(FIRRTLType input,
                                       std::optional<Location> loc) {
-  return UIntType::get(input.getContext(), 1);
+  return UIntType::get(input.getContext(), 1, isConst(input));
 }
 
 //===----------------------------------------------------------------------===//
@@ -3625,7 +3732,7 @@ FIRRTLType BitsPrimOp::inferReturnType(ValueRange operands,
         "high must be smaller than the width of input, but got high = ", high,
         ", width = ", width);
 
-  return UIntType::get(input.getContext(), high - low + 1);
+  return UIntType::get(input.getContext(), high - low + 1, inputi.isConst());
 }
 
 LogicalResult impl::validateOneOperandOneConst(ValueRange operands,
@@ -3653,7 +3760,7 @@ FIRRTLType HeadPrimOp::inferReturnType(ValueRange operands,
   if (width != -1 && amount > width)
     return emitInferRetTypeError(loc, "amount larger than input width");
 
-  return UIntType::get(input.getContext(), amount);
+  return UIntType::get(input.getContext(), amount, inputi.isConst());
 }
 
 LogicalResult MuxPrimOp::validateArguments(ValueRange operands,
@@ -3677,11 +3784,11 @@ LogicalResult MuxPrimOp::validateArguments(ValueRange operands,
 /// - Vectors inferred based on the element type.
 /// - Bundles inferred in a pairwise fashion based on the field types.
 static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
-                                         FIRRTLBaseType low,
+                                         FIRRTLBaseType low, bool isConst,
                                          std::optional<Location> loc) {
   // If the types are identical we're done.
   if (high == low)
-    return low;
+    return low.getConstType(isConst);
 
   // The base types need to be equivalent.
   if (high.getTypeID() != low.getTypeID())
@@ -3696,10 +3803,10 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
     int32_t highWidth = high.getBitWidthOrSentinel();
     int32_t lowWidth = low.getBitWidthOrSentinel();
     if (lowWidth == -1)
-      return low;
+      return low.getConstType(isConst);
     if (highWidth == -1)
-      return high;
-    return lowWidth > highWidth ? low : high;
+      return high.getConstType(isConst);
+    return (lowWidth > highWidth ? low : high).getConstType(isConst);
   }
 
   // Infer vector types by comparing the element types.
@@ -3708,7 +3815,7 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
   if (highVector && lowVector &&
       highVector.getNumElements() == lowVector.getNumElements()) {
     auto inner = inferMuxReturnType(highVector.getElementType(),
-                                    lowVector.getElementType(), loc);
+                                    lowVector.getElementType(), isConst, loc);
     if (!inner)
       return {};
     return FVectorType::get(inner, lowVector.getNumElements());
@@ -3732,8 +3839,8 @@ static FIRRTLBaseType inferMuxReturnType(FIRRTLBaseType high,
           break;
         }
         auto element = highElements[i];
-        element.type =
-            inferMuxReturnType(highElements[i].type, lowElements[i].type, loc);
+        element.type = inferMuxReturnType(highElements[i].type,
+                                          lowElements[i].type, isConst, loc);
         if (!element.type)
           return {};
         newElements.push_back(element);
@@ -3760,7 +3867,12 @@ FIRRTLType MuxPrimOp::inferReturnType(ValueRange operands,
   auto lowType = operands[2].getType().dyn_cast<FIRRTLBaseType>();
   if (!highType || !lowType)
     return emitInferRetTypeError(loc, "operands must be base type");
-  return inferMuxReturnType(highType, lowType, loc);
+
+  // Determine constness of the result type
+  bool isConst = firrtl::isConst(operands[0].getType()) && highType.isConst() &&
+                 lowType.isConst();
+
+  return inferMuxReturnType(highType, lowType, isConst, loc);
 }
 
 FIRRTLType PadPrimOp::inferReturnType(ValueRange operands,
@@ -3779,7 +3891,8 @@ FIRRTLType PadPrimOp::inferReturnType(ValueRange operands,
     return inputi;
 
   width = std::max<int32_t>(width, amount);
-  return IntType::get(input.getContext(), inputi.isSigned(), width);
+  return IntType::get(input.getContext(), inputi.isSigned(), width,
+                      inputi.isConst());
 }
 
 FIRRTLType ShlPrimOp::inferReturnType(ValueRange operands,
@@ -3797,7 +3910,8 @@ FIRRTLType ShlPrimOp::inferReturnType(ValueRange operands,
   if (width != -1)
     width += amount;
 
-  return IntType::get(input.getContext(), inputi.isSigned(), width);
+  return IntType::get(input.getContext(), inputi.isSigned(), width,
+                      inputi.isConst());
 }
 
 FIRRTLType ShrPrimOp::inferReturnType(ValueRange operands,
@@ -3815,7 +3929,8 @@ FIRRTLType ShrPrimOp::inferReturnType(ValueRange operands,
   if (width != -1)
     width = std::max<int32_t>(1, width - amount);
 
-  return IntType::get(input.getContext(), inputi.isSigned(), width);
+  return IntType::get(input.getContext(), inputi.isSigned(), width,
+                      inputi.isConst());
 }
 
 FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
@@ -3837,7 +3952,7 @@ FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
     width -= amount;
   }
 
-  return IntType::get(input.getContext(), false, width);
+  return IntType::get(input.getContext(), false, width, inputi.isConst());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -44,7 +44,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   }
 
   // If the types are the exact same we can just connect them.
-  if (dstType == srcType && dstType.isPassive() &&
+  if (mixedConstTypes(dstType, srcType) && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
     builder.create<StrictConnectOp>(dst, src);
     return;
@@ -122,7 +122,8 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // Strict connect requires the types to be completely equal, including
   // connecting uint<1> to abstract reset types.
-  assert("Connect Types are equal" && dstType == src.getType());
+  assert("Connect Types are equal" &&
+         mixedConstTypes(dstType, src.getType().cast<FIRRTLBaseType>()));
   builder.create<StrictConnectOp>(dst, src);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -176,19 +176,23 @@ static bool peelType(Type type, SmallVectorImpl<FlatBundleFieldEntry> &fields,
         // Otherwise, we have a bundle type.  Break it down.
         for (size_t i = 0, e = bundle.getNumElements(); i < e; ++i) {
           auto elt = bundle.getElement(i);
+          auto eltType = elt.type;
+          eltType = eltType.getConstType(eltType.isConst() || bundle.isConst());
           // Construct the suffix to pass down.
           tmpSuffix.resize(0);
           tmpSuffix.push_back('_');
           tmpSuffix.append(elt.name.getValue());
-          fields.emplace_back(elt.type, i, bundle.getFieldID(i), tmpSuffix,
+          fields.emplace_back(eltType, i, bundle.getFieldID(i), tmpSuffix,
                               elt.isFlip);
         }
         return true;
       })
       .Case<FVectorType>([&](auto vector) {
         // Increment the field ID to point to the first element.
+        auto eltType = vector.getElementType();
+        eltType = eltType.getConstType(eltType.isConst() || vector.isConst());
         for (size_t i = 0, e = vector.getNumElements(); i != e; ++i) {
-          fields.emplace_back(vector.getElementType(), i, vector.getFieldID(i),
+          fields.emplace_back(eltType, i, vector.getFieldID(i),
                               "_" + std::to_string(i), false);
         }
         return true;

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2889,4 +2889,35 @@ firrtl.module private @RWProbeUnused(in %in: !firrtl.uint<4>, in %clk: !firrtl.c
   firrtl.connect %r, %w : !firrtl.uint, !firrtl.uint
   firrtl.connect %out, %r : !firrtl.uint, !firrtl.uint
 }
+
+// CHECK-LABEL: firrtl.module @ConstToNonConstTypeConnect
+firrtl.module @ConstToNonConstTypeConnect(in %in: !firrtl.const.uint<4>, out %out: !firrtl.uint<4>) {
+  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.uint<4>, !firrtl.const.uint<4>
+  firrtl.connect %out, %in : !firrtl.uint<4>, !firrtl.const.uint<4>
+}
+
+// CHECK-LABEL: firrtl.module @ConstToNonConstBundleTypeConnect
+firrtl.module @ConstToNonConstBundleTypeConnect(in %in: !firrtl.bundle<a: const.uint<4>>, out %out: !firrtl.bundle<a: uint<4>>) {
+  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.bundle<a: uint<4>>, !firrtl.bundle<a: const.uint<4>>
+  firrtl.connect %out, %in : !firrtl.bundle<a: uint<4>>, !firrtl.bundle<a: const.uint<4>>
+}
+
+// CHECK-LABEL: firrtl.module @ConstToNonConstVectorTypeConnect
+firrtl.module @ConstToNonConstVectorTypeConnect(in %in: !firrtl.vector<const.uint<4>, 2>, out %out: !firrtl.vector<uint<4>, 2>) {
+  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.vector<uint<4>, 2>, !firrtl.vector<const.uint<4>, 2>
+  firrtl.connect %out, %in : !firrtl.vector<uint<4>, 2>, !firrtl.vector<const.uint<4>, 2>
+}
+
+// This checks that a folded const type from an originally non-const op propagates const to downstream/inserted ops
+// CHECK-LABEL: firrtl.module @ConstTypeReinference
+firrtl.module @ConstTypeReinference(in %constIn: !firrtl.const.uint<4>, in %nonConstIn: !firrtl.uint<3>, out %out: !firrtl.sint<6>) {
+  // CHECK-NEXT: [[VAL0:%.+]] = firrtl.pad %constIn, 5 : (!firrtl.const.uint<4>) -> !firrtl.const.uint<5>
+  // CHECK-NEXT: [[VAL1:%.+]] = firrtl.neg [[VAL0]] : (!firrtl.const.uint<5>) -> !firrtl.const.sint<6>
+  // CHECK-NEXT: firrtl.strictconnect %out, [[VAL1]] : !firrtl.sint<6>, !firrtl.const.sint<6>
+  %sub = firrtl.sub %nonConstIn, %nonConstIn : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<4>
+  %add = firrtl.add %constIn, %sub : (!firrtl.const.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  %neg = firrtl.neg %add : (!firrtl.uint<5>) -> !firrtl.sint<6>
+  firrtl.connect %out, %neg : !firrtl.sint<6>, !firrtl.sint<6>
+}
+
 }

--- a/test/Dialect/FIRRTL/const-errors.mlir
+++ b/test/Dialect/FIRRTL/const-errors.mlir
@@ -30,6 +30,17 @@ firrtl.module @test(in %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, out %out : 
 
 // -----
 
+// firrtl.ref.define non-'const' to 'const' flow is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %a: !firrtl.uint<1>, out %_a: !firrtl.probe<const.uint<1>>) {
+  %0 = firrtl.ref.send %a : !firrtl.uint<1>
+  // expected-error @+1 {{type mismatch}}
+  firrtl.ref.define %_a, %0 : !firrtl.probe<const.uint<1>>, !firrtl.probe<uint<1>>
+}
+}
+
+// -----
+
 // Primitive ops with all 'const' operands must have a 'const' result type
 firrtl.circuit "test" {
 firrtl.module @test(in %a: !firrtl.const.uint<4>, in %b: !firrtl.const.uint<4>) {

--- a/test/Dialect/FIRRTL/const-errors.mlir
+++ b/test/Dialect/FIRRTL/const-errors.mlir
@@ -20,6 +20,26 @@ firrtl.module @test(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in 
 
 // -----
 
+// nested 'const' firrtl.reg is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: const.uint<1>>
+}
+}
+
+// -----
+
+// nested 'const' firrtl.regreset is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.bundle<a: uint<1>>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.bundle<a: uint<1>>, !firrtl.bundle<a: const.uint<1>>
+}
+}
+
+// -----
+
 // firrtl.strictconnect non-'const' to 'const' flow is invalid
 firrtl.circuit "test" {
 firrtl.module @test(in %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, out %out : !firrtl.bundle<a: const.uint<1>, b: sint<2>>) {

--- a/test/Dialect/FIRRTL/const-errors.mlir
+++ b/test/Dialect/FIRRTL/const-errors.mlir
@@ -1,0 +1,49 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// 'const' firrtl.reg is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.uint<1>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.const.uint<1>
+}
+}
+
+// -----
+
+// 'const' firrtl.regreset is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.uint<1>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.uint<1>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.uint<1>, !firrtl.const.uint<1>
+}
+}
+
+// -----
+
+// firrtl.strictconnect non-'const' to 'const' flow is invalid
+firrtl.circuit "test" {
+firrtl.module @test(in %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, out %out : !firrtl.bundle<a: const.uint<1>, b: sint<2>>) {
+  // expected-error @+1 {{type mismatch}}
+  firrtl.strictconnect %out, %in : !firrtl.bundle<a: const.uint<1>, b: sint<2>>, !firrtl.bundle<a: uint<1>, b: sint<2>>
+}
+}
+
+// -----
+
+// Primitive ops with all 'const' operands must have a 'const' result type
+firrtl.circuit "test" {
+firrtl.module @test(in %a: !firrtl.const.uint<4>, in %b: !firrtl.const.uint<4>) {
+  // expected-error @+1 {{'firrtl.and' op inferred type(s) '!firrtl.const.uint<4>' are incompatible with return type(s) of operation '!firrtl.uint<4>'}}
+  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.const.uint<4>) -> !firrtl.uint<4>
+}
+}
+
+// -----
+
+// Primitive ops with mixed 'const' operands must have a non-'const' result type
+firrtl.circuit "test" {
+firrtl.module @test(in %a: !firrtl.const.uint<4>, in %b: !firrtl.uint<4>) {
+  // expected-error @+1 {{'firrtl.and' op inferred type(s) '!firrtl.uint<4>' are incompatible with return type(s) of operation '!firrtl.const.uint<4>'}}
+  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.uint<4>) -> !firrtl.const.uint<4>
+}
+}

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -128,4 +128,25 @@ firrtl.module @MixedConstSubtag(in %in : !firrtl.enum<a: uint<1>, b: const.uint<
   firrtl.connect %b, %1 : !firrtl.const.uint<2>, !firrtl.const.uint<2>
 }
 
+// Test parsing/printing of strictconnect when both operands are const
+// CHECK-LABEL: firrtl.module @ConstStrictconnect
+firrtl.module @ConstStrictconnect(in %in : !firrtl.const.uint<3>, out %out : !firrtl.const.uint<3>) {
+  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.const.uint<3>
+  firrtl.strictconnect %out, %in : !firrtl.const.uint<3>
+}
+
+// Test parsing/printing of strictconnect when constness of operands is mixed
+// CHECK-LABEL: firrtl.module @MixedConstStrictconnect
+firrtl.module @MixedConstStrictconnect(in %in : !firrtl.const.bundle<a: uint<1>, b: sint<2>>, out %out : !firrtl.bundle<a: uint<1>, b: sint<2>>) {
+  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, !firrtl.const.bundle<a: uint<1>, b: sint<2>>
+  firrtl.strictconnect %out, %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, !firrtl.const.bundle<a: uint<1>, b: sint<2>>
+}
+
+// Test parsing/printing of multibit mux when constness of operands is mixed
+// CHECK-LABEL: firrtl.module @MixedConstMultibitMux
+firrtl.module @MixedConstMultibitMux(in %index: !firrtl.uint<2>, in %source_0: !firrtl.const.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.const.uint<1>) {
+  // CHECK-NEXT: [[VAL:%.+]] = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.const.uint<1>, !firrtl.uint<1>, !firrtl.const.uint<1>
+  %0 = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.const.uint<1>, !firrtl.uint<1>, !firrtl.const.uint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -142,6 +142,24 @@ firrtl.module @MixedConstStrictconnect(in %in : !firrtl.const.bundle<a: uint<1>,
   firrtl.strictconnect %out, %in : !firrtl.bundle<a: uint<1>, b: sint<2>>, !firrtl.const.bundle<a: uint<1>, b: sint<2>>
 }
 
+// Test parsing/printing of ref.define when both operands are const
+// CHECK-LABEL: firrtl.module @ConstRefDefine
+firrtl.module @ConstRefDefine(in %a: !firrtl.const.uint<1>, out %_a: !firrtl.probe<const.uint<1>>) {
+  // CHECK-NEXT: [[VAL:%.+]] = firrtl.ref.send %a : !firrtl.const.uint<1>
+  // CHECK-NEXT: firrtl.ref.define %_a, [[VAL]] : !firrtl.probe<const.uint<1>>
+  %0 = firrtl.ref.send %a : !firrtl.const.uint<1>
+  firrtl.ref.define %_a, %0 : !firrtl.probe<const.uint<1>>
+}
+
+// Test parsing/printing of ref.define when constness of operands is mixed
+// CHECK-LABEL: firrtl.module @MixedConstRefDefine
+firrtl.module @MixedConstRefDefine(in %a: !firrtl.const.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
+  // CHECK-NEXT: [[VAL:%.+]] = firrtl.ref.send %a : !firrtl.const.uint<1>
+  // CHECK-NEXT: firrtl.ref.define %_a, [[VAL]] : !firrtl.probe<uint<1>>, !firrtl.probe<const.uint<1>>
+  %0 = firrtl.ref.send %a : !firrtl.const.uint<1>
+  firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<const.uint<1>>
+}
+
 // Test parsing/printing of multibit mux when constness of operands is mixed
 // CHECK-LABEL: firrtl.module @MixedConstMultibitMux
 firrtl.module @MixedConstMultibitMux(in %index: !firrtl.uint<2>, in %source_0: !firrtl.const.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.const.uint<1>) {

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -160,6 +160,28 @@ firrtl.module @MixedConstRefDefine(in %a: !firrtl.const.uint<1>, out %_a: !firrt
   firrtl.ref.define %_a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<const.uint<1>>
 }
 
+// Sub access of a ref to a const vector should always have a ref to a const const result
+// CHECK-LABEL: firrtl.module @ConstRefVectorSub
+firrtl.module @ConstRefVectorSub(in %a: !firrtl.const.vector<uint<1>, 3>, out %_a: !firrtl.probe<const.uint<1>>) {
+  // CHECK-NEXT: [[VAL0:%.+]] = firrtl.ref.send %a : !firrtl.const.vector<uint<1>, 3>
+  // CHECK-NEXT: [[VAL1:%.+]] = firrtl.ref.sub [[VAL0]][0] : !firrtl.probe<const.vector<uint<1>, 3>>
+  // CHECK-NEXT: firrtl.ref.define %_a, [[VAL1]] : !firrtl.probe<const.uint<1>>
+  %0 = firrtl.ref.send %a : !firrtl.const.vector<uint<1>, 3>
+  %1 = firrtl.ref.sub %0[0] : !firrtl.probe<const.vector<uint<1>, 3>>
+  firrtl.ref.define %_a, %1 : !firrtl.probe<const.uint<1>>
+}
+
+// Sub access of a ref to a const bundle should always have a ref to a const result
+// CHECK-LABEL: firrtl.module @ConstRefBundleSub
+firrtl.module @ConstRefBundleSub(in %a: !firrtl.const.bundle<a: uint<1>, b: sint<2>>, out %_a: !firrtl.probe<const.uint<1>>) {
+  // CHECK-NEXT: [[VAL0:%.+]] = firrtl.ref.send %a : !firrtl.const.bundle<a: uint<1>, b: sint<2>>
+  // CHECK-NEXT: [[VAL1:%.+]] = firrtl.ref.sub [[VAL0]][0] : !firrtl.probe<const.bundle<a: uint<1>, b: sint<2>>>
+  // CHECK-NEXT: firrtl.ref.define %_a, [[VAL1]] : !firrtl.probe<const.uint<1>>
+  %0 = firrtl.ref.send %a : !firrtl.const.bundle<a: uint<1>, b: sint<2>>
+  %1 = firrtl.ref.sub %0[0] : !firrtl.probe<const.bundle<a: uint<1>, b: sint<2>>>
+  firrtl.ref.define %_a, %1 : !firrtl.probe<const.uint<1>>
+}
+
 // Test parsing/printing of multibit mux when constness of operands is mixed
 // CHECK-LABEL: firrtl.module @MixedConstMultibitMux
 firrtl.module @MixedConstMultibitMux(in %index: !firrtl.uint<2>, in %source_0: !firrtl.const.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.const.uint<1>) {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -844,7 +844,7 @@ firrtl.circuit "Top"   {
 
 firrtl.circuit "AnalogRegister" {
   firrtl.module @AnalogRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.analog'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.analog'}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.analog
   }
 }
@@ -853,7 +853,7 @@ firrtl.circuit "AnalogRegister" {
 
 firrtl.circuit "AnalogVectorRegister" {
   firrtl.module @AnalogVectorRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<analog, 2>
   }
 }
@@ -1005,7 +1005,7 @@ firrtl.module @NonRefNode(in %in1 : !firrtl.probe<uint<8>>) {
 
 firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.probe<uint<8>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1244,6 +1244,24 @@ firrtl.module private @is1436_FOO() {
     } @SubmoduleWithAggregate(out a: !firrtl.vector<uint<1>, 1>)
   }
 
+  // CHECK-LABEL: firrtl.module @ConstBundle
+  firrtl.module @ConstBundle(in %a: !firrtl.const.bundle<a: uint<1>>) {}
+  // CHECK-SAME: in %a_a: !firrtl.const.uint<1>
+
+  // CHECK-LABEL: firrtl.module @ConstBundleElement
+  firrtl.module @ConstBundleElement(in %a: !firrtl.bundle<a: const.uint<1>>) {}
+  // CHECK-SAME: in %a_a: !firrtl.const.uint<1>
+
+  // CHECK-LABEL: firrtl.module @ConstVector
+  firrtl.module @ConstVector(in %a: !firrtl.const.vector<uint<1>, 2>) {}
+  // CHECK-SAME: in %a_0: !firrtl.const.uint<1>
+  // CHECK-SAME: in %a_1: !firrtl.const.uint<1>
+
+  // CHECK-LABEL: firrtl.module @ConstVectorElement
+  firrtl.module @ConstVectorElement(in %a: !firrtl.vector<const.uint<1>, 2>) {}
+  // CHECK-SAME: in %a_0: !firrtl.const.uint<1>
+  // CHECK-SAME: in %a_1: !firrtl.const.uint<1>
+
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -561,7 +561,7 @@ circuit DefineWidths:
   module DefineWidths:
     input in : UInt<1>
     output p : Probe<UInt>
-    define p = probe(in) ; expected-error {{'firrtl.ref.define' op requires all operands to have the same type}}
+    define p = probe(in) ; expected-error {{type mismatch between destination '!firrtl.probe<uint>' and source '!firrtl.probe<uint<1>>'}}
 
 
 ;// -----


### PR DESCRIPTION
This pr contains the following changes:
- For primitive ops, if all operands to an op are `const`, the result is `const`. If any operand is non-`const`, the result is non-`const`.
- Allow `const` to non-`const` flow for `strictconnect`
- Disallow `const` registers
- Cache purely non-`const` aggregate types for quick type comparisons
- `fold` functions update the op result type to allow for non-'const' to 'const' type propagation
  - This isn't fully implemented for folding to a constant attribute yet since constant ops don't have 'const' result types yet, which will be updated in a later pr
  - Some canonicalization tests have been added but most canonicalization functionality involving `const` will be covered in the later constant op pr
  - This change means `fold` functions might modify the op and return a result, which can be seen as bending the rules about what `fold` functions are allowed to do. I'm open to alternative approaches.