### PR TITLE
Backport to Firtool 1.34.1

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -43,16 +43,21 @@ struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
   void eraseEmptyModule(FModuleOp module);
   void forwardConstantOutputPort(FModuleOp module);
 
+  void markAlive(InstanceOp instance) {
+    markBlockUndeletable(instance->getBlock());
+    liveInstances.insert(instance);
+  }
+
   void markAlive(Value value) {
     //  If the value is already in `liveSet`, skip it.
-    if (liveSet.insert(value).second)
+    if (liveValues.insert(value).second)
       worklist.push_back(value);
   }
 
   /// Return true if the value is known alive.
   bool isKnownAlive(Value value) const {
     assert(value && "null should not be used");
-    return liveSet.count(value);
+    return liveValues.count(value);
   }
 
   /// Return true if the value is assumed dead.
@@ -72,6 +77,10 @@ struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
   void visitConnect(FConnectLike connect);
   void visitSubelement(Operation *op);
   void markBlockExecutable(Block *block);
+  void markBlockUndeletable(Block *block) { undeletableBlocks.insert(block); }
+  bool isBlockUndeletable(Block *block) const {
+    return undeletableBlocks.contains(block);
+  }
   void markDeclaration(Operation *op);
   void markInstanceOp(InstanceOp instanceOp);
   void markUnknownSideEffectOp(Operation *op);
@@ -89,15 +98,26 @@ private:
   /// A worklist of values whose liveness recently changed, indicating the
   /// users need to be reprocessed.
   SmallVector<Value, 64> worklist;
-  llvm::DenseSet<Value> liveSet;
+  llvm::DenseSet<Value> liveValues;
+  llvm::DenseSet<InstanceOp> liveInstances;
+
+  /// The set of modules that cannot be removed for several reasons (side
+  /// effects, ports/decls have don't touch).
+  DenseSet<Block *> undeletableBlocks;
+
+  /// This keeps track of input ports that need to be kept if the associated
+  /// instance is alive.
+  DenseMap<InstanceOp, SmallVector<Value>> lazyLiveInputPorts;
 };
 } // namespace
 
 void IMDeadCodeElimPass::markDeclaration(Operation *op) {
   assert(isDeclaration(op) && "only a declaration is expected");
-  if (!isDeletableDeclaration(op))
+  if (!isDeletableDeclaration(op)) {
     for (auto result : op->getResults())
       markAlive(result);
+    markBlockUndeletable(op->getBlock());
+  }
 }
 
 void IMDeadCodeElimPass::markUnknownSideEffectOp(Operation *op) {
@@ -107,6 +127,7 @@ void IMDeadCodeElimPass::markUnknownSideEffectOp(Operation *op) {
     markAlive(result);
   for (auto operand : op->getOperands())
     markAlive(operand);
+  markBlockUndeletable(op->getBlock());
 }
 
 void IMDeadCodeElimPass::visitUser(Operation *op) {
@@ -134,12 +155,16 @@ void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
       // Otherwise this is an inuput from it or an inout, mark it as alive.
       markAlive(portVal);
     }
+    markAlive(instance);
+
     return;
   }
 
   // Otherwise this is a defined module.
   auto fModule = cast<FModuleOp>(op);
   markBlockExecutable(fModule.getBodyBlock());
+  if (isBlockUndeletable(fModule.getBodyBlock()) || instance.getInnerSym())
+    markAlive(instance);
 
   // Ok, it is a normal internal module reference so populate
   // resultPortToInstanceResultMapping.
@@ -158,10 +183,16 @@ void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
   if (!executableBlocks.insert(block).second)
     return; // Already executable.
 
+  auto fmodule = cast<FModuleOp>(block->getParentOp());
+  if (fmodule.isPublic() || !fmodule.getAnnotationsAttr().empty())
+    markBlockUndeletable(block);
+
   // Mark ports with don't touch as alive.
   for (auto blockArg : block->getArguments())
