### PR TITLE
[PyCDE] [Docs] Mention to add upstream remote to fetch tags when building wheels

### DIFF
--- a/docs/PyCDE/compiling.md
+++ b/docs/PyCDE/compiling.md
@@ -30,9 +30,10 @@ git submodule update --init
 
 ### Installing and Building with Wheels
 
-You'll need the git tags since the package versioning step needs them:
+If you are using a fork, you'll need the git tags since the package versioning step requires them:
 
 ```bash
+git remote add upstream git@github.com:llvm/circt.git
 git fetch upstream --tags
 ```
 


### PR DESCRIPTION
Fixes #5017