### PR TITLE
[Seq] Lower FirMemOp to HWModuleGeneratedOp

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -21,12 +21,12 @@ namespace seq {
 
 #define GEN_PASS_DECL
 #include "circt/Dialect/Seq/SeqPasses.h.inc"
-#undef GEN_PASS_DECL
 
 std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
 std::unique_ptr<mlir::Pass>
 createSeqFIRRTLLowerToSVPass(const LowerSeqFIRRTLToSVOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
+std::unique_ptr<mlir::Pass> createLowerFirMemPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -44,4 +44,10 @@ def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def LowerFirMem : Pass<"lower-seq-firmem", "mlir::ModuleOp"> {
+  let summary = "Lower seq.firmem ops to instances of hw.module.generated ops";
+  let constructor = "circt::seq::createLowerFirMemPass()";
+  let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 #endif // CIRCT_DIALECT_SEQ_SEQPASSES

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTSeqTransforms
-  LowerSeqToSV.cpp
+  LowerFirMem.cpp
   LowerSeqHLMem.cpp
+  LowerSeqToSV.cpp
 
   DEPENDS
   CIRCTSeqTransformsIncGen

--- a/lib/Dialect/Seq/Transforms/LowerFirMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerFirMem.cpp
@@ -1,0 +1,523 @@
+//===- LowerFirMem.cpp - Seq FIRRTL memory lowering -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transform translate Seq FirMem ops to instances of HW generated modules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/Namespace.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Parallel.h"
+
+#define DEBUG_TYPE "lower-firmem"
+
+using namespace circt;
+using namespace seq;
+using namespace hw;
+using hw::HWModuleGeneratedOp;
+using llvm::MapVector;
+using llvm::SmallDenseSet;
+
+//===----------------------------------------------------------------------===//
+// FIR Memory Parametrization
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// The configuration of a FIR memory.
+struct FirMemConfig {
+  size_t numReadPorts = 0;
+  size_t numWritePorts = 0;
+  size_t numReadWritePorts = 0;
+  size_t dataWidth = 0;
+  size_t depth = 0;
+  size_t readLatency = 0;
+  size_t writeLatency = 0;
+  size_t maskBits = 0;
+  RUW readUnderWrite = RUW::Undefined;
+  WUW writeUnderWrite = WUW::Undefined;
+  SmallVector<int32_t, 1> writeClockIDs;
+  StringRef initFilename;
+  bool initIsBinary = false;
+  bool initIsInline = false;
+  Attribute outputFile;
+  StringRef prefix;
+
+  llvm::hash_code hash_value() const {
+    return llvm::hash_combine(numReadPorts, numWritePorts, numReadWritePorts,
+                              dataWidth, depth, readLatency, writeLatency,
+                              maskBits, readUnderWrite, writeUnderWrite,
+                              initFilename, initIsBinary, initIsInline,
+                              outputFile, prefix) ^
+           llvm::hash_combine_range(writeClockIDs.begin(), writeClockIDs.end());
+  }
+
+  auto getTuple() const {
+    return std::make_tuple(numReadPorts, numWritePorts, numReadWritePorts,
+                           dataWidth, depth, readLatency, writeLatency,
+                           maskBits, readUnderWrite, writeUnderWrite,
+                           writeClockIDs, initFilename, initIsBinary,
+                           initIsInline, outputFile, prefix);
+  }
+
+  bool operator==(const FirMemConfig &other) const {
+    return getTuple() == other.getTuple();
+  }
+};
+} // namespace
+
+namespace llvm {
+template <>
+struct DenseMapInfo<FirMemConfig> {
+  static inline FirMemConfig getEmptyKey() {
+    FirMemConfig cfg;
+    cfg.depth = DenseMapInfo<size_t>::getEmptyKey();
+    return cfg;
+  }
+  static inline FirMemConfig getTombstoneKey() {
+    FirMemConfig cfg;
+    cfg.depth = DenseMapInfo<size_t>::getTombstoneKey();
+    return cfg;
+  }
+  static unsigned getHashValue(const FirMemConfig &cfg) {
+    return cfg.hash_value();
+  }
+  static bool isEqual(const FirMemConfig &lhs, const FirMemConfig &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_DEF_LOWERFIRMEM
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+struct LowerFirMemPass : public impl::LowerFirMemBase<LowerFirMemPass> {
+  /// A vector of unique `FirMemConfig`s and all the `FirMemOp`s that use it.
+  using UniqueConfig = std::pair<FirMemConfig, SmallVector<FirMemOp, 1>>;
+  using UniqueConfigs = std::vector<UniqueConfig>;
+
+  void runOnOperation() override;
+
+  UniqueConfigs collectMemories(ArrayRef<HWModuleOp> modules);
+  FirMemConfig collectMemory(FirMemOp op);
+
+  SmallVector<HWModuleGeneratedOp>
+  createMemoryModules(MutableArrayRef<UniqueConfig> configs);
+  HWModuleGeneratedOp createMemoryModule(UniqueConfig &config,
+                                         OpBuilder &builder,
+                                         FlatSymbolRefAttr schemaSymRef,
+                                         Namespace &globalNamespace);
+
+  void lowerMemoriesInModule(
+      HWModuleOp module,
+      ArrayRef<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>> mems);
+};
+} // namespace
+
+void LowerFirMemPass::runOnOperation() {
+  // Gather all HW modules. We'll parallelize over them.
+  SmallVector<HWModuleOp> modules;
+  getOperation().walk([&](HWModuleOp op) {
+    modules.push_back(op);
+    return WalkResult::skip();
+  });
+  LLVM_DEBUG(llvm::dbgs() << "Lowering memories in " << modules.size()
+                          << " modules\n");
+
+  // Gather all `FirMemOp`s in the HW modules and group them by configuration.
+  auto uniqueMems = collectMemories(modules);
+  LLVM_DEBUG(llvm::dbgs() << "Found " << uniqueMems.size()
+                          << " unique memory congiurations\n");
+  if (uniqueMems.empty())
+    return;
+
+  // Create the `HWModuleGeneratedOp`s for each unique configuration. The result
+  // is a vector of the same size as `uniqueMems`, with a `HWModuleGeneratedOp`
+  // for every unique memory configuration.
+  auto genOps = createMemoryModules(uniqueMems);
+
+  // Group the list of memories that we need to update per HW module. This will
+  // allow us to parallelize across HW modules.
+  MapVector<
+      HWModuleOp,
+      SmallVector<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>>>
+      memsToLowerByModule;
+
+  for (auto [config, genOp] : llvm::zip(uniqueMems, genOps))
+    for (auto memOp : config.second)
+      memsToLowerByModule[memOp->getParentOfType<HWModuleOp>()].push_back(
+          {&config.first, genOp, memOp});
+
+  // Replace all `FirMemOp`s with instances of the generated module.
+  if (getContext().isMultithreadingEnabled()) {
+    llvm::parallelForEach(memsToLowerByModule, [&](auto pair) {
+      lowerMemoriesInModule(pair.first, pair.second);
+    });
+  } else {
+    for (auto [module, mems] : memsToLowerByModule)
+      lowerMemoriesInModule(module, mems);
+  }
+}
+
+/// Collect the memories in a list of HW modules.
+LowerFirMemPass::UniqueConfigs
+LowerFirMemPass::collectMemories(ArrayRef<HWModuleOp> modules) {
+  // For each module in the list populate a separate vector of `FirMemOp`s in
+  // that module. This allows for the traversal of the HW modules to be
+  // parallelized.
+  using ModuleMemories = SmallVector<std::pair<FirMemConfig, FirMemOp>, 0>;
+  SmallVector<ModuleMemories> memories(modules.size());
+
+  auto collect = [&](HWModuleOp module, ModuleMemories &memories) {
+    // TODO: Check if this module is in the DUT hierarchy.
+    // bool isInDut = state.isInDUT(module);
+    module.walk([&](seq::FirMemOp op) {
+      memories.push_back({collectMemory(op), op});
+    });
+  };
+
+  if (getContext().isMultithreadingEnabled()) {
+    llvm::parallelFor(0, modules.size(),
+                      [&](auto idx) { collect(modules[idx], memories[idx]); });
+  } else {
+    for (auto [module, moduleMemories] : llvm::zip(modules, memories))
+      collect(module, moduleMemories);
+  }
+
+  // Group the gathered memories by unique `FirMemConfig` details.
+  MapVector<FirMemConfig, SmallVector<FirMemOp, 1>> grouped;
+  for (auto [module, moduleMemories] : llvm::zip(modules, memories))
+    for (auto [summary, memOp] : moduleMemories)
+      grouped[summary].push_back(memOp);
+
+  return grouped.takeVector();
+}
+
+/// Trace a value through wires to its original definition.
+static Value lookThroughWires(Value value) {
+  while (value) {
+    if (auto wireOp = value.getDefiningOp<WireOp>()) {
+      value = wireOp.getInput();
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+/// Determine the exact parametrization of the memory that should be generated
+/// for a given `FirMemOp`.
+FirMemConfig LowerFirMemPass::collectMemory(FirMemOp op) {
+  FirMemConfig cfg;
+  cfg.dataWidth = op.getType().getWidth();
+  cfg.depth = op.getType().getDepth();
+  cfg.readLatency = op.getReadLatency();
+  cfg.writeLatency = op.getWriteLatency();
+  cfg.maskBits = op.getType().getMaskWidth().value_or(1);
+  cfg.readUnderWrite = op.getRuw();
+  cfg.writeUnderWrite = op.getWuw();
+  if (auto init = op.getInitAttr()) {
+    cfg.initFilename = init.getFilename();
+    cfg.initIsBinary = init.getIsBinary();
+    cfg.initIsInline = init.getIsInline();
+  }
+  cfg.outputFile = op.getOutputFileAttr();
+  if (auto prefix = op.getPrefixAttr())
+    cfg.prefix = prefix.getValue();
+  // TODO: Handle modName (maybe not?)
+  // TODO: Handle groupID (maybe not?)
+
+  // Count the read, write, and read-write ports, and identify the clocks
+  // driving the write ports.
+  SmallDenseMap<Value, unsigned> clockValues;
+  for (auto *user : op->getUsers()) {
+    if (isa<FirMemReadOp>(user))
+      ++cfg.numReadPorts;
+    else if (isa<FirMemWriteOp>(user))
+      ++cfg.numWritePorts;
+    else if (isa<FirMemReadWriteOp>(user))
+      ++cfg.numReadWritePorts;
+
+    // Assign IDs to the values used as clock. This allows later passes to
+    // easily detect which clocks are effectively driven by the same value.
+    if (isa<FirMemWriteOp, FirMemReadWriteOp>(user)) {
+      auto clock = lookThroughWires(user->getOperand(2));
+      cfg.writeClockIDs.push_back(
+          clockValues.insert({clock, clockValues.size()}).first->second);
+    }
+  }
+
+  return cfg;
+}
+
+/// Create the `HWModuleGeneratedOp` for a list of memory parametrizations.
+SmallVector<HWModuleGeneratedOp>
+LowerFirMemPass::createMemoryModules(MutableArrayRef<UniqueConfig> configs) {
+  // Create the generator schema.
+  OpBuilder builder(getOperation());
+  builder.setInsertionPointToStart(getOperation().getBody());
+  std::array<StringRef, 14> schemaFields = {
+      "depth",          "numReadPorts",    "numWritePorts", "numReadWritePorts",
+      "readLatency",    "writeLatency",    "width",         "maskGran",
+      "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename",
+      "initIsBinary",   "initIsInline"};
+  auto schemaOp = builder.create<hw::HWGeneratorSchemaOp>(
+      getOperation().getLoc(), "FIRRTLMem", "FIRRTL_Memory",
+      builder.getStrArrayAttr(schemaFields));
+  auto schemaSymRef = FlatSymbolRefAttr::get(schemaOp);
+
+  // Create the individual memory modules.
+  SymbolCache symbolCache;
+  symbolCache.addDefinitions(getOperation());
+  Namespace globalNamespace;
+  globalNamespace.add(symbolCache);
+
+  SmallVector<HWModuleGeneratedOp> genOps;
+  genOps.reserve(configs.size());
+  for (auto &config : configs)
+    genOps.push_back(
+        createMemoryModule(config, builder, schemaSymRef, globalNamespace));
+
+  return genOps;
+}
+
+/// Create the `HWModuleGeneratedOp` for a single memory parametrization.
+HWModuleGeneratedOp
+LowerFirMemPass::createMemoryModule(UniqueConfig &config, OpBuilder &builder,
+                                    FlatSymbolRefAttr schemaSymRef,
+                                    Namespace &globalNamespace) {
+  const auto &mem = config.first;
+  auto &memOps = config.second;
+
+  // Pick a name for the memory. Honor the optional prefix and try to mention
+  // the names of the memory instances that use this configuration.
+  SmallDenseSet<StringRef> usedNames;
+  SmallString<32> nameBuffer;
+  nameBuffer += mem.prefix;
+  for (auto memOp : memOps) {
+    if (auto memName = memOp.getName()) {
+      if (usedNames.insert(*memName).second) {
+        if (usedNames.size() > 1)
+          nameBuffer.push_back('_');
+        nameBuffer += *memName;
+      }
+    }
+  }
+  if (nameBuffer.empty())
+    nameBuffer += "mem";
+  auto name = builder.getStringAttr(globalNamespace.newName(nameBuffer));
+
+  LLVM_DEBUG(llvm::dbgs() << "Creating " << name << " for " << mem.depth
+                          << " x " << mem.dataWidth << " memory\n");
+
+  bool withMask = mem.maskBits > 1;
+  SmallVector<hw::PortInfo> ports;
+
+  // Common types used for memory ports.
+  Type bitType = IntegerType::get(&getContext(), 1);
+  Type dataType =
+      IntegerType::get(&getContext(), std::max((size_t)1, mem.dataWidth));
+  Type maskType = IntegerType::get(&getContext(), mem.maskBits);
+  Type addrType = IntegerType::get(&getContext(),
+                                   std::max(1U, llvm::Log2_64_Ceil(mem.depth)));
+
+  // Helper to add an input port.
+  size_t inputIdx = 0;
+  auto addInput = [&](StringRef prefix, size_t idx, StringRef suffix,
+                      Type type) {
+    ports.push_back({builder.getStringAttr(prefix + Twine(idx) + suffix),
+                     PortDirection::INPUT, type, inputIdx++});
+  };
+
+  // Helper to add an output port.
+  size_t outputIdx = 0;
+  auto addOutput = [&](StringRef prefix, size_t idx, StringRef suffix,
+                       Type type) {
+    ports.push_back({builder.getStringAttr(prefix + Twine(idx) + suffix),
+                     PortDirection::OUTPUT, type, outputIdx++});
+  };
+
+  // Helper to add the ports common to read, read-write, and write ports.
+  auto addCommonPorts = [&](StringRef prefix, size_t idx) {
+    addInput(prefix, idx, "_addr", addrType);
+    addInput(prefix, idx, "_en", bitType);
+    addInput(prefix, idx, "_clk", bitType);
+  };
+
+  // Add the read ports.
+  for (size_t i = 0, e = mem.numReadPorts; i != e; ++i) {
+    addCommonPorts("R", i);
+    addOutput("R", i, "_data", dataType);
+  }
+
+  // Add the read-write ports.
+  for (size_t i = 0, e = mem.numReadWritePorts; i != e; ++i) {
+    addCommonPorts("RW", i);
+    addInput("RW", i, "_wmode", bitType);
+    addInput("RW", i, "_wdata", dataType);
+    addOutput("RW", i, "_rdata", dataType);
+    if (withMask)
+      addInput("RW", i, "_wmask", maskType);
+  }
+
+  // Add the write ports.
+  for (size_t i = 0, e = mem.numWritePorts; i != e; ++i) {
+    addCommonPorts("W", i);
+    addInput("W", i, "_data", dataType);
+    if (withMask)
+      addInput("W", i, "_mask", maskType);
+  }
+
+  // Mask granularity is the number of data bits that each mask bit can
+  // guard. By default it is equal to the data bitwidth.
+  auto genAttr = [&](StringRef name, Attribute attr) {
+    return builder.getNamedAttr(name, attr);
+  };
+  auto genAttrUI32 = [&](StringRef name, uint32_t value) {
+    return genAttr(name, builder.getUI32IntegerAttr(value));
+  };
+  NamedAttribute genAttrs[] = {
+      genAttr("depth", builder.getI64IntegerAttr(mem.depth)),
+      genAttrUI32("numReadPorts", mem.numReadPorts),
+      genAttrUI32("numWritePorts", mem.numWritePorts),
+      genAttrUI32("numReadWritePorts", mem.numReadWritePorts),
+      genAttrUI32("readLatency", mem.readLatency),
+      genAttrUI32("writeLatency", mem.writeLatency),
+      genAttrUI32("width", mem.dataWidth),
+      genAttrUI32("maskGran", mem.dataWidth / mem.maskBits),
+      genAttr("readUnderWrite",
+              seq::RUWAttr::get(builder.getContext(), mem.readUnderWrite)),
+      genAttr("writeUnderWrite",
+              seq::WUWAttr::get(builder.getContext(), mem.writeUnderWrite)),
+      genAttr("writeClockIDs", builder.getI32ArrayAttr(mem.writeClockIDs)),
+      genAttr("initFilename", builder.getStringAttr(mem.initFilename)),
+      genAttr("initIsBinary", builder.getBoolAttr(mem.initIsBinary)),
+      genAttr("initIsInline", builder.getBoolAttr(mem.initIsInline))};
+
+  // Combine the locations of all actual `FirMemOp`s to be the location of the
+  // generated memory.
+  Location loc = memOps.front().getLoc();
+  if (memOps.size() > 1) {
+    SmallVector<Location> locs;
+    for (auto memOp : memOps)
+      locs.push_back(memOp.getLoc());
+    loc = FusedLoc::get(&getContext(), locs);
+  }
+
+  // Create the module.
+  auto genOp = builder.create<hw::HWModuleGeneratedOp>(
+      loc, schemaSymRef, name, ports, StringRef{}, ArrayAttr{}, genAttrs);
+  if (mem.outputFile)
+    genOp->setAttr("output_file", mem.outputFile);
+
+  return genOp;
+}
+
+/// Replace all `FirMemOp`s in an HW module with an instance of the
+/// corresponding generated module.
+void LowerFirMemPass::lowerMemoriesInModule(
+    HWModuleOp module,
+    ArrayRef<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>> mems) {
+  LLVM_DEBUG(llvm::dbgs() << "Lowering " << mems.size() << " memories in "
+                          << module.getName() << "\n");
+
+  hw::ConstantOp constOneOp;
+  auto constOne = [&] {
+    if (!constOneOp) {
+      auto builder = OpBuilder::atBlockBegin(module.getBodyBlock());
+      constOneOp = builder.create<hw::ConstantOp>(module.getLoc(),
+                                                  builder.getI1Type(), 1);
+    }
+    return constOneOp;
+  };
+  auto valueOrOne = [&](Value value) { return value ? value : constOne(); };
+
+  for (auto [config, genOp, memOp] : mems) {
+    LLVM_DEBUG(llvm::dbgs() << "- Lowering " << memOp.getName() << "\n");
+    SmallVector<Value> inputs;
+    SmallVector<Value> outputs;
+
+    auto addInput = [&](Value value) { inputs.push_back(value); };
+    auto addOutput = [&](Value value) { outputs.push_back(value); };
+
+    // Add the read ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemReadOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addOutput(port.getData());
+    }
+
+    // Add the read-write ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemReadWriteOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addInput(port.getMode());
+      addInput(port.getWriteData());
+      addOutput(port.getReadData());
+      if (config->maskBits > 1)
+        addInput(valueOrOne(port.getMask()));
+    }
+
+    // Add the write ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemWriteOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addInput(port.getData());
+      if (config->maskBits > 1)
+        addInput(valueOrOne(port.getMask()));
+    }
+
+    // Create the module instance.
+    StringRef memName = "mem";
+    if (auto name = memOp.getName(); name && !name->empty())
+      memName = *name;
+    ImplicitLocOpBuilder builder(memOp.getLoc(), memOp);
+    auto instOp = builder.create<hw::InstanceOp>(
+        genOp, builder.getStringAttr(memName + "_ext"), inputs, ArrayAttr{},
+        memOp.getInnerSymAttr());
+    for (auto [oldOutput, newOutput] : llvm::zip(outputs, instOp.getResults()))
+      oldOutput.replaceAllUsesWith(newOutput);
+
+    // Carry attributes over from the `FirMemOp` to the `InstanceOp`.
+    auto defaultAttrNames = memOp.getAttributeNames();
+    for (auto namedAttr : memOp->getAttrs())
+      if (!llvm::is_contained(defaultAttrNames, namedAttr.getName()))
+        instOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+
+    // Get rid of the `FirMemOp`.
+    for (auto *user : llvm::make_early_inc_range(memOp->getUsers()))
+      user->erase();
+    memOp.erase();
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<Pass> circt::seq::createLowerFirMemPass() {
+  return std::make_unique<LowerFirMemPass>();
+}

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -148,8 +148,10 @@ public:
   }
 };
 
-struct LowerSeqHLMemPass
-    : public circt::seq::impl::LowerSeqHLMemBase<LowerSeqHLMemPass> {
+#define GEN_PASS_DEF_LOWERSEQHLMEM
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+struct LowerSeqHLMemPass : public impl::LowerSeqHLMemBase<LowerSeqHLMemPass> {
   void runOnOperation() override;
 };
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -31,17 +31,24 @@ using namespace circt;
 using namespace seq;
 
 namespace {
+#define GEN_PASS_DEF_LOWERSEQTOSV
+#define GEN_PASS_DEF_LOWERSEQFIRRTLTOSV
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
 struct SeqToSVPass : public impl::LowerSeqToSVBase<SeqToSVPass> {
   void runOnOperation() override;
 };
+
 struct SeqFIRRTLToSVPass
     : public impl::LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
   void runOnOperation() override;
-  using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::disableRegRandomization;
-  using LowerSeqFIRRTLToSVBase<
-      SeqFIRRTLToSVPass>::addVivadoRAMAddressConflictSynthesisBugWorkaround;
-  using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::LowerSeqFIRRTLToSVBase;
-  using LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass>::numSubaccessRestored;
+
+  using LowerSeqFIRRTLToSVBase::LowerSeqFIRRTLToSVBase;
+
+  using LowerSeqFIRRTLToSVBase::
+      addVivadoRAMAddressConflictSynthesisBugWorkaround;
+  using LowerSeqFIRRTLToSVBase::disableRegRandomization;
+  using LowerSeqFIRRTLToSVBase::numSubaccessRestored;
 };
 } // anonymous namespace
 

--- a/lib/Dialect/Seq/Transforms/PassDetails.h
+++ b/lib/Dialect/Seq/Transforms/PassDetails.h
@@ -20,15 +20,4 @@
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "mlir/Pass/Pass.h"
 
-namespace circt {
-namespace seq {
-
-#define GEN_PASS_DEF_LOWERSEQFIRRTLTOSV
-#define GEN_PASS_DEF_LOWERSEQHLMEM
-#define GEN_PASS_DEF_LOWERSEQTOSV
-#include "circt/Dialect/Seq/SeqPasses.h.inc"
-
-} // namespace seq
-} // namespace circt
-
 #endif // DIALECT_SEQ_TRANSFORMS_PASSDETAILS_H

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
@@ -1,0 +1,199 @@
+// RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics %s | FileCheck %s --check-prefix CHECK --check-prefix RANDOMIZE
+// RUN: circt-opt --lower-firrtl-to-hw=disable-mem-randomization --verify-diagnostics %s | FileCheck %s
+
+// RANDOMIZE: sv.ifdef "RANDOMIZE"
+// RANDOMIZE-NEXT: else
+// RANDOMIZE-NEXT: sv.ifdef "RANDOMIZE_MEM_INIT"
+// RANDOMIZE-NEXT: sv.verbatim "`define RANDOMIZE"
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: hw.module @Foo
+  firrtl.module @Foo(
+    in %clk: !firrtl.clock,
+    in %en: !firrtl.uint<1>,
+    in %addr: !firrtl.uint<4>,
+    in %wdata: !firrtl.uint<42>,
+    in %wmode: !firrtl.uint<1>,
+    in %mask2: !firrtl.uint<2>,
+    in %mask3: !firrtl.uint<3>,
+    in %mask6: !firrtl.uint<6>
+  ) {
+    // CHECK-NEXT: %mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_port %mem1[%addr], clock %clk enable %en :
+    // CHECK-NEXT: hw.wire [[RDATA]] sym @mem1_data
+    %mem1_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.clk = firrtl.subfield %mem1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.en = firrtl.subfield %mem1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.addr = firrtl.subfield %mem1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.data = firrtl.subfield %mem1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.strictconnect %mem1_r.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem1_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem1_r.addr, %addr : !firrtl.uint<4>
+    %mem1_data = firrtl.node sym @mem1_data %mem1_r.data : !firrtl.uint<42>
+
+    // CHECK-NEXT: %mem2 = seq.firmem 1, 2, old, port_order : <13 x 42, mask 2>
+    // CHECK-NEXT: seq.firmem.write_port %mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 :
+    %mem2_w = firrtl.mem Old {depth = 13 : i64, name = "mem2", portNames = ["w"], readLatency = 1 : i32, writeLatency = 2 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.clk = firrtl.subfield %mem2_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.en = firrtl.subfield %mem2_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.addr = firrtl.subfield %mem2_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.data = firrtl.subfield %mem2_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.mask = firrtl.subfield %mem2_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    firrtl.strictconnect %mem2_w.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem2_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem2_w.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem2_w.data, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem2_w.mask, %mask2 : !firrtl.uint<2>
+
+    // CHECK-NEXT: %mem3 = seq.firmem 3, 2, new, port_order : <14 x 42, mask 3>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 :
+    // CHECK-NEXT: hw.wire [[RDATA]] sym @mem3_data
+    %mem3_rw = firrtl.mem New {depth = 14 : i64, name = "mem3", portNames = ["rw"], readLatency = 3 : i32, writeLatency = 2 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.clk = firrtl.subfield %mem3_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.en = firrtl.subfield %mem3_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.addr = firrtl.subfield %mem3_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wdata = firrtl.subfield %mem3_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.rdata = firrtl.subfield %mem3_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wmask = firrtl.subfield %mem3_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wmode = firrtl.subfield %mem3_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    firrtl.strictconnect %mem3_rw.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem3_rw.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem3_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem3_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem3_rw.wmask, %mask3 : !firrtl.uint<3>
+    firrtl.strictconnect %mem3_rw.wmode, %wmode : !firrtl.uint<1>
+    %mem3_data = firrtl.node sym @mem3_data %mem3_rw.rdata : !firrtl.uint<42>
+
+    // CHECK-NEXT: %mem4 = seq.firmem 4, 5, undefined, port_order : <15 x 42, mask 6>
+    // CHECK-NEXT: [[RDATA1:%.+]] = seq.firmem.read_port %mem4[%addr], clock %clk enable %en :
+    // CHECK-NEXT: seq.firmem.write_port %mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 :
+    // CHECK-NEXT: [[RDATA2:%.+]] = seq.firmem.read_write_port %mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 :
+    // CHECK-NEXT: hw.wire [[RDATA1]] sym @mem4_data0
+    // CHECK-NEXT: hw.wire [[RDATA2]] sym @mem4_data1
+    %mem4_r, %mem4_w, %mem4_rw = firrtl.mem Undefined {depth = 15 : i64, name = "mem4", portNames = ["r", "w", "rw"], readLatency = 4 : i32, writeLatency = 5 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.clk = firrtl.subfield %mem4_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.clk = firrtl.subfield %mem4_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.clk = firrtl.subfield %mem4_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.en = firrtl.subfield %mem4_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.en = firrtl.subfield %mem4_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.en = firrtl.subfield %mem4_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.addr = firrtl.subfield %mem4_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.addr = firrtl.subfield %mem4_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.addr = firrtl.subfield %mem4_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_w.data = firrtl.subfield %mem4_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.wdata = firrtl.subfield %mem4_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.data = firrtl.subfield %mem4_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_rw.rdata = firrtl.subfield %mem4_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_w.mask = firrtl.subfield %mem4_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.wmask = firrtl.subfield %mem4_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_rw.wmode = firrtl.subfield %mem4_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    firrtl.strictconnect %mem4_r.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_w.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_rw.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_rw.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_r.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_w.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_w.data, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem4_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem4_w.mask, %mask6 : !firrtl.uint<6>
+    firrtl.strictconnect %mem4_rw.wmask, %mask6 : !firrtl.uint<6>
+    firrtl.strictconnect %mem4_rw.wmode, %wmode : !firrtl.uint<1>
+    %mem4_data0 = firrtl.node sym @mem4_data0 %mem4_r.data : !firrtl.uint<42>
+    %mem4_data1 = firrtl.node sym @mem4_data1 %mem4_rw.rdata : !firrtl.uint<42>
+  }
+
+  // CHECK-LABEL: hw.module @ZeroDataWidth
+  firrtl.module @ZeroDataWidth(in %data: !firrtl.uint<0>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 0>
+    // CHECK: seq.firmem.write_port %mem[%z_i4] = %z_i1
+    %mem_w = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
+  }
+
+  // FIRRTL memories with a single mask bit for the entire word should lower to
+  // a memory without any mask, and instead have that single mask bit be merged
+  // into the enable condition on the write port.
+  //
+  // CHECK-LABEL: hw.module @FoldSingleMaskBitIntoEnable
+  firrtl.module @FoldSingleMaskBitIntoEnable(in %en: !firrtl.uint<1>, in %mask: !firrtl.uint<1>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %en, %mask :
+    // CHECK-NEXT: seq.firmem.write_port %mem[%z_i4] = %z_i42, clock %z_i1 enable [[TMP]] :
+    %mem_w = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    %mem_w.en = firrtl.subfield %mem_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    %mem_w.mask = firrtl.subfield %mem_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.strictconnect %mem_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem_w.mask, %mask : !firrtl.uint<1>
+  }
+
+  // FIRRTL memories with a single mask bit for the entire word should lower to
+  // a memory without any mask, and instead have that single mask bit be merged
+  // into the mode operand on the read-write port.
+  //
+  // CHECK-LABEL: hw.module @FoldSingleMaskBitIntoMode
+  firrtl.module @FoldSingleMaskBitIntoMode(in %mode: !firrtl.uint<1>, in %mask: !firrtl.uint<1>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and bin %mode, %mask :
+    // CHECK-NEXT: seq.firmem.read_write_port %mem[%z_i4] = %z_i42 if [[TMP]], clock %z_i1 enable %z_i1 :
+    %mem_rw = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %mem_rw.wmode = firrtl.subfield %mem_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %mem_rw.wmask = firrtl.subfield %mem_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.strictconnect %mem_rw.wmode, %mode : !firrtl.uint<1>
+    firrtl.strictconnect %mem_rw.wmask, %mask : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: hw.module @MemInit
+  firrtl.module @MemInit() {
+    // CHECK: %mem1 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", false, false>
+    %mem1_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", false, false>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    // CHECK: %mem2 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", false, true>
+    %mem2_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem2", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", false, true>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    // CHECK: %mem3 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", true, false>
+    %mem3_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem3", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", true, false>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+  }
+
+  // CHECK-LABEL: hw.module @IncompleteRead
+  firrtl.module @IncompleteRead(
+    in %clock: !firrtl.clock,
+    in %addr: !firrtl.uint<4>,
+    in %en: !firrtl.uint<1>
+  ) {
+    // The read port has no use of the data field.
+    //
+    // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: seq.firmem.read_port %mem[%addr], clock %clock enable %en :
+    %mem_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.clk = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.en = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.addr = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.strictconnect %mem_r.clk, %clock : !firrtl.clock
+    firrtl.strictconnect %mem_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem_r.addr, %addr : !firrtl.uint<4>
+  }
+
+  // CHECK-LABEL: hw.module @Depth1
+  firrtl.module @Depth1(
+    in %clock: !firrtl.clock,
+    in %addr: !firrtl.uint<1>,
+    in %en: !firrtl.uint<1>,
+    out %data: !firrtl.uint<42>
+  ) {
+    // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, port_order : <1 x 42>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_port %mem[%addr], clock %clock enable %en :
+    // CHECK-NEXT: hw.output [[RDATA]]
+    %mem_r = firrtl.mem Undefined {depth = 1 : i64, name = "mem", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.clk = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.addr = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.en = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.data = firrtl.subfield %mem_r[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %mem_r.clk, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %mem_r.addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %mem_r.en, %en : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %data, %mem_r.data : !firrtl.uint<42>, !firrtl.uint<42>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1,7 +1,5 @@
 // RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw)" -verify-diagnostics %s | FileCheck %s
-// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM
 // RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_REG
-// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
 
 // DISABLE_RANDOM-LABEL: module @Simple
 firrtl.circuit "Simple"   attributes {annotations = [{class =
@@ -46,16 +44,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:     sv.verbatim "`define INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-
-  //These come from MemSimple, IncompleteRead, and MemDepth1
-  // CHECK-LABEL: hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
-  // CHECK: hw.module.generated @aa_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @ab_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @mem0_combMem, @FIRRTLMem(%R0_addr: i1, %R0_en: i1, %R0_clk: i1) -> (R0_data: i32) attributes {depth = 1 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 32 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 1 : i32, width = 32 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @tbMemoryKind1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8) -> (R0_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_mask_combMem, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1, %RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i40, %RW0_wmask: i4, %W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i40, %W0_mask: i4) -> (R0_data: i40, RW0_rdata: i40) attributes {depth = 1022 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 10 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 40 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_combMem_0, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
   // CHECK-LABEL: hw.module @Simple
   firrtl.module @Simple(in %in1: !firrtl.uint<4>,
@@ -668,158 +656,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
   }
 
-  //  module MemSimple :
-  //     input clock1  : Clock
-  //     input clock2  : Clock
-  //     input inpred  : UInt<1>
-  //     input indata  : SInt<42>
-  //     output result : SInt<42>
-  //     output result2 : SInt<42>
-  //
-  //     mem _M : @[Decoupled.scala 209:27]
-  //           data-type => SInt<42>
-  //           depth => 12
-  //           read-latency => 0
-  //           write-latency => 1
-  //           reader => read
-  //           writer => write
-  //           readwriter => rw
-  //           read-under-write => undefined
-  //
-  //     result <= _M.read.data
-  //     result2 <= _M.rw.rdata
-  //
-  //     _M.read.addr <= UInt<1>("h0")
-  //     _M.read.en <= UInt<1>("h1")
-  //     _M.read.clk <= clock1
-  //     _M.rw.addr <= UInt<1>("h0")
-  //     _M.rw.en <= UInt<1>("h1")
-  //     _M.rw.clk <= clock1
-  //     _M.rw.wmask <= UInt<1>("h1")
-  //     _M.rw.wmode <= UInt<1>("h1")
-  //     _M.write.addr <= validif(inpred, UInt<3>("h0"))
-  //     _M.write.en <= mux(inpred, UInt<1>("h1"), UInt<1>("h0"))
-  //     _M.write.clk <= clock2
-  //     _M.write.data <= validif(inpred, indata)
-  //     _M.write.mask <= validif(inpred, UInt<1>("h1"))
-
-  // CHECK-LABEL: hw.module private @MemSimple(
-  firrtl.module private @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
-                           in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>,
-                           out %result: !firrtl.sint<42>,
-                           out %result2: !firrtl.sint<42>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-  // CHECK: %[[v1:.+]] = comb.and bin %true, %inpred : i1
-  // CHECK: %[[v2:.+]] = comb.and bin %inpred, %true : i1
-  // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @_M_combMem_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %[[v1]]: i1, RW0_wdata: %indata: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
-  // CHECK: hw.output %_M_ext.R0_data, %_M_ext.RW0_rdata : i42, i42
-
-      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
-      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %result2, %1 : !firrtl.sint<42>, !firrtl.sint<42>
-      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
-
-      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %5, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %8, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %10 = firrtl.subfield %_M_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %10, %indata : !firrtl.sint<42>, !firrtl.sint<42>
-
-      %11 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %11, %c0_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
-      %12 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %12, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %13 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %13, %clock2 : !firrtl.clock, !firrtl.clock
-      %14 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %14, %indata : !firrtl.sint<42>, !firrtl.sint<42>
-      %15 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %15, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-
-  // CHECK-LABEL: hw.module private @MemSimple_mask(
-  firrtl.module private @MemSimple_mask(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
-                           in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<40>,
-                           out %result: !firrtl.sint<40>,
-                           out %result2: !firrtl.sint<40>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c0_ui10 = firrtl.constant 0 : !firrtl.uint<10>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-    %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
-    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 1022 : i64, name = "_M_mask", portNames = ["read", "rw", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-    // CHECK: %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata = hw.instance "_M_mask_ext" @_M_mask_combMem(R0_addr: %c0_i10: i10, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i10: i10, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %indata: i40, RW0_wmask: %c0_i4: i4, W0_addr: %c0_i10: i10, W0_en: %inpred: i1, W0_clk: %clock2: i1, W0_data: %indata: i40, W0_mask: %c0_i4: i4) -> (R0_data: i40, RW0_rdata: i40)
-    // CHECK: hw.output %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata : i40, i40
-
-      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %result, %0 : !firrtl.sint<40>, !firrtl.sint<40>
-      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %result2, %1 : !firrtl.sint<40>, !firrtl.sint<40>
-      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %2, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
-
-      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>,  wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %5, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %8, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %10 = firrtl.subfield %_M_rw[wdata] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %10, %indata : !firrtl.sint<40>, !firrtl.sint<40>
-
-      %11 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %11, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %12 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %12, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %13 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %13, %clock2 : !firrtl.clock, !firrtl.clock
-      %14 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %14, %indata : !firrtl.sint<40>, !firrtl.sint<40>
-      %15 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %15, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-  }
-  // CHECK-LABEL: hw.module private @IncompleteRead(
-  // The read port has no use of the data field.
-  firrtl.module private @IncompleteRead(in %clock1: !firrtl.clock) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-
-    // CHECK:  %_M_ext.R0_data = hw.instance "_M_ext" @_M_combMem(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1) -> (R0_data: i42)
-    %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    // Read port.
-    %6 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %6, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-    %7 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %8 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %8, %clock1 : !firrtl.clock, !firrtl.clock
-  }
-
   // CHECK-LABEL: hw.module private @top_modx() -> (tmp27: i23) {
   // CHECK-NEXT:    %c0_i23 = hw.constant 0 : i23
   // CHECK-NEXT:    %c42_i23 = hw.constant 42 : i23
@@ -905,22 +741,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %2 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>
   }
 
-  // CHECK-LABEL: hw.module private @MemDepth1
-  firrtl.module private @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
-                           in %addr: !firrtl.uint<1>, out %data: !firrtl.uint<32>) {
-    // CHECK: %mem0_ext.R0_data = hw.instance "mem0_ext" @mem0_combMem(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
-    // CHECK: hw.output %mem0_ext.R0_data : i32
-    %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %0 = firrtl.subfield %mem0_load0[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %1 = firrtl.subfield %mem0_load0[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %mem0_load0[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %data, %2 : !firrtl.uint<32>, !firrtl.uint<32>
-    %3 = firrtl.subfield %mem0_load0[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
-}
-
   // https://github.com/llvm/circt/issues/1115
   // CHECK-LABEL: hw.module private @issue1115
   firrtl.module private @issue1115(in %a: !firrtl.sint<20>, out %tmp59: !firrtl.sint<2>) {
@@ -973,47 +793,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %chckcoverAnno_clock = firrtl.instance chkcoverAnno @chkcoverAnno(in clock: !firrtl.clock)
-  }
-
-  // CHECK-LABEL: hw.module private @MemoryWritePortBehavior
-  firrtl.module private @MemoryWritePortBehavior(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
-    // This memory has both write ports driven by the same clock.  It should be
-    // lowered to an "aa" memory. Even if the clock is passed via different wires,
-    // we should identify the clocks to be same.
-    //
-    // CHECK: hw.instance "aa_ext" @aa_combMem
-    %memory_aa_w0, %memory_aa_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "aa", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_aa_w0 = firrtl.subfield %memory_aa_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_aa_w1 = firrtl.subfield %memory_aa_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %cwire1 = firrtl.wire : !firrtl.clock
-    %cwire2 = firrtl.wire : !firrtl.clock
-    firrtl.connect %cwire1, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %cwire2, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_aa_w0, %cwire1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_aa_w1, %cwire2 : !firrtl.clock, !firrtl.clock
-
-    // This memory has different clocks for each write port.  It should be
-    // lowered to an "ab" memory.
-    //
-    // CHECK: hw.instance "ab_ext" @ab_combMem
-    %memory_ab_w0, %memory_ab_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_w0 = firrtl.subfield %memory_ab_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_w1 = firrtl.subfield %memory_ab_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    firrtl.connect %clk_ab_w0, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_ab_w1, %clock2 : !firrtl.clock, !firrtl.clock
-
-    // This memory is the same as the first memory, but a node is used to alias
-    // the second write port clock (e.g., this could be due to a dont touch
-    // annotation blocking this from being optimized away).  This should be
-    // lowered to an "aa" since they are identical.
-    //
-    // CHECK: hw.instance "ab_node_ext" @aa_combMem
-    %memory_ab_node_w0, %memory_ab_node_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab_node", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_node_w0 = firrtl.subfield %memory_ab_node_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_node_w1 = firrtl.subfield %memory_ab_node_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    firrtl.connect %clk_ab_node_w0, %clock1 : !firrtl.clock, !firrtl.clock
-    %tmp = firrtl.node %clock1 : !firrtl.clock
-    firrtl.connect %clk_ab_node_w1, %tmp : !firrtl.clock, !firrtl.clock
   }
 
   // CHECK-LABEL: hw.module private @AsyncResetBasic(
@@ -1087,7 +866,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
     // CHECK: %regResetName = seq.firreg %regResetName clock %clock sym @regResetSym reset sync %reset, %value : i42
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    // CHECK: {{%.+}} = hw.instance "memName_ext" sym @memSym
+    // CHECK: %memName = seq.firmem sym @memSym 0, 1, undefined, port_order : <12 x 42>
     firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -1235,32 +1014,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %4 = hw.array_get %3[%index]
     // CHECK-NEXT: hw.output %4 : i1
   }
-
-  firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
-    %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %0 = firrtl.subfield %tbMemoryKind1_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %1 = firrtl.subfield %tbMemoryKind1_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %2 = firrtl.subfield %tbMemoryKind1_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %3 = firrtl.subfield %tbMemoryKind1_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %4 = firrtl.subfield %tbMemoryKind1_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %5 = firrtl.subfield %tbMemoryKind1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %6 = firrtl.subfield %tbMemoryKind1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %7 = firrtl.subfield %tbMemoryKind1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %8 = firrtl.subfield %tbMemoryKind1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    firrtl.connect %8, %clock : !firrtl.clock, !firrtl.clock
-    firrtl.connect %7, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %6, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    firrtl.connect %rData, %5 : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
-    firrtl.connect %3, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %2, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    firrtl.connect %1, %wMask : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %0, %wData : !firrtl.uint<8>, !firrtl.uint<8>
-  }
-  // CHECK-LABEL: hw.module private @inferUnmaskedMemory
-  // CHECK-NEXT:   %[[v0:.+]] = comb.and bin %rEn, %wMask : i1
-  // CHECK-NEXT:   %tbMemoryKind1_ext.R0_data = hw.instance "tbMemoryKind1_ext" @tbMemoryKind1_combMem(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
-  // CHECK-NEXT:   hw.output %tbMemoryKind1_ext.R0_data : i8
 
   // CHECK-LABEL: hw.module private @eliminateSingleOutputConnects
   // CHECK-NOT:     [[WIRE:%.+]] = sv.wire

--- a/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
+++ b/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
@@ -31,7 +31,7 @@ circuit Foo :
       ; INIT_OUTLINE-NEXT;   */
       ; INIT_OUTLINE:        endmodule
       ;
-      ; INIT_OUTLINE:      FILE "m_combMem_init.sv"
+      ; INIT_OUTLINE:      FILE "[[memoryModule]]_init.sv"
       ; INIT_OUTLINE-NOT:  FILE
       ; INIT_OUTLINE:      module [[bindModule]]();
       ; INIT_OUTLINE:        initial

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -1,0 +1,97 @@
+// RUN: circt-opt --lower-seq-firmem %s --verify-diagnostics | FileCheck %s
+
+// hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
+// hw.module.generated @mem_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem3_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem_combMem_0, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i1) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 0 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 0 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem_combMem_1, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem2_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem4_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK-LABEL: hw.module @Foo
+hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
+  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "mem1A_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "mem1B_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
+  %mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %0 = seq.firmem.read_port %mem1A[%addr], clock %clk enable %en : <12 x 42>
+  %1 = seq.firmem.read_port %mem1B[%addr], clock %clk enable %en : <12 x 42>
+  comb.xor %0, %1 : i42
+
+  // CHECK-NEXT: hw.instance "mem2_ext" @mem2(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
+  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
+  seq.firmem.write_port %mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i2
+
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "mem3_ext" @mem3(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
+  // CHECK-NEXT: comb.xor [[TMP]]
+  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
+  %2 = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i3
+  comb.xor %2 : i42
+
+  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "mem4_ext" @mem4(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
+  %mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
+  %3 = seq.firmem.read_port %mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>
+  %4 = seq.firmem.read_write_port %mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  seq.firmem.write_port %mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  comb.xor %3, %4 : i42
+}
+
+// CHECK-LABEL: hw.module @SeparateOutputFiles
+hw.module @SeparateOutputFiles() {
+  // CHECK-NEXT: hw.instance "mem1_ext" @mem1
+  // CHECK-NEXT: hw.instance "mem2_ext" @mem2
+  %mem1 = seq.firmem 0, 1, undefined, port_order {output_file = "foo"} : <24 x 1337>
+  %mem2 = seq.firmem 0, 1, undefined, port_order {output_file = "bar"} : <24 x 1337>
+}
+
+// CHECK-LABEL: hw.module @SeparatePrefices
+hw.module @SeparatePrefices() {
+  // CHECK-NEXT: hw.instance "mem1_ext" @foo_mem1
+  %mem1 = seq.firmem 0, 1, undefined, port_order {prefix = "foo_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "mem2_ext" @bar_mem2
+  %mem2 = seq.firmem 0, 1, undefined, port_order {prefix = "bar_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "mem3_ext" @uwu_mem3_mem4
+  // CHECK-NEXT: hw.instance "mem4_ext" @uwu_mem3_mem4
+  %mem3 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+  %mem4 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+}
+
+
+// CHECK-LABEL: hw.module @MemoryWritePortBehavior
+hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
+  %z_i8 = sv.constantZ : i8
+  %z_i1 = sv.constantZ : i1
+  %z_i4 = sv.constantZ : i4
+
+  // This memory has both write ports driven by the same clock.  It should be
+  // lowered to an "aa" memory. Even if the clock is passed via different
+  // wires, we should identify the clocks to be same.
+  //
+  // CHECK: hw.instance "mem1_ext" @mem1_mem3
+  %mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  %cwire1 = hw.wire %clock1 : i1
+  %cwire2 = hw.wire %clock1 : i1
+  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>
+
+  // This memory has different clocks for each write port. It should be
+  // lowered to an "ab" memory.
+  //
+  // CHECK: hw.instance "mem2_ext" @mem2
+  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>
+
+  // This memory is the same as the first memory, but a node is used to alias
+  // the second write port clock (e.g., this could be due to a dont touch
+  // annotation blocking this from being optimized away). This should be
+  // lowered to an "aa" since they are identical.
+  //
+  // CHECK: hw.instance "mem3_ext" @mem1_mem3
+  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+}

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -11,29 +11,31 @@ circuit test: %[[{
   }]]
   module test:
     input p: UInt<1>
-    input addr: UInt<4>
+    input addr1: UInt<4>
+    input addr2: UInt<4>
+    input addr3: UInt<4>
     input clock: Clock
     input data: UInt<8>
     output out0: UInt<8>
     output out1: UInt<8>
 
-    ; CHECK: testmem_combMem testmem_ext (
+    ; CHECK: testmem testmem_ext (
     smem testmem : UInt<8>[16], undefined
 
     ; CHECK: .R0_en (1'h1)
-    node _T_0 = addr
+    node _T_0 = addr1
     when p:
       read mport testport0 = testmem[_T_0], clock
     out0 <= testport0
 
     ; CHECK: .R1_en (1'h1),
     wire _T_1: UInt<4>
-    _T_1 <= addr
+    _T_1 <= addr2
     when p:
       read mport testport1 = testmem[_T_1], clock
     out1 <= testport1
 
-    node writeAddr = addr
+    node writeAddr = addr3
     when p:
       write mport testport2 = testmem[writeAddr], clock
     testport2 <= data

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -41,7 +41,7 @@ circuit Foo : %[[
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix1_"
-    ; SIM-HW:       hw.instance "mem_ext" @prefix1_mem_combMem
+    ; SIM-HW:       hw.instance "mem_ext" @prefix1_mem
     mem mem :
       data-type => UInt<1>
       depth => 8
@@ -84,7 +84,7 @@ circuit Foo : %[[
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix2_"
-    ; SIM-HW:       hw.instance "mem_ext" @prefix2_mem_combMem
+    ; SIM-HW:       hw.instance "mem_ext" @prefix2_mem
     mem mem :
       data-type => UInt<1>
       depth => 8

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -707,6 +707,7 @@ static LogicalResult processBuffer(
           {/*disableRandomization=*/!isRandomEnabled(RandomKind::Reg),
            /*addVivadoRAMAddressConflictSynthesisBugWorkaround=*/
            addVivadoRAMAddressConflictSynthesisBugWorkaround}));
+      pm.addPass(seq::createLowerFirMemPass());
       pm.addPass(sv::createHWMemSimImplPass(
           replSeqMem, ignoreReadEnableMem, addMuxPragmas,
           !isRandomEnabled(RandomKind::Mem), !isRandomEnabled(RandomKind::Reg),


### PR DESCRIPTION
In a nutshell, `LowerFirMem` outlines the `hw.module.generated` op creation from `LowerToHW`, with a few tweaks.

More details: add the `LowerFirMem` pass which lowers `seq.firmem` ops to a corresponding `hw.module.generated` op. The pass intends to reflect what `LowerToHW` does in `lowerMemoryDecls`: it collects a list of memory ops in the design, distills them down into memory parameters, deduplicates those parameters, creates one `hw.module.generated` op for each unique memory config, and replaces the memory ops with instances of this generated module.

The `LowerFirMem` pass is intended as an intermediate solution to allow `seq.firmem` to be lowered through `HWMemSimImpl` without changing the latter's implementation. Existing tools that have passes operating on `hw.module.generated`-style memories can simply run the `LowerFirMem` pass and have the new `seq.firmem` work with their existing pipeline.

A few commits down the road we'll want to make `HWMemSimImpl` work directly with `seq.firmem` ops, at which point `LowerFirMem` can go away again. At that point tools are expected to have updated their memory passes to work with `seq.firmem` directly, completing the transition.