### PR TITLE
[OM] Add Reference attribute.

### DIFF
--- a/include/circt/Dialect/OM/OMAttributes.h
+++ b/include/circt/Dialect/OM/OMAttributes.h
@@ -13,6 +13,9 @@
 #ifndef CIRCT_DIALECT_OM_OMATTRIBUTES_H
 #define CIRCT_DIALECT_OM_OMATTRIBUTES_H
 
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "mlir/IR/Attributes.h"
+
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/OM/OMAttributes.h.inc"
 

--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -14,5 +14,24 @@
 #define CIRCT_DIALECT_OM_OMATTRIBUTES_TD
 
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
+def ReferenceAttr : AttrDef<OMDialect, "Reference", [TypedAttrInterface]> {
+  let summary = "An attribute that wraps a #hw.innerNameRef with !om.ref type";
+
+  let mnemonic = "ref";
+
+  let parameters = (ins
+    "circt::hw::InnerRefAttr":$innerRef
+  );
+
+  let assemblyFormat = [{
+    `<` $innerRef `>`
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Type getType();
+  }];
+}
 
 #endif // CIRCT_DIALECT_OM_OMATTRIBUTES_TD

--- a/include/circt/Dialect/OM/OMDialect.td
+++ b/include/circt/Dialect/OM/OMDialect.td
@@ -27,7 +27,12 @@ def OMDialect : Dialect {
     [Object Model Dialect Rationale](./RationaleOM.md).
   }];
 
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
+
+  let dependentDialects = [
+    "circt::hw::HWDialect"
+  ];
 
   let extraClassDeclaration = [{
     /// Register all OM types.

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -27,4 +27,10 @@ def ClassType : TypeDef<OMDialect, "Class", []> {
   }];
 }
 
+def ReferenceType : TypeDef<OMDialect, "Reference", []> {
+  let summary = "A type that represents a reference to a hardware entity.";
+
+  let mnemonic = "ref";
+}
+
 #endif // CIRCT_DIALECT_OM_OMTYPES_TD

--- a/lib/Dialect/OM/CMakeLists.txt
+++ b/lib/Dialect/OM/CMakeLists.txt
@@ -16,11 +16,13 @@ add_circt_dialect_library(
 
   DEPENDS
   MLIROMIncGen
+  MLIROMAttrIncGen
 
   LINK_COMPONENTS
   Support
 
   LINK_LIBS PRIVATE
+  CIRCTHW
   MLIRIR
 )
 

--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -12,9 +12,20 @@
 
 #include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt::om;
 
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/OM/OMAttributes.cpp.inc"
+
+Type circt::om::ReferenceAttr::getType() {
+  return ReferenceType::get(getContext());
+}
 
 void circt::om::OMDialect::registerAttributes() {
   addAttributes<

--- a/lib/Dialect/OM/OMDialect.cpp
+++ b/lib/Dialect/OM/OMDialect.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
 
 #include "circt/Dialect/OM/OMDialect.cpp.inc"

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -78,6 +78,16 @@ om.class @NestedField4() {
   %1 = om.object.field %0, [@foo, @bar, @baz] : (!om.class.type<@NestedField3>) -> i1
 }
 
+// CHECK-LABEL: @ReferenceParameter
+// CHECK-SAME: !om.ref
 om.class @ReferenceParameter(%arg0: !om.ref) {
   om.class.field @myref, %arg0 : !om.ref
+}
+
+// CHECK-LABEL: @ReferenceConstant
+om.class @ReferenceConstant() {
+  // CHECK: %[[const:.+]] = om.constant #om.ref<<@A::@inst_1>> : !om.ref
+  %0 = om.constant #om.ref<#hw.innerNameRef<@A::@inst_1>> : !om.ref
+  // CHECK: om.class.field @myref, %[[const]] : !om.ref
+  om.class.field @myref, %0 : !om.ref
 }

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -77,3 +77,7 @@ om.class @NestedField4() {
   // CHECK: %{{.+}} = om.object.field %[[nested]], [@foo, @bar, @baz] : (!om.class.type<@NestedField3>) -> i1
   %1 = om.object.field %0, [@foo, @bar, @baz] : (!om.class.type<@NestedField3>) -> i1
 }
+
+om.class @ReferenceParameter(%arg0: !om.ref) {
+  om.class.field @myref, %arg0 : !om.ref
+}


### PR DESCRIPTION
This is a wrapper around a hw.innerNameRef with !om.ref type. This is needed because the OM dialect constant ops need typed attributes, so a hw.innerNameRef can't be used directly. That is really what we want to capture, so this simply wraps the HW dialect attribute and provides a type so it can work in the OM dialect type system.

Note that this does not encode hierarchical paths. This can be accomplished in a variety of ways if necessary, but for now simply referencing an inner symbol should be sufficient for many use cases. If hierarchical paths are needed, the instance graph can be elaborated and this information combined with the inner symbol references.

Depends on https://github.com/llvm/circt/pull/5083