### PR TITLE
[FIRRTL][LowerMatches] Fix matches with 0 and 1 variants

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
@@ -74,7 +74,7 @@ static void lowerMatch(MatchOp match) {
 }
 
 void LowerMatchesPass::runOnOperation() {
-  getOperation()->walk<mlir::WalkOrder::PostOrder>(&lowerMatch);
+  getOperation()->walk(&lowerMatch);
   markAnalysesPreserved<InstanceGraph>();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
@@ -26,10 +26,16 @@ class LowerMatchesPass : public LowerMatchesBase<LowerMatchesPass> {
 } // end anonymous namespace
 
 static void lowerMatch(MatchOp match) {
-  ImplicitLocOpBuilder b(match.getLoc(), match);
 
-  auto input = match.getInput();
+  // If this is an empty enumeration statement, just delete the match.
   auto numCases = match->getNumRegions();
+  if (!numCases) {
+    match->erase();
+    return;
+  }
+
+  ImplicitLocOpBuilder b(match.getLoc(), match);
+  auto input = match.getInput();
   for (size_t i = 0; i < numCases - 1; ++i) {
     // Create a WhenOp which tests the enum's tag.
     auto condition = b.create<IsTagOp>(input, match.getFieldIndexAttr(i));
@@ -51,25 +57,24 @@ static void lowerMatch(MatchOp match) {
     b.setInsertionPointToStart(&when.getElseBlock());
   }
 
-  // The final else is not handled with a conditional, move the case block to
-  // the default block.
-  auto *defaultBlock = b.getInsertionBlock();
-  auto *caseBlock = &match->getRegions().back().front();
-  caseBlock->moveBefore(defaultBlock);
-  defaultBlock->erase();
+  // At this point, the insertion point is either in the final else-block, or
+  // if there was only 1 variant, right before the match operation.
 
   // Replace the block argument with a subtag op.
-  b.setInsertionPointToStart(caseBlock);
   auto data = b.create<SubtagOp>(input, match.getFieldIndexAttr(numCases - 1));
-  caseBlock->getArgument(0).replaceAllUsesWith(data);
-  caseBlock->eraseArgument(0);
 
-  // Erase the match op.
+  // Get the final block from the match statement, and splice it into the
+  // current insertion point.
+  auto *caseBlock = &match->getRegions().back().front();
+  caseBlock->getArgument(0).replaceAllUsesWith(data);
+  auto *defaultBlock = b.getInsertionBlock();
+  defaultBlock->getOperations().splice(b.getInsertionPoint(),
+                                       caseBlock->getOperations());
   match->erase();
 }
 
 void LowerMatchesPass::runOnOperation() {
-  getOperation()->walk(&lowerMatch);
+  getOperation()->walk<mlir::WalkOrder::PostOrder>(&lowerMatch);
   markAnalysesPreserved<InstanceGraph>();
 }
 

--- a/test/Dialect/FIRRTL/lower-matches.fir
+++ b/test/Dialect/FIRRTL/lower-matches.fir
@@ -2,6 +2,24 @@
 
 firrtl.circuit "LowerMatches" {
 
+// CHECK-LABEL: firrtl.module @EmptyEnum
+firrtl.module @EmptyEnum(in %enum : !firrtl.enum<>) {
+  firrtl.match %enum : !firrtl.enum<> {
+  }
+// CHECK-NEXT: }
+}
+
+// CHECK-LABEL: firrtl.module @OneVariant
+firrtl.module @OneVariant(in %enum : !firrtl.enum<a: uint<8>>, out %out : !firrtl.uint<8>) {
+  // CHECK: %0 = firrtl.subtag %enum[a] : !firrtl.enum<a: uint<8>>
+  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.uint<8>
+  firrtl.match %enum : !firrtl.enum<a: uint<8>> {
+    case a(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+    }
+  }
+}
+
 // CHECK-LABEL: firrtl.module @LowerMatches
 firrtl.module @LowerMatches(in %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>, out %out : !firrtl.uint<8>) {
 


### PR DESCRIPTION
This fixes two bugs in LowerMatches.

The first is when the match has no case statements, we would underflow an integer and crash assuming too many regions.  This was fixed by just deleting the match statement when there are no cases.

The second bug comes from a single case statement.  The code assumed that we would be inserting in to the `else` block of a WhenOp, and that it could replace the current block with the case's block.  This is not actually true when there is a single case, where the current block and insertion point is at the MatchOp.  We fix this by splicing the case's block in to the current insertion point.