### PR TITLE
[FIRRTL] Add `MatchOp` statement

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -228,6 +228,50 @@ def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
   }];
 }
 
+def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
+    RecursiveMemoryEffects, RecursivelySpeculatable]> {
+  let summary = "Match Statement";
+  let description = [{
+    The "firrtl.match" operation represents a pattern matching statement on a
+    enumeration. This operation does not return a value and cannot be used as an
+    expression. Last connect semantics work similarly to a when statement.
+
+    Example:
+    ```mlir
+      firrtl.match %in : !firrtl.enum<Some: uint<1>, None: uint<0>> {
+        case Some(%arg0) {
+          !firrtl.strictconnect %w, %arg0 : !firrtl.uint<1>
+        }
+        case None(%arg0) {
+          !firrt.strictconnect %w, %c1 : !firrtl.uint<1>
+        }
+      }
+    ```
+  }];
+  let arguments = (ins FEnumType:$input, I32ArrayAttr:$tags);
+  let results = (outs);
+  let regions = (region VariadicRegion<SizedRegion<1>>:$regions);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$input,
+                   "::mlir::ArrayAttr":$tags,
+                   "::llvm::MutableArrayRef<std::unique_ptr<Region>>":$regions)>
+  ];
+
+  let extraClassDeclaration = [{
+    IntegerAttr getFieldIndexAttr(size_t caseIndex) {
+      return getTags()[caseIndex].cast<IntegerAttr>();
+    }
+
+    uint32_t getFieldIndex(size_t caseIndex) {
+      return getFieldIndexAttr(caseIndex).getUInt();
+    }
+  }];
+}
+
 def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
   let summary = "Force procedural statement";
   let description = "Maps to the corresponding `sv.force` operation.";

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -881,6 +881,38 @@ firrtl.circuit "MismatchedRegister" {
 
 // -----
 
+firrtl.circuit "EnumOutOfRange" {
+  firrtl.module @EnumSameCase(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{the tag index 1 is out of the range of valid tags in '!firrtl.enum<a: uint<8>>'}}
+    "firrtl.match"(%enum) ({
+    ^bb0(%arg0: !firrtl.uint<8>):
+    }) {tags = [1 : i32]} : (!firrtl.enum<a: uint<8>>) -> ()
+  }
+}
+// -----
+
+firrtl.circuit "EnumSameCase" {
+  firrtl.module @EnumSameCase(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{the tag "a" is matched more than once}}
+    "firrtl.match"(%enum) ({
+    ^bb0(%arg0: !firrtl.uint<8>):
+    }, {
+    ^bb0(%arg0: !firrtl.uint<8>):
+    }) {tags = [0 : i32, 0 : i32]} : (!firrtl.enum<a: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "EnumNonExaustive" {
+  firrtl.module @EnumNonExaustive(in %enum : !firrtl.enum<a : uint<8>>) {
+    // expected-error @+1 {{missing case for tag "a"}}
+    "firrtl.match"(%enum) {tags = []} : (!firrtl.enum<a: uint<8>>) -> ()
+  }
+}
+
+// -----
+
 // expected-error @+1 {{'firrtl.circuit' op main module 'private_main' must be public}}
 firrtl.circuit "private_main" {
   firrtl.module private @private_main() {}

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -204,6 +204,14 @@ firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
 
   %c1_u1 = firrtl.constant 0 : !firrtl.uint<8>
   %some = firrtl.enumcreate Some(%c1_u1) : !firrtl.enum<None: uint<0>, Some: uint<8>>
-}
 
+  firrtl.match %in : !firrtl.enum<a: uint<1>, b: uint<2>> {
+    case a(%arg0) {
+      %w = firrtl.wire : !firrtl.uint<1>
+    }
+    case b(%arg0) {
+      %x = firrtl.wire : !firrtl.uint<1>
+    }
+  }
+}
 }


### PR DESCRIPTION
This commit adds a match statement operation to the FIRRTL dialect. Match is used as an eliminator for enumeration types.  It enforces exaustive case handling on all enumeration variants.