### PR TITLE
[ExportVerilog] Union type output support

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1442,11 +1442,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
           if (needsPadding) {
             os << " struct packed {";
             if (element.offset) {
-              StringRef paddingName = "__pre_padding";
-              if (element.name == paddingName)
-                paddingName = "__pre_padding_real";
-              os << "logic [" << element.offset - 1 << ":0] " << paddingName
-                 << "; ";
+              os << "logic [" << element.offset - 1 << ":0] "
+                 << "__pre_padding_" << element.name.getValue() << "; ";
             }
           }
 
@@ -1461,12 +1458,9 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
 
           if (needsPadding) {
             if (elementWidth + (int64_t)element.offset < unionWidth) {
-              StringRef paddingName = "__post_padding";
-              if (element.name == paddingName)
-                paddingName = "__post_padding_real";
               os << " logic ["
                  << unionWidth - (elementWidth + element.offset) - 1 << ":0] "
-                 << paddingName << ";";
+                 << "__post_padding_" << element.name.getValue() << ";";
             }
             os << "} " << emitter.getVerilogStructFieldName(element.name)
                << ";";

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1389,3 +1389,27 @@ hw.module @DontInlineAggregateConstantIntoPorts() -> () {
   %0 = hw.aggregate_constant [0 : i4, 1 : i4] : !hw.array<2xi4>
   hw.instance "i0" @Array(a: %0: !hw.array<2xi4>) -> ()
 }
+
+// CHECK-LABEL: module FooA(
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [9:0] b; logic [5:0] __post_padding;} b;} test
+// CHECK-NEXT:  );
+!unionA = !hw.union<a: i16, b: i10>
+hw.module @FooA(%test: !unionA) {}
+
+// CHECK-LABEL: module FooB(
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding; logic [9:0] b; logic [3:0] __post_padding;} b;} test
+// CHECK-NEXT:  );
+!unionB = !hw.union<a: i16, b: i10 offset 2>
+hw.module @FooB(%test: !unionB) {}
+
+// CHECK-LABEL: module FooC(
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding_real; logic [9:0] __pre_padding; logic [3:0] __post_padding;} __pre_padding;} test
+// CHECK-NEXT:  );
+!unionC = !hw.union<a: i16, __pre_padding: i10 offset 2>
+hw.module @FooC(%test: !unionC) {}
+
+// CHECK-LABEL: module FooD(
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding; logic [9:0] __post_padding; logic [3:0] __post_padding_real;} __post_padding;} test
+// CHECK-NEXT:  );
+!unionD = !hw.union<a: i16, __post_padding: i10 offset 2>
+hw.module @FooD(%test: !unionD) {}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1391,25 +1391,13 @@ hw.module @DontInlineAggregateConstantIntoPorts() -> () {
 }
 
 // CHECK-LABEL: module FooA(
-// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [9:0] b; logic [5:0] __post_padding;} b;} test
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [9:0] b; logic [5:0] __post_padding_b;} b;} test
 // CHECK-NEXT:  );
 !unionA = !hw.union<a: i16, b: i10>
 hw.module @FooA(%test: !unionA) {}
 
 // CHECK-LABEL: module FooB(
-// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding; logic [9:0] b; logic [3:0] __post_padding;} b;} test
+// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding_b; logic [9:0] b; logic [3:0] __post_padding_b;} b;} test
 // CHECK-NEXT:  );
 !unionB = !hw.union<a: i16, b: i10 offset 2>
 hw.module @FooB(%test: !unionB) {}
-
-// CHECK-LABEL: module FooC(
-// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding_real; logic [9:0] __pre_padding; logic [3:0] __post_padding;} __pre_padding;} test
-// CHECK-NEXT:  );
-!unionC = !hw.union<a: i16, __pre_padding: i10 offset 2>
-hw.module @FooC(%test: !unionC) {}
-
-// CHECK-LABEL: module FooD(
-// CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [1:0] __pre_padding; logic [9:0] __post_padding; logic [3:0] __post_padding_real;} __post_padding;} test
-// CHECK-NEXT:  );
-!unionD = !hw.union<a: i16, __post_padding: i10 offset 2>
-hw.module @FooD(%test: !unionD) {}


### PR DESCRIPTION
Teach ExportVerilog how to output union types with proper padding. Does not include union operation support. When those are implemented, the field names will be different depending on padding.

Tested with Questa.