### PR TITLE
[HW] Apply some clang-tidy suggestions

### DIFF
--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -132,9 +132,9 @@ bool OutputFileAttr::isDirectory() {
 
 /// Option         ::= 'excludeFromFileList' | 'includeReplicatedOp'
 /// OutputFileAttr ::= 'output_file<' directory ',' name (',' Option)* '>'
-Attribute OutputFileAttr::parse(AsmParser &p, Type type) {
+Attribute OutputFileAttr::parse(AsmParser &odsParser, Type type) {
   StringAttr filename;
-  if (p.parseLess() || p.parseAttribute<StringAttr>(filename))
+  if (odsParser.parseLess() || odsParser.parseAttribute<StringAttr>(filename))
     return Attribute();
 
   // Parse the additional keyword attributes.  Its easier to let people specify
@@ -142,32 +142,32 @@ Attribute OutputFileAttr::parse(AsmParser &p, Type type) {
   bool excludeFromFileList = false;
   bool includeReplicatedOps = false;
   while (true) {
-    if (p.parseOptionalComma())
+    if (odsParser.parseOptionalComma())
       break;
-    if (!p.parseOptionalKeyword("excludeFromFileList"))
+    if (!odsParser.parseOptionalKeyword("excludeFromFileList"))
       excludeFromFileList = true;
-    else if (!p.parseKeyword("includeReplicatedOps",
-                             "or 'excludeFromFileList'"))
+    else if (!odsParser.parseKeyword("includeReplicatedOps",
+                                     "or 'excludeFromFileList'"))
       includeReplicatedOps = true;
     else
       return Attribute();
   }
 
-  if (p.parseGreater())
+  if (odsParser.parseGreater())
     return Attribute();
 
-  return OutputFileAttr::getFromFilename(p.getContext(), filename.getValue(),
-                                         excludeFromFileList,
-                                         includeReplicatedOps);
+  return OutputFileAttr::getFromFilename(
+      odsParser.getContext(), filename.getValue(), excludeFromFileList,
+      includeReplicatedOps);
 }
 
-void OutputFileAttr::print(AsmPrinter &p) const {
-  p << "<" << getFilename();
+void OutputFileAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << getFilename();
   if (getExcludeFromFilelist().getValue())
-    p << ", excludeFromFileList";
+    odsPrinter << ", excludeFromFileList";
   if (getIncludeReplicatedOps().getValue())
-    p << ", includeReplicatedOps";
-  p << ">";
+    odsPrinter << ", includeReplicatedOps";
+  odsPrinter << ">";
 }
 
 //===----------------------------------------------------------------------===//
@@ -184,20 +184,22 @@ FileListAttr FileListAttr::getFromFilename(MLIRContext *context,
 // EnumFieldAttr
 //===----------------------------------------------------------------------===//
 
-Attribute EnumFieldAttr::parse(AsmParser &p, Type) {
+Attribute EnumFieldAttr::parse(AsmParser &odsParser, Type) {
   StringRef field;
   Type type;
-  if (p.parseLess() || p.parseKeyword(&field) || p.parseComma() ||
-      p.parseType(type) || p.parseGreater())
+  if (odsParser.parseLess() || odsParser.parseKeyword(&field) ||
+      odsParser.parseComma() || odsParser.parseType(type) ||
+      odsParser.parseGreater())
     return Attribute();
-  return EnumFieldAttr::get(p.getEncodedSourceLoc(p.getCurrentLocation()),
-                            StringAttr::get(p.getContext(), field), type);
+  return EnumFieldAttr::get(
+      odsParser.getEncodedSourceLoc(odsParser.getCurrentLocation()),
+      StringAttr::get(odsParser.getContext(), field), type);
 }
 
-void EnumFieldAttr::print(AsmPrinter &p) const {
-  p << "<" << getField().getValue() << ", ";
-  p.printType(getType().getValue());
-  p << ">";
+void EnumFieldAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << getField().getValue() << ", ";
+  odsPrinter.printType(getType().getValue());
+  odsPrinter << ">";
 }
 
 EnumFieldAttr EnumFieldAttr::get(Location loc, StringAttr value,
@@ -220,22 +222,22 @@ EnumFieldAttr EnumFieldAttr::get(Location loc, StringAttr value,
 // InnerRefAttr
 //===----------------------------------------------------------------------===//
 
-Attribute InnerRefAttr::parse(AsmParser &p, Type type) {
+Attribute InnerRefAttr::parse(AsmParser &odsParser, Type type) {
   SymbolRefAttr attr;
-  if (p.parseLess() || p.parseAttribute<SymbolRefAttr>(attr) ||
-      p.parseGreater())
+  if (odsParser.parseLess() || odsParser.parseAttribute<SymbolRefAttr>(attr) ||
+      odsParser.parseGreater())
     return Attribute();
   if (attr.getNestedReferences().size() != 1)
     return Attribute();
   return InnerRefAttr::get(attr.getRootReference(), attr.getLeafReference());
 }
 
-void InnerRefAttr::print(AsmPrinter &p) const {
-  p << "<";
-  p.printSymbolName(getModule().getValue());
-  p << "::";
-  p.printSymbolName(getName().getValue());
-  p << ">";
+void InnerRefAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<";
+  odsPrinter.printSymbolName(getModule().getValue());
+  odsPrinter << "::";
+  odsPrinter.printSymbolName(getName().getValue());
+  odsPrinter << ">";
 }
 
 //===----------------------------------------------------------------------===//
@@ -346,71 +348,75 @@ void InnerSymAttr::print(AsmPrinter &odsPrinter) const {
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//
 
-Attribute ParamDeclAttr::parse(AsmParser &p, Type trailing) {
+Attribute ParamDeclAttr::parse(AsmParser &odsParser, Type odsType) {
   std::string name;
   Type type;
   Attribute value;
   // < "FOO" : i32 > : i32
   // < "FOO" : i32 = 0 > : i32
   // < "FOO" : none >
-  if (p.parseLess() || p.parseString(&name) || p.parseColonType(type))
+  if (odsParser.parseLess() || odsParser.parseString(&name) ||
+      odsParser.parseColonType(type))
     return Attribute();
 
-  if (succeeded(p.parseOptionalEqual())) {
-    if (p.parseAttribute(value, type))
+  if (succeeded(odsParser.parseOptionalEqual())) {
+    if (odsParser.parseAttribute(value, type))
       return Attribute();
   }
 
-  if (p.parseGreater())
+  if (odsParser.parseGreater())
     return Attribute();
 
   if (value)
-    return ParamDeclAttr::get(p.getContext(),
-                              p.getBuilder().getStringAttr(name), type, value);
+    return ParamDeclAttr::get(odsParser.getContext(),
+                              odsParser.getBuilder().getStringAttr(name), type,
+                              value);
   return ParamDeclAttr::get(name, type);
 }
 
-void ParamDeclAttr::print(AsmPrinter &p) const {
-  p << "<" << getName() << ": " << getType();
+void ParamDeclAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << getName() << ": " << getType();
   if (getValue()) {
-    p << " = ";
-    p.printAttributeWithoutType(getValue());
+    odsPrinter << " = ";
+    odsPrinter.printAttributeWithoutType(getValue());
   }
-  p << ">";
+  odsPrinter << ">";
 }
 
 //===----------------------------------------------------------------------===//
 // ParamDeclRefAttr
 //===----------------------------------------------------------------------===//
 
-Attribute ParamDeclRefAttr::parse(AsmParser &p, Type type) {
+Attribute ParamDeclRefAttr::parse(AsmParser &odsParser, Type type) {
   StringAttr name;
-  if (p.parseLess() || p.parseAttribute(name) || p.parseGreater() ||
-      (!type && (p.parseColon() || p.parseType(type))))
+  if (odsParser.parseLess() || odsParser.parseAttribute(name) ||
+      odsParser.parseGreater() ||
+      (!type && (odsParser.parseColon() || odsParser.parseType(type))))
     return Attribute();
 
   return ParamDeclRefAttr::get(name, type);
 }
 
-void ParamDeclRefAttr::print(AsmPrinter &p) const {
-  p << "<" << getName() << ">";
+void ParamDeclRefAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << getName() << ">";
 }
 
 //===----------------------------------------------------------------------===//
 // ParamVerbatimAttr
 //===----------------------------------------------------------------------===//
 
-Attribute ParamVerbatimAttr::parse(AsmParser &p, Type type) {
+Attribute ParamVerbatimAttr::parse(AsmParser &odsParser, Type type) {
   StringAttr text;
-  if (p.parseLess() || p.parseAttribute(text) || p.parseGreater() ||
-      (!type && (p.parseColon() || p.parseType(type))))
+  if (odsParser.parseLess() || odsParser.parseAttribute(text) ||
+      odsParser.parseGreater() ||
+      (!type && (odsParser.parseColon() || odsParser.parseType(type))))
     return Attribute();
 
-  return ParamVerbatimAttr::get(p.getContext(), text, type);
+  return ParamVerbatimAttr::get(odsParser.getContext(), text, type);
 }
 
-void ParamVerbatimAttr::print(AsmPrinter &p) const {
-  p << "<" << getValue() << ">";
+void ParamVerbatimAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << getValue() << ">";
 }
 
 //===----------------------------------------------------------------------===//
@@ -879,10 +885,11 @@ TypedAttr ParamExprAttr::get(PEO opcode, ArrayRef<TypedAttr> operandsIn) {
   return Base::get(operands[0].getContext(), opcode, operands, type);
 }
 
-Attribute ParamExprAttr::parse(AsmParser &p, Type type) {
+Attribute ParamExprAttr::parse(AsmParser &odsParser, Type type) {
   // We require an opcode suffix like `#hw.param.expr.add`, we don't allow
   // parsing a plain `#hw.param.expr` on its own.
-  p.emitError(p.getNameLoc(), "#hw.param.expr should have opcode suffix");
+  odsParser.emitError(odsParser.getNameLoc(),
+                      "#hw.param.expr should have opcode suffix");
   return {};
 }
 
@@ -907,11 +914,12 @@ static Attribute parseParamExprWithOpcode(StringRef opcodeStr,
   return ParamExprAttr::get(*opcode, operands);
 }
 
-void ParamExprAttr::print(AsmPrinter &p) const {
-  p << "." << stringifyPEO(getOpcode()) << '<';
-  llvm::interleaveComma(getOperands(), p.getStream(),
-                        [&](Attribute op) { p.printAttributeWithoutType(op); });
-  p << '>';
+void ParamExprAttr::print(AsmPrinter &odsPrinter) const {
+  odsPrinter << "." << stringifyPEO(getOpcode()) << '<';
+  llvm::interleaveComma(
+      getOperands(), odsPrinter.getStream(),
+      [&](Attribute op) { odsPrinter.printAttributeWithoutType(op); });
+  odsPrinter << '>';
 }
 
 // Replaces any ParamDeclRefAttr within a parametric expression with its

--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -102,7 +102,7 @@ Operation *HWDialect::materializeConstant(OpBuilder &builder, Attribute value,
   }
 
   // Parameter expressions materialize into hw.param.value.
-  auto parentOp = builder.getBlock()->getParentOp();
+  auto *parentOp = builder.getBlock()->getParentOp();
   auto curModule = dyn_cast<HWModuleOp>(parentOp);
   if (!curModule)
     curModule = parentOp->getParentOfType<HWModuleOp>();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -322,29 +322,30 @@ LogicalResult ConstantOp::verify() {
 
 /// Build a ConstantOp from an APInt, infering the result type from the
 /// width of the APInt.
-void ConstantOp::build(OpBuilder &builder, OperationState &result,
+void ConstantOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                        const APInt &value) {
 
-  auto type = IntegerType::get(builder.getContext(), value.getBitWidth());
-  auto attr = builder.getIntegerAttr(type, value);
-  return build(builder, result, type, attr);
+  auto type = IntegerType::get(odsBuilder.getContext(), value.getBitWidth());
+  auto attr = odsBuilder.getIntegerAttr(type, value);
+  return build(odsBuilder, odsState, type, attr);
 }
 
 /// Build a ConstantOp from an APInt, infering the result type from the
 /// width of the APInt.
-void ConstantOp::build(OpBuilder &builder, OperationState &result,
+void ConstantOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                        IntegerAttr value) {
-  return build(builder, result, value.getType(), value);
+  return build(odsBuilder, odsState, value.getType(), value);
 }
 
 /// This builder allows construction of small signed integers like 0, 1, -1
 /// matching a specified MLIR IntegerType.  This shouldn't be used for general
 /// constant folding because it only works with values that can be expressed in
 /// an int64_t.  Use APInt's instead.
-void ConstantOp::build(OpBuilder &builder, OperationState &result, Type type,
-                       int64_t value) {
+void ConstantOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                       Type type, int64_t value) {
   auto numBits = type.cast<IntegerType>().getWidth();
-  build(builder, result, APInt(numBits, (uint64_t)value, /*isSigned=*/true));
+  build(odsBuilder, odsState,
+        APInt(numBits, (uint64_t)value, /*isSigned=*/true));
 }
 
 void ConstantOp::getAsmResultNames(
@@ -403,27 +404,27 @@ OpFoldResult WireOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
+LogicalResult WireOp::canonicalize(WireOp op, PatternRewriter &rewriter) {
   // Block if the wire has any attributes.
-  if (hasAdditionalAttributes(wire, {"sv.namehint"}))
+  if (hasAdditionalAttributes(op, {"sv.namehint"}))
     return failure();
 
   // If the wire has a symbol, then we can't delete it.
-  if (wire.getInnerSymAttr())
+  if (op.getInnerSymAttr())
     return failure();
 
   // If the wire has a name or an `sv.namehint` attribute, propagate it as an
   // `sv.namehint` to the expression.
-  if (auto *inputOp = wire.getInput().getDefiningOp()) {
-    auto name = wire.getNameAttr();
+  if (auto *inputOp = op.getInput().getDefiningOp()) {
+    auto name = op.getNameAttr();
     if (!name || name.getValue().empty())
-      name = wire->getAttrOfType<StringAttr>("sv.namehint");
+      name = op->getAttrOfType<StringAttr>("sv.namehint");
     if (name)
       rewriter.updateRootInPlace(
           inputOp, [&] { inputOp->setAttr("sv.namehint", name); });
   }
 
-  rewriter.replaceOp(wire, wire.getInput());
+  rewriter.replaceOp(op, op.getInput());
   return success();
 }
 
@@ -837,21 +838,21 @@ void hw::modifyModulePorts(
   moduleOp->setAttr("resultLocs", ArrayAttr::get(context, newResultLocs));
 }
 
-void HWModuleOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                        StringAttr name, const ModulePortInfo &ports,
                        ArrayAttr parameters,
                        ArrayRef<NamedAttribute> attributes, StringAttr comment,
                        bool shouldEnsureTerminator) {
-  buildModule<HWModuleOp>(builder, result, name, ports, parameters, attributes,
-                          comment);
+  buildModule<HWModuleOp>(odsBuilder, odsState, name, ports, parameters,
+                          attributes, comment);
 
   // Create a region and a block for the body.
-  auto *bodyRegion = result.regions[0].get();
+  auto *bodyRegion = odsState.regions[0].get();
   Block *body = new Block();
   bodyRegion->push_back(body);
 
   // Add arguments to the body block.
-  auto unknownLoc = builder.getUnknownLoc();
+  auto unknownLoc = odsBuilder.getUnknownLoc();
   for (auto port : ports.inputs) {
     auto loc = port.loc ? Location(port.loc) : unknownLoc;
     auto type = port.type;
@@ -861,16 +862,16 @@ void HWModuleOp::build(OpBuilder &builder, OperationState &result,
   }
 
   if (shouldEnsureTerminator)
-    HWModuleOp::ensureTerminator(*bodyRegion, builder, result.location);
+    HWModuleOp::ensureTerminator(*bodyRegion, odsBuilder, odsState.location);
 }
 
-void HWModuleOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                        StringAttr name, ArrayRef<PortInfo> ports,
                        ArrayAttr parameters,
                        ArrayRef<NamedAttribute> attributes,
                        StringAttr comment) {
-  build(builder, result, name, ModulePortInfo(ports), parameters, attributes,
-        comment);
+  build(odsBuilder, odsState, name, ModulePortInfo(ports), parameters,
+        attributes, comment);
 }
 
 void HWModuleOp::build(OpBuilder &builder, OperationState &odsState,
@@ -916,23 +917,23 @@ StringAttr HWModuleGeneratedOp::getVerilogModuleNameAttr() {
       ::mlir::SymbolTable::getSymbolAttrName());
 }
 
-void HWModuleExternOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleExternOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                              StringAttr name, const ModulePortInfo &ports,
                              StringRef verilogName, ArrayAttr parameters,
                              ArrayRef<NamedAttribute> attributes) {
-  buildModule<HWModuleExternOp>(builder, result, name, ports, parameters,
+  buildModule<HWModuleExternOp>(odsBuilder, odsState, name, ports, parameters,
                                 attributes, {});
 
   if (!verilogName.empty())
-    result.addAttribute("verilogName", builder.getStringAttr(verilogName));
+    odsState.addAttribute("verilogName", odsBuilder.getStringAttr(verilogName));
 }
 
-void HWModuleExternOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleExternOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                              StringAttr name, ArrayRef<PortInfo> ports,
                              StringRef verilogName, ArrayAttr parameters,
                              ArrayRef<NamedAttribute> attributes) {
-  build(builder, result, name, ModulePortInfo(ports), verilogName, parameters,
-        attributes);
+  build(odsBuilder, odsState, name, ModulePortInfo(ports), verilogName,
+        parameters, attributes);
 }
 
 void HWModuleExternOp::modifyPorts(
@@ -946,24 +947,24 @@ void HWModuleExternOp::modifyPorts(
 void HWModuleExternOp::appendOutputs(
     ArrayRef<std::pair<StringAttr, Value>> outputs) {}
 
-void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleGeneratedOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                                 FlatSymbolRefAttr genKind, StringAttr name,
                                 const ModulePortInfo &ports,
                                 StringRef verilogName, ArrayAttr parameters,
                                 ArrayRef<NamedAttribute> attributes) {
-  buildModule<HWModuleGeneratedOp>(builder, result, name, ports, parameters,
-                                   attributes, {});
-  result.addAttribute("generatorKind", genKind);
+  buildModule<HWModuleGeneratedOp>(odsBuilder, odsState, name, ports,
+                                   parameters, attributes, {});
+  odsState.addAttribute("generatorKind", genKind);
   if (!verilogName.empty())
-    result.addAttribute("verilogName", builder.getStringAttr(verilogName));
+    odsState.addAttribute("verilogName", odsBuilder.getStringAttr(verilogName));
 }
 
-void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
+void HWModuleGeneratedOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                                 FlatSymbolRefAttr genKind, StringAttr name,
                                 ArrayRef<PortInfo> ports, StringRef verilogName,
                                 ArrayAttr parameters,
                                 ArrayRef<NamedAttribute> attributes) {
-  build(builder, result, genKind, name, ModulePortInfo(ports), verilogName,
+  build(odsBuilder, odsState, genKind, name, ModulePortInfo(ports), verilogName,
         parameters, attributes);
 }
 
@@ -1104,10 +1105,8 @@ PortInfo hw::getModuleOutputPort(Operation *op, size_t idx) {
 }
 
 static bool hasAttribute(StringRef name, ArrayRef<NamedAttribute> attrs) {
-  for (auto &argAttr : attrs)
-    if (argAttr.getName() == name)
-      return true;
-  return false;
+  return llvm::any_of(attrs,
+                      [&](auto argAttr) { return argAttr.getName() == name; });
 }
 
 template <typename ModuleTy>
@@ -1483,17 +1482,17 @@ LogicalResult HWModuleOp::verifyBody() { return success(); }
 //===----------------------------------------------------------------------===//
 
 /// Create a instance that refers to a known module.
-void InstanceOp::build(OpBuilder &builder, OperationState &result,
+void InstanceOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                        Operation *module, StringAttr name,
                        ArrayRef<Value> inputs, ArrayAttr parameters,
                        StringAttr sym_name) {
   if (!parameters)
-    parameters = builder.getArrayAttr({});
+    parameters = odsBuilder.getArrayAttr({});
 
   auto [argNames, resultNames] =
       instance_like_impl::getHWModuleArgAndResultNames(module);
   FunctionType modType = getModuleType(module);
-  build(builder, result, modType.getResults(), name,
+  build(odsBuilder, odsState, modType.getResults(), name,
         FlatSymbolRefAttr::get(SymbolTable::getSymbolName(module)), inputs,
         argNames, resultNames, parameters, sym_name);
 }
@@ -1658,17 +1657,16 @@ LogicalResult OutputOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult
-GlobalRefOp::verifySymbolUses(mlir::SymbolTableCollection &symTables) {
+GlobalRefOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
   Operation *parent = (*this)->getParentOp();
-  SymbolTable &symTable = symTables.getSymbolTable(parent);
+  SymbolTable &symTable = symbolTable.getSymbolTable(parent);
   StringAttr symNameAttr = (*this).getSymNameAttr();
   auto hasGlobalRef = [&](Attribute attr) -> bool {
     if (!attr)
       return false;
-    for (auto ref : attr.cast<ArrayAttr>().getAsRange<GlobalRefAttr>())
-      if (ref.getGlblSym().getAttr() == symNameAttr)
-        return true;
-    return false;
+    return llvm::any_of(
+        attr.cast<ArrayAttr>().getAsRange<GlobalRefAttr>(),
+        [&](auto ref) { return ref.getGlblSym().getAttr() == symNameAttr; });
   };
   // For all inner refs in the namepath, ensure they have a corresponding
   // GlobalRefAttr to this GlobalRefOp.
@@ -1762,7 +1760,7 @@ ParseResult ArrayCreateOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(elemType))
     return failure();
 
-  if (operands.size() == 0)
+  if (operands.empty())
     return parser.emitError(inputOperandsLoc,
                             "Cannot construct an array of length 0");
   result.addTypes({ArrayType::get(elemType, operands.size())});
@@ -1780,15 +1778,15 @@ void ArrayCreateOp::print(OpAsmPrinter &p) {
   p << " : " << getInputs()[0].getType();
 }
 
-void ArrayCreateOp::build(OpBuilder &b, OperationState &state,
-                          ValueRange values) {
-  assert(values.size() > 0 && "Cannot build array of zero elements");
-  Type elemType = values[0].getType();
+void ArrayCreateOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                          ValueRange inputs) {
+  assert(!inputs.empty() && "Cannot build array of zero elements");
+  Type elemType = inputs[0].getType();
   assert(llvm::all_of(
-             values,
+             inputs,
              [elemType](Value v) -> bool { return v.getType() == elemType; }) &&
          "All values must have same type.");
-  build(b, state, ArrayType::get(elemType, values.size()), values);
+  build(odsBuilder, odsState, ArrayType::get(elemType, inputs.size()), inputs);
 }
 
 LogicalResult ArrayCreateOp::verify() {
@@ -1947,7 +1945,7 @@ LogicalResult ArraySliceOp::canonicalize(ArraySliceOp op,
   if (!offsetOpt)
     return failure();
 
-  auto inputOp = op.getInput().getDefiningOp();
+  auto *inputOp = op.getInput().getDefiningOp();
   if (auto inputSlice = dyn_cast_or_null<ArraySliceOp>(inputOp)) {
     // slice(slice(a, n), m) -> slice(a, n + m)
     if (inputSlice == op)
@@ -2012,7 +2010,7 @@ LogicalResult ArraySliceOp::canonicalize(ArraySliceOp op,
         break;
     }
 
-    assert(chunks.size() > 0 && "missing sliced items");
+    assert(!chunks.empty() && "missing sliced items");
     if (chunks.size() == 1)
       rewriter.replaceOp(op, chunks[0]);
     else
@@ -2062,12 +2060,12 @@ static void printArrayConcatTypes(OpAsmPrinter &p, Operation *,
   llvm::interleaveComma(inputTypes, p, [&p](Type t) { p << t; });
 }
 
-void ArrayConcatOp::build(OpBuilder &b, OperationState &state,
-                          ValueRange values) {
-  assert(!values.empty() && "Cannot build array of zero elements");
-  ArrayType arrayTy = values[0].getType().cast<ArrayType>();
+void ArrayConcatOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                          ValueRange inputs) {
+  assert(!inputs.empty() && "Cannot build array of zero elements");
+  ArrayType arrayTy = inputs[0].getType().cast<ArrayType>();
   Type elemTy = arrayTy.getElementType();
-  assert(llvm::all_of(values,
+  assert(llvm::all_of(inputs,
                       [elemTy](Value v) -> bool {
                         return v.getType().isa<ArrayType>() &&
                                v.getType().cast<ArrayType>().getElementType() ==
@@ -2076,9 +2074,9 @@ void ArrayConcatOp::build(OpBuilder &b, OperationState &state,
          "All values must be of ArrayType with the same element type.");
 
   uint64_t resultSize = 0;
-  for (Value val : values)
+  for (Value val : inputs)
     resultSize += val.getType().cast<ArrayType>().getSize();
-  build(b, state, ArrayType::get(elemTy, resultSize), values);
+  build(odsBuilder, odsState, ArrayType::get(elemTy, resultSize), inputs);
 }
 
 OpFoldResult ArrayConcatOp::fold(FoldAdaptor adaptor) {
@@ -2486,7 +2484,7 @@ OpFoldResult StructExtractOp::fold(FoldAdaptor) {
 
 LogicalResult StructExtractOp::canonicalize(StructExtractOp op,
                                             PatternRewriter &rewriter) {
-  auto inputOp = op.getInput().getDefiningOp();
+  auto *inputOp = op.getInput().getDefiningOp();
 
   // b = extract(inject(x["a"], v0)["b"]) => extract(x, "b")
   if (auto structInject = dyn_cast_or_null<StructInjectOp>(inputOp)) {
@@ -2671,14 +2669,13 @@ void UnionExtractOp::print(OpAsmPrinter &printer) {
   printExtractOp(printer, *this);
 }
 
-LogicalResult UnionExtractOp::inferReturnTypes(MLIRContext *context,
-                                               std::optional<Location> loc,
-                                               ValueRange operands,
-                                               DictionaryAttr attrs,
-                                               mlir::RegionRange regions,
-                                               SmallVectorImpl<Type> &results) {
-  results.push_back(cast<UnionType>(getCanonicalType(operands[0].getType()))
-                        .getFieldType(attrs.getAs<StringAttr>("field")));
+LogicalResult UnionExtractOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  inferredReturnTypes.push_back(
+      cast<UnionType>(getCanonicalType(operands[0].getType()))
+          .getFieldType(attributes.getAs<StringAttr>("field")));
   return success();
 }
 

--- a/lib/Dialect/HW/InstanceGraphBase.cpp
+++ b/lib/Dialect/HW/InstanceGraphBase.cpp
@@ -98,7 +98,7 @@ HWModuleLike InstanceGraphBase::getReferencedModule(HWInstanceLike op) {
   return lookup(op.getReferencedModuleNameAttr())->getModule();
 }
 
-InstanceGraphBase::~InstanceGraphBase() {}
+InstanceGraphBase::~InstanceGraphBase() = default;
 
 void InstanceGraphBase::replaceInstance(HWInstanceLike inst,
                                         HWInstanceLike newInst) {
@@ -163,7 +163,7 @@ InstanceGraphBase::getInferredTopLevelNodes() {
               return true;
             }
             marked.insert(node);
-            for (auto use : *node) {
+            for (auto *use : *node) {
               InstanceGraphNode *targetModule = use->getTarget();
               candidateTopLevels.remove(targetModule);
               if (cycleUtil(targetModule, trace))
@@ -175,7 +175,7 @@ InstanceGraphBase::getInferredTopLevelNodes() {
           };
 
   bool cyclic = false;
-  for (auto moduleIt : *this) {
+  for (auto *moduleIt : *this) {
     if (visited.contains(moduleIt))
       continue;
 

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -96,7 +96,7 @@ ParseResult module_like_impl::parseModuleFunctionSignature(
 
   // Parse the argument list.
   if (parser.parseArgumentList(args, OpAsmParser::Delimiter::Paren,
-                               /*allowTypes=*/true, /*allowAttrs=*/true))
+                               /*allowType=*/true, /*allowAttrs=*/true))
     return failure();
 
   // Parse the result list.

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -36,7 +36,7 @@ namespace {
 // provided 'parameters'.
 static std::string generateModuleName(Namespace &ns, hw::HWModuleOp moduleOp,
                                       ArrayAttr parameters) {
-  assert(parameters.size() != 0);
+  assert(!parameters.empty());
   std::string name = moduleOp.getName().str();
   for (auto param : parameters) {
     auto paramAttr = param.cast<ParamDeclAttr>();
@@ -80,7 +80,7 @@ static hw::HWModuleOp targetModuleOp(hw::InstanceOp instanceOp,
   if (!targetHWModule)
     return {}; // Won't specialize external modules.
 
-  if (targetHWModule.getParameters().size() == 0)
+  if (targetHWModule.getParameters().empty())
     return {}; // nothing to record or specialize
 
   return targetHWModule;
@@ -385,7 +385,7 @@ void HWSpecializePass::runOnOperation() {
   while (!registry.uniqueModuleParameters.empty()) {
     // The registry for the next specialization loop
     ParameterSpecializationRegistry nextRegistry;
-    for (auto it : registry.uniqueModuleParameters) {
+    for (const auto &it : registry.uniqueModuleParameters) {
       for (auto parameters : it.second) {
         HWModuleOp specializedModule;
         if (failed(specializeModule(builder, parameters, sc, ns, it.first,


### PR DESCRIPTION
Should we adhere to the `readability-inconsistent-declaration-parameter-name` clang-tidy check? Feels a bit strange to me to explicitly add that check in `.clang-tidy`, but then ignore it for most functions.