### PR TITLE
LLVM Bump

### DIFF
--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -19,7 +19,9 @@
 #include <utility>
 
 namespace mlir {
+namespace affine {
 struct DependenceComponent;
+} // namespace affine
 namespace func {
 class FuncOp;
 } // namespace func
@@ -32,9 +34,10 @@ namespace analysis {
 /// It represents the destination of the dependence edge, the type of the
 /// dependence, and the components associated with each enclosing loop.
 struct MemoryDependence {
-  MemoryDependence(Operation *source,
-                   mlir::DependenceResult::ResultEnum dependenceType,
-                   ArrayRef<mlir::DependenceComponent> dependenceComponents)
+  MemoryDependence(
+      Operation *source,
+      mlir::affine::DependenceResult::ResultEnum dependenceType,
+      ArrayRef<mlir::affine::DependenceComponent> dependenceComponents)
       : source(source), dependenceType(dependenceType),
         dependenceComponents(dependenceComponents.begin(),
                              dependenceComponents.end()) {}
@@ -43,10 +46,10 @@ struct MemoryDependence {
   Operation *source;
 
   // The dependence type denotes whether or not there is a dependence.
-  mlir::DependenceResult::ResultEnum dependenceType;
+  mlir::affine::DependenceResult::ResultEnum dependenceType;
 
   // The dependence components include lower and upper bounds for each loop.
-  SmallVector<mlir::DependenceComponent> dependenceComponents;
+  SmallVector<mlir::affine::DependenceComponent> dependenceComponents;
 };
 
 /// MemoryDependenceResult captures a set of memory dependences. The map key is

--- a/include/circt/Analysis/SchedulingAnalysis.h
+++ b/include/circt/Analysis/SchedulingAnalysis.h
@@ -39,10 +39,11 @@ namespace analysis {
 struct CyclicSchedulingAnalysis {
   CyclicSchedulingAnalysis(Operation *funcOp, AnalysisManager &am);
 
-  CyclicProblem &getProblem(AffineForOp forOp);
+  CyclicProblem &getProblem(affine::AffineForOp forOp);
 
 private:
-  void analyzeForOp(AffineForOp forOp, MemoryDependenceAnalysis memoryAnalysis);
+  void analyzeForOp(affine::AffineForOp forOp,
+                    MemoryDependenceAnalysis memoryAnalysis);
 
   DenseMap<Operation *, CyclicProblem> problems;
 };

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -357,7 +357,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     static_assert(
         ConcreteOp::template hasTrait<OpTrait::InnerSymbolTable>(),
         "expected operation to be an inner symbol table");
-    return verifyModuleLikeOpInterface(op);
+    return verifyModuleLikeOpInterface(cast<::circt::firrtl::FModuleLike>(op));
   }];
 }
 
@@ -452,7 +452,9 @@ def Forceable : OpInterface<"Forceable"> {
     /// Attribute name for 'forceable' tracking.
     static StringRef getForceableAttrName() { return "forceable"; }
   }];
-  let verify = [{ return detail::verifyForceableOp($_op); }];
+  let verify = [{
+    return detail::verifyForceableOp(cast<::circt::firrtl::Forceable>($_op));
+  }];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -35,7 +35,7 @@ mlir::FailureOr<mlir::Type> evaluateParametricType(mlir::Location loc,
 
 /// Evaluates a parametric attribute (param.decl.ref/param.expr) based on a set
 /// of provided parameter values.
-mlir::FailureOr<mlir::Attribute>
+mlir::FailureOr<mlir::TypedAttr>
 evaluateParametricAttr(mlir::Location loc, mlir::ArrayAttr parameters,
                        mlir::Attribute paramAttr);
 

--- a/include/circt/Dialect/HW/HWModuleGraph.h
+++ b/include/circt/Dialect/HW/HWModuleGraph.h
@@ -183,7 +183,7 @@ struct llvm::DOTGraphTraits<circt::hw::HWModuleOp>
       os << " style=bold";
 
     return os.str();
-  };
+  }
 };
 
 #endif // CIRCT_DIALECT_HW_HWMODULEGRAPH_H

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -284,7 +284,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   ];
 
   let verify = [{
-    return verifyInnerSymAttr(op);
+    return verifyInnerSymAttr(cast<circt::hw::InnerSymbolOpInterface>(op));
   }];
 }
 

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -87,6 +87,7 @@ class AsmParser;
 class AsmPrinter;
 class Attribute;
 class Block;
