### PR TITLE
[FIRRTL] Support AttributeAnnotation

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -201,6 +201,28 @@ Annotations here are written in their JSON format. A "reference target"
 indicates that the annotation could target any object in the hierarchy,
 although there may be further restrictions in the annotation.
 
+### [AttributeAnnotation](https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.13/latest/firrtl/AttributeAnnotation.html)
+
+| Property    | Type   | Description                  |
+| ----------  | ------ | ---------------------------- |
+| class       | string | `firrtl.AttributeAnnotation` |
+| target      | string | A reference target           |
+| description | string | An attribute                 |
+
+This annotation attaches SV attributes to a specified target. A reference
+target must be a wire, node, reg, or module. This annotation doesn't prevent
+optimizations so it's necessary to add dontTouch annotation if users want to
+preseve the target.
+
+Example:
+```json
+{
+  "class": "firrtl.AttributeAnnotation",
+  "target": "~Foo|Foo>r",
+  "description": "debug = \"true\""
+}
+```
+
 ### BlackBox
 
 | Property   | Type   | Description                  |
@@ -388,6 +410,28 @@ Example:
 {
   "class":"sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
   "filename":"SRAMPorts.txt"
+}
+```
+
+### [DocStringAnnotation](https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.13/latest/firrtl/DocStringAnnotation.html)
+
+| Property    | Type   | Description                  |
+| ----------  | ------ | ---------------------------- |
+| class       | string | `firrtl.DocStringAnnotation` |
+| target      | string | A reference target           |
+| description | string | An attribute                 |
+
+This annotation attaches a comment to a specified target. A reference
+target must be a wire, node, reg, or module. This annotation doesn't prevent
+optimizations so it's necessary to add dontTouch annotation if users want to
+preseve the target.
+
+Example:
+```json
+{
+  "class": "firrtl.DocStringAnnotation",
+  "target": "~Foo|Foo>r",
+  "description": "comment"
 }
 ```
 

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -210,9 +210,8 @@ constexpr const char *wiringSinkAnnoClass =
 constexpr const char *wiringSourceAnnoClass =
     "firrtl.passes.wiring.SourceAnnotation";
 
-// Attribute/DocString annotations.
+// Attribute annotations.
 constexpr const char *attributeAnnoClass = "firrtl.AttributeAnnotation";
-constexpr const char *docStringAnnoClass = "firrtl.DocStringAnnotation";
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -210,6 +210,7 @@ constexpr const char *wiringSinkAnnoClass =
 constexpr const char *wiringSourceAnnoClass =
     "firrtl.passes.wiring.SourceAnnotation";
 
+// Attribute/DocString annotations.
 constexpr const char *attributeAnnoClass = "firrtl.AttributeAnnotation";
 constexpr const char *docStringAnnoClass = "firrtl.DocStringAnnotation";
 

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -210,6 +210,9 @@ constexpr const char *wiringSinkAnnoClass =
 constexpr const char *wiringSourceAnnoClass =
     "firrtl.passes.wiring.SourceAnnotation";
 
+constexpr const char *attributeAnnoClass = "firrtl.AttributeAnnotation";
+constexpr const char *docStringAnnoClass = "firrtl.DocStringAnnotation";
+
 } // namespace firrtl
 } // namespace circt
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -355,7 +355,6 @@ static LogicalResult applyConventionAnno(const AnnoPathValue &target,
   return error() << "can only target to a module or extmodule";
 }
 
-template <bool isComment = false>
 static LogicalResult applyAttributeAnnotation(const AnnoPathValue &target,
                                               DictionaryAttr anno,
                                               ApplyState &state) {
@@ -380,7 +379,7 @@ static LogicalResult applyAttributeAnnotation(const AnnoPathValue &target,
               "register";
 
   auto name = anno.getAs<StringAttr>("description");
-  auto svAttr = sv::SVAttributeAttr::get(name.getContext(), name, isComment);
+  auto svAttr = sv::SVAttributeAttr::get(name.getContext(), name);
   sv::addSVAttributes(op, {svAttr});
   return success();
 }
@@ -565,8 +564,7 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
      {stdResolve, applyLoadMemoryAnno<true>}},
     {wiringSinkAnnoClass, {stdResolve, applyWiring}},
     {wiringSourceAnnoClass, {stdResolve, applyWiring}},
-    {attributeAnnoClass, {stdResolve, applyAttributeAnnotation<false>}},
-    {docStringAnnoClass, {stdResolve, applyAttributeAnnotation<true>}}}};
+    {attributeAnnoClass, {stdResolve, applyAttributeAnnotation}}}};
 
 /// Lookup a record for a given annotation class.  Optionally, returns the
 /// record for "circuit.missing" if the record doesn't exist.

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/SV/SVAttributes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -354,6 +355,27 @@ static LogicalResult applyConventionAnno(const AnnoPathValue &target,
   return error() << "can only target to a module or extmodule";
 }
 
+template <bool isComment = false>
+static LogicalResult applyAttributeAnnotation(const AnnoPathValue &target,
+                                              DictionaryAttr anno,
+                                              ApplyState &state) {
+  auto *op = target.ref.getOp();
+
+  if (!target.isLocal())
+    return mlir::emitError(op->getLoc()) << "must be local";
+
+  if (!target.ref.isa<OpAnnoTarget>())
+    return mlir::emitError(op->getLoc()) << "must target an operation";
+
+  if (!isa<FModuleOp, WireOp, NodeOp, RegOp, RegResetOp>(op))
+    return mlir::emitError(op->getLoc()) << "unhandled operation";
+
+  auto name = anno.getAs<StringAttr>("description");
+  auto svAttr = sv::SVAttributeAttr::get(name.getContext(), name, isComment);
+  sv::addSVAttributes(op, {svAttr});
+  return success();
+}
+
 /// Update a memory op with attributes about memory file loading.
 template <bool isInline>
 static LogicalResult applyLoadMemoryAnno(const AnnoPathValue &target,
@@ -534,8 +556,8 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
      {stdResolve, applyLoadMemoryAnno<true>}},
     {wiringSinkAnnoClass, {stdResolve, applyWiring}},
     {wiringSourceAnnoClass, {stdResolve, applyWiring}},
-
-}};
+    {attributeAnnoClass, {stdResolve, applyAttributeAnnotation<false>}},
+    {docStringAnnoClass, {stdResolve, applyAttributeAnnotation<true>}}}};
 
 /// Lookup a record for a given annotation class.  Optionally, returns the
 /// record for "circuit.missing" if the record doesn't exist.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1643,11 +1643,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-SAME:  attributes {sv.attributes = [#sv.attribute<"keep_hierarchy = \22true\22">]}
   // CHECK-NEXT: %w = hw.wire %a {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]}
   // CHECK-NEXT: %n = hw.wire %w {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]}
-  // CHECK-NEXT: %r = seq.firreg %a clock %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22">]}
+  // CHECK-NEXT: %r = seq.firreg %a clock %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22", emitAsComment>]}
   firrtl.module @SVAttr(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b1: !firrtl.uint<1>, out %b2: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>, sv.attributes = [#sv.attribute<"keep_hierarchy = \22true\22">]} {
     %w = firrtl.wire {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
     %n = firrtl.node %w {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
-    %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22">]} : !firrtl.clock, !firrtl.uint<1>
+    %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22", emitAsComment>]} : !firrtl.clock, !firrtl.uint<1>
     firrtl.strictconnect %w, %a : !firrtl.uint<1>
     firrtl.strictconnect %b1, %n : !firrtl.uint<1>
     firrtl.strictconnect %r, %a : !firrtl.uint<1>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1638,4 +1638,19 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:      }
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
+
+  // CHECK-LABEL: @SVAttr
+  // CHECK-SAME:  attributes {sv.attributes = [#sv.attribute<"keep_hierarchy = \22true\22">]}
+  // CHECK-NEXT: %w = hw.wire %a {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]}
+  // CHECK-NEXT: %n = hw.wire %w {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]}
+  // CHECK-NEXT: %r = seq.firreg %a clock %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22">]}
+  firrtl.module @SVAttr(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b1: !firrtl.uint<1>, out %b2: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>, sv.attributes = [#sv.attribute<"keep_hierarchy = \22true\22">]} {
+    %w = firrtl.wire {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
+    %n = firrtl.node %w {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
+    %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22">]} : !firrtl.clock, !firrtl.uint<1>
+    firrtl.strictconnect %w, %a : !firrtl.uint<1>
+    firrtl.strictconnect %b1, %n : !firrtl.uint<1>
+    firrtl.strictconnect %r, %a : !firrtl.uint<1>
+    firrtl.strictconnect %b2, %r : !firrtl.uint<1>
+  }
 }

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -284,3 +284,32 @@ firrtl.circuit "RefAnno" attributes {rawAnnotations = [{
     firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
   }
 }
+
+// -----
+// Reject AttributeAnnotations on ports.
+
+
+
+// expected-error @+1 {{Unable to apply annotation:}}
+firrtl.circuit "Anno" attributes {rawAnnotations = [{
+  class = "firrtl.AttributeAnnotation",
+  target = "~Anno|Anno>in",
+  description = "attr"
+}]} {
+  // expected-error @+1 {{firrtl.AttributeAnnotation must target an operation. Currently ports are not supported}}
+  firrtl.module @Anno(in %in : !firrtl.uint<1>) {}
+}
+
+// -----
+// Reject AttributeAnnotations on external modules.
+
+// expected-error @+1 {{Unable to apply annotation:}}
+firrtl.circuit "Anno" attributes {rawAnnotations = [{
+  class = "firrtl.AttributeAnnotation",
+  target = "~Anno|Ext",
+  description = "ext"
+}]} {
+  // expected-error @+1 {{firrtl.AttributeAnnotation unhandled operation. The target must be a module, wire, node or register}}
+  firrtl.extmodule @Ext()
+  firrtl.module @Anno(in %in : !firrtl.uint<1>) {}
+}

--- a/test/firtool/sv-attr.fir
+++ b/test/firtool/sv-attr.fir
@@ -15,9 +15,6 @@ circuit Foo: %[[{"class": "firrtl.AttributeAnnotation",
                  "target": "~Foo|Foo>n"},
                 {"class": "firrtl.AttributeAnnotation",
                  "description": "keep = \"true\"",
-                 "target": "~Foo|Foo>r"},
-                {"class": "firrtl.DocStringAnnotation",
-                 "description": "comment",
                  "target": "~Foo|Foo>r"}]]
   ; CHECK: (* keep_hierarchy = "true" *)
   ; CHECK-NEXT: module Foo
@@ -33,7 +30,6 @@ circuit Foo: %[[{"class": "firrtl.AttributeAnnotation",
     ; CHECK-NEXT: wire n
     node n = w;
     ; CHECK:      (* keep = "true" *) 
-    ; CHECK-SAME: /* comment */
     ; CHECK-NEXT: reg r
     reg r: UInt<1>, clock
     w <= a

--- a/test/firtool/sv-attr.fir
+++ b/test/firtool/sv-attr.fir
@@ -1,0 +1,42 @@
+; RUN: firtool %s | FileCheck %s
+
+circuit Foo: %[[{"class": "firrtl.AttributeAnnotation",
+                 "description": "keep_hierarchy = \"true\"",
+                 "target": "~Foo|Foo"},
+                {"class": "firrtl.AttributeAnnotation",
+                 "description": "mark_debug = \"yes\"",
+                 "target": "~Foo|Foo>w"},
+                {"class": "firrtl.transforms.DontTouchAnnotation",
+                 "target": "~Foo|Foo>w"},
+                {"class": "firrtl.AttributeAnnotation",
+                 "description": "mark_debug = \"yes\"",
+                 "target": "~Foo|Foo>n"},
+                {"class": "firrtl.transforms.DontTouchAnnotation",
+                 "target": "~Foo|Foo>n"},
+                {"class": "firrtl.AttributeAnnotation",
+                 "description": "keep = \"true\"",
+                 "target": "~Foo|Foo>r"},
+                {"class": "firrtl.DocStringAnnotation",
+                 "description": "comment",
+                 "target": "~Foo|Foo>r"}]]
+  ; CHECK: (* keep_hierarchy = "true" *)
+  ; CHECK-NEXT: module Foo
+  module Foo:
+    input a: UInt<1>
+    input clock: Clock
+    output b1: UInt<1>
+    output b2: UInt<1>
+    ; CHECK: (* mark_debug = "yes" *)
+    ; CHECK-NEXT: wire w
+    wire w: UInt<1>
+    ; CHECK:      (* mark_debug = "yes" *)
+    ; CHECK-NEXT: wire n
+    node n = w;
+    ; CHECK:      (* keep = "true" *) 
+    ; CHECK-SAME: /* comment */
+    ; CHECK-NEXT: reg r
+    reg r: UInt<1>, clock
+    w <= a
+    b1 <= n
+    r <= a
+    b2 <= r


### PR DESCRIPTION
This PR adds support for AttributeAnnotation. LowerAnnotation pass lowers
these annotations into`sv.attribute` dialect attributes. LowerToHW is also modified to move these attritutes.

SFC implementation: https://github.com/chipsalliance/firrtl/pull/1643

