### PR TITLE
[FIRRTL][InferResets] Fix inference through ref.sub.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -818,8 +818,8 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
                   .Case<BundleType>([&](auto type) {
                     return getFieldID(type, op.getIndex());
                   });
-          traceResets(op.getResult().getType().getType(), op.getResult(), 0,
-                      aggType, op.getInput(), fieldID, op.getLoc());
+          traceResets(op.getType(), op.getResult(), 0, op.getResult().getType(),
+                      op.getInput(), fieldID, op.getLoc());
         });
   });
 }

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -887,20 +887,25 @@ firrtl.circuit "RefResetBundle" {
 firrtl.circuit "RefResetSub" {
   // CHECK-LABEL: firrtl.module @RefResetSub
   // CHECK-NOT: firrtl.reset
-  firrtl.module @RefResetSub(in %driver: !firrtl.asyncreset, out %out_a : !firrtl.reset, out %out_b: !firrtl.reset) {
-  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset> 
-  %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: reset>
-  %ref_r_a = firrtl.ref.sub %ref_r[0] : !firrtl.probe<bundle<a: reset, b : reset>>
-  %ref_r_b = firrtl.ref.sub %ref_r[1] : !firrtl.probe<bundle<a: reset, b : reset>>
+  firrtl.module @RefResetSub(in %driver: !firrtl.asyncreset, out %out_a : !firrtl.reset, out %out_b: !firrtl.vector<reset,2>) {
+  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: vector<reset, 2>> 
+  %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
+  %ref_r_a = firrtl.ref.sub %ref_r[0] : !firrtl.probe<bundle<a: reset, b : vector<reset, 2>>>
   %reset_a = firrtl.ref.resolve %ref_r_a : !firrtl.probe<reset>
-  %reset_b = firrtl.ref.resolve %ref_r_b : !firrtl.probe<reset>
-  firrtl.strictconnect %out_a, %reset_a : !firrtl.reset
-  firrtl.strictconnect %out_b, %reset_b : !firrtl.reset
 
-   %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
-   %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>
+  %ref_r_b = firrtl.ref.sub %ref_r[1] : !firrtl.probe<bundle<a: reset, b : vector<reset, 2>>>
+  %reset_b = firrtl.ref.resolve %ref_r_b : !firrtl.probe<vector<reset, 2>>
+
+  firrtl.strictconnect %out_a, %reset_a : !firrtl.reset
+  firrtl.strictconnect %out_b, %reset_b : !firrtl.vector<reset, 2>
+
+   %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
+   %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
+   %r_b_0 = firrtl.subindex %r_b[0] : !firrtl.vector<reset, 2>
+   %r_b_1 = firrtl.subindex %r_b[1] : !firrtl.vector<reset, 2>
    firrtl.connect %r_a, %driver : !firrtl.reset, !firrtl.asyncreset
-   firrtl.connect %r_b, %driver : !firrtl.reset, !firrtl.asyncreset
+   firrtl.connect %r_b_0, %driver : !firrtl.reset, !firrtl.asyncreset
+   firrtl.connect %r_b_1, %driver : !firrtl.reset, !firrtl.asyncreset
   }
 }
 


### PR DESCRIPTION
Use same types for both sides, avoid uneven indexing.

Add test that crashes without this change.