+class TypedAttr;
 class IRMapping;
 class BlockArgument;
 class BoolAttr;
@@ -159,9 +160,12 @@ class WalkResult;
 enum class RegionKind;
 struct CallInterfaceCallable;
 struct LogicalResult;
-struct MemRefAccess;
 struct OperationState;
 class OperationName;
+
+namespace affine {
+struct MemRefAccess;
+} // namespace affine
 
 template <typename T>
 class FailureOr;
@@ -223,7 +227,6 @@ using mlir::IRMapping;                 // NOLINT(misc-unused-using-decls)
 using mlir::Location;                  // NOLINT(misc-unused-using-decls)
 using mlir::LocationAttr;              // NOLINT(misc-unused-using-decls)
 using mlir::LogicalResult;             // NOLINT(misc-unused-using-decls)
-using mlir::MemRefAccess;              // NOLINT(misc-unused-using-decls)
 using mlir::MemRefType;                // NOLINT(misc-unused-using-decls)
 using mlir::MLIRContext;               // NOLINT(misc-unused-using-decls)
 using mlir::ModuleOp;                  // NOLINT(misc-unused-using-decls)
@@ -265,6 +268,7 @@ using mlir::TupleType;                 // NOLINT(misc-unused-using-decls)
 using mlir::Type;                      // NOLINT(misc-unused-using-decls)
 using mlir::TypeAttr;                  // NOLINT(misc-unused-using-decls)
 using mlir::TypeConverter;             // NOLINT(misc-unused-using-decls)
+using mlir::TypedAttr;                 // NOLINT(misc-unused-using-decls)
 using mlir::TypeID;                    // NOLINT(misc-unused-using-decls)
 using mlir::TypeRange;                 // NOLINT(misc-unused-using-decls)
 using mlir::TypeStorage;               // NOLINT(misc-unused-using-decls)
@@ -274,6 +278,7 @@ using mlir::Value;                     // NOLINT(misc-unused-using-decls)
 using mlir::ValueRange;                // NOLINT(misc-unused-using-decls)
 using mlir::VectorType;                // NOLINT(misc-unused-using-decls)
 using mlir::WalkResult;                // NOLINT(misc-unused-using-decls)
+using mlir::affine::MemRefAccess;      // NOLINT(misc-unused-using-decls)
 namespace OpTrait = mlir::OpTrait;
 } // namespace circt
 

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/BuiltinOps.h"
 
 using namespace mlir;
+using namespace mlir::affine;
 using namespace circt::analysis;
 
 /// Helper to iterate through memory operation pairs and check for dependences
