### PR TITLE
[LowerTypes] Preserve rwprobes, forceable.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -628,7 +628,7 @@ bool TypeLoweringVisitor::lowerProducer(
 }
 
 void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
-  for (auto user : llvm::make_early_inc_range(val.getUsers())) {
+  for (auto *user : llvm::make_early_inc_range(val.getUsers())) {
     TypeSwitch<Operation *, void>(user)
         .Case<SubindexOp>([mapping](SubindexOp sio) {
           Value repl = mapping[sio.getIndex()];

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1265,11 +1265,10 @@ bool TypeLoweringVisitor::visitExpr(RefSendOp op) {
     return builder->create<RefSendOp>(
         getSubWhatever(op.getBase(), field.index));
   };
-  // XXX: When stop force-lowering references, there's a problem
-  // if we lower because not passive, but this won't be reflected
-  // along the define chain.
-  // Handle in same reconstruction approach as Forceable?
-  return lowerProducer(op, clone, op.getBase().getType());
+  // Be careful re:what gets lowered, consider ref.send of non-passive
+  // and whether we're using the ref or the base type to choose
+  // whether this should be lowered.
+  return lowerProducer(op, clone);
 }
 
 bool TypeLoweringVisitor::visitExpr(RefResolveOp op) {
@@ -1279,6 +1278,7 @@ bool TypeLoweringVisitor::visitExpr(RefResolveOp op) {
     return builder->create<RefResolveOp>(src);
   };
   // Lower according to lowering of the reference.
+  // Particularly, preserve if rwprobe.
   return lowerProducer(op, clone, op.getRef().getType());
 }
 

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1179,16 +1179,12 @@ firrtl.module private @is1436_FOO() {
 
     // Check lowering force and release operations.
     // Use self-assigns for simplicity.
-    // For now, expand force if the "source" operand is expanded.
-    // CHECK: %[[BOV_REF_A:.+]] = firrtl.ref.sub %[[BOV_REF]][0]
-    // CHECK: %[[BOV_REF_A_0:.+]] = firrtl.ref.sub %[[BOV_REF_A]][0]
-    // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_A_0]], %[[BOV_A_0]] :
-    // CHECK: %[[BOV_REF_A_1:.+]] = firrtl.ref.sub %[[BOV_REF_A]][1]
-    // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_A_1]], %[[BOV_A_1]] :
-    // CHECK: %[[BOV_REF_B:.+]] = firrtl.ref.sub %[[BOV_REF]][1]
-    // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_B]], %[[BOV_B]] :
+    // Source operand may need to be materialized from its elements.
+    // CHECK: vectorcreate
+    // CHECK: bundlecreate
+    // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF]],
     firrtl.ref.force %clock, %pred, %inst_bov_ref, %inst_bov : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
-    // CHECK-COUNT-3: firrtl.ref.force_initial %pred,
+    // CHECK: firrtl.ref.force_initial %pred, %[[BOV_REF]],
     firrtl.ref.force_initial %pred, %inst_bov_ref, %inst_bov : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK: firrtl.ref.release %clock, %pred, %[[BOV_REF]] :
     firrtl.ref.release %clock, %pred, %inst_bov_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1108,85 +1108,92 @@ firrtl.module private @is1436_FOO() {
 
   // CHECK-LABEL: firrtl.module private @RefTypeBV_RW
   firrtl.module private @RefTypeBV_RW(
-    out %vec_ref: !firrtl.rwprobe<vector<uint<1>,2>>,
-    out %vec: !firrtl.vector<uint<1>,2>,
-    out %bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>,
-    out %bov: !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>,
+    // CHECK-SAME: rwprobe<vector<uint<1>, 2>>
+    out %vec_ref: !firrtl.rwprobe<vector<uint<1>, 2>>,
+    // CHECK-NOT: firrtl.vector
+    out %vec: !firrtl.vector<uint<1>, 2>,
+    // CHECK-SAME: rwprobe<bundle
+    out %bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>,
+    // CHECK-NOT: bundle
+    out %bov: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>,
+    // CHECK: firrtl.probe
     out %probe: !firrtl.probe<uint<2>>
   ) {
-    // Forceable declaration expanded into ground elements.
-    // CHECK-NEXT: %{{.+}}, %[[X_A_0_REF:.+]] = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
-    // CHECK-NEXT: %{{.+}}, %[[X_A_1_REF:.+]] = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
-    // CHECK-NEXT: %{{.+}}, %[[X_B_REF:.+]] = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    %x, %x_ref = firrtl.wire forceable : !firrtl.bundle<a: vector<uint<1>, 2>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    // Forceable declaration are never expanded into ground elements.
+    // CHECK-NEXT: %{{.+}}, %[[X_REF:.+]] = firrtl.wire forceable : !firrtl.bundle<a: vector<uint<1>, 2>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    %x, %x_ref = firrtl.wire forceable : !firrtl.bundle<a: vector<uint<1>, 2>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
 
-    // Define using forceable ref expanded.
-    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_A_0_REF]] : !firrtl.rwprobe<uint<1>>
-    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_A_1_REF]] : !firrtl.rwprobe<uint<1>>
-    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_B_REF]] : !firrtl.rwprobe<uint<2>>
-    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    // Define using forceable ref preserved.
+    // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_REF]] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1> ,2>, b: uint<2>>>
 
