### PR TITLE
[Seq] Lower FirMemOp to HWModuleGeneratedOp

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -32,6 +32,7 @@ createSeqFIRRTLLowerToSVPass(const LowerSeqFIRRTLToSVOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
 std::unique_ptr<mlir::Pass>
 createExternalizeClockGatePass(const ExternalizeClockGateOptions &options = {});
+std::unique_ptr<mlir::Pass> createLowerFirMemPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -77,4 +77,10 @@ def ExternalizeClockGate: Pass<"externalize-clock-gate", "mlir::ModuleOp"> {
   ];
 }
 
+def LowerFirMem : Pass<"lower-seq-firmem", "mlir::ModuleOp"> {
+  let summary = "Lower seq.firmem ops to instances of hw.module.generated ops";
+  let constructor = "circt::seq::createLowerFirMemPass()";
+  let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 #endif // CIRCT_DIALECT_SEQ_SEQPASSES

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTSeqTransforms
   ExternalizeClockGate.cpp
+  LowerFirMem.cpp
   LowerSeqHLMem.cpp
   LowerSeqToSV.cpp
 

--- a/lib/Dialect/Seq/Transforms/LowerFirMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerFirMem.cpp
@@ -1,0 +1,525 @@
+//===- LowerFirMem.cpp - Seq FIRRTL memory lowering -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transform translate Seq FirMem ops to instances of HW generated modules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/Namespace.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Parallel.h"
+
+#define DEBUG_TYPE "lower-firmem"
+
+using namespace circt;
+using namespace seq;
+using namespace hw;
+using hw::HWModuleGeneratedOp;
+using llvm::MapVector;
+using llvm::SmallDenseSet;
+
+//===----------------------------------------------------------------------===//
+// FIR Memory Parametrization
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// The configuration of a FIR memory.
+struct FirMemConfig {
+  size_t numReadPorts = 0;
+  size_t numWritePorts = 0;
+  size_t numReadWritePorts = 0;
+  size_t dataWidth = 0;
+  size_t depth = 0;
+  size_t readLatency = 0;
+  size_t writeLatency = 0;
+  size_t maskBits = 0;
+  RUW readUnderWrite = RUW::Undefined;
+  WUW writeUnderWrite = WUW::Undefined;
+  SmallVector<int32_t, 1> writeClockIDs;
+  StringRef initFilename;
+  bool initIsBinary = false;
+  bool initIsInline = false;
+  Attribute outputFile;
+  StringRef prefix;
+
+  llvm::hash_code hashValue() const {
+    return llvm::hash_combine(numReadPorts, numWritePorts, numReadWritePorts,
+                              dataWidth, depth, readLatency, writeLatency,
+                              maskBits, readUnderWrite, writeUnderWrite,
+                              initFilename, initIsBinary, initIsInline,
+                              outputFile, prefix) ^
+           llvm::hash_combine_range(writeClockIDs.begin(), writeClockIDs.end());
+  }
+
+  auto getTuple() const {
+    return std::make_tuple(numReadPorts, numWritePorts, numReadWritePorts,
+                           dataWidth, depth, readLatency, writeLatency,
+                           maskBits, readUnderWrite, writeUnderWrite,
+                           writeClockIDs, initFilename, initIsBinary,
+                           initIsInline, outputFile, prefix);
+  }
+
+  bool operator==(const FirMemConfig &other) const {
+    return getTuple() == other.getTuple();
+  }
+};
+} // namespace
+
+namespace llvm {
+template <>
+struct DenseMapInfo<FirMemConfig> {
+  static inline FirMemConfig getEmptyKey() {
+    FirMemConfig cfg;
+    cfg.depth = DenseMapInfo<size_t>::getEmptyKey();
+    return cfg;
+  }
+  static inline FirMemConfig getTombstoneKey() {
+    FirMemConfig cfg;
+    cfg.depth = DenseMapInfo<size_t>::getTombstoneKey();
+    return cfg;
+  }
+  static unsigned getHashValue(const FirMemConfig &cfg) {
+    return cfg.hashValue();
+  }
+  static bool isEqual(const FirMemConfig &lhs, const FirMemConfig &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_DEF_LOWERFIRMEM
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+struct LowerFirMemPass : public impl::LowerFirMemBase<LowerFirMemPass> {
+  /// A vector of unique `FirMemConfig`s and all the `FirMemOp`s that use it.
+  using UniqueConfig = std::pair<FirMemConfig, SmallVector<FirMemOp, 1>>;
+  using UniqueConfigs = std::vector<UniqueConfig>;
+
+  void runOnOperation() override;
+
+  UniqueConfigs collectMemories(ArrayRef<HWModuleOp> modules);
+  FirMemConfig collectMemory(FirMemOp op);
+
+  SmallVector<HWModuleGeneratedOp>
+  createMemoryModules(MutableArrayRef<UniqueConfig> configs);
+  HWModuleGeneratedOp createMemoryModule(UniqueConfig &config,
+                                         OpBuilder &builder,
+                                         FlatSymbolRefAttr schemaSymRef,
+                                         Namespace &globalNamespace);
+
+  void lowerMemoriesInModule(
+      HWModuleOp module,
+      ArrayRef<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>> mems);
+};
+} // namespace
+
+void LowerFirMemPass::runOnOperation() {
+  // Gather all HW modules. We'll parallelize over them.
+  SmallVector<HWModuleOp> modules;
+  getOperation().walk([&](HWModuleOp op) {
+    modules.push_back(op);
+    return WalkResult::skip();
+  });
+  LLVM_DEBUG(llvm::dbgs() << "Lowering memories in " << modules.size()
+                          << " modules\n");
+
+  // Gather all `FirMemOp`s in the HW modules and group them by configuration.
+  auto uniqueMems = collectMemories(modules);
+  LLVM_DEBUG(llvm::dbgs() << "Found " << uniqueMems.size()
+                          << " unique memory congiurations\n");
+  if (uniqueMems.empty()) {
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  // Create the `HWModuleGeneratedOp`s for each unique configuration. The result
+  // is a vector of the same size as `uniqueMems`, with a `HWModuleGeneratedOp`
+  // for every unique memory configuration.
+  auto genOps = createMemoryModules(uniqueMems);
+
+  // Group the list of memories that we need to update per HW module. This will
+  // allow us to parallelize across HW modules.
+  MapVector<
+      HWModuleOp,
+      SmallVector<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>>>
+      memsToLowerByModule;
+
+  for (auto [config, genOp] : llvm::zip(uniqueMems, genOps))
+    for (auto memOp : config.second)
+      memsToLowerByModule[memOp->getParentOfType<HWModuleOp>()].push_back(
+          {&config.first, genOp, memOp});
+
+  // Replace all `FirMemOp`s with instances of the generated module.
+  if (getContext().isMultithreadingEnabled()) {
+    llvm::parallelForEach(memsToLowerByModule, [&](auto pair) {
+      lowerMemoriesInModule(pair.first, pair.second);
+    });
+  } else {
+    for (auto [module, mems] : memsToLowerByModule)
+      lowerMemoriesInModule(module, mems);
+  }
+}
+
+/// Collect the memories in a list of HW modules.
+LowerFirMemPass::UniqueConfigs
+LowerFirMemPass::collectMemories(ArrayRef<HWModuleOp> modules) {
+  // For each module in the list populate a separate vector of `FirMemOp`s in
+  // that module. This allows for the traversal of the HW modules to be
+  // parallelized.
+  using ModuleMemories = SmallVector<std::pair<FirMemConfig, FirMemOp>, 0>;
+  SmallVector<ModuleMemories> memories(modules.size());
+
+  auto collect = [&](HWModuleOp module, ModuleMemories &memories) {
+    // TODO: Check if this module is in the DUT hierarchy.
+    // bool isInDut = state.isInDUT(module);
+    module.walk([&](seq::FirMemOp op) {
+      memories.push_back({collectMemory(op), op});
+    });
+  };
+
+  if (getContext().isMultithreadingEnabled()) {
+    llvm::parallelFor(0, modules.size(),
+                      [&](auto idx) { collect(modules[idx], memories[idx]); });
+  } else {
+    for (auto [module, moduleMemories] : llvm::zip(modules, memories))
+      collect(module, moduleMemories);
+  }
+
+  // Group the gathered memories by unique `FirMemConfig` details.
+  MapVector<FirMemConfig, SmallVector<FirMemOp, 1>> grouped;
+  for (auto [module, moduleMemories] : llvm::zip(modules, memories))
+    for (auto [summary, memOp] : moduleMemories)
+      grouped[summary].push_back(memOp);
+
+  return grouped.takeVector();
+}
+
+/// Trace a value through wires to its original definition.
+static Value lookThroughWires(Value value) {
+  while (value) {
+    if (auto wireOp = value.getDefiningOp<WireOp>()) {
+      value = wireOp.getInput();
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+/// Determine the exact parametrization of the memory that should be generated
+/// for a given `FirMemOp`.
+FirMemConfig LowerFirMemPass::collectMemory(FirMemOp op) {
+  FirMemConfig cfg;
+  cfg.dataWidth = op.getType().getWidth();
+  cfg.depth = op.getType().getDepth();
+  cfg.readLatency = op.getReadLatency();
+  cfg.writeLatency = op.getWriteLatency();
+  cfg.maskBits = op.getType().getMaskWidth().value_or(1);
+  cfg.readUnderWrite = op.getRuw();
+  cfg.writeUnderWrite = op.getWuw();
+  if (auto init = op.getInitAttr()) {
+    cfg.initFilename = init.getFilename();
+    cfg.initIsBinary = init.getIsBinary();
+    cfg.initIsInline = init.getIsInline();
+  }
+  cfg.outputFile = op.getOutputFileAttr();
+  if (auto prefix = op.getPrefixAttr())
+    cfg.prefix = prefix.getValue();
+  // TODO: Handle modName (maybe not?)
+  // TODO: Handle groupID (maybe not?)
+
+  // Count the read, write, and read-write ports, and identify the clocks
+  // driving the write ports.
+  SmallDenseMap<Value, unsigned> clockValues;
+  for (auto *user : op->getUsers()) {
+    if (isa<FirMemReadOp>(user))
+      ++cfg.numReadPorts;
+    else if (isa<FirMemWriteOp>(user))
+      ++cfg.numWritePorts;
+    else if (isa<FirMemReadWriteOp>(user))
+      ++cfg.numReadWritePorts;
+
+    // Assign IDs to the values used as clock. This allows later passes to
+    // easily detect which clocks are effectively driven by the same value.
+    if (isa<FirMemWriteOp, FirMemReadWriteOp>(user)) {
+      auto clock = lookThroughWires(user->getOperand(2));
+      cfg.writeClockIDs.push_back(
+          clockValues.insert({clock, clockValues.size()}).first->second);
+    }
+  }
+
+  return cfg;
+}
+
+/// Create the `HWModuleGeneratedOp` for a list of memory parametrizations.
+SmallVector<HWModuleGeneratedOp>
+LowerFirMemPass::createMemoryModules(MutableArrayRef<UniqueConfig> configs) {
+  // Create the generator schema.
+  OpBuilder builder(getOperation());
+  builder.setInsertionPointToStart(getOperation().getBody());
+  std::array<StringRef, 14> schemaFields = {
+      "depth",          "numReadPorts",    "numWritePorts", "numReadWritePorts",
+      "readLatency",    "writeLatency",    "width",         "maskGran",
+      "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename",
+      "initIsBinary",   "initIsInline"};
+  auto schemaOp = builder.create<hw::HWGeneratorSchemaOp>(
+      getOperation().getLoc(), "FIRRTLMem", "FIRRTL_Memory",
+      builder.getStrArrayAttr(schemaFields));
+  auto schemaSymRef = FlatSymbolRefAttr::get(schemaOp);
+
+  // Create the individual memory modules.
+  SymbolCache symbolCache;
+  symbolCache.addDefinitions(getOperation());
+  Namespace globalNamespace;
+  globalNamespace.add(symbolCache);
+
+  SmallVector<HWModuleGeneratedOp> genOps;
+  genOps.reserve(configs.size());
+  for (auto &config : configs)
+    genOps.push_back(
+        createMemoryModule(config, builder, schemaSymRef, globalNamespace));
+
+  return genOps;
+}
+
+/// Create the `HWModuleGeneratedOp` for a single memory parametrization.
+HWModuleGeneratedOp
+LowerFirMemPass::createMemoryModule(UniqueConfig &config, OpBuilder &builder,
+                                    FlatSymbolRefAttr schemaSymRef,
+                                    Namespace &globalNamespace) {
+  const auto &mem = config.first;
+  auto &memOps = config.second;
+
+  // Pick a name for the memory. Honor the optional prefix and try to mention
+  // the names of the memory instances that use this configuration.
+  SmallDenseSet<StringRef> usedNames;
+  SmallString<32> nameBuffer;
+  nameBuffer += mem.prefix;
+  for (auto memOp : memOps) {
+    if (auto memName = memOp.getName()) {
+      if (usedNames.insert(*memName).second) {
+        if (usedNames.size() > 1)
+          nameBuffer.push_back('_');
+        nameBuffer += *memName;
+      }
+    }
+  }
+  if (nameBuffer.empty())
+    nameBuffer += "mem";
+  auto name = builder.getStringAttr(globalNamespace.newName(nameBuffer));
+
+  LLVM_DEBUG(llvm::dbgs() << "Creating " << name << " for " << mem.depth
+                          << " x " << mem.dataWidth << " memory\n");
+
+  bool withMask = mem.maskBits > 1;
+  SmallVector<hw::PortInfo> ports;
+
+  // Common types used for memory ports.
+  Type bitType = IntegerType::get(&getContext(), 1);
+  Type dataType =
+      IntegerType::get(&getContext(), std::max((size_t)1, mem.dataWidth));
+  Type maskType = IntegerType::get(&getContext(), mem.maskBits);
+  Type addrType = IntegerType::get(&getContext(),
+                                   std::max(1U, llvm::Log2_64_Ceil(mem.depth)));
+
+  // Helper to add an input port.
+  size_t inputIdx = 0;
+  auto addInput = [&](StringRef prefix, size_t idx, StringRef suffix,
+                      Type type) {
+    ports.push_back({builder.getStringAttr(prefix + Twine(idx) + suffix),
+                     PortDirection::INPUT, type, inputIdx++});
+  };
+
+  // Helper to add an output port.
+  size_t outputIdx = 0;
+  auto addOutput = [&](StringRef prefix, size_t idx, StringRef suffix,
+                       Type type) {
+    ports.push_back({builder.getStringAttr(prefix + Twine(idx) + suffix),
+                     PortDirection::OUTPUT, type, outputIdx++});
+  };
+
+  // Helper to add the ports common to read, read-write, and write ports.
+  auto addCommonPorts = [&](StringRef prefix, size_t idx) {
+    addInput(prefix, idx, "_addr", addrType);
+    addInput(prefix, idx, "_en", bitType);
+    addInput(prefix, idx, "_clk", bitType);
+  };
+
+  // Add the read ports.
+  for (size_t i = 0, e = mem.numReadPorts; i != e; ++i) {
+    addCommonPorts("R", i);
+    addOutput("R", i, "_data", dataType);
+  }
+
+  // Add the read-write ports.
+  for (size_t i = 0, e = mem.numReadWritePorts; i != e; ++i) {
+    addCommonPorts("RW", i);
+    addInput("RW", i, "_wmode", bitType);
+    addInput("RW", i, "_wdata", dataType);
+    addOutput("RW", i, "_rdata", dataType);
+    if (withMask)
+      addInput("RW", i, "_wmask", maskType);
+  }
+
+  // Add the write ports.
+  for (size_t i = 0, e = mem.numWritePorts; i != e; ++i) {
+    addCommonPorts("W", i);
+    addInput("W", i, "_data", dataType);
+    if (withMask)
+      addInput("W", i, "_mask", maskType);
+  }
+
+  // Mask granularity is the number of data bits that each mask bit can
+  // guard. By default it is equal to the data bitwidth.
+  auto genAttr = [&](StringRef name, Attribute attr) {
+    return builder.getNamedAttr(name, attr);
+  };
+  auto genAttrUI32 = [&](StringRef name, uint32_t value) {
+    return genAttr(name, builder.getUI32IntegerAttr(value));
+  };
+  NamedAttribute genAttrs[] = {
+      genAttr("depth", builder.getI64IntegerAttr(mem.depth)),
+      genAttrUI32("numReadPorts", mem.numReadPorts),
+      genAttrUI32("numWritePorts", mem.numWritePorts),
+      genAttrUI32("numReadWritePorts", mem.numReadWritePorts),
+      genAttrUI32("readLatency", mem.readLatency),
+      genAttrUI32("writeLatency", mem.writeLatency),
+      genAttrUI32("width", mem.dataWidth),
+      genAttrUI32("maskGran", mem.dataWidth / mem.maskBits),
+      genAttr("readUnderWrite",
+              seq::RUWAttr::get(builder.getContext(), mem.readUnderWrite)),
+      genAttr("writeUnderWrite",
+              seq::WUWAttr::get(builder.getContext(), mem.writeUnderWrite)),
+      genAttr("writeClockIDs", builder.getI32ArrayAttr(mem.writeClockIDs)),
+      genAttr("initFilename", builder.getStringAttr(mem.initFilename)),
+      genAttr("initIsBinary", builder.getBoolAttr(mem.initIsBinary)),
+      genAttr("initIsInline", builder.getBoolAttr(mem.initIsInline))};
+
+  // Combine the locations of all actual `FirMemOp`s to be the location of the
+  // generated memory.
+  Location loc = memOps.front().getLoc();
+  if (memOps.size() > 1) {
+    SmallVector<Location> locs;
+    for (auto memOp : memOps)
+      locs.push_back(memOp.getLoc());
+    loc = FusedLoc::get(&getContext(), locs);
+  }
+
+  // Create the module.
+  auto genOp = builder.create<hw::HWModuleGeneratedOp>(
+      loc, schemaSymRef, name, ports, StringRef{}, ArrayAttr{}, genAttrs);
+  if (mem.outputFile)
+    genOp->setAttr("output_file", mem.outputFile);
+
+  return genOp;
+}
+
+/// Replace all `FirMemOp`s in an HW module with an instance of the
+/// corresponding generated module.
+void LowerFirMemPass::lowerMemoriesInModule(
+    HWModuleOp module,
+    ArrayRef<std::tuple<FirMemConfig *, HWModuleGeneratedOp, FirMemOp>> mems) {
+  LLVM_DEBUG(llvm::dbgs() << "Lowering " << mems.size() << " memories in "
+                          << module.getName() << "\n");
+
+  hw::ConstantOp constOneOp;
+  auto constOne = [&] {
+    if (!constOneOp) {
+      auto builder = OpBuilder::atBlockBegin(module.getBodyBlock());
+      constOneOp = builder.create<hw::ConstantOp>(module.getLoc(),
+                                                  builder.getI1Type(), 1);
+    }
+    return constOneOp;
+  };
+  auto valueOrOne = [&](Value value) { return value ? value : constOne(); };
+
+  for (auto [config, genOp, memOp] : mems) {
+    LLVM_DEBUG(llvm::dbgs() << "- Lowering " << memOp.getName() << "\n");
+    SmallVector<Value> inputs;
+    SmallVector<Value> outputs;
+
+    auto addInput = [&](Value value) { inputs.push_back(value); };
+    auto addOutput = [&](Value value) { outputs.push_back(value); };
+
+    // Add the read ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemReadOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addOutput(port.getData());
+    }
+
+    // Add the read-write ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemReadWriteOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addInput(port.getMode());
+      addInput(port.getWriteData());
+      addOutput(port.getReadData());
+      if (config->maskBits > 1)
+        addInput(valueOrOne(port.getMask()));
+    }
+
+    // Add the write ports.
+    for (auto *op : memOp->getUsers()) {
+      auto port = dyn_cast<FirMemWriteOp>(op);
+      if (!port)
+        continue;
+      addInput(port.getAddress());
+      addInput(valueOrOne(port.getEnable()));
+      addInput(port.getClock());
+      addInput(port.getData());
+      if (config->maskBits > 1)
+        addInput(valueOrOne(port.getMask()));
+    }
+
+    // Create the module instance.
+    StringRef memName = "mem";
+    if (auto name = memOp.getName(); name && !name->empty())
+      memName = *name;
+    ImplicitLocOpBuilder builder(memOp.getLoc(), memOp);
+    auto instOp = builder.create<hw::InstanceOp>(
+        genOp, builder.getStringAttr(memName + "_ext"), inputs, ArrayAttr{},
+        memOp.getInnerSymAttr());
+    for (auto [oldOutput, newOutput] : llvm::zip(outputs, instOp.getResults()))
+      oldOutput.replaceAllUsesWith(newOutput);
+
+    // Carry attributes over from the `FirMemOp` to the `InstanceOp`.
+    auto defaultAttrNames = memOp.getAttributeNames();
+    for (auto namedAttr : memOp->getAttrs())
+      if (!llvm::is_contained(defaultAttrNames, namedAttr.getName()))
+        instOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+
+    // Get rid of the `FirMemOp`.
+    for (auto *user : llvm::make_early_inc_range(memOp->getUsers()))
+      user->erase();
+    memOp.erase();
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<Pass> circt::seq::createLowerFirMemPass() {
+  return std::make_unique<LowerFirMemPass>();
+}

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -148,8 +148,10 @@ public:
   }
 };
 
-struct LowerSeqHLMemPass
-    : public circt::seq::impl::LowerSeqHLMemBase<LowerSeqHLMemPass> {
+#define GEN_PASS_DEF_LOWERSEQHLMEM
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+struct LowerSeqHLMemPass : public impl::LowerSeqHLMemBase<LowerSeqHLMemPass> {
   void runOnOperation() override;
 };
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -38,10 +38,16 @@ using namespace circt;
 using namespace seq;
 
 namespace {
+#define GEN_PASS_DEF_LOWERSEQTOSV
+#define GEN_PASS_DEF_LOWERSEQFIRRTLTOSV
+#define GEN_PASS_DEF_LOWERSEQFIRRTLINITTOSV
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
 struct SeqToSVPass : public impl::LowerSeqToSVBase<SeqToSVPass> {
   void runOnOperation() override;
   using LowerSeqToSVBase::lowerToAlwaysFF;
 };
+
 struct SeqFIRRTLToSVPass
     : public impl::LowerSeqFIRRTLToSVBase<SeqFIRRTLToSVPass> {
   void runOnOperation() override;

--- a/lib/Dialect/Seq/Transforms/PassDetails.h
+++ b/lib/Dialect/Seq/Transforms/PassDetails.h
@@ -20,15 +20,4 @@
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "mlir/Pass/Pass.h"
 
-namespace circt {
-namespace seq {
-
-#define GEN_PASS_DEF_LOWERSEQFIRRTLTOSV
-#define GEN_PASS_DEF_LOWERSEQHLMEM
-#define GEN_PASS_DEF_LOWERSEQTOSV
-#include "circt/Dialect/Seq/SeqPasses.h.inc"
-
-} // namespace seq
-} // namespace circt
-
 #endif // DIALECT_SEQ_TRANSFORMS_PASSDETAILS_H

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -215,6 +215,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
            FirtoolOptions::RandomKind::Reg),
        /*emitSeparateAlwaysBlocks=*/
        opt.emitSeparateAlwaysBlocks}));
+  pm.addPass(seq::createLowerFirMemPass());
   pm.addPass(sv::createHWMemSimImplPass(
       opt.replSeqMem, opt.ignoreReadEnableMem, opt.addMuxPragmas,
       !opt.isRandomEnabled(FirtoolOptions::RandomKind::Mem),

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -1,0 +1,97 @@
+// RUN: circt-opt --lower-seq-firmem %s --verify-diagnostics | FileCheck %s
+
+// hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
+// hw.module.generated @mem_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem3_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem_combMem_0, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i1) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 0 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 0 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem_combMem_1, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem2_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// hw.module.generated @mem4_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK-LABEL: hw.module @Foo
+hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
+  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "mem1A_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "mem1B_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
+  %mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %0 = seq.firmem.read_port %mem1A[%addr], clock %clk enable %en : <12 x 42>
+  %1 = seq.firmem.read_port %mem1B[%addr], clock %clk enable %en : <12 x 42>
+  comb.xor %0, %1 : i42
+
+  // CHECK-NEXT: hw.instance "mem2_ext" @mem2(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
+  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
+  seq.firmem.write_port %mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i2
+
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "mem3_ext" @mem3(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
+  // CHECK-NEXT: comb.xor [[TMP]]
+  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
+  %2 = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i3
+  comb.xor %2 : i42
+
+  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "mem4_ext" @mem4(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
+  %mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
+  %3 = seq.firmem.read_port %mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>
+  %4 = seq.firmem.read_write_port %mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  seq.firmem.write_port %mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  comb.xor %3, %4 : i42
+}
+
+// CHECK-LABEL: hw.module @SeparateOutputFiles
+hw.module @SeparateOutputFiles() {
+  // CHECK-NEXT: hw.instance "mem1_ext" @mem1
+  // CHECK-NEXT: hw.instance "mem2_ext" @mem2
+  %mem1 = seq.firmem 0, 1, undefined, port_order {output_file = "foo"} : <24 x 1337>
+  %mem2 = seq.firmem 0, 1, undefined, port_order {output_file = "bar"} : <24 x 1337>
+}
+
+// CHECK-LABEL: hw.module @SeparatePrefices
+hw.module @SeparatePrefices() {
+  // CHECK-NEXT: hw.instance "mem1_ext" @foo_mem1
+  %mem1 = seq.firmem 0, 1, undefined, port_order {prefix = "foo_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "mem2_ext" @bar_mem2
+  %mem2 = seq.firmem 0, 1, undefined, port_order {prefix = "bar_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "mem3_ext" @uwu_mem3_mem4
+  // CHECK-NEXT: hw.instance "mem4_ext" @uwu_mem3_mem4
+  %mem3 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+  %mem4 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+}
+
+
+// CHECK-LABEL: hw.module @MemoryWritePortBehavior
+hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
+  %z_i8 = sv.constantZ : i8
+  %z_i1 = sv.constantZ : i1
+  %z_i4 = sv.constantZ : i4
+
+  // This memory has both write ports driven by the same clock.  It should be
+  // lowered to an "aa" memory. Even if the clock is passed via different
+  // wires, we should identify the clocks to be same.
+  //
+  // CHECK: hw.instance "mem1_ext" @mem1_mem3
+  %mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  %cwire1 = hw.wire %clock1 : i1
+  %cwire2 = hw.wire %clock1 : i1
+  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>
+
+  // This memory has different clocks for each write port. It should be
+  // lowered to an "ab" memory.
+  //
+  // CHECK: hw.instance "mem2_ext" @mem2
+  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>
+
+  // This memory is the same as the first memory, but a node is used to alias
+  // the second write port clock (e.g., this could be due to a dont touch
+  // annotation blocking this from being optimized away). This should be
+  // lowered to an "aa" since they are identical.
+  //
+  // CHECK: hw.instance "mem3_ext" @mem1_mem3
+  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+}


### PR DESCRIPTION
Add the `LowerFirMem` pass which lowers `seq.firmem` ops to a corresponding `hw.module.generated` op. The pass intends to reflect what `LowerToHW` does in `lowerMemoryDecls`: it collects a list of memory ops in the design, distills them down into memory parameters, deduplicates those parameters, creates one `hw.module.generated` op for each unique memory config, and replaces the memory ops with instances of this generated module.

The `LowerFirMem` pass is intended as an intermediate solution to allow `seq.firmem` to be lowered through `HWMemSimImpl` without changing the latter's implementation. Existing tools that have passes operating on `hw.module.generated`-style memories can simply run the `LowerFirMem` pass and have the new `seq.firmem` work with their existing pipeline.

A few commits down the road we'll want to make `HWMemSimImpl` work directly with `seq.firmem` ops, at which point `LowerFirMem` can go away again. At that point tools are expected to have updated their memory passes to work with `seq.firmem` directly, completing the transition.

This also adds the `LowerFirMem` pass to the firtool pipeline, but it doesn't do anything yet since nothing in the pipeline currently creates `seq.firmem` ops. This will be changed in a follow-up commit.

**Follow-up work:** This pass is just temporary. It will work with `seq.mem` directly once `seq.firmem` and `seq.hlmem` are merged. As soon as HWMemSimImpl and other passes are updated to work with `seq.mem` directly themselves, this pass will go away again.