### PR TITLE
[Seq] Add FirMem op

### DIFF
--- a/include/circt/Dialect/Seq/CMakeLists.txt
+++ b/include/circt/Dialect/Seq/CMakeLists.txt
@@ -19,6 +19,11 @@ mlir_tablegen(SeqEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRSeqEnumsIncGen)
 add_dependencies(circt-headers MLIRSeqEnumsIncGen)
 
+mlir_tablegen(SeqAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=seq)
+mlir_tablegen(SeqAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=seq)
+add_public_tablegen_target(MLIRSeqAttributesIncGen)
+add_dependencies(circt-headers MLIRSeqAttributesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS SeqPasses.td)
 mlir_tablegen(SeqPasses.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTSeqTransformsIncGen)

--- a/include/circt/Dialect/Seq/SeqAttributes.h
+++ b/include/circt/Dialect/Seq/SeqAttributes.h
@@ -14,5 +14,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 
 #include "circt/Dialect/Seq/SeqEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Seq/SeqAttributes.h.inc"
 
 #endif // CIRCT_DIALECT_SEQ_SEQATTRIBUTES_H

--- a/include/circt/Dialect/Seq/SeqAttributes.td
+++ b/include/circt/Dialect/Seq/SeqAttributes.td
@@ -30,4 +30,28 @@ def WUWAttr : I32EnumAttr<"WUW", "Write-Under-Write Behavior",
 
 }
 
+/// An attribute holding information about memory initialization.
+def FirMemInitAttr : AttrDef<SeqDialect, "FirMemInit"> {
+  let mnemonic = "firmem.init";
+  let summary = "Memory initialization information";
+  let description = [{
+    This attribute captures what the initial contents of a memory should be.
+    At the moment this is modeled primarily with simulation in mind, where the
+    memory contents are pre-loaded from a file at simulation startup.
+
+    The `filename` specifies a file on disk that contains the initial contents
+    for this memory. If `isBinary` is set, the file is interpreted as a binary
+    file, otherwise it is treated as hexadecimal. This is modeled after the
+    `$readmemh` and `$readmemb` SystemVerilog functions. If `isInline` is set,
+    the initialization is emitted directly in the memory model; otherwise it is
+    split out into a separate module that can be bound in.
+  }];
+  let parameters = (ins
+    "mlir::StringAttr":$filename,
+    "bool":$isBinary,
+    "bool":$isInline
+  );
+  let assemblyFormat = "`<` $filename `,` $isBinary `,` $isInline `>`";
+}
+
 #endif // CIRCT_DIALECT_SEQ_SEQATTRIBUTES_TD

--- a/include/circt/Dialect/Seq/SeqDialect.td
+++ b/include/circt/Dialect/Seq/SeqDialect.td
@@ -23,11 +23,14 @@ def SeqDialect : Dialect {
 
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
   let cppNamespace = "::circt::seq";
 
   let extraClassDeclaration = [{
-    /// Register all Seq types.
+    /// Register all types.
     void registerTypes();
+    /// Register all attributes.
+    void registerAttributes();
   }];
 }
 

--- a/include/circt/Dialect/Seq/SeqOps.h
+++ b/include/circt/Dialect/Seq/SeqOps.h
@@ -15,6 +15,7 @@
 
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "circt/Dialect/HW/HWTypes.h"

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -15,6 +15,7 @@
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/Seq/SeqAttributes.td"
 include "circt/Dialect/Seq/SeqOpInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 // Base class for the operation in this dialect.
 class SeqOp<string mnemonic, list<Trait> traits = []> :
@@ -85,6 +86,10 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     }]>,
   ];
 }
