### PR TITLE
[circt-reduce] Fix tests for portability again, prefer /usr/bin/env.

### DIFF
--- a/test/Dialect/Arc/Reduction/pattern-registration.mlir
+++ b/test/Dialect/Arc/Reduction/pattern-registration.mlir
@@ -4,7 +4,7 @@
 // This test checks that only the reduction patterns of dialects that occur in
 // the input file are registered
 
-// RUN: circt-reduce %s --test /bin/cat --list | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg cat --list | FileCheck %s
 
 // CHECK: arc-strip-sv
 // CHECK-NEXT: cse

--- a/test/Dialect/Arc/Reduction/state-elimination.mlir
+++ b/test/Dialect/Arc/Reduction/state-elimination.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "DummyArc(%arg0)" --keep-best=0 --include arc-state-elimination | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "DummyArc(%arg0)" --keep-best=0 --include arc-state-elimination | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%clk: i1, %en: i1, %rst: i1, %arg0: i32) -> (out: i32) {

--- a/test/Dialect/FIRRTL/Reduction/annotation-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/annotation-remover.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "%anotherWire = firrtl.wire" --keep-best=0 --include annotation-remover | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "%anotherWire = firrtl.wire" --keep-best=0 --include annotation-remover | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK: firrtl.module @Foo

--- a/test/Dialect/FIRRTL/Reduction/connect-source-operand-forward.mlir
+++ b/test/Dialect/FIRRTL/Reduction/connect-source-operand-forward.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder | FileCheck %s
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %val: !firrtl.uint<2>) {

--- a/test/Dialect/FIRRTL/Reduction/memory-stubber.mlir
+++ b/test/Dialect/FIRRTL/Reduction/memory-stubber.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "firrtl.module @Basic" --keep-best=0 --include memory-stubber | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "firrtl.module @Basic" --keep-best=0 --include memory-stubber | FileCheck %s
 
 firrtl.circuit "Basic"   {
   // CHECK-LABEL: @Basic

--- a/test/Dialect/FIRRTL/Reduction/node-symbol-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/node-symbol-remover.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK: firrtl.module @Foo

--- a/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
+++ b/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
@@ -4,7 +4,7 @@
 // This test checks that only the reduction patterns of dialects that occur in
 // the input file are registered
 
-// RUN: circt-reduce %s --test /bin/cat --list | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg cat --list | FileCheck %s
 
 // CHECK:      firrtl-lower-chirrtl
 // CHECK-NEXT: firrtl-infer-widths

--- a/test/Dialect/FIRRTL/Reduction/port-pruner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/port-pruner.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo

--- a/test/Dialect/HW/Reduction/hw-constantifier.mlir
+++ b/test/Dialect/HW/Reduction/hw-constantifier.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include hw-constantifier | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include hw-constantifier | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%arg0: i32, %arg1: i32) -> (out0: i32, out1: i32) {

--- a/test/Dialect/HW/Reduction/hw-module-externalizer.mlir
+++ b/test/Dialect/HW/Reduction/hw-module-externalizer.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.instance" --keep-best=0 --include hw-module-externalizer | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.instance" --keep-best=0 --include hw-module-externalizer | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%arg0: i32) -> (out: i32) {

--- a/test/Dialect/HW/Reduction/hw-operand-forwarder.mlir
+++ b/test/Dialect/HW/Reduction/hw-operand-forwarder.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include hw-operand0-forwarder | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include hw-operand0-forwarder | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%arg0: i32, %arg1: i32) -> (out: i32) {

--- a/test/Dialect/HW/Reduction/pattern-registration.mlir
+++ b/test/Dialect/HW/Reduction/pattern-registration.mlir
@@ -4,7 +4,7 @@
 // This test checks that only the reduction patterns of dialects that occur in
 // the input file are registered
 
-// RUN: circt-reduce %s --test /bin/cat --list | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg cat --list | FileCheck %s
 
 // CHECK:      hw-module-externalizer
 // CHECK-NEXT: hw-constantifier

--- a/test/circt-reduce/canonicalize-reduction.mlir
+++ b/test/circt-reduce/canonicalize-reduction.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include canonicalize | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include canonicalize | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%arg0: i32) -> (out: i32) {

--- a/test/circt-reduce/cse-reduction.mlir
+++ b/test/circt-reduce/cse-reduction.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include cse | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include cse | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo() {

--- a/test/circt-reduce/operation-pruner.mlir
+++ b/test/circt-reduce/operation-pruner.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /bin/grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include operation-pruner | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.module @Foo" --keep-best=0 --include operation-pruner | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%arg0: i32) -> (out: i32) {


### PR DESCRIPTION
Don't make assumptions beyond /usr/bin/env regarding the location of various common utilities.

Fixes tests on NixOS.