### PR TITLE
Bump LLVM

### DIFF
--- a/include/circt-c/Dialect/Seq.h
+++ b/include/circt-c/Dialect/Seq.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Sequential, seq);
-MLIR_CAPI_EXPORTED void registerSeqPasses();
+MLIR_CAPI_EXPORTED void registerSeqPasses(void);
 
 #ifdef __cplusplus
 }

--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -19,7 +19,9 @@
 #include <utility>
 
 namespace mlir {
+namespace affine {
 struct DependenceComponent;
+} // namespace affine
 namespace func {
 class FuncOp;
 } // namespace func
@@ -32,9 +34,10 @@ namespace analysis {
 /// It represents the destination of the dependence edge, the type of the
 /// dependence, and the components associated with each enclosing loop.
 struct MemoryDependence {
-  MemoryDependence(Operation *source,
-                   mlir::DependenceResult::ResultEnum dependenceType,
-                   ArrayRef<mlir::DependenceComponent> dependenceComponents)
+  MemoryDependence(
+      Operation *source,
+      mlir::affine::DependenceResult::ResultEnum dependenceType,
+      ArrayRef<mlir::affine::DependenceComponent> dependenceComponents)
       : source(source), dependenceType(dependenceType),
         dependenceComponents(dependenceComponents.begin(),
                              dependenceComponents.end()) {}
@@ -43,10 +46,10 @@ struct MemoryDependence {
   Operation *source;
 
   // The dependence type denotes whether or not there is a dependence.
-  mlir::DependenceResult::ResultEnum dependenceType;
+  mlir::affine::DependenceResult::ResultEnum dependenceType;
 
   // The dependence components include lower and upper bounds for each loop.
-  SmallVector<mlir::DependenceComponent> dependenceComponents;
+  SmallVector<mlir::affine::DependenceComponent> dependenceComponents;
 };
 
 /// MemoryDependenceResult captures a set of memory dependences. The map key is

--- a/include/circt/Analysis/SchedulingAnalysis.h
+++ b/include/circt/Analysis/SchedulingAnalysis.h
@@ -39,10 +39,11 @@ namespace analysis {
 struct CyclicSchedulingAnalysis {
   CyclicSchedulingAnalysis(Operation *funcOp, AnalysisManager &am);
 
-  CyclicProblem &getProblem(AffineForOp forOp);
+  CyclicProblem &getProblem(affine::AffineForOp forOp);
 
 private:
-  void analyzeForOp(AffineForOp forOp, MemoryDependenceAnalysis memoryAnalysis);
+  void analyzeForOp(affine::AffineForOp forOp,
+                    MemoryDependenceAnalysis memoryAnalysis);
 
   DenseMap<Operation *, CyclicProblem> problems;
 };

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -357,7 +357,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     static_assert(
         ConcreteOp::template hasTrait<OpTrait::InnerSymbolTable>(),
         "expected operation to be an inner symbol table");
-    return verifyModuleLikeOpInterface(op);
+    return verifyModuleLikeOpInterface(cast<FModuleLike>(op));
   }];
 }
 
@@ -452,7 +452,7 @@ def Forceable : OpInterface<"Forceable"> {
     /// Attribute name for 'forceable' tracking.
     static StringRef getForceableAttrName() { return "forceable"; }
   }];
