### PR TITLE
[ESI] ESI CPP Cosim API -> ESI CPP API

### DIFF
--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -252,7 +252,7 @@ class System:
       # defined so we can go through and output the typedefs delcarations.
       lambda sys: TypeAlias.declare_aliases(sys.mod),
       "builtin.module(lower-hwarith-to-hw, msft-lower-constructs, msft-lower-instances)",
-      "builtin.module(esi-emit-cpp-cosim-api{{output-file=ESISystem.h}})",
+      "builtin.module(esi-emit-cpp-api{{output-file=ESISystem.h}})",
       "builtin.module(esi-emit-collateral{{tops={tops} schema-file=schema.capnp}})",
       "builtin.module(esi-clean-metadata)",
       "builtin.module(lower-msft-to-hw{{verilog-file={verilog_file}}})",

--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -28,7 +28,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createESIPortLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESITypeLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESItoHWPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIConnectServicesPass();
-std::unique_ptr<OperationPass<ModuleOp>> createESIAddCPPCosimAPIPass();
+std::unique_ptr<OperationPass<ModuleOp>> createESIAddCPPAPIPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESICleanMetadataPass();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/ESI/ESIPasses.td
+++ b/include/circt/Dialect/ESI/ESIPasses.td
@@ -24,9 +24,9 @@ def ESIConnectServices : Pass<"esi-connect-services", "mlir::ModuleOp"> {
     "circt::comb::CombDialect"];
 }
 
