### PR TITLE
[Handshake] Remove handshake.select

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -481,39 +481,6 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
   }];
 }
 
-def SelectOp : Handshake_Op<"select", [
-  Pure,
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
-  DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
-  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
-  TypesMatchWith<"data operand type matches true branch result type",
-                    "trueOperand", "falseOperand", "$_self">,
-  TypesMatchWith<"data operand type matches false branch result type",
-                    "falseOperand", "result", "$_self">
-]> {
-  let summary = "Select operation";
-  let description = [{
-     The select operation will select between two inputs based on an input
-     conditional. The select operation differs from a mux in that
-     1. All operands must be valid before the operation can transact
-     2. All operands will be transacted at simultaneously
-
-     The 'select' operation is intended to handle 'std.select' and other
-     ternary-like operators, which considers strictly dataflow. The 'mux' operator
-     considers control+dataflow between blocks.
-
-     Example:
-     ```mlir
-     %res = select %cond, %true, %false : i32
-     ```
-  }];
-
-  let arguments = (ins I1 : $condOperand,
-                       AnyType : $trueOperand, AnyType : $falseOperand);
-  let results = (outs AnyType : $result);
-  let hasCustomAssemblyFormat = 1;
-}
-
 def SinkOp : Handshake_Op<"sink", [
   SOSTInterface, DeclareOpInterfaceMethods<ExecutableOpInterface>
 ]> {

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -33,11 +33,10 @@ public:
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
             ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp, MemoryOp,
-            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
-            handshake::SelectOp, SourceOp, StoreOp, SyncOp, PackOp, UnpackOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitHandshake(opNode, args...);
-            })
+            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, SourceOp,
+            StoreOp, SyncOp, PackOp, UnpackOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitHandshake(opNode, args...);
+        })
         .Default([&](auto opNode) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
         });
@@ -73,7 +72,6 @@ public:
   HANDLE(LazyForkOp);
   HANDLE(LoadOp);
   HANDLE(MemoryOp);
-  HANDLE(handshake::SelectOp);
   HANDLE(ExternalMemoryOp);
   HANDLE(MergeOp);
   HANDLE(MuxOp);
@@ -106,9 +104,10 @@ public:
             arith::CmpIOp, arith::AddIOp, arith::SubIOp, arith::MulIOp,
             arith::DivSIOp, arith::RemSIOp, arith::DivUIOp, arith::RemUIOp,
             arith::XOrIOp, arith::AndIOp, arith::OrIOp, arith::ShLIOp,
-            arith::ShRSIOp, arith::ShRUIOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitStdExpr(opNode, args...);
-        })
+            arith::ShRSIOp, arith::ShRUIOp, arith::SelectOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitStdExpr(opNode, args...);
+            })
         .Default([&](auto opNode) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
         });

--- a/integration_test/Dialect/Handshake/helper.py
+++ b/integration_test/Dialect/Handshake/helper.py
@@ -73,7 +73,7 @@ class HandshakeDataPort(HandshakePort):
     assert (self.isReady())
     for res in results:
       await self.waitUntilValid()
-      assert (self.data.value == res)
+      assert self.data.value == res, f"Expected {res}, got {self.data.value}"
       await RisingEdge(self.dut.clock)
 
 

--- a/integration_test/Dialect/Handshake/max/max.mlir
+++ b/integration_test/Dialect/Handshake/max/max.mlir
@@ -24,21 +24,21 @@
 
 // Computes the maximum of all inputs
 func.func @top(%in0: i64, %in1: i64, %in2: i64, %in3: i64, %in4: i64, %in5: i64, %in6: i64, %in7: i64) -> i64 {
-  %c0 = arith.cmpi slt, %in0, %in1 : i64
+  %c0 = arith.cmpi sge, %in0, %in1 : i64
   %t0 = arith.select %c0, %in0, %in1 : i64
-  %c1 = arith.cmpi slt, %in2, %in3 : i64
+  %c1 = arith.cmpi sge, %in2, %in3 : i64
   %t1 = arith.select %c1, %in2, %in3 : i64
-  %c2 = arith.cmpi slt, %in4, %in5 : i64
+  %c2 = arith.cmpi sge, %in4, %in5 : i64
   %t2 = arith.select %c2, %in4, %in5 : i64
-  %c3 = arith.cmpi slt, %in6, %in7 : i64
+  %c3 = arith.cmpi sge, %in6, %in7 : i64
   %t3 = arith.select %c3, %in6, %in7 : i64
 
-  %c4 = arith.cmpi slt, %t0, %t1 : i64
+  %c4 = arith.cmpi sge, %t0, %t1 : i64
   %t4 = arith.select %c4, %t0, %t1 : i64
-  %c5 = arith.cmpi slt, %t2, %t3 : i64
+  %c5 = arith.cmpi sge, %t2, %t3 : i64
   %t5 = arith.select %c5, %t2, %t3 : i64
 
-  %c6 = arith.cmpi slt, %t4, %t5 : i64
+  %c6 = arith.cmpi sge, %t4, %t5 : i64
   %t6 = arith.select %c6, %t4, %t5 : i64
   return %t6 : i64
 }

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1396,58 +1396,6 @@ bool HandshakeBuilder::visitHandshake(MuxOp op) {
   return true;
 }
 
