### PR TITLE
[FIRRTL] Add LowerOpenAggs pass.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -30,6 +30,8 @@ createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations = false,
                                  bool ignoreClasslessAnnotations = false,
                                  bool noRefTypePorts = false);
 
+std::unique_ptr<mlir::Pass> createLowerOpenAggsPass();
+
 /// Configure which aggregate values will be preserved by the LowerTypes pass.
 namespace PreserveAggregate {
 enum PreserveMode {

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -640,6 +640,15 @@ def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createLowerIntrinsicsPass()";
 }
 
+def LowerOpenAggs : Pass<"firrtl-lower-open-aggs", "firrtl::CircuitOp"> {
+  let summary = "Lower 'Open' aggregates by splitting out non-hardware elements";
+  let description = [{
+     This pass lowers aggregates of the more open varieties into their equivalents
+     using only hardware types, by pulling out non-hardware to other locations.
+  }];
+  let constructor = "circt::firrtl::createLowerOpenAggsPass()";
+}
+
 def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
   let summary = "Write out TraceAnnotations to an output annotation file";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerIntrinsics.cpp
   LowerMatches.cpp
   LowerMemory.cpp
+  LowerOpenAggs.cpp
   LowerTypes.cpp
   LowerXMR.cpp
   MergeConnections.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -202,6 +202,11 @@ LogicalResult Visitor::visit(FModuleLike mod) {
           auto newPort = port;
           newPort.type = pmi.hwType;
           newPorts.emplace_back(idxOfInsertPoint, newPort);
+
+          // If want to run this pass later, need to fixup annotations.
+          if (!port.annotations.empty())
+            return mlir::emitError(port.loc)
+                   << "annotations on open aggregates not handled yet";
         } else {
           if (port.sym)
             return mlir::emitError(port.loc)
@@ -440,6 +445,11 @@ LogicalResult Visitor::visitDecl(InstanceOp op) {
                           /*symName=*/StringAttr{}, loc,
                           AnnotationSet(op.getPortAnnotation(index)));
           newPorts.emplace_back(idxOfInsertPoint, hwPort);
+
+          // If want to run this pass later, need to fixup annotations.
+          if (!op.getPortAnnotation(index).empty())
+            return mlir::emitError(op.getLoc())
+                   << "annotations on open aggregates not handled yet";
         } else {
           if (!op.getPortAnnotation(index).empty())
             return mlir::emitError(op.getLoc())

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -137,8 +137,7 @@ public:
 
   LogicalResult visitUnhandledOp(Operation *op) {
     auto notOpenAggType = [](auto type) {
-      auto ftype = dyn_cast<FIRRTLType>(type);
-      return !ftype || isa<RefType>(type) || !ftype.containsReference();
+      return !isa<OpenBundleType, OpenVectorType>(type);
     };
     if (!llvm::all_of(op->getOperandTypes(), notOpenAggType) ||
         !llvm::all_of(op->getResultTypes(), notOpenAggType))

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -1,0 +1,604 @@
+//===- LowerOpenAggs.cpp - Lower Open Aggregate Types -----------*- C++ -*-===//
+
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the LowerOpenAggs pass.  This pass replaces the open
+// aggregate types with hardware aggregates, with non-hardware fields
+// expanded out as with LowerTypes.
+//
+// This pass is ref-specific for now.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/IR/Visitors.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#include <vector>
+
+#define DEBUG_TYPE "firrtl-lower-open-aggs"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+
+/// Information on non-hw (ref) elements.
+struct NonHWField {
+  /// Type of the field, not a hardware type.
+  FIRRTLType type;
+  /// FieldID relative to base of converted type.
+  uint64_t fieldID;
+  /// Relative orientation.  False means aligned.
+  bool isFlip;
+  /// String suffix naming this field.
+  SmallString<16> suffix;
+  /// Print this structure to llvm::errs().
+  void dump() const;
+};
+
+/// Mapped port info
+struct PortMappingInfo {
+  /// Preserve this port, map use of old directly to new.
+  bool identity;
+
+  // When not identity, the port will be split:
+
+  /// Type of the hardware-only portion.  May be null, indicating all non-hw.
+  Type hwType;
+  /// List of the individual non-hw fields to be split out.
+  SmallVector<NonHWField, 0> fields;
+
+  /// Determine number of types this argument maps to.
+  size_t count(bool includeErased = false) const {
+    if (identity)
+      return 1;
+    return fields.size() + (hwType ? 1 : 0) + (includeErased ? 1 : 0);
+  }
+  void dump() const;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const NonHWField &field) {
+  return os << llvm::formatv(
+             "non-HW(type={0}, fieldID={1}, isFlip={2}, suffix={3})",
+             field.type, field.fieldID, field.isFlip, field.suffix);
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const PortMappingInfo &pmi) {
+  if (pmi.identity)
+    return os << "(identity)";
+
+  os << "[[hw portion: ";
+  if (pmi.hwType)
+    os << pmi.hwType;
+  else
+    os << "(none)";
+  os << ", fields: ";
+  llvm::interleaveComma(pmi.fields, os);
+  return os << "]]";
+}
+
+} // namespace
+
+void NonHWField::dump() const { llvm::errs() << *this; }
+void PortMappingInfo::dump() const { llvm::errs() << *this; }
+
+template <typename Range>
+LogicalResult walkPortMappings(
+    Range &&range, bool includeErased,
+    llvm::function_ref<LogicalResult(size_t, PortMappingInfo &, size_t)>
+        callback) {
+  size_t count = 0;
+  for (const auto &[index, pmi] : llvm::enumerate(range)) {
+    if (failed(callback(index, pmi, count)))
+      return failure();
+    count += pmi.count(includeErased);
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Visitor
+//===----------------------------------------------------------------------===//
+
+namespace {
+class Visitor : public FIRRTLVisitor<Visitor, LogicalResult> {
+public:
+  explicit Visitor(MLIRContext *context) : context(context){};
+
+  /// Entrypoint.
+  LogicalResult visit(FModuleLike mod);
+
+  using FIRRTLVisitor<Visitor, LogicalResult>::visitDecl;
+  using FIRRTLVisitor<Visitor, LogicalResult>::visitExpr;
+  using FIRRTLVisitor<Visitor, LogicalResult>::visitStmt;
+
+  LogicalResult visitDecl(InstanceOp op);
+
+  LogicalResult visitExpr(OpenSubfieldOp op);
+  LogicalResult visitExpr(OpenSubindexOp op);
+
+  LogicalResult visitUnhandledOp(Operation *op) { return success(); }
+
+  LogicalResult visitInvalidOp(Operation *op) { return success(); }
+
+private:
+  /// Convert a type to its HW-only projection.,
+  /// Gather non-hw elements encountered and their names / positions.
+  /// Returns a PortMappingInfo with its findings.
+  PortMappingInfo mapPortType(Type type);
+
+  MLIRContext *context;
+
+  /// Map non-HW fields to their new Value.
+  DenseMap<FieldRef, Value> nonHWValues;
+
+  /// Map from port to its hw-only aggregate equivalent.
+  DenseMap<Value, std::optional<Value>> hwOnlyAggMap;
+
+  /// List of operations to erase at the end.
+  SmallVector<Operation *> opsToErase;
+};
+} // namespace
+
+LogicalResult Visitor::visit(FModuleLike mod) {
+  auto ports = mod.getPorts();
+
+  SmallVector<PortMappingInfo, 16> portMappings(
+      llvm::map_range(ports, [&](auto &p) { return mapPortType(p.type); }));
+
+  /// Total number of types mapped to.
+  /// Include erased ports.
+  size_t countWithErased = 0;
+  for (auto &pmi : portMappings)
+    countWithErased += pmi.count(/*includeErased=*/true);
+
+  /// Ports to add.
+  SmallVector<std::pair<unsigned, PortInfo>> newPorts;
+
+  /// Ports to remove.
+  BitVector portsToErase(countWithErased);
+
+  /// Go through each port mapping, gathering information about all new ports.
+  LLVM_DEBUG(llvm::dbgs() << "Ports for "
+                          << cast<mlir::SymbolOpInterface>(*mod).getName()
+                          << ":\n");
+  auto result = walkPortMappings(
+      portMappings, /*includeErased=*/true,
+      [&](auto index, auto &pmi, auto newIndex) -> LogicalResult {
+        LLVM_DEBUG(llvm::dbgs() << "\t" << ports[index].name << " : "
+                                << ports[index].type << " => " << pmi << "\n");
+        // Index for inserting new points next to this point.
+        // (Immediately after current port's index).
+        auto idxOfInsertPoint = index + 1;
+
+        if (pmi.identity)
+          return success();
+
+        auto &port = ports[index];
+
+        // If not identity, mark this port for eventual removal.
+        portsToErase.set(newIndex);
+
+        // Create new hw-only port, this will generally replace this port.
+        if (pmi.hwType) {
+          auto newPort = port;
+          newPort.type = pmi.hwType;
+          newPorts.emplace_back(idxOfInsertPoint, newPort);
+        } else {
+          if (port.sym)
+            return mlir::emitError(port.loc)
+                   << "symbol found on aggregate with no HW";
+          if (!port.annotations.empty())
+            return mlir::emitError(port.loc)
+                   << "annotations found on aggregate with no HW";
+        }
+
+        // Create ports for each non-hw field.
+        for (const auto &[findex, field] : llvm::enumerate(pmi.fields)) {
+          auto name = StringAttr::get(context,
+                                      Twine(port.name.strref()) + field.suffix);
+          auto orientation =
+              (Direction)((unsigned)port.direction ^ field.isFlip);
+          PortInfo pi(name, field.type, orientation, /*symName=*/StringAttr{},
+                      port.loc, std::nullopt);
+          newPorts.emplace_back(idxOfInsertPoint, pi);
+        }
+        return success();
+      });
+  if (failed(result))
+    return failure();
+
+  // Insert the new ports!
+  mod.insertPorts(newPorts);
+
+  assert(mod->getNumRegions() == 1);
+
+  // (helper to determine/get the body block if present)
+  auto getBodyBlock = [](auto mod) {
+    auto &blocks = mod->getRegion(0).getBlocks();
+    return !blocks.empty() ? &blocks.front() : nullptr;
+  };
+
+  // Process body block.
+  // Create mapping for ports, then visit all operations within.
+  if (auto *block = getBodyBlock(mod)) {
+    // Create mappings for split ports.
+    auto result =
+        walkPortMappings(portMappings, /*includeErased=*/true,
+                         [&](auto index, PortMappingInfo &pmi, auto newIndex) {
+                           // Nothing to do for identity.
+                           if (pmi.identity)
+                             return success();
+
+                           // newIndex is index of this port after insertion.
+                           // This will be removed.
+                           assert(portsToErase.test(newIndex));
+                           auto oldPort = block->getArgument(newIndex);
+                           auto newPortIndex = newIndex;
+
+                           // Create mappings for split ports.
+                           if (pmi.hwType)
+                             hwOnlyAggMap[oldPort] =
+                                 block->getArgument(++newPortIndex);
+                           else
+                             hwOnlyAggMap[oldPort] = std::nullopt;
+
+                           for (auto &field : pmi.fields) {
+                             auto ref = FieldRef(oldPort, field.fieldID);
+                             auto newVal = block->getArgument(++newPortIndex);
+                             nonHWValues[ref] = newVal;
+                           }
+                           return success();
+                         });
+    if (failed(result))
+      return failure();
+
+    // Walk the module.
+    if (block
+            ->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+              return dispatchVisitor(op);
+            })
+            .wasInterrupted())
+      return failure();
+
+    // Cleanup dead operations.
+    for (auto &op : llvm::reverse(opsToErase))
+      op->erase();
+  }
+
+  // Drop dead ports.
+  mod.erasePorts(portsToErase);
+
+  return success();
+}
+
+LogicalResult Visitor::visitExpr(OpenSubfieldOp op) {
+  // We're indexing into an OpenBundle, which contains some non-hw elements and
+  // may contain hw elements.
+
+  // By the time this is reached, the "root" storage for the input
+  // has already been handled and mapped to its new location(s),
+  // such that the hardware-only contents are split from non-hw.
+
+  // If there is a hardware portion selected by this operation,
+  // create a "closed" subfieldop using the hardware-only new storage,
+  // and add an entry mapping our old (soon, dead) result to
+  // this new hw-only result (of the subfieldop).
+
+  // Downstream indexing operations will expect that they can
+  // still chase up through this operation, and that they will find
+  // the hw-only portion in the map.
+
+  // If this operation selects a non-hw element (not mixed),
+  // look up where that ref now lives and update all users to use that instead.
+  // (This case falls under "this selects only non-hw", which means
+  // that this operation is now dead).
+
+  // Chase this to its original root.
+  // If the FieldRef for this selection has a new home,
+  // RAUW to that value and this op is dead.
+  auto resultRef = getFieldRefFromValue(op.getResult());
+
+  // In all cases, this operation will be dead and should be removed.
+  opsToErase.push_back(op);
+
+  if (nonHWValues.contains(resultRef)) {
+    auto newResult = nonHWValues[resultRef];
+    assert(op.getResult().getType() == newResult.getType());
+    assert(!isa<FIRRTLBaseType>(newResult.getType()));
+    op.getResult().replaceAllUsesWith(newResult);
+    return success();
+  }
+
+  assert(hwOnlyAggMap.count(op.getInput()));
+
+  auto newInput = hwOnlyAggMap[op.getInput()];
+  // Skip if no hw-only portion.  This is dead.
+  if (!newInput.has_value()) {
+    hwOnlyAggMap[op.getResult()] = std::nullopt;
+    return success();
+  }
+
+  auto bundleType = cast<BundleType>(newInput->getType());
+
+  // Recompute the "actual" index for this field, it may have changed.
+  auto fieldName = op.getFieldName();
+  auto newFieldIndex = bundleType.getElementIndex(fieldName);
+  assert(newFieldIndex.has_value());
+
+  ImplicitLocOpBuilder builder(op.getLoc(), op);
+  auto newOp = builder.create<SubfieldOp>(*newInput, *newFieldIndex);
+  if (auto name = op->getAttrOfType<StringAttr>("name"))
+    newOp->setAttr("name", name);
+
+  hwOnlyAggMap[op.getResult()] = newOp;
+
+  if (isa<FIRRTLBaseType>(op.getType()))
+    op.getResult().replaceAllUsesWith(newOp.getResult());
+
+  return success();
+}
+
+LogicalResult Visitor::visitExpr(OpenSubindexOp op) {
+  auto resultRef = getFieldRefFromValue(op.getResult());
+
+  // In all cases, this operation will be dead and should be removed.
+  opsToErase.push_back(op);
+  if (nonHWValues.contains(resultRef)) {
+    auto newResult = nonHWValues[resultRef];
+    assert(op.getResult().getType() == newResult.getType());
+    assert(!isa<FIRRTLBaseType>(newResult.getType()));
+    op.getResult().replaceAllUsesWith(newResult);
+    return success();
+  }
+
+  assert(hwOnlyAggMap.count(op.getInput()));
+
+  auto newInput = hwOnlyAggMap[op.getInput()];
+  // Skip if no hw-only portion.  This is dead.
+  if (!newInput.has_value()) {
+    hwOnlyAggMap[op.getResult()] = std::nullopt;
+    return success();
+  }
+
+  ImplicitLocOpBuilder builder(op.getLoc(), op);
+  auto newOp = builder.create<SubindexOp>(*newInput, op.getIndex());
+  if (auto name = op->getAttrOfType<StringAttr>("name"))
+    newOp->setAttr("name", name);
+
+  hwOnlyAggMap[op.getResult()] = newOp;
+
+  if (isa<FIRRTLBaseType>(op.getType()))
+    op.getResult().replaceAllUsesWith(newOp.getResult());
+  return success();
+}
+
+LogicalResult Visitor::visitDecl(InstanceOp op) {
+  // Rewrite ports same strategy as for modules.
+
+  SmallVector<PortMappingInfo, 16> portMappings(llvm::map_range(
+      op.getResultTypes(), [&](auto type) { return mapPortType(type); }));
+
+  /// Total number of types mapped to.
+  size_t countWithErased = 0;
+  for (auto &pmi : portMappings)
+    countWithErased += pmi.count(/*includeErased=*/true);
+
+  /// Ports to add.
+  SmallVector<std::pair<unsigned, PortInfo>> newPorts;
+
+  /// Ports to remove.
+  BitVector portsToErase(countWithErased);
+
+  /// Go through each port mapping, gathering information about all new ports.
+  LLVM_DEBUG(llvm::dbgs() << "Ports for " << op << ":\n");
+  auto result = walkPortMappings(
+      portMappings, /*includeErased=*/true,
+      [&](auto index, auto &pmi, auto newIndex) -> LogicalResult {
+        LLVM_DEBUG(llvm::dbgs() << "\t" << op.getPortName(index) << " : "
+                                << op.getType(index) << " => " << pmi << "\n");
+        // Index for inserting new points next to this point.
+        // (Immediately after current port's index).
+        auto idxOfInsertPoint = index + 1;
+
+        if (pmi.identity)
+          return success();
+
+        // If not identity, mark this port for eventual removal.
+        portsToErase.set(newIndex);
+
+        auto portName = op.getPortName(index);
+        auto portDirection = op.getPortDirection(index);
+        auto loc = op.getLoc();
+
+        // Create new hw-only port, this will generally replace this port.
+        if (pmi.hwType) {
+          PortInfo hwPort(portName, pmi.hwType, portDirection,
+                          /*symName=*/StringAttr{}, loc,
+                          AnnotationSet(op.getPortAnnotation(index)));
+          newPorts.emplace_back(idxOfInsertPoint, hwPort);
+        } else {
+          if (!op.getPortAnnotation(index).empty())
+            return mlir::emitError(op.getLoc())
+                   << "annotations found on aggregate with no HW";
+        }
+
+        // Create ports for each non-hw field.
+        for (const auto &[findex, field] : llvm::enumerate(pmi.fields)) {
+          auto name =
+              StringAttr::get(context, Twine(portName.strref()) + field.suffix);
+          auto orientation =
+              (Direction)((unsigned)portDirection ^ field.isFlip);
+          PortInfo pi(name, field.type, orientation, /*symName=*/StringAttr{},
+                      loc, std::nullopt);
+          newPorts.emplace_back(idxOfInsertPoint, pi);
+        }
+        return success();
+      });
+  if (failed(result))
+    return failure();
+
+  // If no new ports, we're done.
+  if (newPorts.empty())
+    return success();
+
+  // Create new instance op with desired ports.
+
+  // TODO: add and erase ports without intermediate + various array attributes.
+  auto tempOp = op.cloneAndInsertPorts(newPorts);
+  opsToErase.push_back(tempOp);
+  ImplicitLocOpBuilder builder(op.getLoc(), op);
+  auto newInst = tempOp.erasePorts(builder, portsToErase);
+
+  auto mappingResult = walkPortMappings(
+      portMappings, /*includeErased=*/false,
+      [&](auto index, PortMappingInfo &pmi, auto newIndex) {
+        // Identity means index -> newIndex.
+        auto oldResult = op.getResult(index);
+        if (pmi.identity) {
+          // (Just do the RAUW here instead of tracking the mapping for this
+          // too.)
+          assert(oldResult.getType() == newInst.getType(newIndex));
+          oldResult.replaceAllUsesWith(newInst.getResult(newIndex));
+          return success();
+        }
+
+        // Create mappings for updating open aggregate users.
+        auto newPortIndex = newIndex;
+        if (pmi.hwType)
+          hwOnlyAggMap[oldResult] = newInst.getResult(newPortIndex++);
+        else
+          hwOnlyAggMap[oldResult] = std::nullopt;
+
+        for (auto &field : pmi.fields) {
+          auto ref = FieldRef(oldResult, field.fieldID);
+          auto newVal = newInst.getResult(newPortIndex++);
+          assert(newVal.getType() == field.type);
+          nonHWValues[ref] = newVal;
+        }
+        return success();
+      });
+  if (failed(mappingResult))
+    return failure();
+
+  opsToErase.push_back(op);
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Type Conversion
+//===----------------------------------------------------------------------===//
+
+PortMappingInfo Visitor::mapPortType(Type type) {
+  PortMappingInfo pi{false, {}, {}};
+  auto ftype = dyn_cast<FIRRTLType>(type);
+  // Ports that aren't open aggregates are left alone.
+  if (!ftype || !isa<OpenBundleType, OpenVectorType>(ftype)) {
+    pi.identity = true;
+    return pi;
+  }
+
+  // TODO: Manage SmallString for suffix instead of Twine of pieces (since will
+  // conv to vector anyway).
+  // NOLINTBEGIN(misc-no-recursion)
+  auto recurse = [&](auto &&f, FIRRTLType type, const Twine &suffix = "",
+                     bool flip = false,
+                     uint64_t fieldID = 0) -> FIRRTLBaseType {
+    return TypeSwitch<FIRRTLType, FIRRTLBaseType>(type)
+        .Case<FIRRTLBaseType>([](auto base) { return base; })
+        .template Case<OpenBundleType>(
+            [&](OpenBundleType obTy) -> FIRRTLBaseType {
+              SmallVector<BundleType::BundleElement> hwElements;
+              for (const auto &[index, element] :
+                   llvm::enumerate(obTy.getElements()))
+                if (auto base =
+                        f(f, element.type, suffix + "_" + element.name.strref(),
+                          flip ^ element.isFlip,
+                          fieldID + obTy.getFieldID(index)))
+                  hwElements.emplace_back(element.name, element.isFlip, base);
+
+              if (hwElements.empty())
+                return FIRRTLBaseType{};
+
+              return BundleType::get(context, hwElements, obTy.isConst());
+            })
+        .template Case<OpenVectorType>(
+            [&](OpenVectorType ovTy) -> FIRRTLBaseType {
+              FIRRTLBaseType convert;
+              for (auto idx : llvm::seq<size_t>(0U, ovTy.getNumElements()))
+                convert = f(f, ovTy.getElementType(), suffix + "_" + Twine(idx),
+                            flip, fieldID + ovTy.getFieldID(idx));
+
+              if (!convert)
+                return FIRRTLBaseType{};
+
+              return FVectorType::get(convert, ovTy.getNumElements(),
+                                      ovTy.isConst());
+            })
+        .template Case<RefType>([&](auto ref) {
+          // Do this better, don't re-serialize so much?
+          auto f = NonHWField{ref, fieldID, flip, {}};
+          suffix.toVector(f.suffix);
+          pi.fields.emplace_back(std::move(f));
+          return FIRRTLBaseType{};
+        })
+        .Default(FIRRTLBaseType{});
+  };
+
+  pi.hwType = recurse(recurse, ftype);
+  assert(pi.hwType != type);
+  // NOLINTEND(misc-no-recursion)
+
+  return pi;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerOpenAggsPass : public LowerOpenAggsBase<LowerOpenAggsPass> {
+  LowerOpenAggsPass() = default;
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+// This is the main entrypoint for the lowering pass.
+void LowerOpenAggsPass::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "===- Running Lower Open Aggregates Pass "
+                      "------------------------------------------------===\n");
+  SmallVector<Operation *, 0> ops(getOperation().getOps<FModuleLike>());
+
+  auto result = failableParallelForEach(&getContext(), ops, [&](Operation *op) {
+    Visitor visitor(&getContext());
+    return visitor.visit(cast<FModuleLike>(op));
+  });
+
+  if (result.failed())
+    signalPassFailure();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerOpenAggsPass() {
+  return std::make_unique<LowerOpenAggsPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -541,8 +541,6 @@ PortMappingInfo Visitor::mapPortType(Type type) {
     return pi;
   }
 
-  // TODO: Manage SmallString for suffix instead of Twine of pieces (since will
-  // conv to vector anyway).
   // NOLINTBEGIN(misc-no-recursion)
   auto recurse = [&](auto &&f, FIRRTLType type, const Twine &suffix = "",
                      bool flip = false,

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt --pass-pipeline="builtin.module(firrtl.circuit(firrtl-lower-open-aggs))" %s --split-input-file --verify-diagnostics
+
+firrtl.circuit "Symbol" {
+  // expected-error @below {{symbol found on aggregate with no HW}}
+  firrtl.module @Symbol(out %r : !firrtl.openbundle<p: probe<uint<1>>> sym @bad) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -9,3 +9,46 @@ firrtl.circuit "Symbol" {
     firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
   }
 }
+
+// -----
+
+firrtl.circuit "Annotation" {
+  // expected-error @below {{annotations found on aggregate with no HW}}
+  firrtl.module @Annotation(out %r : !firrtl.openbundle<p: probe<uint<1>>>) attributes {portAnnotations = [[{class = "circt.test"}]]} {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+  }
+}
+
+// -----
+// Open aggregates are expected to be removed before annotations,
+// but check this is detected and an appropriate diagnostic is presented.
+
+firrtl.circuit "MixedAnnotation" {
+  // expected-error @below {{annotations on open aggregates not handled yet}}
+  firrtl.module @MixedAnnotation(out %r : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>) attributes {portAnnotations = [[{class = "circt.test"}]]} {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+    %r_a = firrtl.opensubfield %r[a] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
+    firrtl.strictconnect %r_a, %zero : !firrtl.uint<1>
+  }
+}
+
+// -----
+// Reject unhandled ops w/open types in them.
+
+firrtl.circuit "UnhandledOp" {
+  firrtl.module @UnhandledOp(out %r : !firrtl.openbundle<p: probe<uint<1>>>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
+    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
+
+    // expected-error @below {{unhandled use or producer of types containing references}}
+    %x = firrtl.wire : !firrtl.openbundle<p : probe<uint<1>>>
+  }
+}

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -100,4 +100,10 @@ firrtl.circuit "Bundle" {
     firrtl.strictconnect %1, %3 : !firrtl.uint<1>
     firrtl.strictconnect %0, %2 : !firrtl.vector<uint<1>, 2>
   }
+
+// CHECK-LABEL: extmodule @ExtProbes
+  firrtl.extmodule @ExtProbes(
+    out r: !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>,
+    out mixed: !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>,
+    out nohw: !firrtl.openbundle<x: openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>>) attributes {convention = #firrtl<convention scalarized>}
 }

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -1,0 +1,103 @@
+// RUN: circt-opt --pass-pipeline="builtin.module(firrtl.circuit(firrtl-lower-open-aggs))" %s --split-input-file | FileCheck %s --implicit-check-not=openvector --implicit-check-not=openbundle --implicit-check-not=opensub
+
+// CHECK-LABEL: circuit "Bundle"
+firrtl.circuit "Bundle" {
+// CHECK-LABEL: module private @Child
+  firrtl.module private @Child(in %in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>,
+                               out %r: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>) {
+    %0 = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.ref.define %r, %0 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+  }
+// CHECK-LABEL: module private @Probe
+// CHECK-SAME: in %in
+// All probes
+// CHECK-NOT:  out %r:
+// CHECK-SAME: out %r_a: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>,
+// CHECK-SAME: out %r_b: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>,
+// Mixed HW / nonHW.
+// "mixed" has non-hw removed but preserved structure:
+// CHECK-SAME: out %mixed: !firrtl.bundle<a: uint<1>, x flip: vector<bundle<data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>,
+// CHECK-SAME: out %mixed_x_0_p: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>,
+// CHECK-SAME: out %mixed_x_1_p: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>,
+// All probes, but interior structure has no HW projection.
+// CHECK-NOT:  out %nohw:
+// CHECK-SAME: out %nohw_x_0_p: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>,
+// CHECK-SAME: out %nohw_x_1_p: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>) {
+  firrtl.module private @Probe(in %in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>,
+                               out %r: !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>,
+                               out %mixed: !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>,
+                               out %nohw: !firrtl.openbundle<x: openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>>) {
+    %0 = firrtl.opensubfield %nohw[x] : !firrtl.openbundle<x: openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>>
+    %1 = firrtl.opensubindex %0[1] : !firrtl.openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>
+    %2 = firrtl.opensubfield %1[p] : !firrtl.openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %3 = firrtl.opensubindex %0[0] : !firrtl.openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>
+    %4 = firrtl.opensubfield %3[p] : !firrtl.openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %5 = firrtl.opensubfield %mixed[x] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %6 = firrtl.opensubindex %5[1] : !firrtl.openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>
+    %7 = firrtl.opensubfield %6[data] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %8 = firrtl.opensubfield %6[p] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %9 = firrtl.opensubindex %5[0] : !firrtl.openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>
+    %10 = firrtl.opensubfield %9[data] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %11 = firrtl.opensubfield %9[p] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %12 = firrtl.opensubfield %mixed[b] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %13 = firrtl.opensubfield %mixed[a] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %14 = firrtl.opensubfield %r[b] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %15 = firrtl.opensubfield %r[a] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %c1_in, %c1_r = firrtl.instance c1 interesting_name @Child(in in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out r: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>)
+    %16 = firrtl.ref.sub %c1_r[1] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    %17 = firrtl.ref.sub %c1_r[0] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    %c2_in, %c2_r = firrtl.instance c2 interesting_name @Child(in in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out r: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>)
+    %18 = firrtl.ref.sub %c2_r[0] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %c1_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.strictconnect %c2_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.ref.define %15, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %14, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    %19 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
+    firrtl.strictconnect %13, %19 : !firrtl.uint<1>
+    %20 = firrtl.ref.resolve %16 : !firrtl.probe<vector<uint<1>, 2>>
+    firrtl.strictconnect %12, %20 : !firrtl.vector<uint<1>, 2>
+    firrtl.ref.define %11, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %8, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    %21 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
+    firrtl.strictconnect %10, %21 : !firrtl.uint<1>
+    %22 = firrtl.ref.resolve %18 : !firrtl.probe<uint<1>>
+    firrtl.strictconnect %7, %22 : !firrtl.uint<1>
+    firrtl.ref.define %4, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.ref.define %2, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+  }
+// CHECK-LABEL: module @Bundle
+  firrtl.module @Bundle(in %in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out1: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out2: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out3: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out4: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out5: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out6: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out %out7: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.subfield %out7[b] : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %1 = firrtl.subfield %out7[a] : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %p_in, %p_r, %p_mixed, %p_nohw = firrtl.instance p interesting_name @Probe(in in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out r: !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, out mixed: !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>, out nohw: !firrtl.openbundle<x: openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>>)
+    %2 = firrtl.opensubfield %p_mixed[b] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %3 = firrtl.opensubfield %p_mixed[a] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %4 = firrtl.opensubfield %p_nohw[x] : !firrtl.openbundle<x: openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>>
+    %5 = firrtl.opensubindex %4[1] : !firrtl.openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>
+    %6 = firrtl.opensubfield %5[p] : !firrtl.openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %7 = firrtl.opensubindex %4[0] : !firrtl.openvector<openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>, 2>
+    %8 = firrtl.opensubfield %7[p] : !firrtl.openbundle<p: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %9 = firrtl.opensubfield %p_mixed[x] : !firrtl.openbundle<a: uint<1>, x flip: openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>, b: vector<uint<1>, 2>>
+    %10 = firrtl.opensubindex %9[1] : !firrtl.openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>
+    %11 = firrtl.opensubfield %10[p] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %12 = firrtl.opensubindex %9[0] : !firrtl.openvector<openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>, 2>
+    %13 = firrtl.opensubfield %12[p] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
+    %14 = firrtl.opensubfield %p_r[b] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    %15 = firrtl.opensubfield %p_r[a] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
+    firrtl.strictconnect %p_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %16 = firrtl.ref.resolve %15 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out1, %16 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %17 = firrtl.ref.resolve %14 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out2, %17 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %18 = firrtl.ref.resolve %13 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out3, %18 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %19 = firrtl.ref.resolve %11 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out4, %19 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %20 = firrtl.ref.resolve %8 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out5, %20 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    %21 = firrtl.ref.resolve %6 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
+    firrtl.strictconnect %out6, %21 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.strictconnect %1, %3 : !firrtl.uint<1>
+    firrtl.strictconnect %0, %2 : !firrtl.vector<uint<1>, 2>
+  }
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -512,6 +512,9 @@ static LogicalResult processBuffer(
   if (failed(applyPassManagerCLOptions(pm)))
     return failure();
 
+  // Legalize away "open" aggregates to hw-only versions.
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerOpenAggsPass());
+
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
       disableAnnotationsUnknown, disableAnnotationsClassless,
       lowerAnnotationsNoRefTypePorts));

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -512,9 +512,6 @@ static LogicalResult processBuffer(
   if (failed(applyPassManagerCLOptions(pm)))
     return failure();
 
-  // Legalize away "open" aggregates to hw-only versions.
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerOpenAggsPass());
-
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
       disableAnnotationsUnknown, disableAnnotationsClassless,
       lowerAnnotationsNoRefTypePorts));


### PR DESCRIPTION
Immediately after parsing (cc #5128), "lower" the open aggregates containing mixed hardware into their hardware-only "projections", pulling out the non-hw elements (refs) and rewriting all opensub* ops accordingly.