### PR TITLE
[FIRRTL] Fix enumcreate printed form

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2910,7 +2910,7 @@ LogicalResult FEnumCreateOp::verify() {
 void FEnumCreateOp::print(OpAsmPrinter &printer) {
   printer << ' ';
   printer.printKeywordOrString(getFieldName());
-  printer << '(' << getFieldName() << ')';
+  printer << '(' << getInput() << ')';
   SmallVector<StringRef> elidedAttrs = {"fieldIndex"};
   printer.printOptionalAttrDictWithKeyword((*this)->getAttrs(), elidedAttrs);
   printer << " : " << getResult().getType();

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -198,14 +198,20 @@ firrtl.module @InnerSymAttr() {
 firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
                         out %out : !firrtl.uint<2>, out %tag : !firrtl.uint<1>) {
   %v = firrtl.subtag %in[b] : !firrtl.enum<a: uint<1>, b: uint<2>>
+  // CHECK: = firrtl.subtag %in[b] : !firrtl.enum<a: uint<1>, b: uint<2>>
+
   %t = firrtl.tagextract %in : !firrtl.enum<a: uint<1>, b: uint<2>>
+  // CHECK: = firrtl.tagextract %in : !firrtl.enum<a: uint<1>, b: uint<2>>
+
   firrtl.strictconnect %out, %v : !firrtl.uint<2>
   firrtl.strictconnect %tag, %t : !firrtl.uint<1>
 
   %p = firrtl.istag %in a : !firrtl.enum<a: uint<1>, b: uint<2>>
+  // CHECK: = firrtl.istag %in a : !firrtl.enum<a: uint<1>, b: uint<2>>
 
-  %c1_u1 = firrtl.constant 0 : !firrtl.uint<8>
-  %some = firrtl.enumcreate Some(%c1_u1) : !firrtl.enum<None: uint<0>, Some: uint<8>>
+  %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
+  %some = firrtl.enumcreate Some(%c1_ui8) : !firrtl.enum<None: uint<0>, Some: uint<8>>
+  // CHECK: = firrtl.enumcreate Some(%c1_ui8) : !firrtl.enum<None: uint<0>, Some: uint<8>>
 
   firrtl.match %in : !firrtl.enum<a: uint<1>, b: uint<2>> {
     case a(%arg0) {
@@ -215,5 +221,14 @@ firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
       %x = firrtl.wire : !firrtl.uint<1>
     }
   }
+  // CHECK: firrtl.match %in : !firrtl.enum<a: uint<1>, b: uint<2>> {
+  // CHECK:   case a(%arg0) {
+  // CHECK:     %w = firrtl.wire : !firrtl.uint<1>
+  // CHECK:   }
+  // CHECK:   case b(%arg0) {
+  // CHECK:     %x = firrtl.wire : !firrtl.uint<1>
+  // CHECK:   }
+  // CHECK: }
+
 }
 }


### PR DESCRIPTION
The printer for enumcreate was accidentally printing the tag string instead of the input SSA value.  This fixes the problem while also adding some CHECK lines in the basic IR test for the enumeration related operations.