-bool HandshakeBuilder::visitHandshake(handshake::SelectOp op) {
-  ValueVector selectSubfields = portList[0];
-  Value selectValid = selectSubfields[0];
-  Value selectReady = selectSubfields[1];
-  Value selectData = selectSubfields[2];
-
-  ValueVector resultSubfields = portList[3];
-  Value resultValid = resultSubfields[0];
-  Value resultReady = resultSubfields[1];
-  Value resultData = resultSubfields[2];
-
-  ValueVector trueSubfields = portList[1];
-  Value trueValid = trueSubfields[0];
-  Value trueReady = trueSubfields[1];
-  Value trueData = trueSubfields[2];
-
-  ValueVector falseSubfields = portList[2];
-  Value falseValid = falseSubfields[0];
-  Value falseReady = falseSubfields[1];
-  Value falseData = falseSubfields[2];
-
-  auto bitType = UIntType::get(rewriter.getContext(), 1);
-
-  // Mux the true and false data.
-  auto muxedData =
-      createMuxTree({falseData, trueData}, selectData, insertLoc, rewriter);
-
-  // Connect the selected data signal to the result data.
-  rewriter.create<ConnectOp>(insertLoc, resultData, muxedData);
-
-  // 'and' the arg valids and select valid
-  Value allValid =
-      rewriter.create<WireOp>(insertLoc, bitType, "allValid").getResult();
-  buildReductionTree<AndPrimOp>({trueValid, falseValid, selectValid}, allValid);
-
-  // Connect that to the result valid.
-  rewriter.create<ConnectOp>(insertLoc, resultValid, allValid);
-
-  // 'and' the result valid with the result ready.
-  auto resultValidAndReady =
-      rewriter.create<AndPrimOp>(insertLoc, bitType, allValid, resultReady);
-
-  // Connect that to the 'ready' signal of all inputs. This implies that all
-  // inputs + select is transacted when all are valid (and the output is ready),
-  // but only the selected data is forwarded.
-  rewriter.create<ConnectOp>(insertLoc, selectReady, resultValidAndReady);
-  rewriter.create<ConnectOp>(insertLoc, trueReady, resultValidAndReady);
-  rewriter.create<ConnectOp>(insertLoc, falseReady, resultValidAndReady);
-
-  return true;
-}
-
 /// Please refer to test_merge.mlir test case.
 /// Lowers the MergeOp into primitive FIRRTL ops. This is a simplification of
 /// the ControlMergeOp lowering, since it doesn't need to wait for more than one

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -832,54 +832,6 @@ bool ConditionalBranchOp::isControl() {
                                       getDataOperand());
 }
 
-ParseResult SelectOp::parse(OpAsmParser &parser, OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand, 4> allOperands;
-  Type dataType;
-  SmallVector<Type> operandTypes;
-  llvm::SMLoc allOperandLoc = parser.getCurrentLocation();
-  if (parser.parseOperandList(allOperands) ||
-      parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseColonType(dataType))
-    return failure();
-
-  if (allOperands.size() != 3)
-    return parser.emitError(parser.getCurrentLocation(),
-                            "Expected exactly 3 operands");
-
-  result.addTypes({dataType});
-  operandTypes.push_back(IntegerType::get(parser.getContext(), 1));
-  operandTypes.push_back(dataType);
-  operandTypes.push_back(dataType);
-  if (parser.resolveOperands(allOperands, operandTypes, allOperandLoc,
-                             result.operands))
-    return failure();
-  return success();
-}
-
-void SelectOp::print(OpAsmPrinter &p) {
-  Type type = getTrueOperand().getType();
-  p << " " << getOperands();
-  p.printOptionalAttrDict((*this)->getAttrs());
-  p << " : " << type;
-}
-
-std::string handshake::SelectOp::getOperandName(unsigned int idx) {
-  switch (idx) {
-  case 0:
-    return "sel";
-  case 1:
-    return "true";
-  case 2:
-    return "false";
-  default:
-    llvm_unreachable("Expected exactly 3 operands");
-  }
-}
-
-bool SelectOp::isControl() {
-  return getTrueOperand().getType().isa<NoneType>();
-}
-
 ParseResult SinkOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand, 4> allOperands;
   Type type;

