### PR TITLE
[LowerToHW] Gate force/release on ifndef SYNTHESIS, not VERILATOR.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3890,7 +3890,8 @@ LogicalResult FIRRTLLowering::visitStmt(ForceOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
-  addToIfDefBlock("VERILATOR", std::function<void()>(), [&]() {
+  // #ifndef SYNTHESIS
+  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToInitialBlock([&]() { builder.create<sv::ForceOp>(destVal, srcVal); });
   });
   return success();
@@ -3907,7 +3908,8 @@ LogicalResult FIRRTLLowering::visitStmt(RefForceOp op) {
   if (!destVal)
     return failure();
 
-  addToIfDefBlock("VERILATOR", std::function<void()>(), [&]() {
+  // #ifndef SYNTHESIS
+  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToAlwaysBlock(clock, [&]() {
       addIfProceduralBlock(
           pred, [&]() { builder.create<sv::ForceOp>(destVal, src); });
@@ -3925,7 +3927,8 @@ LogicalResult FIRRTLLowering::visitStmt(RefForceInitialOp op) {
   if (!destVal)
     return failure();
 
-  addToIfDefBlock("VERILATOR", std::function<void()>(), [&]() {
+  // #ifndef SYNTHESIS
+  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToInitialBlock([&]() {
       addIfProceduralBlock(
           pred, [&]() { builder.create<sv::ForceOp>(destVal, src); });
@@ -3943,7 +3946,8 @@ LogicalResult FIRRTLLowering::visitStmt(RefReleaseOp op) {
   if (!destVal)
     return failure();
 
-  addToIfDefBlock("VERILATOR", std::function<void()>(), [&]() {
+  // #ifndef SYNTHESIS
+  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToAlwaysBlock(clock, [&]() {
       addIfProceduralBlock(pred,
                            [&]() { builder.create<sv::ReleaseOp>(destVal); });
@@ -3957,7 +3961,8 @@ LogicalResult FIRRTLLowering::visitStmt(RefReleaseInitialOp op) {
   if (!destVal || !pred)
     return failure();
 
-  addToIfDefBlock("VERILATOR", std::function<void()>(), [&]() {
+  // #ifndef SYNTHESIS
+  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToInitialBlock([&]() {
       addIfProceduralBlock(pred,
                            [&]() { builder.create<sv::ReleaseOp>(destVal); });

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1601,7 +1601,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:  %[[XMR2:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
   // CHECK-NEXT:  %[[XMR3:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
   // CHECK-NEXT:  %[[XMR4:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
-  // CHECK-NEXT:  sv.ifdef  "VERILATOR" {
+  // CHECK-NEXT:  sv.ifdef  "SYNTHESIS" {
   // CHECK-NEXT:  } else {
   // CHECK-NEXT:    sv.always posedge %clock {
   // CHECK-NEXT:      sv.if %c {


### PR DESCRIPTION
Gate these on not SYNTHESIS, don't worry about VERILATOR.

Verilator does support these as of [4.218 (2022-01-17)](https://verilator.org/guide/latest/changes.html#verilator-4-218-2022-01-17), but behavior isn't quite per spec.

SYNTHESIS is more relevant concern.