-def ESIAddCPPCosimAPI: Pass<"esi-emit-cpp-cosim-api", "mlir::ModuleOp"> {
+def ESIAddCPPAPI: Pass<"esi-emit-cpp-api", "mlir::ModuleOp"> {
   let summary = "Add C++ cosimulation API to the module";
-  let constructor = "circt::esi::createESIAddCPPCosimAPIPass()";
+  let constructor = "circt::esi::createESIAddCPPAPIPass()";
   let dependentDialects = ["circt::sv::SVDialect"];
     let options = [
     Option<"outputFile", "output-file", "std::string",

--- a/integration_test/ESI/cosim/loopback-cpp/loopback.mlir
+++ b/integration_test/ESI/cosim/loopback-cpp/loopback.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: esi-cosim
 // RUN: rm -rf %t && mkdir %t && cd %t
-// RUN: circt-opt %s --esi-connect-services --esi-emit-cpp-cosim-api="output-file=ESISystem.h" --esi-emit-collateral=schema-file=%t/schema.capnp --esi-clean-metadata > %t/4.mlir
+// RUN: circt-opt %s --esi-connect-services --esi-emit-cpp-api="output-file=ESISystem.h" --esi-emit-collateral=schema-file=%t/schema.capnp --esi-clean-metadata > %t/4.mlir
 // RUN: circt-opt %t/4.mlir --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw --export-split-verilog -o %t/3.mlir
 // RUN: circt-translate %t/4.mlir -export-esi-capnp -verify-diagnostics > %t/schema.capnp
 

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -23,10 +23,10 @@ set(srcs
 
   cosim/APIUtilities.cpp
 
-  # C++ cosimulation API
-  cosim/CPP/ESIAddCPPCosimAPI.cpp
-  cosim/CPP/ESIEmitCPPCosimAPI.cpp
-  cosim/CPP/CPPCosimAPI.cpp
+  # C++ API
+  cosim/CPP/ESIAddCPPAPI.cpp
+  cosim/CPP/ESIEmitCPPAPI.cpp
+  cosim/CPP/CPPAPI.cpp
 )
 
 set(ESI_RUNTIME_DIR ${CIRCT_BINARY_DIR}/include/circt/Dialect/ESI)

--- a/lib/Dialect/ESI/cosim/CPP/CPPAPI.cpp
+++ b/lib/Dialect/ESI/cosim/CPP/CPPAPI.cpp
@@ -1,4 +1,4 @@
-//===- CPPCosimAPI.cpp ------------------------------------------*- C++ -*-===//
+//===- CPPAPI.cpp -----------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  Code for generating the ESI C++ cosimulation API.
+//  Code for generating the ESI C++ API.
 //
 //===----------------------------------------------------------------------===//
 
-#include "CPPCosimAPI.h"
+#include "CPPAPI.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 #include "circt/Dialect/HW/HWDialect.h"
@@ -31,7 +31,7 @@
 
 using namespace circt;
 using namespace esi;
-using namespace cppcosimapi;
+using namespace cppapi;
 
 //===----------------------------------------------------------------------===//
 // CPPType class implementation.

--- a/lib/Dialect/ESI/cosim/CPP/CPPAPI.h
+++ b/lib/Dialect/ESI/cosim/CPP/CPPAPI.h
@@ -1,4 +1,4 @@
-//===- CPPCosimAPI.h - ESI C++ cosim api ------------------------*- C++ -*-===//
+//===- CPPAPI.h - ESI C++ api -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Code for generating the ESI C++ cosimulation API.
+// Code for generating the ESI C++ API.
 //
 //===----------------------------------------------------------------------===//
 
 // NOLINTNEXTLINE(llvm-header-guard)
-#ifndef CIRCT_DIALECT_ESI_COSIM_CPPAPI_CPPCOSIMAPI_H
-#define CIRCT_DIALECT_ESI_COSIM_CPPAPI_CPPCOSIMAPI_H
+#ifndef CIRCT_DIALECT_ESI_CPPAPI_CPPAPI_H
+#define CIRCT_DIALECT_ESI_CPPAPI_CPPAPI_H
 
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/ESI/cosim/APIUtilities.h"
@@ -24,11 +24,10 @@
 
 namespace circt {
 namespace esi {
-namespace cppcosimapi {
+namespace cppapi {
 
-// Writes the C++ cosimulation API for the given module to the provided
-// output stream.
-LogicalResult exportCosimCPPAPI(ModuleOp module, llvm::raw_ostream &os);
+// Writes the C++ API for the given module to the provided output stream.
+LogicalResult exportCPPAPI(ModuleOp module, llvm::raw_ostream &os);
 
 // Generate and reason about a C++ type for a particular Cap'nProto and MLIR
 // type.
@@ -36,7 +35,7 @@ class CPPType : public ESICosimType {
 public:
   using ESICosimType::ESICosimType;
 
-  /// Returns true if the type is supported for cosimulation.
+  /// Returns true if the type is supported for the CPP API.
   bool isSupported() const override;
 
   /// Write out the C++ name of this type.
@@ -63,9 +62,9 @@ struct CPPEndpoint {
 
   esi::ServicePortInfo portInfo;
 
-  // A mapping of MLIR types to their CPPType counterparts. Ensures consistency
-  // between the emitted type signatures and those used in the service endpoint
-  // API.
+  // A mapping of MLIR types to their CPPType counterparts. Ensures
+  // consistency between the emitted type signatures and those used in the
+  // service endpoint API.
   const llvm::MapVector<mlir::Type, CPPType> &types;
 };
 
@@ -111,7 +110,7 @@ private:
   SmallVectorImpl<CPPService> &cppServices;
 };
 
-} // namespace cppcosimapi
+} // namespace cppapi
 } // namespace esi
 } // namespace circt
 

--- a/lib/Dialect/ESI/cosim/CPP/ESIAddCPPAPI.cpp
+++ b/lib/Dialect/ESI/cosim/CPP/ESIAddCPPAPI.cpp
@@ -1,4 +1,4 @@
-//===- ESIAddCPPCosimAPI.cpp - ESI C++ cosim API addition -------*- C++ -*-===//
+//===- ESIAddCPPAPI.cpp - ESI C++ API addition ------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Add the C++ ESI Capnp cosim API into the current module.
+// Add the C++ ESI API into the current module.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,7 +24,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/JSON.h"
 
-#include "CPPCosimAPI.h"
+#include "CPPAPI.h"
 
 #include <iostream>
 #include <memory>
@@ -32,38 +32,30 @@
 using namespace mlir;
 using namespace circt;
 using namespace circt::esi;
-using namespace cppcosimapi;
+using namespace cppapi;
 
 namespace {
-struct ESIAddCPPCosimAPIPass
-    : public ESIAddCPPCosimAPIBase<ESIAddCPPCosimAPIPass> {
+struct ESIAddCPPAPIPass : public ESIAddCPPAPIBase<ESIAddCPPAPIPass> {
   void runOnOperation() override;
 
   LogicalResult emitAPI(llvm::raw_ostream &os);
 };
 } // anonymous namespace
 
-LogicalResult ESIAddCPPCosimAPIPass::emitAPI(llvm::raw_ostream &os) {
+LogicalResult ESIAddCPPAPIPass::emitAPI(llvm::raw_ostream &os) {
   ModuleOp mod = getOperation();
-  return exportCosimCPPAPI(mod, os);
+  return exportCPPAPI(mod, os);
 }
 
-void ESIAddCPPCosimAPIPass::runOnOperation() {
+void ESIAddCPPAPIPass::runOnOperation() {
   ModuleOp mod = getOperation();
   auto *ctxt = &getContext();
-
-  // Check for cosim endpoints in the design. If the design doesn't have any
-  // we don't need a schema.
-  WalkResult cosimWalk =
-      mod.walk([](CosimEndpointOp _) { return WalkResult::interrupt(); });
-  if (!cosimWalk.wasInterrupted())
-    return;
 
   // Generate the API.
   std::string apiStrBuffer;
   llvm::raw_string_ostream os(apiStrBuffer);
   if (failed(emitAPI(os))) {
-    mod.emitError("Failed to emit ESI C++ cosim API");
+    mod.emitError("Failed to emit ESI C++ API");
     return;
   }
 
@@ -83,7 +75,6 @@ void ESIAddCPPCosimAPIPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>>
-circt::esi::createESIAddCPPCosimAPIPass() {
-  return std::make_unique<ESIAddCPPCosimAPIPass>();
+std::unique_ptr<OperationPass<ModuleOp>> circt::esi::createESIAddCPPAPIPass() {
+  return std::make_unique<ESIAddCPPAPIPass>();
 }

--- a/test/Dialect/ESI/cpp_cosim.mlir
+++ b/test/Dialect/ESI/cpp_cosim.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --esi-emit-cpp-cosim-api="to-stderr=true" -o %t 2>&1 | FileCheck %s
+// RUN: circt-opt %s --esi-emit-cpp-api="to-stderr=true" -o %t 2>&1 | FileCheck %s
 
 !TWrite = !esi.channel<!hw.struct<addr: i32, data: i8>>
 


### PR DESCRIPTION
Removes most of the prose about an "ESI CPP cosim API", which is not a thing.

I expect that we have to do further refactorings whenever we have more backends than just the cosimulation backend, but we'll cross that bridge when we get there.