-  let verify = [{ return detail::verifyForceableOp($_op); }];
+  let verify = [{ return detail::verifyForceableOp(cast<Forceable>($_op)); }];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -284,7 +284,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   ];
 
   let verify = [{
-    return verifyInnerSymAttr(op);
+    return verifyInnerSymAttr(cast<InnerSymbolOpInterface>(op));
   }];
 }
 

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -47,13 +47,13 @@ void TestDependenceAnalysisPass::runOnOperation() {
   MemoryDependenceAnalysis analysis(getOperation());
 
   getOperation().walk([&](Operation *op) {
-    if (!isa<AffineReadOpInterface, AffineWriteOpInterface>(op))
+    if (!isa<affine::AffineReadOpInterface, affine::AffineWriteOpInterface>(op))
       return;
 
     SmallVector<Attribute> deps;
 
     for (auto dep : analysis.getDependences(op)) {
-      if (dep.dependenceType != mlir::DependenceResult::HasDependence)
+      if (dep.dependenceType != mlir::affine::DependenceResult::HasDependence)
         continue;
 
       SmallVector<Attribute> comps;
@@ -97,8 +97,8 @@ void TestSchedulingAnalysisPass::runOnOperation() {
 
   CyclicSchedulingAnalysis analysis = getAnalysis<CyclicSchedulingAnalysis>();
 
-  getOperation().walk([&](AffineForOp forOp) {
-    if (isa<AffineForOp>(forOp.getBody()->front()))
+  getOperation().walk([&](affine::AffineForOp forOp) {
+    if (isa<affine::AffineForOp>(forOp.getBody()->front()))
       return;
     CyclicProblem problem = analysis.getProblem(forOp);
     forOp.getBody()->walk([&](Operation *op) {

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -53,7 +53,7 @@ intptr_t hwArrayTypeGetSize(MlirType type) {
 bool hwTypeIsAIntType(MlirType type) { return unwrap(type).isa<IntType>(); }
 
 MlirType hwParamIntTypeGet(MlirAttribute parameter) {
-  return wrap(IntType::get(unwrap(parameter)));
+  return wrap(IntType::get(unwrap(parameter).cast<mlir::TypedAttr>()));
 }
 
 MlirAttribute hwParamIntTypeGetWidthAttr(MlirType type) {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -107,11 +107,11 @@ struct SubExprInfo {
 // Helper routines
 //===----------------------------------------------------------------------===//
 
-static Attribute getInt32Attr(MLIRContext *ctx, uint32_t value) {
+static IntegerAttr getInt32Attr(MLIRContext *ctx, uint32_t value) {
   return Builder(ctx).getI32IntegerAttr(value);
 }
 
-static Attribute getIntAttr(MLIRContext *ctx, Type t, const APInt &value) {
+static IntegerAttr getIntAttr(MLIRContext *ctx, Type t, const APInt &value) {
   return Builder(ctx).getIntegerAttr(t, value);
 }
 
@@ -1324,7 +1324,7 @@ static void emitDims(ArrayRef<Attribute> dims, raw_ostream &os, Location loc,
     auto negOne = getIntAttr(
         loc.getContext(), typedAttr.getType(),
         APInt(typedAttr.getType().getIntOrFloatBitWidth(), -1L, true));
-    width = ParamExprAttr::get(PEO::Add, width, negOne);
+    width = ParamExprAttr::get(PEO::Add, typedAttr, negOne);
     os << '[';
     emitter.printParamValue(width, os, [loc]() {
       return mlir::emitError(loc, "invalid parameter in type");

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -518,8 +518,10 @@ Value AggregateConstantOpConversion::constructAggregate(
   };
 
   return TypeSwitch<Type, Value>(type)
-      .Case<IntegerType>(
-          [&](auto ty) { return builder.create<LLVM::ConstantOp>(loc, data); })
+      .Case<IntegerType>([&](auto ty) {
+        return builder.create<LLVM::ConstantOp>(loc,
+                                                data.cast<mlir::TypedAttr>());
+      })
       .Case<hw::ArrayType, hw::StructType>([&](auto ty) {
         Value aggVal = builder.create<LLVM::UndefOp>(loc, llvmType);
         auto arrayAttr = data.cast<ArrayAttr>();

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -724,7 +724,9 @@ public:
     // Check if a submodule has already been created for the op. If so,
     // instantiate the submodule. Else, run the pattern-defined module
     // builder.
-    hw::HWModuleLike implModule = checkSubModuleOp(ls.parentModule, op);
+    hw::HWModuleLike implModule;
+    if (auto implOp = checkSubModuleOp(ls.parentModule, op))
+      implModule = dyn_cast<hw::HWModuleLike>(implOp);
     if (!implModule) {
       auto portInfo = ModulePortInfo(getPortInfoForOp(op));
 

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -66,7 +66,7 @@ public:
     addLegalDialect<mlir::func::FuncDialect>();
     addLegalDialect<mlir::arith::ArithDialect>();
     addIllegalDialect<mlir::scf::SCFDialect>();
-    addIllegalDialect<mlir::AffineDialect>();
+    addIllegalDialect<mlir::affine::AffineDialect>();
 
     /// The root operation to be replaced is marked dynamically legal
     /// based on the lowering status of the given operation, see
@@ -1236,8 +1236,9 @@ static LogicalResult getOpMemRef(Operation *op, Value &out) {
     out = memOp.getMemRef();
   else if (auto memOp = dyn_cast<memref::StoreOp>(op))
     out = memOp.getMemRef();
-  else if (isa<mlir::AffineReadOpInterface, mlir::AffineWriteOpInterface>(op)) {
-    MemRefAccess access(op);
+  else if (isa<mlir::affine::AffineReadOpInterface,
+               mlir::affine::AffineWriteOpInterface>(op)) {
+    affine::MemRefAccess access(op);
     out = access.memref;
   }
   if (out != Value())
@@ -1246,8 +1247,9 @@ static LogicalResult getOpMemRef(Operation *op, Value &out) {
 }
 
 static bool isMemoryOp(Operation *op) {
-  return isa<memref::LoadOp, memref::StoreOp, mlir::AffineReadOpInterface,
-             mlir::AffineWriteOpInterface>(op);
+  return isa<memref::LoadOp, memref::StoreOp,
+             mlir::affine::AffineReadOpInterface,
+             mlir::affine::AffineWriteOpInterface>(op);
 }
 
 LogicalResult
@@ -1299,41 +1301,42 @@ HandshakeLowering::replaceMemoryOps(ConversionPatternRewriter &rewriter,
           newOp = rewriter.create<handshake::StoreOp>(
               op.getLoc(), storeOp.getValueToStore(), operands);
         })
-        .Case<mlir::AffineReadOpInterface, mlir::AffineWriteOpInterface>(
-            [&](auto) {
-              // Get essential memref access inforamtion.
-              MemRefAccess access(&op);
-              // The address of an affine load/store operation can be a result
-              // of an affine map, which is a linear combination of constants
-              // and parameters. Therefore, we should extract the affine map of
-              // each address and expand it into proper expressions that
-              // calculate the result.
-              mlir::AffineMap map;
-              if (auto loadOp = dyn_cast<mlir::AffineReadOpInterface>(op))
-                map = loadOp.getAffineMap();
-              else
-                map = dyn_cast<mlir::AffineWriteOpInterface>(op).getAffineMap();
+        .Case<mlir::affine::AffineReadOpInterface,
+              mlir::affine::AffineWriteOpInterface>([&](auto) {
+          // Get essential memref access inforamtion.
+          affine::MemRefAccess access(&op);
+          // The address of an affine load/store operation can be a result
+          // of an affine map, which is a linear combination of constants
+          // and parameters. Therefore, we should extract the affine map of
+          // each address and expand it into proper expressions that
+          // calculate the result.
+          mlir::AffineMap map;
+          if (auto loadOp = dyn_cast<mlir::affine::AffineReadOpInterface>(op))
+            map = loadOp.getAffineMap();
+          else
+            map = dyn_cast<mlir::affine::AffineWriteOpInterface>(op)
+                      .getAffineMap();
 
-              // The returned object from expandAffineMap is an optional list of
-              // the expansion results from the given affine map, which are the
-              // actual address indices that can be used as operands for
-              // handshake LoadOp/StoreOp. The following processing requires it
-              // to be a valid result.
-              auto operands =
-                  expandAffineMap(rewriter, op.getLoc(), map, access.indices);
-              assert(operands && "Address operands of affine memref access "
-                                 "cannot be reduced.");
+          // The returned object from expandAffineMap is an optional list of
+          // the expansion results from the given affine map, which are the
+          // actual address indices that can be used as operands for
+          // handshake LoadOp/StoreOp. The following processing requires it
+          // to be a valid result.
+          auto operands = affine::expandAffineMap(rewriter, op.getLoc(), map,
+                                                  access.indices);
+          assert(operands && "Address operands of affine memref access "
+                             "cannot be reduced.");
 
-              if (isa<mlir::AffineReadOpInterface>(op)) {
-                auto loadOp = rewriter.create<handshake::LoadOp>(
-                    op.getLoc(), access.memref, *operands);
-                newOp = loadOp;
-                op.getResult(0).replaceAllUsesWith(loadOp.getDataResult());
-              } else {
-                newOp = rewriter.create<handshake::StoreOp>(
-                    op.getLoc(), op.getOperand(0), *operands);
-              }
-            })
+          if (isa<mlir::affine::AffineReadOpInterface>(op)) {
+            auto loadOp = rewriter.create<handshake::LoadOp>(
+                op.getLoc(), access.memref, *operands);
+            newOp = loadOp;
+            op.getResult(0).replaceAllUsesWith(loadOp.getDataResult());
+          } else {
+            newOp = rewriter.create<handshake::StoreOp>(
+                op.getLoc(), op.getOperand(0), *operands);
+          }
+        })
         .Default([&](auto) {
           op.emitOpError("Load/store operation cannot be handled.");
         });
@@ -1714,7 +1717,6 @@ static LogicalResult lowerFuncOp(func::FuncOp funcOp, MLIRContext *ctx,
 
   return success();
 }
-
 
 namespace {
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -34,7 +34,7 @@ static Value createGenericOp(Location loc, OperationName name,
   return builder.create(state)->getResult(0);
 }
 
-static Attribute getIntAttr(const APInt &value, MLIRContext *context) {
+static IntegerAttr getIntAttr(const APInt &value, MLIRContext *context) {
   return IntegerAttr::get(IntegerType::get(context, value.getBitWidth()),
                           value);
 }
@@ -282,7 +282,8 @@ static Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
 
   // Fold constants with ParamExprAttr::get which handles simple constants as
   // well as parameter expressions.
-  return hw::ParamExprAttr::get(paramOpcode, operands[0], operands[1]);
+  return hw::ParamExprAttr::get(paramOpcode, cast<mlir::TypedAttr>(operands[0]),
+                                cast<mlir::TypedAttr>(operands[1]));
 }
 
 OpFoldResult ShlOp::fold(FoldAdaptor adaptor) {
@@ -1316,9 +1317,10 @@ OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
       auto negOne = getIntAttr(
           APInt::getAllOnes(getLhs().getType().getIntOrFloatBitWidth()),
           getContext());
-      auto rhsNeg =
-          hw::ParamExprAttr::get(hw::PEO::Mul, adaptor.getRhs(), negOne);
-      return hw::ParamExprAttr::get(hw::PEO::Add, adaptor.getLhs(), rhsNeg);
+      auto rhsNeg = hw::ParamExprAttr::get(
+          hw::PEO::Mul, cast<mlir::TypedAttr>(adaptor.getRhs()), negOne);
+      return hw::ParamExprAttr::get(
+          hw::PEO::Add, cast<mlir::TypedAttr>(adaptor.getLhs()), rhsNeg);
     }
 
     // sub(x - 0) -> x

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -652,7 +652,7 @@ LogicalResult ESIConnectServicesPass::surfaceReqs(
         Operation::create(inst->getLoc(), inst->getName(), newResultTypes,
                           newOperands, b.getDictionaryAttr(newAttrs),
                           inst->getSuccessors(), inst->getRegions()));
-    newModuleInstantiations.push_back(newHWInst);
+    newModuleInstantiations.push_back(cast<hw::HWInstanceLike>(newHWInst));
 
     // Replace all uses of the instance being replaced.
     for (auto [newV, oldV] :

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -92,7 +92,7 @@ Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
     return Attribute();
 
   if (value)
-    return ParamDeclAttr::get(name, value);
+    return ParamDeclAttr::get(name, value.cast<mlir::TypedAttr>());
   return ParamDeclAttr::get(name, type);
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -599,7 +599,7 @@ FIRRTLBaseType::getSubTypeByFieldID(uint64_t fieldID) {
           [&](auto type) { return type.getSubTypeByFieldID(fieldID); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
-        return std::pair(FIRRTLBaseType(), 0);
+        return std::pair(circt::hw::FieldIDTypeInterface(), 0);
       });
 }
 
@@ -1103,7 +1103,8 @@ BundleType::getSubTypeByFieldID(uint64_t fieldID) {
     return {*this, 0};
   auto fieldIDs = getImpl()->fieldIDs;
   auto subfieldIndex = getIndexForFieldID(fieldID);
-  auto subfieldType = getElementType(subfieldIndex);
+  auto subfieldType =
+      getElementType(subfieldIndex).cast<circt::hw::FieldIDTypeInterface>();
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
   return {subfieldType, subfieldID};
 }
@@ -1213,7 +1214,8 @@ std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
 FVectorType::getSubTypeByFieldID(uint64_t fieldID) {
   if (fieldID == 0)
     return {*this, 0};
-  return {getElementType(), getIndexForFieldID(fieldID)};
+  return {getElementType().cast<circt::hw::FieldIDTypeInterface>(),
+          getIndexForFieldID(fieldID)};
 }
 
 uint64_t FVectorType::getMaxFieldID() {
@@ -1387,7 +1389,8 @@ FEnumType::getSubTypeByFieldID(uint64_t fieldID) {
     return {*this, 0};
   auto fieldIDs = getImpl()->fieldIDs;
   auto subfieldIndex = getIndexForFieldID(fieldID);
-  auto subfieldType = getElementType(subfieldIndex);
+  auto subfieldType =
+      getElementType(subfieldIndex).cast<circt::hw::FieldIDTypeInterface>();
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
   return {subfieldType, subfieldID};
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3521,7 +3521,7 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
         parseToken(FIRToken::equal, "expected '=' in parameter"))
       return failure();
 
-    Attribute value;
+    mlir::TypedAttr value;
     switch (getToken().getKind()) {
     default:
       return emitError("expected parameter value"), failure();

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -392,7 +392,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
     dutModuleMap[module] = true;
     return true;
   }
-  auto *node = instanceGraph->lookup(module);
+  auto *node = instanceGraph->lookup(cast<hw::HWModuleLike>(module));
   bool anyParentIsDut = false;
   if (node)
     for (auto *u : node->uses()) {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -429,7 +429,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   if (it != body->end()) {
     dutMod = dyn_cast<FModuleOp>(*it);
     auto &instanceGraph = getAnalysis<InstanceGraph>();
-    auto *node = instanceGraph.lookup(&(*it));
+    auto *node = instanceGraph.lookup(dutMod);
     llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
       dutModuleSet.insert(node->getModule());
     });

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -717,7 +717,8 @@ struct Deduper {
 private:
   /// Get a cached namespace for a module.
   ModuleNamespace &getNamespace(Operation *module) {
-    auto [it, inserted] = moduleNamespaces.try_emplace(module, module);
+    auto [it, inserted] =
+        moduleNamespaces.try_emplace(module, cast<FModuleLike>(module));
     return it->second;
   }
 
@@ -748,7 +749,7 @@ private:
   /// of the "toModule".
   void replaceInstances(FModuleLike toModule, Operation *fromModule) {
     // Replace all instances of the other module.
-    auto *fromNode = instanceGraph[fromModule];
+    auto *fromNode = instanceGraph[cast<hw::HWModuleLike>(fromModule)];
     auto *toNode = instanceGraph[::cast<hw::HWModuleLike>(*toModule)];
     auto toModuleRef = FlatSymbolRefAttr::get(toModule.moduleNameAttr());
     for (auto *oldInstRec : llvm::make_early_inc_range(fromNode->uses())) {
@@ -777,7 +778,8 @@ private:
 
     auto loc = fromModule->getLoc();
     SmallVector<FlatSymbolRefAttr> nlas;
-    for (auto *instanceRecord : instanceGraph[fromModule]->uses()) {
+    for (auto *instanceRecord :
+         instanceGraph[cast<hw::HWModuleLike>(fromModule)]->uses()) {
       auto parent = cast<FModuleOp>(*instanceRecord->getParent()->getModule());
       auto inst = instanceRecord->getInstance();
       namepath[0] = OpAnnoTarget(inst).getNLAReference(getNamespace(parent));

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -719,7 +719,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
     mod = tracker.op->getParentOfType<FModuleOp>();
 
   // Get all the paths instantiating this module.
-  auto paths = instancePaths->getAbsolutePaths(mod);
+  auto paths = instancePaths->getAbsolutePaths(cast<hw::HWModuleLike>(mod));
   if (paths.empty()) {
     tracker.op->emitError("OMIR node targets uninstantiated component `")
         << opName.getValue() << "`";

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -517,7 +517,7 @@ void LowerMemoryPass::runOnOperation() {
     return AnnotationSet(&op).hasAnnotation(dutAnnoClass);
   });
   if (it != body->end())
-    dut = instanceGraph.lookup(&(*it));
+    dut = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
 
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -48,7 +48,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     });
     if (it != body->end()) {
       auto &instanceGraph = getAnalysis<InstanceGraph>();
-      auto *node = instanceGraph.lookup(&(*it));
+      auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
       llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
         dutModuleSet.insert(node->getModule());
       });

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -365,7 +365,7 @@ Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
     return Attribute();
 
   if (value)
-    return ParamDeclAttr::get(name, value);
+    return ParamDeclAttr::get(name, value.cast<mlir::TypedAttr>());
   return ParamDeclAttr::get(name, type);
 }
 
@@ -572,7 +572,7 @@ static TypedAttr simplifyAssocOp(
       operands.pop_back();
   }
 
-  return operands.size() == 1 ? operands[0] : Attribute();
+  return operands.size() == 1 ? operands[0] : TypedAttr();
 }
 
 /// Analyze an operand to an add.  If it is a multiplication by a constant (e.g.
@@ -939,7 +939,7 @@ replaceDeclRefInExpr(Location loc,
       auto res = replaceDeclRefInExpr(loc, parameters, operand);
       if (failed(res))
         return {failure()};
-      replacedOperands.push_back(*res);
+      replacedOperands.push_back(res->cast<mlir::TypedAttr>());
     }
     return {
         hw::ParamExprAttr::get(paramExprAttr.getOpcode(), replacedOperands)};
@@ -995,7 +995,7 @@ FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
                                    intAttr.getValue().getSExtValue())};
 
         // Otherwise parameter references are still involved
-        return hw::IntType::get(*evaluatedWidth);
+        return hw::IntType::get(evaluatedWidth->cast<mlir::TypedAttr>());
       })
       .Case<hw::ArrayType>([&](hw::ArrayType arrayType) -> FailureOr<Type> {
         auto size =

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -128,6 +128,7 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
                                             bool &needArgNamesAttr) {
   using namespace mlir::function_interface_impl;
 
+  auto functionInterface = cast<mlir::FunctionOpInterface>(op);
   Region &body = op->getRegion(0);
   bool isExternal = body.empty();
   SmallString<32> resultNameStr;
@@ -157,7 +158,7 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
     }
 
     p.printType(argTypes[i]);
-    p.printOptionalAttrDict(getArgAttrs(op, i));
+    p.printOptionalAttrDict(getArgAttrs(functionInterface, i));
 
     // TODO: `printOptionalLocationSpecifier` will emit aliases for locations,
     // even if they are not printed.  This will have to be fixed upstream.  For
@@ -184,7 +185,7 @@ void module_like_impl::printModuleSignature(OpAsmPrinter &p, Operation *op,
       p.printKeywordOrString(getModuleResultNameAttr(op, i).getValue());
       p << ": ";
       p.printType(resultTypes[i]);
-      p.printOptionalAttrDict(getResultAttrs(op, i));
+      p.printOptionalAttrDict(getResultAttrs(functionInterface, i));
 
       // TODO: `printOptionalLocationSpecifier` will emit aliases for locations,
       // even if they are not printed.  This will have to be fixed upstream. For

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -232,8 +232,8 @@ static LogicalResult registerNestedParametricInstanceOps(
                                               instanceParameterValue);
       if (failed(evaluated))
         return WalkResult::interrupt();
-      evaluatedInstanceParameters.push_back(
-          hw::ParamDeclAttr::get(instanceParameterDecl.getName(), *evaluated));
+      evaluatedInstanceParameters.push_back(hw::ParamDeclAttr::get(
+          instanceParameterDecl.getName(), evaluated->cast<mlir::TypedAttr>()));
     }
 
     auto evaluatedInstanceParametersAttr =

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -106,7 +106,8 @@ LogicalResult addSinkOps(Region &r, OpBuilder &rewriter) {
       // equivalents
       // TODO: should we use other indicator for op that has been erased?
       if (isa<mlir::cf::CondBranchOp, mlir::cf::BranchOp, memref::LoadOp,
-              mlir::AffineReadOpInterface, mlir::AffineForOp>(op))
+              mlir::affine::AffineReadOpInterface, mlir::affine::AffineForOp>(
+              op))
         continue;
 
       if (op.getNumResults() == 0)

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -677,12 +677,13 @@ ParseResult llhd::ProcOp::parse(OpAsmParser &parser, OperationState &result) {
 /// verification.
 static void printProcArguments(OpAsmPrinter &p, Operation *op,
                                ArrayRef<Type> types, uint64_t numIns) {
+  auto functionInterface = cast<mlir::FunctionOpInterface>(op);
   Region &body = op->getRegion(0);
   auto printList = [&](unsigned i, unsigned max) -> void {
     for (; i < max; ++i) {
       p << body.front().getArgument(i) << " : " << types[i];
       p.printOptionalAttrDict(
-          ::mlir::function_interface_impl::getArgAttrs(op, i));
+          ::mlir::function_interface_impl::getArgAttrs(functionInterface, i));
 
       if (i < max - 1)
         p << ", ";

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int registerOnlyHW() {
+int registerOnlyHW(void) {
   MlirContext ctx = mlirContextCreate();
   // The built-in dialect is always loaded.
   if (mlirContextGetNumLoadedDialects(ctx) != 1)
@@ -77,7 +77,7 @@ int registerOnlyHW() {
   return 0;
 }
 
-int testHWTypes() {
+int testHWTypes(void) {
   MlirContext ctx = mlirContextCreate();
   MlirDialectHandle hwHandle = mlirGetDialectHandle__hw__();
   mlirDialectHandleRegisterDialect(hwHandle, ctx);
@@ -123,7 +123,7 @@ int testHWTypes() {
   return 0;
 }
 
-int main() {
+int main(void) {
   fprintf(stderr, "@registration\n");
   int errcode = registerOnlyHW();
   fprintf(stderr, "%d\n", errcode);

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
   circt::registerAllDialects(registry);
 
   // From circt-opt, register subset of MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
   circt::registerAllDialects(registry);
 
   // From circt-opt, register subset of MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
   // Register MLIR stuff
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
 
   DialectRegistry registry;
   // Register MLIR dialects.
-  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::arith::ArithDialect>();


### PR DESCRIPTION
The following updates were made:
- use affine namespace for affine analysis - see https://github.com/llvm/llvm-project/commit/4c48f016effde67d500fc95290096aec9f3bdb70
- explicit cast from Operation * to op interface types and Attribute to TypedAttr - see https://github.com/llvm/llvm-project/commit/6089d612a580738df00c22a43e6f2c29bd216af9
- address c strict-prototype warnings by adding void parameters