### PR TITLE
[FIRRTL] Add LowerMatches pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -83,6 +83,8 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass>
 createEmitOMIRPass(mlir::StringRef outputFilename = "");
 
+std::unique_ptr<mlir::Pass> createLowerMatchesPass();
+
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
 std::unique_ptr<mlir::Pass> createFlattenMemoryPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -257,6 +257,15 @@ def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
 }
 
+def LowerMatches : Pass<"firrtl-lower-matches", "firrtl::FModuleOp"> {
+  let summary = "Remove all matchs conditional blocks";
+  let description = [{
+    Lowers FIRRTL match statements in to when statements, which can later be
+    lowered with ExpandWhens.
+  }];
+  let constructor = "circt::firrtl::createLowerMatchesPass()";
+}
+
 def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let summary = "Remove all when conditional blocks.";
   let description = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -169,11 +169,12 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
   };
 
   if (auto blockArg = val.dyn_cast<BlockArgument>()) {
-    auto op = val.getParentBlock()->getParentOp();
-    auto direction =
-        cast<FModuleLike>(op).getPortDirection(blockArg.getArgNumber());
-    if (direction == Direction::Out)
-      return swap();
+    auto *op = val.getParentBlock()->getParentOp();
+    if (auto moduleLike = dyn_cast<FModuleLike>(op)) {
+      auto direction = moduleLike.getPortDirection(blockArg.getArgNumber());
+      if (direction == Direction::Out)
+        return swap();
+    }
     return accumulatedFlow;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
   LowerIntrinsics.cpp
+  LowerMatches.cpp
   LowerMemory.cpp
   LowerTypes.cpp
   LowerXMR.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
@@ -1,0 +1,78 @@
+//===- LowerMatches.cpp - Lower match statements to whens -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the LowerMatchesPass, which lowers match statements to when
+// statements
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+class LowerMatchesPass : public LowerMatchesBase<LowerMatchesPass> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+static void lowerMatch(MatchOp match) {
+  ImplicitLocOpBuilder b(match.getLoc(), match);
+
+  auto input = match.getInput();
+  auto numCases = match->getNumRegions();
+  for (size_t i = 0; i < numCases - 1; ++i) {
+    // Create a WhenOp which tests the enum's tag.
+    auto condition = b.create<IsTagOp>(input, match.getFieldIndexAttr(i));
+    auto when = b.create<WhenOp>(condition, /*withElse=*/true);
+
+    // Move the case block to the WhenOp.
+    auto *thenBlock = &when.getThenBlock();
+    auto *caseBlock = &match.getRegion(i).front();
+    caseBlock->moveBefore(thenBlock);
+    thenBlock->erase();
+
+    // Replace the block argument with a subtag op.
+    b.setInsertionPointToStart(caseBlock);
+    auto data = b.create<SubtagOp>(input, match.getFieldIndexAttr(i));
+    caseBlock->getArgument(0).replaceAllUsesWith(data);
+    caseBlock->eraseArgument(0);
+
+    // Change insertion to the else block.
+    b.setInsertionPointToStart(&when.getElseBlock());
+  }
+
+  // The final else is not handled with a conditional, move the case block to
+  // the default block.
+  auto *defaultBlock = b.getInsertionBlock();
+  auto *caseBlock = &match->getRegions().back().front();
+  caseBlock->moveBefore(defaultBlock);
+  defaultBlock->erase();
+
+  // Replace the block argument with a subtag op.
+  b.setInsertionPointToStart(caseBlock);
+  auto data = b.create<SubtagOp>(input, match.getFieldIndexAttr(numCases - 1));
+  caseBlock->getArgument(0).replaceAllUsesWith(data);
+  caseBlock->eraseArgument(0);
+
+  // Erase the match op.
+  match->erase();
+}
+
+void LowerMatchesPass::runOnOperation() {
+  getOperation()->walk(&lowerMatch);
+  markAnalysesPreserved<InstanceGraph>();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerMatchesPass() {
+  return std::make_unique<LowerMatchesPass>();
+}

--- a/test/Dialect/FIRRTL/lower-matches.fir
+++ b/test/Dialect/FIRRTL/lower-matches.fir
@@ -1,0 +1,35 @@
+// RUN: circt-opt --pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-matches)))" %s | FileCheck %s
+
+firrtl.circuit "LowerMatches" {
+
+// CHECK-LABEL: firrtl.module @LowerMatches
+firrtl.module @LowerMatches(in %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>, out %out : !firrtl.uint<8>) {
+
+   // CHECK-NEXT: %0 = firrtl.istag %enum a : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT: firrtl.when %0 : !firrtl.uint<1> {
+   // CHECK-NEXT:   %1 = firrtl.subtag %enum[a] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:   firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+   // CHECK-NEXT: } else {
+   // CHECK-NEXT:   %1 = firrtl.istag %enum b : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:   firrtl.when %1 : !firrtl.uint<1> {
+   // CHECK-NEXT:     %2 = firrtl.subtag %enum[b] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.uint<8>
+   // CHECK-NEXT:   } else {
+   // CHECK-NEXT:     %2 = firrtl.subtag %enum[c] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.uint<8>
+   // CHECK-NEXT:   }
+   // CHECK-NEXT: }
+  firrtl.match %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>> {
+    case a(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+    }
+    case b(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+    }
+    case c(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+    }
+  }
+
+}
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -576,6 +576,7 @@ static LogicalResult processBuffer(
       preserveAggregate, firrtl::PreserveAggregate::None));
   // Only enable expand whens if lower types is also enabled.
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
+  modulePM.addPass(firrtl::createLowerMatchesPass());
   modulePM.addPass(firrtl::createExpandWhensPass());
   modulePM.addPass(firrtl::createSFCCompatPass());
 


### PR DESCRIPTION
The lower matches pass transform match statements into when statements. This allows them to be handled by ExpandWhens, including all the fun things it does such as initialization checking.  When lowering to when statements, the final case handled by the match is transformed in to the "default" branch and the enumeration tag for this case is not explicitly checked anymore.

The new pass was inserted in to the firtool pipeline right before ExpandWhens runs.

To pass flow checking, we needed to handle teach the `foldFlow` function what to do when the block argument belonged to a match statement. Although the flow should always be `source`, it is returning the accumulated flow in case we relax the restriction that enumeration types are always passive.