### PR TITLE
[FIRRTL][ExpandWhens] Use port locs when emitting init errors

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -678,17 +678,17 @@ LogicalResult ModuleVisitor::checkInitialization() {
 
     // Get the op which defines the sink, and emit an error.
     FieldRef dest = std::get<0>(destAndConnect);
+    auto loc = dest.getValue().getLoc();
     auto *definingOp = dest.getDefiningOp();
     if (auto mod = dyn_cast<FModuleLike>(definingOp))
-      mlir::emitError(definingOp->getLoc())
-          << "port \"" + getFieldName(dest).first +
-                 "\" not fully initialized in module \""
-          << mod.moduleName() << "\"";
+      mlir::emitError(loc) << "port \"" << getFieldName(dest).first
+                           << "\" not fully initialized in module \""
+                           << mod.moduleName() << "\"";
     else
-      definingOp->emitError(
-          "sink \"" + getFieldName(dest).first +
-          "\" not fully initialized in module \"" +
-          definingOp->getParentOfType<FModuleLike>().moduleName() + "\"");
+      mlir::emitError(loc)
+          << "sink \"" << getFieldName(dest).first
+          << "\" not fully initialized in module \""
+          << definingOp->getParentOfType<FModuleLike>().moduleName() << "\"";
     failed = true;
   }
   if (failed)


### PR DESCRIPTION
Before this change, an error on a port used the location of the defining module, instead of the location of the port, as this code was written before block arguments had locations associated with them.  We now emit good port locations from Chisel, and reliably preserve them throughout the pipeline, so it makes sense to use the port's location to emit the error.

This also changes how we emit errors for regular operations.  Since this error message is expected to be user facing, it is better if we do not dump the IR for the operation.