### PR TITLE
[FIRRTL][LowerTypes] Use agg create ops for unlowered users. 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -667,6 +667,13 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
           // user has already been processed.
           ImplicitLocOpBuilder b(user->getLoc(), user);
 
+          // This shouldn't happen (non-FIRRTLBaseType's in lowered types, or
+          // refs), check explicitly here for clarity/early detection.
+          assert(llvm::none_of(mapping, [](auto v) {
+            auto fbasetype = dyn_cast<FIRRTLBaseType>(v.getType());
+            return !fbasetype || fbasetype.containsReference();
+          }));
+
           Value input =
               TypeSwitch<Type, Value>(val.getType())
                   .template Case<FVectorType>([&](auto vecType) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -654,10 +654,17 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
           refSub.replaceAllUsesWith(repl);
           refSub.erase();
         })
-        .Case<RefForceOp, RefForceInitialOp, RefSendOp, VectorCreateOp,
-              BundleCreateOp>([&](auto op) {
-          // Reconstruct the aggregate for the ref operation.
-          // (or vector/bundle create that were inserted.. woof.)
+        .Default([&](auto op) {
+          // This means we have already processed the user, and it didn't lower
+          // its inputs. This is an opaque user, which will continue to have
+          // aggregate type as input, even after LowerTypes. So, construct the
+          // vector/bundle back from the lowered elements to ensure a valid
+          // input into the opaque op. This only supports Bundles and Vectors.
+
+          // This builder ensures that the aggregate construction happens at the
+          // user location, and the LowerTypes algorithm will not touch them any
+          // more, because LowerTypes was reverse iterating on the block and the
+          // user has already been processed.
           ImplicitLocOpBuilder b(user->getLoc(), user);
 
           Value input =
@@ -674,40 +681,6 @@ void TypeLoweringVisitor::processUsers(Value val, ArrayRef<Value> mapping) {
                 << val.getType();
             return;
           }
-          user->replaceUsesOfWith(val, input);
-        })
-        .Default([&](auto _) {
-          // This means, we have already processed the user, and it didn't lower
-          // its inputs. This is an opaque user, which will continue to have
-          // aggregate type as input, even after LowerTypes. So, construct the
-          // vector/bundle back from the lowered elements to ensure a valid
-          // input into the opaque op. This only supports Bundle or vector of
-          // ground type elements. Recursive aggregate types are not yet
-          // supported.
-
-          // This builder ensures that the aggregate construction happens at the
-          // user location, and the LowerTypes algorithm will not touch them any
-          // more, because LowerTypes was reverse iterating on the block and the
-          // user has already been processed.
-          ImplicitLocOpBuilder b(user->getLoc(), user);
-          // Cat all the field elements.
-          Value accumulate;
-          for (auto v : mapping) {
-            if (!v.getType().cast<FIRRTLBaseType>().isGround()) {
-              user->emitError("cannot handle an opaque user of aggregate types "
-                              "with non-ground type elements");
-              return;
-            }
-            if (isa<FVectorType>(val.getType()))
-              accumulate =
-                  (accumulate ? b.createOrFold<CatPrimOp>(v, accumulate) : v);
-            else
-              // Bundle subfields are filled from MSB to LSB.
-              accumulate =
-                  (accumulate ? b.createOrFold<CatPrimOp>(accumulate, v) : v);
-          }
-          // Cast it back to the original aggregate type.
-          auto input = b.createOrFold<BitCastOp>(val.getType(), accumulate);
           user->replaceUsesOfWith(val, input);
         });
   }


### PR DESCRIPTION
These are easier to generate and more semantically meaningful
in the IR, compared to the previous bitcast(cat({x_0, ..., x_n})).

This also extends support to work with aggregates of more than
just directly ground types (e.g., vector-of-bundles).