### PR TITLE
[ESI] Refactor ESI cosim API type emission

### DIFF
--- a/include/circt/Dialect/ESI/ESITypes.h
+++ b/include/circt/Dialect/ESI/ESITypes.h
@@ -25,4 +25,13 @@
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/ESI/ESITypes.h.inc"
 
+namespace circt {
+namespace esi {
+
+// If 'type' is an esi:ChannelType, will return the inner type of said channel.
+// Else, returns 'type'.
+mlir::Type innerType(mlir::Type type);
+} // namespace esi
+} // namespace circt
+
 #endif

--- a/include/circt/Dialect/ESI/cosim/APIUtilities.h
+++ b/include/circt/Dialect/ESI/cosim/APIUtilities.h
@@ -1,0 +1,67 @@
+//===- APIUtilities.h - ESI general-purpose cosim API utilities -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities and classes applicable to all cosim API generators.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef CIRCT_DIALECT_ESI_COSIM_ESICOSIM_H
+#define CIRCT_DIALECT_ESI_COSIM_ESICOSIM_H
+
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/MapVector.h"
+
+#include <memory>
+
+namespace circt {
+namespace esi {
+
+/// Every time we implement a breaking change in the schema generation,
+/// increment this number. It is a seed for all the schema hashes.
+constexpr uint64_t esiCosimSchemaVersion = 1;
+
+// Base type for all Cosim-implementing type emitters.
+class ESICosimType {
+public:
+  using FieldInfo = hw::StructType::FieldInfo;
+
+  ESICosimType(mlir::Type);
+  virtual ~ESICosimType() = default;
+  bool operator==(const ESICosimType &) const;
+
+  /// Get the type back.
+  mlir::Type getType() const { return type; }
+
+  /// Returns true if the type is currently supported.
+  virtual bool isSupported() const;
+
+  llvm::ArrayRef<FieldInfo> getFields() const { return fieldTypes; }
+
+  // API-safe name for this type which should work with most languages.
+  StringRef name() const;
+
+  // Capnproto-safe type id for this type.
+  uint64_t typeID() const;
+
+protected:
+  /// Cosim requires that everything be contained in a struct. ESI doesn't so
+  /// we wrap non-struct types in a struct.
+  llvm::SmallVector<FieldInfo> fieldTypes;
+
+  mlir::Type type;
+  mutable std::string cachedName;
+  mutable std::optional<uint64_t> cachedID;
+};
+
+} // namespace esi
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ESI_COSIM_ESICOSIM_H

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -19,6 +19,8 @@ set(srcs
   Passes/ESILowerPorts.cpp
   Passes/ESILowerToHW.cpp
   Passes/ESILowerTypes.cpp
+  cosim/APIUtilities.cpp
+
 )
 
 set(ESI_LinkLibs

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -48,11 +48,6 @@ struct ExportCosimSchema {
     });
   }
 
-  /// Emit an ID in capnp format.
-  llvm::raw_ostream &emitId(uint64_t id) {
-    return os << "@" << llvm::format_hex(id, /*width=*/16 + 2);
-  }
-
   /// Emit the whole schema.
   LogicalResult emit();
 
@@ -69,19 +64,21 @@ private:
 
   // All the `esi.cosim` input and output types encountered during the IR walk.
   // This is NOT in a deterministic order!
