### PR TITLE
[FIRRTL][IMDCE] Remove dead Invalid Value op

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -20,6 +21,13 @@
 
 using namespace circt;
 using namespace firrtl;
+
+// Return true if this op has side-effects except for alloc and read.
+static bool hasUnknownSideEffect(Operation *op) {
+  return !(mlir::isMemoryEffectFree(op) ||
+           mlir::hasSingleEffect<mlir::MemoryEffects::Allocate>(op) ||
+           mlir::hasSingleEffect<mlir::MemoryEffects::Read>(op));
+}
 
 /// Return true if this is a wire or a register or a node.
 static bool isDeclaration(Operation *op) {
@@ -199,10 +207,10 @@ void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
       markDeclaration(&op);
     else if (auto instance = dyn_cast<InstanceOp>(op))
       markInstanceOp(instance);
-    else if (isa<FConnectLike, InvalidValueOp>(op))
-      // Skip connect op and invalid values.
+    else if (isa<FConnectLike>(op))
+      // Skip connect op.
       continue;
-    else if (!mlir::isMemoryEffectFree(&op))
+    else if (hasUnknownSideEffect(&op))
       markUnknownSideEffectOp(&op);
 
     // TODO: Handle attach etc.
@@ -389,8 +397,8 @@ void IMDeadCodeElimPass::rewriteModuleBody(FModuleOp module) {
       continue;
     }
 
-    // Delete dead wires, regs and nodes.
-    if ((isDeclaration(&op) || isa<InvalidValueOp>(&op)) &&
+    // Delete dead wires, regs, nodes and alloc/read ops.
+    if ((isDeclaration(&op) || !hasUnknownSideEffect(&op)) &&
         isAssumedDead(&op)) {
       LLVM_DEBUG(llvm::dbgs() << "DEAD: " << op << "\n";);
       assert(op.use_empty() && "users should be already removed");

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -199,8 +199,8 @@ void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
       markDeclaration(&op);
     else if (auto instance = dyn_cast<InstanceOp>(op))
       markInstanceOp(instance);
-    else if (isa<FConnectLike>(op))
-      // Skip connect op.
+    else if (isa<FConnectLike, InvalidValueOp>(op))
+      // Skip connect op and invalid values.
       continue;
     else if (!mlir::isMemoryEffectFree(&op))
       markUnknownSideEffectOp(&op);
@@ -390,7 +390,8 @@ void IMDeadCodeElimPass::rewriteModuleBody(FModuleOp module) {
     }
 
     // Delete dead wires, regs and nodes.
-    if (isDeclaration(&op) && isAssumedDead(&op)) {
+    if ((isDeclaration(&op) || isa<InvalidValueOp>(&op)) &&
+        isAssumedDead(&op)) {
       LLVM_DEBUG(llvm::dbgs() << "DEAD: " << op << "\n";);
       assert(op.use_empty() && "users should be already removed");
       op.erase();

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -321,6 +321,10 @@ firrtl.circuit "DeadInputPort"  {
 // -----
 
 firrtl.circuit "DeleteInstance" {
+  // CHECK-NOT: @InvalidValue
+  firrtl.module private @InvalidValue() {
+      %invalid_ui289 = firrtl.invalidvalue : !firrtl.uint<289>
+  }
   firrtl.module private @SideEffect1(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock) {
     firrtl.printf %clock, %a, "foo"  : !firrtl.clock, !firrtl.uint<1>
   }
@@ -334,6 +338,8 @@ firrtl.circuit "DeleteInstance" {
   }
   // CHECK-LABEL: DeleteInstance
   firrtl.module @DeleteInstance(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
+    // CHECK-NOT: inv
+    firrtl.instance inv @InvalidValue()
     // CHECK-NOT: p1
     // CHECK: instance p2 @PassThrough
     // CHECK-NEXT: instance s @SideEffect2


### PR DESCRIPTION
Recently we've changed the modeling of InvalidValueOp to have side-effect so it's necessary to handle invalid values specially.