### PR TITLE
[ExportVerilog] Remove uneeded parenthesis around UnionCreate

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2883,7 +2883,7 @@ SubExprInfo ExprEmitter::visitTypeOp(UnionCreateOp op) {
 
   // If the element has no padding, emit it directly.
   if (elementWidth == unionWidth) {
-    emitSubExpr(op.getInput(), Selection);
+    emitSubExpr(op.getInput(), LowestPrecedence);
     return {Unary, IsUnsigned};
   }
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1022,8 +1022,9 @@ hw.module @structExtractFromTemporary(%cond: i1, %a: !hw.struct<c: i1>, %b: !hw.
 // CHECK-NEXT:    input [1:0] in,
 // CHECK-NEXT:    output union packed { struct packed {logic a; logic [0:0] __post_padding_a;} a;logic [1:0] b;} out
 hw.module @unionCreateNoPadding(%in: i2) -> (out: !hw.union<a: i1, b: i2>) {
-  // CHECK: assign out = in;
-  %0 = hw.union_create "b", %in : !hw.union<a: i1, b: i2>
+  // CHECK: assign out = in + in;
+  %add = comb.add %in, %in : i2
+  %0 = hw.union_create "b", %add : !hw.union<a: i1, b: i2>
   hw.output %0 : !hw.union<a: i1, b: i2>
 }
 


### PR DESCRIPTION
When no padding is required for UnionCreate, we spill to a wire and we emit the RHS expression directly as the RHS of an assignment.  The RHS of an assignment does not need parenthesis around it. This PR switches the precedence of that case from `Selection` to `LowestPrecedence` to elide it.

As an example, we used to emit:
```verilog
assign out = (in + in);
```
but we now emit:
```verilog
assign out = in + in;
```