-    if (hasDontTouch(blockArg))
+    if (hasDontTouch(blockArg)) {
       markAlive(blockArg);
+      markBlockUndeletable(block);
+    }
 
   for (auto &op : *block) {
     if (isDeclaration(&op))
@@ -223,11 +254,19 @@ void IMDeadCodeElimPass::runOnOperation() {
   auto circuit = getOperation();
   instanceGraph = &getAnalysis<InstanceGraph>();
 
+  // Create a vector of modules in the post order of instance graph.
+  // FIXME: We copy the list of modules into a vector first to avoid iterator
+  // invalidation while we mutate the instance graph. See issue 3387.
+  SmallVector<FModuleOp, 0> modules(llvm::make_filter_range(
+      llvm::map_range(
+          llvm::post_order(instanceGraph),
+          [](auto *node) { return dyn_cast<FModuleOp>(*node->getModule()); }),
+      [](auto module) { return module; }));
+
   // Forward constant output ports to caller sides so that we can eliminate
   // constant outputs.
-  for (auto *node : llvm::post_order(instanceGraph))
-    if (auto module = dyn_cast_or_null<FModuleOp>(*node->getModule()))
-      forwardConstantOutputPort(module);
+  for (auto module : modules)
+    forwardConstantOutputPort(module);
 
   for (auto module : circuit.getBodyBlock()->getOps<FModuleOp>()) {
     // Mark the ports of public modules as alive.
@@ -252,16 +291,6 @@ void IMDeadCodeElimPass::runOnOperation() {
                         circuit.getBodyBlock()->getOps<FModuleOp>(),
                         [&](auto op) { rewriteModuleBody(op); });
 
-  // Erase empty modules. To erase empty modules transitively, it is necessary
-  // to visit modules in the post order of instance graph.
-  // FIXME: We copy the list of modules into a vector first to avoid iterator
-  // invalidation while we mutate the instance graph. See issue 3387.
-  SmallVector<FModuleOp, 0> modules(llvm::make_filter_range(
-      llvm::map_range(
-          llvm::post_order(instanceGraph),
-          [](auto *node) { return dyn_cast<FModuleOp>(*node->getModule()); }),
-      [](auto module) { return module; }));
-
   for (auto module : modules)
     eraseEmptyModule(module);
 }
@@ -280,9 +309,16 @@ void IMDeadCodeElimPass::visitValue(Value value) {
     // If the port is input, it's necessary to mark corresponding input ports of
     // instances as alive. We don't have to propagate the liveness of output
     // ports.
-    if (portDirection == Direction::In)
-      for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
-        markAlive(userOfResultPort);
+    if (portDirection == Direction::In) {
+      for (auto userOfResultPort :
+           resultPortToInstanceResultMapping[blockArg]) {
+        auto instance = userOfResultPort.getDefiningOp<InstanceOp>();
+        if (liveInstances.contains(instance))
+          markAlive(userOfResultPort);
+        else
+          lazyLiveInputPorts[instance].push_back(userOfResultPort);
+      }
+    }
     return;
   }
 
@@ -298,6 +334,12 @@ void IMDeadCodeElimPass::visitValue(Value value) {
     if (!module || module.getPortDirection(instanceResult.getResultNumber()) ==
                        Direction::In)
       return;
+
+    // If the output port is alive, mark the instnace as alive. Propagate the
+    // liveness of input ports accumulated so far.
+    if (liveInstances.insert(instance).second)
+      for (auto inputPort : lazyLiveInputPorts[instance])
+        markAlive(inputPort);
 
     BlockArgument modulePortVal =
         module.getArgument(instanceResult.getResultNumber());
@@ -370,14 +412,55 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
   if (!isBlockExecutable(module.getBodyBlock()))
     return;
 
-  // Ports of public modules cannot be modified.
-  if (module.isPublic())
-    return;
-
   InstanceGraphNode *instanceGraphNode =
       instanceGraph->lookup(module.moduleNameAttr());
   LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
                           << "\n");
+
+  auto replaceInstanceResultWithWire = [&](ImplicitLocOpBuilder &builder,
+                                           unsigned index,
+                                           InstanceOp instance) {
+    auto result = instance.getResult(index);
+    if (isAssumedDead(result)) {
+      // If the result is dead, replace the result with an unrealiazed
+      // conversion cast which works as a dummy placeholder.
+      auto wire = builder
+                      .create<mlir::UnrealizedConversionCastOp>(
+                          ArrayRef<Type>{result.getType()}, ArrayRef<Value>{})
+                      ->getResult(0);
+      result.replaceAllUsesWith(wire);
+      return;
+    }
+
+    // If RefType and live, don't want to leave wire around.
+
+    Value wire = builder.create<WireOp>(result.getType()).getResult();
+    result.replaceAllUsesWith(wire);
+    // If a module port is dead but its instance result is alive, the port
+    // is used as a temporary wire so make sure that a replaced wire is
+    // putted into `liveSet`.
+    liveValues.erase(result);
+    liveValues.insert(wire);
+  };
+
+  // First, delete dead instances.
+  for (auto *use : llvm::make_early_inc_range(instanceGraphNode->uses())) {
+    auto instance = cast<InstanceOp>(*use->getInstance());
+    if (!liveInstances.count(instance)) {
+      // Replace old instance results with dummy wires.
+      ImplicitLocOpBuilder builder(instance.getLoc(), instance);
+      for (auto index : llvm::seq(0u, instance.getNumResults()))
+        replaceInstanceResultWithWire(builder, index, instance);
+      // Make sure that we update the instance graph.
+      use->erase();
+      instance.erase();
+    }
+  }
+
+  // Ports of public modules cannot be modified.
+  if (module.isPublic())
+    return;
+
   unsigned numOldPorts = module.getNumPorts();
   llvm::BitVector deadPortIndexes(numOldPorts);
 
@@ -414,8 +497,8 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
       WireOp wire = builder.create<WireOp>(argument.getType());
 
       // Since `liveSet` contains the port, we have to erase it from the set.
-      liveSet.erase(argument);
-      liveSet.insert(wire);
+      liveValues.erase(argument);
+      liveValues.insert(wire);
       argument.replaceAllUsesWith(wire);
       deadPortIndexes.set(index);
       continue;
@@ -423,9 +506,13 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
 
     // Replace the port with a dummy wire. This wire should be erased within
     // `rewriteModuleBody`.
-    WireOp wire = builder.create<WireOp>(argument.getType());
+    Value wire = builder
+                     .create<mlir::UnrealizedConversionCastOp>(
+                         ArrayRef<Type>{argument.getType()}, ArrayRef<Value>{})
+                     ->getResult(0);
+
     argument.replaceAllUsesWith(wire);
-    assert(isAssumedDead(wire.getResult()) && "dummy wire must be dead");
+    assert(isAssumedDead(wire) && "dummy wire must be dead");
     deadPortIndexes.set(index);
   }
 
@@ -436,48 +523,40 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
   // Erase arguments of the old module from liveSet to prevent from creating
   // dangling pointers.
   for (auto arg : module.getArguments())
-    liveSet.erase(arg);
+    liveValues.erase(arg);
 
   // Delete ports from the module.
   module.erasePorts(deadPortIndexes);
 
   // Add arguments of the new module to liveSet.
   for (auto arg : module.getArguments())
-    liveSet.insert(arg);
+    liveValues.insert(arg);
 
   // Rewrite all uses.
-  for (auto *use : instanceGraphNode->uses()) {
+  for (auto *use : llvm::make_early_inc_range(instanceGraphNode->uses())) {
     auto instance = cast<InstanceOp>(*use->getInstance());
     ImplicitLocOpBuilder builder(instance.getLoc(), instance);
     // Replace old instance results with dummy wires.
-    for (auto index : deadPortIndexes.set_bits()) {
-      auto result = instance.getResult(index);
-      WireOp wire = builder.create<WireOp>(result.getType());
-      result.replaceAllUsesWith(wire);
-      // If a module port is dead but its instance result is alive, the port is
-      // used as a temporary wire so make sure that a replaced wire is putted
-      // into `liveSet`.
-      if (isKnownAlive(result)) {
-        assert(oldPorts[index].direction == Direction::In &&
-               "If a dead module port is alive in instance results, the "
-               "corresponding port must be input");
-        liveSet.insert(wire);
-      }
-    }
+    for (auto index : deadPortIndexes.set_bits())
+      replaceInstanceResultWithWire(builder, index, instance);
 
     // Since we will rewrite instance op, it is necessary to remove old
     // instance results from liveSet.
     for (auto oldResult : instance.getResults())
-      liveSet.erase(oldResult);
+      liveValues.erase(oldResult);
 
     // Create a new instance op without dead ports.
     auto newInstance = instance.erasePorts(builder, deadPortIndexes);
 
     // Mark new results as alive.
     for (auto newResult : newInstance.getResults())
-      liveSet.insert(newResult);
+      liveValues.insert(newResult);
 
     instanceGraph->replaceInstance(instance, newInstance);
+    if (liveInstances.contains(instance)) {
+      liveInstances.erase(instance);
+      liveInstances.insert(newInstance);
+    }
     // Remove old one.
     instance.erase();
   }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -239,10 +239,9 @@ firrtl.circuit "RefPorts" {
     %dest3_resolved = firrtl.ref.resolve %dest3 : !firrtl.ref<uint<1>>
     firrtl.strictconnect %dest, %dest3_resolved : !firrtl.uint<1>
 
-    // Check dead resolve is deleted, even if send isn't.
-    // (Instance is dead too but need context-sensitive analysis to show that.)
-    // CHECK: @live_ref
-    %source4, %dest4 = firrtl.instance live_ref @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.ref<uint<1>>)
+    // Check dead resolve is deleted.
+    // CHECK-NOT: dead_instance
+    %source4, %dest4 = firrtl.instance dead_instance @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.ref<uint<1>>)
     firrtl.strictconnect %source4, %source : !firrtl.uint<1>
     // CHECK-NOT: firrtl.ref.resolve
     %unused5 = firrtl.ref.resolve %dest4 : !firrtl.ref<uint<1>>
@@ -316,5 +315,39 @@ firrtl.circuit "DeadInputPort"  {
     %bar_a = firrtl.instance bar  @Bar(in a: !firrtl.uint<1>)
     firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
     firrtl.strictconnect %b, %bar_a : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "DeleteInstance" {
+  firrtl.module private @SideEffect1(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock) {
+    firrtl.printf %clock, %a, "foo"
+  }
+  firrtl.module private @SideEffect2(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock) {
+    %s1_a, %s1_clock = firrtl.instance s1 @SideEffect1(in a: !firrtl.uint<1>, in clock: !firrtl.clock)
+    firrtl.strictconnect %s1_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %s1_clock, %clock : !firrtl.clock
+  }
+  firrtl.module private @PassThrough(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+  }
+  // CHECK-LABEL: DeleteInstance
+  firrtl.module @DeleteInstance(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
+    // CHECK-NOT: p1
+    // CHECK: instance p2 @PassThrough
+    // CHECK-NEXT: instance s @SideEffect2
+    %p1_a, %p1_b = firrtl.instance p1 @PassThrough(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %p2_a, %p2_b = firrtl.instance p2 @PassThrough(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %s_a, %s_clock = firrtl.instance s @SideEffect2(in a: !firrtl.uint<1>, in clock: !firrtl.clock)
+    // CHECK-NEXT: firrtl.strictconnect %s_a, %a : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %s_clock, %clock : !firrtl.clock
+    // CHECK-NEXT: firrtl.strictconnect %p2_a, %a : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %b, %p2_b : !firrtl.uint<1>
+    firrtl.strictconnect %s_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %s_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %p1_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %p2_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %b, %p2_b : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -321,6 +321,10 @@ firrtl.circuit "DeadInputPort"  {
 // -----
 
 firrtl.circuit "DeleteInstance" {
+  // CHECK-NOT: @InvalidValue
+  firrtl.module private @InvalidValue() {
+      %invalid_ui289 = firrtl.invalidvalue : !firrtl.uint<289>
+  }
   firrtl.module private @SideEffect1(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock) {
     firrtl.printf %clock, %a, "foo"
   }
@@ -334,6 +338,8 @@ firrtl.circuit "DeleteInstance" {
   }
   // CHECK-LABEL: DeleteInstance
   firrtl.module @DeleteInstance(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
+    // CHECK-NOT: inv
+    firrtl.instance inv @InvalidValue()
     // CHECK-NOT: p1
     // CHECK: instance p2 @PassThrough
     // CHECK-NEXT: instance s @SideEffect2

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1113,3 +1113,29 @@ firrtl.circuit "Top" {
     firrtl.strictconnect %_a, %1 : !firrtl.ref<uint<1>>
   }
 }
+
+
+// -----
+
+// PR #4882 fixes a bug, which was producing invalid NLAs.
+// error: 'hw.hierpath' op  module: "instNameRename" does not contain any instance with symbol: "w"
+// Due to coincidental name collisions, renaming was not updating the actual hierpath.
+firrtl.circuit "Bug4882Rename"  {
+  hw.hierpath private @nla_5560 [@Bug4882Rename::@w, @Bar2::@x]
+  firrtl.module private @Bar2() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %x = firrtl.wire sym @x  {annotations = [{circt.nonlocal = @nla_5560, class = "test0"}]} : !firrtl.uint<8>
+  }
+  firrtl.module private @Bar1() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    firrtl.instance bar3 sym @w  @Bar3()
+  }
+  firrtl.module private @Bar3()  {
+    %w = firrtl.wire sym @w1   : !firrtl.uint<8>
+  }
+  firrtl.module @Bug4882Rename() {
+  // CHECK-LABEL: firrtl.module @Bug4882Rename() {
+    firrtl.instance no sym @no  @Bar1()
+    // CHECK-NEXT: firrtl.instance no_bar3 sym @w_0 @Bar3()
+    firrtl.instance bar2 sym @w  @Bar2()
+    // CHECK-NEXT: %bar2_x = firrtl.wire sym @x {annotations = [{class = "test0"}]}
+  }
+}

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -284,6 +284,16 @@ module {
 // CHECK: %[[or1:.+]] = comb.or
 // CHECK-NOT: %[[or1]]
 
+// In InstancesWithCycles, the only_testcode instances should be extracted, but the non_testcode instances should not
+// CHECK-LABEL: @InstancesWithCycles_cover
+// CHECK: hw.instance "only_testcode_and_instance0"
+// CHECK: hw.instance "only_testcode_and_instance1"
+// CHECK-LABEL: @InstancesWithCycles
+// CHECK-NOT: hw.instance "only_testcode_and_instance0"
+// CHECK-NOT: hw.instance "only_testcode_and_instance1"
+// CHECK: hw.instance "non_testcode_and_instance0"
+// CHECK: hw.instance "non_testcode_and_instance1"
+
 module attributes {
   firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
 } {
@@ -383,5 +393,26 @@ module attributes {
       sv.cover %0, immediate
       sv.cover %foo.b, immediate
     }
+  }
+
+  hw.module private @Passthrough(%in: i1) -> (out: i1) {
+    hw.output %in : i1
+  }
+
+  hw.module @InstancesWithCycles(%clock: i1, %in: i1) -> (out: i1) {
+    %0 = hw.instance "non_testcode_and_instance0" @Passthrough(in: %1: i1) -> (out: i1)
+    %1 = hw.instance "non_testcode_and_instance1" @Passthrough(in: %0: i1) -> (out: i1)
+
+    %2 = hw.instance "only_testcode_and_instance0" @Passthrough(in: %3: i1) -> (out: i1)
+    %3 = hw.instance "only_testcode_and_instance1" @Passthrough(in: %2: i1) -> (out: i1)
+    %4 = comb.or %2, %3 : i1
+
+    sv.always posedge %clock {
+      sv.cover %1, immediate
+      sv.cover %2, immediate
+      sv.cover %4, immediate
+    }
+
+    hw.output %0 : i1
   }
 }


### PR DESCRIPTION
Do backport to 1.34.0

* [IMDCE] Propagate instance livenesss in a context-sensitive way 
* [ETC] Enhance instance extraction to extract dependent instances. (#4910)
* [FIRRTL][IMDCE] Remove dead Invalid Value op (#4996) 
* [ModuleInliner] Rework instance rename code, fix issue as w/PR4882. 