### PR TITLE
[FIRRTL] firtool: Run merge-cnxns regardless of agg preserv.

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -662,8 +662,7 @@ static LogicalResult processBuffer(
     pm.nest<firrtl::CircuitOp>().addPass(
         firrtl::createEmitOMIRPass(omirOutFile));
 
-  if (!disableOptimization &&
-      preserveAggregate != firrtl::PreserveAggregate::None)
+  if (!disableOptimization)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createMergeConnectionsPass(
             !disableAggressiveMergeConnections.getValue()));


### PR DESCRIPTION
Force targets should not be "lowered", this is needed to avoid issues.

See https://github.com/llvm/circt/pull/5051 .