### PR TITLE
[Handshake] Remove cmerge return type inference

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -390,7 +390,6 @@ def MuxOp : Handshake_Op<"mux", [
 
 def ControlMergeOp : Handshake_Op<"control_merge", [
   Pure, MergeLikeOpInterface, HasClock, SOSTInterface,
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>
 ]> {
@@ -410,9 +409,21 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
 
   let arguments = (ins Variadic<AnyType> : $dataOperands);
   let results = (outs AnyType : $result, AnyType : $index);
+  
+  let builders = [OpBuilder<
+    (ins "ValueRange":$operands), [{
+      assert(!operands.empty() && "cmerge needs at least one operand");
+      $_state.addOperands(operands);
+      // By default, the index result has an Index type
+      SmallVector<Type> resultTypes { operands[0].getType(), 
+                                      $_builder.getIndexType()};
+      $_state.addTypes(resultTypes);
+  }]>];
+  
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
+
 }
 
 def BranchOp : Handshake_Op<"br", [

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -423,7 +423,6 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasCanonicalizer = 1;
-
 }
 
 def BranchOp : Handshake_Op<"br", [

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -415,9 +415,8 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
       assert(!operands.empty() && "cmerge needs at least one operand");
       $_state.addOperands(operands);
       // By default, the index result has an Index type
-      SmallVector<Type> resultTypes { operands[0].getType(), 
-                                      $_builder.getIndexType()};
-      $_state.addTypes(resultTypes);
+      $_state.addTypes(ArrayRef<Type>{operands[0].getType(),
+                                      $_builder.getIndexType()});
   }]>];
   
   let hasCustomAssemblyFormat = 1;

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -91,14 +91,13 @@ static LogicalResult verifyIndexWideEnough(Operation *op, Value indexVal,
   else if (indexType.isIndex())
     indexWidth = IndexType::kInternalStorageBitWidth;
   else
-    return op->emitError("unsupported type for indexing operand: ")
-           << indexType;
+    return op->emitError("unsupported type for indexing value: ") << indexType;
 
   // Check whether the bitwidth can support the provided number of operands
   if (indexWidth < 64) {
     uint64_t maxNumOperands = (uint64_t)1 << indexWidth;
     if (numOperands > maxNumOperands)
-      return op->emitError("bitwidth of indexing operand is ")
+      return op->emitError("bitwidth of indexing value is ")
              << indexWidth << ", which can index into " << maxNumOperands
              << " operands, but found " << numOperands << " operands";
   }
@@ -447,19 +446,6 @@ LogicalResult MuxOp::verify() {
 std::string handshake::ControlMergeOp::getResultName(unsigned int idx) {
   assert(idx == 0 || idx == 1);
   return idx == 0 ? "dataOut" : "index";
-}
-
-LogicalResult ControlMergeOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, mlir::RegionRange regions,
-    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
-  // ControlMerge must have at least one data operand
-  if (operands.empty())
-    return failure();
-  // Result type is type of any data operand and, by default, an index type
-  inferredReturnTypes.push_back(operands[0].getType());
-  inferredReturnTypes.push_back(IndexType::get(context));
-  return success();
 }
 
 ParseResult ControlMergeOp::parse(OpAsmParser &parser, OperationState &result) {

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -10,7 +10,7 @@ handshake.func @invalid_merge_like_wrong_type(%arg0: i1, %arg1: i32, %arg2: i64)
 // -----
 
 handshake.func @invalid_mux_unsupported_select(%arg0: tensor<i1>, %arg1: i32, %arg2: i32) {
-  // expected-error @+1 {{unsupported type for indexing operand: 'tensor<i1>'}}
+  // expected-error @+1 {{unsupported type for indexing value: 'tensor<i1>'}}
   %0 = mux %arg0 [%arg1, %arg2] : tensor<i1>, i32
   return %0 : i32
 }
@@ -18,9 +18,25 @@ handshake.func @invalid_mux_unsupported_select(%arg0: tensor<i1>, %arg1: i32, %a
 // -----
 
 handshake.func @invalid_mux_narrow_select(%arg0: i1, %arg1: i32, %arg2: i32, %arg3: i32) {
-  // expected-error @+1 {{bitwidth of indexing operand is 1, which can index into 2 operands, but found 3 operands}}
+  // expected-error @+1 {{bitwidth of indexing value is 1, which can index into 2 operands, but found 3 operands}}
   %0 = mux %arg0 [%arg1, %arg2, %arg3] : i1, i32
   return %0 : i32
+}
+
+// -----
+
+handshake.func @invalid_cmerge_unsupported_index(%arg1: i32, %arg2: i32) -> tensor<i1> {
+  // expected-error @+1 {{unsupported type for indexing value: 'tensor<i1>'}}
+  %result, %index = control_merge %arg1, %arg2 : i32, tensor<i1>
+  return %index : tensor<i1>
+}
+
+// -----
+
+handshake.func @invalid_cmerge_narrow_index(%arg1: i32, %arg2: i32, %arg3: i32) -> i1 {
+  // expected-error @+1 {{bitwidth of indexing value is 1, which can index into 2 operands, but found 3 operands}}
+  %result, %index = control_merge %arg1, %arg2, %arg3 : i32, i1
+  return %index : i1
 }
 
 // -----

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -26,7 +26,7 @@ handshake.func @invalid_mux_narrow_select(%arg0: i1, %arg1: i32, %arg2: i32, %ar
 // -----
 
 handshake.func @invalid_cmerge_unsupported_index(%arg1: i32, %arg2: i32) -> tensor<i1> {
-  // expected-error @+1 {{unsupported type for indexing value: 'tensor<i1>'}}
+  // expected-error @below {{unsupported type for indexing value: 'tensor<i1>'}}
   %result, %index = control_merge %arg1, %arg2 : i32, tensor<i1>
   return %index : tensor<i1>
 }
@@ -34,7 +34,7 @@ handshake.func @invalid_cmerge_unsupported_index(%arg1: i32, %arg2: i32) -> tens
 // -----
 
 handshake.func @invalid_cmerge_narrow_index(%arg1: i32, %arg2: i32, %arg3: i32) -> i1 {
-  // expected-error @+1 {{bitwidth of indexing value is 1, which can index into 2 operands, but found 3 operands}}
+  // expected-error @below {{bitwidth of indexing value is 1, which can index into 2 operands, but found 3 operands}}
   %result, %index = control_merge %arg1, %arg2, %arg3 : i32, i1
   return %index : i1
 }


### PR DESCRIPTION
This commit removes the `InferTypeOpInterface` from `ControlMergeOp` because it no longer made sense w.r.t. the variable type of the index result introduced in #4929. Additionally, when parsing a control_merge with an index type different than `index`, it would raise an error because of the mismatch between the parsed and inferred types. Example code that would trigger it below.

```mlir
handshake.func @test(%arg1: i32, %arg2: i32) {
    %result, %index = control_merge %arg1, %arg2 : i32, i64
    return
}
```

The commit also adds a custom builder for `ControlMergeOp` (that was previously auto-generated by `InferTypeOpInterface`) to allow creating the operation without explicitly providing return types. The builder defaults to an `Index` type for the op's second result.