### PR TITLE
[Seq] Add an option to lower `seq.compreg` to `always` blocks

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -23,7 +23,8 @@ namespace seq {
 #include "circt/Dialect/Seq/SeqPasses.h.inc"
 #undef GEN_PASS_DECL
 
-std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
+std::unique_ptr<mlir::Pass>
+createSeqLowerToSVPass(std::optional<bool> lowerToAlwaysFF = {});
 std::unique_ptr<mlir::Pass>
 createSeqFIRRTLLowerToSVPass(const LowerSeqFIRRTLToSVOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -19,6 +19,10 @@ def LowerSeqToSV: Pass<"lower-seq-to-sv", "mlir::ModuleOp"> {
   let summary = "Lower sequential ops to SV.";
   let constructor = "circt::seq::createSeqLowerToSVPass()";
   let dependentDialects = ["circt::sv::SVDialect"];
+  let options = [
+    Option<"lowerToAlwaysFF", "lower-to-always-ff", "bool", "true",
+           "Place assignments to registers into `always_ff` blocks">
+  ];
 }
 
 def LowerSeqFIRRTLToSV: Pass<"lower-seq-firrtl-to-sv", "hw::HWModuleOp"> {


### PR DESCRIPTION
`always_ff` blocks do not allow registers to be set in initial blocks. This PR adds an option to emit register assignments from within always blocks to bypass the restriction.