### PR TITLE
[FIRRTL][Dedup] Print integer constants as hexadecimal

### DIFF
--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -403,6 +403,23 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
 
 // -----
 
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{first operation has attribute 'test' with value 0x21}}
+  firrtl.module @Test0() attributes {test = 33 : i8} { }
+  // expected-note@below {{second operation has value 0x20}}
+  firrtl.module @Test1() attributes {test = 32 : i8} { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
 // This test is checking that we don't crash when the two modules we want
 // deduped were actually deduped with another module.
 


### PR DESCRIPTION
Since Chisel always emits FIRRTL with integer constants encoded in radix 16, it is helpful to report deduplication errors in the same base, as it makes the it easier to compare the error message to the FIRRTL IR.