### PR TITLE
[FIRRTL][InferWidths] Support enum types

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -32,7 +32,8 @@ public:
         .template Case<
             ConstantOp, SpecialConstantOp, AggregateConstantOp, InvalidValueOp,
             SubfieldOp, SubindexOp, SubaccessOp, IsTagOp, SubtagOp,
-            BundleCreateOp, VectorCreateOp, MultibitMuxOp, TagExtractOp,
+            BundleCreateOp, VectorCreateOp, FEnumCreateOp, MultibitMuxOp,
+            TagExtractOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
@@ -96,6 +97,7 @@ public:
   HANDLE(AggregateConstantOp, Unhandled);
   HANDLE(BundleCreateOp, Unhandled);
   HANDLE(VectorCreateOp, Unhandled);
+  HANDLE(FEnumCreateOp, Unhandled);
   HANDLE(SubfieldOp, Unhandled);
   HANDLE(SubindexOp, Unhandled);
   HANDLE(SubaccessOp, Unhandled);

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -710,6 +710,20 @@ bool firrtl::areTypesEquivalent(FIRRTLType destFType, FIRRTLType srcFType,
     return true;
   }
 
+  // Enum types can be connected if they have the same size, element names, and
+  // element types.
+  auto dstEnumType = destType.dyn_cast<FEnumType>();
+  auto srcEnumType = destType.dyn_cast<FEnumType>();
+  if (dstEnumType && srcEnumType) {
+    if (dstEnumType.getNumElements() != srcEnumType.getNumElements())
+      return false;
+    // Enums requires the types to match exactly.
+    for (const auto &[dst, src] : llvm::zip(dstEnumType, srcEnumType))
+      if (!areTypesEquivalent(dst.type, src.type))
+        return false;
+    return true;
+  }
+
   // Ground types can be connected if their passive, widthless versions
   // are equal or the widthless source type is a const version of the widthless
   // destination type.

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -49,9 +49,11 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.invalidvalue : !firrtl.uint<0>
     // CHECK: firrtl.invalidvalue : !firrtl.bundle<x: uint<0>>
     // CHECK: firrtl.invalidvalue : !firrtl.vector<uint<0>, 2>
+    // CHECK: firrtl.invalidvalue : !firrtl.enum<a: uint<0>>
     %invalid_0 = firrtl.invalidvalue : !firrtl.uint
     %invalid_1 = firrtl.invalidvalue : !firrtl.bundle<x: uint>
     %invalid_2 = firrtl.invalidvalue : !firrtl.vector<uint, 2>
+    %invalid_3 = firrtl.invalidvalue : !firrtl.enum<a: uint>
   }
 
   // CHECK-LABEL: @InferOutput
@@ -667,6 +669,15 @@ firrtl.circuit "Foo" {
     %w_a = firrtl.subfield %w[b] : !firrtl.bundle<a: vector<uint<10>, 10>, b: uint>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %w_a, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @InferEnum
+  firrtl.module @InferEnum(in %in : !firrtl.enum<a: uint<3>>) {
+    // CHECK: %w = firrtl.wire : !firrtl.enum<a: uint<3>>
+    %w = firrtl.wire : !firrtl.enum<a: uint>
+    firrtl.connect %w, %in : !firrtl.enum<a: uint>, !firrtl.enum<a: uint<3>>
+    // CHECK: %0 = firrtl.subtag %w[a] : !firrtl.enum<a: uint<3>>
+    %0 = firrtl.subtag %w[a] : !firrtl.enum<a: uint>
   }
 
   // CHECK-LABEL: InferComplexBundles


### PR DESCRIPTION
This adds support for enum types and the subtag operation to InferWidths.  It constrains all widths inside enum types to be exactly identical. The subtag op's result size is constrained to match the payload size of the matching tag of the input enumeration value.