### PR TITLE
[OM] Add a Reference type.

### DIFF
--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -27,4 +27,10 @@ def ClassType : TypeDef<OMDialect, "Class", []> {
   }];
 }
 
+def ReferenceType : TypeDef<OMDialect, "Reference", []> {
+  let summary = "A type that represents a reference to a hardware entity.";
+
+  let mnemonic = "ref";
+}
+
 #endif // CIRCT_DIALECT_OM_OMTYPES_TD

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -77,3 +77,7 @@ om.class @NestedField4() {
   // CHECK: %{{.+}} = om.object.field %[[nested]], [@foo, @bar, @baz] : (!om.class.type<@NestedField3>) -> i1
   %1 = om.object.field %0, [@foo, @bar, @baz] : (!om.class.type<@NestedField3>) -> i1
 }
+
+om.class @ReferenceParameter(%arg0: !om.ref) {
+  om.class.field @myref, %arg0 : !om.ref
+}


### PR DESCRIPTION
This is an opaque type that indicates a value is a reference to a hardware entity. This allows values in OM dialect's type system to include references in parameters, fields, etc.