### PR TITLE
[FIRRTL] Register const updates

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -374,7 +374,7 @@ def RegResetOp : ReferableDeclOp<"regreset", [Forceable]> {
 
   let arguments = (
     ins ClockType:$clockVal, AnyResetType:$resetSignal,
-        AnyRegisterType:$resetValue,
+        FIRRTLBaseType:$resetValue,
         StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
         OptionalAttr<InnerSymAttr>:$inner_sym,

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -50,6 +50,8 @@ struct RecursiveTypeProperties {
   bool containsReference : 1;
   /// Whether the type contains an analog type.
   bool containsAnalog : 1;
+  /// Whether the type contains a const type.
+  bool containsConst : 1;
   /// Whether the type has any uninferred bit widths.
   bool hasUninferredWidth : 1;
   /// Whether the type has any uninferred reset.
@@ -79,8 +81,10 @@ public:
   /// types recursively within itself.
   bool isPassive() const { return getRecursiveTypeProperties().isPassive; }
 
-  /// Returns true if this is a "passive" that which is not analog.
-  bool isRegisterType() { return isPassive() && !containsAnalog(); }
+  /// Returns true if this is a non-const "passive" that which is not analog.
+  bool isRegisterType() {
+    return isPassive() && !containsAnalog() && !containsConst();
+  }
 
   /// Return true if this is a 'ground' type, aka a non-aggregate type.
   bool isGround();
@@ -92,6 +96,9 @@ public:
   /// Returns true if this is a 'const' type that can only hold compile-time
   /// constant values
   bool isConst();
+
+  /// Returns true if this is or contains a 'const' type.
+  bool containsConst() { return getRecursiveTypeProperties().containsConst; }
 
   /// Return true if this is or contains an Analog type.
   bool containsAnalog() { return getRecursiveTypeProperties().containsAnalog; }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -148,7 +148,7 @@ def AnyResetType : FIRRTLDialectType<
 def AnyRegisterType : FIRRTLDialectType<
     CPred<"$_self.isa<FIRRTLBaseType>() && "
           "$_self.cast<FIRRTLBaseType>().isRegisterType()">,
-    "a passive base type that does not contain analog",
+    "a passive non-'const' base type that does not contain analog",
     "::circt::firrtl::FIRRTLBaseType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2249,7 +2249,7 @@ LogicalResult RegResetOp::verify() {
   FIRRTLBaseType regType = getResult().getType();
 
   // The type of the initialiser must be equivalent to the register type.
-  if (!areTypesEquivalent(resetType, regType))
+  if (!areTypesEquivalent(regType, resetType))
     return emitError("type mismatch between register ")
            << regType << " and reset value " << resetType;
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -438,17 +438,17 @@ bool FIRRTLBaseType::isConst() { return getImpl()->isConst; }
 /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
 RecursiveTypeProperties FIRRTLBaseType::getRecursiveTypeProperties() const {
   return TypeSwitch<FIRRTLBaseType, RecursiveTypeProperties>(*this)
-      .Case<ClockType, ResetType, AsyncResetType>([](Type type) {
-        return RecursiveTypeProperties{true, false, false, false,
-                                       type.isa<ResetType>()};
+      .Case<ClockType, ResetType, AsyncResetType>([](FIRRTLBaseType type) {
+        return RecursiveTypeProperties{
+            true, false, false, type.isConst(), false, type.isa<ResetType>()};
       })
       .Case<SIntType, UIntType>([](auto type) {
-        return RecursiveTypeProperties{true, false, false, !type.hasWidth(),
-                                       false};
+        return RecursiveTypeProperties{
+            true, false, false, type.isConst(), !type.hasWidth(), false};
       })
       .Case<AnalogType>([](auto type) {
-        return RecursiveTypeProperties{true, false, true, !type.hasWidth(),
-                                       false};
+        return RecursiveTypeProperties{
+            true, false, true, type.isConst(), !type.hasWidth(), false};
       })
       .Case<BundleType>([](BundleType bundleType) {
         return bundleType.getRecursiveTypeProperties();
@@ -484,7 +484,7 @@ FIRRTLBaseType FIRRTLBaseType::getPassiveType() {
 FIRRTLBaseType FIRRTLBaseType::getConstType(bool isConst) {
   return TypeSwitch<FIRRTLBaseType, FIRRTLBaseType>(*this)
       .Case<ClockType, ResetType, AsyncResetType, AnalogType, SIntType,
-            UIntType, BundleType, FVectorType>(
+            UIntType, BundleType, FVectorType, FEnumType>(
           [&](auto type) { return type.getConstType(isConst); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
@@ -924,8 +924,8 @@ struct circt::firrtl::detail::BundleTypeStorage
 
   BundleTypeStorage(ArrayRef<BundleType::BundleElement> elements, bool isConst)
       : detail::FIRRTLBaseTypeStorage(isConst),
-        elements(elements.begin(), elements.end()), props{true, false, false,
-                                                          false, false} {
+        elements(elements.begin(), elements.end()), props{true,  false, false,
+                                                          false, false, false} {
     uint64_t fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {
@@ -934,6 +934,7 @@ struct circt::firrtl::detail::BundleTypeStorage
       props.isPassive &= eltInfo.isPassive & !element.isFlip;
       props.containsAnalog |= eltInfo.containsAnalog;
       props.containsReference |= eltInfo.containsReference;
+      props.containsConst |= eltInfo.containsConst;
       props.hasUninferredWidth |= eltInfo.hasUninferredWidth;
       props.hasUninferredReset |= eltInfo.hasUninferredReset;
       fieldID += 1;
@@ -1130,7 +1131,10 @@ struct circt::firrtl::detail::FVectorTypeStorage
   FVectorTypeStorage(FIRRTLBaseType elementType, size_t numElements,
                      bool isConst)
       : detail::FIRRTLBaseTypeStorage(isConst), elementType(elementType),
-        numElements(numElements) {}
+        numElements(numElements),
+        props(elementType.getRecursiveTypeProperties()) {
+    props.containsConst |= isConst;
+  }
 
   bool operator==(const KeyTy &key) const {
     return key == std::make_tuple(elementType, numElements, isConst);
@@ -1148,6 +1152,7 @@ struct circt::firrtl::detail::FVectorTypeStorage
 
   /// This holds the bits for the type's recursive properties, and can hold a
   /// pointer to a passive version of the type.
+  RecursiveTypeProperties props;
   FIRRTLBaseType passiveType;
 };
 
@@ -1239,7 +1244,7 @@ struct circt::firrtl::detail::FEnumTypeStorage : detail::FIRRTLBaseTypeStorage {
   FEnumTypeStorage(ArrayRef<FEnumType::EnumElement> elements, bool isConst)
       : detail::FIRRTLBaseTypeStorage(isConst),
         elements(elements.begin(), elements.end()) {
-    RecursiveTypeProperties props{true, false, false, false, false};
+    RecursiveTypeProperties props{true, false, false, false, false, false};
     uint64_t fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {
@@ -1247,6 +1252,7 @@ struct circt::firrtl::detail::FEnumTypeStorage : detail::FIRRTLBaseTypeStorage {
       auto eltInfo = type.getRecursiveTypeProperties();
       props.isPassive &= eltInfo.isPassive;
       props.containsAnalog |= eltInfo.containsAnalog;
+      props.containsConst |= eltInfo.containsConst;
       props.hasUninferredWidth |= eltInfo.hasUninferredWidth;
       fieldID += 1;
       fieldIDs.push_back(fieldID);

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -924,8 +924,9 @@ struct circt::firrtl::detail::BundleTypeStorage
 
   BundleTypeStorage(ArrayRef<BundleType::BundleElement> elements, bool isConst)
       : detail::FIRRTLBaseTypeStorage(isConst),
-        elements(elements.begin(), elements.end()), props{true,  false, false,
-                                                          false, false, false} {
+        elements(elements.begin(), elements.end()), props{true,  false,
+                                                          false, isConst,
+                                                          false, false} {
     uint64_t fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {
@@ -1169,7 +1170,7 @@ size_t FVectorType::getNumElements() const { return getImpl()->numElements; }
 
 /// Return the recursive properties of the type.
 RecursiveTypeProperties FVectorType::getRecursiveTypeProperties() const {
-  return getElementType().getRecursiveTypeProperties();
+  return getImpl()->props;
 }
 
 /// Return this type with any flip types recursively removed from itself.
@@ -1244,7 +1245,7 @@ struct circt::firrtl::detail::FEnumTypeStorage : detail::FIRRTLBaseTypeStorage {
   FEnumTypeStorage(ArrayRef<FEnumType::EnumElement> elements, bool isConst)
       : detail::FIRRTLBaseTypeStorage(isConst),
         elements(elements.begin(), elements.end()) {
-    RecursiveTypeProperties props{true, false, false, false, false, false};
+    RecursiveTypeProperties props{true, false, false, isConst, false, false};
     uint64_t fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -128,4 +128,9 @@ firrtl.module @MixedConstSubtag(in %in : !firrtl.enum<a: uint<1>, b: const.uint<
   firrtl.connect %b, %1 : !firrtl.const.uint<2>, !firrtl.const.uint<2>
 }
 
+// CHECK-LABEL: firrtl.module @ConstRegResetValue
+firrtl.module @ConstRegResetValue(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetValue: !firrtl.const.sint<1>) {
+  %0 = firrtl.regreset %clock, %reset, %resetValue : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.sint<1>, !firrtl.sint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -844,7 +844,7 @@ firrtl.circuit "Top"   {
 
 firrtl.circuit "AnalogRegister" {
   firrtl.module @AnalogRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.analog'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.analog'}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.analog
   }
 }
@@ -853,7 +853,7 @@ firrtl.circuit "AnalogRegister" {
 
 firrtl.circuit "AnalogVectorRegister" {
   firrtl.module @AnalogVectorRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.vector<analog, 2>'}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<analog, 2>
   }
 }
@@ -1005,7 +1005,7 @@ firrtl.module @NonRefNode(in %in1 : !firrtl.probe<uint<8>>) {
 
 firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog}}
     %r = firrtl.reg %clock : !firrtl.clock, !firrtl.probe<uint<8>>
   }
 }
@@ -1245,4 +1245,44 @@ firrtl.circuit "SubtagNoCase" {
 firrtl.module @SubtagNoCase(in %in : !firrtl.enum<None: uint<0>, Some: uint<8>>) {
   // expected-error @below {{unknown field SomeOther in enum type}}
   %some = firrtl.subtag %in[SomeOther] : !firrtl.enum<None: uint<0>, Some: uint<8>>
+}
+
+// -----
+// 'const' firrtl.reg is invalid
+
+firrtl.circuit "ConstReg" {
+firrtl.module @ConstReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.uint<1>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.const.uint<1>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "ConstRegReset" {
+firrtl.module @ConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.uint<1>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.uint<1>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.uint<1>, !firrtl.const.uint<1>
+}
+}
+
+// -----
+
+// nested 'const' firrtl.reg is invalid
+firrtl.circuit "NestedConstReg" {
+firrtl.module @NestedConstReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: const.uint<1>>
+}
+}
+
+// -----
+
+// nested 'const' firrtl.regreset is invalid
+firrtl.circuit "NestedConstRegReset" {
+firrtl.module @NestedConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.bundle<a: uint<1>>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.bundle<a: uint<1>>, !firrtl.bundle<a: const.uint<1>>
+}
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1258,6 +1258,36 @@ firrtl.module @ConstReg(in %clock: !firrtl.clock) {
 }
 
 // -----
+// 'const' firrtl.reg is invalid
+
+firrtl.circuit "ConstBundleReg" {
+firrtl.module @ConstBundleReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.bundle<a: uint<1>>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.const.bundle<a: uint<1>>
+}
+}
+
+// -----
+// 'const' firrtl.reg is invalid
+
+firrtl.circuit "ConstVectorReg" {
+firrtl.module @ConstVectorReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.vector<uint<1>, 3>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.const.vector<uint<1>, 3>
+}
+}
+
+// -----
+// 'const' firrtl.reg is invalid
+
+firrtl.circuit "ConstEnumReg" {
+firrtl.module @ConstEnumReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.enum<a: uint<1>>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.const.enum<a: uint<1>>
+}
+}
+
+// -----
 // 'const' firrtl.regreset is invalid
 
 firrtl.circuit "ConstRegReset" {
@@ -1268,21 +1298,101 @@ firrtl.module @ConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncr
 }
 
 // -----
+// 'const' firrtl.regreset is invalid
 
+firrtl.circuit "ConstRegReset" {
+firrtl.module @ConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.uint<1>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.uint<1>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.uint<1>, !firrtl.const.uint<1>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "ConstBundleRegReset" {
+firrtl.module @ConstBundleRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.bundle<a: uint<1>>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.bundle<a: uint<1>>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.bundle<a: uint<1>>, !firrtl.const.bundle<a: uint<1>>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "ConstVectorRegReset" {
+firrtl.module @ConstVectorRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.vector<uint<1>, 3>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.vector<uint<1>, 3>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "ConstEnumRegReset" {
+firrtl.module @ConstEnumRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.enum<a: uint<1>>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.const.enum<a: uint<1>>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.enum<a: uint<1>>, !firrtl.const.enum<a: uint<1>>
+}
+}
+
+// -----
 // nested 'const' firrtl.reg is invalid
-firrtl.circuit "NestedConstReg" {
-firrtl.module @NestedConstReg(in %clock: !firrtl.clock) {
+
+firrtl.circuit "BundleNestedConstReg" {
+firrtl.module @BundleNestedConstReg(in %clock: !firrtl.clock) {
   // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
   %r = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: const.uint<1>>
 }
 }
 
 // -----
+// nested 'const' firrtl.reg is invalid
 
+firrtl.circuit "VectorNestedConstReg" {
+firrtl.module @VectorNestedConstReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.vector<const.uint<1>, 3>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<const.uint<1>, 3>
+}
+}
+
+// -----
+// nested 'const' firrtl.reg is invalid
+
+firrtl.circuit "EnumNestedConstReg" {
+firrtl.module @EnumNestedConstReg(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.enum<a: const.uint<1>>'}}
+  %r = firrtl.reg %clock : !firrtl.clock, !firrtl.enum<a: const.uint<1>>
+}
+}
+
+// -----
 // nested 'const' firrtl.regreset is invalid
-firrtl.circuit "NestedConstRegReset" {
-firrtl.module @NestedConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.bundle<a: uint<1>>) {
+
+firrtl.circuit "BundleNestedConstRegReset" {
+firrtl.module @BundleNestedConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.const.bundle<a: uint<1>>) {
   // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.bundle<a: const.uint<1>>'}}
   %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.bundle<a: uint<1>>, !firrtl.bundle<a: const.uint<1>>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "VectorNestedConstRegReset" {
+firrtl.module @VectorNestedConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.vector<const.uint<1>, 3>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.vector<const.uint<1>, 3>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<const.uint<1>, 3>, !firrtl.vector<const.uint<1>, 3>
+}
+}
+
+// -----
+// 'const' firrtl.regreset is invalid
+
+firrtl.circuit "EnumNestedConstRegReset" {
+firrtl.module @EnumNestedConstRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %resetVal: !firrtl.enum<a: const.uint<1>>) {
+  // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.enum<a: const.uint<1>>'}}
+  %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.enum<a: const.uint<1>>, !firrtl.enum<a: const.uint<1>>
 }
 }


### PR DESCRIPTION
This disallows register types from being const. Register reset values are allowed to be const or contain const members.

In order to efficiently check if a type is const or contains const members, containsConst has been added to RecursiveTypeProperties.