### PR TITLE
[Arc] Preserve extern modules as internal inputs/outputs

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -200,11 +200,6 @@ def SplitLoops : Pass<"arc-split-loops", "mlir::ModuleOp"> {
 def StripSV : Pass<"arc-strip-sv", "mlir::ModuleOp"> {
   let summary = "Remove SV wire, reg, and assigns";
   let constructor = "circt::arc::createStripSVPass()";
-  let options = [
-    Option<"replaceExtModuleOutputs", "replace-ext-module-outputs",
-      "bool", "true", "When enabled replaces all extern module instance "
-      "outputs with 0 and removes the instances and external modules">,
-  ];
   let dependentDialects = ["arc::ArcDialect", "comb::CombDialect",
                            "hw::HWDialect", "seq::SeqDialect"];
 }

--- a/lib/Dialect/Arc/Transforms/InlineModules.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineModules.cpp
@@ -64,6 +64,8 @@ struct PrefixingInliner : public InlinerInterface {
   void updateNames(Operation *op) const {
     if (auto name = op->getAttrOfType<StringAttr>("name"))
       op->setAttr("name", updateName(name));
+    if (auto name = op->getAttrOfType<StringAttr>("instanceName"))
+      op->setAttr("instanceName", updateName(name));
     if (auto namesAttr = op->getAttrOfType<ArrayAttr>("names")) {
       SmallVector<Attribute> names(namesAttr.getValue().begin(),
                                    namesAttr.getValue().end());

--- a/test/Dialect/Arc/inline-modules.mlir
+++ b/test/Dialect/Arc/inline-modules.mlir
@@ -75,3 +75,16 @@ hw.module private @NamesB() {
 hw.module private @NamesC() {
   hw.constant true {name = "x"}
 }
+
+
+// CHECK-LABEL: hw.module @ExtModuleA
+hw.module @ExtModuleA() {
+  // CHECK-NEXT: hw.instance "c0" @ExtModuleC
+  // CHECK-NEXT: hw.instance "b/c1" @ExtModuleC
+  hw.instance "c0" @ExtModuleC() -> ()
+  hw.instance "b" @ExtModuleB() -> ()
+}
+hw.module private @ExtModuleB() {
+  hw.instance "c1" @ExtModuleC() -> ()
+}
+hw.module.extern private @ExtModuleC()

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -1,7 +1,4 @@
-// RUN: split-file %s %t
-
-//--- defaults
-// RUN: circt-opt %t/defaults --arc-strip-sv --verify-diagnostics | FileCheck %t/defaults
+// RUN: circt-opt %s --arc-strip-sv --verify-diagnostics | FileCheck %s
 
 // CHECK-NOT: sv.verbatim
 // CHECK-NOT: sv.ifdef
@@ -21,22 +18,6 @@ hw.module @Foo(%clock: i1, %a: i4) -> (z: i4) {
   hw.output %2 : i4
 }
 // CHECK-NEXT: }
-
-// CHECK-NOT: hw.module.extern @PeripheryBus
-hw.module.extern @PeripheryBus() -> (clock: i1, reset: i1)
-// CHECK-LABEL: hw.module @Top
-hw.module @Top() {
-  %c0_i7 = hw.constant 0 : i7
-  // expected-warning @below {{StripSV: outputs of external module instance replaced with zero value!}}
-  %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
-  // CHECK-NOT: hw.instance
-  // CHECK: [[RST:%.+]] = comb.mux %false{{.*}}, %c0_i7, %int_rtc_tick_value : i7
-  // CHECK: %int_rtc_tick_value = seq.compreg [[RST]], %false{{.*}} : i7
-  %int_rtc_tick_value = seq.firreg %int_rtc_tick_value clock %subsystem_pbus.clock reset sync %subsystem_pbus.reset, %c0_i7 : i7
-}
-
-//--- dontReplaceExtModuleOutputs
-// RUN: circt-opt %t/dontReplaceExtModuleOutputs --arc-strip-sv=replace-ext-module-outputs=false | FileCheck %t/dontReplaceExtModuleOutputs
 
 // CHECK-LABEL: hw.module.extern @PeripheryBus
 hw.module.extern @PeripheryBus() -> (clock: i1, reset: i1)


### PR DESCRIPTION
Preserve instances of external modules in the arcilator pipeline rather than removing them and replacing their outputs with zero. The inputs of the extmodule act like outputs of the overall circuit, and the outputs of the extmodule act like inputs of the overall circuit. During state lowering, create write-only states for extmodule inputs (like taps) that just capture whatever the circuit applies to the extmodule, and create read-only states for extmodule outputs that the circuit only reads. This allows the user of the software model to treat extmodule ports like regular ports of the circuit and read/write the corresponding states.

Remove the extmodule stubbing in `StripSV`, since the default behavior of the read/write-only states is to be reset to zero. So if the user of the model does not write the extmodule outputs to any value, they will remain at zero.