### PR TITLE
[FIRRTL] Add `getFieldNameAttr` helper to SubTagOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -363,14 +363,18 @@ def SubtagOp : FIRRTLExprOp<"subtag"> {
   let firrtlExtraClassDeclaration = [{
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType().cast<FEnumType>()
+      return FieldRef(getInput(), getInput().getType()
                                             .getFieldID(getFieldIndex()));
     }
 
     /// Return the name of the accessed field.
+    StringAttr getFieldNameAttr() {
+      return getInput().getType().getElementNameAttr(getFieldIndex());
+    }
+
+    /// Return the name of the accessed field.
     StringRef getFieldName() {
-      return getInput().getType().cast<FEnumType>()
-        .getElementName(getFieldIndex());
+      return getFieldNameAttr().getValue();
     }
   }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -342,6 +342,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
     std::optional<unsigned> getElementIndex(StringRef name);
 
     /// Look up an element's name by index. This asserts if index is invalid.
+    StringAttr getElementNameAttr(size_t index);
     StringRef getElementName(size_t index);
 
     /// Look up an element by name.  This returns None on failure.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1318,10 +1318,14 @@ std::optional<unsigned> FEnumType::getElementIndex(StringRef name) {
   return std::nullopt;
 }
 
-StringRef FEnumType::getElementName(size_t index) {
+StringAttr FEnumType::getElementNameAttr(size_t index) {
   assert(index < getNumElements() &&
          "index must be less than number of fields in enum");
-  return getElements()[index].name.getValue();
+  return getElements()[index].name;
+}
+
+StringRef FEnumType::getElementName(size_t index) {
+  return getElementNameAttr(index).getValue();
 }
 
 std::optional<FEnumType::EnumElement> FEnumType::getElement(StringAttr name) {


### PR DESCRIPTION
This operation already has a helper `getFieldName` which returns a `StringRef`, but during lowering to the HW dialect it's helpful to get the value as a `StringAttr`.