### PR TITLE
[Arc][LowerState] Fix combinational loop false positives

### DIFF
--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -260,3 +260,17 @@ hw.module @SeparateResets(%clock: i1, %i0: i42, %rst1: i1, %rst2: i1) -> (out1: 
 // CHECK:   }
 // CHECK: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i42>
 // CHECK: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i42>
+
+// Regression check on worklist producing false positive comb loop errors.
+// CHECK-LABEL: @CombLoopRegression
+hw.module @CombLoopRegression(%clk: i1) {
+  %0 = arc.state @CombLoopRegressionArc1(%3, %3) clock %clk lat 1 : (i1, i1) -> i1
+  %1, %2 = arc.state @CombLoopRegressionArc2(%0) lat 0 : (i1) -> (i1, i1)
+  %3 = arc.state @CombLoopRegressionArc1(%1, %2) lat 0 : (i1, i1) -> i1
+}
+arc.define @CombLoopRegressionArc1(%arg0: i1, %arg1: i1) -> i1 {
+  arc.output %arg0 : i1
+}
+arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
+  arc.output %arg0, %arg0 : i1, i1
+}


### PR DESCRIPTION
Fix the worklist that materializes values in clock trees to do a proper depth-first traversal of the operands, instead of trying to push the operands onto the worklist all at once. Doing the latter would lead to issues where all operands of an operation would be pushed onto the worklist, but then one of those operands might also depend on some of those operands:

    %0 = comb.and %x, %y
    %1 = comb.or %0, %y
    arc.state @foo(%0, %1)

This would push `%0` and `%1` onto the worklist, but then when trying to materialize `%1` the pass would falsely detect a combination loop when it tries to materialize `%0` and sees that it's already in the worklist.

This fix now collects all nested operands of an operation and tracks them alongside the operation, but then only processes the operands one-by-one such that a proper depth-first pattern is traced out.

Fixes #5053.