### PR TITLE
[FIRRTL] Add clock gate intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -23,6 +23,7 @@ include "circt/Dialect/HW/HWTypes.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class ReferableDeclOp<string mnemonic, list<Trait> traits = []> :
   FIRRTLOp<mnemonic, traits # [HasCustomSSAName,
@@ -538,6 +539,34 @@ def WireOp : ReferableDeclOp<"wire", [Forceable]> {
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
     (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict) `:`
     qualified(type($result)) (`,` qualified(type($ref))^)?
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Clock Gate Intrinsic
+//===----------------------------------------------------------------------===//
+
+def ClockGateIntrinsicOp : FIRRTLOp<"int.clock_gate", [Pure]> {
+  let summary = "Safely gates a clock with an enable signal";
+  let description = [{
+    The `int.clock_gate` enables and disables a clock safely, without glitches,
+    based on a boolean enable value. If the enable input is 1, the output clock
+    produced by the clock gate is identical to the input clock. If the enable
+    input is 0, the output clock is a constant zero.
+
+    The enable input is sampled at the rising edge of the input clock; any
+    changes on the enable before or after that edge are ignored and do not
+    affect the output clock.
+  }];
+
+  let arguments = (ins ClockType:$input,
+                       UInt1Type:$enable,
+                       Optional<UInt1Type>:$test_enable);
+  let results = (outs ClockType:$output);
+  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
+  let assemblyFormat = [{
+    operands attr-dict `:` type($enable) (`,` type($test_enable)^)?
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -680,7 +680,8 @@ def HeadPrimOp : PrimOp<"head"> {
 }
 
 def MuxPrimOp : PrimOp<"mux"> {
-  let arguments = (ins UInt1Type:$sel, PassiveType:$high, PassiveType:$low);
+  let arguments = (ins UInt1OrUnsizedType:$sel, PassiveType:$high,
+                       PassiveType:$low);
   let results = (outs PassiveType:$result);
 
   let assemblyFormat =
@@ -754,7 +755,8 @@ def TailPrimOp : PrimOp<"tail"> {
 // Verif and SV specific
 //===----------------------------------------------------------------------===//
 
-def IsXIntrinsicOp : FIRRTLExprOp<"int.isX"> {
+def IsXIntrinsicOp : FIRRTLOp<"int.isX",
+    [HasCustomSSAName, Pure]> {
   let summary = "Test for 'x";
   let description = [{
     The `int.isX` expression checks that the operand is not a verilog literal
@@ -769,7 +771,8 @@ def IsXIntrinsicOp : FIRRTLExprOp<"int.isX"> {
   let assemblyFormat = "$arg attr-dict `:` type($arg)";
 }
 
-def PlusArgsTestIntrinsicOp : FIRRTLExprOp<"int.plusargs.test"> {
+def PlusArgsTestIntrinsicOp : FIRRTLOp<"int.plusargs.test",
+    [HasCustomSSAName, Pure]> {
   let summary = "SystemVerilog `$test$plusargs` call";
 
   let arguments = (ins StrAttr:$formatString);
@@ -777,13 +780,13 @@ def PlusArgsTestIntrinsicOp : FIRRTLExprOp<"int.plusargs.test"> {
   let assemblyFormat = "$formatString attr-dict";
 }
 
-def PlusArgsValueIntrinsicOp
-: FIRRTLOp<"int.plusargs.value", [HasCustomSSAName, Pure]> {
+def PlusArgsValueIntrinsicOp : FIRRTLOp<"int.plusargs.value",
+    [HasCustomSSAName, Pure]> {
   let summary = "SystemVerilog `$value$plusargs` call";
 
   let arguments = (ins StrAttr:$formatString);
   let results = (outs UInt1Type:$found, AnyType:$result);
-  let assemblyFormat = "$formatString attr-dict `:` type($found) `,` type($result)";
+  let assemblyFormat = "$formatString attr-dict `:` type($result)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -20,7 +20,7 @@ include "FIRRTLDialect.td"
 //===----------------------------------------------------------------------===//
 
 class FIRRTLDialectType<Pred pred, string summary, string cpp, string desc = "">
-  : DialectType<FIRRTLDialect,pred, summary, cpp> {
+  : DialectType<FIRRTLDialect, pred, summary, cpp> {
   let description = desc;
 }
 
@@ -44,8 +44,10 @@ def FIRRTLBaseType : FIRRTLDialectType<
 def ForeignType : FIRRTLDialectType<CPred<"!$_self.isa<FIRRTLType>()">,
                                     "foreign type", "::mlir::Type">;
 
-def ClockType : FIRRTLDialectType<CPred<"$_self.isa<ClockType>()">,
-    "clock", "::circt::firrtl::ClockType">;
+def ClockType :
+  FIRRTLDialectType<CPred<"$_self.isa<ClockType>()">, "clock",
+                    "::circt::firrtl::ClockType">,
+  BuildableType<"::circt::firrtl::ClockType::get($_builder.getContext())">;
 
 def IntType : FIRRTLDialectType<CPred<"$_self.isa<IntType>()">,
  "sint or uint type", "::circt::firrtl::IntType">;
@@ -81,17 +83,6 @@ def SizedType : FIRRTLDialectType<CPred<"$_self.isa<FIRRTLBaseType>() && "
     "a sized type (contains no uninferred widths)", "::circt::firrtl::FIRRTLType">;
 def SizedOrForeignType : AnyTypeOf<[SizedType, ForeignType]>;
 
-def UInt1Type : FIRRTLDialectType<
-    CPred<"$_self.isa<UIntType>() && "
-          "($_self.cast<UIntType>().getWidth() == 1 ||"
-          " $_self.cast<UIntType>().getWidth() == std::nullopt)">,
-    "UInt<1> or UInt", "::circt::firrtl::UIntType">;
-
-def UInt32Type : FIRRTLDialectType<
-    CPred<"$_self.isa<UIntType>() && "
-          "$_self.cast<UIntType>().getWidth() == 32">,
-    "UInt<32>", "::circt::firrtl::UIntType">;
-
 def AsyncResetType : FIRRTLDialectType<
     CPred<"$_self.isa<AsyncResetType>()">,
     "AsyncReset", "::circt::firrtl::AsyncResetType">;
@@ -115,6 +106,30 @@ def RWProbe : FIRRTLDialectType<
 // TODO: When Refs can appear within Base, need to disallow that too.
 def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
 def StrictConnectableType : AnyTypeOf<[PassiveType, ForeignType]>;
+
+//===----------------------------------------------------------------------===//
+// Sized and Unsized Integers
+//===----------------------------------------------------------------------===//
+
+def UnsizedUIntType :
+  FIRRTLDialectType<
+    CPred<"$_self.isa<UIntType>() && "
+          "$_self.cast<UIntType>().getWidth() == std::nullopt">,
+    "uint with uninferred width", "::circt::firrtl::UIntType">,
+  BuildableType<"::circt::firrtl::UIntType::get($_builder.getContext())">;
+
+class SizedUIntType<int width> :
+  FIRRTLDialectType<
+    CPred<"$_self.isa<UIntType>() && "
+          "$_self.cast<UIntType>().getWidth() == " # width>,
+    width # "-bit uint", "::circt::firrtl::UIntType">,
+  BuildableType<
+    "::circt::firrtl::UIntType::get($_builder.getContext(), " # width # ")">;
+
+def UInt1Type : SizedUIntType<1>;
+def UInt32Type : SizedUIntType<32>;
+
+def UInt1OrUnsizedType : AnyTypeOf<[UInt1Type, UnsizedUIntType]>;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3841,23 +3841,6 @@ FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
 }
 
 //===----------------------------------------------------------------------===//
-// Verif Expressions
-//===----------------------------------------------------------------------===//
-
-FIRRTLType IsXIntrinsicOp::inferReturnType(ValueRange operands,
-                                           ArrayRef<NamedAttribute> attrs,
-                                           std::optional<Location> loc) {
-  return UIntType::get(operands[0].getContext(), 1);
-}
-
-FIRRTLType
-PlusArgsTestIntrinsicOp::inferReturnType(ValueRange operands,
-                                         ArrayRef<NamedAttribute> attrs,
-                                         std::optional<Location> loc) {
-  return UIntType::get(attrs[0].getName().getContext(), 1);
-}
-
-//===----------------------------------------------------------------------===//
 // VerbatimExprOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1498,7 +1498,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     %2 = firrtl.int.plusargs.test "foo"
     firrtl.strictconnect %io2, %2 : !firrtl.uint<1>
-    %3, %4 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
+    %3, %4 = firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
     firrtl.strictconnect %io3, %3 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %4 : !firrtl.uint<5>
 

--- a/test/Dialect/FIRRTL/basic.mlir
+++ b/test/Dialect/FIRRTL/basic.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+// Basic MLIR operation parser round-tripping
+
+firrtl.circuit "Basic" {
+firrtl.extmodule @Basic()
+
+// CHECK-LABEL: firrtl.module @Intrinsics
+firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+  // CHECK-NEXT: firrtl.int.sizeof %ui : (!firrtl.uint) -> !firrtl.uint<32>
+  %size = firrtl.int.sizeof %ui : (!firrtl.uint) -> !firrtl.uint<32>
+
+  // CHECK-NEXT: firrtl.int.isX %ui : !firrtl.uint
+  %isx = firrtl.int.isX %ui : !firrtl.uint
+
+  // CHECK-NEXT: firrtl.int.plusargs.test "foo"
+  // CHECK-NEXT: firrtl.int.plusargs.value "bar" : !firrtl.uint<5>
+  %foo_found = firrtl.int.plusargs.test "foo"
+  %bar_found, %bar_value = firrtl.int.plusargs.value "bar" : !firrtl.uint<5>
+
+  // CHECK-NEXT: firrtl.int.clock_gate %clock, %ui1 : !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.int.clock_gate %clock, %ui1, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %cg0 = firrtl.int.clock_gate %clock, %ui1 : !firrtl.uint<1>
+  %cg1 = firrtl.int.clock_gate %clock, %ui1, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+}

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2889,4 +2889,40 @@ firrtl.module private @RWProbeUnused(in %in: !firrtl.uint<4>, in %clk: !firrtl.c
   firrtl.connect %r, %w : !firrtl.uint, !firrtl.uint
   firrtl.connect %out, %r : !firrtl.uint, !firrtl.uint
 }
+
+
+// CHECK-LABEL: firrtl.module @ClockGateIntrinsic
+firrtl.module @ClockGateIntrinsic(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, in %testEnable: !firrtl.uint<1>) {
+  // CHECK-NEXT: firrtl.specialconstant 0
+  %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+  // CHECK-NEXT: %zeroClock = firrtl.node interesting_name %c0_clock
+  %0 = firrtl.int.clock_gate %c0_clock, %enable : !firrtl.uint<1>
+  %zeroClock = firrtl.node interesting_name %0 : !firrtl.clock
+
+  // CHECK-NEXT: %alwaysOff1 = firrtl.node interesting_name %c0_clock
+  // CHECK-NEXT: %alwaysOff2 = firrtl.node interesting_name %c0_clock
+  %1 = firrtl.int.clock_gate %clock, %c0_ui1 : !firrtl.uint<1>
+  %2 = firrtl.int.clock_gate %clock, %c0_ui1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %alwaysOff1 = firrtl.node interesting_name %1 : !firrtl.clock
+  %alwaysOff2 = firrtl.node interesting_name %2 : !firrtl.clock
+
+  // CHECK-NEXT: %alwaysOn1 = firrtl.node interesting_name %clock
+  // CHECK-NEXT: %alwaysOn2 = firrtl.node interesting_name %clock
+  // CHECK-NEXT: %alwaysOn3 = firrtl.node interesting_name %clock
+  %3 = firrtl.int.clock_gate %clock, %c1_ui1 : !firrtl.uint<1>
+  %4 = firrtl.int.clock_gate %clock, %c1_ui1, %testEnable : !firrtl.uint<1>, !firrtl.uint<1>
+  %5 = firrtl.int.clock_gate %clock, %enable, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %alwaysOn1 = firrtl.node interesting_name %3 : !firrtl.clock
+  %alwaysOn2 = firrtl.node interesting_name %4 : !firrtl.clock
+  %alwaysOn3 = firrtl.node interesting_name %5 : !firrtl.clock
+
+  // CHECK-NEXT: [[TMP:%.+]] = firrtl.int.clock_gate %clock, %enable :
+  // CHECK-NEXT: %dropTestEnable = firrtl.node interesting_name [[TMP]]
+  %6 = firrtl.int.clock_gate %clock, %enable, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %dropTestEnable = firrtl.node interesting_name %6 : !firrtl.clock
+}
+
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -36,7 +36,7 @@ firrtl.circuit "Foo" {
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter4(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter4
-    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
+    // CHECK: firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
     firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }
@@ -75,9 +75,28 @@ firrtl.circuit "Foo" {
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter8(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter8
-    // CHECK: %5:2 = firrtl.int.plusargs.value "foo" : !firrtl.uint<1>, !firrtl.uint<5>
+    // CHECK: firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
     firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }
 
+  // CHECK-NOT: ClockGate0
+  // CHECK-NOT: ClockGate1
+  firrtl.extmodule @ClockGate0(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.clock_gate"}]}
+  firrtl.intmodule @ClockGate1(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {intrinsic = "circt.clock_gate"}
+
+  // CHECK: ClockGate
+  firrtl.module @ClockGate(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>) {
+    // CHECK-NOT: ClockGate0
+    // CHECK: firrtl.int.clock_gate
+    %in1, %en1, %out1 = firrtl.instance "" @ClockGate0(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    firrtl.strictconnect %in1, %clk : !firrtl.clock
+    firrtl.strictconnect %en1, %en : !firrtl.uint<1>
+
+    // CHECK-NOT: ClockGate1
+    // CHECK: firrtl.int.clock_gate
+    %in2, %en2, %out2 = firrtl.instance "" @ClockGate1(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    firrtl.strictconnect %in2, %clk : !firrtl.clock
+    firrtl.strictconnect %en2, %en : !firrtl.uint<1>
+  }
 }


### PR DESCRIPTION
Add a new `firrtl.int.clock_gate` operation to represent clock gates. This new op is intended to eventually replace the magic `EICG_wrapper` extmodule that some passes in the firtool pipeline are sensitive to (mainly `WireDFT` and `ExtractInstances`).

This commit merely adds the op, canonicalization, basic round-tripping tests, and the required snippets in `LowerIntrinsics`. It does not add any handling of the intrinsic to the pipeline yet.

As a drive-by improvement it also makes the `UInt1Type` in `FIRRTLTypes.td` a `BuildableType` and requiring an inferred width. This allows `UInt1Type`s to be omitted from assembly formats. The `mux` gets a shiny new `UInt1OrUnsizedType` to continue accepting uninferred widths for the condition.