### PR TITLE
[HandshakeToHW] Add `handshake.instance` lowering

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -117,6 +117,7 @@ def FuncOp : Op<Handshake_Dialect, "func", [
 // InstanceOp
 def InstanceOp : Handshake_Op<"instance", [
     CallOpInterface,
+    HasClock,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>
 ]> {
   let summary = "module instantiate operation";

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -259,13 +259,17 @@ static HWModuleLike checkSubModuleOp(mlir::ModuleOp parentModule,
 
 static HWModuleLike checkSubModuleOp(mlir::ModuleOp parentModule,
                                      Operation *oldOp) {
-  auto moduleOp = checkSubModuleOp(parentModule, getSubModuleName(oldOp));
+  HWModuleLike targetModule;
+  if (auto instanceOp = dyn_cast<handshake::InstanceOp>(oldOp))
+    targetModule = checkSubModuleOp(parentModule, instanceOp.getModule());
+  else
+    targetModule = checkSubModuleOp(parentModule, getSubModuleName(oldOp));
 
   if (isa<handshake::InstanceOp>(oldOp))
-    assert(moduleOp &&
+    assert(targetModule &&
            "handshake.instance target modules should always have been lowered "
            "before the modules that reference them!");
-  return moduleOp;
+  return targetModule;
 }
 
 /// Returns a vector of PortInfo's which defines the HW interface of the
@@ -728,6 +732,7 @@ public:
     if (!implModule) {
       auto portInfo = ModulePortInfo(getPortInfoForOp(op));
 
+      submoduleBuilder.setInsertionPoint(op->getParentOp());
       implModule = submoduleBuilder.create<hw::HWModuleOp>(
           op.getLoc(), submoduleBuilder.getStringAttr(getSubModuleName(op)),
           portInfo, [&](OpBuilder &b, hw::HWModulePortAccessor &ports) {
@@ -1020,6 +1025,20 @@ public:
     unwrappedIO.inputs.erase(unwrappedIO.inputs.begin());
     buildMuxLogic(s, unwrappedIO, select);
   };
+};
+
+class InstanceConversionPattern
+    : public HandshakeConversionPattern<handshake::InstanceOp> {
+public:
+  using HandshakeConversionPattern<
+      handshake::InstanceOp>::HandshakeConversionPattern;
+  void buildModule(handshake::InstanceOp op, BackedgeBuilder &bb, RTLBuilder &s,
+                   hw::HWModulePortAccessor &ports) const override {
+    assert(false &&
+           "If we indeed perform conversion in post-order, this "
+           "should never be called. The base HandshakeConversionPattern logic "
+           "will instantiate the external module.");
+  }
 };
 
 class ReturnConversionPattern
@@ -1874,6 +1893,7 @@ static LogicalResult convertFuncOp(ESITypeConverter &typeConverter,
       SourceConversionPattern, SinkConversionPattern, ConstantConversionPattern,
       MergeConversionPattern, ControlMergeConversionPattern,
       LoadConversionPattern, StoreConversionPattern, MemoryConversionPattern,
+      InstanceConversionPattern,
       // Arith operations.
       ExtendConversionPattern<arith::ExtUIOp, /*signExtend=*/false>,
       ExtendConversionPattern<arith::ExtSIOp, /*signExtend=*/true>,
@@ -1916,7 +1936,8 @@ public:
     ConversionTarget target(getContext());
     // All top-level logic of a handshake module will be the interconnectivity
     // between instantiated modules.
-    target.addLegalOp<hw::HWModuleOp, hw::OutputOp, hw::InstanceOp>();
+    target.addLegalOp<hw::HWModuleOp, hw::HWModuleExternOp, hw::OutputOp,
+                      hw::InstanceOp>();
     target
         .addIllegalDialect<handshake::HandshakeDialect, arith::ArithDialect>();
 

--- a/test/Conversion/HandshakeToHW/test_instance.mlir
+++ b/test/Conversion/HandshakeToHW/test_instance.mlir
@@ -1,0 +1,42 @@
+// RUN: circt-opt -lower-handshake-to-hw -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   hw.module @foo(
+// CHECK-SAME:                   %[[VAL_0:.*]]: !esi.channel<i32>,
+// CHECK-SAME:                   %[[VAL_1:.*]]: i1,
+// CHECK-SAME:                   %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i32>) {
+// CHECK:           hw.output %[[VAL_0]] : !esi.channel<i32>
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @bar(
+// CHECK-SAME:                   %[[VAL_0:.*]]: !esi.channel<i32>,
+// CHECK-SAME:                   %[[VAL_1:.*]]: i1,
+// CHECK-SAME:                   %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<i32>) {
+// CHECK:           %[[VAL_3:.*]] = hw.instance "foo0" @foo(in: %[[VAL_0]]: !esi.channel<i32>, clock: %[[VAL_1]]: i1, reset: %[[VAL_2]]: i1) -> (out0: !esi.channel<i32>)
+// CHECK:           hw.output %[[VAL_3]] : !esi.channel<i32>
+// CHECK:         }
+handshake.func @foo(%in : i32) -> (i32) {
+    handshake.return %in : i32
+}
+
+handshake.func @bar(%in : i32) -> (i32) {
+    %out = handshake.instance @foo(%in) : (i32) -> (i32)
+    handshake.return %out : i32
+}
+
+// -----
+
+// CHECK:         hw.module.extern @foo(%[[VAL_4:.*]]: !esi.channel<i32>, %[[VAL_5:.*]]: i1, %[[VAL_6:.*]]: i1) -> (out0: !esi.channel<i32>)
+
+// CHECK-LABEL:   hw.module @bar(
+// CHECK-SAME:                   %[[VAL_4]]: !esi.channel<i32>,
+// CHECK-SAME:                   %[[VAL_5]]: i1,
+// CHECK-SAME:                   %[[VAL_6]]: i1) -> (out0: !esi.channel<i32>) {
+// CHECK:           %[[VAL_0:.*]] = hw.instance "foo0" @foo(in: %[[VAL_4]]: !esi.channel<i32>, clock: %[[VAL_5]]: i1, reset: %[[VAL_6]]: i1) -> (out0: !esi.channel<i32>)
+// CHECK:           hw.output %[[VAL_0]] : !esi.channel<i32>
+// CHECK:         }
+handshake.func @foo(%in : i32) -> (i32)
+
+handshake.func @bar(%in : i32) -> (i32) {
+    %out = handshake.instance @foo(%in) : (i32) -> (i32)
+    handshake.return %out : i32
+}


### PR DESCRIPTION
+adds missing "hasClock" attribute from `InstanceOp`.
+always sets the insertion point for the `SubModuleBuilder` (some funk was happening where, sometimes, the insertion point of it would be inside the `hw.module` from which the `handshake.func` was converted from.