-  llvm::SmallVector<capnp::TypeSchema> types;
+  llvm::SmallVector<std::shared_ptr<capnp::CapnpTypeSchema>> types;
 };
 } // anonymous namespace
 
 LogicalResult ExportCosimSchema::visitEndpoint(CosimEndpointOp ep) {
-  capnp::TypeSchema sendTypeSchema(ep.getSend().getType());
-  if (!sendTypeSchema.isSupported())
+  auto sendTypeSchema =
+      std::make_shared<capnp::CapnpTypeSchema>(ep.getSend().getType());
+  if (!sendTypeSchema->isSupported())
     return ep.emitOpError("Type ")
            << ep.getSend().getType() << " not supported.";
   types.push_back(sendTypeSchema);
 
-  capnp::TypeSchema recvTypeSchema(ep.getRecv().getType());
-  if (!recvTypeSchema.isSupported())
+  auto recvTypeSchema =
+      std::make_shared<capnp::CapnpTypeSchema>(ep.getRecv().getType());
+  if (!recvTypeSchema->isSupported())
     return ep.emitOpError("Type '")
            << ep.getRecv().getType() << "' not supported.";
   types.push_back(recvTypeSchema);
@@ -91,11 +88,11 @@ LogicalResult ExportCosimSchema::visitEndpoint(CosimEndpointOp ep) {
   if (epName)
     os << epName << " endpoint at " << ep.getLoc() << ":\n";
   os << "#   Send type: ";
-  sendTypeSchema.writeMetadata(os);
+  sendTypeSchema->writeMetadata(os);
   os << "\n";
 
   os << "#   Recv type: ";
-  recvTypeSchema.writeMetadata(os);
+  recvTypeSchema->writeMetadata(os);
   os << "\n";
 
   return success();
@@ -130,26 +127,25 @@ LogicalResult ExportCosimSchema::emit() {
 
   // We need a sorted list to ensure determinism.
   llvm::sort(types.begin(), types.end(),
-             [](capnp::TypeSchema &a, capnp::TypeSchema &b) {
-               return a.capnpTypeID() > b.capnpTypeID();
-             });
+             [](auto &a, auto &b) { return a->typeID() > b->typeID(); });
 
   // Compute and emit the capnp file id.
   uint64_t fileHash = 2544816649379317016; // Some random number.
-  for (capnp::TypeSchema &schema : types)
-    fileHash =
-        llvm::hashing::detail::hash_16_bytes(fileHash, schema.capnpTypeID());
+  for (auto &schema : types)
+    fileHash = llvm::hashing::detail::hash_16_bytes(fileHash, schema->typeID());
   // Capnp IDs always have a '1' high bit.
   fileHash |= 0x8000000000000000;
-  emitId(fileHash) << ";\n\n";
+  capnp::emitCapnpID(os, fileHash) << ";\n\n";
 
   os << "#########################################################\n"
      << "## Types for your design.\n"
      << "#########################################################\n\n";
   // Iterate through the various types and emit their schemas.
-  auto *end = std::unique(types.begin(), types.end());
-  for (auto *typeIter = types.begin(); typeIter < end; ++typeIter) {
-    if (failed(typeIter->write(os)))
+  auto end = std::unique(
+      types.begin(), types.end(),
+      [&](const auto &lhs, const auto &rhs) { return *lhs == *rhs; });
+  for (auto typeIter = types.begin(); typeIter != end; ++typeIter) {
+    if (failed((*typeIter)->write(os)))
       // If we fail during an emission, dump out early since the output may be
       // corrupted.
       return failure();

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -147,3 +147,12 @@ void ESIDialect::registerTypes() {
 #include "circt/Dialect/ESI/ESITypes.cpp.inc"
       >();
 }
+
+mlir::Type circt::esi::innerType(mlir::Type type) {
+  circt::esi::ChannelType chan =
+      type.dyn_cast_or_null<circt::esi::ChannelType>();
+  if (chan) // Unwrap the channel if it's a channel.
+    type = chan.getInner();
+
+  return type;
+}

--- a/lib/Dialect/ESI/Passes/ESIEmitCollateral.cpp
+++ b/lib/Dialect/ESI/Passes/ESIEmitCollateral.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/ESI/ESIPasses.h"
 #include "circt/Dialect/ESI/ESIServices.h"
+#include "circt/Dialect/ESI/cosim/APIUtilities.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/LLVM.h"
@@ -26,10 +27,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/JSON.h"
-
-#ifdef CAPNP
-#include "../capnp/ESICapnp.h"
-#endif
 
 using namespace circt;
 using namespace circt::esi;
@@ -89,11 +86,9 @@ static llvm::json::Value toJSON(Attribute attr) {
         if (auto chanType = t.dyn_cast<ChannelType>()) {
           Type inner = chanType.getInner();
           typeMD["hw_bitwidth"] = hw::getBitWidth(inner);
-#ifdef CAPNP
-          capnp::TypeSchema schema(inner);
-          typeMD["capnp_type_id"] = schema.capnpTypeID();
-          typeMD["capnp_name"] = schema.name().str();
-#endif
+          ESICosimType cosimSchema(inner);
+          typeMD["capnp_type_id"] = cosimSchema.typeID();
+          typeMD["capnp_name"] = cosimSchema.name().str();
         } else {
           typeMD["hw_bitwidth"] = hw::getBitWidth(t);
         }

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -340,10 +340,10 @@ CosimLowering::matchAndRewrite(CosimEndpointOp ep, OpAdaptor adaptor,
   circt::BackedgeBuilder bb(rewriter, loc);
   Type ui64Type =
       IntegerType::get(ctxt, 64, IntegerType::SignednessSemantics::Unsigned);
-  capnp::TypeSchema sendTypeSchema(send.getType());
+  capnp::CapnpTypeSchema sendTypeSchema(send.getType());
   if (!sendTypeSchema.isSupported())
     return rewriter.notifyMatchFailure(ep, "Send type not supported yet");
-  capnp::TypeSchema recvTypeSchema(ep.getRecv().getType());
+  capnp::CapnpTypeSchema recvTypeSchema(ep.getRecv().getType());
   if (!recvTypeSchema.isSupported())
     return rewriter.notifyMatchFailure(ep, "Recv type not supported yet");
 
@@ -355,14 +355,12 @@ CosimLowering::matchAndRewrite(CosimEndpointOp ep, OpAdaptor adaptor,
     params.push_back(
         ParamDeclAttr::get("ENDPOINT_ID_EXT", StringAttr::get(ctxt, "")));
   params.push_back(ParamDeclAttr::get(
-      "SEND_TYPE_ID",
-      IntegerAttr::get(ui64Type, sendTypeSchema.capnpTypeID())));
+      "SEND_TYPE_ID", IntegerAttr::get(ui64Type, sendTypeSchema.typeID())));
   params.push_back(
       ParamDeclAttr::get("SEND_TYPE_SIZE_BITS",
                          rewriter.getI32IntegerAttr(sendTypeSchema.size())));
   params.push_back(ParamDeclAttr::get(
-      "RECV_TYPE_ID",
-      IntegerAttr::get(ui64Type, recvTypeSchema.capnpTypeID())));
+      "RECV_TYPE_ID", IntegerAttr::get(ui64Type, recvTypeSchema.typeID())));
   params.push_back(
       ParamDeclAttr::get("RECV_TYPE_SIZE_BITS",
                          rewriter.getI32IntegerAttr(recvTypeSchema.size())));
@@ -430,7 +428,7 @@ public:
                                        "encode.capnp lowering requires the ESI "
                                        "capnp plugin, which was disabled.");
 #else
-    capnp::TypeSchema encodeType(enc.getDataToEncode().getType());
+    capnp::CapnpTypeSchema encodeType(enc.getDataToEncode().getType());
     if (!encodeType.isSupported())
       return rewriter.notifyMatchFailure(enc, "Type not supported yet");
     auto operands = adaptor.getOperands();
@@ -458,7 +456,7 @@ public:
                                        "decode.capnp lowering requires the ESI "
                                        "capnp plugin, which was disabled.");
 #else
-    capnp::TypeSchema decodeType(dec.getDecodedData().getType());
+    capnp::CapnpTypeSchema decodeType(dec.getDecodedData().getType());
     if (!decodeType.isSupported())
       return rewriter.notifyMatchFailure(dec, "Type not supported yet");
     auto operands = adaptor.getOperands();

--- a/lib/Dialect/ESI/capnp/ESICapnp.h
+++ b/lib/Dialect/ESI/capnp/ESICapnp.h
@@ -14,7 +14,12 @@
 #ifndef CIRCT_DIALECT_ESI_CAPNP_ESICAPNP_H
 #define CIRCT_DIALECT_ESI_CAPNP_ESICAPNP_H
 
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/ESI/cosim/APIUtilities.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/Format.h"
 
 #include <memory>
 
@@ -33,37 +38,24 @@ namespace circt {
 namespace esi {
 namespace capnp {
 
-/// Every time we implement a breaking change in the schema generation,
-/// increment this number. It is a seed for all the schema hashes.
-constexpr uint64_t esiCosimSchemaVersion = 1;
+/// Emit an ID in capnp format.
+inline llvm::raw_ostream &emitCapnpID(llvm::raw_ostream &os, int64_t id) {
+  return os << "@" << llvm::format_hex(id, /*width=*/16 + 2);
+}
 
 namespace detail {
-struct TypeSchemaImpl;
+struct CapnpTypeSchemaImpl;
 } // namespace detail
 
 /// Generate and reason about a Cap'nProto schema for a particular MLIR type.
-class TypeSchema {
+class CapnpTypeSchema : public ESICosimType {
 public:
-  TypeSchema(mlir::Type);
-  bool operator==(const TypeSchema &) const;
+  CapnpTypeSchema(mlir::Type);
 
-  /// Get the type back.
-  mlir::Type getType() const;
-
-  /// Get the Cap'nProto schema ID for a type.
-  uint64_t capnpTypeID() const;
-
-  /// Returns true if the type is currently supported.
-  bool isSupported() const;
+  using ESICosimType::operator==;
 
   /// Size in bits of the capnp message.
   size_t size() const;
-
-  /// Get the capnp struct name.
-  llvm::StringRef name() const;
-
-  /// Write out the name and ID in capnp schema format.
-  void writeMetadata(llvm::raw_ostream &os) const;
 
   /// Write out the schema in its entirety.
   mlir::LogicalResult write(llvm::raw_ostream &os) const;
@@ -75,10 +67,13 @@ public:
   mlir::Value buildDecoder(mlir::OpBuilder &, mlir::Value clk,
                            mlir::Value valid, mlir::Value capnpData) const;
 
+  /// Write out the name and ID in capnp schema format.
+  void writeMetadata(llvm::raw_ostream &os) const;
+
 private:
   /// The implementation of this. Separate to hide the details and avoid having
   /// to include the capnp headers in this header.
-  std::shared_ptr<detail::TypeSchemaImpl> s;
+  std::shared_ptr<detail::CapnpTypeSchemaImpl> s;
 
   /// Cache of the decode/encode modules;
   static llvm::SmallDenseMap<Type, hw::HWModuleOp> decImplMods;

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -16,7 +16,9 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "mlir/Support/IndentedOstream.h"
 
+// NOLINTNEXTLINE(clang-diagnostic-error)
 #include "capnp/schema-parser.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -39,70 +41,26 @@ struct Slice;
 } // anonymous namespace
 
 //===----------------------------------------------------------------------===//
-// Utilities.
-//===----------------------------------------------------------------------===//
-
-namespace {
-/// Intentation utils.
-class IndentingOStream {
-public:
-  IndentingOStream(llvm::raw_ostream &os) : os(os) {}
-
-  template <typename T>
-  IndentingOStream &operator<<(T t) {
-    os << t;
-    return *this;
-  }
-
-  IndentingOStream &indent() {
-    os.indent(currentIndent);
-    return *this;
-  }
-  IndentingOStream &pad(size_t space) {
-    os.indent(space);
-    return *this;
-  }
-  void addIndent() { currentIndent += 2; }
-  void reduceIndent() { currentIndent -= 2; }
-  operator llvm::raw_ostream &() { return os; }
-
-private:
-  llvm::raw_ostream &os;
-  size_t currentIndent = 0;
-};
-} // namespace
-
-/// Emit an ID in capnp format.
-static llvm::raw_ostream &emitId(llvm::raw_ostream &os, int64_t id) {
-  return os << "@" << llvm::format_hex(id, /*width=*/16 + 2);
-}
-
-//===----------------------------------------------------------------------===//
-// TypeSchema class implementation.
+// CapnpTypeSchema class implementation.
 //===----------------------------------------------------------------------===//
 
 namespace circt {
 namespace esi {
 namespace capnp {
+
 namespace detail {
-/// Actual implementation of `TypeSchema` to keep all the details out of the
-/// header.
-struct TypeSchemaImpl {
+/// Actual implementation of `CapnpTypeSchema` to keep all the details out of
+/// the header.
+struct CapnpTypeSchemaImpl {
 public:
-  TypeSchemaImpl(Type type);
-  TypeSchemaImpl(const TypeSchemaImpl &) = delete;
-
-  Type getType() const { return type; }
-
-  uint64_t capnpTypeID() const;
-
-  bool isSupported() const;
-  size_t size() const;
-  StringRef name() const;
+  CapnpTypeSchemaImpl(CapnpTypeSchema &base);
+  CapnpTypeSchemaImpl(const CapnpTypeSchemaImpl &) = delete;
   LogicalResult write(llvm::raw_ostream &os) const;
-  void writeMetadata(llvm::raw_ostream &os) const;
 
-  bool operator==(const TypeSchemaImpl &) const;
+  bool operator==(const CapnpTypeSchemaImpl &) const;
+
+  // Compute the expected size of the capnp message in bits.
+  size_t size() const;
 
   /// Build an HW/SV dialect capnp encoder for this type.
   hw::HWModuleOp buildEncoder(Value clk, Value valid, Value);
@@ -111,19 +69,11 @@ public:
 
 private:
   ::capnp::ParsedSchema getSchema() const;
-  ::capnp::StructSchema getTypeSchema() const;
+  ::capnp::StructSchema getCapnpTypeSchema() const;
 
-  Type type;
-  /// Capnp requires that everything be contained in a struct. ESI doesn't so we
-  /// wrap non-struct types in a capnp struct. During decoder/encoder
-  /// construction, it's convenient to use the capnp model so assemble the
-  /// virtual list of `Type`s here.
-  using FieldInfo = hw::StructType::FieldInfo;
-  SmallVector<FieldInfo> fieldTypes;
+  CapnpTypeSchema &base;
 
   ::capnp::SchemaParser parser;
-  mutable std::optional<uint64_t> cachedID;
-  mutable std::string cachedName;
   mutable ::capnp::ParsedSchema rootSchema;
   mutable ::capnp::StructSchema typeSchema;
 };
@@ -192,34 +142,20 @@ static bool isPointerType(::capnp::schema::Type::Reader type) {
   }
 }
 
-TypeSchemaImpl::TypeSchemaImpl(Type t) : type(t) {
-  TypeSwitch<Type>(type)
-      .Case([this](IntegerType t) {
-        fieldTypes.push_back(
-            FieldInfo{StringAttr::get(t.getContext(), "i"), t});
-      })
-      .Case([this](hw::ArrayType t) {
-        fieldTypes.push_back(
-            FieldInfo{StringAttr::get(t.getContext(), "l"), t});
-      })
-      .Case([this](hw::StructType t) {
-        fieldTypes.append(t.getElements().begin(), t.getElements().end());
-      })
-      .Default([](Type) {});
-}
+CapnpTypeSchemaImpl::CapnpTypeSchemaImpl(CapnpTypeSchema &base) : base(base) {}
 
 /// Write a valid capnp schema to memory, then parse it out of memory using the
 /// capnp library. Writing and parsing text within a single process is ugly, but
 /// this is by far the easiest way to do this. This isn't the use case for which
 /// Cap'nProto was designed.
-::capnp::ParsedSchema TypeSchemaImpl::getSchema() const {
+::capnp::ParsedSchema CapnpTypeSchemaImpl::getSchema() const {
   if (rootSchema != ::capnp::ParsedSchema())
     return rootSchema;
 
   // Write the schema to `schemaText`.
   std::string schemaText;
   llvm::raw_string_ostream os(schemaText);
-  emitId(os, 0xFFFFFFFFFFFFFFFF) << ";\n";
+  emitCapnpID(os, 0xFFFFFFFFFFFFFFFF) << ";\n";
   auto rc = write(os);
   assert(succeeded(rc) && "Failed schema text output.");
   (void)rc;
@@ -239,10 +175,10 @@ TypeSchemaImpl::TypeSchemaImpl(Type t) : type(t) {
 }
 
 /// Find the schema corresponding to `type` and return it.
-::capnp::StructSchema TypeSchemaImpl::getTypeSchema() const {
+::capnp::StructSchema CapnpTypeSchemaImpl::getCapnpTypeSchema() const {
   if (typeSchema != ::capnp::StructSchema())
     return typeSchema;
-  uint64_t id = capnpTypeID();
+  uint64_t id = base.typeID();
   for (auto schemaNode : getSchema().getAllNested()) {
     if (schemaNode.getProto().getId() == id) {
       typeSchema = schemaNode.asStruct();
@@ -251,54 +187,6 @@ TypeSchemaImpl::TypeSchemaImpl(Type t) : type(t) {
   }
   llvm_unreachable("A node with a matching ID should always be found.");
 }
-
-// We compute a deterministic hash based on the type. Since llvm::hash_value
-// changes from execution to execution, we don't use it.
-uint64_t TypeSchemaImpl::capnpTypeID() const {
-  if (cachedID)
-    return *cachedID;
-
-  // Get the MLIR asm type, padded to a multiple of 64 bytes.
-  std::string typeName;
-  llvm::raw_string_ostream osName(typeName);
-  osName << type;
-  size_t overhang = osName.tell() % 64;
-  if (overhang != 0)
-    osName.indent(64 - overhang);
-  osName.flush();
-  const char *typeNameC = typeName.c_str();
-
-  uint64_t hash = esiCosimSchemaVersion;
-  for (size_t i = 0, e = typeName.length() / 64; i < e; ++i)
-    hash =
-        llvm::hashing::detail::hash_33to64_bytes(&typeNameC[i * 64], 64, hash);
-
-  // Capnp IDs always have a '1' high bit.
-  cachedID = hash | 0x8000000000000000;
-  return *cachedID;
-}
-
-/// Returns true if the type is currently supported.
-static bool isSupported(Type type, bool outer = false) {
-  return llvm::TypeSwitch<::mlir::Type, bool>(type)
-      .Case([](IntegerType t) { return t.getWidth() <= 64; })
-      .Case([](hw::ArrayType t) { return isSupported(t.getElementType()); })
-      .Case([outer](hw::StructType t) {
-        // We don't yet support structs containing structs.
-        if (!outer)
-          return false;
-        // A struct is supported if all of its elements are.
-        for (auto field : t.getElements()) {
-          if (!isSupported(field.type))
-            return false;
-        }
-        return true;
-      })
-      .Default([](Type) { return false; });
-}
-
-/// Returns true if the type is currently supported.
-bool TypeSchemaImpl::isSupported() const { return ::isSupported(type, true); }
 
 /// Returns the expected size of an array (capnp list) in 64-bit words.
 static int64_t size(hw::ArrayType mType, capnp::schema::Field::Reader cField) {
@@ -336,47 +224,14 @@ static int64_t size(capnp::schema::Node::Struct::Reader cStruct,
 }
 
 // Compute the expected size of the capnp message in bits.
-size_t TypeSchemaImpl::size() const {
-  auto schema = getTypeSchema();
+size_t CapnpTypeSchemaImpl::size() const {
+  auto schema = getCapnpTypeSchema();
   auto structProto = schema.getProto().getStruct();
-  return ::size(structProto, fieldTypes) * 64;
-}
-
-/// Write a valid Capnp name for 'type'.
-static void emitName(Type type, uint64_t id, llvm::raw_ostream &os) {
-  llvm::TypeSwitch<Type>(type)
-      .Case([&os](IntegerType intTy) {
-        std::string intName;
-        llvm::raw_string_ostream(intName) << intTy;
-        // Capnp struct names must start with an uppercase character.
-        intName[0] = toupper(intName[0]);
-        os << intName;
-      })
-      .Case([&os](hw::ArrayType arrTy) {
-        os << "ArrayOf" << arrTy.getSize() << 'x';
-        emitName(arrTy.getElementType(), 0, os);
-      })
-      .Case([&os](NoneType) { os << "None"; })
-      .Case([&os, id](hw::StructType t) { os << "Struct" << id; })
-      .Default([](Type) {
-        assert(false && "Type not supported. Please check support first with "
-                        "isSupported()");
-      });
-}
-
-/// For now, the name is just the type serialized. This works only because we
-/// only support ints.
-StringRef TypeSchemaImpl::name() const {
-  if (cachedName == "") {
-    llvm::raw_string_ostream os(cachedName);
-    emitName(type, capnpTypeID(), os);
-    cachedName = os.str();
-  }
-  return cachedName;
+  return ::size(structProto, base.getFields()) * 64;
 }
 
 /// Write a valid Capnp type.
-static void emitCapnpType(Type type, IndentingOStream &os) {
+static void emitCapnpType(Type type, llvm::raw_ostream &os) {
   llvm::TypeSwitch<Type>(type)
       .Case([&os](IntegerType intTy) {
         auto w = intTy.getWidth();
@@ -421,40 +276,32 @@ static void emitCapnpType(Type type, IndentingOStream &os) {
 /// This function is essentially a placeholder which only supports ints. It'll
 /// need to be re-worked when we start supporting structs, arrays, unions,
 /// enums, etc.
-LogicalResult TypeSchemaImpl::write(llvm::raw_ostream &rawOS) const {
-  IndentingOStream os(rawOS);
+LogicalResult CapnpTypeSchemaImpl::write(llvm::raw_ostream &rawOS) const {
+  mlir::raw_indented_ostream os(rawOS);
 
   // Since capnp requires messages to be structs, emit a wrapper struct.
-  os.indent() << "struct ";
-  writeMetadata(rawOS);
+  os << "struct ";
+  base.writeMetadata(rawOS);
   os << " {\n";
-  os.addIndent();
+  os.indent();
 
   size_t counter = 0;
   size_t maxNameLength = 0;
-  for (auto field : fieldTypes)
+  for (auto field : base.getFields())
     maxNameLength = std::max(maxNameLength, field.name.size());
 
-  for (auto field : fieldTypes) {
+  for (auto field : base.getFields()) {
     // Specify the actual type, followed by the capnp field.
-    os.indent() << field.name.getValue();
-    os.pad(maxNameLength - field.name.size()) << " @" << counter++ << " :";
-    emitCapnpType(field.type, os);
+    os << field.name.getValue();
+    std::string padding = std::string(maxNameLength - field.name.size(), ' ');
+    os << padding << " @" << counter++ << " :";
+    emitCapnpType(field.type, os.getOStream());
     os << ";  # Actual type is " << field.type << ".\n";
   }
 
-  os.reduceIndent();
-  os.indent() << "}\n\n";
+  os.unindent();
+  os << "}\n\n";
   return success();
-}
-
-void TypeSchemaImpl::writeMetadata(llvm::raw_ostream &os) const {
-  os << name() << " ";
-  emitId(os, capnpTypeID());
-}
-
-bool TypeSchemaImpl::operator==(const TypeSchemaImpl &that) const {
-  return type == that.type;
 }
 
 //===----------------------------------------------------------------------===//
@@ -941,15 +788,15 @@ CapnpSegmentBuilder::build(::capnp::schema::Node::Struct::Reader cStruct,
 
 /// Build an HW/SV dialect capnp encoder module for this type. Inputs need to
 /// be packed and unpadded.
-hw::HWModuleOp TypeSchemaImpl::buildEncoder(Value clk, Value valid,
-                                            Value operandVal) {
+hw::HWModuleOp CapnpTypeSchemaImpl::buildEncoder(Value clk, Value valid,
+                                                 Value operandVal) {
   Location loc = operandVal.getDefiningOp()->getLoc();
   ModuleOp topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
   OpBuilder b = OpBuilder::atBlockEnd(topMod.getBody());
 
   SmallString<64> modName;
   modName.append("encode");
-  modName.append(name());
+  modName.append(base.name());
   SmallVector<hw::PortInfo, 4> ports;
   ports.push_back(hw::PortInfo{b.getStringAttr("clk"), hw::PortDirection::INPUT,
                                clk.getType(), 0});
@@ -971,14 +818,14 @@ hw::HWModuleOp TypeSchemaImpl::buildEncoder(Value clk, Value valid,
   GasketComponent operand(b, innerBlock->getArgument(2));
   operand.setLoc(loc);
 
-  ::capnp::schema::Node::Reader rootProto = getTypeSchema().getProto();
+  ::capnp::schema::Node::Reader rootProto = getCapnpTypeSchema().getProto();
   auto st = rootProto.getStruct();
   CapnpSegmentBuilder seg(b, loc, size());
 
   // The values in the struct we are encoding.
   SmallVector<GasketComponent, 16> fieldValues;
-  assert(operand.getValue().getType() == type);
-  if (auto structTy = type.dyn_cast<hw::StructType>()) {
+  assert(operand.getValue().getType() == base.getType());
+  if (auto structTy = base.getType().dyn_cast<hw::StructType>()) {
     for (auto field : structTy.getElements()) {
       fieldValues.push_back(GasketComponent(
           b, b.create<hw::StructExtractOp>(loc, operand, field)));
@@ -1116,15 +963,15 @@ static GasketComponent decodeField(Type type,
 
 /// Build an HW/SV dialect capnp decoder module for this type. Outputs packed
 /// and unpadded data.
-hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
-                                            Value operandVal) {
+hw::HWModuleOp CapnpTypeSchemaImpl::buildDecoder(Value clk, Value valid,
+                                                 Value operandVal) {
   auto loc = operandVal.getDefiningOp()->getLoc();
   auto topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
   OpBuilder b = OpBuilder::atBlockEnd(topMod.getBody());
 
   SmallString<64> modName;
   modName.append("decode");
-  modName.append(name());
+  modName.append(base.name());
   SmallVector<hw::PortInfo, 4> ports;
   ports.push_back(hw::PortInfo{b.getStringAttr("clk"), hw::PortDirection::INPUT,
                                clk.getType(), 0});
@@ -1134,7 +981,7 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
                                hw::PortDirection::INPUT, operandVal.getType(),
                                2});
   ports.push_back(hw::PortInfo{b.getStringAttr("decoded"),
-                               hw::PortDirection::OUTPUT, getType(), 0});
+                               hw::PortDirection::OUTPUT, base.getType(), 0});
   hw::HWModuleOp retMod = b.create<hw::HWModuleOp>(
       operandVal.getLoc(), b.getStringAttr(modName), ports);
 
@@ -1163,7 +1010,7 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
   AssertBuilder asserts(loc, ifValid.getBodyRegion());
 
   // The next 64-bits of a capnp message is the root struct pointer.
-  ::capnp::schema::Node::Reader rootProto = getTypeSchema().getProto();
+  ::capnp::schema::Node::Reader rootProto = getCapnpTypeSchema().getProto();
   auto ptr = operand.slice(0, 64).name("rootPointer");
 
   // Since this is the root, we _expect_ the offset to be zero but that's only
@@ -1171,7 +1018,7 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
   // TODO: support cases where the pointer offset is non-zero.
   Slice assertPtr(ptr);
   auto typeAndOffset = assertPtr.slice(0, 32).name("typeAndOffset");
-  if (getType().isInteger(0)) {
+  if (base.getType().isInteger(0)) {
     asserts.assertEqual(typeAndOffset.slice(0, 2), 0);
     asserts.assertEqual(typeAndOffset.slice(2, 30), 0x3FFFFFFF);
   } else {
@@ -1203,24 +1050,25 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
   SmallVector<GasketComponent, 64> fieldValues;
   for (auto field : st.getFields()) {
     uint16_t idx = field.getCodeOrder();
-    assert(idx < fieldTypes.size() && "Capnp struct longer than fieldTypes.");
-    fieldValues.push_back(decodeField(fieldTypes[idx].type, field, dataSection,
-                                      ptrSection, asserts));
+    assert(idx < base.getFields().size() &&
+           "Capnp struct longer than fieldTypes.");
+    fieldValues.push_back(decodeField(base.getFields()[idx].type, field,
+                                      dataSection, ptrSection, asserts));
   }
 
   // What to return depends on the type. (e.g. structs have to be constructed
   // from the field values.)
   GasketComponent ret =
-      TypeSwitch<Type, GasketComponent>(type)
+      TypeSwitch<Type, GasketComponent>(base.getType())
           .Case([&fieldValues](IntegerType) { return fieldValues[0]; })
           .Case([&fieldValues](hw::ArrayType) { return fieldValues[0]; })
           .Case([&](hw::StructType) {
             SmallVector<Value, 8> rawValues(llvm::map_range(
                 fieldValues, [](GasketComponent c) { return c.getValue(); }));
-            return GasketComponent(
-                b, b.create<hw::StructCreateOp>(loc, type, rawValues));
+            return GasketComponent(b, b.create<hw::StructCreateOp>(
+                                          loc, base.getType(), rawValues));
           });
-  ret.name(name());
+  ret.name(base.name());
 
   innerBlock->getTerminator()->erase();
   b.setInsertionPointToEnd(innerBlock);
@@ -1230,46 +1078,39 @@ hw::HWModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
 }
 
 //===----------------------------------------------------------------------===//
-// TypeSchema wrapper.
+// CapnpTypeSchema wrapper.
 //===----------------------------------------------------------------------===//
 
 llvm::SmallDenseMap<Type, hw::HWModuleOp>
-    circt::esi::capnp::TypeSchema::decImplMods;
+    circt::esi::capnp::CapnpTypeSchema::decImplMods;
 llvm::SmallDenseMap<Type, hw::HWModuleOp>
-    circt::esi::capnp::TypeSchema::encImplMods;
+    circt::esi::capnp::CapnpTypeSchema::encImplMods;
 
-circt::esi::capnp::TypeSchema::TypeSchema(Type type) {
-  circt::esi::ChannelType chan = type.dyn_cast<circt::esi::ChannelType>();
-  if (chan) // Unwrap the channel if it's a channel.
-    type = chan.getInner();
-  s = std::make_shared<detail::TypeSchemaImpl>(type);
+size_t circt::esi::capnp::CapnpTypeSchema::size() const { return s->size(); }
+
+circt::esi::capnp::CapnpTypeSchema::CapnpTypeSchema(Type outerType)
+    : circt::esi::ESICosimType(outerType) {
+  s = std::make_shared<detail::CapnpTypeSchemaImpl>(*this);
 }
-Type circt::esi::capnp::TypeSchema::getType() const { return s->getType(); }
-uint64_t circt::esi::capnp::TypeSchema::capnpTypeID() const {
-  return s->capnpTypeID();
-}
-bool circt::esi::capnp::TypeSchema::isSupported() const {
-  return s->isSupported();
-}
-size_t circt::esi::capnp::TypeSchema::size() const { return s->size(); }
-StringRef circt::esi::capnp::TypeSchema::name() const { return s->name(); }
+
 LogicalResult
-circt::esi::capnp::TypeSchema::write(llvm::raw_ostream &os) const {
+circt::esi::capnp::CapnpTypeSchema::write(llvm::raw_ostream &os) const {
   return s->write(os);
 }
-void circt::esi::capnp::TypeSchema::writeMetadata(llvm::raw_ostream &os) const {
-  s->writeMetadata(os);
+
+void circt::esi::capnp::CapnpTypeSchema::writeMetadata(
+    llvm::raw_ostream &os) const {
+  os << name() << " ";
+  emitCapnpID(os, typeID());
 }
-bool circt::esi::capnp::TypeSchema::operator==(const TypeSchema &that) const {
-  return *s == *that.s;
-}
-Value circt::esi::capnp::TypeSchema::buildEncoder(OpBuilder &builder, Value clk,
-                                                  Value valid,
-                                                  Value operand) const {
+
+Value circt::esi::capnp::CapnpTypeSchema::buildEncoder(OpBuilder &builder,
+                                                       Value clk, Value valid,
+                                                       Value rawData) const {
   hw::HWModuleOp encImplMod;
   auto encImplIT = encImplMods.find(getType());
   if (encImplIT == encImplMods.end()) {
-    encImplMod = s->buildEncoder(clk, valid, operand);
+    encImplMod = s->buildEncoder(clk, valid, rawData);
     encImplMods[getType()] = encImplMod;
   } else {
     encImplMod = encImplIT->second;
@@ -1280,18 +1121,18 @@ Value circt::esi::capnp::TypeSchema::buildEncoder(OpBuilder &builder, Value clk,
   instName.append(name());
   instName.append("Inst");
   auto encodeInst =
-      builder.create<hw::InstanceOp>(operand.getLoc(), encImplMod, instName,
-                                     ArrayRef<Value>{clk, valid, operand});
+      builder.create<hw::InstanceOp>(rawData.getLoc(), encImplMod, instName,
+                                     ArrayRef<Value>{clk, valid, rawData});
   return encodeInst.getResult(0);
 }
 
-Value circt::esi::capnp::TypeSchema::buildDecoder(OpBuilder &builder, Value clk,
-                                                  Value valid,
-                                                  Value operand) const {
+Value circt::esi::capnp::CapnpTypeSchema::buildDecoder(OpBuilder &builder,
+                                                       Value clk, Value valid,
+                                                       Value capnpData) const {
   hw::HWModuleOp decImplMod;
   auto decImplIT = decImplMods.find(getType());
   if (decImplIT == decImplMods.end()) {
-    decImplMod = s->buildDecoder(clk, valid, operand);
+    decImplMod = s->buildDecoder(clk, valid, capnpData);
     decImplMods[getType()] = decImplMod;
   } else {
     decImplMod = decImplIT->second;
@@ -1302,7 +1143,7 @@ Value circt::esi::capnp::TypeSchema::buildDecoder(OpBuilder &builder, Value clk,
   instName.append(name());
   instName.append("Inst");
   auto decodeInst =
-      builder.create<hw::InstanceOp>(operand.getLoc(), decImplMod, instName,
-                                     ArrayRef<Value>{clk, valid, operand});
+      builder.create<hw::InstanceOp>(capnpData.getLoc(), decImplMod, instName,
+                                     ArrayRef<Value>{clk, valid, capnpData});
   return decodeInst.getResult(0);
 }

--- a/lib/Dialect/ESI/cosim/APIUtilities.cpp
+++ b/lib/Dialect/ESI/cosim/APIUtilities.cpp
@@ -1,0 +1,138 @@
+//===- APIUtilities.cpp - ESI general-purpose cosim API utilities - C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities and classes applicable to all cosim API generators.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/ESI/cosim/APIUtilities.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/ESI/ESITypes.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/Support/IndentedOstream.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/IntervalMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Format.h"
+
+namespace circt {
+namespace esi {
+
+/// Returns true if the type is currently supported.
+// NOLINTNEXTLINE(misc-no-recursion)
+static bool isSupported(Type type, bool outer = false) {
+  return llvm::TypeSwitch<::mlir::Type, bool>(type)
+      .Case([](IntegerType t) { return t.getWidth() <= 64; })
+      .Case([](hw::ArrayType t) { return isSupported(t.getElementType()); })
+      .Case([outer](hw::StructType t) {
+        // We don't yet support structs containing structs.
+        if (!outer)
+          return false;
+        // A struct is supported if all of its elements are.
+        for (auto field : t.getElements()) {
+          if (!isSupported(field.type))
+            return false;
+        }
+        return true;
+      })
+      .Default([](Type) { return false; });
+}
+
+bool ESICosimType::isSupported() const {
+  return circt::esi::isSupported(type, true);
+}
+
+ESICosimType::ESICosimType(Type typeArg) : type(innerType(typeArg)) {
+  TypeSwitch<Type>(type)
+      .Case([this](IntegerType t) {
+        fieldTypes.push_back(
+            FieldInfo{StringAttr::get(t.getContext(), "i"), t});
+      })
+      .Case([this](hw::ArrayType t) {
+        fieldTypes.push_back(
+            FieldInfo{StringAttr::get(t.getContext(), "l"), t});
+      })
+      .Case([this](hw::StructType t) {
+        fieldTypes.append(t.getElements().begin(), t.getElements().end());
+      })
+      .Default([](Type) {});
+}
+
+bool ESICosimType::operator==(const ESICosimType &that) const {
+  return type == that.type;
+}
+
+/// Write a valid Capnp name for 'type'.
+// NOLINTNEXTLINE(misc-no-recursion)
+static void emitName(Type type, uint64_t id, llvm::raw_ostream &os) {
+  llvm::TypeSwitch<Type>(type)
+      .Case([&os](IntegerType intTy) {
+        std::string intName;
+        llvm::raw_string_ostream(intName) << intTy;
+        // Capnp struct names must start with an uppercase character.
+        intName[0] = toupper(intName[0]);
+        os << intName;
+      })
+      .Case([&os](hw::ArrayType arrTy) {
+        os << "ArrayOf" << arrTy.getSize() << 'x';
+        emitName(arrTy.getElementType(), 0, os);
+      })
+      .Case([&os](NoneType) { os << "None"; })
+      .Case([&os, id](hw::StructType t) { os << "Struct" << id; })
+      .Default([](Type) {
+        assert(false && "Type not supported. Please check support first with "
+                        "isSupported()");
+      });
+}
+
+/// For now, the name is just the type serialized. This works only because we
+/// only support ints.
+StringRef ESICosimType::name() const {
+  if (cachedName.empty()) {
+    llvm::raw_string_ostream os(cachedName);
+    emitName(type, typeID(), os);
+    cachedName = os.str();
+  }
+  return cachedName;
+}
+
+// We compute a deterministic hash based on the type. Since llvm::hash_value
+// changes from execution to execution, we don't use it.
+uint64_t ESICosimType::typeID() const {
+  if (cachedID)
+    return *cachedID;
+
+  // Get the MLIR asm type, padded to a multiple of 64 bytes.
+  std::string typeName;
+  llvm::raw_string_ostream osName(typeName);
+  osName << type;
+  size_t overhang = osName.tell() % 64;
+  if (overhang != 0)
+    osName.indent(64 - overhang);
+  osName.flush();
+  const char *typeNameC = typeName.c_str();
+
+  uint64_t hash = esiCosimSchemaVersion;
+  for (size_t i = 0, e = typeName.length() / 64; i < e; ++i)
+    hash =
+        llvm::hashing::detail::hash_33to64_bytes(&typeNameC[i * 64], 64, hash);
+
+  // Capnp IDs always have a '1' high bit.
+  cachedID = hash | 0x8000000000000000;
+  return *cachedID;
+}
+
+} // namespace esi
+} // namespace circt


### PR DESCRIPTION
... to prepare for the C++ API; refactors the `TypeSchema` to remove any (...most) capnp related functionality in favor of a more general `ESICosimType` class.