### PR TITLE
[FIRRTL] Add support for refs-in-bundles.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -255,7 +255,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     }];
 
   let arguments = (ins BundleType:$input, I32Attr:$fieldIndex);
-  let results = (outs FIRRTLBaseType:$result);
+  let results = (outs FIRRTLType:$result);
   let hasFolder = 1;
   let hasCanonicalizer = 1;
   let hasVerifier = 1;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -212,9 +212,9 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
     struct BundleElement {
       StringAttr name;
       bool isFlip;
-      FIRRTLBaseType type;
+      FIRRTLType type;
 
-      BundleElement(StringAttr name, bool isFlip, FIRRTLBaseType type)
+      BundleElement(StringAttr name, bool isFlip, FIRRTLType type)
           : name(name), isFlip(isFlip), type(type) {}
 
       bool operator==(const BundleElement &rhs) const {
@@ -248,11 +248,11 @@ def BundleImpl : FIRRTLImplType<"Bundle", [FieldIDTypeInterface]> {
     BundleElement getElement(size_t index);
 
     /// Look up an element type by name.
-    FIRRTLBaseType getElementType(StringAttr name);
-    FIRRTLBaseType getElementType(StringRef name);
+    FIRRTLType getElementType(StringAttr name);
+    FIRRTLType getElementType(StringRef name);
 
     /// Look up an element type by index.
-    FIRRTLBaseType getElementType(size_t index);
+    FIRRTLType getElementType(size_t index);
 
     /// Return the recursive properties of the type.
     RecursiveTypeProperties getRecursiveTypeProperties() const;
@@ -400,14 +400,14 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
   }];
 }
 
