### PR TITLE
[HW] Remove `getGroundFields` from `FieldIDTypeInterface`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -173,11 +173,6 @@ public:
   /// subfield op. Returns the new id and whether the id is in the given
   /// child.
   std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
-
-  /// Get the number of ground (non-aggregate) fields in the type.  A field
-  /// which is a bundle or vector is not counted, but the recursive ground
-  /// fields of are.
-  uint64_t getGroundFields() const;
 };
 
 /// Returns whether the two types are equivalent.  This implements the exact

--- a/include/circt/Dialect/HW/HWTypeInterfaces.td
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.td
@@ -45,14 +45,6 @@ def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
       child.
     }], "std::pair<uint64_t, bool>", "rootChildFieldID",
     (ins "uint64_t":$fieldID, "uint64_t":$index)>,
-
-    InterfaceMethod<[{
-      Returns the effective field id when treating the index field as the
-      root of the type.  Essentially maps a fieldID to a fieldID after a
-      subfield op. Returns the new id and whether the id is in the given
-      child.
-    }], "uint64_t", "getGroundFields">
-
   ];
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -624,20 +624,6 @@ std::pair<uint64_t, bool> FIRRTLBaseType::rootChildFieldID(uint64_t fieldID,
       });
 }
 
-uint64_t FIRRTLBaseType::getGroundFields() const {
-  return TypeSwitch<FIRRTLBaseType, uint64_t>(*this)
-      .Case<BundleType>([](auto type) {
-        unsigned sum = 0;
-        for (auto &field : type.getElements())
-          sum += field.type.getGroundFields();
-        return sum;
-      })
-      .Case<FVectorType>([](auto type) {
-        return type.getNumElements() * type.getElementType().getGroundFields();
-      })
-      .Default([](Type) { return 1; });
-}
-
 /// Helper to implement the equivalence logic for a pair of bundle elements.
 /// Note that the FIRRTL spec requires bundle elements to have the same
 /// orientation, but this only compares their passive types. The FIRRTL dialect
@@ -1475,8 +1461,6 @@ std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
                                                     uint64_t index) const {
   return {0, fieldID == 0};
 }
-
-uint64_t RefType::getGroundFields() const { return 1; }
 
 //===----------------------------------------------------------------------===//
 // AnalogType


### PR DESCRIPTION
This function does not appear to be used anywhere. I am motivated to remove it as I don't know what value to return for union-like types.