### PR TITLE
[FIRRTLToHW] Lower memories to seq.firmem

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -184,20 +184,6 @@ static void moveVerifAnno(ModuleOp top, AnnotationSet &annos,
   }
 }
 
-static SmallVector<FirMemory>
-mergeFIRRTLMemories(const SmallVector<FirMemory> &lhs,
-                    SmallVector<FirMemory> rhs) {
-  if (rhs.empty())
-    return lhs;
-  // lhs is always sorted and uniqued
-  llvm::sort(rhs);
-  rhs.erase(std::unique(rhs.begin(), rhs.end()), rhs.end());
-  SmallVector<FirMemory> retval;
-  std::set_union(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
-                 std::back_inserter(retval));
-  return retval;
-}
-
 static unsigned getBitWidthFromVectorSize(unsigned size) {
   return size == 1 ? 1 : llvm::Log2_64_Ceil(size);
 }
@@ -299,14 +285,6 @@ struct CircuitLoweringState {
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 
-  // Given the FirMemory name, return the generated op module name. This map
-  // maintains the appropriate names for the deduped memories.
-  StringAttr getGenOpMemName(StringAttr oldName) const {
-    auto iter = memoryNameMap.find(oldName);
-    assert(iter != memoryNameMap.end() && "Memory name map not found");
-    return iter->getSecond();
-  }
-
 private:
   friend struct FIRRTLModuleLowering;
   friend struct FIRRTLLowering;
@@ -348,12 +326,6 @@ private:
   /// A mapping of instances to their forced instantiation names (if
   /// applicable).
   DenseMap<std::pair<Attribute, Attribute>, Attribute> instanceForceNames;
-
-  /// Map of original FirMemory name to the Generated Op name. All the deduped
-  /// memories have the same FirMemory name (because it is derived from the
-  /// memory parameters), but the generated op name depends on the MemOp name,
-  /// which is selected after dedup.
-  DenseMap<StringAttr, StringAttr> memoryNameMap;
 
   /// Cached nla table analysis.
   NLATable *nlaTable = nullptr;
@@ -443,9 +415,6 @@ private:
                                 CircuitLoweringState &loweringState);
   LogicalResult lowerModuleOperations(hw::HWModuleOp module,
                                       CircuitLoweringState &loweringState);
-
-  void lowerMemoryDecls(ArrayRef<FirMemory> mems,
-                        CircuitLoweringState &loweringState);
 };
 
 } // end anonymous namespace
@@ -579,43 +548,6 @@ void FIRRTLModuleLowering::runOnOperation() {
         moduleHierarchyFileAttrName,
         ArrayAttr::get(&getContext(), testHarnessHierarchyFiles));
 
-  // Collect all the memories in the module. Construct the FirMemory, set the
-  // DUT flag and also record the Memop.
-  auto collectFIRRTLMemories =
-      [&state](FModuleOp module) -> SmallVector<FirMemory> {
-    SmallVector<FirMemory> retval;
-    // Check if this module is in the DUT hierarchy.
-    bool isInDut = state.isInDUT(module);
-    for (auto op : module.getBodyBlock()->getOps<MemOp>()) {
-      auto sum = op.getSummary();
-      sum.isInDut = isInDut;
-      sum.op = op;
-      retval.push_back(sum);
-    }
-    return retval;
-  };
-
-  // 1. First collect the memories as FirMemory, set the DUT flag and also
-  // record the MemOp.
-  // 2. Then Dedup the memories using the mergeFIRRTLMemories routine. This uses
-  // the memory parameters to merge memories with the exactly same parameters.
-  // 3. Then For each of the deduped memories, create the HWModuleGeneratedOp,
-  // and assign a unique name to the wrapper module based on the MemOp name. It
-  // is important to use the MemOp name because appropriate prefixes have to be
-  // respected, also the correct output directory needs to be set based on the
-  // DUT or testbench hierarchy.
-  SmallVector<FirMemory> memories;
-  if (getContext().isMultithreadingEnabled()) {
-    memories = llvm::parallelTransformReduce(
-        modulesToProcess.begin(), modulesToProcess.end(),
-        SmallVector<FirMemory>(), mergeFIRRTLMemories, collectFIRRTLMemories);
-  } else {
-    for (auto m : modulesToProcess)
-      memories = mergeFIRRTLMemories(memories, collectFIRRTLMemories(m));
-  }
-  if (!memories.empty())
-    lowerMemoryDecls(memories, state);
-
   // Now that we've lowered all of the modules, move the bodies over and
   // update any instances that refer to the old modules.
   auto result = mlir::failableParallelForEachN(
@@ -641,128 +573,6 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   // Now that the modules are moved over, remove the Circuit.
   circuit.erase();
-}
-
-void FIRRTLModuleLowering::lowerMemoryDecls(ArrayRef<FirMemory> mems,
-                                            CircuitLoweringState &state) {
-  assert(!mems.empty());
-  auto namesp = CircuitNamespace(state.circuitOp);
-  state.used_RANDOMIZE_MEM_INIT = 1;
-  // Insert memories at the bottom of the file.
-  OpBuilder b(state.circuitOp);
-  b.setInsertionPointAfter(state.circuitOp);
-  std::array<StringRef, 14> schemaFields = {
-      "depth",          "numReadPorts",    "numWritePorts", "numReadWritePorts",
-      "readLatency",    "writeLatency",    "width",         "maskGran",
-      "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename",
-      "initIsBinary",   "initIsInline"};
-  auto schemaFieldsAttr = b.getStrArrayAttr(schemaFields);
-  auto schema = b.create<hw::HWGeneratorSchemaOp>(
-      mems.front().loc, "FIRRTLMem", "FIRRTL_Memory", schemaFieldsAttr);
-  auto memorySchema = SymbolRefAttr::get(schema);
-
-  Type b1Type = IntegerType::get(&getContext(), 1);
-
-  for (auto &mem : mems) {
-    SmallVector<hw::PortInfo> ports;
-    size_t inputPin = 0;
-    size_t outputPin = 0;
-    // We don't need a single bit mask, it can be combined with enable. Create
-    // an unmasked memory if maskBits = 1.
-
-    auto makePortCommon = [&](StringRef prefix, size_t idx, Type bAddrType) {
-      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_addr"),
-                       PortDirection::INPUT, bAddrType, inputPin++});
-      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_en"),
-                       PortDirection::INPUT, b1Type, inputPin++});
-      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_clk"),
-                       PortDirection::INPUT, b1Type, inputPin++});
-    };
-
-    Type bDataType =
-        IntegerType::get(&getContext(), std::max((size_t)1, mem.dataWidth));
-    Type maskType = IntegerType::get(&getContext(), mem.maskBits);
-
-    Type bAddrType = IntegerType::get(
-        &getContext(), std::max(1U, llvm::Log2_64_Ceil(mem.depth)));
-
-    for (size_t i = 0, e = mem.numReadPorts; i != e; ++i) {
-      makePortCommon("R", i, bAddrType);
-      ports.push_back({b.getStringAttr("R" + Twine(i) + "_data"),
-                       PortDirection::OUTPUT, bDataType, outputPin++});
-    }
-    for (size_t i = 0, e = mem.numReadWritePorts; i != e; ++i) {
-      makePortCommon("RW", i, bAddrType);
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmode"),
-                       PortDirection::INPUT, b1Type, inputPin++});
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wdata"),
-                       PortDirection::INPUT, bDataType, inputPin++});
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_rdata"),
-                       PortDirection::OUTPUT, bDataType, outputPin++});
-      // Ignore mask port, if maskBits =1
-      if (mem.isMasked)
-        ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmask"),
-                         PortDirection::INPUT, maskType, inputPin++});
-    }
-
-    for (size_t i = 0, e = mem.numWritePorts; i != e; ++i) {
-      makePortCommon("W", i, bAddrType);
-      ports.push_back({b.getStringAttr("W" + Twine(i) + "_data"),
-                       PortDirection::INPUT, bDataType, inputPin++});
-      // Ignore mask port, if maskBits =1
-      if (mem.isMasked)
-        ports.push_back({b.getStringAttr("W" + Twine(i) + "_mask"),
-                         PortDirection::INPUT, maskType, inputPin++});
-    }
-
-    // Mask granularity is the number of data bits that each mask bit can
-    // guard. By default it is equal to the data bitwidth.
-    auto maskGran = mem.isMasked ? mem.dataWidth / mem.maskBits : mem.dataWidth;
-    NamedAttribute genAttrs[] = {
-        b.getNamedAttr("depth", b.getI64IntegerAttr(mem.depth)),
-        b.getNamedAttr("numReadPorts", b.getUI32IntegerAttr(mem.numReadPorts)),
-        b.getNamedAttr("numWritePorts",
-                       b.getUI32IntegerAttr(mem.numWritePorts)),
-        b.getNamedAttr("numReadWritePorts",
-                       b.getUI32IntegerAttr(mem.numReadWritePorts)),
-        b.getNamedAttr("readLatency", b.getUI32IntegerAttr(mem.readLatency)),
-        b.getNamedAttr("writeLatency", b.getUI32IntegerAttr(mem.writeLatency)),
-        b.getNamedAttr("width", b.getUI32IntegerAttr(mem.dataWidth)),
-        b.getNamedAttr("maskGran", b.getUI32IntegerAttr(maskGran)),
-        b.getNamedAttr("readUnderWrite",
-                       seq::RUWAttr::get(b.getContext(), mem.readUnderWrite)),
-        b.getNamedAttr("writeUnderWrite",
-                       seq::WUWAttr::get(b.getContext(), mem.writeUnderWrite)),
-        b.getNamedAttr("writeClockIDs", b.getI32ArrayAttr(mem.writeClockIDs)),
-        b.getNamedAttr("initFilename",
-                       mem.init ? mem.init.getFilename() : b.getStringAttr("")),
-        b.getNamedAttr(
-            "initIsBinary",
-            b.getBoolAttr(mem.init ? mem.init.getIsBinary() : false)),
-        b.getNamedAttr(
-            "initIsInline",
-            b.getBoolAttr(mem.init ? mem.init.getIsInline() : false))};
-
-    // Make the global module for the memory
-    // Set a name for the memory wrapper module, the combMem is an arbitrary
-    // suffix. It is important to derive the name from the original MemOp name,
-    // to respect the corresponding prefixes..
-    auto memoryName = b.getStringAttr(
-        namesp.newName((mem.prefix ? mem.prefix.getValue() : "") +
-                       cast<MemOp>(mem.op).getName() + "_combMem"));
-    // Now record this generated name for the corresponding FirMemory name,
-    // because all the memories that have the same FirMemory name, will now use
-    // this new generated name at the Instance Op. Basically this is the name
-    // used for all the deduped memories.
-    state.memoryNameMap[mem.getFirMemoryName()] = memoryName;
-    auto genOp = b.create<hw::HWModuleGeneratedOp>(
-        mem.loc, memorySchema, memoryName, ports, StringRef(), ArrayAttr(),
-        genAttrs);
-    // Also set the appropriate directory.
-    if (!mem.isInDut)
-      if (auto testBenchDir = state.getTestBenchDirectory())
-        genOp->setAttr("output_file", testBenchDir);
-  }
 }
 
 /// Emit the file header that defines a bunch of macros.