-def RefImpl : FIRRTLImplType<"Ref", [], "::circt::firrtl::FIRRTLType"> {
+def RefImpl : FIRRTLImplType<"Ref", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>], "::circt::firrtl::FIRRTLType"> {
   let summary = [{
     A reference type, such as `firrtl.probe<uint<1>>` or `firrtl.rwprobe<uint<2>>`.
 
     Used for remote reads and writes of the wrapped base type.
 
     Parameterized over the referenced base type,
-    which must be passive and for now must also be ground.
+    which must be passive and may not contain references.
 
     Not a base type.
 

--- a/lib/Conversion/ExportChiselInterface/ExportChiselInterface.cpp
+++ b/lib/Conversion/ExportChiselInterface/ExportChiselInterface.cpp
@@ -48,8 +48,8 @@ static LogicalResult emitPortType(Location location, FIRRTLType type,
     // Include the direction if the type is not composed of flips and analog
     // signals and we haven't already emitted the direction before recursing to
     // this field.
-    bool emitDirection =
-        baseType.isPassive() && !baseType.containsAnalog() && !hasEmittedDirection;
+    bool emitDirection = baseType.isPassive() && !baseType.containsAnalog() &&
+                         !hasEmittedDirection;
     if (emitDirection) {
       switch (direction) {
       case Direction::In:

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2760,7 +2760,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Since addresses coming from Handshake are IndexType and have a hardcoded
     // 64-bit width in this pass, we may need to truncate down to the actual
     // size of the address port used by the FIRRTL memory.
-    auto memAddrType = memAddr.getType();
+    auto memAddrType = cast<FIRRTLBaseType>(memAddr.getType());
     auto storeAddrType = storeAddrData.getType().cast<FIRRTLBaseType>();
     if (memAddrType != storeAddrType) {
       auto memAddrPassiveType = memAddrType.getPassiveType();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2067,7 +2067,8 @@ FIRRTLBaseType MemOp::getDataType() {
   assert(getNumResults() != 0 && "Mems with no read/write ports are illegal");
 
   if (auto refType = getResult(0).getType().dyn_cast<RefType>())
-    return cast<FIRRTLBaseType>(refType.getType().cast<FVectorType>().getElementType());
+    return cast<FIRRTLBaseType>(
+        refType.getType().cast<FVectorType>().getElementType());
   auto firstPortType = getResult(0).getType().cast<FIRRTLBaseType>();
 
   StringRef dataFieldName = "data";
@@ -2835,7 +2836,8 @@ static bool checkAggConstant(Operation *op, Attribute attr,
       return false;
     }
     return llvm::all_of(attrlist, [&array, op](Attribute attr) {
-      return checkAggConstant(op, attr, cast<FIRRTLBaseType>(array.getElementType()));
+      return checkAggConstant(op, attr,
+                              cast<FIRRTLBaseType>(array.getElementType()));
     });
   }
   if (auto bundle = type.dyn_cast<BundleType>()) {
@@ -4355,8 +4357,9 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
   auto fieldIdx =
       getAttr<IntegerAttr>(attrs, "index").getValue().getZExtValue();
 
-   if (inType.containsReference())
-    return emitInferRetTypeError(loc, "unsupported nested reference type found");
+  if (inType.containsReference())
+    return emitInferRetTypeError(loc,
+                                 "unsupported nested reference type found");
 
   // TODO: Determine ref.sub + rwprobe behavior, test.
   // Probably best to demote to non-rw, but that has implications
@@ -4375,8 +4378,9 @@ FIRRTLType RefSubOp::inferReturnType(ValueRange operands,
                                    "subfield element index is greater than "
                                    "the number of fields in the bundle type");
     }
-    return RefType::get(cast<FIRRTLBaseType>(bundleType.getElement(fieldIdx).type),
-                        refType.getForceable());
+    return RefType::get(
+        cast<FIRRTLBaseType>(bundleType.getElement(fieldIdx).type),
+        refType.getForceable());
   }
 
   return emitInferRetTypeError(

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -633,7 +633,8 @@ uint64_t FIRRTLBaseType::getGroundFields() const {
       .Case<BundleType>([](auto type) {
         unsigned sum = 0;
         for (auto &field : type.getElements())
-          sum += llvm::cast<hw::FieldIDTypeInterface>(field.type).getGroundFields();
+          sum += llvm::cast<hw::FieldIDTypeInterface>(field.type)
+                     .getGroundFields();
         return sum;
       })
       .Case<FVectorType>([](auto type) {
@@ -1211,10 +1212,10 @@ FIRRTLBaseType FVectorType::getPassiveType() {
   // Otherwise, rebuild a passive version.
   return impl->passiveType = FVectorType::get(getElementType().getPassiveType(),
                                               getNumElements(), isConst());
-  //return impl->passiveType = FVectorType::get(
-  //           mapBaseType(getElementType(),
-  //                       [](auto base) { return base.getPassiveType(); }),
-  //           getNumElements(), isConst());
+  // return impl->passiveType = FVectorType::get(
+  //            mapBaseType(getElementType(),
+  //                        [](auto base) { return base.getPassiveType(); }),
+  //            getNumElements(), isConst());
 }
 
 FVectorType FVectorType::getConstType(bool isConst) {
@@ -1496,7 +1497,7 @@ RefType::getSubTypeByFieldID(uint64_t fieldID) const {
 }
 
 std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
-                                                       uint64_t index) const {
+                                                    uint64_t index) const {
   return {0, fieldID == 0};
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -576,6 +576,7 @@ Value circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
   return value;
 }
 
+/// TODO: document, rename for desired ref behavior. ("walkLeafTypes"?)
 /// Walk leaf ground types in the `firrtlType` and apply the function `fn`.
 /// The first argument of `fn` is field ID, and the second argument is a
 /// leaf ground type.
@@ -584,7 +585,7 @@ void circt::firrtl::walkGroundTypes(
     llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn) {
   auto type = getBaseType(firrtlType);
   // If this is a ground type, don't call recursive functions.
-  if (type.isGround())
+  if (type.isGround() || isa<RefType>(type))
     return fn(0, type);
 
   uint64_t fieldID = 0;
@@ -593,7 +594,7 @@ void circt::firrtl::walkGroundTypes(
         .Case<BundleType>([&](BundleType bundle) {
           for (size_t i = 0, e = bundle.getNumElements(); i < e; ++i) {
             fieldID++;
-            f(f, bundle.getElementType(i));
+            f(f, getBaseType(bundle.getElementType(i)));
           }
         })
         .template Case<FVectorType>([&](FVectorType vector) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -762,18 +762,13 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
 
           StringRef fieldName;
           FIRRTLType type;
-          auto fieldLoc = getToken().getLoc();
           if (parseFieldId(fieldName, "expected bundle field name") ||
               parseToken(FIRToken::colon, "expected ':' in bundle") ||
               parseType(type, "expected bundle field type"))
             return failure();
 
-          auto baseType = type.dyn_cast<FIRRTLBaseType>();
-          if (!baseType)
-            return emitError(fieldLoc, "field must be base type");
-
           elements.push_back(
-              {StringAttr::get(getContext(), fieldName), isFlipped, baseType});
+              {StringAttr::get(getContext(), fieldName), isFlipped, type});
           return success();
         }))
       return failure();

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -131,9 +131,10 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
         for (size_t fieldIndex = 0, fend = rType.getNumElements();
              fieldIndex != fend; ++fieldIndex) {
           auto name = rType.getElement(fieldIndex).name.getValue();
-          auto oldField = builder.create<SubfieldOp>(result, fieldIndex);
-          FIRRTLBaseValue newField =
-              builder.create<SubfieldOp>(newResult, fieldIndex);
+          auto oldField = cast<FIRRTLBaseValue>(
+              builder.create<SubfieldOp>(result, fieldIndex).getResult());
+          auto newField = cast<FIRRTLBaseValue>(
+              builder.create<SubfieldOp>(newResult, fieldIndex).getResult());
           // data and mask depend on the memory type which was split.  They can
           // also go both directions, depending on the port direction.
           if (!(name == "data" || name == "mask" || name == "wdata" ||

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -334,7 +334,8 @@ private:
           // Check if this is the mask field.
           if (fName.contains("mask")) {
             // Already 1 bit, nothing to do.
-            if (sf.getResult().getType().getBitWidthOrSentinel() == 1)
+            if (cast<FIRRTLBaseType>(sf.getResult().getType())
+                    .getBitWidthOrSentinel() == 1)
               continue;
             // Check what is the mask field directly connected to.
             // If, a constant 1, then we can replace with unMasked memory.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -67,8 +67,8 @@ struct FlatBundleFieldEntry {
   /// This indicates whether the field was flipped to be an output.
   bool isOutput;
 
-  FlatBundleFieldEntry(const FIRRTLType &type, size_t index,
-                       unsigned fieldID, StringRef suffix, bool isOutput)
+  FlatBundleFieldEntry(const FIRRTLType &type, size_t index, unsigned fieldID,
+                       StringRef suffix, bool isOutput)
       : type(type), index(index), fieldID(fieldID), suffix(suffix),
         isOutput(isOutput) {}
 

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -121,7 +121,7 @@ private:
             auto index = bundle.getIndexForFieldID(targetFieldID);
             newTarget.append(".");
             newTarget.append(bundle.getElementName(index));
-            type = bundle.getElementType(index);
+            type = getBaseType(bundle.getElementType(index));
             targetFieldID -= bundle.getFieldID(index);
           })
           .Default([&](auto) { targetFieldID = 0; });

--- a/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
@@ -149,7 +149,8 @@ FIRRTLBaseType Visitor::convertType(FIRRTLBaseType type,
     SmallVector<BundleType::BundleElement> elements;
     for (auto element : bundleType.getElements()) {
       elements.push_back(BundleType::BundleElement(
-          element.name, element.isFlip, convertType(element.type, dimensions)));
+          element.name, element.isFlip,
+          convertType(cast<FIRRTLBaseType>(element.type), dimensions)));
     }
     return BundleType::get(context, elements);
   }
@@ -795,7 +796,8 @@ Value Visitor::sinkVecDimIntoOperands(ImplicitLocOpBuilder &builder,
       SmallVector<Value> subValues;
       for (auto v : values)
         subValues.push_back(getSubfield(v, i));
-      auto newField = sinkVecDimIntoOperands(builder, elt.type, subValues);
+      auto newField = sinkVecDimIntoOperands(
+          builder, cast<FIRRTLBaseType>(elt.type), subValues);
       newFields.push_back(newField);
       newElements.emplace_back(elt.name, /*isFlip=*/false,
                                newField.getType().cast<FIRRTLBaseType>());


### PR DESCRIPTION
Groundwork for aggregates-with-refs + focus on supporting probes in bundles.

Support (rw)probes in bundles, per FIRRTL 2.0 specification.

Mirrored updates for future FVectorType support included where doing so was essentially the same, will complete support for that separately.

Builds on #5087 .

LowerXMR is not presently field-sensitive, so this works best with default behavior of not preserving aggregates.

Needs lit tests (been testing on crafted .fir inputs).