+
+//===----------------------------------------------------------------------===//
+// FIRRTL-flavored register
+//===----------------------------------------------------------------------===//
 
 def FirRegOp : SeqOp<"firreg",
     [Pure, Clocked, Resettable,
@@ -253,4 +258,163 @@ def ClockGateOp : SeqOp<"clock_gate", [Pure]> {
   let assemblyFormat = [{
     $input `,` $enable (`,` $test_enable^)? attr-dict
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// FIRRTL-flavored memory
+//===----------------------------------------------------------------------===//
+
+def FirMemOp : SeqOp<"firmem", [
+  MemoryEffects<[MemAlloc]>,
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = "A FIRRTL-flavored memory";
+  let description = [{
+    The `seq.firmem` op represents memories lowered from the FIRRTL dialect. It
+    is used to capture some of the peculiarities of what FIRRTL expects from
+    memories, while still representing them at the HW dialect level.
+
+    A `seq.firmem` declares the memory and captures the memory-level parameters
+    such as width and depth or how read/write collisions are resolved. The read,
+    write, and read-write ports are expressed as separate operations that take
+    the declared memory as an operand.
+  }];
+
+  let arguments = (ins
+    I32Attr:$readLatency,
+    I32Attr:$writeLatency,
+    RUWAttr:$ruw,
+    WUWAttr:$wuw,
+    OptionalAttr<StrAttr>:$name,
+    OptionalAttr<SymbolNameAttr>:$inner_sym,
+    OptionalAttr<FirMemInitAttr>:$init,
+    OptionalAttr<StrAttr>:$prefix,
+    OptionalAttr<AnyAttr>:$output_file
+  );
+  let results = (outs FirMemType:$memory);
+
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name)
+    $readLatency `,` $writeLatency `,` $ruw `,` $wuw
+    attr-dict `:` type($memory)
+  }];
+}
+
+class AddressMatchesFirMem<string memoryValue, string addressValue> :
+  TypesMatchWith<"address type should match clog2 of memory depth",
+    memoryValue, addressValue, [{
+      IntegerType::get(
+        $_self.getContext(),
+        std::max(1U, llvm::Log2_64_Ceil(cast<FirMemType>($_self).getDepth())))
+    }]>;
+
+class DataMatchesFirMem<string memoryValue, string dataValue> :
+  TypesMatchWith<"data type should match memory width",
+    memoryValue, dataValue, [{
+      IntegerType::get(
+        $_self.getContext(),
+        std::max(1U, cast<FirMemType>($_self).getWidth()))
+    }]>;
+
+def FirMemReadOp : SeqOp<"firmem.read_port", [
+  MemoryEffects<[MemRead]>,
+  AddressMatchesFirMem<"memory", "address">,
+  DataMatchesFirMem<"memory", "data">
+]> {
+  let summary = "A memory read port";
+  let description = [{
+    The `seq.firmem.read_port` op represents a read port on a `seq.firmem`
+    memory. It takes the memory as an operand, together with the address to
+    be read, the clock on which the read is synchronized, and an optional
+    enable. Omitting the enable operand has the same effect as passing a
+    constant `true` to it.
+  }];
+
+  let arguments = (ins
+    FirMemType:$memory,
+    AnySignlessInteger:$address,
+    I1:$clock,
+    Optional<I1>:$enable
+  );
+  let results = (outs AnySignlessInteger:$data);
+  let assemblyFormat = [{
+    $memory `[` $address `]` `,` `clock` $clock
+    (`enable` $enable^)?
+    attr-dict `:` type($memory)
+  }];
+  let hasCanonicalizeMethod = 1;
+}
+
+def FirMemWriteOp : SeqOp<"firmem.write_port", [
+  MemoryEffects<[MemWrite]>,
+  AddressMatchesFirMem<"memory", "address">,
+  DataMatchesFirMem<"memory", "data">,
+  AttrSizedOperandSegments
+]> {
+  let summary = "A memory write port";
+  let description = [{
+    The `seq.firmem.write_port` op represents a write port on a `seq.firmem`
+    memory. It takes the memory as an operand, together with the address and
+    data to be written, the clock on which the write is synchronized, an
+    optional enable, and and optional write mask. Omitting the enable operand
+    has the same effect as passing a constant `true` to it. Omitting the write
+    mask operand has the same effect as passing an all-ones value to it. A write
+    mask operand can only be present if the `seq.firmem` specifies a mask width;
+    otherwise it must be omitted.
+  }];
+
+  let arguments = (ins
+    FirMemType:$memory,
+    AnySignlessInteger:$address,
+    I1:$clock,
+    Optional<I1>:$enable,
+    AnySignlessInteger:$data,
+    Optional<AnySignlessInteger>:$mask
+  );
+  let assemblyFormat = [{
+    $memory `[` $address `]` `=` $data `,` `clock` $clock
+    (`enable` $enable^)? (`mask` $mask^)?
+    attr-dict `:` type($memory) (`,` type($mask)^)?
+  }];
+  let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
+}
+
+def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
+  MemoryEffects<[MemRead, MemWrite]>,
+  AddressMatchesFirMem<"memory", "address">,
+  DataMatchesFirMem<"memory", "writeData">,
+  DataMatchesFirMem<"memory", "readData">,
+  AttrSizedOperandSegments
+]> {
+  let summary = "A memory read-write port";
+  let description = [{
+    The `seq.firmem.read_write_port` op represents a read-write port on a
+    `seq.firmem` memory. It takes the memory as an operand, together with the
+    address and data to be written, a mode operand indicating whether the port
+    should perform a read (`mode=0`) or a write (`mode=1`), the clock on which
+    the read and write is synchronized, an optional enable, and and optional
+    write mask. Omitting the enable operand has the same effect as passing a
+    constant `true` to it. Omitting the write mask operand has the same effect
+    as passing an all-ones value to it. A write mask operand can only be present
+    if the `seq.firmem` specifies a mask width; otherwise it must be omitted.
+  }];
+
+  let arguments = (ins
+    FirMemType:$memory,
+    AnySignlessInteger:$address,
+    I1:$clock,
+    Optional<I1>:$enable,
+    AnySignlessInteger:$writeData,
+    I1:$mode,
+    Optional<AnySignlessInteger>:$mask
+  );
+  let results = (outs AnySignlessInteger:$readData);
+  let assemblyFormat = [{
+    $memory `[` $address `]` `=` $writeData `if` $mode `,` `clock` $clock
+    (`enable` $enable^)? (`mask` $mask^)?
+    attr-dict `:` type($memory) (`,` type($mask)^)?
+  }];
+  let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 }

