### PR TITLE
[HW] Size enums to the number of tags

### DIFF
--- a/docs/Dialects/HW/RationaleHW.md
+++ b/docs/Dialects/HW/RationaleHW.md
@@ -81,6 +81,17 @@ constructs that work with the inout type.  These aren't necessary
 for combinational logic, but are nonetheless pretty useful when generating
 Verilog.
 
+### `enum` Type
+
+Enum types have the property that the bit width of the type is the minimum 
+necessary to hold the tag values.  Tag values are either explicit or 
+sequentially numbered in tag order from 0.  Enum tags are unsigned values.
+
+### `union` Type
+
+Union types contain a single data element (which may be an aggregate).  They
+optionally have an offset per varient which allows non-SV layouts.
+
 ## `hw.module` and `hw.instance`
 
 The basic structure of a hardware design is made up an "instance tree" of

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -162,7 +162,7 @@ def EnumTypeImpl : HWType<"Enum"> {
     bool contains(mlir::StringRef field);
 
     /// Returns the number of bits used by the enum
-    size_t getWidth();
+    size_t getBitWidth();
 
     /// Returns the index of the requested field, or a nullopt if the field is
     // not part of this enum.

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -161,6 +161,9 @@ def EnumTypeImpl : HWType<"Enum"> {
     /// Returns true if the requested field is part of this enum
     bool contains(mlir::StringRef field);
 
+    /// Returns the number of bits used by the enum
+    size_t getWidth();
+
     /// Returns the index of the requested field, or a nullopt if the field is
     // not part of this enum.
     std::optional<size_t> indexOf(mlir::StringRef field);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -320,7 +320,7 @@ bool ExportVerilog::isZeroBitType(Type type) {
     return llvm::all_of(structType.getElements(),
                         [](auto elem) { return isZeroBitType(elem.type); });
   if (auto enumType = type.dyn_cast<hw::EnumType>())
-    return enumType.getFields().empty()
+    return enumType.getFields().empty();
 
   // We have an open type system, so assume it is ok.
   return false;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -320,7 +320,7 @@ bool ExportVerilog::isZeroBitType(Type type) {
     return llvm::all_of(structType.getElements(),
                         [](auto elem) { return isZeroBitType(elem.type); });
   if (auto enumType = type.dyn_cast<hw::EnumType>())
-    return enumType.getFields().size() == 0;
+    return enumType.getFields().empty()
 
   // We have an open type system, so assume it is ok.
   return false;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1397,7 +1397,10 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
                                    emitter);
       })
       .Case<EnumType>([&](EnumType enumType) {
-        os << "enum {";
+        os << "enum ";
+        if (enumType.getWidth() != 32)
+          os << "bit [" << enumType.getWidth() - 1 << ":0] ";
+        os << "{";
         Type enumPrefixType = optionalAliasType ? optionalAliasType : enumType;
         llvm::interleaveComma(
             enumType.getFields().getAsRange<StringAttr>(), os,

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1398,8 +1398,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
       })
       .Case<EnumType>([&](EnumType enumType) {
         os << "enum ";
-        if (enumType.getWidth() != 32)
-          os << "bit [" << enumType.getWidth() - 1 << ":0] ";
+        if (enumType.getBitWidth() != 32)
+          os << "bit [" << enumType.getBitWidth() - 1 << ":0] ";
         os << "{";
         Type enumPrefixType = optionalAliasType ? optionalAliasType : enumType;
         llvm::interleaveComma(

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -366,7 +366,7 @@ void MachineOpConverter::buildStateCaseMux(
   // Case assignments.
   caseMux = b.create<sv::CaseOp>(
       machineOp.getLoc(), CaseStmtType::CaseStmt,
-      sv::ValidationQualifierTypeEnum::ValidationQualifierUnique, select,
+      /*sv::ValidationQualifierTypeEnum::ValidationQualifierUnique, */ select,
       /*numCases=*/machineOp.getNumStates() + 1, [&](size_t caseIdx) {
         // Make Verilator happy for sized enums.
         if (caseIdx == machineOp.getNumStates())

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -365,8 +365,13 @@ void MachineOpConverter::buildStateCaseMux(
 
   // Case assignments.
   caseMux = b.create<sv::CaseOp>(
-      machineOp.getLoc(), CaseStmtType::CaseStmt, select,
-      /*numCases=*/machineOp.getNumStates(), [&](size_t caseIdx) {
+      machineOp.getLoc(), CaseStmtType::CaseStmt,
+      sv::ValidationQualifierTypeEnum::ValidationQualifierUnique, select,
+      /*numCases=*/machineOp.getNumStates() + 1, [&](size_t caseIdx) {
+        // Make Verilator happy for sized enums.
+        if (caseIdx == machineOp.getNumStates())
+          return std::unique_ptr<sv::CasePattern>(
+              new sv::CaseDefaultPattern(b.getContext()));
         StateOp state = orderedStates[caseIdx];
         return encoding->getCasePattern(state);
       });

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -392,7 +392,7 @@ std::optional<size_t> EnumType::indexOf(mlir::StringRef field) {
   return {};
 }
 
-size_t EnumType::getWidth() { return llvm::Log2_64_Ceil(getFields().size()); }
+size_t EnumType::getBitWidth() { return llvm::Log2_64_Ceil(getFields().size()); }
 
 //===----------------------------------------------------------------------===//
 // ArrayType

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -392,6 +392,8 @@ std::optional<size_t> EnumType::indexOf(mlir::StringRef field) {
   return {};
 }
 
+size_t EnumType::getWidth() { return llvm::Log2_64_Ceil(getFields().size()); }
+
 //===----------------------------------------------------------------------===//
 // ArrayType
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -392,7 +392,9 @@ std::optional<size_t> EnumType::indexOf(mlir::StringRef field) {
   return {};
 }
 
-size_t EnumType::getBitWidth() { return llvm::Log2_64_Ceil(getFields().size()); }
+size_t EnumType::getBitWidth() {
+  return llvm::Log2_64_Ceil(getFields().size());
+}
 
 //===----------------------------------------------------------------------===//
 // ArrayType

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -360,14 +360,13 @@ Type UnionType::getFieldType(mlir::StringRef fieldName) {
 Type EnumType::parse(AsmParser &p) {
   llvm::SmallVector<Attribute> fields;
 
-  if (p.parseLess() || p.parseCommaSeparatedList([&]() {
+  if (p.parseCommaSeparatedList(AsmParser::Delimiter::LessGreater, [&]() {
         StringRef name;
         if (p.parseKeyword(&name))
           return failure();
         fields.push_back(StringAttr::get(p.getContext(), name));
         return success();
-      }) ||
-      p.parseGreater())
+      }))
     return Type();
 
   return get(p.getContext(), ArrayAttr::get(p.getContext(), fields));
@@ -393,7 +392,10 @@ std::optional<size_t> EnumType::indexOf(mlir::StringRef field) {
 }
 
 size_t EnumType::getBitWidth() {
-  return llvm::Log2_64_Ceil(getFields().size());
+  auto w = getFields().size();
+  if (w > 1)
+    return llvm::Log2_64_Ceil(getFields().size());
+  return 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -19,7 +19,7 @@ hw.type_scope @__hw_typedecls {
   hw.typedecl @qux, "customName" : i32
   // CHECK: typedef struct packed {foo a; _other_scope_foo b; } nestedRef;
   hw.typedecl @nestedRef : !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo,i1>, b: !hw.typealias<@_other_scope::@foo,i2>>
-  // CHECK: typedef enum {myEnum_A, myEnum_B, myEnum_C} myEnum;
+  // CHECK: typedef enum bit [1:0] {myEnum_A, myEnum_B, myEnum_C} myEnum;
   hw.typedecl @myEnum : !hw.enum<A, B, C>
 }
 // CHECK: `endif // _TYPESCOPE___hw_typedecls

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -989,11 +989,11 @@ hw.module @ConstantDefBeforeUse() {
 
 // CHECK: `ifndef _TYPESCOPE___AnFSMTypedecl
 // CHECK: `define _TYPESCOPE___AnFSMTypedecl
-// CHECK: typedef enum {_state1_A, _state1_B} _state1;
-// CHECK: typedef enum {_state2_A, _state2_B} _state2;
+// CHECK: typedef enum bit [0:0] {_state1_A, _state1_B} _state1;
+// CHECK: typedef enum bit [0:0] {_state2_A, _state2_B} _state2;
 // CHECK: `endif // _TYPESCOPE___AnFSMTypedecl
 // CHECK-LABEL: module AnFSM
-// CHECK:   enum {A, B} reg_0;
+// CHECK:   enum bit [0:0] {A, B} reg_0;
 // OLD:   _state1     reg_state1;
 // OLD:   _state2     reg_state2;
 // CHECK:   always @(posedge clock) begin

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1751,6 +1751,13 @@ hw.module @ForStatement(%a: i5) -> () {
   }
 }
 
+// CHECK-LABEL: module EnumCheck
+hw.module @EnumCheck(%a : !hw.enum<T>, %b: !hw.enum<>)
+                 -> (c: !hw.enum<T>, d: !hw.enum<>) {
+  // CHECK: input enum bit [0:0] {T} a
+  // CHECK: // input enum bit [0:0] {} b
+  hw.output %a, %b : !hw.enum<T>, !hw.enum<>
+}
 
 // CHECK-LABEL: module intrinsic
 hw.module @intrinsic(%clk: i1) -> (io1: i1, io2: i1, io3: i1, io4: i5) {

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -50,7 +50,7 @@ hw.module @top(%arg0: i1, %arg1: i1, %clk : i1, %rst : i1) -> (out: i8) {
 // CHECK-NEXT:    %output_0 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    %output_1 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    sv.alwayscomb {
-// CHECK-NEXT:      sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case unique %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
 // CHECK-NEXT:        sv.bpassign %state_next, %1 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:        sv.bpassign %output_0, %c0_i8 : i8
@@ -60,6 +60,8 @@ hw.module @top(%arg0: i1, %arg1: i1, %clk : i1, %rst : i1) -> (out: i8) {
 // CHECK-NEXT:        sv.bpassign %state_next, %4 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:        sv.bpassign %output_0, %c1_i8 : i8
 // CHECK-NEXT:        sv.bpassign %output_1, %c42_i8 : i8
+// CHECK-NEXT:      }
+// CHECK-NEXT:      default: {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %5 = sv.read_inout %output_0 : !hw.inout<i8>
@@ -93,20 +95,24 @@ fsm.machine @top(%a0: i1, %arg1: i1) -> (i8, i8) attributes {initialState = "A",
 // CHECK:       %[[CNT_ADD_1:.*]] = comb.add %cnt_reg, %c1_i16 : i16
 // CHECK:       sv.alwayscomb {
 // CHECK-NEXT:    sv.bpassign %cnt_next, %cnt_reg : i16
-// CHECK-NEXT:    sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    sv.case unique %state_reg : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    case A: {
 // CHECK-NEXT:      sv.bpassign %state_next, %[[B:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      sv.bpassign %output_0, %cnt_reg : i16
 // CHECK-NEXT:    }
 // CHECK-NEXT:    case B: {
 // CHECK-NEXT:      sv.bpassign %state_next, %[[A:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:      sv.case %[[STATE_NEXT:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case unique %[[STATE_NEXT:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
 // CHECK-NEXT:        sv.bpassign %cnt_next, %[[CNT_ADD_1]] : i16
 // CHECK-NEXT:      }
 // CHECK-NEXT:      case B: {
 // CHECK-NEXT:      }
+// CHECK-NEXT:      default: {
+// CHECK-NEXT:      }
 // CHECK-NEXT:      sv.bpassign %output_0, %cnt_reg : i16
+// CHECK-NEXT:    }
+// CHECK-NEXT:    default: {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -50,7 +50,7 @@ hw.module @top(%arg0: i1, %arg1: i1, %clk : i1, %rst : i1) -> (out: i8) {
 // CHECK-NEXT:    %output_0 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    %output_1 = sv.reg  : !hw.inout<i8>
 // CHECK-NEXT:    sv.alwayscomb {
-// CHECK-NEXT:      sv.case unique %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
 // CHECK-NEXT:        sv.bpassign %state_next, %1 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:        sv.bpassign %output_0, %c0_i8 : i8
@@ -95,14 +95,14 @@ fsm.machine @top(%a0: i1, %arg1: i1) -> (i8, i8) attributes {initialState = "A",
 // CHECK:       %[[CNT_ADD_1:.*]] = comb.add %cnt_reg, %c1_i16 : i16
 // CHECK:       sv.alwayscomb {
 // CHECK-NEXT:    sv.bpassign %cnt_next, %cnt_reg : i16
-// CHECK-NEXT:    sv.case unique %state_reg : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    case A: {
 // CHECK-NEXT:      sv.bpassign %state_next, %[[B:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      sv.bpassign %output_0, %cnt_reg : i16
 // CHECK-NEXT:    }
 // CHECK-NEXT:    case B: {
 // CHECK-NEXT:      sv.bpassign %state_next, %[[A:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:      sv.case unique %[[STATE_NEXT:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:      sv.case %[[STATE_NEXT:.*]] : !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
 // CHECK-NEXT:        sv.bpassign %cnt_next, %[[CNT_ADD_1]] : i16
 // CHECK-NEXT:      }

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -189,7 +189,7 @@ class Verilator:
                      sources)
     self.ldPaths = ":".join([os.path.dirname(x) for x in dpiLibs])
     debugFlags = []
-    cflags = ["-DVL_TIME_CONTEXT"]
+    cflags = []
     if DebugBuild:
       debugFlags = ["--trace", "--trace-params", "--trace-structs"]
       cflags.append("-DTRACE")

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -189,7 +189,7 @@ class Verilator:
                      sources)
     self.ldPaths = ":".join([os.path.dirname(x) for x in dpiLibs])
     debugFlags = []
-    cflags = []
+    cflags = ["-DVL_TIME_CONTEXT"]
     if DebugBuild:
       debugFlags = ["--trace", "--trace-params", "--trace-structs"]
       cflags.append("-DTRACE")


### PR DESCRIPTION
Let hw.enum be defined as a size based on it's contents, rather than implicitly by the verilog default size.