### PR TITLE
[Arc] Add reset and enable grouping pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -24,6 +24,7 @@ createAddTapsPass(llvm::Optional<bool> tapPorts = {},
                   llvm::Optional<bool> tapWires = {});
 std::unique_ptr<mlir::Pass> createAllocateStatePass();
 std::unique_ptr<mlir::Pass> createDedupPass();
+std::unique_ptr<mlir::Pass> createGroupResetsAndEnablesPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInferStatePropertiesPass();
 std::unique_ptr<mlir::Pass> createInlineArcsPass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -37,6 +37,13 @@ def Dedup : Pass<"arc-dedup", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def GroupResetsAndEnables : Pass<"arc-group-resets-and-enables",
+                                 "mlir::ModuleOp"> {
+  let summary = "Group reset and enable conditions of lowered states";
+  let constructor = "circt::arc::createGroupResetsAndEnablesPass()";
+  let dependentDialects = ["arc::ArcDialect", "mlir::scf::SCFDialect"];
+}
+
 def InferMemories : Pass<"arc-infer-memories", "mlir::ModuleOp"> {
   let summary = "Convert `FIRRTL_Memory` instances to dedicated memory ops";
   let constructor = "circt::arc::createInferMemoriesPass()";

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   AddTaps.cpp
   AllocateState.cpp
   Dedup.cpp
+  GroupResetsAndEnables.cpp
   InferMemories.cpp
   InferStateProperties.cpp
   InlineArcs.cpp

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -24,6 +24,8 @@ using namespace mlir;
 // Rewrite Patterns
 //===----------------------------------------------------------------------===//
 
+namespace {
+
 struct ResetGroupingPattern : public OpRewritePattern<ClockTreeOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ClockTreeOp clockTreeOp,
@@ -112,6 +114,7 @@ struct EnableGroupingPattern : public OpRewritePattern<ClockTreeOp> {
     return success(changed);
   }
 };
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Pass Infrastructure

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -37,7 +37,8 @@ public:
     llvm::MapVector<mlir::Value, SmallVector<scf::IfOp>> resetMap;
 
     for (auto ifOp : clockTreeOp.getBody().getOps<scf::IfOp>())
-      resetMap[ifOp.getCondition()].push_back(ifOp);
+      if (ifOp.getResults().empty())
+        resetMap[ifOp.getCondition()].push_back(ifOp);
 
     // Combine IfOps
     bool changed = false;

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -45,21 +45,19 @@ public:
     for (auto [cond, oldOps] : resetMap) {
       if (oldOps.size() <= 1)
         continue;
-        scf::IfOp lastIfOp = oldOps.pop_back_val();
-        for (auto thisOp : oldOps) {
-          // Inline the before and after region inside the original If
-          rewriter.eraseOp(thisOp->thenBlock()->getTerminator());
-          rewriter.inlineBlockBefore(thisOp->thenBlock(),
-                                     &lastIfOp.thenBlock()->front());
-          // Check we're not inlining an empty block
-          if (auto *elseBlock = thisOp->elseBlock()) {
-            rewriter.eraseOp(elseBlock->getTerminator());
-            rewriter.inlineBlockBefore(elseBlock,
-                                       &lastIfOp.elseBlock()->front());
-          }
-          rewriter.eraseOp(*thisOp);
-          changed = true;
+      scf::IfOp lastIfOp = oldOps.pop_back_val();
+      for (auto thisOp : oldOps) {
+        // Inline the before and after region inside the original If
+        rewriter.eraseOp(thisOp.thenBlock()->getTerminator());
+        rewriter.inlineBlockBefore(thisOp.thenBlock(),
+                                   &lastIfOp.thenBlock()->front());
+        // Check we're not inlining an empty block
+        if (auto *elseBlock = thisOp.elseBlock()) {
+          rewriter.eraseOp(elseBlock->getTerminator());
+          rewriter.inlineBlockBefore(elseBlock, &lastIfOp.elseBlock()->front());
         }
+        rewriter.eraseOp(thisOp);
+        changed = true;
       }
     }
     return success(changed);

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -37,7 +37,6 @@ public:
     llvm::MapVector<mlir::Value, SmallVector<scf::IfOp>> resetMap;
     auto ifOps = clockTreeOp.getBody().getOps<scf::IfOp>();
 
-
     for (auto ifOp : ifOps)
       resetMap[ifOp.getCondition()].push_back(ifOp);
 
@@ -87,7 +86,7 @@ public:
     }
 
     bool changed = false;
-    for (auto *region: groupingRegions) {
+    for (auto *region : groupingRegions) {
       llvm::MapVector<mlir::Value, SmallVector<StateWriteOp>> enableMap;
       auto writeOps = region->getOps<StateWriteOp>();
       for (auto writeOp : writeOps) {
@@ -97,13 +96,13 @@ public:
       for (auto [enable, writeOps] : enableMap) {
         // Only group if multiple writes share an enable
         if (writeOps.size() > 1) {
-            if (isa<scf::IfOp>(region->getParentOp())) {
-              rewriter.setInsertionPoint(region->back().getTerminator());
-            } else {
-              rewriter.setInsertionPointToEnd(&region->back());
-            }
-          scf::IfOp ifOp = rewriter.create<scf::IfOp>(writeOps[0].getLoc(),
-                                                      enable, false);
+          if (isa<scf::IfOp>(region->getParentOp())) {
+            rewriter.setInsertionPoint(region->back().getTerminator());
+          } else {
+            rewriter.setInsertionPointToEnd(&region->back());
+          }
+          scf::IfOp ifOp =
+              rewriter.create<scf::IfOp>(writeOps[0].getLoc(), enable, false);
           for (auto writeOp : writeOps) {
             rewriter.updateRootInPlace(writeOp, [&]() {
               writeOp->moveBefore(ifOp.thenBlock()->getTerminator());

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -95,14 +95,14 @@ public:
           enableMap[writeOp.getCondition()].push_back(writeOp);
       }
       for (auto [enable, writeOps] : enableMap) {
-        // Only group if multiple writes share a reset
+        // Only group if multiple writes share an enable
         if (writeOps.size() > 1) {
             if (isa<scf::IfOp>(region->getParentOp())) {
               rewriter.setInsertionPoint(region->back().getTerminator());
             } else {
               rewriter.setInsertionPointToEnd(&region->back());
             }
-          scf::IfOp ifOp = rewriter.create<scf::IfOp>(rewriter.getUnknownLoc(),
+          scf::IfOp ifOp = rewriter.create<scf::IfOp>(writeOps[0].getLoc(),
                                                       enable, false);
           for (auto writeOp : writeOps) {
             rewriter.updateRootInPlace(writeOp, [&]() {

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -40,6 +40,8 @@ public:
       if (ifOp.getResults().empty())
         resetMap[ifOp.getCondition()].push_back(ifOp);
 
+    // TODO: Check that conflicting memory effects aren't being reordered
+
     // Combine IfOps
     bool changed = false;
     for (auto &[cond, oldOps] : resetMap) {

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -45,18 +45,18 @@ public:
     bool changed = false;
     for (auto [cond, oldOps] : resetMap) {
       if (oldOps.size() > 1) {
-        auto *iteratorStart = oldOps.begin();
-        scf::IfOp firstOp = *(iteratorStart++);
-        for (auto *thisOp = iteratorStart; thisOp != oldOps.end(); thisOp++) {
+        auto iteratorStart = oldOps.rbegin();
+        scf::IfOp lastIfOp = *(iteratorStart++);
+        for (auto thisOp = iteratorStart; thisOp != oldOps.rend(); thisOp++) {
           // Inline the before and after region inside the original If
           rewriter.eraseOp(thisOp->thenBlock()->getTerminator());
           rewriter.inlineBlockBefore(thisOp->thenBlock(),
-                                     firstOp.thenBlock()->getTerminator());
+                                     &lastIfOp.thenBlock()->front());
           // Check we're not inlining an empty block
           if (!thisOp->elseBlock()->empty()) {
             rewriter.eraseOp(thisOp->elseBlock()->getTerminator());
             rewriter.inlineBlockBefore(thisOp->elseBlock(),
-                                       firstOp.elseBlock()->getTerminator());
+                                       &lastIfOp.elseBlock()->front());
           }
           rewriter.eraseOp(*thisOp);
           changed = true;

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -30,12 +30,12 @@ public:
       : RewritePattern(ClockTreeOp::getOperationName(), benefit, context) {}
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    ClockTreeOp moduleOp = dyn_cast<ClockTreeOp>(*op);
+    ClockTreeOp clockTreeOp = dyn_cast<ClockTreeOp>(*op);
 
     // Group similar resets into single IfOps
     // Create a list of reset values and map from them to the states they reset
     llvm::MapVector<mlir::Value, SmallVector<scf::IfOp>> resetMap;
-    auto ifOps = moduleOp.getBody().getOps<scf::IfOp>();
+    auto ifOps = clockTreeOp.getBody().getOps<scf::IfOp>();
 
     for (auto ifOp : ifOps)
       resetMap[ifOp.getCondition()].push_back(ifOp);

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -1,0 +1,157 @@
+//===- GroupResetsAndEnables.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-group-resets-and-enables"
+
+using namespace circt;
+using namespace arc;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Rewrite Patterns
+//===----------------------------------------------------------------------===//
+
+class ResetGroupingPattern
+    : public RewritePattern {
+public:
+  using RewritePattern::RewritePattern;
+  ResetGroupingPattern(PatternBenefit benefit, MLIRContext *context)
+      : RewritePattern(ClockTreeOp::getOperationName(), benefit, context) {}
+  LogicalResult
+  matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
+    ClockTreeOp moduleOp = dyn_cast<ClockTreeOp>(*op);
+
+    // Group similar resets into single IfOps
+    // Create a list of reset values and map from them to the states they reset
+    llvm::MapVector<mlir::Value, SmallVector<scf::IfOp>> resetMap;
+    auto ifOps = moduleOp.getBody().getOps<scf::IfOp>();
+
+    for (auto ifOp: ifOps)
+      resetMap[ifOp.getCondition()].push_back(ifOp);
+
+    // Combine IfOps
+    bool changed = false;
+    for (auto [cond, oldOps]: resetMap) {
+      if (oldOps.size() > 1) {
+        auto iteratorStart = oldOps.rbegin();
+        scf::IfOp firstOp = *(iteratorStart++);
+        for (auto thisOp = iteratorStart; thisOp != oldOps.rend(); thisOp++) {
+          // Inline the before and after region inside the original If
+          rewriter.eraseOp(thisOp->thenBlock()->getTerminator());
+          rewriter.inlineBlockBefore(thisOp->thenBlock(),
+                                     firstOp.thenBlock()->getTerminator());
+          // Check we're not inlining an empty block
+          if (!thisOp->elseBlock()->empty()) {
+              rewriter.eraseOp(thisOp->elseBlock()->getTerminator());
+              rewriter.inlineBlockBefore(thisOp->elseBlock(),
+                                         firstOp.elseBlock()->getTerminator());
+          }
+          rewriter.eraseOp(*thisOp);
+          changed = true;
+        }
+      }
+    }
+    if (!changed)
+      return failure();
+    return success();
+  }
+};
+
+class EnableGroupingPattern
+    : public RewritePattern {
+public:
+  using RewritePattern::RewritePattern;
+  EnableGroupingPattern(PatternBenefit benefit, MLIRContext *context)
+      : RewritePattern(ClockTreeOp::getOperationName(), benefit, context) {}
+  LogicalResult
+  matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
+    ClockTreeOp clockTreeOp = dyn_cast<ClockTreeOp>(*op);
+
+    // Generate vector of blocks to amass StateWrite enables in
+    SmallVector<Block*> groupingBlocks;
+    groupingBlocks.push_back(&clockTreeOp.getBodyBlock());
+    for (auto ifOp: clockTreeOp.getBody().getOps<scf::IfOp>()) {
+      groupingBlocks.push_back(ifOp.thenBlock());
+      groupingBlocks.push_back(ifOp.elseBlock());
+    }
+
+    bool changed = false;
+    for (auto *block: groupingBlocks) {
+      llvm::MapVector<mlir::Value, SmallVector<StateWriteOp>> enableMap;
+      auto writeOps = block->getOps<StateWriteOp>();
+      for (auto writeOp: writeOps) {
+        if (writeOp.getCondition())
+          enableMap[writeOp.getCondition()].push_back(writeOp);
+      }
+      for (auto [enable, writeOps]: enableMap) {
+        // Only group if multiple writes share a reset
+        if (writeOps.size() > 1) {
+          scf::IfOp ifOp = rewriter.create<scf::IfOp>(rewriter.getUnknownLoc(), enable, false);
+          for (auto writeOp: writeOps) {
+            writeOp->moveBefore(ifOp.thenBlock()->getTerminator());
+            writeOp.getConditionMutable().erase(0);
+          }
+          ifOp->moveBefore(block->getTerminator());
+          changed = true;
+        }
+      }
+    }
+    if (!changed)
+      return failure();
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct GroupResetsAndEnablesPass : public GroupResetsAndEnablesBase<GroupResetsAndEnablesPass> {
+  GroupResetsAndEnablesPass() = default;
+  GroupResetsAndEnablesPass(const GroupResetsAndEnablesPass &pass) : GroupResetsAndEnablesPass() {}
+
+  void runOnOperation() override;
+  LogicalResult runOnModel(ModelOp modelOp);
+
+};
+} // namespace
+
+void GroupResetsAndEnablesPass::runOnOperation() {
+  for (auto op :
+       llvm::make_early_inc_range(getOperation().getOps<ModelOp>()))
+    if (failed(runOnModel(op)))
+      return signalPassFailure();
+}
+
+LogicalResult GroupResetsAndEnablesPass::runOnModel(ModelOp modelOp) {
+  LLVM_DEBUG(llvm::dbgs() << "Grouping resets and enables in `" << modelOp.getName()
+                          << "`\n");
+
+  MLIRContext &context = getContext();
+  RewritePatternSet patterns(&context);
+  patterns.insert<ResetGroupingPattern>(1,
+      &context);
+  patterns.insert<EnableGroupingPattern>(1,
+      &context);
+  GreedyRewriteConfig config;
+  config.strictMode = GreedyRewriteStrictness::ExistingOps;
+  (void)applyPatternsAndFoldGreedily(modelOp, std::move(patterns), config);
+  return success();
+}
+
+std::unique_ptr<Pass> arc::createGroupResetsAndEnablesPass() {
+  return std::make_unique<GroupResetsAndEnablesPass>();
+}

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -244,3 +244,58 @@ arc.model "GroupEnablesInReset" {
   %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
+
+// CHECK-LABEL: arc.model "GroupEnablesAndResets"
+arc.model "GroupEnablesAndResets" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
+    %3 = arc.state_read %in_reset : <i1>
+    //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en
+    %4 = arc.state_read %in_en : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET]] {
+    scf.if %3 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:   scf.if [[IN_EN]] {
+      // CHECK-NEXT:    arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+      // CHECK-NEXT:    arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+      // CHECK-NEXT:   }
+      %5 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %5 if %4 : <i4>
+      // CHECK-NEXT: }
+    }
+    scf.if %3 {
+      arc.state_write %2 = %c0_i4 : <i4>
+    } else {
+      %6 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %6 if %4 : <i4>
+    }
+    // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -4,19 +4,10 @@
 arc.model "JustGroupResets" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
@@ -54,20 +45,11 @@ arc.model "JustGroupResets" {
 arc.model "DontGroupResets" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset0 = arc.root_input "reset0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_reset1 = arc.root_input "reset1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
@@ -110,19 +92,10 @@ arc.model "DontGroupResets" {
 arc.model "JustGroupEnables" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en
@@ -153,20 +126,11 @@ arc.model "JustGroupEnables" {
 arc.model "DontGroupEnables" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
@@ -197,20 +161,11 @@ arc.model "DontGroupEnables" {
 arc.model "GroupEnablesInReset" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en1
@@ -249,20 +204,11 @@ arc.model "GroupEnablesInReset" {
 arc.model "GroupEnablesAndResets" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
@@ -304,21 +250,12 @@ arc.model "GroupEnablesAndResets" {
 arc.model "GroupSeparatedResets" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
-  %true = hw.constant true
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  arc.passthrough {
-    %3 = arc.state_read %1 : <i4>
-    arc.state_write %out_out0 = %3 : <i4>
-    %4 = arc.state_read %2 : <i4>
-    arc.state_write %out_out1 = %4 : <i4>
-  }
-  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %0 = arc.state_read %in_clock : <i1>
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -1,0 +1,246 @@
+// RUN: circt-opt %s --arc-group-resets-and-enables | FileCheck %s
+
+// CHECK-LABEL: arc.model "JustGroupResets"
+arc.model "JustGroupResets" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
+    %3 = arc.state_read %in_reset : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET]] {
+    scf.if %3 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I0:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+      // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+      %4 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %4 : <i4>
+      // CHECK-NEXT: }
+    }
+    scf.if %3 {
+      arc.state_write %2 = %c0_i4 : <i4>
+    } else {
+      %5 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %5 : <i4>
+    }
+    // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}
+
+// CHECK-LABEL: arc.model "DontGroupResets"
+arc.model "DontGroupResets" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_reset0 = arc.root_input "reset0", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_reset1 = arc.root_input "reset1", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
+    %3 = arc.state_read %in_reset0 : <i1>
+    //  CHECK: [[IN_RESET1:%.+]] = arc.state_read %in_reset1
+    %4 = arc.state_read %in_reset1 : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET0]] {
+    scf.if %3 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I0:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+      %5 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %5 : <i4>
+      // CHECK-NEXT: }
+    }
+    //  CHECK-NEXT: scf.if [[IN_RESET1]] {
+    scf.if %4 {
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %2 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+      %6 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %6 : <i4>
+    }
+    // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}
+
+// CHECK-LABEL: arc.model "JustGroupEnables"
+arc.model "JustGroupEnables" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en
+    %3 = arc.state_read %in_en : <i1>
+    //   CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+    //   CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    arc.state_write %1 = %c0_i4 : <i4>
+    arc.state_write %2 = %c0_i4 : <i4>
+    // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
+    // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
+    // CHECK-NEXT:   scf.if [[IN_EN]] {
+    // CHECK-NEXT:    arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+    // CHECK-NEXT:    arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+    %4 = arc.state_read %in_i0 : <i4>
+    arc.state_write %1 = %4 if %3 : <i4>
+    %5 = arc.state_read %in_i1 : <i4>
+    arc.state_write %2 = %5 if %3 : <i4>
+    // CHECK-NEXT:  }
+  // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}
+
+// CHECK-LABEL: arc.model "DontGroupEnables"
+arc.model "DontGroupEnables" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
+    %3 = arc.state_read %in_en0 : <i1>
+    //  CHECK: [[IN_EN1:%.+]] = arc.state_read %in_en1
+    %4 = arc.state_read %in_en1 : <i1>
+    //   CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+    //   CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    arc.state_write %1 = %c0_i4 : <i4>
+    arc.state_write %2 = %c0_i4 : <i4>
+    // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
+    // CHECK-NEXT:   arc.state_write [[FOO_ALLOC]] = [[IN_I0]] if [[IN_EN0]]
+    // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
+    // CHECK-NEXT:   arc.state_write [[BAR_ALLOC]] = [[IN_I1]] if [[IN_EN1]]
+    %5 = arc.state_read %in_i0 : <i4>
+    arc.state_write %1 = %5 if %3 : <i4>
+    %6 = arc.state_read %in_i1 : <i4>
+    arc.state_write %2 = %6 if %4 : <i4>
+  // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}
+
+// CHECK-LABEL: arc.model "GroupEnablesInReset"
+arc.model "GroupEnablesInReset" {
+^bb0(%arg0: !arc.storage):
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
+  arc.passthrough {
+    %3 = arc.state_read %1 : <i4>
+    arc.state_write %out_out0 = %3 : <i4>
+    %4 = arc.state_read %2 : <i4>
+    arc.state_write %out_out1 = %4 : <i4>
+  }
+  %out_out0 = arc.root_output "out0", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %out_out1 = arc.root_output "out1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %0 = arc.state_read %in_clock : <i1>
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en1
+    %3 = arc.state_read %in_en1 : <i1>
+    //  CHECK-NEXT: [[IN_RESET:%.+]] = arc.state_read %in_reset
+    %4 = arc.state_read %in_reset : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET]] {
+    scf.if %4 {
+      //   CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      //   CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      arc.state_write %2 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:   scf.if [[IN_EN]] {
+      // CHECK-NEXT:    arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+      // CHECK-NEXT:    arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+      %5 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %5 if %3 : <i4>
+      %6 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %6 if %3 : <i4>
+      // CHECK-NEXT:   }
+    // CHECK-NEXT:  }
+    }
+  // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
+  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
+}

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -41,7 +41,7 @@ arc.model "BasicResetGrouping" {
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET0_1:%.+]] = arc.state_read %in_reset0
     %6 = arc.state_read %in_reset0 : <i1>
-    //  CHECK: [[IN_RESET1_1:%.+]] = arc.state_read %in_reset1
+    //  CHECK-NEXT: [[IN_RESET1_1:%.+]] = arc.state_read %in_reset1
     %7 = arc.state_read %in_reset1 : <i1>
     //  CHECK-NEXT: scf.if [[IN_RESET0_1]] {
     scf.if %6 {
@@ -187,7 +187,7 @@ arc.model "BasicEnableGrouping" {
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN0_1:%.+]] = arc.state_read %in_en0
     %6 = arc.state_read %in_en0 : <i1>
-    //  CHECK: [[IN_EN1_1:%.+]] = arc.state_read %in_en1
+    //  CHECK-NEXT: [[IN_EN1_1:%.+]] = arc.state_read %in_en1
     %7 = arc.state_read %in_en1 : <i1>
     //   CHECK-NEXT: arc.state_write [[FOO_ALLOC]] = %c0_i4
     //   CHECK-NEXT: arc.state_write [[BAR_ALLOC]] = %c0_i4
@@ -252,7 +252,7 @@ arc.model "ResetAndEnableGrouping" {
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %7 = arc.state_read %in_reset : <i1>
-    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
+    //  CHECK-NEXT: [[IN_EN0:%.+]] = arc.state_read %in_en0
     %8 = arc.state_read %in_en0 : <i1>
     //  CHECK-NEXT: scf.if [[IN_RESET]] {
     scf.if %7 {
@@ -283,9 +283,9 @@ arc.model "ResetAndEnableGrouping" {
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %11 = arc.state_read %in_reset : <i1>
-    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
+    //  CHECK-NEXT: [[IN_EN0:%.+]] = arc.state_read %in_en0
     %12 = arc.state_read %in_en0 : <i1>
-    //  CHECK: [[IN_EN1:%.+]] = arc.state_read %in_en1
+    //  CHECK-NEXT: [[IN_EN1:%.+]] = arc.state_read %in_en1
     //  CHECK-NEXT: scf.if [[IN_RESET]] {
     scf.if %11 {
       //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = %c0_i4

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -1,18 +1,20 @@
 // RUN: circt-opt %s --arc-group-resets-and-enables | FileCheck %s
 
-// CHECK-LABEL: arc.model "JustGroupResets"
-arc.model "JustGroupResets" {
+// CHECK-LABEL: arc.model "BasicResetGrouping"
+arc.model "BasicResetGrouping" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_reset0 = arc.root_input "reset0", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_reset1 = arc.root_input "reset1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
+  // Group resets:
   arc.clock_tree %0 {
-    //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
-    %3 = arc.state_read %in_reset : <i1>
-    //  CHECK-NEXT: scf.if [[IN_RESET]] {
+    //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
+    %3 = arc.state_read %in_reset0 : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET0]] {
     scf.if %3 {
       //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
       //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
@@ -35,52 +37,115 @@ arc.model "JustGroupResets" {
     }
     // CHECK-NEXT: }
   }
-  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-}
-
-// CHECK-LABEL: arc.model "DontGroupResets"
-arc.model "DontGroupResets" {
-^bb0(%arg0: !arc.storage):
-  %c0_i4 = hw.constant 0 : i4
-  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_reset0 = arc.root_input "reset0", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_reset1 = arc.root_input "reset1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %0 = arc.state_read %in_clock : <i1>
+  // Don't group resets that don't match:
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET0_1:%.+]] = arc.state_read %in_reset0
+    %6 = arc.state_read %in_reset0 : <i1>
+    //  CHECK: [[IN_RESET1_1:%.+]] = arc.state_read %in_reset1
+    %7 = arc.state_read %in_reset1 : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET0_1]] {
+    scf.if %6 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I0_1:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0_1]]
+      %8 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %8 : <i4>
+      // CHECK-NEXT: }
+    }
+    //  CHECK-NEXT: scf.if [[IN_RESET1_1]] {
+    scf.if %7 {
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = %c0_i4
+      arc.state_write %2 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I1_1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1_1]]
+      %9 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %9 : <i4>
+    }
+    // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  }
+  // Don't group IfOps with return values
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
-    %3 = arc.state_read %in_reset0 : <i1>
-    //  CHECK: [[IN_RESET1:%.+]] = arc.state_read %in_reset1
-    %4 = arc.state_read %in_reset1 : <i1>
+    %10 = arc.state_read %in_reset0 : <i1>
     //  CHECK-NEXT: scf.if [[IN_RESET0]] {
-    scf.if %3 {
-      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+    scf.if %10 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = %c0_i4
       arc.state_write %1 = %c0_i4 : <i4>
       //   CHECK-NEXT: } else {
     } else {
       // CHECK-NEXT:  [[IN_I0:%.+]] = arc.state_read %in_i0
       // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
-      %5 = arc.state_read %in_i0 : <i4>
-      arc.state_write %1 = %5 : <i4>
+      %11 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %11 : <i4>
       // CHECK-NEXT: }
     }
-    //  CHECK-NEXT: scf.if [[IN_RESET1]] {
-    scf.if %4 {
-      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    //  CHECK-NEXT: [[IF_RESULT:%.+]] scf.if [[IN_RESET0]] -> (i4) {
+    %res = scf.if %10 -> (i4) {
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = %c0_i4
+      //   CHECK-NEXT:  scf.yield %c0_i4 : i4
       arc.state_write %2 = %c0_i4 : <i4>
+      scf.yield %c0_i4 : i4
       //   CHECK-NEXT: } else {
     } else {
       // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
       // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
-      %6 = arc.state_read %in_i1 : <i4>
-      arc.state_write %2 = %6 : <i4>
+      //   CHECK-NEXT:  scf.yield %c0_i4 : i4
+      %12 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %12 : <i4>
+      scf.yield %c0_i4 : i4
     }
     // CHECK-NEXT: }
   // CHECK-NEXT: }
+  }
+  // Group resets with no else in an early block (that has its contents moved):
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
+    %13 = arc.state_read %in_reset0 : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET0]] {
+    scf.if %13 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+      // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
+      // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
+      // CHECK-NEXT: }
+    }
+    scf.if %13 {
+      arc.state_write %2 = %c0_i4 : <i4>
+    } else {
+      %14 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %14 : <i4>
+    }
+    // CHECK-NEXT: }
+  }
+  // Group resets with no else in the last if (where contents are moved to):
+  arc.clock_tree %0 {
+    //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
+    %15 = arc.state_read %in_reset0 : <i1>
+    //  CHECK-NEXT: scf.if [[IN_RESET0]] {
+    scf.if %15 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+      arc.state_write %1 = %c0_i4 : <i4>
+      //   CHECK-NEXT: } else {
+    } else {
+      // CHECK-NEXT:  [[IN_I0:%.+]] = arc.state_read %in_i0
+      // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
+      %16 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %16 : <i4>
+      // CHECK-NEXT: }
+    }
+    scf.if %15 {
+      arc.state_write %2 = %c0_i4 : <i4>
+    }
+    // CHECK-NEXT: }
   }
   // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
   // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
@@ -88,25 +153,27 @@ arc.model "DontGroupResets" {
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
 
-// CHECK-LABEL: arc.model "JustGroupEnables"
-arc.model "JustGroupEnables" {
+// CHECK-LABEL: arc.model "BasicEnableGrouping"
+arc.model "BasicEnableGrouping" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
+  // Group enables:
   arc.clock_tree %0 {
-    //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en
-    %3 = arc.state_read %in_en : <i1>
+    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
+    %3 = arc.state_read %in_en0 : <i1>
     //   CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
     //   CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
     arc.state_write %1 = %c0_i4 : <i4>
     arc.state_write %2 = %c0_i4 : <i4>
     // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
     // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
-    // CHECK-NEXT:   scf.if [[IN_EN]] {
+    // CHECK-NEXT:   scf.if [[IN_EN0]] {
     // CHECK-NEXT:    arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
     // CHECK-NEXT:    arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
     %4 = arc.state_read %in_i0 : <i4>
@@ -116,39 +183,24 @@ arc.model "JustGroupEnables" {
     // CHECK-NEXT:  }
   // CHECK-NEXT: }
   }
-  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-}
-
-// CHECK-LABEL: arc.model "DontGroupEnables"
-arc.model "DontGroupEnables" {
-^bb0(%arg0: !arc.storage):
-  %c0_i4 = hw.constant 0 : i4
-  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %0 = arc.state_read %in_clock : <i1>
+  // Don't group non-matching enables:
   arc.clock_tree %0 {
-    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
-    %3 = arc.state_read %in_en0 : <i1>
-    //  CHECK: [[IN_EN1:%.+]] = arc.state_read %in_en1
-    %4 = arc.state_read %in_en1 : <i1>
-    //   CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
-    //   CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    //  CHECK: [[IN_EN0_1:%.+]] = arc.state_read %in_en0
+    %6 = arc.state_read %in_en0 : <i1>
+    //  CHECK: [[IN_EN1_1:%.+]] = arc.state_read %in_en1
+    %7 = arc.state_read %in_en1 : <i1>
+    //   CHECK-NEXT: arc.state_write [[FOO_ALLOC]] = %c0_i4
+    //   CHECK-NEXT: arc.state_write [[BAR_ALLOC]] = %c0_i4
     arc.state_write %1 = %c0_i4 : <i4>
     arc.state_write %2 = %c0_i4 : <i4>
-    // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
-    // CHECK-NEXT:   arc.state_write [[FOO_ALLOC]] = [[IN_I0]] if [[IN_EN0]]
-    // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
-    // CHECK-NEXT:   arc.state_write [[BAR_ALLOC]] = [[IN_I1]] if [[IN_EN1]]
-    %5 = arc.state_read %in_i0 : <i4>
-    arc.state_write %1 = %5 if %3 : <i4>
-    %6 = arc.state_read %in_i1 : <i4>
-    arc.state_write %2 = %6 if %4 : <i4>
+    // CHECK-NEXT:   [[IN_I0_1:%.+]] = arc.state_read %in_i0
+    // CHECK-NEXT:   arc.state_write [[FOO_ALLOC]] = [[IN_I0_1]] if [[IN_EN0_1]]
+    // CHECK-NEXT:   [[IN_I1_1:%.+]] = arc.state_read %in_i1
+    // CHECK-NEXT:   arc.state_write [[BAR_ALLOC]] = [[IN_I1_1]] if [[IN_EN1_1]]
+    %8 = arc.state_read %in_i0 : <i4>
+    arc.state_write %1 = %8 if %6 : <i4>
+    %9 = arc.state_read %in_i1 : <i4>
+    arc.state_write %2 = %9 if %7 : <i4>
   // CHECK-NEXT: }
   }
   // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
@@ -157,16 +209,18 @@ arc.model "DontGroupEnables" {
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
 
-// CHECK-LABEL: arc.model "GroupEnablesInReset"
-arc.model "GroupEnablesInReset" {
+// CHECK-LABEL: arc.model "ResetAndEnableGrouping"
+arc.model "ResetAndEnableGrouping" {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
+  %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
+  // Group resets inside enables
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en1
     %3 = arc.state_read %in_en1 : <i1>
@@ -194,79 +248,48 @@ arc.model "GroupEnablesInReset" {
     }
   // CHECK-NEXT: }
   }
-  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-}
-
-// CHECK-LABEL: arc.model "GroupEnablesAndResets"
-arc.model "GroupEnablesAndResets" {
-^bb0(%arg0: !arc.storage):
-  %c0_i4 = hw.constant 0 : i4
-  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_en = arc.root_input "en", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %0 = arc.state_read %in_clock : <i1>
+  // Group both resets and enables
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
-    %3 = arc.state_read %in_reset : <i1>
-    //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en
-    %4 = arc.state_read %in_en : <i1>
+    %7 = arc.state_read %in_reset : <i1>
+    //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
+    %8 = arc.state_read %in_en0 : <i1>
     //  CHECK-NEXT: scf.if [[IN_RESET]] {
-    scf.if %3 {
-      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
-      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    scf.if %7 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = %c0_i4
       arc.state_write %1 = %c0_i4 : <i4>
       //   CHECK-NEXT: } else {
     } else {
       // CHECK-NEXT:   [[IN_I0:%.+]] = arc.state_read %in_i0
       // CHECK-NEXT:   [[IN_I1:%.+]] = arc.state_read %in_i1
-      // CHECK-NEXT:   scf.if [[IN_EN]] {
+      // CHECK-NEXT:   scf.if [[IN_EN0]] {
       // CHECK-NEXT:    arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
       // CHECK-NEXT:    arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
       // CHECK-NEXT:   }
-      %5 = arc.state_read %in_i0 : <i4>
-      arc.state_write %1 = %5 if %4 : <i4>
+      %9 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %9 if %8 : <i4>
       // CHECK-NEXT: }
     }
-    scf.if %3 {
+    scf.if %7 {
       arc.state_write %2 = %c0_i4 : <i4>
     } else {
-      %6 = arc.state_read %in_i1 : <i4>
-      arc.state_write %2 = %6 if %4 : <i4>
+      %10 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %10 if %8 : <i4>
     }
     // CHECK-NEXT: }
   }
-  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-}
-
-// CHECK-LABEL: arc.model "GroupSeparatedResets"
-arc.model "GroupSeparatedResets" {
-^bb0(%arg0: !arc.storage):
-  %c0_i4 = hw.constant 0 : i4
-  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_reset = arc.root_input "reset", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %0 = arc.state_read %in_clock : <i1>
+  // Group resets that are separated by an enable read
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
-    %3 = arc.state_read %in_reset : <i1>
+    %11 = arc.state_read %in_reset : <i1>
     //  CHECK: [[IN_EN0:%.+]] = arc.state_read %in_en0
-    %4 = arc.state_read %in_en0 : <i1>
+    %12 = arc.state_read %in_en0 : <i1>
     //  CHECK: [[IN_EN1:%.+]] = arc.state_read %in_en1
     //  CHECK-NEXT: scf.if [[IN_RESET]] {
-    scf.if %3 {
-      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
-      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
+    scf.if %11 {
+      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = %c0_i4
+      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = %c0_i4
       arc.state_write %1 = %c0_i4 : <i4>
       //   CHECK-NEXT: } else {
     } else {
@@ -274,66 +297,18 @@ arc.model "GroupSeparatedResets" {
       // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]] if [[IN_EN0]]
       // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
       // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]] if [[IN_EN1]]
-      %5 = arc.state_read %in_i0 : <i4>
-      arc.state_write %1 = %5 if %4 : <i4>
+      %13 = arc.state_read %in_i0 : <i4>
+      arc.state_write %1 = %13 if %12 : <i4>
       // CHECK-NEXT: }
     }
-    %6 = arc.state_read %in_en1 : <i1>
-    scf.if %3 {
+    %14 = arc.state_read %in_en1 : <i1>
+    scf.if %11 {
       arc.state_write %2 = %c0_i4 : <i4>
     } else {
-      %7 = arc.state_read %in_i1 : <i4>
-      arc.state_write %2 = %7 if %6 : <i4>
+      %15 = arc.state_read %in_i1 : <i4>
+      arc.state_write %2 = %15 if %14 : <i4>
     }
     // CHECK-NEXT: }
-  }
-  // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-  %1 = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
-  %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
-}
-
-// CHECK-LABEL: arc.model "DontGroupIfsWithResults"
-arc.model "DontGroupIfsWithResults" {
-^bb0(%arg0: !arc.storage):
-  %c0_i4 = hw.constant 0 : i4
-  %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %in_i0 = arc.root_input "i0", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
-  %in_reset0 = arc.root_input "reset0", %arg0 : (!arc.storage) -> !arc.state<i1>
-  %0 = arc.state_read %in_clock : <i1>
-  arc.clock_tree %0 {
-    //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
-    %3 = arc.state_read %in_reset0 : <i1>
-    //  CHECK-NEXT: scf.if [[IN_RESET0]] {
-    scf.if %3 {
-      //   CHECK-NEXT:  arc.state_write [[FOO_ALLOC:%.+]] = %c0_i4
-      arc.state_write %1 = %c0_i4 : <i4>
-      //   CHECK-NEXT: } else {
-    } else {
-      // CHECK-NEXT:  [[IN_I0:%.+]] = arc.state_read %in_i0
-      // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]]
-      %4 = arc.state_read %in_i0 : <i4>
-      arc.state_write %1 = %4 : <i4>
-      // CHECK-NEXT: }
-    }
-    //  CHECK-NEXT: [[IF_RESULT:%.+]] scf.if [[IN_RESET0]] -> (i4) {
-    %res = scf.if %3 -> (i4) {
-      //   CHECK-NEXT:  arc.state_write [[BAR_ALLOC:%.+]] = %c0_i4
-      //   CHECK-NEXT:  scf.yield %c0_i4 : i4
-      arc.state_write %2 = %c0_i4 : <i4>
-      scf.yield %c0_i4 : i4
-      //   CHECK-NEXT: } else {
-    } else {
-      // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
-      // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]]
-      //   CHECK-NEXT:  scf.yield %c0_i4 : i4
-      %5 = arc.state_read %in_i1 : <i4>
-      arc.state_write %2 = %5 : <i4>
-      scf.yield %c0_i4 : i4
-    }
-    // CHECK-NEXT: }
-  // CHECK-NEXT: }
   }
   // CHECK-NEXT: [[FOO_ALLOC]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i4>
   // CHECK-NEXT: [[BAR_ALLOC]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -69,7 +69,7 @@ arc.model "BasicResetGrouping" {
     // CHECK-NEXT: }
   // CHECK-NEXT: }
   }
-  // Don't group IfOps with return values
+  // Don't group IfOps with return values:
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET0:%.+]] = arc.state_read %in_reset0
     %10 = arc.state_read %in_reset0 : <i1>
@@ -220,7 +220,7 @@ arc.model "ResetAndEnableGrouping" {
   %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
-  // Group resets inside enables
+  // Group enables inside resets:
   arc.clock_tree %0 {
     //  CHECK: [[IN_EN:%.+]] = arc.state_read %in_en1
     %3 = arc.state_read %in_en1 : <i1>
@@ -248,7 +248,7 @@ arc.model "ResetAndEnableGrouping" {
     }
   // CHECK-NEXT: }
   }
-  // Group both resets and enables
+  // Group both resets and enables:
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %7 = arc.state_read %in_reset : <i1>
@@ -279,7 +279,7 @@ arc.model "ResetAndEnableGrouping" {
     }
     // CHECK-NEXT: }
   }
-  // Group resets that are separated by an enable read
+  // Group resets that are separated by an enable read:
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %11 = arc.state_read %in_reset : <i1>

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -225,6 +225,8 @@ static void populatePipeline(PassManager &pm) {
   }
 
   pm.addPass(arc::createGroupResetsAndEnablesPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(createSimpleCanonicalizerPass());
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -224,6 +224,8 @@ static void populatePipeline(PassManager &pm) {
     pm.addPass(createCSEPass());
   }
 
+  pm.addPass(arc::createGroupResetsAndEnablesPass());
+
   // Allocate states.
   if (untilReached(UntilStateAlloc))
     return;


### PR DESCRIPTION
This adds a simple optimizing pass to group similar reset and enable conditions after lowering states. Currently enables are grouped into an `scf.IfOp` if there are at least two that share an enable condition, but perhaps we want a higher threshold to justify that the overhead of the mutations is worthwhile?

Also worth noting that if arbitrary IR is fed into this pass, it's technically possible for the reset grouping to be invalid (as all matching `scf.IfOp` contents are grouped at the final match so that all enable signals will have been fetched, which would lead to non-domination if a value affected in an earlier `IfOp` is used before the final matching `IfOp`), but this shouldn't be able to happen with anything produced by LowerState - is it worth doing some kind of further dependency checking here, or is it satisfactory for it to deal safely with anything it should be fed in the Arcilator pipeline?