### PR TITLE
[FIRRTL] Hoist common type-property methods up to FIRRTLType.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -68,19 +68,13 @@ struct PortInfo {
 
   /// Return true if this is an inout port.  This will be true if the port
   /// contains either bi-directional signals or analog types.
+  /// Non-HW types (e.g., ref types) are never considered InOut.
   bool isInOut() {
-    auto flags = TypeSwitch<Type, RecursiveTypeProperties>(type)
-                     .Case<FIRRTLBaseType>([](auto base) {
-                       return base.getRecursiveTypeProperties();
-                     })
-                     .Case<RefType>([](auto ref) {
-                       return ref.getType().getRecursiveTypeProperties();
-                     })
-                     .Default([](auto) {
-                       llvm_unreachable("unsupported type");
-                       return RecursiveTypeProperties{};
-                     });
-    return !flags.isPassive || flags.containsAnalog;
+    auto baseType = dyn_cast<FIRRTLBaseType>(type);
+    if (!baseType)
+      return false;
+
+    return !baseType.isPassive() || baseType.containsAnalog();
   }
 
   /// Default constructors

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -66,36 +66,11 @@ public:
     return llvm::isa<FIRRTLDialect>(type.getDialect());
   }
 
-protected:
-  using Type::Type;
-};
+  /// Return the recursive properties of the type, containing the `isPassive`,
+  /// `containsAnalog`, and `hasUninferredWidth` bits, among others.
+  RecursiveTypeProperties getRecursiveTypeProperties() const;
 
-// Common base class for all base FIRRTL types.
-class FIRRTLBaseType
-    : public FIRRTLType::TypeBase<FIRRTLBaseType, FIRRTLType,
-                                  detail::FIRRTLBaseTypeStorage> {
-public:
-  using Base::Base;
-
-  /// Return true if this is a "passive" type - one that contains no "flip"
-  /// types recursively within itself.
-  bool isPassive() const { return getRecursiveTypeProperties().isPassive; }
-
-  /// Returns true if this is a non-const "passive" that which is not analog.
-  bool isRegisterType() {
-    return isPassive() && !containsAnalog() && !containsConst();
-  }
-
-  /// Return true if this is a 'ground' type, aka a non-aggregate type.
-  bool isGround();
-
-  /// Return true if this is a "passive" type - one that contains no "flip"
-  /// types recursively within itself.
-  bool isPassive() { return getRecursiveTypeProperties().isPassive; }
-
-  /// Returns true if this is a 'const' type that can only hold compile-time
-  /// constant values
-  bool isConst();
+  /// Convenience methods for accessing recursive type properties:
 
   /// Returns true if this is or contains a 'const' type.
   bool containsConst() { return getRecursiveTypeProperties().containsConst; }
@@ -118,9 +93,33 @@ public:
     return getRecursiveTypeProperties().hasUninferredReset;
   }
 
-  /// Return the recursive properties of the type, containing the `isPassive`,
-  /// `containsAnalog`, and `hasUninferredWidth` bits.
-  RecursiveTypeProperties getRecursiveTypeProperties() const;
+  /// Type classifications:
+
+  /// Return true if this is a 'ground' type, aka a non-aggregate type.
+  bool isGround();
+
+  /// Returns true if this is a 'const' type that can only hold compile-time
+  /// constant values
+  bool isConst();
+
+protected:
+  using Type::Type;
+};
+
+// Common base class for all base FIRRTL types.
+class FIRRTLBaseType
+    : public FIRRTLType::TypeBase<FIRRTLBaseType, FIRRTLType,
+                                  detail::FIRRTLBaseTypeStorage> {
+public:
+  using Base::Base;
+
+  /// Returns true if this is a 'const' type that can only hold compile-time
+  /// constant values
+  bool isConst();
+
+  /// Return true if this is a "passive" type - one that contains no "flip"
+  /// types recursively within itself.
+  bool isPassive() const { return getRecursiveTypeProperties().isPassive; }
 
   /// Return this type with any flip types recursively removed from itself.
   FIRRTLBaseType getPassiveType();
@@ -148,8 +147,15 @@ public:
     return llvm::isa<FIRRTLDialect>(type.getDialect()) && !type.isa<RefType>();
   }
 
