### PR TITLE
[docs] Fix broken docs links in PyCDE and diagrams on Getting Started page

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -9,10 +9,10 @@ Welcome to the CIRCT project!
 methodology to the domain of hardware design tools.
 
 Take a look at the following diagram, which gives a brief overview of the 
-current [dialects and how they interact](includes/img/dialects.svg):
+current [dialects and how they interact](/includes/img/dialects.svg):
 
-<p align="center"><img src="includes/img/dialectlegend.svg"/></p>
-<p align="center"><img src="includes/img/dialects.svg"/></p>
+<p align="center"><img src="/includes/img/dialectlegend.svg"/></p>
+<p align="center"><img src="/includes/img/dialects.svg"/></p>
 
 ## Setting this up
 

--- a/docs/PythonBindings.md
+++ b/docs/PythonBindings.md
@@ -2,7 +2,7 @@
 
 If you are mainly interested in using CIRCT from Python scripts, you need to compile both LLVM/MLIR and CIRCT with Python bindings enabled. Furthermore, you must use a unified build, where LLVM/MLIR and CIRCT are compiled together in one step. 
 
-CIRCT also includes an experimental, opinionated frontend for CIRCT's Python bindings, called [PyCDE](/PyCDE).
+CIRCT also includes an experimental, opinionated frontend for CIRCT's Python bindings, called [PyCDE](PyCDE).
 
 ## Installing and Building with Wheels
 


### PR DESCRIPTION
The current link to PyCDE in https://circt.llvm.org/docs/PythonBindings/ leads to https://circt.llvm.org/PyCDE, which is broken. The correct one is "docs/PyCDE". 

While checking for this, I found that a few more links/images are broken, and building "docs/" using doxygen 1.9.6 does not work. I spent some time fighting it (replacing abs_top_src with hardcoded paths) and still could get similar pages as in the current docs website.

Am I doing something wrong with doxygen? I want to learn more about CIRCT and was checking docs.