### PR TITLE
[FIRRTL] Fix foo.0.0 parsing error

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.h
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.h
@@ -104,7 +104,9 @@ public:
   const llvm::SourceMgr &getSourceMgr() const { return sourceMgr; }
 
   /// Move to the next valid token.
-  void lexToken() { curToken = lexTokenImpl(); }
+  void lexToken(bool stopAtPeriod = false) {
+    curToken = lexTokenImpl(stopAtPeriod);
+  }
 
   const FIRToken &getToken() const { return curToken; }
 
@@ -118,7 +120,7 @@ public:
   FIRLexerCursor getCursor() const;
 
 private:
-  FIRToken lexTokenImpl();
+  FIRToken lexTokenImpl(bool stopAtPeriod = false);
 
   // Helpers.
   FIRToken formToken(FIRToken::Kind kind, const char *tokStart) {
@@ -131,7 +133,7 @@ private:
   FIRToken lexFileInfo(const char *tokStart);
   FIRToken lexInlineAnnotation(const char *tokStart);
   FIRToken lexIdentifierOrKeyword(const char *tokStart);
-  FIRToken lexNumber(const char *tokStart);
+  FIRToken lexNumber(const char *tokStart, bool stopAtPeriod = false);
   FIRToken lexFloatingPoint(const char *tokStart);
   void skipComment();
   FIRToken lexString(const char *tokStart, bool isRaw);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1278,6 +1278,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output p : Probe<UInt<1>>
     p is invalid
 
+  ; CHECK-LABEL: module private @NumericFields
+  ; See: https://github.com/llvm/circt/issues/5110
+  module NumericFields:
+    input a: {0: {0: {bar: UInt<1>}}}
+    output b: UInt<1>
+
+    ; CHECK:      %0 = firrtl.subfield %a["0"]
+    ; CHECK-NEXT: %1 = firrtl.subfield %0["0"]
+    ; CHECK-NEXT: %2 = firrtl.subfield %1[bar]
+    ; CHECK-NEXT: firrtl.strictconnect %b, %2
+    b <= a.0.0.bar
+
 ;// -----
 
 FIRRTL version 3.0.0


### PR DESCRIPTION
Change the FIRRTL lexer to make it context sensitive when parsing fields. This is necessary for situations like "foo.0.0.bar" where lexing after "foo." will lex a float when it needs to lex an integer.  There are other ways of fixing this on the FIRRTL specification side, but this is allowable by the SFC today.

In Chisel, this enables usage of a MixedVec inside a MixedVec.

Fixes #5110.

The fact that we need context-sensitive lexing is troubling. There are discussions on https://github.com/chipsalliance/firrtl-spec/pull/101 on ways to rework the FIRRTL spec to avoid needing this.