+  /// Returns true if this is a non-const "passive" that which is not analog.
+  bool isRegisterType() {
+    return isPassive() && !containsAnalog() && !containsConst();
+  }
+
   /// Return true if this is a valid "reset" type.
   bool isResetType();
+
+  /// Hooks for hw::FieldIDTypeInterface methods.
 
   /// Get the maximum field ID of this type.  For integers and other ground
   /// types, there are no subfields and the maximum field ID is 0.  For bundle

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -70,7 +70,9 @@ public:
   /// `containsAnalog`, and `hasUninferredWidth` bits, among others.
   RecursiveTypeProperties getRecursiveTypeProperties() const;
 
-  /// Convenience methods for accessing recursive type properties:
+  //===--------------------------------------------------------------------===//
+  // Convenience methods for accessing recursive type properties
+  //===--------------------------------------------------------------------===//
 
   /// Returns true if this is or contains a 'const' type.
   bool containsConst() { return getRecursiveTypeProperties().containsConst; }
@@ -93,7 +95,9 @@ public:
     return getRecursiveTypeProperties().hasUninferredReset;
   }
 
-  /// Type classifications:
+  //===--------------------------------------------------------------------===//
+  // Type classifications
+  //===--------------------------------------------------------------------===//
 
   /// Return true if this is a 'ground' type, aka a non-aggregate type.
   bool isGround();
@@ -155,7 +159,9 @@ public:
   /// Return true if this is a valid "reset" type.
   bool isResetType();
 
-  /// Hooks for hw::FieldIDTypeInterface methods.
+  //===--------------------------------------------------------------------===//
+  // hw::FieldIDTypeInterface
+  //===--------------------------------------------------------------------===//
 
   /// Get the maximum field ID of this type.  For integers and other ground
   /// types, there are no subfields and the maximum field ID is 0.  For bundle

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -430,6 +430,11 @@ def RefImpl : FIRRTLImplType<"Ref",
     TypeBuilderWithInferredContext<(ins "::circt::firrtl::FIRRTLBaseType":$type,
                                         CArg<"bool", "false">:$forceable)>
   ];
+
+  let extraClassDeclaration = [{
+    /// Return the recursive properties of the type.
+    RecursiveTypeProperties getRecursiveTypeProperties() const;
+  }];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -457,17 +457,8 @@ RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() const {
         return RecursiveTypeProperties{
             true, false, true, type.isConst(), !type.hasWidth(), false};
       })
-      .Case<BundleType>([](BundleType bundleType) {
-        return bundleType.getRecursiveTypeProperties();
-      })
-      .Case<FVectorType>([](FVectorType vectorType) {
-        return vectorType.getRecursiveTypeProperties();
-      })
-      .Case<FEnumType>([](FEnumType enumType) {
-        return enumType.getRecursiveTypeProperties();
-      })
-      .Case<RefType>(
-          [](auto refType) { return refType.getRecursiveTypeProperties(); })
+      .Case<BundleType, FVectorType, FEnumType, RefType>(
+          [](auto type) { return type.getRecursiveTypeProperties(); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return RecursiveTypeProperties{};

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1478,7 +1478,7 @@ std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
 
 RecursiveTypeProperties RefType::getRecursiveTypeProperties() const {
   auto rtp = getType().getRecursiveTypeProperties();
-  rtp.containsReference |= true;
+  rtp.containsReference = true;
   // References are not "passive", per FIRRTL spec.
   rtp.isPassive = false;
   return rtp;


### PR DESCRIPTION
Split out queries that are reasonable for all FIRRTLType's, leave the rest in FIRRTLBaseType.

Notably:

* RefType is not passive, nor ground.
* isPassive() and getPassiveType() only on FIRRTLBaseType.
* isConst is supported on all FIRRTLType's.

Note that RTP is not stored for all types, but make these properties and basic
predicates using them, part of all FIRRTLType's.