### PR TITLE
[ExportVerilog] Add support for UnionCreate op.

### DIFF
--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -33,7 +33,7 @@ public:
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
                        // Union operations
-                       UnionExtractOp,
+                       UnionCreateOp, UnionExtractOp,
                        // Cast operation
                        BitcastOp, ParamValueOp,
                        // Enum operations
@@ -70,6 +70,7 @@ public:
   HANDLE(StructCreateOp, Unhandled);
   HANDLE(StructExtractOp, Unhandled);
   HANDLE(StructInjectOp, Unhandled);
+  HANDLE(UnionCreateOp, Unhandled);
   HANDLE(UnionExtractOp, Unhandled);
   HANDLE(ArraySliceOp, Unhandled);
   HANDLE(ArrayGetOp, Unhandled);

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1018,6 +1018,33 @@ hw.module @structExtractFromTemporary(%cond: i1, %a: !hw.struct<c: i1>, %b: !hw.
     hw.output %1 : i1
 }
 
+// CHECK-LABEL: module unionCreateNoPadding(
+// CHECK-NEXT:    input [1:0] in,
+// CHECK-NEXT:    output union packed { struct packed {logic a; logic [0:0] __post_padding_a;} a;logic [1:0] b;} out
+hw.module @unionCreateNoPadding(%in: i2) -> (out: !hw.union<a: i1, b: i2>) {
+  // CHECK: assign out = in;
+  %0 = hw.union_create "b", %in : !hw.union<a: i1, b: i2>
+  hw.output %0 : !hw.union<a: i1, b: i2>
+}
+
+// CHECK-LABEL: module unionCreatePadding(
+// CHECK-NEXT:    input in,
+// CHECK-NEXT:    output union packed { struct packed {logic a; logic [0:0] __post_padding_a;} a;logic [1:0] b;} out
+hw.module @unionCreatePadding(%in: i1) -> (out: !hw.union<a: i1, b: i2>) {
+  // CHECK: assign out = {in, 1'h0};
+  %0 = hw.union_create "a", %in : !hw.union<a: i1, b: i2>
+  hw.output %0 : !hw.union<a: i1, b: i2>
+}
+
+// CHECK-LABEL: module unionCreateZeroWidthElement(
+// CHECK-NEXT:    // input /*Zero Width*/ in,
+// CHECK-NEXT:    output union packed {/*a: Zero Width;*/ logic [1:0] b;} out
+hw.module @unionCreateZeroWidthElement(%in: i0) -> (out: !hw.union<a: i0, b: i2>) {
+  // CHECK: assign out = 2'h0;
+  %0 = hw.union_create "a", %in : !hw.union<a: i0, b: i2>
+  hw.output %0 : !hw.union<a: i0, b: i2>
+}
+
 // CHECK-LABEL: unionExtractFromTemporary
 hw.module @unionExtractFromTemporary(%cond: i1, %a: !hw.union<c: i1>, %b: !hw.union<c: i1>) -> (out: i1) {
     %0 = comb.mux %cond, %a, %b : !hw.union<c: i1>


### PR DESCRIPTION
This adds support for `hw::UnionCreateOp` to ExportVerilog.  It works by emitting a bit concatenation and assigning it to a wire with a union type.  Each union member may have a prepadding, which is decided by the member's offset size, and a postpadding to ensure that each union element is the same size. The resulting bitconcat is `{prepadding, data, postpadding}`.  If there is no padding for a particular member, then bitconcat will not be used.

The following example has no offsets, but the member `a` requires post-padding of `1` bit.

```mlir
hw.module @unionCreate(%in: i1) -> (out: !hw.union<a: i1, b: i2>) {
    %0 = hw.union_create "a", %in : !hw.union<a: i1, b: i2>
    hw.output %0 : !hw.union<a: i1, b: i2>
}
```

```verilog
module unionCreate(
  input                                                                                          in,
  output union packed { struct packed {logic a; logic [0:0] __post_padding_a;} a;logic [1:0] b;} out
);

  assign out = {in, 1'h0};
endmodule
```