@@ -3000,7 +2810,7 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
     sv::setSVAttributes(reg, svAttrs);
 
   inputEdge.setValue(reg);
-  circuitState.used_RANDOMIZE_REG_INIT = 1;
+  circuitState.used_RANDOMIZE_REG_INIT = true;
   (void)setLowering(op.getResult(), reg);
   return success();
 }
@@ -3049,17 +2859,13 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
     sv::setSVAttributes(reg, svAttrs);
 
   inputEdge.setValue(reg);
-  circuitState.used_RANDOMIZE_REG_INIT = 1;
+  circuitState.used_RANDOMIZE_REG_INIT = true;
   (void)setLowering(op.getResult(), reg);
 
   return success();
 }
 
 LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
-  auto memName = op.getName();
-  if (memName.empty())
-    memName = "mem";
-
   // TODO: Remove this restriction and preserve aggregates in
   // memories.
   if (isa<BundleType>(op.getDataType()))
@@ -3072,154 +2878,115 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
 
   FirMemory memSummary = op.getSummary();
 
-  // Process each port in turn.
-  SmallVector<Type, 8> resultTypes;
-  SmallVector<Value, 8> operands;
-  DenseMap<Operation *, size_t> returnHolder;
-  SmallVector<Attribute> argNames, resultNames;
+  // Create the memory declaration.
+  auto memType = seq::FirMemType::get(
+      op.getContext(), memSummary.depth, memSummary.dataWidth,
+      memSummary.isMasked ? std::optional<uint32_t>(memSummary.maskBits)
+                          : std::optional<uint32_t>());
 
