### PR TITLE
[NFC][Support] Factor out TypeConversionPattern into support lib

### DIFF
--- a/include/circt/Support/ConversionPatterns.h
+++ b/include/circt/Support/ConversionPatterns.h
@@ -1,0 +1,37 @@
+//===- ConversionPatterns.h - Common Conversion patterns --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_CONVERSIONPATTERNS_H
+#define CIRCT_SUPPORT_CONVERSIONPATTERNS_H
+
+#include "circt/Support/LLVM.h"
+
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace circt {
+
+/// Generic pattern which replaces an operation by one of the same operation
+/// name, but with converted attributes, operands, and result types to eliminate
+/// illegal types. Uses generic builders based on OperationState to make sure
+/// that this pattern can apply to _any_ operation.
+///
+/// Useful when a conversion can be entirely defined by a TypeConverter.
+struct TypeConversionPattern : public mlir::ConversionPattern {
+public:
+  TypeConversionPattern(TypeConverter &converter, MLIRContext *context)
+      : ConversionPattern(converter, MatchAnyOpTypeTag(), 1, context) {}
+  using ConversionPattern::ConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_CONVERSIONPATTERNS_H

--- a/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Support/ConversionPatterns.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -30,101 +31,6 @@ struct ESILowerTypesPass : public LowerESITypesBase<ESILowerTypesPass> {
   void runOnOperation() override;
 };
 } // anonymous namespace
-
-// Converts a function type wrt. the given type converter.
-static FunctionType convertFunctionType(TypeConverter &typeConverter,
-                                        FunctionType type) {
-  // Convert the original function types.
-  llvm::SmallVector<Type> res, arg;
-  llvm::transform(type.getResults(), std::back_inserter(res),
-                  [&](Type t) { return typeConverter.convertType(t); });
-  llvm::transform(type.getInputs(), std::back_inserter(arg),
-                  [&](Type t) { return typeConverter.convertType(t); });
-
-  return FunctionType::get(type.getContext(), arg, res);
-}
-
-namespace {
-/// Generic pattern which replaces an operation by one of the same operation
-/// name, but with converted attributes, operands, and result types to eliminate
-/// illegal types. Uses generic builders based on OperationState to make sure
-/// that this pattern can apply to _any_ operation.
-struct TypeConversionPattern : public ConversionPattern {
-public:
-  TypeConversionPattern(TypeConverter &converter, MLIRContext *context)
-      : ConversionPattern(converter, MatchAnyOpTypeTag(), 1, context) {}
-  using ConversionPattern::ConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
-                  ConversionPatternRewriter &rewriter) const override;
-};
-} // namespace
-
-LogicalResult TypeConversionPattern::matchAndRewrite(
-    Operation *op, ArrayRef<Value> operands,
-    ConversionPatternRewriter &rewriter) const {
-
-  // Convert the TypeAttrs.
-  llvm::SmallVector<NamedAttribute, 4> newAttrs;
-  newAttrs.reserve(op->getAttrs().size());
-  for (auto attr : op->getAttrs()) {
-    if (auto typeAttr = attr.getValue().dyn_cast<TypeAttr>()) {
-      auto innerType = typeAttr.getValue();
-      // TypeConvert::convertType doesn't handle function types, so we need to
-      // handle them manually.
-      if (auto funcType = innerType.dyn_cast<FunctionType>(); innerType) {
-        innerType = convertFunctionType(*getTypeConverter(), funcType);
-      } else {
-        innerType = getTypeConverter()->convertType(innerType);
-      }
-      newAttrs.emplace_back(attr.getName(), TypeAttr::get(innerType));
-    } else {
-      newAttrs.push_back(attr);
-    }
-  }
-
-  // Convert the result types.
-  llvm::SmallVector<Type, 4> newResults;
-  (void)getTypeConverter()->convertTypes(op->getResultTypes(), newResults);
-
-  // Build the state for the edited clone.
-  OperationState state(op->getLoc(), op->getName().getStringRef(), operands,
-                       newResults, newAttrs, op->getSuccessors());
-  for (size_t i = 0, e = op->getNumRegions(); i < e; ++i)
-    state.addRegion();
-
-  // Must create the op before running any modifications on the regions so that
-  // we don't crash with '-debug' and so we have something to 'root update'.
-  Operation *newOp = rewriter.create(state);
-
-  // Move the regions over, converting the signatures as we go.
-  rewriter.startRootUpdate(newOp);
-  for (size_t i = 0, e = op->getNumRegions(); i < e; ++i) {
-    Region &region = op->getRegion(i);
-    Region *newRegion = &newOp->getRegion(i);
-
-    // TypeConverter::SignatureConversion drops argument locations, so we need
-    // to manually copy them over (a verifier in e.g. HWModule checks this).
-    llvm::SmallVector<Location, 4> argLocs;
-    for (auto arg : region.getArguments())
-      argLocs.push_back(arg.getLoc());
-
-    rewriter.inlineRegionBefore(region, *newRegion, newRegion->begin());
-    TypeConverter::SignatureConversion result(newRegion->getNumArguments());
-    (void)getTypeConverter()->convertSignatureArgs(
-        newRegion->getArgumentTypes(), result);
-    rewriter.applySignatureConversion(newRegion, result, getTypeConverter());
-
-    // Apply the argument locations.
-    for (auto [arg, loc] : llvm::zip(newRegion->getArguments(), argLocs))
-      arg.setLoc(loc);
-  }
-  rewriter.finalizeRootUpdate(newOp);
-
-  rewriter.replaceOp(op, newOp->getResults());
-  return success();
-}
 
 namespace {
 /// Materializations and type conversions to lower ESI data windows.

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -24,6 +24,7 @@ add_circt_library(CIRCTSupport
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRTransformUtils
   )
 
 #-------------------------------------------------------------------------------

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -8,6 +8,7 @@ set_source_files_properties("${VERSION_CPP}" PROPERTIES GENERATED TRUE)
 add_circt_library(CIRCTSupport
   APInt.cpp
   BackedgeBuilder.cpp
+  ConversionPatterns.cpp
   CustomDirectiveImpl.cpp
   FieldRef.cpp
   JSON.cpp

--- a/lib/Support/ConversionPatterns.cpp
+++ b/lib/Support/ConversionPatterns.cpp
@@ -1,0 +1,92 @@
+//===- ConversionPatterns.cpp - Common Conversion patterns ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/ConversionPatterns.h"
+
+using namespace circt;
+
+// Converts a function type wrt. the given type converter.
+static FunctionType convertFunctionType(TypeConverter &typeConverter,
+                                        FunctionType type) {
+  // Convert the original function types.
+  llvm::SmallVector<Type> res, arg;
+  llvm::transform(type.getResults(), std::back_inserter(res),
+                  [&](Type t) { return typeConverter.convertType(t); });
+  llvm::transform(type.getInputs(), std::back_inserter(arg),
+                  [&](Type t) { return typeConverter.convertType(t); });
+
+  return FunctionType::get(type.getContext(), arg, res);
+}
+
+LogicalResult TypeConversionPattern::matchAndRewrite(
+    Operation *op, ArrayRef<Value> operands,
+    ConversionPatternRewriter &rewriter) const {
+  // Convert the TypeAttrs.
+  llvm::SmallVector<NamedAttribute, 4> newAttrs;
+  newAttrs.reserve(op->getAttrs().size());
+  for (auto attr : op->getAttrs()) {
+    if (auto typeAttr = attr.getValue().dyn_cast<TypeAttr>()) {
+      auto innerType = typeAttr.getValue();
+      // TypeConvert::convertType doesn't handle function types, so we need to
+      // handle them manually.
+      if (auto funcType = innerType.dyn_cast<FunctionType>(); innerType)
+        innerType = convertFunctionType(*getTypeConverter(), funcType);
+      else
+        innerType = getTypeConverter()->convertType(innerType);
+      newAttrs.emplace_back(attr.getName(), TypeAttr::get(innerType));
+    } else {
+      newAttrs.push_back(attr);
+    }
+  }
+
+  // Convert the result types.
+  llvm::SmallVector<Type, 4> newResults;
+  if (failed(
+          getTypeConverter()->convertTypes(op->getResultTypes(), newResults)))
+    return rewriter.notifyMatchFailure(op->getLoc(), "type conversion failed");
+
+  // Build the state for the edited clone.
+  OperationState state(op->getLoc(), op->getName().getStringRef(), operands,
+                       newResults, newAttrs, op->getSuccessors());
+  for (size_t i = 0, e = op->getNumRegions(); i < e; ++i)
+    state.addRegion();
+
+  // Must create the op before running any modifications on the regions so that
+  // we don't crash with '-debug' and so we have something to 'root update'.
+  Operation *newOp = rewriter.create(state);
+
+  // Move the regions over, converting the signatures as we go.
+  rewriter.startRootUpdate(newOp);
+  for (size_t i = 0, e = op->getNumRegions(); i < e; ++i) {
+    Region &region = op->getRegion(i);
+    Region *newRegion = &newOp->getRegion(i);
+
+    // TypeConverter::SignatureConversion drops argument locations, so we need
+    // to manually copy them over (a verifier in e.g. HWModule checks this).
+    llvm::SmallVector<Location, 4> argLocs;
+    for (auto arg : region.getArguments())
+      argLocs.push_back(arg.getLoc());
+
+    // Move the region and convert the region args.
+    rewriter.inlineRegionBefore(region, *newRegion, newRegion->begin());
+    TypeConverter::SignatureConversion result(newRegion->getNumArguments());
+    if (failed(getTypeConverter()->convertSignatureArgs(
+            newRegion->getArgumentTypes(), result)))
+      return rewriter.notifyMatchFailure(op->getLoc(),
+                                         "type conversion failed");
+    rewriter.applySignatureConversion(newRegion, result, getTypeConverter());
+
+    // Apply the argument locations.
+    for (auto [arg, loc] : llvm::zip(newRegion->getArguments(), argLocs))
+      arg.setLoc(loc);
+  }
+  rewriter.finalizeRootUpdate(newOp);
+
+  rewriter.replaceOp(op, newOp->getResults());
+  return success();
+}


### PR DESCRIPTION
This `ConversionPattern` is used in two places and is likely generally useful. Move it into the support lib.

Fixes #4899 as a side-effect.