### PR TITLE
[FIRRTL] RefType: Implement FieldIDTypeInterface.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -400,7 +400,9 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
   }];
 }
 
-def RefImpl : FIRRTLImplType<"Ref", [], "::circt::firrtl::FIRRTLType"> {
+def RefImpl : FIRRTLImplType<"Ref",
+                             [DeclareTypeInterfaceMethods<FieldIDTypeInterface>],
+                             "::circt::firrtl::FIRRTLType"> {
   let summary = [{
     A reference type, such as `firrtl.probe<uint<1>>` or `firrtl.rwprobe<uint<2>>`.
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1447,6 +1447,33 @@ auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
   return success();
 }
 
+//- RefType implementations of FieldIDTypeInterface --------------------------//
+// Needs to be implemented to be used in a FIRRTL aggregate.
+
+uint64_t RefType::getMaxFieldID() const { return 0; }
+
+// Identical to FIRRTLBaseType's implementation.
+circt::hw::FieldIDTypeInterface
+RefType::getFinalTypeByFieldID(uint64_t fieldID) const {
+  std::pair<circt::hw::FieldIDTypeInterface, uint64_t> pair(*this, fieldID);
+  while (pair.second)
+    pair = pair.first.getSubTypeByFieldID(pair.second);
+  return pair.first;
+}
+
+std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
+RefType::getSubTypeByFieldID(uint64_t fieldID) const {
+  assert(fieldID == 0);
+  return {*this, 0};
+}
+
+std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
+                                                       uint64_t index) const {
+  return {0, fieldID == 0};
+}
+
+uint64_t RefType::getGroundFields() const { return 1; }
+
 //===----------------------------------------------------------------------===//
 // AnalogType
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1452,13 +1452,10 @@ auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
 
 uint64_t RefType::getMaxFieldID() const { return 0; }
 
-// Identical to FIRRTLBaseType's implementation.
 circt::hw::FieldIDTypeInterface
 RefType::getFinalTypeByFieldID(uint64_t fieldID) const {
-  std::pair<circt::hw::FieldIDTypeInterface, uint64_t> pair(*this, fieldID);
-  while (pair.second)
-    pair = pair.first.getSubTypeByFieldID(pair.second);
-  return pair.first;
+  assert(fieldID == 0);
+  return *this;
 }
 
 std::pair<circt::hw::FieldIDTypeInterface, uint64_t>

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1468,7 +1468,7 @@ RefType::getSubTypeByFieldID(uint64_t fieldID) const {
 }
 
 std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
-                                                       uint64_t index) const {
+                                                    uint64_t index) const {
   return {0, fieldID == 0};
 }
 


### PR DESCRIPTION
Needed for putting RefType in aggregates.  There are no fields within a reference regardless of base type, implement as if "ground" type.