### PR TITLE
[Arc] LowerState: fix memory read materialization

### DIFF
--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -446,8 +446,8 @@ LogicalResult ModuleLowering::lowerState(MemoryOp memOp) {
 static Value lowerMemoryReadPortOp(MemoryReadPortOp memReadOp,
                                    OpBuilder &builder) {
   // Lowering MemoryReadOp to LLVM inserts a conditional branch to only perform
-  // the read when the address is within bounds. By inserting an IfOp here I
-  // hope that LLVM is able to merge them.
+  // the read when the address is within bounds. Ideally, LLVM will be able to
+  // merge that check with the mux/condition here.
   Value newRead;
   if (memReadOp.getEnable()) {
     Value read = builder.create<MemoryReadOp>(

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -442,22 +443,21 @@ LogicalResult ModuleLowering::lowerState(MemoryOp memOp) {
   return success();
 }
 
-LogicalResult ModuleLowering::lowerState(MemoryReadPortOp memReadOp) {
-  auto info = getOrCreateClockLowering(memReadOp.getClock());
-  auto enable = info.clock.materializeValue(memReadOp.getEnable());
-  auto address = info.clock.materializeValue(memReadOp.getAddress());
-
+static Value lowerMemoryReadPortOp(MemoryReadPortOp memReadOp,
+                                   OpBuilder &builder) {
   // Lowering MemoryReadOp to LLVM inserts a conditional branch to only perform
   // the read when the address is within bounds. By inserting an IfOp here I
   // hope that LLVM is able to merge them.
-  if (enable) {
-    Value newRead =
-        info.clock.builder
+  Value newRead;
+  if (memReadOp.getEnable()) {
+    newRead =
+        builder
             .create<scf::IfOp>(
-                memReadOp.getLoc(), enable,
+                memReadOp.getLoc(), memReadOp.getEnable(),
                 [&](OpBuilder &builder, Location loc) {
                   Value read = builder.create<MemoryReadOp>(
-                      memReadOp.getLoc(), memReadOp.getMemory(), address);
+                      memReadOp.getLoc(), memReadOp.getMemory(),
+                      memReadOp.getAddress());
                   builder.create<scf::YieldOp>(memReadOp.getLoc(), read);
                 },
                 [&](OpBuilder &builder, Location loc) {
@@ -466,15 +466,22 @@ LogicalResult ModuleLowering::lowerState(MemoryReadPortOp memReadOp) {
                   builder.create<scf::YieldOp>(memReadOp.getLoc(), zero);
                 })
             ->getResult(0);
-    memReadOp.replaceAllUsesWith(newRead);
   } else {
-    Value newRead = info.clock.builder.create<MemoryReadOp>(
-        memReadOp.getLoc(), memReadOp.getMemory(), address);
-    memReadOp.replaceAllUsesWith(newRead);
+    newRead = builder.create<MemoryReadOp>(
+        memReadOp.getLoc(), memReadOp.getMemory(), memReadOp.getAddress());
   }
-
+  memReadOp.replaceAllUsesWith(newRead);
   builder.setInsertionPointAfter(memReadOp);
   memReadOp.erase();
+  return newRead;
+}
+
+LogicalResult ModuleLowering::lowerState(MemoryReadPortOp memReadOp) {
+  auto info = getOrCreateClockLowering(memReadOp.getClock());
+
+  auto newRead = lowerMemoryReadPortOp(memReadOp, builder);
+  info.clock.materializeValue(newRead);
+
   return success();
 }
 
@@ -561,6 +568,17 @@ LogicalResult ModuleLowering::lowerState(TapOp tapOp) {
 }
 
 LogicalResult ModuleLowering::cleanup() {
+  // Lower remaining MemoryReadPort ops to MemoryRead ops. This can occur when
+  // the fan-in of a MemoryReadPortOp contains another such operation and is
+  // materialized before the one in the fan-in as the MemoryReadPortOp is not
+  // marked as a fan-in blocking/termination operation in `shouldMaterialize`.
+  // Adding it there can lead to dominance issues which would then have to be
+  // resolved instead.
+  moduleOp->walk([this](MemoryReadPortOp memReadOp) {
+    builder.setInsertionPoint(memReadOp);
+    lowerMemoryReadPortOp(memReadOp, builder);
+  });
+
   // Establish an order among all operations (to avoid an O(n²) pathological
   // pattern with `moveBefore`) and replicate read operations into the blocks
   // where they have uses. The established order is used to create the read

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -105,13 +105,9 @@ hw.module @MemoryReadWithEnable(%clk0: i1, %en: i1) {
   // CHECK-NEXT: [[INEN:%.+]] = arc.root_input "en", [[PTR]] : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[CLK0:%.+]] = arc.state_read [[INCLK0]] : <i1>
   // CHECK-NEXT: arc.clock_tree [[CLK0]] {
-  // CHECK:        [[EN:%.+]] = arc.state_read [[INEN]] : <i1>
-  // CHECK-NEXT:   %{{.+}} = scf.if [[EN]] -> (i42) {
-  // CHECK-NEXT:     [[TMP:%.+]] = arc.memory_read [[MEM:%.+]][%c0_i2] : <4 x i42>, i2
-  // CHECK-NEXT:     scf.yield [[TMP]] : i42
-  // CHECK-NEXT:   } else {
-  // CHECK:          scf.yield %c0_i42 : i42
-  // CHECK-NEXT:   }
+  // CHECK:        [[TMP:%.+]] = arc.memory_read [[MEM:%.+]][%c0_i2] : <4 x i42>, i2
+  // CHECK-NEXT:   [[EN:%.+]] = arc.state_read [[INEN]] : <i1>
+  // CHECK-NEXT:   %{{.+}} = comb.mux bin [[EN]], [[TMP]], %c0_i42 : i42
   // CHECK-NEXT: }
   // CHECK-NEXT: [[MEM]] = arc.alloc_memory [[PTR]] : (!arc.storage) -> !arc.memory<4 x i42>
 }

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -282,9 +282,7 @@ hw.module private @MemoryPortRegression(%clock: i1, %reset: i1, %in: i3) -> (x: 
   hw.output %4 : i3
 }
 arc.define @Queue_arc_0(%arg0: i1) -> i1 {
-  %true = hw.constant true
-  %0 = comb.xor %arg0, %true : i1
-  arc.output %0 : i1
+  arc.output %arg0 : i1
 }
 arc.define @Queue_arc_1(%arg0: i3) -> i3 {
   arc.output %arg0 : i3

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -270,3 +270,22 @@ arc.define @CombLoopRegressionArc1(%arg0: i1, %arg1: i1) -> i1 {
 arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
   arc.output %arg0, %arg0 : i1, i1
 }
+
+// Regression check for invalid memory port lowering errors.
+// CHECK-LABEL: arc.model "MemoryPortRegression"
+hw.module private @MemoryPortRegression(%clock: i1, %reset: i1, %in: i3) -> (x: i3) {
+  %0 = arc.memory <2 x i3> {name = "ram_ext"}
+  %1 = arc.memory_read_port %0[%3] clock %clock : <2 x i3>, i1
+  arc.memory_write_port %0[%3], %in clock %clock : <2 x i3>, i1
+  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 {names = ["value"]} : (i1) -> i1
+  %4 = arc.state @Queue_arc_1(%1) lat 0 : (i3) -> i3
+  hw.output %4 : i3
+}
+arc.define @Queue_arc_0(%arg0: i1) -> i1 {
+  %true = hw.constant true
+  %0 = comb.xor %arg0, %true : i1
+  arc.output %0 : i1
+}
+arc.define @Queue_arc_1(%arg0: i3) -> i3 {
+  arc.output %arg0 : i3
+}


### PR DESCRIPTION
Applies @maerhart's fix for LowerState memory read materialization, and uses a comb mux to lower memory read ports instead of control flow (for data-flow conditions it's best to use Mux to avoid problems with backends that might have worse performance with control flow, and a later pass can transform muxes into SCF blocks if desired).

@fabianschuiki 