### PR TITLE
[Arc] StripSV: fix dialect dependencies, option and warning for replacing external module instances

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -171,7 +171,13 @@ def SplitLoops : Pass<"arc-split-loops", "mlir::ModuleOp"> {
 def StripSV : Pass<"arc-strip-sv", "mlir::ModuleOp"> {
   let summary = "Remove SV wire, reg, and assigns";
   let constructor = "circt::arc::createStripSVPass()";
-  let dependentDialects = ["seq::SeqDialect", "arc::ArcDialect"];
+  let options = [
+    Option<"replaceExtModuleOutputs", "replace-ext-module-outputs",
+      "bool", "true", "When enabled replaces all extern module instance "
+      "outputs with 0 and removes then and the external modules">,
+  ];
+  let dependentDialects = ["arc::ArcDialect", "comb::CombDialect",
+                           "hw::HWDialect", "seq::SeqDialect"];
 }
 
 #endif // CIRCT_DIALECT_ARC_ARCPASSES_TD

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -1,4 +1,7 @@
-// RUN: circt-opt %s --arc-strip-sv | FileCheck %s
+// RUN: split-file %s %t
+
+//--- defaults
+// RUN: circt-opt %t/defaults --arc-strip-sv --verify-diagnostics | FileCheck %t/defaults
 
 // CHECK-NOT: sv.verbatim
 // CHECK-NOT: sv.ifdef
@@ -18,3 +21,31 @@ hw.module @Foo(%clock: i1, %a: i4) -> (z: i4) {
   hw.output %2 : i4
 }
 // CHECK-NEXT: }
+
+// CHECK-NOT: hw.module.extern @PeripheryBus
+hw.module.extern @PeripheryBus() -> (clock: i1, reset: i1)
+// CHECK-LABEL: hw.module @Top
+hw.module @Top() {
+  %c0_i7 = hw.constant 0 : i7
+  // expected-warning @below {{StripSV: outputs of external module instance replaced with zero value!}}
+  %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
+  // CHECK-NOT: hw.instance
+  // CHECK: [[RST:%.+]] = comb.mux %false{{.*}}, %c0_i7, %int_rtc_tick_value : i7
+  // CHECK: %int_rtc_tick_value = seq.compreg [[RST]], %false{{.*}} : i7
+  %int_rtc_tick_value = seq.firreg %int_rtc_tick_value clock %subsystem_pbus.clock reset sync %subsystem_pbus.reset, %c0_i7 : i7
+}
+
+//--- dontReplaceExtModuleOutputs
+// RUN: circt-opt %t/dontReplaceExtModuleOutputs --arc-strip-sv=replace-ext-module-outputs=false | FileCheck %t/dontReplaceExtModuleOutputs
+
+// CHECK-LABEL: hw.module.extern @PeripheryBus
+hw.module.extern @PeripheryBus() -> (clock: i1, reset: i1)
+// CHECK: hw.module @Top
+hw.module @Top() {
+  %c0_i7 = hw.constant 0 : i7
+  // CHECK: %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
+  %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
+  // CHECK: [[RST:%.+]] = comb.mux %subsystem_pbus.reset, %c0_i7, %int_rtc_tick_value : i7
+  // CHECK: %int_rtc_tick_value = seq.compreg [[RST]], %subsystem_pbus.clock : i7
+  %int_rtc_tick_value = seq.firreg %int_rtc_tick_value clock %subsystem_pbus.clock reset sync %subsystem_pbus.reset, %c0_i7 : i7
+}


### PR DESCRIPTION
* `Comb` and `HW` dialects were not listed as dependent dialects which can lead to a crash when they are built.
* the outputs of instances of external modules are silently replaces with zero values, I think it would be helpful to emit a warning to make it clear to the user that something 'slightly risky' has been done by the compiler
* Also add an option to turn the ext module replacement functionality off as it can be helpful for debugging to see what kind of external modules and instances are used by the design and are still present after module inlining. At some point we want to add proper support for these external modules, e.g., doing blackbox simulation using another simulator via the interop dialect, etc. I guess we also want a proper MLIR operation to represent plusargs at some point?