-  // The result values of the memory are not necessarily in the same order as
-  // the memory module that we're lowering to.  We need to lower the read
-  // ports before the read/write ports, before the write ports.
-  for (unsigned memportKindIdx = 0; memportKindIdx != 3; ++memportKindIdx) {
-    MemOp::PortKind memportKind;
-    switch (memportKindIdx) {
-    default:
-      assert(0 && "invalid idx");
-      break; // Silence warning
-    case 0:
-      memportKind = MemOp::PortKind::Read;
-      break;
-    case 1:
-      memportKind = MemOp::PortKind::ReadWrite;
-      break;
-    case 2:
-      memportKind = MemOp::PortKind::Write;
-      break;
-    }
+  seq::FirMemInitAttr memInit;
+  if (auto init = op.getInitAttr())
+    memInit = seq::FirMemInitAttr::get(init.getContext(), init.getFilename(),
+                                       init.getIsBinary(), init.getIsInline());
 
-    // This is set to the count of the kind of memport we're emitting, for
-    // label names.
-    unsigned portNumber = 0;
+  auto memDecl = builder.create<seq::FirMemOp>(
+      memType, memSummary.readLatency, memSummary.writeLatency,
+      memSummary.readUnderWrite, memSummary.writeUnderWrite, op.getNameAttr(),
+      getInnerSymName(op), memInit, op.getPrefixAttr(), Attribute{});
 
-    // Memories return multiple structs, one for each port, which means we
-    // have two layers of type to split apart.
-    for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
-      // Process all of one kind before the next.
-      if (memportKind != op.getPortKind(i))
-        continue;
+  // If the module is outside the DUT, set the appropriate output directory for
+  // the memory.
+  if (!circuitState.isInDUT(theModule))
+    if (auto testBenchDir = circuitState.getTestBenchDirectory())
+      memDecl.setOutputFileAttr(testBenchDir);
 
-      auto addInput = [&](StringRef portLabel, StringRef portLabel2,
-                          StringRef field, size_t width,
-                          StringRef field2 = "") {
-        auto portType =
-            IntegerType::get(op.getContext(), std::max((size_t)1, width));
+  // Memories return multiple structs, one for each port, which means we
+  // have two layers of type to split apart.
+  for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
+    auto addInput = [&](StringRef field, size_t width,
+                        StringRef field2 = "") -> Value {
+      auto portType =
+          IntegerType::get(op.getContext(), std::max<size_t>(1, width));
 
-        Value backedge = createBackedge(builder.getLoc(), portType);
-        auto accesses = getAllFieldAccesses(op.getResult(i), field);
-        for (auto a : accesses) {
+      Value backedge = createBackedge(builder.getLoc(), portType);
+      auto accesses = getAllFieldAccesses(op.getResult(i), field);
+
+      for (auto a : accesses) {
+        if (a.getType()
+                .cast<FIRRTLBaseType>()
+                .getPassiveType()
+                .getBitWidthOrSentinel() > 0)
+          (void)setLowering(a, backedge);
+        else
+          a->eraseOperand(0);
+      }
+
+      // This handles the case, when the single bit mask field is removed,
+      // and the enable is updated after 'And' with mask bit.
+      if (!field2.empty()) {
+        Value backedge2 = createBackedge(builder.getLoc(), portType);
+        auto accesses2 = getAllFieldAccesses(op.getResult(i), field2);
+        for (auto a : accesses2) {
           if (cast<FIRRTLBaseType>(a.getType())
                   .getPassiveType()
                   .getBitWidthOrSentinel() > 0)
-            (void)setLowering(a, backedge);
+            (void)setLowering(a, backedge2);
           else
             a->eraseOperand(0);
         }
-
-        if (!field2.empty()) {
-          // This handles the case, when the single bit mask field is removed,
-          // and the enable is updated after 'And' with mask bit.
-          auto backedge2 = createBackedge(builder.getLoc(), portType);
-          auto accesses2 = getAllFieldAccesses(op.getResult(i), field2);
-          for (auto a : accesses2) {
-            if (cast<FIRRTLBaseType>(a.getType())
-                    .getPassiveType()
-                    .getBitWidthOrSentinel() > 0)
-              (void)setLowering(a, backedge2);
-            else
-              a->eraseOperand(0);
-          }
-          backedge =
-              builder.createOrFold<comb::AndOp>(backedge, backedge2, true);
-        }
-
-        operands.push_back(backedge);
-        argNames.push_back(
-            builder.getStringAttr(portLabel + Twine(portNumber) + portLabel2));
-      };
-      auto addOutput = [&](StringRef portLabel, StringRef portLabel2,
-                           StringRef field, size_t width) {
-        auto portType =
-            IntegerType::get(op.getContext(), std::max((size_t)1, width));
-        resultTypes.push_back(portType);
-
-        // Now collect the data for the instance.  A op produces multiple
-        // structures, so we need to look through SubfieldOps to see the
-        // true inputs and outputs.
-        auto accesses = getAllFieldAccesses(op.getResult(i), field);
-        // Read data ports are tracked to be updated later
-        for (auto &a : accesses) {
-          if (width)
-            returnHolder[a] = resultTypes.size() - 1;
-          else
-            a->eraseOperand(0);
-        }
-        resultNames.push_back(
-            builder.getStringAttr(portLabel + Twine(portNumber) + portLabel2));
-      };
-
-      if (memportKind == MemOp::PortKind::Read) {
-        addInput("R", "_addr", "addr", llvm::Log2_64_Ceil(memSummary.depth));
-        addInput("R", "_en", "en", 1);
-        addInput("R", "_clk", "clk", 1);
-        addOutput("R", "_data", "data", memSummary.dataWidth);
-      } else if (memportKind == MemOp::PortKind::ReadWrite) {
-        addInput("RW", "_addr", "addr", llvm::Log2_64_Ceil(memSummary.depth));
-        addInput("RW", "_en", "en", 1);
-        addInput("RW", "_clk", "clk", 1);
-        // If maskBits =1, then And the mask field with enable, and update the
-        // enable. Else keep mask port.
-        if (memSummary.isMasked)
-          addInput("RW", "_wmode", "wmode", 1);
-        else
-          addInput("RW", "_wmode", "wmode", 1, "wmask");
-        addInput("RW", "_wdata", "wdata", memSummary.dataWidth);
-        addOutput("RW", "_rdata", "rdata", memSummary.dataWidth);
-        // Ignore mask port, if maskBits =1
-        if (memSummary.isMasked)
-          addInput("RW", "_wmask", "wmask", memSummary.maskBits);
-      } else {
-        addInput("W", "_addr", "addr", llvm::Log2_64_Ceil(memSummary.depth));
-        // If maskBits =1, then And the mask field with enable, and update the
-        // enable. Else keep mask port.
-        if (memSummary.isMasked)
-          addInput("W", "_en", "en", 1);
-        else
-          addInput("W", "_en", "en", 1, "mask");
-        addInput("W", "_clk", "clk", 1);
-        addInput("W", "_data", "data", memSummary.dataWidth);
-        // Ignore mask port, if maskBits =1
-        if (memSummary.isMasked)
-          addInput("W", "_mask", "mask", memSummary.maskBits);
+        backedge = builder.createOrFold<comb::AndOp>(backedge, backedge2, true);
       }
+      return backedge;
+    };
 
-      ++portNumber;
+    auto addOutput = [&](StringRef field, size_t width, Value value) {
+      auto accesses = getAllFieldAccesses(op.getResult(i), field);
+      for (auto &a : accesses) {
+        if (width > 0)
+          (void)setLowering(a, value);
+        else
+          a->eraseOperand(0);
+      }
+    };
+
+    auto memportKind = op.getPortKind(i);
+    if (memportKind == MemOp::PortKind::Read) {
+      auto addr = addInput("addr", llvm::Log2_64_Ceil(memSummary.depth));
+      auto en = addInput("en", 1);
+      auto clk = addInput("clk", 1);
+      auto data = builder.create<seq::FirMemReadOp>(memDecl, addr, clk, en);
+      addOutput("data", memSummary.dataWidth, data);
+    } else if (memportKind == MemOp::PortKind::ReadWrite) {
+      auto addr = addInput("addr", llvm::Log2_64_Ceil(memSummary.depth));
+      auto en = addInput("en", 1);
+      auto clk = addInput("clk", 1);
+      // If maskBits =1, then And the mask field with enable, and update the
+      // enable. Else keep mask port.
+      auto mode = addInput("wmode", 1, memSummary.isMasked ? "" : "wmask");
+      auto wdata = addInput("wdata", memSummary.dataWidth);
+      // Ignore mask port, if maskBits =1
+      Value mask;
+      if (memSummary.isMasked)
+        mask = addInput("wmask", memSummary.maskBits);
+      auto rdata = builder.create<seq::FirMemReadWriteOp>(
+          memDecl, addr, clk, en, wdata, mode, mask);
+      addOutput("rdata", memSummary.dataWidth, rdata);
+    } else {
+      auto addr = addInput("addr", llvm::Log2_64_Ceil(memSummary.depth));
+      // If maskBits =1, then And the mask field with enable, and update the
+      // enable. Else keep mask port.
+      auto en = addInput("en", 1, memSummary.isMasked ? "" : "mask");
+      auto clk = addInput("clk", 1);
+      auto data = addInput("data", memSummary.dataWidth);
+      // Ignore mask port, if maskBits =1
+      Value mask;
+      if (memSummary.isMasked)
+        mask = addInput("mask", memSummary.maskBits);
+      builder.create<seq::FirMemWriteOp>(memDecl, addr, clk, en, data, mask);
     }
   }
 
-  auto memModuleAttr =
-      circuitState.getGenOpMemName(memSummary.getFirMemoryName());
-
-  // Create the instance to replace the memop.
-  auto inst = builder.create<hw::InstanceOp>(
-      resultTypes, builder.getStringAttr(memName + "_ext"), memModuleAttr,
-      operands, builder.getArrayAttr(argNames),
-      builder.getArrayAttr(resultNames),
-      /*parameters=*/builder.getArrayAttr({}),
-      /*sym_name=*/getInnerSymName(op));
-  // Update all users of the result of read ports
-  for (auto &ret : returnHolder)
-    (void)setLowering(ret.first->getResult(0), inst.getResult(ret.second));
+  circuitState.used_RANDOMIZE_MEM_INIT = true;
   return success();
 }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
@@ -1,0 +1,199 @@
+// RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics %s | FileCheck %s --check-prefix CHECK --check-prefix RANDOMIZE
+// RUN: circt-opt --lower-firrtl-to-hw=disable-mem-randomization --verify-diagnostics %s | FileCheck %s
+
+// RANDOMIZE: sv.ifdef "RANDOMIZE"
+// RANDOMIZE-NEXT: else
+// RANDOMIZE-NEXT: sv.ifdef "RANDOMIZE_MEM_INIT"
+// RANDOMIZE-NEXT: sv.macro.def @RANDOMIZE ""
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: hw.module @Foo
+  firrtl.module @Foo(
+    in %clk: !firrtl.clock,
+    in %en: !firrtl.uint<1>,
+    in %addr: !firrtl.uint<4>,
+    in %wdata: !firrtl.uint<42>,
+    in %wmode: !firrtl.uint<1>,
+    in %mask2: !firrtl.uint<2>,
+    in %mask3: !firrtl.uint<3>,
+    in %mask6: !firrtl.uint<6>
+  ) {
+    // CHECK-NEXT: %mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_port %mem1[%addr], clock %clk enable %en :
+    // CHECK-NEXT: hw.wire [[RDATA]] sym @mem1_data
+    %mem1_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.clk = firrtl.subfield %mem1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.en = firrtl.subfield %mem1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.addr = firrtl.subfield %mem1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem1_r.data = firrtl.subfield %mem1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.strictconnect %mem1_r.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem1_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem1_r.addr, %addr : !firrtl.uint<4>
+    %mem1_data = firrtl.node sym @mem1_data %mem1_r.data : !firrtl.uint<42>
+
+    // CHECK-NEXT: %mem2 = seq.firmem 1, 2, old, port_order : <13 x 42, mask 2>
+    // CHECK-NEXT: seq.firmem.write_port %mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 :
+    %mem2_w = firrtl.mem Old {depth = 13 : i64, name = "mem2", portNames = ["w"], readLatency = 1 : i32, writeLatency = 2 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.clk = firrtl.subfield %mem2_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.en = firrtl.subfield %mem2_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.addr = firrtl.subfield %mem2_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.data = firrtl.subfield %mem2_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    %mem2_w.mask = firrtl.subfield %mem2_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
+    firrtl.strictconnect %mem2_w.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem2_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem2_w.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem2_w.data, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem2_w.mask, %mask2 : !firrtl.uint<2>
+
+    // CHECK-NEXT: %mem3 = seq.firmem 3, 2, new, port_order : <14 x 42, mask 3>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 :
+    // CHECK-NEXT: hw.wire [[RDATA]] sym @mem3_data
+    %mem3_rw = firrtl.mem New {depth = 14 : i64, name = "mem3", portNames = ["rw"], readLatency = 3 : i32, writeLatency = 2 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.clk = firrtl.subfield %mem3_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.en = firrtl.subfield %mem3_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.addr = firrtl.subfield %mem3_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wdata = firrtl.subfield %mem3_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.rdata = firrtl.subfield %mem3_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wmask = firrtl.subfield %mem3_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    %mem3_rw.wmode = firrtl.subfield %mem3_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
+    firrtl.strictconnect %mem3_rw.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem3_rw.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem3_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem3_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem3_rw.wmask, %mask3 : !firrtl.uint<3>
+    firrtl.strictconnect %mem3_rw.wmode, %wmode : !firrtl.uint<1>
+    %mem3_data = firrtl.node sym @mem3_data %mem3_rw.rdata : !firrtl.uint<42>
+
+    // CHECK-NEXT: %mem4 = seq.firmem 4, 5, undefined, port_order : <15 x 42, mask 6>
+    // CHECK-NEXT: [[RDATA1:%.+]] = seq.firmem.read_port %mem4[%addr], clock %clk enable %en :
+    // CHECK-NEXT: seq.firmem.write_port %mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 :
+    // CHECK-NEXT: [[RDATA2:%.+]] = seq.firmem.read_write_port %mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 :
+    // CHECK-NEXT: hw.wire [[RDATA1]] sym @mem4_data0
+    // CHECK-NEXT: hw.wire [[RDATA2]] sym @mem4_data1
+    %mem4_r, %mem4_w, %mem4_rw = firrtl.mem Undefined {depth = 15 : i64, name = "mem4", portNames = ["r", "w", "rw"], readLatency = 4 : i32, writeLatency = 5 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.clk = firrtl.subfield %mem4_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.clk = firrtl.subfield %mem4_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.clk = firrtl.subfield %mem4_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.en = firrtl.subfield %mem4_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.en = firrtl.subfield %mem4_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.en = firrtl.subfield %mem4_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.addr = firrtl.subfield %mem4_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_w.addr = firrtl.subfield %mem4_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.addr = firrtl.subfield %mem4_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_w.data = firrtl.subfield %mem4_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.wdata = firrtl.subfield %mem4_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_r.data = firrtl.subfield %mem4_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem4_rw.rdata = firrtl.subfield %mem4_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_w.mask = firrtl.subfield %mem4_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
+    %mem4_rw.wmask = firrtl.subfield %mem4_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    %mem4_rw.wmode = firrtl.subfield %mem4_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
+    firrtl.strictconnect %mem4_r.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_w.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_rw.clk, %clk : !firrtl.clock
+    firrtl.strictconnect %mem4_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_rw.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem4_r.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_w.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.strictconnect %mem4_w.data, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem4_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.strictconnect %mem4_w.mask, %mask6 : !firrtl.uint<6>
+    firrtl.strictconnect %mem4_rw.wmask, %mask6 : !firrtl.uint<6>
+    firrtl.strictconnect %mem4_rw.wmode, %wmode : !firrtl.uint<1>
+    %mem4_data0 = firrtl.node sym @mem4_data0 %mem4_r.data : !firrtl.uint<42>
+    %mem4_data1 = firrtl.node sym @mem4_data1 %mem4_rw.rdata : !firrtl.uint<42>
+  }
+
+  // CHECK-LABEL: hw.module @ZeroDataWidth
+  firrtl.module @ZeroDataWidth(in %data: !firrtl.uint<0>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 0>
+    // CHECK: seq.firmem.write_port %mem[{{%.+}}] = {{%.+}}, clock {{.+}} enable {{%.+}} : <12 x 0>
+    %mem_w = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
+  }
+
+  // FIRRTL memories with a single mask bit for the entire word should lower to
+  // a memory without any mask, and instead have that single mask bit be merged
+  // into the enable condition on the write port.
+  //
+  // CHECK-LABEL: hw.module @FoldSingleMaskBitIntoEnable
+  firrtl.module @FoldSingleMaskBitIntoEnable(in %en: !firrtl.uint<1>, in %mask: !firrtl.uint<1>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK: [[TMP:%.+]] = comb.and bin %en, %mask :
+    // CHECK: seq.firmem.write_port %mem[{{%.+}}] = {{%.+}}, clock {{%.+}} enable [[TMP]] :
+    %mem_w = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    %mem_w.en = firrtl.subfield %mem_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    %mem_w.mask = firrtl.subfield %mem_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+    firrtl.strictconnect %mem_w.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem_w.mask, %mask : !firrtl.uint<1>
+  }
+
+  // FIRRTL memories with a single mask bit for the entire word should lower to
+  // a memory without any mask, and instead have that single mask bit be merged
+  // into the mode operand on the read-write port.
+  //
+  // CHECK-LABEL: hw.module @FoldSingleMaskBitIntoMode
+  firrtl.module @FoldSingleMaskBitIntoMode(in %mode: !firrtl.uint<1>, in %mask: !firrtl.uint<1>) {
+    // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK: [[TMP:%.+]] = comb.and bin %mode, %mask :
+    // CHECK: seq.firmem.read_write_port %mem[{{%.+}}] = {{%.+}} if [[TMP]], clock {{%.+}} enable {{%.+}} :
+    %mem_rw = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %mem_rw.wmode = firrtl.subfield %mem_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %mem_rw.wmask = firrtl.subfield %mem_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    firrtl.strictconnect %mem_rw.wmode, %mode : !firrtl.uint<1>
+    firrtl.strictconnect %mem_rw.wmask, %mask : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: hw.module @MemInit
+  firrtl.module @MemInit() {
+    // CHECK: %mem1 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", false, false>
+    %mem1_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", false, false>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    // CHECK: %mem2 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", false, true>
+    %mem2_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem2", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", false, true>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    // CHECK: %mem3 = seq.firmem
+    // CHECK-SAME: init = #seq.firmem.init<"mem.txt", true, false>
+    %mem3_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem3", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32, init = #firrtl.meminit<"mem.txt", true, false>} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+  }
+
+  // CHECK-LABEL: hw.module @IncompleteRead
+  firrtl.module @IncompleteRead(
+    in %clock: !firrtl.clock,
+    in %addr: !firrtl.uint<4>,
+    in %en: !firrtl.uint<1>
+  ) {
+    // The read port has no use of the data field.
+    //
+    // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+    // CHECK-NEXT: seq.firmem.read_port %mem[%addr], clock %clock enable %en :
+    %mem_r = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.clk = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.en = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.addr = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.strictconnect %mem_r.clk, %clock : !firrtl.clock
+    firrtl.strictconnect %mem_r.en, %en : !firrtl.uint<1>
+    firrtl.strictconnect %mem_r.addr, %addr : !firrtl.uint<4>
+  }
+
+  // CHECK-LABEL: hw.module @Depth1
+  firrtl.module @Depth1(
+    in %clock: !firrtl.clock,
+    in %addr: !firrtl.uint<1>,
+    in %en: !firrtl.uint<1>,
+    out %data: !firrtl.uint<42>
+  ) {
+    // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, port_order : <1 x 42>
+    // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_port %mem[%addr], clock %clock enable %en :
+    // CHECK-NEXT: hw.output [[RDATA]]
+    %mem_r = firrtl.mem Undefined {depth = 1 : i64, name = "mem", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.clk = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.addr = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.en = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %mem_r.data = firrtl.subfield %mem_r[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<42>>
+    firrtl.connect %mem_r.clk, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %mem_r.addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %mem_r.en, %en : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %data, %mem_r.data : !firrtl.uint<42>, !firrtl.uint<42>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1,7 +1,5 @@
 // RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw)" -verify-diagnostics %s | FileCheck %s
-// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM
 // RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_REG
-// RUN: circt-opt -pass-pipeline="builtin.module(lower-firrtl-to-hw{disable-mem-randomization disable-reg-randomization})" -verify-diagnostics %s | FileCheck %s --check-prefix DISABLE_RANDOM --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
 
 // DISABLE_RANDOM-LABEL: module @Simple
 firrtl.circuit "Simple"   attributes {annotations = [{class =
@@ -46,16 +44,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:     sv.macro.def @INIT_RANDOM_PROLOG_ ""
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-
-  //These come from MemSimple, IncompleteRead, and MemDepth1
-  // CHECK-LABEL: hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
-  // CHECK: hw.module.generated @aa_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @ab_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @mem0_combMem, @FIRRTLMem(%R0_addr: i1, %R0_en: i1, %R0_clk: i1) -> (R0_data: i32) attributes {depth = 1 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 32 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 1 : i32, width = 32 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @tbMemoryKind1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8) -> (R0_data: i8) attributes {depth = 16 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_mask_combMem, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1, %RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i40, %RW0_wmask: i4, %W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i40, %W0_mask: i4) -> (R0_data: i40, RW0_rdata: i40) attributes {depth = 1022 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 10 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : i32, width = 40 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK: hw.module.generated @_M_combMem_0, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
   // CHECK-LABEL: hw.module @Simple
   firrtl.module @Simple(in %in1: !firrtl.uint<4>,
@@ -665,158 +653,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
   }
 
-  //  module MemSimple :
-  //     input clock1  : Clock
-  //     input clock2  : Clock
-  //     input inpred  : UInt<1>
-  //     input indata  : SInt<42>
-  //     output result : SInt<42>
-  //     output result2 : SInt<42>
-  //
-  //     mem _M : @[Decoupled.scala 209:27]
-  //           data-type => SInt<42>
-  //           depth => 12
-  //           read-latency => 0
-  //           write-latency => 1
-  //           reader => read
-  //           writer => write
-  //           readwriter => rw
-  //           read-under-write => undefined
-  //
-  //     result <= _M.read.data
-  //     result2 <= _M.rw.rdata
-  //
-  //     _M.read.addr <= UInt<1>("h0")
-  //     _M.read.en <= UInt<1>("h1")
-  //     _M.read.clk <= clock1
-  //     _M.rw.addr <= UInt<1>("h0")
-  //     _M.rw.en <= UInt<1>("h1")
-  //     _M.rw.clk <= clock1
-  //     _M.rw.wmask <= UInt<1>("h1")
-  //     _M.rw.wmode <= UInt<1>("h1")
-  //     _M.write.addr <= validif(inpred, UInt<3>("h0"))
-  //     _M.write.en <= mux(inpred, UInt<1>("h1"), UInt<1>("h0"))
-  //     _M.write.clk <= clock2
-  //     _M.write.data <= validif(inpred, indata)
-  //     _M.write.mask <= validif(inpred, UInt<1>("h1"))
-
-  // CHECK-LABEL: hw.module private @MemSimple(
-  firrtl.module private @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
-                           in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>,
-                           out %result: !firrtl.sint<42>,
-                           out %result2: !firrtl.sint<42>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-  // CHECK: %[[v1:.+]] = comb.and bin %true, %inpred : i1
-  // CHECK: %[[v2:.+]] = comb.and bin %inpred, %true : i1
-  // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @_M_combMem_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %[[v1]]: i1, RW0_wdata: %indata: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
-  // CHECK: hw.output %_M_ext.R0_data, %_M_ext.RW0_rdata : i42, i42
-
-      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
-      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %result2, %1 : !firrtl.sint<42>, !firrtl.sint<42>
-      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-      firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
-
-      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %5, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %8, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %10 = firrtl.subfield %_M_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>
-      firrtl.connect %10, %indata : !firrtl.sint<42>, !firrtl.sint<42>
-
-      %11 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %11, %c0_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
-      %12 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %12, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %13 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %13, %clock2 : !firrtl.clock, !firrtl.clock
-      %14 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %14, %indata : !firrtl.sint<42>, !firrtl.sint<42>
-      %15 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
-      firrtl.connect %15, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-
-  // CHECK-LABEL: hw.module private @MemSimple_mask(
-  firrtl.module private @MemSimple_mask(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
-                           in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<40>,
-                           out %result: !firrtl.sint<40>,
-                           out %result2: !firrtl.sint<40>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c0_ui10 = firrtl.constant 0 : !firrtl.uint<10>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-    %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
-    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 1022 : i64, name = "_M_mask", portNames = ["read", "rw", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-    // CHECK: %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata = hw.instance "_M_mask_ext" @_M_mask_combMem(R0_addr: %c0_i10: i10, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i10: i10, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %indata: i40, RW0_wmask: %c0_i4: i4, W0_addr: %c0_i10: i10, W0_en: %inpred: i1, W0_clk: %clock2: i1, W0_data: %indata: i40, W0_mask: %c0_i4: i4) -> (R0_data: i40, RW0_rdata: i40)
-    // CHECK: hw.output %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata : i40, i40
-
-      %0 = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %result, %0 : !firrtl.sint<40>, !firrtl.sint<40>
-      %1 = firrtl.subfield %_M_rw[rdata] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %result2, %1 : !firrtl.sint<40>, !firrtl.sint<40>
-      %2 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %2, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %3 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>
-      firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
-
-      %5 = firrtl.subfield %_M_rw[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>,  wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %5, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %6 = firrtl.subfield %_M_rw[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw[wmask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %8, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-      %9 = firrtl.subfield %_M_rw[wmode] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %10 = firrtl.subfield %_M_rw[wdata] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>
-      firrtl.connect %10, %indata : !firrtl.sint<40>, !firrtl.sint<40>
-
-      %11 = firrtl.subfield %_M_write[addr] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %11, %c0_ui10 : !firrtl.uint<10>, !firrtl.uint<10>
-      %12 = firrtl.subfield %_M_write[en] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %12, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
-      %13 = firrtl.subfield %_M_write[clk] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %13, %clock2 : !firrtl.clock, !firrtl.clock
-      %14 = firrtl.subfield %_M_write[data] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %14, %indata : !firrtl.sint<40>, !firrtl.sint<40>
-      %15 = firrtl.subfield %_M_write[mask] : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-      firrtl.connect %15, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
-  }
-  // CHECK-LABEL: hw.module private @IncompleteRead(
-  // The read port has no use of the data field.
-  firrtl.module private @IncompleteRead(in %clock1: !firrtl.clock) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-
-    // CHECK:  %_M_ext.R0_data = hw.instance "_M_ext" @_M_combMem(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1) -> (R0_data: i42)
-    %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    // Read port.
-    %6 = firrtl.subfield %_M_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %6, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
-    %7 = firrtl.subfield %_M_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %8 = firrtl.subfield %_M_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
-    firrtl.connect %8, %clock1 : !firrtl.clock, !firrtl.clock
-  }
-
   // CHECK-LABEL: hw.module private @top_modx() -> (tmp27: i23) {
   // CHECK-NEXT:    %c0_i23 = hw.constant 0 : i23
   // CHECK-NEXT:    %c42_i23 = hw.constant 42 : i23
@@ -935,22 +771,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %2 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>
   }
 
-  // CHECK-LABEL: hw.module private @MemDepth1
-  firrtl.module private @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
-                           in %addr: !firrtl.uint<1>, out %data: !firrtl.uint<32>) {
-    // CHECK: %mem0_ext.R0_data = hw.instance "mem0_ext" @mem0_combMem(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
-    // CHECK: hw.output %mem0_ext.R0_data : i32
-    %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %0 = firrtl.subfield %mem0_load0[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
-    %1 = firrtl.subfield %mem0_load0[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.subfield %mem0_load0[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %data, %2 : !firrtl.uint<32>, !firrtl.uint<32>
-    %3 = firrtl.subfield %mem0_load0[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
-}
-
   // https://github.com/llvm/circt/issues/1115
   // CHECK-LABEL: hw.module private @issue1115
   firrtl.module private @issue1115(in %a: !firrtl.sint<20>, out %tmp59: !firrtl.sint<2>) {
@@ -1003,47 +823,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %chckcoverAnno_clock = firrtl.instance chkcoverAnno @chkcoverAnno(in clock: !firrtl.clock)
-  }
-
-  // CHECK-LABEL: hw.module private @MemoryWritePortBehavior
-  firrtl.module private @MemoryWritePortBehavior(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
-    // This memory has both write ports driven by the same clock.  It should be
-    // lowered to an "aa" memory. Even if the clock is passed via different wires,
-    // we should identify the clocks to be same.
-    //
-    // CHECK: hw.instance "aa_ext" @aa_combMem
-    %memory_aa_w0, %memory_aa_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "aa", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_aa_w0 = firrtl.subfield %memory_aa_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_aa_w1 = firrtl.subfield %memory_aa_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %cwire1 = firrtl.wire : !firrtl.clock
-    %cwire2 = firrtl.wire : !firrtl.clock
-    firrtl.connect %cwire1, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %cwire2, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_aa_w0, %cwire1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_aa_w1, %cwire2 : !firrtl.clock, !firrtl.clock
-
-    // This memory has different clocks for each write port.  It should be
-    // lowered to an "ab" memory.
-    //
-    // CHECK: hw.instance "ab_ext" @ab_combMem
-    %memory_ab_w0, %memory_ab_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_w0 = firrtl.subfield %memory_ab_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_w1 = firrtl.subfield %memory_ab_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    firrtl.connect %clk_ab_w0, %clock1 : !firrtl.clock, !firrtl.clock
-    firrtl.connect %clk_ab_w1, %clock2 : !firrtl.clock, !firrtl.clock
-
-    // This memory is the same as the first memory, but a node is used to alias
-    // the second write port clock (e.g., this could be due to a dont touch
-    // annotation blocking this from being optimized away).  This should be
-    // lowered to an "aa" since they are identical.
-    //
-    // CHECK: hw.instance "ab_node_ext" @aa_combMem
-    %memory_ab_node_w0, %memory_ab_node_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab_node", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_node_w0 = firrtl.subfield %memory_ab_node_w0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %clk_ab_node_w1 = firrtl.subfield %memory_ab_node_w1[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    firrtl.connect %clk_ab_node_w0, %clock1 : !firrtl.clock, !firrtl.clock
-    %tmp = firrtl.node %clock1 : !firrtl.clock
-    firrtl.connect %clk_ab_node_w1, %tmp : !firrtl.clock, !firrtl.clock
   }
 
   // CHECK-LABEL: hw.module private @AsyncResetBasic(
@@ -1117,7 +896,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
     // CHECK: %regResetName = seq.firreg %regResetName clock %clock sym @regResetSym reset sync %reset, %value : i42
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    // CHECK: {{%.+}} = hw.instance "memName_ext" sym @memSym
+    // CHECK: %memName = seq.firmem sym @memSym 0, 1, undefined, port_order : <12 x 42>
     firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -1265,32 +1044,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %4 = hw.array_get %3[%index]
     // CHECK-NEXT: hw.output %4 : i1
   }
-
-  firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
-    %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %0 = firrtl.subfield %tbMemoryKind1_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %1 = firrtl.subfield %tbMemoryKind1_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %2 = firrtl.subfield %tbMemoryKind1_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %3 = firrtl.subfield %tbMemoryKind1_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %4 = firrtl.subfield %tbMemoryKind1_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    %5 = firrtl.subfield %tbMemoryKind1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %6 = firrtl.subfield %tbMemoryKind1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %7 = firrtl.subfield %tbMemoryKind1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    %8 = firrtl.subfield %tbMemoryKind1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    firrtl.connect %8, %clock : !firrtl.clock, !firrtl.clock
-    firrtl.connect %7, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %6, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    firrtl.connect %rData, %5 : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
-    firrtl.connect %3, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %2, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
-    firrtl.connect %1, %wMask : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %0, %wData : !firrtl.uint<8>, !firrtl.uint<8>
-  }
-  // CHECK-LABEL: hw.module private @inferUnmaskedMemory
-  // CHECK-NEXT:   %[[v0:.+]] = comb.and bin %rEn, %wMask : i1
-  // CHECK-NEXT:   %tbMemoryKind1_ext.R0_data = hw.instance "tbMemoryKind1_ext" @tbMemoryKind1_combMem(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
-  // CHECK-NEXT:   hw.output %tbMemoryKind1_ext.R0_data : i8
 
   // CHECK-LABEL: hw.module private @eliminateSingleOutputConnects
   // CHECK-NOT:     [[WIRE:%.+]] = sv.wire

--- a/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
+++ b/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
@@ -31,7 +31,7 @@ circuit Foo :
       ; INIT_OUTLINE-NEXT;   */
       ; INIT_OUTLINE:        endmodule
       ;
-      ; INIT_OUTLINE:      FILE "m_combMem_init.sv"
+      ; INIT_OUTLINE:      FILE "[[memoryModule]]_init.sv"
       ; INIT_OUTLINE-NOT:  FILE
       ; INIT_OUTLINE:      module [[bindModule]]();
       ; INIT_OUTLINE:        initial

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -1,64 +1,72 @@
 // RUN: circt-opt --lower-seq-firmem %s --verify-diagnostics | FileCheck %s
 
-// hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
-// hw.module.generated @mem_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem3_combMem, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem_combMem_0, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i1) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 0 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 0 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem_combMem_1, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem2_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// hw.module.generated @mem4_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs", "initFilename", "initIsBinary", "initIsInline"]
+
+// CHECK: hw.module.generated @m0_mem1_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem2_12x42, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem3_12x42, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem4_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK: hw.module.generated @m1_mem1_24x1337, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1337 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, output_file = "foo", readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1337 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m1_mem2_24x1337, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1337 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, output_file = "bar", readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1337 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK: hw.module.generated @foo_m2_mem1_24x9001, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 9001 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 9001 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @bar_m2_mem2_24x9001, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 9001 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 9001 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @uwu_m2_mem_24x9001, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 9001 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 9001 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK: hw.module.generated @m3_mem_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m3_mem2_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
-  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "mem1A_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
-  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "mem1B_ext" @mem1A_mem1B(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "m0_mem1A_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "m0_mem1B_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
-  %mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
-  %mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
-  %0 = seq.firmem.read_port %mem1A[%addr], clock %clk enable %en : <12 x 42>
-  %1 = seq.firmem.read_port %mem1B[%addr], clock %clk enable %en : <12 x 42>
+  %m0_mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %m0_mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
+  %0 = seq.firmem.read_port %m0_mem1A[%addr], clock %clk enable %en : <12 x 42>
+  %1 = seq.firmem.read_port %m0_mem1B[%addr], clock %clk enable %en : <12 x 42>
   comb.xor %0, %1 : i42
 
-  // CHECK-NEXT: hw.instance "mem2_ext" @mem2(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
-  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
-  seq.firmem.write_port %mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i2
+  // CHECK-NEXT: hw.instance "m0_mem2_ext" @m0_mem2_12x42(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
+  %m0_mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
+  seq.firmem.write_port %m0_mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i2
 
-  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "mem3_ext" @mem3(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "m0_mem3_ext" @m0_mem3_12x42(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP]]
-  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
-  %2 = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i3
+  %m0_mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
+  %2 = seq.firmem.read_write_port %m0_mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i3
   comb.xor %2 : i42
 
-  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "mem4_ext" @mem4(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "m0_mem4_ext" @m0_mem4_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
-  %mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
-  %3 = seq.firmem.read_port %mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>
-  %4 = seq.firmem.read_write_port %mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
-  seq.firmem.write_port %mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  %m0_mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
+  %3 = seq.firmem.read_port %m0_mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>
+  %4 = seq.firmem.read_write_port %m0_mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  seq.firmem.write_port %m0_mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
   comb.xor %3, %4 : i42
 }
 
 // CHECK-LABEL: hw.module @SeparateOutputFiles
 hw.module @SeparateOutputFiles() {
-  // CHECK-NEXT: hw.instance "mem1_ext" @mem1
-  // CHECK-NEXT: hw.instance "mem2_ext" @mem2
-  %mem1 = seq.firmem 0, 1, undefined, port_order {output_file = "foo"} : <24 x 1337>
-  %mem2 = seq.firmem 0, 1, undefined, port_order {output_file = "bar"} : <24 x 1337>
+  // CHECK-NEXT: hw.instance "m1_mem1_ext" @m1_mem1_24x1337(
+  // CHECK-NEXT: hw.instance "m1_mem2_ext" @m1_mem2_24x1337(
+  %m1_mem1 = seq.firmem 0, 1, undefined, port_order {output_file = "foo"} : <24 x 1337>
+  %m1_mem2 = seq.firmem 0, 1, undefined, port_order {output_file = "bar"} : <24 x 1337>
 }
 
 // CHECK-LABEL: hw.module @SeparatePrefices
 hw.module @SeparatePrefices() {
-  // CHECK-NEXT: hw.instance "mem1_ext" @foo_mem1
-  %mem1 = seq.firmem 0, 1, undefined, port_order {prefix = "foo_"} : <24 x 9001>
-  // CHECK-NEXT: hw.instance "mem2_ext" @bar_mem2
-  %mem2 = seq.firmem 0, 1, undefined, port_order {prefix = "bar_"} : <24 x 9001>
-  // CHECK-NEXT: hw.instance "mem3_ext" @uwu_mem3_mem4
-  // CHECK-NEXT: hw.instance "mem4_ext" @uwu_mem3_mem4
-  %mem3 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
-  %mem4 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "m2_mem1_ext" @foo_m2_mem1_24x9001(
+  %m2_mem1 = seq.firmem 0, 1, undefined, port_order {prefix = "foo_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "m2_mem2_ext" @bar_m2_mem2_24x9001(
+  %m2_mem2 = seq.firmem 0, 1, undefined, port_order {prefix = "bar_"} : <24 x 9001>
+  // CHECK-NEXT: hw.instance "m2_mem3_ext" @uwu_m2_mem_24x9001(
+  // CHECK-NEXT: hw.instance "m2_mem4_ext" @uwu_m2_mem_24x9001(
+  %m2_mem3 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
+  %m2_mem4 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
 }
-
 
 // CHECK-LABEL: hw.module @MemoryWritePortBehavior
 hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
@@ -70,28 +78,28 @@ hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
   // lowered to an "aa" memory. Even if the clock is passed via different
   // wires, we should identify the clocks to be same.
   //
-  // CHECK: hw.instance "mem1_ext" @mem1_mem3
-  %mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  // CHECK: hw.instance "m3_mem1_ext" @m3_mem_12x8
+  %m3_mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
   %cwire1 = hw.wire %clock1 : i1
   %cwire2 = hw.wire %clock1 : i1
-  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>
-  seq.firmem.write_port %mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>
 
   // This memory has different clocks for each write port. It should be
   // lowered to an "ab" memory.
   //
-  // CHECK: hw.instance "mem2_ext" @mem2
-  %mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
-  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
-  seq.firmem.write_port %mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>
+  // CHECK: hw.instance "m3_mem2_ext" @m3_mem2_12x8
+  %m3_mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>
 
   // This memory is the same as the first memory, but a node is used to alias
   // the second write port clock (e.g., this could be due to a dont touch
   // annotation blocking this from being optimized away). This should be
   // lowered to an "aa" since they are identical.
   //
-  // CHECK: hw.instance "mem3_ext" @mem1_mem3
-  %mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
-  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
-  seq.firmem.write_port %mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  // CHECK: hw.instance "m3_mem3_ext" @m3_mem_12x8
+  %m3_mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
+  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
 }

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -11,29 +11,31 @@ circuit test: %[[{
   }]]
   module test:
     input p: UInt<1>
-    input addr: UInt<4>
+    input addr1: UInt<4>
+    input addr2: UInt<4>
+    input addr3: UInt<4>
     input clock: Clock
     input data: UInt<8>
     output out0: UInt<8>
     output out1: UInt<8>
 
-    ; CHECK: testmem_combMem testmem_ext (
+    ; CHECK: testmem_16x8 testmem_ext (
     smem testmem : UInt<8>[16], undefined
 
     ; CHECK: .R0_en (1'h1)
-    node _T_0 = addr
+    node _T_0 = addr1
     when p:
       read mport testport0 = testmem[_T_0], clock
     out0 <= testport0
 
     ; CHECK: .R1_en (1'h1),
     wire _T_1: UInt<4>
-    _T_1 <= addr
+    _T_1 <= addr2
     when p:
       read mport testport1 = testmem[_T_1], clock
     out1 <= testport1
 
-    node writeAddr = addr
+    node writeAddr = addr3
     when p:
       write mport testport2 = testmem[writeAddr], clock
     testport2 <= data

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -41,7 +41,7 @@ circuit Foo : %[[
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix1_"
-    ; SIM-HW:       hw.instance "mem_ext" @prefix1_mem_combMem
+    ; SIM-HW:       hw.instance "mem_ext" @prefix1_mem
     mem mem :
       data-type => UInt<1>
       depth => 8
@@ -84,7 +84,7 @@ circuit Foo : %[[
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix2_"
-    ; SIM-HW:       hw.instance "mem_ext" @prefix2_mem_combMem
+    ; SIM-HW:       hw.instance "mem_ext" @prefix2_mem
     mem mem :
       data-type => UInt<1>
       depth => 8


### PR DESCRIPTION
Make `LowerToHW` emit `seq.firmem` operations for memories instead of emitting generator ops. These memory ops are then lowered to generator ops later in the firtool pipeline through the Seq `LowerFirMem` pass, which is already in place.

The main change is replacing the generator op creation in `LowerToHW` with code that constructs the FirMem and associated ports, which is conceptually simpler.

This commit also outlines memory lowering tests into a separate `lower-to-hw-memories.mlir` file and combines it with a few more test cases.

The only change to firtool Verilog output should be a loss of the `_combMem` suffix on memories.

**Follow-up work:** Once this lands, `seq.firmem` and `seq.hlmem` can be collapsed into a unified `seq.mem`. Passes like HWMemSimImpl (and at least one SiFive-internal pass I can think of) can then be updated to work with `seq.mem` directly. Afterwards the `seq.mem`-to-`hw.module.generated` lowering pass can be removed again.