### PR TITLE
[FIRRTL] Match register value to reset value

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -362,7 +362,8 @@ def RegOp : ReferableDeclOp<"reg", [Forceable]> {
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
+def RegResetOp : ReferableDeclOp<"regreset", [AllTypesMatch<["resetValue","result"]>,
+                                              Forceable]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:
@@ -446,7 +447,7 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
     operands (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict)
-    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
+    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
 
   }];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -24,6 +24,10 @@ namespace firrtl {
 void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
 void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
 
+/// Emit a extend and uninferred cast of a passive type
+Value expandPassiveType(ImplicitLocOpBuilder &builder, FIRRTLBaseType dstType,
+                        Value rhs);
+
 /// Utiility for generating a constant attribute.
 IntegerAttr getIntAttr(Type type, const APInt &value);
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3197,19 +3197,26 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   ArrayAttr annotations = getConstants().emptyArrayAttr;
   Value result;
   StringAttr sym = {};
+  auto firType = dyn_cast<FIRRTLBaseType>(type);
+  if (!firType)
+    return emitError("cannot have non-firrtl types");
+
   // TODO: isConst -> hasConst.
   bool forceable = !isConst(type);
-  if (resetSignal)
+  if (resetSignal) {
+    if (type != resetSignal.getType())
+      resetValue = expandPassiveType(builder, firType, resetValue);
     result = builder
                  .create<RegResetOp>(type, clock, resetSignal, resetValue, id,
                                      NameKindEnum::InterestingName, annotations,
                                      sym, forceable)
                  .getResult();
-  else
+  } else {
     result = builder
                  .create<RegOp>(type, clock, id, NameKindEnum::InterestingName,
                                 annotations, sym, forceable)
                  .getResult();
+  }
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1328,10 +1328,9 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         // least 1 bit wide. We don't do this here since the MLIR FIRRTL
         // dialect enforces the reset signal to be an async reset or a
         // `uint<1>`.
-        declareVars(op.getResult(), op.getLoc());
-        // Contrain the register to be greater than or equal to the reset
-        // signal.
-        constrainTypes(op.getResult(), op.getResetValue());
+        // Contrain the register to beequal to the reset signal.
+        unifyTypes(FieldRef(op.getResult(), 0), FieldRef(op.getResetValue(), 0),
+                   op.getResult().getType());
       })
       .Case<NodeOp>([&](auto op) {
         // Nodes have the same type as their input.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -61,7 +61,7 @@ firrtl.circuit "unprocessedAnnotations" {
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation3'}}
     %3 = firrtl.reg %clock {annotations = [{class = "firrtl.transforms.RemainingAnnotation3"}]} : !firrtl.clock, !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation4'}}
-    %4 = firrtl.regreset %clock, %reset, %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation4"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %4 = firrtl.regreset %clock, %reset, %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation4"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation5'}}
     %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw",
     "write"], readLatency = 0 : i32, writeLatency = 1 : i32, annotations = [{class =

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -902,13 +902,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %w, %0 : !firrtl.uint<0>, !firrtl.uint<0>
   }
 
-  // CHECK-LABEL: ASQ
-  // https://github.com/llvm/circt/issues/699
-  firrtl.module private @ASQ(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %widx_widx_bin = firrtl.regreset %clock, %reset, %c0_ui1 {name = "widx_widx_bin"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<4>
-  }
-
   // CHECK-LABEL: hw.module private @Struct0bits(%source: !hw.struct<valid: i1, ready: i1, data: i0>) {
   // CHECK-NEXT:    hw.output
   // CHECK-NEXT:  }
@@ -1032,10 +1025,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c9_ui42 = firrtl.constant 9 : !firrtl.uint<42>
     %c-9_si42 = firrtl.constant -9 : !firrtl.sint<42>
     // The following should not error because the reset values are constant.
-    %r0 = firrtl.regreset %clock, %arst, %c9_ui42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
-    %r1 = firrtl.regreset %clock, %srst, %c9_ui42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
-    %r2 = firrtl.regreset %clock, %arst, %c-9_si42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.sint<42>, !firrtl.sint<42>
-    %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>
+    %r0 = firrtl.regreset %clock, %arst, %c9_ui42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>
+    %r1 = firrtl.regreset %clock, %srst, %c9_ui42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>
+    %r2 = firrtl.regreset %clock, %arst, %c-9_si42 : !firrtl.clock, !firrtl.asyncreset, !firrtl.sint<42>
+    %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<42>
   }
 
   // CHECK-LABEL: hw.module private @BitCast1
@@ -1095,7 +1088,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %wireName = hw.wire %z_i42 sym @wireSym : i42
     %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: %regName = seq.firreg %regName clock %clock sym @regSym : i42
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>
     // CHECK: %regResetName = seq.firreg %regResetName clock %clock sym @regResetSym reset sync %reset, %value : i42
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: {{%.+}} = hw.instance "memName_ext" sym @memSym
@@ -1177,20 +1170,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %a, %c0_ui0 : !firrtl.uint<0>, !firrtl.uint<0>
   }
 
-  // CHECK-LABEL: hw.module private @RegResetStructWiden
-  firrtl.module private @RegResetStructWiden(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %init: !firrtl.bundle<a: uint<2>>) {
-    // CHECK:      [[FALSE:%.*]] = hw.constant false
-    // CHECK-NEXT: [[A:%.*]] = hw.struct_extract %init["a"] : !hw.struct<a: i2>
-    // CHECK-NEXT: [[PADDED:%.*]] = comb.concat [[FALSE]], [[A]] : i1, i2
-    // CHECK-NEXT: [[STRUCT:%.*]] = hw.struct_create ([[PADDED]]) : !hw.struct<a: i3>
-    // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, [[STRUCT]] : !hw.struct<a: i3>
-    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<3>>
-  }
-
   // CHECK-LABEL: hw.module private @AggregateInvalidValue
   firrtl.module private @AggregateInvalidValue(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
-    %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
+    %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     // CHECK:      %c0_i101 = hw.constant 0 : i101
     // CHECK-NEXT: %0 = hw.bitcast %c0_i101 : (i101) -> !hw.struct<a: i1, b: !hw.array<10xi10>>
     // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>
@@ -1353,7 +1336,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %value: !firrtl.uint<2>
   ) {
     %regA = firrtl.reg %clock: !firrtl.clock, !firrtl.uint<2>
-    %regB = firrtl.regreset %clock, %reset, %value: !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %regB = firrtl.regreset %clock, %reset, %value: !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>
     firrtl.strictconnect %regA, %value : !firrtl.uint<2>
     firrtl.strictconnect %regB, %value : !firrtl.uint<2>
     // CHECK-NEXT: %regA = seq.firreg %value clock %clock : i2
@@ -1365,7 +1348,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                            in %reset: !firrtl.uint<1>,
                            in %value: !firrtl.uint<2>,
                            out %result: !firrtl.uint<2>) {
-    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>
 
     // CHECK: %count = seq.firreg %count clock %clock reset sync %reset, %value : i2
     // CHECK: hw.output %count : i2
@@ -1378,7 +1361,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                            in %reset: !firrtl.asyncreset,
                            in %value: !firrtl.uint<2>,
                            out %result: !firrtl.uint<2>) {
-    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>
 
     // CHECK: %count = seq.firreg %value clock %clock reset async %reset, %value : i2
     // CHECK: hw.output %count : i2

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -10,7 +10,7 @@
 
 // Stage 0 ready wire and valid register.
 // CHECK:   %readyWire0 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %ctrlValidWire0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire0 = firrtl.wire : !firrtl.uint<1>
 
@@ -36,7 +36,7 @@
 
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %ctrlValidWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire1 = firrtl.wire : !firrtl.uint<1>
 
@@ -60,7 +60,7 @@
 
 // Stage 2 logics.
 // CHECK:   %readyWire2 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 
 // CHECK:   %[[VAL_10:.+]] = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_11:.+]] = firrtl.or %[[VAL_10:.+]], %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -98,7 +98,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %[[arg1]][data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK:   %c0_ui64 = firrtl.constant 0 : !firrtl.uint<64>
 
-// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>
 
 // CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
 // CHECK:   firrtl.strictconnect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>
@@ -107,7 +107,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[SUCC_DATA0:.+]] = firrtl.mux(%readyReg{{.*}}, %ctrlDataReg, %dataReg0)
 // CHECK:   firrtl.strictconnect %ctrlDataWire0, %[[SUCC_DATA0]]
 
-// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>
 
 // CHECK:   %[[CTRL_DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_6 {name = "ctrlDataReg"}
 // CHECK:   %[[SUCC_DATA1:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG1]], %dataReg1)
@@ -141,8 +141,8 @@ handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none
 // -----
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_in_ui64_out_ui64_1slots_seq_init_42
-// CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>
 
 handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none) {
   %0 = buffer [1] seq %arg0 {initValues=[42]} : index
@@ -154,7 +154,7 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
 // CHECK-LABEL: firrtl.module @handshake_buffer_in_tuple_ui32_ui32_out_tuple_ui32_ui32_2slots_seq(
 // CHECK: %[[VALUE:.*]] = firrtl.constant 0 : !firrtl.sint<64>
 // CHECK: %[[ZERO_BUNDLE:.*]] = firrtl.bitcast %[[VALUE]] : (!firrtl.sint<64>) -> !firrtl.bundle<field0: uint<32>, field1: uint<32>>
-// CHECK: %dataReg0 = firrtl.regreset %{{.*}}, %{{.*}}, %[[ZERO_BUNDLE]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>
+// CHECK: %dataReg0 = firrtl.regreset %{{.*}}, %{{.*}}, %[[ZERO_BUNDLE]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>
 
 handshake.func @test_buffer_tuple_seq(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) {
   %0 = buffer [2] seq %t : tuple<i32, i32>
@@ -175,7 +175,7 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_1slots_seq_init_0_1ins_1outs_ctrl(
 // CHECK: %[[C1:.*]] = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK: %validReg0 = firrtl.regreset  %clock, %reset, %[[C1]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %validReg0 = firrtl.regreset  %clock, %reset, %[[C1]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 handshake.func @test_buffer_init_none_type(%arg0: none, ...) -> (none) {
   %0 = buffer [1] seq %arg0 {initValues = [0]}: none
   return %0 : none

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -24,7 +24,7 @@
 // CHECK:   firrtl.strictconnect %notAllDone, %7 : !firrtl.uint<1>
 
 // Result 0 logic.
-// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %8 = firrtl.and %done0, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.strictconnect %emtd0, %8 : !firrtl.uint<1>
 
@@ -42,7 +42,7 @@
 // CHECK:   firrtl.strictconnect %done0, %12 : !firrtl.uint<1>
 
 // Result1 logic.
-// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %13 = firrtl.and %done1, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.strictconnect %emtd1, %13 : !firrtl.uint<1>
 

--- a/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_pack_unpack.mlir
@@ -66,7 +66,7 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK:  firrtl.strictconnect %[[VAL_16]], %[[VAL_17]] : !firrtl.uint<1>
 
 // Result 0 logic.
-// CHECK:  %[[VAL_18:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  %[[VAL_18:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_19:.*]] = firrtl.and %[[VAL_12]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.strictconnect %[[VAL_18]], %[[VAL_19]] : !firrtl.uint<1>
 // CHECK:  %[[VAL_20:.*]] = firrtl.wire  : !firrtl.uint<1>
@@ -81,7 +81,7 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK:  firrtl.strictconnect %[[VAL_12]], %[[VAL_25]] : !firrtl.uint<1>
 
 // Result 1 logic.
-// CHECK:  %[[VAL_26:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  %[[VAL_26:.*]] = firrtl.regreset %[[CLOCK]], %[[RESET]], %[[VAL_11]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[VAL_27:.*]] = firrtl.and %[[VAL_13]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.strictconnect %[[VAL_26]], %[[VAL_27]] : !firrtl.uint<1>
 // CHECK:  %[[VAL_28:.*]] = firrtl.wire  : !firrtl.uint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sync.mlir
@@ -41,7 +41,7 @@
 // CHECK:             %[[VAL_36:.*]] = firrtl.wire   : !firrtl.uint<1>
 // CHECK:             %[[VAL_37:.*]] = firrtl.not %[[VAL_33]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_36]], %[[VAL_37]] : !firrtl.uint<1>
-// CHECK:             %[[VAL_38:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_38:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_39:.*]] = firrtl.and %[[VAL_30]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_38]], %[[VAL_39]] : !firrtl.uint<1>
 // CHECK:             %[[VAL_40:.*]] = firrtl.wire   : !firrtl.uint<1>
@@ -54,7 +54,7 @@
 // CHECK:             firrtl.strictconnect %[[VAL_43]], %[[VAL_44]] : !firrtl.uint<1>
 // CHECK:             %[[VAL_45:.*]] = firrtl.or %[[VAL_43]], %[[VAL_38]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_30]], %[[VAL_45]] : !firrtl.uint<1>
-// CHECK:             %[[VAL_46:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_46:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_47:.*]] = firrtl.and %[[VAL_31]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_46]], %[[VAL_47]] : !firrtl.uint<1>
 // CHECK:             %[[VAL_48:.*]] = firrtl.wire   : !firrtl.uint<1>
@@ -67,7 +67,7 @@
 // CHECK:             firrtl.strictconnect %[[VAL_51]], %[[VAL_52]] : !firrtl.uint<1>
 // CHECK:             %[[VAL_53:.*]] = firrtl.or %[[VAL_51]], %[[VAL_46]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_31]], %[[VAL_53]] : !firrtl.uint<1>
-// CHECK:             %[[VAL_54:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_54:.*]] = firrtl.regreset  %[[VAL_6]], %[[VAL_7]], %[[VAL_29]]  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:             %[[VAL_55:.*]] = firrtl.and %[[VAL_32]], %[[VAL_36]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:             firrtl.strictconnect %[[VAL_54]], %[[VAL_55]] : !firrtl.uint<1>
 // CHECK:             %[[VAL_56:.*]] = firrtl.wire   : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -83,7 +83,7 @@ circuit Foo:
     input x : SInt<4>
     output y : SInt<4>
     output z : SInt<4>
-    ; CHECK: %r = firrtl.regreset %clock, %reset, %c0_si1
+    ; CHECK: %r = firrtl.regreset %clock, %reset, %c0_si4
     reg r : SInt<4>, clock with : (reset => (reset, asSInt(UInt(0))))
     r <= x
     wire w : SInt<4>

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.mlir
@@ -17,33 +17,33 @@ firrtl.circuit "AsyncResetConst" {
   ) {
     // Constant check should handle trivial cases.
     %c0_ui = firrtl.constant 0 : !firrtl.uint<8>
-    %0 = firrtl.regreset %clock, %reset, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %0 = firrtl.regreset %clock, %reset, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
 
     // Constant check should see through nodes.
     %node = firrtl.node %c0_ui : !firrtl.uint<8>
-    %1 = firrtl.regreset %clock, %reset, %node : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %1 = firrtl.regreset %clock, %reset, %node : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
 
     // Constant check should see through subfield connects.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %bundle0.a = firrtl.subfield %bundle0[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
-    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>
 
     // Constant check should see through multiple connect hops.
     %bundle1 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
-    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>
 
     // Constant check should see through subindex connects.
     %vector0 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %vector0.a = firrtl.subindex %vector0[0] : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
-    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>
 
     // Constant check should see through multiple connect hops.
     %vector1 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector1, %vector0 : !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
-    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>
 
     firrtl.connect %z0, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z1, %1 : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -221,8 +221,8 @@ firrtl.circuit "removePad"   {
 firrtl.circuit "asyncReset"   {
   // CHECK-LABEL: firrtl.module @asyncReset
   firrtl.module @asyncReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %en: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-    %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<4>, !firrtl.uint<8>
+    %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     %0 = firrtl.mux(%en, %c0_ui4, %r) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
@@ -344,7 +344,7 @@ firrtl.circuit "regConstReset"   {
   // CHECK-LABEL: firrtl.module @regConstReset
   firrtl.module @regConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-    %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
     %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
@@ -387,7 +387,7 @@ firrtl.circuit "uninitSelfReg"   {
   // CHECK-LABEL: firrtl.module @constResetReg(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   firrtl.module @constResetReg(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
     firrtl.strictconnect %r, %r : !firrtl.uint<8>
     firrtl.strictconnect %z, %r : !firrtl.uint<8>
     // CHECK: %[[C11:.+]] = firrtl.constant 11 : !firrtl.uint<8>
@@ -398,7 +398,7 @@ firrtl.circuit "uninitSelfReg"   {
   // CHECK-LABEL: firrtl.module @regSameConstReset
   firrtl.module @regSameConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
     firrtl.strictconnect %r, %c11_ui4 : !firrtl.uint<8>
     firrtl.strictconnect %z, %r : !firrtl.uint<8>
     // CHECK: %[[C13:.+]] = firrtl.constant 11 : !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
@@ -14,7 +14,7 @@ firrtl.circuit "Foo" {
     %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
     %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>
 
     %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
     firrtl.connect %instName_clockIn, %clock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -360,7 +360,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %bar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %baz = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %baz = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -766,7 +766,7 @@ firrtl.circuit "Foo"  attributes {
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     // CHECK: %_T_3 = firrtl.regreset
     // CHECK-SAME: {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
-    %_T_3 = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    %_T_3 = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
     // CHECK-NEXT: %_T_4 = chirrtl.seqmem
     // CHECK-SAME: {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
     %_T_4 = chirrtl.seqmem Undefined  : !chirrtl.cmemory<vector<uint<1>, 9>, 256>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2046,8 +2046,8 @@ firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<
   %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   // CHECK: %bar1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %foo2, %dummy : !firrtl.uint<1>
-  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+  %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
 
   firrtl.strictconnect %bar2, %bar1 : !firrtl.uint<1> // Force a use to trigger a crash on a sink replacement
 
@@ -2061,7 +2061,7 @@ firrtl.module @ForceableRegResetToNode(in %clock: !firrtl.clock, in %dummy : !fi
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   // CHECK: %reg, %reg_ref = firrtl.node %dummy forceable : !firrtl.uint<1>
-  %reg, %reg_f = firrtl.regreset %clock, %one_asyncreset, %dummy forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
+  %reg, %reg_f = firrtl.regreset %clock, %one_asyncreset, %dummy forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
   firrtl.ref.define %ref, %reg_f: !firrtl.rwprobe<uint<1>>
 
   firrtl.connect %reg, %dummy: !firrtl.uint<1>, !firrtl.uint<1>
@@ -2297,7 +2297,7 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
 // CHECK-LABEL: firrtl.module @constReg3
 firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11
@@ -2309,7 +2309,7 @@ firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
@@ -2322,7 +2322,7 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
   %resCond = firrtl.and %reset, %cond : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %r = firrtl.regreset %clock, %resCond, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %resCond, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
@@ -2330,22 +2330,9 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
-// Cannot optimize if bit mismatch with constant reset.
-// CHECK-LABEL: firrtl.module @constReg5
-firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
-  // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  // CHECK: firrtl.strictconnect %r, %0
-  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-}
-
 // Should not crash when the reset value is a block argument.
-firrtl.module @constReg7(in %v: !firrtl.uint<1>, in %clock: !firrtl.clock, in %reset: !firrtl.reset) {
-  %r = firrtl.regreset %clock, %reset, %v  : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<4>
+firrtl.module @constReg7(in %v: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.reset) {
+  %r = firrtl.regreset %clock, %reset, %v  : !firrtl.clock, !firrtl.reset, !firrtl.uint<4>
 }
 
 // Check that firrtl.regreset reset mux folding doesn't respects
@@ -2354,14 +2341,14 @@ firrtl.module @constReg7(in %v: !firrtl.uint<1>, in %clock: !firrtl.clock, in %r
 firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.regreset sym @s2
-  %r1 = firrtl.regreset sym @s2 %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  %r1 = firrtl.regreset sym @s2 %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   %0 = firrtl.mux(%reset, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.regreset
   // CHECK-SAME: Foo
-  %r2 = firrtl.regreset  %clock, %reset, %c1_ui1 {annotations = [{class = "Foo"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  %r2 = firrtl.regreset  %clock, %reset, %c1_ui1 {annotations = [{class = "Foo"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   %1 = firrtl.mux(%reset, %c1_ui1, %r2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out2, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -2752,7 +2739,7 @@ firrtl.module @CrashAllUnusedPorts() {
 firrtl.module @CrashRegResetWithOneReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_d: !firrtl.uint<1>, out %io_q: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>) {
   %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+  %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
   %0 = firrtl.mux(%io_en, %io_d, %reg) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %reg, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %io_q, %reg : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -75,7 +75,7 @@ firrtl.circuit "Foo" {
     %someReg = firrtl.reg %someClock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: reg someReg2 : UInt<1>, someClock with :
     // CHECK:   reset => (someReset, ui1)
-    %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>
     // CHECK: node someNode = ui1
     %someNode = firrtl.node %ui1 : !firrtl.uint<1>
     // CHECK: stop(someClock, ui1, 42) : foo

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -204,7 +204,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.clock, in %reset: !firrtl.uint<2>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // expected-error @+1 {{'firrtl.regreset' op operand #1 must be Reset, but got '!firrtl.uint<2>'}}
-    %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : !firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>, !firrtl.uint<1>
+    %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : !firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>
   }
 }
 
@@ -855,17 +855,6 @@ firrtl.circuit "AnalogVectorRegister" {
   firrtl.module @AnalogVectorRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<analog, 2>
-  }
-}
-
-// -----
-
-firrtl.circuit "MismatchedRegister" {
-  firrtl.module @MismatchedRegister(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %z: !firrtl.vector<uint<1>, 1>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // expected-error @+1 {{type mismatch between register '!firrtl.vector<uint<1>, 1>' and reset value '!firrtl.uint<1>'}}
-    %r = firrtl.regreset %clock, %reset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>
-    firrtl.connect %z, %r : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -524,7 +524,7 @@ firrtl.module @aggregate_register(in %clock: !firrtl.clock) {
 
 // CHECK-LABEL: @aggregate_regreset
 firrtl.module @aggregate_regreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %resetval: !firrtl.vector<uint<1>, 2>) {
-  %0 = firrtl.regreset %clock, %reset, %resetval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.regreset %clock, %reset, %resetval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>
   // CHECK:      %1 = firrtl.subindex %0[0]
   // CHECK-NEXT: firrtl.connect %1, %1
   // CHECK-NEXT: %2 = firrtl.subindex %0[1]

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -325,7 +325,7 @@ firrtl.circuit "Oscillators"   {
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
     %0 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %s : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -339,7 +339,7 @@ firrtl.circuit "Oscillators"   {
     %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %0 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %0 : !firrtl.uint<1>
@@ -354,7 +354,7 @@ firrtl.circuit "Oscillators"   {
     %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
     %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -370,7 +370,7 @@ firrtl.circuit "Oscillators"   {
     %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
-    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
     %0 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -471,7 +471,7 @@ firrtl.circuit "Issue3372"  {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %other_zero = firrtl.instance other interesting_name  @Other(out zero: !firrtl.uint<1>)
-    %shared = firrtl.regreset interesting_name %clock, %other_zero, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %shared = firrtl.regreset interesting_name %clock, %other_zero, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %shared, %shared : !firrtl.uint<1>
     %test = firrtl.wire interesting_name  : !firrtl.uint<1>
     firrtl.strictconnect %test, %shared : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -14,7 +14,7 @@ firrtl.circuit "top" {
     %dead_reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %dead_reg, %dead_wire : !firrtl.uint<1>
 
-    %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
 
     %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -64,9 +64,9 @@ firrtl.module @CastingToOtherTypes(in %a: !firrtl.uint<1>, out %v: !firrtl.uint<
 // CHECK-LABEL: firrtl.module @ModuleBoundariesChild
 // CHECK-SAME: in %childReset: !firrtl.uint<1>
 firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  %c123_ui = firrtl.constant 123 : !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>
   firrtl.strictconnect %r, %x : !firrtl.uint<8>
   firrtl.strictconnect %z, %r : !firrtl.uint<8>
 }
@@ -92,9 +92,9 @@ firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: 
   // CHECK: {{.*}} = firrtl.instance c @MultipleModuleBoundariesChild(in resetIn: !firrtl.uint<1>, out resetOut: !firrtl.uint<1>)
   %c_resetIn, %c_resetOut = firrtl.instance c @MultipleModuleBoundariesChild(in resetIn: !firrtl.reset, out resetOut: !firrtl.reset)
   firrtl.connect %c_resetIn, %reset : !firrtl.reset, !firrtl.uint<1>
-  %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  %c123_ui = firrtl.constant 123 : !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>
   firrtl.strictconnect %r, %x : !firrtl.uint<8>
   firrtl.strictconnect %z, %r : !firrtl.uint<8>
 }
@@ -190,18 +190,18 @@ firrtl.module @ResetDrivesAsyncResetOrBool3(in %in: !firrtl.uint<1>, out %out: !
 // CHECK-LABEL: firrtl.module @DedupDifferentlyChild1
 // CHECK-SAME: in %childReset: !firrtl.uint<1>
 firrtl.module @DedupDifferentlyChild1(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  %c123_ui = firrtl.constant 123 : !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>
   firrtl.strictconnect %r, %x : !firrtl.uint<8>
   firrtl.strictconnect %z, %r : !firrtl.uint<8>
 }
 // CHECK-LABEL: firrtl.module @DedupDifferentlyChild2
 // CHECK-SAME: in %childReset: !firrtl.asyncreset
 firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  %c123_ui = firrtl.constant 123 : !firrtl.uint
-  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  %c123_ui = firrtl.constant 123 : !firrtl.uint<8>
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>
   firrtl.strictconnect %r, %x : !firrtl.uint<8>
   firrtl.strictconnect %z, %r : !firrtl.uint<8>
 }
@@ -379,7 +379,7 @@ firrtl.circuit "Top" {
 
     // Existing async reset remains untouched.
     // CHECK: %reg2 = firrtl.regreset %clock, %reset, %c1_ui8
-    %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
     firrtl.strictconnect %reg2, %in : !firrtl.uint<8>
 
     // Existing sync reset is moved to mux.
@@ -387,7 +387,7 @@ firrtl.circuit "Top" {
     // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %reg3)
     // CHECK: %1 = firrtl.mux(%init, %c1_ui8, %in)
     // CHECK: firrtl.strictconnect %reg3, %1
-    %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
     firrtl.strictconnect %reg3, %in : !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subfield op.
@@ -398,7 +398,7 @@ firrtl.circuit "Top" {
     // CHECK: %7 = firrtl.mux(%init, %5, %in)
     // CHECK: firrtl.strictconnect %6, %7
     %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
-    %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>
     %0 = firrtl.subfield %reg4[a] : !firrtl.bundle<a: uint<8>>
     firrtl.strictconnect %0, %in : !firrtl.uint<8>
 
@@ -411,7 +411,7 @@ firrtl.circuit "Top" {
     // CHECK: %13 = firrtl.mux(%init, %11, %in)
     // CHECK: firrtl.strictconnect %12, %13
     %reset5 = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>
     %1 = firrtl.subindex %reg5[0] : !firrtl.vector<uint<8>, 1>
     firrtl.strictconnect %1, %in : !firrtl.uint<8>
 
@@ -424,7 +424,7 @@ firrtl.circuit "Top" {
     // CHECK: %19 = firrtl.mux(%init, %17, %in)
     // CHECK: firrtl.strictconnect %18, %19
     %reset6 = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>
     %2 = firrtl.subaccess %reg6[%in] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
     firrtl.strictconnect %2, %in : !firrtl.uint<8>
 
@@ -523,9 +523,9 @@ firrtl.circuit "ReusePorts" {
 firrtl.circuit "FullAsyncNested" {
   // CHECK-LABEL: firrtl.module @FullAsyncNestedDeeper
   firrtl.module @FullAsyncNestedDeeper(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1
-    %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<8>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<8>
+    // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui8
+    %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
     firrtl.strictconnect %io_out_REG, %io_in : !firrtl.uint<8>
     firrtl.strictconnect %io_out, %io_out_REG : !firrtl.uint<8>
   }
@@ -749,10 +749,10 @@ firrtl.circuit "SubAccess" {
     portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<2>
     %arr = firrtl.wire : !firrtl.vector<uint<8>, 1>
-    %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>
     %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
     firrtl.strictconnect %2, %in : !firrtl.uint<8>
-    // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>
     // CHECK-NEXT: %0 = firrtl.mux(%init, %c1_ui2, %reg6)
     // CHECK: firrtl.strictconnect %reg6, %0
     // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -530,16 +530,19 @@ firrtl.circuit "Foo" {
     in %rst: !firrtl.asyncreset,
     in %x: !firrtl.uint<6>
   ) {
-    // CHECK: %0 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
-    // CHECK: %1 = firrtl.regreset %clk, %rst, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<6>
-    // CHECK: %2:2 = firrtl.regreset %clk, %rst, %c0_ui17 forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>, !firrtl.rwprobe<uint<17>>
-    // CHECK: %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint<17>
+    // CHECK: %0 = firrtl.regreset %clk, %rst, %c0_ui6 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<6>
+    // CHECK: %1 = firrtl.regreset %clk, %rst, %c0_ui6_0 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<6>
+    // CHECK: %2:2 = firrtl.regreset %clk, %rst, %c0_ui17 forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.rwprobe<uint<17>>
+    // CHECK: %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>
     %c0_ui = firrtl.constant 0 : !firrtl.uint
     %c0_ui17 = firrtl.constant 0 : !firrtl.uint<17>
-    %0 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
-    %1 = firrtl.regreset %clk, %rst, %c0_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint
-    %2:2 = firrtl.regreset %clk, %rst, %c0_ui17 forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint, !firrtl.rwprobe<uint>
-    %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
+    %c0_a = firrtl.widthCast %c0_ui : (!firrtl.uint) -> !firrtl.uint
+    %c0_b = firrtl.widthCast %c0_ui : (!firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.regreset %clk, %rst, %c0_a : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint
+    %1 = firrtl.regreset %clk, %rst, %c0_b : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint
+    %t = firrtl.widthCast %c0_ui17 : (!firrtl.uint<17>) -> !firrtl.uint
+    %2:2 = firrtl.regreset %clk, %rst, %t forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.rwprobe<uint>
+    %3 = firrtl.regreset %clk, %rst, %t : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint
     %4 = firrtl.wire : !firrtl.uint
     %5 = firrtl.xor %1, %4 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -267,8 +267,8 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   %node = firrtl.node %u8 {name = "node"} : !firrtl.uint<8>
   // CHECK: %myinst_reg = firrtl.reg %myinst_clock : !firrtl.clock, !firrtl.uint<8>
   %reg = firrtl.reg %clock {name = "reg"} : !firrtl.clock, !firrtl.uint<8>
-  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
+  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>
   // CHECK: %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   // CHECK: %myinst_wire = firrtl.wire  : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/inner-names.mlir
+++ b/test/Dialect/FIRRTL/inner-names.mlir
@@ -20,8 +20,8 @@ firrtl.circuit "Foo" {
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
     // CHECK: %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
     %regName = firrtl.reg sym @regSym %clock : !firrtl.clock, !firrtl.uint<42>
-    // CHECK: %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
-    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    // CHECK: %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>
     // CHECK: %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
   }

--- a/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl-errors.mlir
@@ -4,7 +4,7 @@ firrtl.circuit "NoInferredEnables" {
 firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %v: !firrtl.uint<32>) {
   %ram = chirrtl.seqmem Undefined  : !chirrtl.cmemory<uint<32>, 16>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
   // expected-warning @+1 {{memory port is never enabled}}
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -393,7 +393,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset, %init {name = "r"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r = firrtl.regreset %clock, %reset, %init {name = "r"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -402,8 +402,8 @@ firrtl.circuit "TopLevel" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %r_0, %a_d_0 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %r_1, %a_d_1 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %a_q_0, %r_0 : !firrtl.uint<1>
@@ -414,7 +414,7 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-NEXT:  firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // AGGREGATE-NEXT:  %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // AGGREGATE-NEXT:  %r = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+  // AGGREGATE-NEXT:  %r = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %2 = firrtl.subindex %a_d[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %3 = firrtl.subindex %r[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  firrtl.strictconnect %3, %2 : !firrtl.uint<1>
@@ -438,7 +438,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset, %init {name = ""} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r = firrtl.regreset %clock, %reset, %init {name = ""} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -447,8 +447,8 @@ firrtl.circuit "TopLevel" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %0, %a_d_0 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %1, %a_d_1 : !firrtl.uint<1>
   // CHECK:   firrtl.strictconnect %a_q_0, %0 : !firrtl.uint<1>
@@ -535,7 +535,7 @@ firrtl.circuit "TopLevel" {
     %1 = firrtl.subindex %bazInit[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %bar = firrtl.reg %clock  {annotations = [{a = "a"}], name = "bar"} : !firrtl.clock, !firrtl.vector<uint<1>, 2>
-    %baz = firrtl.regreset %clock, %reset, %bazInit  {annotations = [{b = "b"}], name = "baz"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %baz = firrtl.regreset %clock, %reset, %bazInit  {annotations = [{b = "b"}], name = "baz"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>
   }
   // CHECK: firrtl.reg
   // CHECK-SAME: annotations = [{a = "a"}]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -337,11 +337,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint) -> !firrtl.uint
     node n8 = mux(reset, i8, UInt(4))
 
-    ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+    ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
     reg _t_2621 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0")) @[Edges.scala 230:27]
 
-    ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>
     reg _t_1601 : UInt<2>, clock with :
       (reset => (reset, UInt<2>("h00"))) @[Edges.scala 230:27]
 

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -224,7 +224,7 @@ firrtl.circuit "Forceable" {
     %reg, %reg_f = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     firrtl.ref.define %reg_ref, %reg_f : !firrtl.rwprobe<uint<2>>
 
-    %regreset, %regreset_f = firrtl.regreset %clock, %reset, %value forceable : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    %regreset, %regreset_f = firrtl.regreset %clock, %reset, %value forceable : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     firrtl.ref.define %regreset_ref, %regreset_f : !firrtl.rwprobe<uint<2>>
   }
 }

--- a/test/Dialect/FIRRTL/register-optimizer.mlir
+++ b/test/Dialect/FIRRTL/register-optimizer.mlir
@@ -36,7 +36,7 @@ firrtl.circuit "invalidReg"   {
   // CHECK-LABEL: @constantRegResetWrite
   firrtl.module @constantRegResetWrite(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
-    %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %foobar, %c : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
@@ -47,7 +47,7 @@ firrtl.circuit "invalidReg"   {
   // CHECK-LABEL: @constantRegResetWriteSelf
   firrtl.module @constantRegResetWriteSelf(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
-    %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.strictconnect %foobar, %foobar : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
@@ -67,7 +67,7 @@ firrtl.circuit "invalidReg"   {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
     // regreset
-    %regreset = firrtl.regreset %clock, %reset, %c0_ui2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %regreset = firrtl.regreset %clock, %reset, %c0_ui2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>
 
     firrtl.strictconnect %regreset, %c0_ui2 : !firrtl.uint<2>
 
@@ -81,13 +81,4 @@ firrtl.circuit "invalidReg"   {
     firrtl.strictconnect %result7, %reg: !firrtl.uint<4>
   }
 
-  // CHECK-LABEL: RegResetImplicitExtOrTrunc
-  firrtl.module @RegResetImplicitExtOrTrunc(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %out: !firrtl.uint<4>) {
-    // CHECK: firrtl.regreset
-    %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    %r = firrtl.regreset %clock, %reset, %c0_ui3 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<2>
-    %0 = firrtl.cat %r, %r : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
-    firrtl.strictconnect %r, %r : !firrtl.uint<2>
-    firrtl.strictconnect %out, %0 : !firrtl.uint<4>
-  }
 }

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -12,7 +12,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1_dead = firrtl.invalidvalue : !firrtl.uint<1>
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %invalid_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %invalid_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -25,7 +25,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.connect %inv, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -47,7 +47,7 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.strictconnect %inv1_1, %inv : !firrtl.bundle<a: uint<1>>
 
     // CHECK: firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<a: uint<1>>, 2>
-    %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>, !firrtl.vector<bundle<a: uint<1>>, 2>
+    %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.strictconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.strictconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
   }
@@ -61,7 +61,7 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.connect %inv, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %x, %inv : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %x  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %x  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -78,7 +78,7 @@ firrtl.circuit "SFCCompatTests" {
     %submodule_inv = firrtl.instance submodule  @InvalidInstancePort_Submodule(in inv: !firrtl.uint<1>)
     firrtl.connect %submodule_inv, %inv : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.reg %clock
-    %r = firrtl.regreset %clock, %reset, %submodule_inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %submodule_inv  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -88,7 +88,7 @@ firrtl.circuit "SFCCompatTests" {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     %0 = firrtl.not %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: firrtl.regreset %clock
-    %r = firrtl.regreset %clock, %reset, %0  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %0  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %q, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -100,7 +100,7 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.connect %inv, %invalid_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
     %_T = firrtl.node %inv  : !firrtl.uint<8>
     // CHECK: firrtl.regreset %clock
-    %r = firrtl.regreset %clock, %reset, %_T  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    %r = firrtl.regreset %clock, %reset, %_T  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>
     firrtl.connect %r, %d : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %q, %r : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -127,21 +127,21 @@ firrtl.circuit "SFCCompatTests" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
     firrtl.strictconnect %r0_init, %c0_ui1 : !firrtl.uint<1>
-    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
 
     %r1_init = firrtl.node %c0_ui1 : !firrtl.uint<1>
-    %r1 = firrtl.regreset %clock, %reset, %r1_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r1 = firrtl.regreset %clock, %reset, %r1_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
 
     %inv_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     %r2_init = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %r2_init, %inv_ui1 : !firrtl.uint<1>
-    %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
 
     %c0_si1 = firrtl.asSInt %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
     %c0_clock = firrtl.asClock %c0_si1 : (!firrtl.sint<1>) -> !firrtl.clock
     %c0_asyncreset = firrtl.asAsyncReset %c0_clock : (!firrtl.clock) -> !firrtl.asyncreset
     %r3_init = firrtl.asUInt %c0_asyncreset : (!firrtl.asyncreset) -> !firrtl.uint<1>
-    %r3 = firrtl.regreset %clock, %reset, %r3_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r3 = firrtl.regreset %clock, %reset, %r3_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @TailPrimOp
@@ -151,7 +151,7 @@ firrtl.circuit "SFCCompatTests" {
     %1 = firrtl.tail %0, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
     firrtl.strictconnect %r0_init, %1: !firrtl.uint<1>
-    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
   }
 }
 
@@ -161,7 +161,7 @@ firrtl.circuit "NonConstantAsyncReset_Port" {
   // expected-note @below {{reset driver is "x"}}
   firrtl.module @NonConstantAsyncReset_Port(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %x: !firrtl.uint<1>) {
     // expected-error @below {{register "r0" has an async reset, but its reset value "x" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %x : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %x : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
   }
 }
 
@@ -173,7 +173,7 @@ firrtl.circuit "NonConstantAsyncReset_PrimOp" {
     // expected-note @+1 {{reset driver is here}}
     %c1_ui1 = firrtl.not %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-error @below {{register "r0" has an async reset, but its reset value is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    %r0 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
   }
 }
 
@@ -185,7 +185,7 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate0" {
     %value = firrtl.wire : !firrtl.vector<uint<1>, 2>
     firrtl.strictconnect %value, %x : !firrtl.vector<uint<1>, 2>
     // expected-error @below {{register "r0" has an async reset, but its reset value "value" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>
   }
 }
 
@@ -211,6 +211,6 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate1" {
     firrtl.strictconnect %value_1, %subfield : !firrtl.uint<1>
 
     // expected-error @below {{register "r0" has an async reset, but its reset value "value[1]" is not driven with a constant value through wires, nodes, or connects}}
-    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>
   }
 }

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -127,13 +127,6 @@ firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {
   %2 = firrtl.dshlw %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
 }
 
-// We allow implicit truncation of a register's reset value.
-// CHECK-LABEL: @RegResetTruncation
-firrtl.module @RegResetTruncation(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %value: !firrtl.bundle<a: uint<2>>, out %out: !firrtl.bundle<a: uint<1>>) {
-  %r2 = firrtl.regreset %clock, %reset, %value  : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<1>>
-  firrtl.connect %out, %r2 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
-}
-
 // CHECK-LABEL: @TestNodeName
 firrtl.module @TestNodeName(in %in1 : !firrtl.uint<8>) {
   // CHECK: %n1 = firrtl.node %in1 : !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -190,8 +190,8 @@ firrtl.circuit "Test" {
      %rval = firrtl.aggregateconstant [[1, 2], [3, 4]] : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2> 
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %rsig = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
-    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
+    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<4>, 2>, b: vector<uint<8>, 2>>
+    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
   }
 
   // CHECK-LABEL: @TestRegResetMaterializedFromExplodedBundle
@@ -206,8 +206,8 @@ firrtl.circuit "Test" {
     %rval = firrtl.subindex %storage[0] : !firrtl.vector<bundle<a: uint<4>, b: uint<8>>, 2>
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %rsig = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
-    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>, !firrtl.bundle<a: uint<4>, b: uint<8>>
+    // CHECK: %r = firrtl.regreset %clock, %c0_ui1, %5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>
+    %r = firrtl.regreset %clock, %rsig, %rval : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: uint<8>>
   }
 
   // CHECK-LABEL: @TestRegResetMaterializedFromDeepExplodedBundle
@@ -223,11 +223,11 @@ firrtl.circuit "Test" {
     // CHECK: %8 = firrtl.bundlecreate %5, %3 : (!firrtl.uint<8>, !firrtl.uint<16>) -> !firrtl.bundle<c: uint<8>, d: uint<16>>
     // CHECK: %9 = firrtl.bundlecreate %7, %8 : (!firrtl.uint<4>, !firrtl.bundle<c: uint<8>, d: uint<16>>) -> !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
     // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %reg = firrtl.regreset %clock, %c0_ui1, %9 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
+    // CHECK: %reg = firrtl.regreset %clock, %c0_ui1, %9 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
     %reset_value_storage = firrtl.aggregateconstant [[1, [2, 3]], [4, [5, 6]]] : !firrtl.vector<bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, 2> 
     %reset_value = firrtl.subindex %reset_value_storage[1] : !firrtl.vector<bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, 2>
     %reset = firrtl.constant 0 : !firrtl.uint<1>
-    %reg = firrtl.regreset %clock, %reset, %reset_value : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
+    %reg = firrtl.regreset %clock, %reset, %reset_value : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<4>, b: bundle<c: uint<8>, d: uint<16>>>
   }
 
   // CHECK-LABEL: @TestInstance

--- a/test/circt-reduce/test/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/test/connect-source-operand-forward.mlir
@@ -6,7 +6,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %val: !firrtl.uint<2>) {
     %a = firrtl.wire : !firrtl.uint<1>
     %b = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    %c = firrtl.regreset %clock, %reset, %reset : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %c = firrtl.regreset %clock, %reset, %reset : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.bits %val 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
Remove another implicit extension from the code.  The parser arranges to have the necessary adaptation.