-    // Update ref.sub uses.
-    // CHECK-NEXT: %[[v_0:.+]] = firrtl.ref.resolve %[[X_A_0_REF]]
-    // CHECK-NEXT: %[[v_1:.+]] = firrtl.ref.resolve %[[X_A_1_REF]]
+    // Preserve ref.sub uses.
+    // CHECK-NEXT: %[[X_REF_A:.+]] = firrtl.ref.sub %[[X_REF]][0]
+    // CHECK-NEXT: %[[X_A:.+]] = firrtl.ref.resolve %[[X_REF_A]]
+    // CHECK-NEXT: %[[v_0:.+]] = firrtl.subindex %[[X_A]][0]
     // CHECK-NEXT: firrtl.strictconnect %vec_0, %[[v_0]]
+    // CHECK-NEXT: %[[v_1:.+]] = firrtl.subindex %[[X_A]][1]
     // CHECK-NEXT: firrtl.strictconnect %vec_1, %[[v_1]]
-    %x_ref_a = firrtl.ref.sub %x_ref[0] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
-    %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.rwprobe<vector<uint<1>,2>>
-    firrtl.strictconnect %vec, %x_a : !firrtl.vector<uint<1>,2>
+    %x_ref_a = firrtl.ref.sub %x_ref[0] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.rwprobe<vector<uint<1>, 2>>
+    firrtl.strictconnect %vec, %x_a : !firrtl.vector<uint<1>, 2>
 
     // Check chained ref.sub's work.
+    // CHECK-NEXT: %[[X_A_1_REF:.+]] = firrtl.ref.sub %[[X_REF_A]][1]
     // CHECK-NEXT: firrtl.ref.resolve %[[X_A_1_REF]]
-    %x_ref_a_1 = firrtl.ref.sub %x_ref_a[1] : !firrtl.rwprobe<vector<uint<1>,2>>
+    %x_ref_a_1 = firrtl.ref.sub %x_ref_a[1] : !firrtl.rwprobe<vector<uint<1>, 2>>
     %x_a_1 = firrtl.ref.resolve %x_ref_a_1 : !firrtl.rwprobe<uint<1>>
 
     // Ref to flipped field.
+    // CHECK-NEXT: %[[X_B_REF:.+]] = firrtl.ref.sub %[[X_REF]][1]
     // CHECK-NEXT: firrtl.ref.resolve %[[X_B_REF]]
-    %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.rwprobe<uint<2>>
 
     // TODO: Handle rwprobe --> probe define, enable this.
     // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>
 
-    // Check resolve is fully expanded.
-    // CHECK-NEXT: %[[READ_A_0:.+]] = firrtl.ref.resolve %[[X_A_0_REF]]
-    // CHECK-NEXT: %[[READ_A_1:.+]] = firrtl.ref.resolve %[[X_A_1_REF]]
-    // CHECK-NEXT: %[[READ_B:.+]] = firrtl.ref.resolve %[[X_B_REF]]
-    // CHECK-NEXT: firrtl.strictconnect %bov_a_0, %[[READ_A_0]]
-    // CHECK-NEXT: firrtl.strictconnect %bov_a_1, %[[READ_A_1]]
-    // CHECK-NEXT: firrtl.strictconnect %bov_b, %[[READ_B]]
-    %x_read = firrtl.ref.resolve %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
-    firrtl.strictconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>
+    // Check resolve of rwprobe is preserved.
+    // CHECK-NEXT: = firrtl.ref.resolve %[[X_REF]]
+    // CHECK: firrtl.strictconnect %bov_a_0,
+    // CHECK: firrtl.strictconnect %bov_a_1,
+    // CHECK: firrtl.strictconnect %bov_b,
+    %x_read = firrtl.ref.resolve %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    firrtl.strictconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK-NEXT: }
   }
   // Check how rwprobe's of aggregates in instances are handled.
