### PR TITLE
[FIRRTL] Lower complex enums to use hw enums for the tag

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -842,10 +842,8 @@ Type circt::firrtl::lowerType(Type type) {
     if (simple)
       return tagTy;
     auto bodyTy = hw::UnionType::get(type.getContext(), hwfields);
-    auto tagImplTy = IntegerType::get(type.getContext(),
-                                      llvm::Log2_64_Ceil(hwfields.size()));
     hw::StructType::FieldInfo fields[2] = {
-        {StringAttr::get(type.getContext(), "tag"), tagImplTy},
+        {StringAttr::get(type.getContext(), "tag"), tagTy},
         {StringAttr::get(type.getContext(), "body"), bodyTy}};
     return hw::StructType::get(type.getContext(), fields);
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -853,8 +853,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.strictconnect %sink, %source : !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>
   }
 
-  // CHECK-LABEL:  hw.module private @DataEnum(%source: !hw.struct<tag: i2, body: !hw.union<a: i2, b: i1, c: i32>>) -> (sink: !hw.struct<tag: i2, body: !hw.union<a: i2, b: i1, c: i32>>) {
-  // CHECK-NEXT:    hw.output %source : !hw.struct<tag: i2, body: !hw.union<a: i2, b: i1, c: i32>>
+  // CHECK-LABEL:  hw.module private @DataEnum(%source: !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>) -> (sink: !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>) {
+  // CHECK-NEXT:    hw.output %source : !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>
   // CHECK-NEXT:  }
   firrtl.module private @DataEnum(in %source: !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>,
                               out %sink: !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>) {


### PR DESCRIPTION
The tag field of complex enumerations was being lowered to an integer type, but using a SV enumeration to represent the tag values is a lot cleaner.  Now that enumerations default to using the smallest storage needed, this can be fixed.