### PR TITLE
[FIRRTL] Add Enumerations to FIRRTL

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -336,6 +336,47 @@ def SubaccessOp : FIRRTLExprOp<"subaccess"> {
   let hasCanonicalizer = true;
 }
 
+def IsTagOp : FIRRTLExprOp<"istag"> {
+  let summary = "Test the active variant of an enumeration";
+  let description = [{
+    
+    Example:
+    ```mlir
+    ```
+  }];
+  let arguments = (ins FEnumType:$input, I32Attr:$fieldIndex);
+  let results = (outs UInt1Type:$result);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
+      auto enumType = input.getType().cast<FEnumType>();
+      auto fieldIndex = enumType.getElementIndex(fieldName);
+      assert(fieldIndex.has_value() && "subtag operation to unknown field");
+      return build($_builder, $_state, input, *fieldIndex);
+    }]>
+  ];
+  
+  let firrtlExtraClassDeclaration = [{
+    /// Return a `FieldRef` to the accessed field.
+    FieldRef getAccessedField() {
+      return FieldRef(getInput(), getInput().getType().cast<FEnumType>()
+                                            .getFieldID(getFieldIndex()));
+    }
+
+    /// Return the name of the accessed field.
+    StringAttr getFieldNameAttr() {
+      return getInput().getType().cast<FEnumType>()
+        .getElementNameAttr(getFieldIndex());
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getFieldNameAttr().getValue();
+    }
+  }];
+}
+
 def SubtagOp : FIRRTLExprOp<"subtag"> {
   let summary = "Extract an element of a enum value";
   let description = [{
@@ -363,14 +404,18 @@ def SubtagOp : FIRRTLExprOp<"subtag"> {
   let firrtlExtraClassDeclaration = [{
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType().cast<FEnumType>()
+      return FieldRef(getInput(), getInput().getType()
                                             .getFieldID(getFieldIndex()));
     }
 
     /// Return the name of the accessed field.
+    StringAttr getFieldNameAttr() {
+      return getInput().getType().getElementNameAttr(getFieldIndex());
+    }
+
+    /// Return the name of the accessed field.
     StringRef getFieldName() {
-      return getInput().getType().cast<FEnumType>()
-        .getElementName(getFieldIndex());
+      return getFieldNameAttr().getValue();
     }
   }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -228,6 +228,51 @@ def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
   }];
 }
 
+def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
+                               RecursiveMemoryEffects, RecursivelySpeculatable]> {
+  let summary = "Match Statement";
+  let description = [{
+    The "firrtl.match" operation represents a pattern matching statement on a
+    enumeration. This operation does not return a value and cannot be used as an
+    expression. Last connect semantics work similarly to a when statement.
+
+    Example:
+    
+    ```mlir
+      firrtl.match %in : !firrtl.enum<Some: uint<1>, None: uint<0>> {
+        case Some %arg0 {
+          !firrtl.strictconnect %w, %arg0 : !firrtl.uint<1>
+        }
+        case None %arg0 {
+          !firrt.strictconnect %w, %c1 : !firrtl.uint<1>
+        }
+      }
+    ```
+  }];
+  let arguments = (ins FEnumType:$input, StrArrayAttr:$tags);
+  let results = (outs);
+  let regions = (region VariadicRegion<SizedRegion<1>>:$regions);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$input,
+                   "::mlir::ArrayAttr":$tags,
+                   "::llvm::MutableArrayRef<std::unique_ptr<Region>>":$regions)>
+  ];
+
+  let extraClassDeclaration = [{
+    StringAttr getTagAttr(size_t index) {
+      return getTags()[index].cast<StringAttr>();
+    }
+
+    StringRef getTag(size_t index) {
+      return getTagAttr(index).getValue();
+    }
+  }];
+}
+
 def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
   let summary = "Force procedural statement";
   let description = "Maps to the corresponding `sv.force` operation.";

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -342,6 +342,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
     std::optional<unsigned> getElementIndex(StringRef name);
 
     /// Look up an element's name by index. This asserts if index is invalid.
+    StringAttr getElementNameAttr(size_t index);
     StringRef getElementName(size_t index);
 
     /// Look up an element by name.  This returns None on failure.

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -31,8 +31,8 @@ public:
         // Basic Expressions
         .template Case<
             ConstantOp, SpecialConstantOp, AggregateConstantOp, InvalidValueOp,
