### PR TITLE
[ExportVerilog] Transform anonymous enumerations in to typedefs

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -23,6 +23,7 @@ createTestApplyLoweringOptionPass(llvm::StringRef options);
 std::unique_ptr<mlir::Pass> createTestApplyLoweringOptionPass();
 
 std::unique_ptr<mlir::Pass> createPrepareForEmissionPass();
+std::unique_ptr<mlir::Pass> createLegalizeAnonEnumsPass();
 
 std::unique_ptr<mlir::Pass> createExportVerilogPass(llvm::raw_ostream &os);
 std::unique_ptr<mlir::Pass> createExportVerilogPass();

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -92,6 +92,18 @@ def TestApplyLoweringOption : Pass<"test-apply-lowering-options",
   ];
 }
 
+def LegalizeAnonEnums : Pass<"legalize-anon-enums", "mlir::ModuleOp"> {
+  let summary = "Prepare anonymous enumeration types for ExportVerilog";
+  let description = [{
+    This pass transforms all anonymous enumeration types into typedecls to work
+    around difference in how anonymous enumerations work in SystemVerilog.
+  }];
+  let constructor = "createLegalizeAnonEnumsPass()";
+  let dependentDialects = [
+    "circt::sv::SVDialect", "circt::comb::CombDialect", "circt::hw::HWDialect"
+  ];
+}
+
 def PrepareForEmission : Pass<"prepare-for-emission",
                               "hw::HWModuleOp"> {
   let summary = "Prepare IR for ExportVerilog";

--- a/lib/Conversion/ExportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ExportVerilog/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_circt_translation_library(CIRCTExportVerilog
   ApplyLoweringOptions.cpp
   ExportVerilog.cpp
+  LegalizeAnonEnums.cpp
   LegalizeNames.cpp
   PrepareForEmission.cpp
   PruneZeroValuedLogic.cpp
@@ -23,4 +24,4 @@ add_circt_translation_library(CIRCTExportVerilog
   MLIRPass
   MLIRSideEffectInterfaces
   MLIRTransforms
-  )
+)

--- a/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
@@ -1,0 +1,191 @@
+//===- LegalizeAnonEnums.cpp - Legalizes anonymous enumerations -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass replaces all anonymous enumeration with typedecls in the output
+// Verilog.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../PassDetail.h"
+#include "ExportVerilogInternals.h"
+#include "circt/Conversion/ExportVerilog.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/DenseSet.h"
+
+using namespace circt;
+using namespace hw;
+using namespace sv;
+
+namespace {
+struct LegalizeAnonEnums : public LegalizeAnonEnumsBase<LegalizeAnonEnums> {
+  /// Creates a TypeScope on demand for anonymous enumerations.
+  TypeScopeOp getTypeScope() {
+    auto topLevel = getOperation();
+    if (!typeScope) {
+      auto builder = OpBuilder::atBlockBegin(&topLevel.getRegion().front());
+      typeScope = builder.create<TypeScopeOp>(topLevel.getLoc(), "Enums");
+      typeScope.getBodyRegion().push_back(new Block());
+      mlir::SymbolTable symbolTable(topLevel);
+      symbolTable.insert(typeScope);
+    }
+    return typeScope;
+  }
+
+  /// Helper to create TypeDecls and TypeAliases for EnumTypes;
+  Type getEnumTypeDecl(EnumType type) {
+    auto &typeAlias = enumTypeAliases[type];
+    if (typeAlias)
+      return typeAlias;
+    auto *context = &getContext();
+    auto loc = UnknownLoc::get(context);
+    auto typeScope = getTypeScope();
+    auto builder = OpBuilder::atBlockEnd(&typeScope.getRegion().front());
+    auto declName = StringAttr::get(context, "enum" + Twine(enumCount++));
+    builder.create<TypedeclOp>(loc, declName, TypeAttr::get(type), nullptr);
+    auto symRef = SymbolRefAttr::get(typeScope.getSymNameAttr(),
+                                     FlatSymbolRefAttr::get(declName));
+    typeAlias = TypeAliasType::get(symRef, type);
+    return typeAlias;
+  }
+
+  /// Process a type, replacing any anonymous enumerations contained within.
+  Type processType(Type type) {
+    auto *context = &getContext();
+    if (auto structType = dyn_cast<StructType>(type)) {
+      bool changed = false;
+      SmallVector<StructType::FieldInfo> fields;
+      for (auto &element : structType.getElements()) {
+        if (auto newFieldType = processType(element.type)) {
+          changed = true;
+          fields.push_back({element.name, newFieldType});
+        } else {
+          fields.push_back(element);
+        }
+      }
+      if (changed)
+        return StructType::get(context, fields);
+      return {};
+    }
+
+    if (auto arrayType = dyn_cast<ArrayType>(type)) {
+      if (auto newElementType = processType(arrayType.getElementType()))
+        return ArrayType::get(newElementType, arrayType.getSize());
+      return {};
+    }
+
+    if (auto unionType = dyn_cast<UnionType>(type)) {
+      bool changed = false;
+      SmallVector<UnionType::FieldInfo> fields;
+      for (const auto &element : unionType.getElements()) {
+        if (auto newFieldType = processType(element.type)) {
+          fields.push_back({element.name, newFieldType, element.offset});
+          changed = true;
+        } else {
+          fields.push_back(element);
+        }
+      }
+      if (changed)
+        return UnionType::get(context, fields);
+      return {};
+    }
+
+    if (auto typeAlias = dyn_cast<TypeAliasType>(type)) {
+      // Enum type aliases have already been handled.
+      if (isa<EnumType>(typeAlias.getInnerType()))
+        return {};
+      // Otherwise recursively update the type alias.
+      return processType(typeAlias.getInnerType());
+    }
+
+    if (auto inoutType = dyn_cast<InOutType>(type)) {
+      if (auto newType = processType(inoutType.getElementType()))
+        return InOutType::get(newType);
+      return {};
+    }
+
+    // EnumTypes must be changed into TypeAlias.
+    if (auto enumType = dyn_cast<EnumType>(type))
+      return getEnumTypeDecl(enumType);
+
+    if (auto funcType = dyn_cast<FunctionType>(type)) {
+      bool changed = false;
+      SmallVector<Type> inputs;
+      for (auto &type : funcType.getInputs()) {
+        if (auto newType = processType(type)) {
+          inputs.push_back(newType);
+          changed = true;
+        } else {
+          inputs.push_back(type);
+        }
+      }
+      SmallVector<Type> results;
+      for (auto &type : funcType.getResults()) {
+        if (auto newType = processType(type)) {
+          results.push_back(newType);
+          changed = true;
+        } else {
+          results.push_back(type);
+        }
+      }
+      if (changed)
+        return FunctionType::get(context, inputs, results);
+      return {};
+    }
+
+    // Default case is that it is not an aggregate type.
+    return {};
+  };
+
+  void runOnOperation() override {
+    enumCount = 0;
+    typeScope = {};
+
+    // Perform the actual walk looking for anonymous enumeration types.
+    getOperation().walk([&](Operation *op) {
+      // If this is a constant operation, make sure to update the constant
+      // to reference the typedef, otherwise we will emit the wrong constant.
+      // Theoretically we should be searching all attributes on every operation
+      // for EnumFieldAttrs.
+      if (auto enumConst = dyn_cast<EnumConstantOp>(op)) {
+        auto fieldAttr = enumConst.getField();
+        if (auto newType = processType(fieldAttr.getType().getValue()))
+          enumConst.setFieldAttr(
+              EnumFieldAttr::get(op->getLoc(), fieldAttr.getField(), newType));
+      }
+
+      // Update the operation signature if it is function-like.
+      if (auto funcLike = dyn_cast<mlir::FunctionOpInterface>(op))
+        if (auto newType = processType(funcLike.getFunctionType()))
+          funcLike.setFunctionTypeAttr(TypeAttr::get(newType));
+
+      // Update all operations results.
+      for (auto result : op->getResults())
+        if (auto newType = processType(result.getType()))
+          result.setType(newType);
+
+      // Update all block arguments.
+      for (auto &region : op->getRegions())
+        for (auto &block : region.getBlocks())
+          for (auto arg : block.getArguments())
+            if (auto newType = processType(arg.getType()))
+              arg.setType(newType);
+    });
+
+    enumTypeAliases.clear();
+  }
+
+  TypeScopeOp typeScope;
+  unsigned enumCount;
+  DenseMap<Type, Type> enumTypeAliases;
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::createLegalizeAnonEnumsPass() {
+  return std::make_unique<LegalizeAnonEnums>();
+}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1427,19 +1427,6 @@ hw.module @DontInlineAggregateConstantIntoPorts() -> () {
   hw.instance "i0" @Array(a: %0: !hw.array<2xi4>) -> ()
 }
 
-// CHECK-LABEL: module EnumCmp(
-// CHECK-NEXT:   input enum bit [0:0] {A, B} test,
-// CHECK-NEXT:   output result
-// CHECK-NEXT:  )
-// CHECK-EMPTY:
-// CHECK-NEXT:   assign result = test == A;
-// CHECK-NEXT: endmodule
-hw.module @EnumCmp(%test: !hw.enum<A, B>) -> (result: i1) {
-  %A = hw.enum.constant A : !hw.enum<A, B>
-  %0 = hw.enum.cmp %test, %A : !hw.enum<A, B>, !hw.enum<A, B>
-  hw.output %0 : i1
-}
-
 // CHECK-LABEL: module FooA(
 // CHECK-NEXT:    input union packed {logic [15:0] a; struct packed {logic [9:0] b; logic [5:0] __post_padding_b;} b;} test
 // CHECK-NEXT:    output [15:0] a,

--- a/test/Conversion/ExportVerilog/hw-enums.mlir
+++ b/test/Conversion/ExportVerilog/hw-enums.mlir
@@ -1,0 +1,104 @@
+// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100,emitBindComments' -export-verilog -split-input-file -o %t.mlir | FileCheck %s
+
+// CHECK-LABEL: module EnumCheck
+hw.module @EnumCheck(%a : !hw.enum<T>, %b: !hw.enum<>)
+                 -> (c: !hw.enum<T>, d: !hw.enum<>) {
+  // CHECK: input enum bit [0:0] {T} a
+  // CHECK: // input enum bit [0:0] {} b
+  hw.output %a, %b : !hw.enum<T>, !hw.enum<>
+}
+
+// CHECK-LABEL: module EnumCmp(
+// CHECK-NEXT:   input enum bit [0:0] {A, B} test,
+// CHECK-NEXT:   output result
+// CHECK-NEXT:  )
+// CHECK-EMPTY:
+// CHECK-NEXT:   assign result = test == A;
+// CHECK-NEXT: endmodule
+hw.module @EnumCmp(%test: !hw.enum<A, B>) -> (result: i1) {
+  %A = hw.enum.constant A : !hw.enum<A, B>
+  %0 = hw.enum.cmp %test, %A : !hw.enum<A, B>, !hw.enum<A, B>
+  hw.output %0 : i1
+}
+
+// Mixing !hw.enum types which alias in their fields - one anonymous enum
+// and two aliasing named enums.
+
+// CHECK: `ifndef _TYPESCOPE___AnFSMTypedecl
+// CHECK: `define _TYPESCOPE___AnFSMTypedecl
+// CHECK: typedef enum bit [0:0] {_state1_A, _state1_B} _state1;
+// CHECK: typedef enum bit [0:0] {_state2_A, _state2_B} _state2;
+// CHECK: `endif // _TYPESCOPE___AnFSMTypedecl
+// CHECK-LABEL: module AnFSM
+// CHECK:   enum bit [0:0] {A, B} reg_0;
+// OLD:   _state1     reg_state1;
+// OLD:   _state2     reg_state2;
+// CHECK:   always @(posedge clock) begin
+// CHECK:     case (reg_0)
+// CHECK:       A:
+// CHECK:         reg_0 <= B;
+// CHECK:       default:
+// CHECK:         reg_0 <= A;
+// CHECK:     endcase
+// CHECK:   end
+// NEW:   _state1     reg_state1;
+// CHECK:   always @(posedge clock) begin
+// CHECK:     case (reg_state1)
+// CHECK:       _state1_A:
+// CHECK:         reg_state1 <= _state1_B;
+// CHECK:       default:
+// CHECK:         reg_state1 <= _state1_A;
+// CHECK:     endcase
+// CHECK:   end
+// NEW:   _state2     reg_state2;
+// CHECK:   always @(posedge clock) begin
+// CHECK:     case (reg_state2)
+// CHECK:       _state2_A:
+// CHECK:         reg_state2 <= _state2_B;
+// CHECK:       default:
+// CHECK:         reg_state2 <= _state2_A;
+// CHECK:     endcase
+// CHECK:   end
+// CHECK: endmodule
+
+hw.type_scope @__AnFSMTypedecl {
+  hw.typedecl @_state1 : !hw.enum<A, B>
+  hw.typedecl @_state2 : !hw.enum<A, B>
+}
+
+hw.module @AnFSM(%clock : i1) {
+  // Anonymous enum
+  %reg = sv.reg : !hw.inout<!hw.enum<A, B>>
+  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B>>
+  %A = hw.enum.constant A : !hw.enum<A, B>
+  %B = hw.enum.constant B : !hw.enum<A, B>
+  sv.always posedge %clock {
+    sv.case case %reg_read : !hw.enum<A, B>
+      case A : { sv.passign %reg, %B : !hw.enum<A, B> }
+      default : { sv.passign %reg, %A : !hw.enum<A, B> }
+  }
+
+  // typedecl'd # 1
+  %reg_state1 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
+  %reg_read_state1 = sv.read_inout %reg_state1 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
+
+  %A_state1 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
+  %B_state1 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
+  sv.always posedge %clock {
+    sv.case case %reg_read_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
+      case A : { sv.passign %reg_state1, %B_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>> }
+      default : { sv.passign %reg_state1, %A_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>> }
+  }
+
+  // typedecl'd # 2
+  %reg_state2 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
+  %reg_read_state2 = sv.read_inout %reg_state2 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
+
+  %A_state2 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
+  %B_state2 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
+  sv.always posedge %clock {
+    sv.case case %reg_read_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
+      case A : { sv.passign %reg_state2, %B_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>> }
+      default : { sv.passign %reg_state2, %A_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>> }
+  }
+}

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -984,88 +984,6 @@ hw.module @ConstantDefBeforeUse() {
   }
 }
 
-// Mixing !hw.enum types which alias in their fields - one anonymous enum
-// and two aliasing named enums.
-
-// CHECK: `ifndef _TYPESCOPE___AnFSMTypedecl
-// CHECK: `define _TYPESCOPE___AnFSMTypedecl
-// CHECK: typedef enum bit [0:0] {_state1_A, _state1_B} _state1;
-// CHECK: typedef enum bit [0:0] {_state2_A, _state2_B} _state2;
-// CHECK: `endif // _TYPESCOPE___AnFSMTypedecl
-// CHECK-LABEL: module AnFSM
-// CHECK:   enum bit [0:0] {A, B} reg_0;
-// OLD:   _state1     reg_state1;
-// OLD:   _state2     reg_state2;
-// CHECK:   always @(posedge clock) begin
-// CHECK:     case (reg_0)
-// CHECK:       A:
-// CHECK:         reg_0 <= B;
-// CHECK:       default:
-// CHECK:         reg_0 <= A;
-// CHECK:     endcase
-// CHECK:   end
-// NEW:   _state1     reg_state1;
-// CHECK:   always @(posedge clock) begin
-// CHECK:     case (reg_state1)
-// CHECK:       _state1_A:
-// CHECK:         reg_state1 <= _state1_B;
-// CHECK:       default:
-// CHECK:         reg_state1 <= _state1_A;
-// CHECK:     endcase
-// CHECK:   end
-// NEW:   _state2     reg_state2;
-// CHECK:   always @(posedge clock) begin
-// CHECK:     case (reg_state2)
-// CHECK:       _state2_A:
-// CHECK:         reg_state2 <= _state2_B;
-// CHECK:       default:
-// CHECK:         reg_state2 <= _state2_A;
-// CHECK:     endcase
-// CHECK:   end
-// CHECK: endmodule
-
-hw.type_scope @__AnFSMTypedecl {
-  hw.typedecl @_state1 : !hw.enum<A, B>
-  hw.typedecl @_state2 : !hw.enum<A, B>
-}
-
-hw.module @AnFSM(%clock : i1) {
-  // Anonymous enum
-  %reg = sv.reg : !hw.inout<!hw.enum<A, B>>
-  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B>>
-  %A = hw.enum.constant A : !hw.enum<A, B>
-  %B = hw.enum.constant B : !hw.enum<A, B>
-  sv.always posedge %clock {
-    sv.case case %reg_read : !hw.enum<A, B>
-      case A : { sv.passign %reg, %B : !hw.enum<A, B> }
-      default : { sv.passign %reg, %A : !hw.enum<A, B> }
-  }
-
-  // typedecl'd # 1
-  %reg_state1 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
-  %reg_read_state1 = sv.read_inout %reg_state1 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
-
-  %A_state1 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
-  %B_state1 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
-  sv.always posedge %clock {
-    sv.case case %reg_read_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
-      case A : { sv.passign %reg_state1, %B_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>> }
-      default : { sv.passign %reg_state1, %A_state1 : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>> }
-  }
-
-  // typedecl'd # 2
-  %reg_state2 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
-  %reg_read_state2 = sv.read_inout %reg_state2 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
-
-  %A_state2 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
-  %B_state2 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
-  sv.always posedge %clock {
-    sv.case case %reg_read_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
-      case A : { sv.passign %reg_state2, %B_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>> }
-      default : { sv.passign %reg_state2, %A_state2 : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>> }
-  }
-}
-
 // Constants defined after use in non-procedural regions should be moved to the
 // top of the block.
 // CHECK-LABEL: module ConstantDefAfterUse
@@ -1749,14 +1667,6 @@ hw.module @ForStatement(%a: i5) -> () {
       sv.bpassign %index, %RANDOM : i32
     }
   }
-}
-
-// CHECK-LABEL: module EnumCheck
-hw.module @EnumCheck(%a : !hw.enum<T>, %b: !hw.enum<>)
-                 -> (c: !hw.enum<T>, d: !hw.enum<>) {
-  // CHECK: input enum bit [0:0] {T} a
-  // CHECK: // input enum bit [0:0] {} b
-  hw.output %a, %b : !hw.enum<T>, !hw.enum<>
 }
 
 // CHECK-LABEL: module intrinsic


### PR DESCRIPTION
Our Verilog output for anonymous enumeration is highly problematic:
every time we write out the type, the variants or members of the
enumeration enter the global namespace.  This makes it impossible to
have multiple declarations share the same enumeration type.

This adds walk of all operations in the ModuleOp to find and replace all
enumeration types used with typedefs.  The typedefs are automatically
injected into a typescope with the name "Enums".

Here is an example of what that looks like:
```verilog
ifndef _TYPESCOPE_Enums
`define _TYPESCOPE_Enums
typedef enum bit [0:0] {enum0_A, enum0_B} enum0;
`endif // _TYPESCOPE_Enums

module EnumCmp(
  input  enum0 test,
  output       result
)

  assign result = test == enum0_A;
endmodule
```

This also adds support for 0 width typedecls, which allow us to comment
out the zero width typedefs and the ports of that type.