@@ -129,7 +130,7 @@ circt::analysis::MemoryDependenceAnalysis::MemoryDependenceAnalysis(
 
   // Collect affine loops grouped by nesting depth.
   std::vector<SmallVector<AffineForOp, 2>> depthToLoops;
-  mlir::gatherLoops(funcOp, depthToLoops);
+  mlir::affine::gatherLoops(funcOp, depthToLoops);
 
   // Collect load and store operations to check.
   SmallVector<Operation *> memoryOps;

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -23,6 +23,7 @@
 #include <limits>
 
 using namespace mlir;
+using namespace mlir::affine;
 
 /// CyclicSchedulingAnalysis constructs a CyclicProblem for each AffineForOp by
 /// performing a memory dependence analysis and inserting dependences into the
@@ -117,7 +118,7 @@ void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
   // terminator to ensure the problem schedules them before the terminator.
   auto *anchor = forOp.getBody()->getTerminator();
   forOp.getBody()->walk([&](Operation *op) {
-    if (!isa<mlir::AffineStoreOp, memref::StoreOp>(op))
+    if (!isa<AffineStoreOp, memref::StoreOp>(op))
       return;
     Problem::Dependence dep(op, anchor);
     auto depInserted = problem.insertDependence(dep);

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
+using namespace mlir::affine;
 using namespace circt::analysis;
 
 //===----------------------------------------------------------------------===//
@@ -53,7 +54,7 @@ void TestDependenceAnalysisPass::runOnOperation() {
     SmallVector<Attribute> deps;
 
     for (auto dep : analysis.getDependences(op)) {
-      if (dep.dependenceType != mlir::DependenceResult::HasDependence)
+      if (dep.dependenceType != DependenceResult::HasDependence)
         continue;
 
       SmallVector<Attribute> comps;

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -53,7 +53,7 @@ intptr_t hwArrayTypeGetSize(MlirType type) {
 bool hwTypeIsAIntType(MlirType type) { return unwrap(type).isa<IntType>(); }
 
 MlirType hwParamIntTypeGet(MlirAttribute parameter) {
-  return wrap(IntType::get(unwrap(parameter)));
+  return wrap(IntType::get(unwrap(parameter).cast<TypedAttr>()));
 }
 
 MlirAttribute hwParamIntTypeGetWidthAttr(MlirType type) {

--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -43,6 +43,7 @@ using namespace mlir::arith;
 using namespace mlir::memref;
 using namespace mlir::scf;
 using namespace mlir::func;
+using namespace mlir::affine;
 using namespace circt;
 using namespace circt::analysis;
 using namespace circt::scheduling;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -107,11 +107,11 @@ struct SubExprInfo {
 // Helper routines
 //===----------------------------------------------------------------------===//
 
-static Attribute getInt32Attr(MLIRContext *ctx, uint32_t value) {
+static TypedAttr getInt32Attr(MLIRContext *ctx, uint32_t value) {
   return Builder(ctx).getI32IntegerAttr(value);
 }
 
-static Attribute getIntAttr(MLIRContext *ctx, Type t, const APInt &value) {
+static TypedAttr getIntAttr(MLIRContext *ctx, Type t, const APInt &value) {
   return Builder(ctx).getIntegerAttr(t, value);
 }
 
@@ -1316,7 +1316,7 @@ static void emitDims(ArrayRef<Attribute> dims, raw_ostream &os, Location loc,
 
     // Otherwise it must be a parameterized dimension.  Shove the "-1" into the
     // attribute so it gets printed in canonical form.
-    auto typedAttr = width.dyn_cast<mlir::TypedAttr>();
+    auto typedAttr = width.dyn_cast<TypedAttr>();
     if (!typedAttr) {
       mlir::emitError(loc, "untyped dimension attribute ") << width;
       continue;
@@ -1324,7 +1324,7 @@ static void emitDims(ArrayRef<Attribute> dims, raw_ostream &os, Location loc,
     auto negOne = getIntAttr(
         loc.getContext(), typedAttr.getType(),
         APInt(typedAttr.getType().getIntOrFloatBitWidth(), -1L, true));
-    width = ParamExprAttr::get(PEO::Add, width, negOne);
+    width = ParamExprAttr::get(PEO::Add, typedAttr, negOne);
     os << '[';
     emitter.printParamValue(width, os, [loc]() {
       return mlir::emitError(loc, "invalid parameter in type");

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -518,8 +518,9 @@ Value AggregateConstantOpConversion::constructAggregate(
   };
 
   return TypeSwitch<Type, Value>(type)
-      .Case<IntegerType>(
-          [&](auto ty) { return builder.create<LLVM::ConstantOp>(loc, data); })
+      .Case<IntegerType>([&](auto ty) {
+        return builder.create<LLVM::ConstantOp>(loc, data.cast<TypedAttr>());
+      })
       .Case<hw::ArrayType, hw::StructType>([&](auto ty) {
         Value aggVal = builder.create<LLVM::UndefOp>(loc, llvmType);
         auto arrayAttr = data.cast<ArrayAttr>();

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -248,18 +248,18 @@ static std::string getSubModuleName(Operation *oldOp) {
 /// Check whether a submodule with the same name has been created elsewhere in
 /// the top level module. Return the matched module operation if true, otherwise
 /// return nullptr.
-static Operation *checkSubModuleOp(mlir::ModuleOp parentModule,
-                                   StringRef modName) {
+static HWModuleLike checkSubModuleOp(mlir::ModuleOp parentModule,
+                                     StringRef modName) {
   if (auto mod = parentModule.lookupSymbol<HWModuleOp>(modName))
     return mod;
   if (auto mod = parentModule.lookupSymbol<HWModuleExternOp>(modName))
     return mod;
-  return nullptr;
+  return {};
 }
 
-static Operation *checkSubModuleOp(mlir::ModuleOp parentModule,
-                                   Operation *oldOp) {
-  auto *moduleOp = checkSubModuleOp(parentModule, getSubModuleName(oldOp));
+static HWModuleLike checkSubModuleOp(mlir::ModuleOp parentModule,
+                                     Operation *oldOp) {
+  auto moduleOp = checkSubModuleOp(parentModule, getSubModuleName(oldOp));
 
   if (isa<handshake::InstanceOp>(oldOp))
     assert(moduleOp &&

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -48,6 +48,7 @@
 
 using namespace mlir;
 using namespace mlir::func;
+using namespace mlir::affine;
 using namespace circt;
 using namespace circt::handshake;
 using namespace std;
@@ -66,7 +67,7 @@ public:
     addLegalDialect<mlir::func::FuncDialect>();
     addLegalDialect<mlir::arith::ArithDialect>();
     addIllegalDialect<mlir::scf::SCFDialect>();
-    addIllegalDialect<mlir::AffineDialect>();
+    addIllegalDialect<AffineDialect>();
 
     /// The root operation to be replaced is marked dynamically legal
     /// based on the lowering status of the given operation, see
@@ -1236,7 +1237,7 @@ static LogicalResult getOpMemRef(Operation *op, Value &out) {
     out = memOp.getMemRef();
   else if (auto memOp = dyn_cast<memref::StoreOp>(op))
     out = memOp.getMemRef();
-  else if (isa<mlir::AffineReadOpInterface, mlir::AffineWriteOpInterface>(op)) {
+  else if (isa<AffineReadOpInterface, AffineWriteOpInterface>(op)) {
     MemRefAccess access(op);
     out = access.memref;
   }
@@ -1246,8 +1247,8 @@ static LogicalResult getOpMemRef(Operation *op, Value &out) {
 }
 
 static bool isMemoryOp(Operation *op) {
-  return isa<memref::LoadOp, memref::StoreOp, mlir::AffineReadOpInterface,
-             mlir::AffineWriteOpInterface>(op);
+  return isa<memref::LoadOp, memref::StoreOp, AffineReadOpInterface,
+             AffineWriteOpInterface>(op);
 }
 
 LogicalResult
@@ -1299,41 +1300,40 @@ HandshakeLowering::replaceMemoryOps(ConversionPatternRewriter &rewriter,
           newOp = rewriter.create<handshake::StoreOp>(
               op.getLoc(), storeOp.getValueToStore(), operands);
         })
-        .Case<mlir::AffineReadOpInterface, mlir::AffineWriteOpInterface>(
-            [&](auto) {
-              // Get essential memref access inforamtion.
-              MemRefAccess access(&op);
-              // The address of an affine load/store operation can be a result
-              // of an affine map, which is a linear combination of constants
-              // and parameters. Therefore, we should extract the affine map of
-              // each address and expand it into proper expressions that
-              // calculate the result.
-              mlir::AffineMap map;
-              if (auto loadOp = dyn_cast<mlir::AffineReadOpInterface>(op))
-                map = loadOp.getAffineMap();
-              else
-                map = dyn_cast<mlir::AffineWriteOpInterface>(op).getAffineMap();
+        .Case<AffineReadOpInterface, AffineWriteOpInterface>([&](auto) {
+          // Get essential memref access inforamtion.
+          MemRefAccess access(&op);
+          // The address of an affine load/store operation can be a result
+          // of an affine map, which is a linear combination of constants
+          // and parameters. Therefore, we should extract the affine map of
+          // each address and expand it into proper expressions that
+          // calculate the result.
+          AffineMap map;
+          if (auto loadOp = dyn_cast<AffineReadOpInterface>(op))
+            map = loadOp.getAffineMap();
+          else
+            map = dyn_cast<AffineWriteOpInterface>(op).getAffineMap();
 
-              // The returned object from expandAffineMap is an optional list of
-              // the expansion results from the given affine map, which are the
-              // actual address indices that can be used as operands for
-              // handshake LoadOp/StoreOp. The following processing requires it
-              // to be a valid result.
-              auto operands =
-                  expandAffineMap(rewriter, op.getLoc(), map, access.indices);
-              assert(operands && "Address operands of affine memref access "
-                                 "cannot be reduced.");
+          // The returned object from expandAffineMap is an optional list of
+          // the expansion results from the given affine map, which are the
+          // actual address indices that can be used as operands for
+          // handshake LoadOp/StoreOp. The following processing requires it
+          // to be a valid result.
+          auto operands =
+              expandAffineMap(rewriter, op.getLoc(), map, access.indices);
+          assert(operands && "Address operands of affine memref access "
+                             "cannot be reduced.");
 
-              if (isa<mlir::AffineReadOpInterface>(op)) {
-                auto loadOp = rewriter.create<handshake::LoadOp>(
-                    op.getLoc(), access.memref, *operands);
-                newOp = loadOp;
-                op.getResult(0).replaceAllUsesWith(loadOp.getDataResult());
-              } else {
-                newOp = rewriter.create<handshake::StoreOp>(
-                    op.getLoc(), op.getOperand(0), *operands);
-              }
-            })
+          if (isa<AffineReadOpInterface>(op)) {
+            auto loadOp = rewriter.create<handshake::LoadOp>(
+                op.getLoc(), access.memref, *operands);
+            newOp = loadOp;
+            op.getResult(0).replaceAllUsesWith(loadOp.getDataResult());
+          } else {
+            newOp = rewriter.create<handshake::StoreOp>(
+                op.getLoc(), op.getOperand(0), *operands);
+          }
+        })
         .Default([&](auto) {
           op.emitOpError("Load/store operation cannot be handled.");
         });
@@ -1714,7 +1714,6 @@ static LogicalResult lowerFuncOp(func::FuncOp funcOp, MLIRContext *ctx,
 
   return success();
 }
-
 
 namespace {
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -34,7 +34,7 @@ static Value createGenericOp(Location loc, OperationName name,
   return builder.create(state)->getResult(0);
 }
 
-static Attribute getIntAttr(const APInt &value, MLIRContext *context) {
+static TypedAttr getIntAttr(const APInt &value, MLIRContext *context) {
   return IntegerAttr::get(IntegerType::get(context, value.getBitWidth()),
                           value);
 }
@@ -282,7 +282,8 @@ static Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
 
   // Fold constants with ParamExprAttr::get which handles simple constants as
   // well as parameter expressions.
-  return hw::ParamExprAttr::get(paramOpcode, operands[0], operands[1]);
+  return hw::ParamExprAttr::get(paramOpcode, operands[0].cast<TypedAttr>(),
+                                operands[1].cast<TypedAttr>());
 }
 
 OpFoldResult ShlOp::fold(FoldAdaptor adaptor) {
@@ -1316,9 +1317,10 @@ OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
       auto negOne = getIntAttr(
           APInt::getAllOnes(getLhs().getType().getIntOrFloatBitWidth()),
           getContext());
-      auto rhsNeg =
-          hw::ParamExprAttr::get(hw::PEO::Mul, adaptor.getRhs(), negOne);
-      return hw::ParamExprAttr::get(hw::PEO::Add, adaptor.getLhs(), rhsNeg);
+      auto rhsNeg = hw::ParamExprAttr::get(
+          hw::PEO::Mul, adaptor.getRhs().cast<TypedAttr>(), negOne);
+      return hw::ParamExprAttr::get(hw::PEO::Add,
+                                    adaptor.getLhs().cast<TypedAttr>(), rhsNeg);
     }
 
     // sub(x - 0) -> x

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -652,7 +652,7 @@ LogicalResult ESIConnectServicesPass::surfaceReqs(
         Operation::create(inst->getLoc(), inst->getName(), newResultTypes,
                           newOperands, b.getDictionaryAttr(newAttrs),
                           inst->getSuccessors(), inst->getRegions()));
-    newModuleInstantiations.push_back(newHWInst);
+    newModuleInstantiations.push_back(cast<hw::HWInstanceLike>(newHWInst));
 
     // Replace all uses of the instance being replaced.
     for (auto [newV, oldV] :

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -76,7 +76,7 @@ void FIRRTLDialect::registerAttributes() {
 Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
   std::string name;
   Type type;
-  Attribute value;
+  TypedAttr value;
   // < "FOO" : i32 > : i32
   // < "FOO" : i32 = 0 > : i32
   // < "FOO" : none >

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -599,7 +599,7 @@ FIRRTLBaseType::getSubTypeByFieldID(uint64_t fieldID) {
           [&](auto type) { return type.getSubTypeByFieldID(fieldID); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
-        return std::pair(FIRRTLBaseType(), 0);
+        return std::pair(circt::hw::FieldIDTypeInterface(), 0);
       });
 }
 
@@ -1105,7 +1105,7 @@ BundleType::getSubTypeByFieldID(uint64_t fieldID) {
   auto subfieldIndex = getIndexForFieldID(fieldID);
   auto subfieldType = getElementType(subfieldIndex);
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
-  return {subfieldType, subfieldID};
+  return {subfieldType.cast<circt::hw::FieldIDTypeInterface>(), subfieldID};
 }
 
 uint64_t BundleType::getMaxFieldID() { return getImpl()->maxFieldID; }
@@ -1213,7 +1213,8 @@ std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
 FVectorType::getSubTypeByFieldID(uint64_t fieldID) {
   if (fieldID == 0)
     return {*this, 0};
-  return {getElementType(), getIndexForFieldID(fieldID)};
+  return {getElementType().cast<circt::hw::FieldIDTypeInterface>(),
+          getIndexForFieldID(fieldID)};
 }
 
 uint64_t FVectorType::getMaxFieldID() {
@@ -1389,7 +1390,7 @@ FEnumType::getSubTypeByFieldID(uint64_t fieldID) {
   auto subfieldIndex = getIndexForFieldID(fieldID);
   auto subfieldType = getElementType(subfieldIndex);
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
-  return {subfieldType, subfieldID};
+  return {subfieldType.cast<circt::hw::FieldIDTypeInterface>(), subfieldID};
 }
 
 uint64_t FEnumType::getMaxFieldID() { return getImpl()->maxFieldID; }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3521,7 +3521,7 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
         parseToken(FIRToken::equal, "expected '=' in parameter"))
       return failure();
 
-    Attribute value;
+    TypedAttr value;
     switch (getToken().getKind()) {
     default:
       return emitError("expected parameter value"), failure();

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -392,7 +392,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
     dutModuleMap[module] = true;
     return true;
   }
-  auto *node = instanceGraph->lookup(module);
+  auto *node = instanceGraph->lookup(cast<hw::HWModuleLike>(module));
   bool anyParentIsDut = false;
   if (node)
     for (auto *u : node->uses()) {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -429,7 +429,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   if (it != body->end()) {
     dutMod = dyn_cast<FModuleOp>(*it);
     auto &instanceGraph = getAnalysis<InstanceGraph>();
-    auto *node = instanceGraph.lookup(&(*it));
+    auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
     llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
       dutModuleSet.insert(node->getModule());
     });

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -712,7 +712,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   // Get all the paths instantiating this module. If there is an NLA already
   // attached to this tracker, we use it as a base to disambiguate the path to
   // the memory.
-  Operation *mod;
+  hw::HWModuleLike mod;
   if (tracker.nla)
     mod = instanceGraph->lookup(tracker.nla.root())->getModule();
   else

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -517,7 +517,7 @@ void LowerMemoryPass::runOnOperation() {
     return AnnotationSet(&op).hasAnnotation(dutAnnoClass);
   });
   if (it != body->end())
-    dut = instanceGraph.lookup(&(*it));
+    dut = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
 
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -466,6 +466,8 @@ TypeLoweringVisitor::getPreservationModeForModule(FModuleLike module) {
   case Convention::Internal:
     return aggregatePreservationMode;
   }
+  llvm_unreachable("Unknown convention");
+  return aggregatePreservationMode;
 }
 
 Value TypeLoweringVisitor::getSubWhatever(Value val, size_t index) {

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -48,7 +48,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     });
     if (it != body->end()) {
       auto &instanceGraph = getAnalysis<InstanceGraph>();
-      auto *node = instanceGraph.lookup(&(*it));
+      auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
       llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
         dutModuleSet.insert(node->getModule());
       });

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -878,8 +878,8 @@ void Inliner::cloneAndRename(
     assert(newOpToRename);
     // TODO: If want to work before ExpandWhen's, more work needed!
     // Handle what we can for now.
-    assert(origOp == &op || !isa<InstanceOp>(origOp) &&
-                                "Cannot handle instances not at top-level");
+    assert((origOp == &op || !isa<InstanceOp>(origOp)) &&
+           "Cannot handle instances not at top-level");
 
     // Instances require extra handling to update HierPathOp's if their symbols
     // change.

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -133,6 +133,8 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
   SmallString<32> resultNameStr;
   mlir::OpPrintingFlags flags;
 
+  auto funcOp = cast<mlir::FunctionOpInterface>(op);
+
   p << '(';
   for (unsigned i = 0, e = argTypes.size(); i < e; ++i) {
     if (i > 0)
@@ -157,7 +159,7 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
     }
 
     p.printType(argTypes[i]);
-    p.printOptionalAttrDict(getArgAttrs(op, i));
+    p.printOptionalAttrDict(getArgAttrs(funcOp, i));
 
     // TODO: `printOptionalLocationSpecifier` will emit aliases for locations,
     // even if they are not printed.  This will have to be fixed upstream.  For
@@ -184,7 +186,7 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
       p.printKeywordOrString(getModuleResultNameAttr(op, i).getValue());
       p << ": ";
       p.printType(resultTypes[i]);
-      p.printOptionalAttrDict(getResultAttrs(op, i));
+      p.printOptionalAttrDict(getResultAttrs(funcOp, i));
 
       // TODO: `printOptionalLocationSpecifier` will emit aliases for locations,
       // even if they are not printed.  This will have to be fixed upstream. For

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -28,6 +28,7 @@
 using namespace circt;
 using namespace handshake;
 using namespace mlir;
+using namespace mlir::affine;
 
 using BlockValues = DenseMap<Block *, std::vector<Value>>;
 
@@ -106,7 +107,7 @@ LogicalResult addSinkOps(Region &r, OpBuilder &rewriter) {
       // equivalents
       // TODO: should we use other indicator for op that has been erased?
       if (isa<mlir::cf::CondBranchOp, mlir::cf::BranchOp, memref::LoadOp,
-              mlir::AffineReadOpInterface, mlir::AffineForOp>(op))
+              AffineReadOpInterface, AffineForOp>(op))
         continue;
 
       if (op.getNumResults() == 0)

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -681,8 +681,8 @@ static void printProcArguments(OpAsmPrinter &p, Operation *op,
   auto printList = [&](unsigned i, unsigned max) -> void {
     for (; i < max; ++i) {
       p << body.front().getArgument(i) << " : " << types[i];
-      p.printOptionalAttrDict(
-          ::mlir::function_interface_impl::getArgAttrs(op, i));
+      p.printOptionalAttrDict(::mlir::function_interface_impl::getArgAttrs(
+          cast<mlir::FunctionOpInterface>(op), i));
 
       if (i < max - 1)
         p << ", ";

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
   circt::registerAllDialects(registry);
 
   // From circt-opt, register subset of MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
   circt::registerAllDialects(registry);
 
   // From circt-opt, register subset of MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
   // Register MLIR stuff
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
 
   DialectRegistry registry;
   // Register MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::arith::ArithDialect>();


### PR DESCRIPTION
TypedAttr changed requiring adjustments to HWAttributes. Affine was moved to its own namespace.