--- a/test/Conversion/HandshakeToFIRRTL/test_select.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_select.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   firrtl.circuit "test_select"   {
-// CHECK:           firrtl.module @handshake_select_in_ui1_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK-LABEL:   firrtl.circuit "test_select" {
+// CHECK:           firrtl.module @arith_select_in_ui1_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
 // CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
 // CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
 // CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
@@ -14,30 +14,27 @@
 // CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]][valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]][ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             %[[VAL_16:.*]] = firrtl.bits %[[VAL_6]] 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_17:.*]] = firrtl.mux(%[[VAL_16]], %[[VAL_9]], %[[VAL_12]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-// CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_17]] : !firrtl.uint<32>, !firrtl.uint<32>
-// CHECK:             %[[VAL_18:.*]] = firrtl.wire  : !firrtl.uint<1>
-// CHECK:             %[[VAL_19:.*]] = firrtl.and %[[VAL_10]], %[[VAL_7]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:             %[[VAL_20:.*]] = firrtl.and %[[VAL_4]], %[[VAL_19]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_18]], %[[VAL_20]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_16:.*]] = firrtl.mux(%[[VAL_6]], %[[VAL_9]], %[[VAL_12]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+// CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_16]] : !firrtl.uint<32>, !firrtl.uint<32>
+// CHECK:             %[[VAL_17:.*]] = firrtl.and %[[VAL_7]], %[[VAL_10]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_18:.*]] = firrtl.and %[[VAL_4]], %[[VAL_17]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_19:.*]] = firrtl.and %[[VAL_14]], %[[VAL_18]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.connect %[[VAL_13]], %[[VAL_18]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             %[[VAL_21:.*]] = firrtl.and %[[VAL_18]], %[[VAL_14]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_5]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_8]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_11]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_5]], %[[VAL_19]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_8]], %[[VAL_19]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_11]], %[[VAL_19]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:           }
-// CHECK:           firrtl.module @test_select(in %[[VAL_22:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_23:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_24:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_25:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_26:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_27:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_28:.*]]: !firrtl.clock, in %[[VAL_29:.*]]: !firrtl.uint<1>) {
-// CHECK:             %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = firrtl.instance handshake_select0  @handshake_select_in_ui1_ui32_ui32_out_ui32(in sel: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in true: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in false: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
-// CHECK:             firrtl.connect %[[VAL_30]], %[[VAL_22]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
-// CHECK:             firrtl.connect %[[VAL_31]], %[[VAL_23]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_32]], %[[VAL_24]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_26]], %[[VAL_33]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_27]], %[[VAL_25]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:           firrtl.module @test_select(in %[[VAL_20:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_21:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_22:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_23:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_24:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_25:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_26:.*]]: !firrtl.clock, in %[[VAL_27:.*]]: !firrtl.uint<1>) {
+// CHECK:             %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = firrtl.instance arith_select0 @arith_select_in_ui1_ui32_ui32_out_ui32(in in0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in in1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in in2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
+// CHECK:             firrtl.connect %[[VAL_28]], %[[VAL_20]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             firrtl.connect %[[VAL_29]], %[[VAL_21]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_30]], %[[VAL_22]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_24]], %[[VAL_31]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_25]], %[[VAL_23]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:           }
 // CHECK:         }
 
 handshake.func @test_select(%arg0: i1, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) {
-  %0 = select %arg0, %arg1, %arg2 : i32
+  %0 = arith.select %arg0, %arg1, %arg2 : i32
   return %0, %arg3 : i32, none
 }

--- a/test/Conversion/HandshakeToHW/test_select.mlir
+++ b/test/Conversion/HandshakeToHW/test_select.mlir
@@ -1,18 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @handshake_select_in_ui1_ui32_ui32_out_ui32(
-// CHECK-SAME:                                                          %[[VAL_0:.*]]: !esi.channel<i1>, %[[VAL_1:.*]]: !esi.channel<i32>, %[[VAL_2:.*]]: !esi.channel<i32>) -> (out0: !esi.channel<i32>) {
+// CHECK-LABEL:   hw.module @arith_select_in_ui1_ui32_ui32_out_ui32(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !esi.channel<i1>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: !esi.channel<i32>,
+// CHECK-SAME:                                                      %[[VAL_2:.*]]: !esi.channel<i32>) -> (out0: !esi.channel<i32>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i1
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_5]] : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_5]] : i32
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : i32
-// CHECK:           %[[VAL_12]] = comb.mux %[[VAL_3]], %[[VAL_6]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_13]] = comb.and %[[VAL_4]], %[[VAL_7]], %[[VAL_9]] : i1
-// CHECK:           %[[VAL_5]] = comb.and %[[VAL_13]], %[[VAL_11]] : i1
+// CHECK:           %[[VAL_5]] = comb.and %[[VAL_11]], %[[VAL_13]] : i1
+// CHECK:           %[[VAL_12]] = comb.mux %[[VAL_3]], %[[VAL_6]], %[[VAL_8]] : i32
 // CHECK:           hw.output %[[VAL_10]] : !esi.channel<i32>
 // CHECK:         }
 
 handshake.func @test_select(%arg0: i1, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) {
-  %0 = select %arg0, %arg1, %arg2 : i32
+  %0 = arith.select %arg0, %arg1, %arg2 : i32
   return %0, %arg3 : i32, none
 }

