### PR TITLE
[ESI] Add clean metadata pass

### DIFF
--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -253,6 +253,7 @@ class System:
       lambda sys: TypeAlias.declare_aliases(sys.mod),
       "builtin.module(msft-lower-constructs, msft-lower-instances)",
       "builtin.module(esi-emit-collateral{{tops={tops} schema-file=schema.capnp}})",
+      "builtin.module(esi-clean-metadata)",
       "builtin.module(lower-msft-to-hw{{verilog-file={verilog_file}}})",
       "builtin.module(lower-hwarith-to-hw)",
       "builtin.module(hw.module(lower-seq-hlmem))",

--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -28,6 +28,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createESIPortLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESITypeLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESItoHWPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIConnectServicesPass();
+std::unique_ptr<OperationPass<ModuleOp>> createESICleanMetadataPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/ESI/ESIPasses.td
+++ b/include/circt/Dialect/ESI/ESIPasses.td
@@ -37,6 +37,12 @@ def ESIEmitCollateral: Pass<"esi-emit-collateral", "mlir::ModuleOp"> {
   ];
 }
 
+def ESICleanMetadata : Pass<"esi-clean-metadata", "mlir::ModuleOp"> {
+  let summary = "Clean up ESI service metadata";
+  let constructor = "circt::esi::createESICleanMetadataPass()";
+  let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 def LowerESIToPhysical: Pass<"lower-esi-to-physical", "mlir::ModuleOp"> {
   let summary = "Lower ESI abstract Ops to ESI physical ops.";
   let constructor = "circt::esi::createESIPhysicalLoweringPass()";

--- a/integration_test/ESI/cosim/loopback.mlir
+++ b/integration_test/ESI/cosim/loopback.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: esi-cosim
 // RUN: rm -rf %t6 && mkdir %t6 && cd %t6
-// RUN: circt-opt %s --esi-connect-services --esi-emit-collateral=schema-file=%t2.capnp > %t4.mlir
+// RUN: circt-opt %s --esi-connect-services --esi-emit-collateral=schema-file=%t2.capnp --esi-clean-metadata > %t4.mlir
 // RUN: circt-opt %t4.mlir --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw --export-split-verilog -o %t3.mlir
 // RUN: circt-translate %t4.mlir -export-esi-capnp -verify-diagnostics > %t2.capnp
 // RUN: cd ..

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -19,6 +19,8 @@ set(srcs
   Passes/ESILowerPorts.cpp
   Passes/ESILowerToHW.cpp
   Passes/ESILowerTypes.cpp
+  Passes/ESICleanMetadata.cpp
+
   cosim/APIUtilities.cpp
 
 )

--- a/lib/Dialect/ESI/Passes/ESICleanMetadata.cpp
+++ b/lib/Dialect/ESI/Passes/ESICleanMetadata.cpp
@@ -1,0 +1,48 @@
+//===- ESICleanMetadata.cpp - Clean ESI metadata ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// ESI clean metadata pass.
+//===----------------------------------------------------------------------===//
+
+#include "../PassDetails.h"
+
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/ESI/ESIPasses.h"
+
+using namespace circt;
+using namespace esi;
+
+namespace {
+struct ESICleanMetadataPass
+    : public ESICleanMetadataBase<ESICleanMetadataPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void ESICleanMetadataPass::runOnOperation() {
+  auto mod = getOperation();
+
+  // Delete all service declarations.
+  mod.walk([&](ServiceHierarchyMetadataOp op) { op.erase(); });
+  // Track declarations which are still used so that the service impl reqs are
+  // still valid.
+  DenseSet<StringAttr> stillUsed;
+  mod.walk([&](ServiceImplementReqOp req) {
+    auto sym = req.getServiceSymbol();
+    if (sym.has_value())
+      stillUsed.insert(StringAttr::get(req.getContext(), *sym));
+  });
+  mod.walk([&](ServiceDeclOpInterface decl) {
+    if (!stillUsed.contains(SymbolTable::getSymbolName(decl)))
+      decl.getOperation()->erase();
+  });
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+circt::esi::createESICleanMetadataPass() {
+  return std::make_unique<ESICleanMetadataPass>();
+}

--- a/lib/Dialect/ESI/Passes/ESIEmitCollateral.cpp
+++ b/lib/Dialect/ESI/Passes/ESIEmitCollateral.cpp
@@ -241,22 +241,6 @@ void ESIEmitCollateralPass::emitServiceJSON() {
                                            StringAttr::get(ctxt, os.str()));
   auto outputFileAttr = OutputFileAttr::getFromFilename(ctxt, "services.json");
   verbatim->setAttr("output_file", outputFileAttr);
-
-  // By now, we should be done with all of the service declarations and
-  // metadata ops so we should delete them.
-  mod.walk([&](ServiceHierarchyMetadataOp op) { op.erase(); });
-  // Track declarations which are still used so that the service impl reqs are
-  // still valid.
-  DenseSet<StringAttr> stillUsed;
-  mod.walk([&](ServiceImplementReqOp req) {
-    auto sym = req.getServiceSymbol();
-    if (sym.has_value())
-      stillUsed.insert(StringAttr::get(req.getContext(), *sym));
-  });
-  mod.walk([&](ServiceDeclOpInterface decl) {
-    if (!stillUsed.contains(SymbolTable::getSymbolName(decl)))
-      decl.getOperation()->erase();
-  });
 }
 
 void ESIEmitCollateralPass::runOnOperation() {

--- a/test/Dialect/ESI/services_collateral.mlir
+++ b/test/Dialect/ESI/services_collateral.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: capnp
-// RUN: circt-opt %s --esi-connect-services --esi-emit-collateral=tops=LoopbackCosimTopWrapper,LoopbackCosimBSP --lower-msft-to-hw --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw  --export-verilog -o %t1.mlir  | FileCheck %s
+// RUN: circt-opt %s --esi-connect-services --esi-emit-collateral=tops=LoopbackCosimTopWrapper,LoopbackCosimBSP --esi-clean-metadata --lower-msft-to-hw --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw  --export-verilog -o %t1.mlir  | FileCheck %s
 
 // CHECK-LABEL: // ----- 8< ----- FILE "services.json" ----- 8< -----
 


### PR DESCRIPTION
Moves metadata cleaning from the `esi-emit-collateral` pass to a separate pass.