### PR TITLE
[HW] Add an enum comparison operation

### DIFF
--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -169,4 +169,22 @@ def EnumConstantOp : HWOp<"enum.constant", [Pure, ConstantLike,
   ];
 }
 
+def EnumCmpOp : HWOp<"enum.cmp", [Pure]> {
+  let summary = "Compare two values of an enumeration";
+  let description = [{
+    This operation compares two values with the same enumeration type, returning
+    0 if they are different, and 1 if they are the same.
+
+    Example:
+    ```mlir
+      %enumcmp = hw.enum.cmp %A, %B : !hw.enum<A, B, C>, !hw.enum<A, B, C>
+    ```
+  }];
+  let arguments = (ins EnumType:$lhs, EnumType:$rhs);
+  let results = (outs I1:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` qualified(type($lhs)) `,` qualified(type($rhs))
+  }];
+}
+
 #endif // CIRCT_DIALECT_HW_HWMISCOPS_TD

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -121,6 +121,10 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   %bigArray = hw.array_concat %arrCreated, %arr2 : !hw.array<2 x i19>, !hw.array<3 x i19>
   // CHECK-NEXT: %A = hw.enum.constant A : !hw.enum<A, B, C>
   %A_enum = hw.enum.constant A : !hw.enum<A, B, C>
+  // CHECK-NEXT: %B = hw.enum.constant B : !hw.enum<A, B, C>
+  %B_enum = hw.enum.constant B : !hw.enum<A, B, C>
+  // CHECK-NEXT: = hw.enum.cmp %A, %B : !hw.enum<A, B, C>, !hw.enum<A, B, C>
+  %enumcmp = hw.enum.cmp %A_enum, %B_enum : !hw.enum<A, B, C>, !hw.enum<A, B, C>
 
   // CHECK-NEXT: hw.aggregate_constant [false, true] : !hw.struct<a: i1, b: i1>
   hw.aggregate_constant [false, true] : !hw.struct<a: i1, b: i1>


### PR DESCRIPTION
There is currently no way to compare the value of two enumerations as an expression.  There is an `icmp` operation, but it only accepts IntegerTypes, and it would complicate things to allow enums to be used everywhere an integer is allowed.  The other way to compare enumerations is using case statements, but it can't be used as an expression.

This PR adds an equality comparison operator for enumeration types. Theoretically we should be able to support other types of comparisons, such as `<`, since enumeration members are ordered. Since all I care about is equality, this does not support those other kinds of comparisons.  

It would also make sense to me to add a more generic equality operation which could support comparison of structs, unions, and arrays as well as enumerations.

I elected to implement exactly what I needed, since I feel like I can't predict future needs here.