-            SubfieldOp, SubindexOp, SubaccessOp, SubtagOp, BundleCreateOp,
-            VectorCreateOp, MultibitMuxOp, TagExtractOp,
+            SubfieldOp, SubindexOp, SubaccessOp, IsTagOp, SubtagOp,
+            BundleCreateOp, VectorCreateOp, MultibitMuxOp, TagExtractOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
@@ -97,6 +97,7 @@ public:
   HANDLE(SubfieldOp, Unhandled);
   HANDLE(SubindexOp, Unhandled);
   HANDLE(SubaccessOp, Unhandled);
+  HANDLE(IsTagOp, Unhandled);
   HANDLE(SubtagOp, Unhandled);
   HANDLE(TagExtractOp, Unhandled);
   HANDLE(MultibitMuxOp, Unhandled);

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -83,6 +83,8 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass>
 createEmitOMIRPass(mlir::StringRef outputFilename = "");
 
+std::unique_ptr<mlir::Pass> createLowerMatchesPass();
+
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
 std::unique_ptr<mlir::Pass> createFlattenMemoryPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -257,6 +257,15 @@ def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
 }
 
+def LowerMatches : Pass<"firrtl-lower-matches", "firrtl::FModuleOp"> {
+  let summary = "Remove all matchs conditional blocks";
+  let description = [{
+    Lowers FIRRTL match statements in to when statements, which can later be
+    lowered with ExpandWhens.
+  }];
+  let constructor = "circt::firrtl::createLowerMatchesPass()";
+}
+
 def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let summary = "Remove all when conditional blocks.";
   let description = [{

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -282,7 +282,9 @@ def UnionCreateOp : HWOp<"union_create", [Pure]> {
   let hasCustomAssemblyFormat = 1;
 }
 
-def UnionExtractOp : HWOp<"union_extract", [Pure]> {
+def UnionExtractOp : HWOp<"union_extract", [Pure, 
+    DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+  ]> {
   let summary = "Get a union member.";
   let description = [{
     Get the value of a union, interpreting it as the type of the specified

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -169,4 +169,20 @@ def EnumConstantOp : HWOp<"enum.constant", [Pure, ConstantLike,
   ];
 }
 
+def EnumCmpOp : HWOp<"enum.cmp", [Pure]> {
+  let summary = "Compare two values of an enumeration";
+  let description = [{
+    
+    Example:
+    ```mlir
+    ```
+  }];
+  let arguments = (ins EnumType:$lhs, EnumType:$rhs);
+  let results = (outs I1:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` qualified(type($lhs)) `,` qualified(type($rhs))
+  }];
+}
+
 #endif // CIRCT_DIALECT_HW_HWMISCOPS_TD

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -35,7 +35,9 @@ public:
                        // Cast operation
                        BitcastOp, ParamValueOp,
                        // Enum operations
-                       EnumConstantOp>([&](auto expr) -> ResultType {
+                       EnumConstantOp, EnumCmpOp,
+                       // Union operations
+                       UnionCreateOp, UnionExtractOp>([&](auto expr) -> ResultType {
           return thisCast->visitTypeOp(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -72,7 +74,10 @@ public:
   HANDLE(ArrayGetOp, Unhandled);
   HANDLE(ArrayCreateOp, Unhandled);
   HANDLE(ArrayConcatOp, Unhandled);
+  HANDLE(EnumCmpOp, Unhandled);
   HANDLE(EnumConstantOp, Unhandled);
+  HANDLE(UnionCreateOp, Unhandled);
+  HANDLE(UnionExtractOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1542,6 +1542,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(VectorCreateOp op);
   LogicalResult visitExpr(BundleCreateOp op);
   LogicalResult visitExpr(AggregateConstantOp op);
+  LogicalResult visitExpr(IsTagOp op);
+  LogicalResult visitExpr(SubtagOp op);
   LogicalResult visitUnhandledOp(Operation *op) { return failure(); }
   LogicalResult visitInvalidOp(Operation *op) { return failure(); }
 
@@ -2716,6 +2718,28 @@ LogicalResult FIRRTLLowering::visitExpr(AggregateConstantOp op) {
 
   return setLoweringTo<hw::AggregateConstantOp>(op, resultType,
                                                 attr.cast<ArrayAttr>());
+}
+
+LogicalResult FIRRTLLowering::visitExpr(IsTagOp op) {
+  auto tagName = op.getFieldNameAttr();
+  auto lhs = getLoweredValue(op.getInput());
+  if (isa<hw::StructType>(lhs.getType()))
+    lhs = builder.create<hw::StructExtractOp>(lhs, "tag");
+  llvm::errs() << "lhs=" << lhs << "\n";
+  auto enumField = hw::EnumFieldAttr::get(op.getLoc(), tagName, lhs.getType());
+  auto rhs = builder.create<hw::EnumConstantOp>(enumField);
+  return setLoweringTo<hw::EnumCmpOp>(op, lhs, rhs);
+}
+
+LogicalResult FIRRTLLowering::visitExpr(SubtagOp op) {
+  auto tagName = op.getFieldNameAttr();
+  auto enumType = lowerType(op.getInput().getType());
+  auto input = getLoweredValue(op.getInput());
+  if (isa<hw::StructType>(enumType)) {
+    auto field = builder.create<hw::StructExtractOp>(input, "body");
+    return setLoweringTo<hw::UnionExtractOp>(op, field, tagName);
+  }
+  return setLoweringTo<hw::ConstantOp>(op, APInt(0, 0, false));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -604,6 +604,12 @@ void circt::firrtl::walkGroundTypes(
             f(f, vector.getElementType());
           }
         })
+        .template Case<FEnumType>([&](FEnumType fenum) {
+          for (size_t i = 0, e = fenum.getNumElements(); i < e; ++i) {
+            fieldID++;
+            f(f, fenum.getElementType(i));
+          }
+        })
         .Default([&](FIRRTLBaseType groundType) {
           assert(groundType.isGround() &&
                  "only ground types are expected here");
@@ -842,10 +848,8 @@ Type circt::firrtl::lowerType(Type type) {
     if (simple)
       return tagTy;
     auto bodyTy = hw::UnionType::get(type.getContext(), hwfields);
-    auto tagImplTy = IntegerType::get(type.getContext(),
-                                      llvm::Log2_64_Ceil(hwfields.size()));
     hw::StructType::FieldInfo fields[2] = {
-        {StringAttr::get(type.getContext(), "tag"), tagImplTy},
+        {StringAttr::get(type.getContext(), "tag"), tagTy},
         {StringAttr::get(type.getContext(), "body"), bodyTy}};
     return hw::StructType::get(type.getContext(), fields);
   }

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.h
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.h
@@ -131,6 +131,7 @@ private:
   FIRToken lexFileInfo(const char *tokStart);
   FIRToken lexInlineAnnotation(const char *tokStart);
   FIRToken lexIdentifierOrKeyword(const char *tokStart);
+  FIRToken lexTag(const char *tokStart);
   FIRToken lexNumber(const char *tokStart);
   FIRToken lexFloatingPoint(const char *tokStart);
   void skipComment();

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -54,7 +54,7 @@ TOK_LITERAL(floatingpoint)  // 42.0
 TOK_LITERAL(version)        // 1.2.3
 TOK_LITERAL(string)         // "foo"
 TOK_LITERAL(raw_string)     // 'foo'
-
+TOK_LITERAL(tag)            // #foo
 TOK_LITERAL(fileinfo)
 TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]
 
@@ -90,6 +90,7 @@ TOK_KEYWORD(Reset)
 TOK_KEYWORD(SInt)
 TOK_KEYWORD(UInt)
 TOK_KEYWORD(attach)
+TOK_KEYWORD(case)
 TOK_KEYWORD(circuit)
 TOK_KEYWORD(cmem)
 TOK_KEYWORD(define)
@@ -104,6 +105,7 @@ TOK_KEYWORD(input)
 TOK_KEYWORD(inst)
 TOK_KEYWORD(invalid)
 TOK_KEYWORD(is)
+TOK_KEYWORD(match)
 TOK_KEYWORD(mem)
 TOK_KEYWORD(module)
 TOK_KEYWORD(mport)

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -22,11 +22,12 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
   LowerIntrinsics.cpp
+  LowerMatches.cpp
   LowerMemory.cpp
   LowerTypes.cpp
   LowerXMR.cpp
-  MergeConnections.cpp
   MemToRegOfVec.cpp
+  MergeConnections.cpp
   ModuleInliner.cpp
   PrefixModules.cpp
   PrintFIRRTLFieldSource.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1655,6 +1655,8 @@ void InferenceMapping::declareVars(Value value, Location loc, bool isDerived) {
       declare(vecType.getElementType());
       // Skip past the rest of the elements
       fieldID = save + vecType.getMaxFieldID();
+    } else if (auto enumType = type.dyn_cast<FEnumType>()) {
+      // Enum types can't have uninferred widths, so just skip this element.
     } else {
       llvm_unreachable("Unknown type inside a bundle!");
     }

--- a/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
@@ -1,0 +1,82 @@
+//===- VBToBV.cpp - "Vector of Bundle" to "Bundle of Vector" ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the VBToBV pass, which takes any bundle embedded in
+// a vector, and converts it to a vector embedded within a bundle.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include <mlir/IR/ImplicitLocOpBuilder.h>
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+class LowerMatchesPass : public LowerMatchesBase<LowerMatchesPass> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+static void lowerMatch(MatchOp match) {
+  ImplicitLocOpBuilder b(match.getLoc(), match);
+
+  auto input = match.getInput();
+  auto numCases = match->getNumRegions();
+  for (size_t i = 0; i < numCases - 1; ++i) {
+    // Create a WhenOp which tests the enum's tag.
+    auto condition = b.create<IsTagOp>(input, match.getTag(i));
+    auto when = b.create<WhenOp>(condition, /*withElse=*/true);
+
+    // Move the case block to the WhenOp.
+    auto *thenBlock = &when.getThenBlock();
+    auto *caseBlock = &match.getRegion(i).front();
+    caseBlock->moveBefore(thenBlock);
+    thenBlock->erase();
+
+    // Replace the block argument with a subtag op.
+    b.setInsertionPointToStart(caseBlock);
+    auto data = b.create<SubtagOp>(input, match.getTag(i));
+    caseBlock->getArgument(0).replaceAllUsesWith(data);
+    caseBlock->eraseArgument(0);
+
+    // Change insertion to the else block.
+    b.setInsertionPointToStart(&when.getElseBlock());
+  }
+
+  // The final else is not handled with a conditional, move the case block to
+  // the default block.
+  auto *defaultBlock = b.getInsertionBlock();
+  auto *caseBlock = &match->getRegions().back().front();
+  caseBlock->moveBefore(defaultBlock);
+  defaultBlock->erase();
+
+  // Replace the block argument with a subtag op.
+  b.setInsertionPointToStart(caseBlock);
+  auto data = b.create<SubtagOp>(input, match.getTag(numCases - 1));
+  caseBlock->getArgument(0).replaceAllUsesWith(data);
+  caseBlock->eraseArgument(0);
+
+  // Erase the match op.
+  match->erase();
+}
+
+void LowerMatchesPass::runOnOperation() {
+  getOperation()->walk(&lowerMatch);
+  markAnalysesPreserved<InstanceGraph>();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerMatchesPass() {
+  return std::make_unique<LowerMatchesPass>();
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -881,6 +881,49 @@ firrtl.circuit "MismatchedRegister" {
 
 // -----
 
+firrtl.circuit "EnumNonExistentLabel" {
+  firrtl.module @EnumNonExistentLabel(in %0 : !firrtl.uint<1>) {
+    // expected-error @+1 {{tag A is not a member of the enumeration '!firrtl.enum<B: uint<1>>'}}
+    %1 = firrtl.fenumcreate A(%0) : !firrtl.enum<B: uint<1>>
+  }
+}
+
+// -----
+
+firrtl.circuit "EnumNonExistentLabel" {
+  firrtl.module @EnumNonExistentLabel(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{the label "b" is not a member of the enumeration '!firrtl.enum<a: uint<8>>'}}
+    firrtl.match %enum : !firrtl.enum<a : uint<8>> {
+      case b(%0) { }
+    }
+  }
+}
+
+
+// -----
+
+firrtl.circuit "EnumSameCase" {
+  firrtl.module @EnumSameCase(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{the label "a" is matched more than once}}
+    "firrtl.match"(%enum) ({
+    ^bb0(%arg0: !firrtl.uint<8>):
+    }, {
+    ^bb0(%arg0: !firrtl.uint<8>):
+    }) {labels = ["a", "a"]} : (!firrtl.enum<a: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "EnumNonExaustive" {
+  firrtl.module @EnumNonExaustive(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{missing case for label "a"}}
+    "firrtl.match"(%enum) {labels = []} : (!firrtl.enum<a: uint<8>>) -> ()
+  }
+}
+
+// -----
+
 // expected-error @+1 {{'firrtl.circuit' op main module 'private_main' must be public}}
 firrtl.circuit "private_main" {
   firrtl.module private @private_main() {}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1155,6 +1155,24 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.instance module interesting_name @SomeModule
     module.in <= UInt(1)
 
+  ; CHECK-LABEL: firrtl.module private @EnumTypes
+  module EnumTypes:
+    ; CHECK-SAME: in %i: !firrtl.enum<Some: uint<8>, None: uint<0>>
+    input i : [#Some : UInt<8>, #None]
+    output o : UInt<8>
+
+    ; CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
+    ; CHECK: %0 = firrtl.fenumcreate Some(%c0_ui8) : !firrtl.enum<Some: uint<8>, None: uint<0>>
+    node n = #Some(UInt<8>(0)) : [#Some : UInt<8>, #None]
+
+    match i:
+      #Some(x):
+        o <= x
+      #None:
+        o is invalid
+
+
+
   ; CHECK-LABEL: module private @RefsChild(
   ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>
   ; CHECK-SAME: out %rw: !firrtl.rwprobe<uint<1>>
@@ -1289,3 +1307,4 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module ProbeInvalidate:
     output p : Probe<UInt<1>>
     p is invalid
+  

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -415,6 +415,13 @@ circuit DefineIntoSubindex:
 
 ;// -----
 
+circuit EnumEmptyTagInType:
+  module EnumEmptyTagInType:
+    ; expected-error @+1 {{invalid tag name}}
+    wire w : [# : UInt<8>]
+
+;// -----
+
 circuit DefineIntoProbe:
   module DefineIntoProbe:
     input in : UInt<1>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -197,6 +197,10 @@ firrtl.module @InnerSymAttr() {
 // CHECK-LABEL: firrtl.module @EnumTest
 firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
                         out %out : !firrtl.uint<2>, out %tag : !firrtl.uint<1>) {
+  %c1_u1 = firrtl.constant 0 : !firrtl.uint<8>
+
+  %some = firrtl.fenumcreate Some(%c1_u1) : !firrtl.enum<None: uint<0>, Some: uint<8>>
+
   %v = firrtl.subtag %in[b] : !firrtl.enum<a: uint<1>, b: uint<2>>
   %t = firrtl.tagextract %in : !firrtl.enum<a: uint<1>, b: uint<2>>
   firrtl.strictconnect %out, %v : !firrtl.uint<2>
@@ -204,6 +208,14 @@ firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
 
   %c1_u1 = firrtl.constant 0 : !firrtl.uint<8>
   %some = firrtl.enumcreate Some(%c1_u1) : !firrtl.enum<None: uint<0>, Some: uint<8>>
-}
 
+  firrtl.match %in : !firrtl.enum<a: uint<1>, b: uint<2>> {
+    case a(%arg0) {
+      %w = firrtl.wire : !firrtl.uint<1>
+    }
+    case b(%arg0) {
+      %x = firrtl.wire : !firrtl.uint<1>
+    }
+  }
+}
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -576,6 +576,7 @@ static LogicalResult processBuffer(
       preserveAggregate, firrtl::PreserveAggregate::None));
   // Only enable expand whens if lower types is also enabled.
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
+  modulePM.addPass(firrtl::createLowerMatchesPass());
   modulePM.addPass(firrtl::createExpandWhensPass());
   modulePM.addPass(firrtl::createSFCCompatPass());
 


### PR DESCRIPTION
This is mostly a scratch pad while I work on this. I will be force pushing and moving things out of this PR as I go.  

Example 1:
```
circuit Executor:
  module Executor:
    input opcode : [#add, #sub, #mul]
    input arg0: UInt<8>
    input arg1 : UInt<8>
    output result : UInt<8>
    match opcode:
      #add:
        result <= add(arg0, arg1)
      #sub:
        result <= sub(arg0, arg1)
      #mul:
        result <= mul(arg0, arg1)
```
```verilog
module Executor(
  input  enum bit [1:0] {add, sub, mul} opcode,
  input  [7:0]                          arg0,
                                        arg1,
  output [7:0]                          result
);
  assign result = opcode == add ? arg0 + arg1 : opcode == sub ? arg0 - arg1 : arg0 * arg1;
endmodule
```

Example 2:
```
circuit Test:
  module Test:
    input i : [#a: UInt<8>, #b: UInt<16>]
    output o : UInt<16>
    match i:
      #a(v):
        o <= v
      #b(v):
        o <= v
```
```verilog
module Test(
  input  struct packed {enum bit [0:0] {a, b} tag; union packed {logic [7:0] a; logic [15:0] b; } body; } i,
  output [15:0]                                                                                           o
);
  assign o = i.tag == a ? {8'h0, i.body.a} : i.body.b;
endmodule
```