--- a/include/circt/Dialect/Seq/SeqTypes.td
+++ b/include/circt/Dialect/Seq/SeqTypes.td
@@ -63,3 +63,19 @@ def HLMemType : SeqType<"HLMem",[
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }
+
+def FirMemType : SeqType<"FirMem"> {
+  let summary = "A FIRRTL-flavored memory";
+  let description = [{
+    The `!seq.firmem` type represents a FIRRTL-flavored memory declared by a
+    `seq.firmem` operation. It captures the parameters of the memory that are
+    relevant to the read, write, and read-write ports, such as width and depth.
+  }];
+  let mnemonic = "firmem";
+  let parameters = (ins
+    "uint32_t":$depth,
+    "uint32_t":$width,
+    OptionalParameter<"llvm::Optional<uint32_t>">:$maskWidth
+  );
+  let assemblyFormat = "`<` $depth `x` $width (`,` `mask` $maskWidth^)? `>`";
+}

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -24,6 +24,7 @@ add_circt_dialect_library(CIRCTSeq
   CIRCTSV
   MLIRSeqIncGen
   MLIRSeqEnumsIncGen
+  MLIRSeqAttributesIncGen
 
   LINK_COMPONENTS
   Support

--- a/lib/Dialect/Seq/SeqAttributes.cpp
+++ b/lib/Dialect/Seq/SeqAttributes.cpp
@@ -17,3 +17,11 @@ using namespace seq;
 
 #include "circt/Dialect/Seq/SeqEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Seq/SeqAttributes.cpp.inc"
+
+void SeqDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/Seq/SeqAttributes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/Seq/SeqDialect.cpp
+++ b/lib/Dialect/Seq/SeqDialect.cpp
@@ -26,6 +26,7 @@ using namespace seq;
 
 void SeqDialect::initialize() {
   registerTypes();
+  registerAttributes();
 
   // Register operations.
   addOperations<

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -120,3 +120,48 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %testEnable: i1) {
   %6 = seq.clock_gate %clock, %enable, %false
   %dropTestEnable = hw.wire %6 sym @dropTestEnable : i1
 }
+
+// CHECK-LABEL: @FirMem
+hw.module @FirMem(%addr: i4, %clock: i1, %data: i42) -> (out: i42) {
+  %true = hw.constant true
+  %false = hw.constant false
+  %c0_i3 = hw.constant 0 : i3
+  %c-1_i3 = hw.constant -1 : i3
+
+  // CHECK: [[MEM:%.+]] = seq.firmem
+  %0 = seq.firmem 0, 1, undefined, undefined : <12 x 42, mask 3>
+
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock :
+  %1 = seq.firmem.read_port %0[%addr], clock %clock enable %true : <12 x 42, mask 3>
+
+  // CHECK-NEXT: seq.firmem.write_port %0[%addr] = %data, clock %clock {w0}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %true {w0} : <12 x 42, mask 3>
+  // CHECK-NOT: {w1}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %false {w1} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.write_port %0[%addr] = %data, clock %clock {w2}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c-1_i3 {w2} : <12 x 42, mask 3>, i3
+  // CHECK-NOT: {w3}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c0_i3 {w3} : <12 x 42, mask 3>, i3
+  // CHECK-NOT: {w4}
+  seq.firmem.write_port %0[%addr] = %data, clock %true {w4} : <12 x 42, mask 3>
+  // CHECK-NOT: {w5}
+  seq.firmem.write_port %0[%addr] = %data, clock %false {w5} : <12 x 42, mask 3>
+
+  // CHECK-NEXT: seq.firmem.read_write_port [[MEM]][%addr] = %data if %true, clock %clock {rw0}
+  %2 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %true {rw0} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock enable %false {rw1}
+  %3 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %false {rw1} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_write_port [[MEM]][%addr] = %data if %true, clock %clock {rw2}
+  %4 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c-1_i3 {rw2} : <12 x 42, mask 3>, i3
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock {rw3}
+  %5 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c0_i3 {rw3} : <12 x 42, mask 3>, i3
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock {rw4}
+  %6 = seq.firmem.read_write_port %0[%addr] = %data if %false, clock %clock {rw4} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %true {rw5}
+  %7 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %true {rw5} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %false {rw6}
+  %8 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %false {rw6} : <12 x 42, mask 3>
+
+  %9 = comb.xor %1, %2, %3, %4, %5, %6, %7, %8 : i42
+  hw.output %9 : i42
+}

--- a/test/Dialect/Seq/firmem.mlir
+++ b/test/Dialect/Seq/firmem.mlir
@@ -1,0 +1,55 @@
+// RUN: circt-opt %s --verify-diagnostics | circt-opt --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: hw.module @Basic
+hw.module @Basic() {
+  // CHECK-NEXT: seq.firmem 0, 1, undefined, undefined : <3 x 19>
+  %0 = seq.firmem 0, 1, undefined, undefined : <3 x 19>
+
+  // CHECK-NEXT: seq.firmem sym @someMem 0, 1, undefined, undefined : <3 x 19>
+  %1 = seq.firmem sym @someMem 0, 1, undefined, undefined : <3 x 19>
+
+  // CHECK-NEXT: %myMem1 = seq.firmem 0, 1, undefined, undefined : <3 x 19>
+  %2 = seq.firmem name "myMem1" 0, 1, undefined, undefined : <3 x 19>
+
+  // CHECK-NEXT: %myMem2 = seq.firmem 0, 1, undefined, undefined : <3 x 19>
+  %myMem2 = seq.firmem 0, 1, undefined, undefined : <3 x 19>
+
+  // CHECK-NEXT: %myMem3 = seq.firmem 0, 1, undefined, undefined : <3 x 19>
+  %ignoredName = seq.firmem name "myMem3" 0, 1, undefined, undefined : <3 x 19>
+
+  // CHECK-NEXT: seq.firmem 0, 1, undefined, undefined {init = #seq.firmem.init<"mem.txt", false, false>} : <3 x 19>
+  %3 = seq.firmem 0, 1, undefined, undefined {init = #seq.firmem.init<"mem.txt", false, false>} : <3 x 19>
+}
+
+// CHECK-LABEL: hw.module @Ports
+hw.module @Ports(%clock: i1, %enable: i1, %address: i4, %data: i20, %mode: i1, %mask: i4) {
+  // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, undefined : <12 x 20>
+  // CHECK-NEXT: %mem2 = seq.firmem 0, 1, undefined, undefined : <12 x 20, mask 4>
+  %mem = seq.firmem 0, 1, undefined, undefined : <12 x 20>
+  %mem2 = seq.firmem 0, 1, undefined, undefined : <12 x 20, mask 4>
+
+  // Read ports
+  // CHECK-NEXT: [[R0:%.+]] = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>
+  // CHECK-NEXT: [[R1:%.+]] = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>
+  %0 = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>
+  %1 = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>
+
+  // Write ports
+  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>
+  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>
+  // CHECK-NEXT: seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i4
+  seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>
+  seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>
+  seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i4
+
+  // Read-write ports
+  // CHECK-NEXT: [[R2:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>
+  // CHECK-NEXT: [[R3:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>
+  // CHECK-NEXT: [[R4:%.+]] = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i4
+  %2 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>
+  %3 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>
+  %4 = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i4
+
+  // CHECK-NEXT: comb.xor [[R0]], [[R1]], [[R2]], [[R3]], [[R4]]
+  comb.xor %0, %1, %2, %3, %4 : i20
+}


### PR DESCRIPTION
Add a new `FirMemOp` to the Seq dialect to capture the semantics of FIRRTL memories at the HW level. The intent behind this change is the same as for `FirRegOp`, which captures the specifics of FIRRTL registers but within the type system and abstraction level of the HW dialect.

Memories are represented as a declaration with the `seq.firmem` which returns a value representing the memory itself. This value is of type `!seq.firmem<12 x 42, mask 2>` which represents an opaque handle to the memory; it encodes the depth (`12`) and width (`42`) of the memory, plus an optional mask if the memory is to support masked writes.

Memory ports are represented as separate operations:

- `seq.firmem.read_port`
- `seq.firmem.write_port`
- `seq.firmem.read_write_port`

These operations take the memory itself as their first operand. The remaining operands are the specific signals required for the corresponding type of port: clocks, enables, masks, mode select, etc. Read and read-write ports also return the read data as their result. Enables and masks are optional to allow for more concise IR for simple memory configurations.

Representing ports as separate ops in the IR has the advantage that adding and removing ports is trivial; the standard CSE and canonicalization even allow for collapsing duplicate ports and removing permanently disabled ports. Separate ops also make building up memories in the IR a lot simpler, since the operands and results associated with a port are grouped together, instead of having to spread them across an overall operand and result list on the overall memory. Getting a memory's ports means walking the list of users of the declaration op, which is very cheap since the only users are the port operations.

This commit merely adds the `FirMemOp` alongside some canonicalization and general tests, but the op isn't used by any part of CIRCT yet. Use in FIRRTL-to-HW lowering follows as a separate commit.

*After some discussion:* the intent is for `seq.firmem` and `seq.hlmem` to be unified into a `seq.mem` once the memory handling has been factored out of the FIRRTL-to-HW lowering.