--- a/test/Conversion/StandardToHandshake/arith-ops.mlir
+++ b/test/Conversion/StandardToHandshake/arith-ops.mlir
@@ -6,21 +6,21 @@
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_1]] : f32
 // CHECK:           %[[VAL_7:.*]] = merge %[[VAL_2]] : i32
 // CHECK:           %[[VAL_8:.*]] = merge %[[VAL_3]] : i32
-// CHECK:           %[[VAL_4x:.*]] = merge %[[VAL_4]] : none
-// CHECK:           %[[VAL_9:.*]] = arith.subf %[[VAL_5]], %[[VAL_6]] : f32
-// CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_12:.*]] = arith.divsi %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_13:.*]] = arith.divui %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_14:.*]] = arith.remsi %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_15:.*]] = arith.remui %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_16:.*]] = select %[[VAL_11]], %[[VAL_8]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_17:.*]] = arith.divf %[[VAL_5]], %[[VAL_6]] : f32
-// CHECK:           %[[VAL_18:.*]] = arith.remf %[[VAL_5]], %[[VAL_6]] : f32
-// CHECK:           %[[VAL_19:.*]] = arith.andi %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_20:.*]] = arith.ori %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_21:.*]] = arith.xori %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           return %[[VAL_9]], %[[VAL_12]], %[[VAL_4x]] : f32, i32, none
+// CHECK:           %[[VAL_9:.*]] = merge %[[VAL_4]] : none
+// CHECK:           %[[VAL_10:.*]] = arith.subf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_11:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_13:.*]] = arith.divsi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_14:.*]] = arith.divui %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_15:.*]] = arith.remsi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_16:.*]] = arith.remui %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_17:.*]] = arith.select %[[VAL_12]], %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_18:.*]] = arith.divf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_19:.*]] = arith.remf %[[VAL_5]], %[[VAL_6]] : f32
+// CHECK:           %[[VAL_20:.*]] = arith.andi %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_21:.*]] = arith.ori %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_22:.*]] = arith.xori %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           return %[[VAL_10]], %[[VAL_13]], %[[VAL_9]] : f32, i32, none
 // CHECK:         }
 func.func @ops(f32, f32, i32, i32) -> (f32, i32) {
 ^bb0(%arg0: f32, %arg1: f32, %arg2: i32, %arg3: i32):


### PR DESCRIPTION
I introduced `handshake.select` back in the day to distinguish it from `handshake.mux`. What i somehow failed to realize is that `handshake.select` has always lowered to a unit-rate actor, which completely removes the need for the operation. The fix all along seems to just lower it to a comb/firrtl mux with unit rate semantics.

Furthermore, looks like there was a bug in the lowerings, wherein the operands of `arith.select` in standard to handshake was being swapped (hence the change in max.mlir, which was actually incorrect before).

Handshake to FIRRTL is... eghh... could have done a "nicer" implementation which factors out the join logic, but i can't be bothered - this pass is supposed to be deprecated, anyways, and i can't wait for the day when it is removed.