### PR TITLE
[ETC] Don't relocate instances that were only in extracted test code.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -1487,11 +1487,6 @@ modules. This attribute has type `OutputFileAttr`.
 Used by SVExtractTestCode.  Specifies the output directory for extracted
 modules. This attribute has type `OutputFileAttr`.
 
-### firrtl.extract.testbench
-
-Used by SVExtractTestCode.  Specifies the output directory for extracted
-testbench only modules. This attribute has type `OutputFileAttr`.
-
 ### firrtl.extract.assert.bindfile
 
 Used by SVExtractTestCode.  Specifies the output file for extracted

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -505,15 +505,6 @@ void FIRRTLModuleLowering::runOnOperation() {
   circuitAnno.removeAnnotationsWithClass(
       extractAssertAnnoClass, extractAssumeAnnoClass, extractCoverageAnnoClass);
 
-  // Pass along the testbench directory for ExtractTestCode to use later.
-  if (auto tbAnno = circuitAnno.getAnnotation(testBenchDirAnnoClass)) {
-    auto dirName = tbAnno.getMember<StringAttr>("dirname");
-    auto testBenchDir = hw::OutputFileAttr::getAsDirectory(
-        &getContext(), dirName.getValue(), /*excludeFromFileList=*/true,
-        /*includeReplicatedOps=*/true);
-    getOperation()->setAttr("firrtl.extract.testbench", testBenchDir);
-  }
-
   state.processRemainingAnnotations(circuit, circuitAnno);
   // Iterate through each operation in the circuit body, transforming any
   // FModule's we come across. If any module fails to lower, return early.

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -227,14 +227,6 @@ module {
 // -----
 // Check instance extraction
 
-// All instances of Baz are extracted, so it should be output to the testbench.
-// CHECK-LABEL: @Baz
-// CHECK-SAME: output_file = #hw.output_file<"testbench{{/|\\\\}}", excludeFromFileList, includeReplicatedOps>
-
-// All instances of Bozo are extracted, so it should be output to the testbench.
-// CHECK-LABEL: @Bozo
-// CHECK: #hw.output_file<"testbench
-
 // In AllExtracted, instances foo, bar, and baz should be extracted.
 // CHECK-LABEL: @AllExtracted_cover
 // CHECK: hw.instance "foo"
@@ -294,9 +286,7 @@ module {
 // CHECK: hw.instance "non_testcode_and_instance0"
 // CHECK: hw.instance "non_testcode_and_instance1"
 
-module attributes {
-  firrtl.extract.testbench = #hw.output_file<"testbench/", excludeFromFileList, includeReplicatedOps>
-} {
+module {
   hw.module private @Foo(%a: i1) -> (b: i1) {
     hw.output %a : i1
   }


### PR DESCRIPTION
These don't actually belong in the testbench directory; they are still part of the design. So for now, simply leave them in the directory they were initially declared.