-  // Temporary until no longer need to lower these.
   // CHECK-LABEL: firrtl.module private @InstWithRWProbeOfAgg
   firrtl.module private @InstWithRWProbeOfAgg(in %clock : !firrtl.clock, in %pred : !firrtl.uint<1>) {
-    // CHECK: {{((%[^,]+, ){4})}}
-    // CHECK-SAME: %[[BOV_REF_A_0:[^,]+]], %[[BOV_REF_A_1:[^,]+]], %[[BOV_REF_B:[^,]+]],
+    // CHECK: {{((%[^,]+, ){3})}}
+    // CHECK-SAME: %[[BOV_REF:[^,]+]],
     // CHECK-SAME: %[[BOV_A_0:.+]],        %[[BOV_A_1:.+]],        %[[BOV_B:.+]],        %{{.+}} = firrtl.instance
     // CHECK-NOT: firrtl.probe
     // CHECK-SAME: probe: !firrtl.probe<uint<2>>)
     %inst_vec_ref, %inst_vec, %inst_bov_ref, %inst_bov, %inst_probe = firrtl.instance inst @RefTypeBV_RW(
-      out vec_ref: !firrtl.rwprobe<vector<uint<1>,2>>,
-      out vec: !firrtl.vector<uint<1>,2>,
-      out bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>,
-      out bov: !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>,
+      out vec_ref: !firrtl.rwprobe<vector<uint<1>, 2>>,
+      out vec: !firrtl.vector<uint<1>, 2>,
+      out bov_ref: !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>,
+      out bov: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>,
       out probe: !firrtl.probe<uint<2>>)
 
     // Check lowering force and release operations.
     // Use self-assigns for simplicity.
+    // For now, expand force if the "source" operand is expanded.
+    // CHECK: %[[BOV_REF_A:.+]] = firrtl.ref.sub %[[BOV_REF]][0]
+    // CHECK: %[[BOV_REF_A_0:.+]] = firrtl.ref.sub %[[BOV_REF_A]][0]
     // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_A_0]], %[[BOV_A_0]] :
+    // CHECK: %[[BOV_REF_A_1:.+]] = firrtl.ref.sub %[[BOV_REF_A]][1]
     // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_A_1]], %[[BOV_A_1]] :
+    // CHECK: %[[BOV_REF_B:.+]] = firrtl.ref.sub %[[BOV_REF]][1]
     // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF_B]], %[[BOV_B]] :
-    firrtl.ref.force %clock, %pred, %inst_bov_ref, %inst_bov : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>
+    firrtl.ref.force %clock, %pred, %inst_bov_ref, %inst_bov : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK-COUNT-3: firrtl.ref.force_initial %pred,
-    firrtl.ref.force_initial %pred, %inst_bov_ref, %inst_bov : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>,2>, b: uint<2>>
-    // CHECK-COUNT-3: firrtl.ref.release %clock, %pred, 
-    firrtl.ref.release %clock, %pred, %inst_bov_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
-    // CHECK-COUNT-3: firrtl.ref.release_initial %pred, 
-    firrtl.ref.release_initial %pred, %inst_bov_ref : !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>,2>, b: uint<2>>>
+    firrtl.ref.force_initial %pred, %inst_bov_ref, %inst_bov : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    // CHECK: firrtl.ref.release %clock, %pred, %[[BOV_REF]] :
+    firrtl.ref.release %clock, %pred, %inst_bov_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
+    // CHECK: firrtl.ref.release_initial %pred, %[[BOV_REF]] :
+    firrtl.ref.release_initial %pred, %inst_bov_ref : !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     // CHECK-NEXT: }
   }
 


### PR DESCRIPTION
Don't lower these as much as possible.

Keep the always-lower-(non-rw-)probe behavior
to workaround the memtaps / 4479 issue.

Also, if we need to lower the source operand,
re-construct/materialize it (like "Source Materialization").

This does of course mean rwprobe'ing something means it needs to be okay to preserve as an aggregate.