### PR TITLE
[Arc] Add LatencyRetiming pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -96,6 +96,10 @@ def DefineOp : ArcOp<"define", [
                            "' attribute of function type";
       return mlir::success();
     }
+
+    /// Returns true if the arc returns the inputs directly and in the same
+    /// order, otherwise false.
+    bool isPassthrough();
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -28,6 +28,7 @@ std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 std::unique_ptr<mlir::Pass> createInferStatePropertiesPass();
 std::unique_ptr<mlir::Pass> createInlineArcsPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
+std::unique_ptr<mlir::Pass> createLatencyRetimingPass();
 std::unique_ptr<mlir::Pass> createLegalizeStateUpdatePass();
 std::unique_ptr<mlir::Pass> createLowerClocksToFuncsPass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -78,6 +78,19 @@ def InferStateProperties : Pass<"arc-infer-state-properties",
   let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect"];
 }
 
+def LatencyRetiming : Pass<"arc-latency-retiming", "mlir::ModuleOp"> {
+  let summary = "Push latencies through the design";
+  let constructor = "circt::arc::createLatencyRetimingPass()";
+  let dependentDialects = ["arc::ArcDialect"];
+
+  let statistics = [
+    Statistic<"numOpsRemoved", "num-ops-removed",
+      "Number of zero-latency passthrough states removed">,
+    Statistic<"latencyUnitsSaved", "latency-units-saved",
+      "Number of latency units saved by merging them in a successor state">
+  ];
+}
+
 def LegalizeStateUpdate : Pass<"arc-legalize-state-update", "mlir::ModuleOp"> {
   let summary = "Insert temporaries such that state reads don't see writes";
   let constructor = "circt::arc::createLegalizeStateUpdatePass()";

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -35,36 +35,37 @@
 // classes here should be imported from the `mlir` namespace, not the `llvm`
 // namespace.
 namespace circt {
-using mlir::APFloat;
-using mlir::APInt;
-using mlir::APSInt;
-using mlir::ArrayRef;
-using mlir::BitVector;
-using mlir::cast;
-using mlir::cast_or_null;
-using mlir::DenseMap;
-using mlir::DenseMapInfo;
-using mlir::DenseSet;
-using mlir::dyn_cast;
-using mlir::dyn_cast_or_null;
-using mlir::function_ref;
-using mlir::isa;
-using mlir::isa_and_nonnull;
-using mlir::iterator_range;
-using mlir::MutableArrayRef;
-using mlir::PointerUnion;
-using mlir::raw_ostream;
-using mlir::SmallPtrSet;
-using mlir::SmallPtrSetImpl;
-using mlir::SmallString;
-using mlir::SmallVector;
-using mlir::SmallVectorImpl;
-using mlir::StringLiteral;
-using mlir::StringRef;
-using mlir::StringSet;
-using mlir::TinyPtrVector;
-using mlir::Twine;
-using mlir::TypeSwitch;
+using mlir::APFloat;          // NOLINT(misc-unused-using-decls)
+using mlir::APInt;            // NOLINT(misc-unused-using-decls)
+using mlir::APSInt;           // NOLINT(misc-unused-using-decls)
+using mlir::ArrayRef;         // NOLINT(misc-unused-using-decls)
+using mlir::BitVector;        // NOLINT(misc-unused-using-decls)
+using mlir::cast;             // NOLINT(misc-unused-using-decls)
+using mlir::cast_or_null;     // NOLINT(misc-unused-using-decls)
+using mlir::DenseMap;         // NOLINT(misc-unused-using-decls)
+using mlir::DenseMapInfo;     // NOLINT(misc-unused-using-decls)
+using mlir::DenseSet;         // NOLINT(misc-unused-using-decls)
+using mlir::dyn_cast;         // NOLINT(misc-unused-using-decls)
+using mlir::dyn_cast_or_null; // NOLINT(misc-unused-using-decls)
+using mlir::function_ref;     // NOLINT(misc-unused-using-decls)
+using mlir::isa;              // NOLINT(misc-unused-using-decls)
+using mlir::isa_and_nonnull;  // NOLINT(misc-unused-using-decls)
+using mlir::iterator_range;   // NOLINT(misc-unused-using-decls)
+using mlir::MutableArrayRef;  // NOLINT(misc-unused-using-decls)
+using mlir::PointerUnion;     // NOLINT(misc-unused-using-decls)
+using mlir::raw_ostream;      // NOLINT(misc-unused-using-decls)
+using mlir::SetVector;        // NOLINT(misc-unused-using-decls)
+using mlir::SmallPtrSet;      // NOLINT(misc-unused-using-decls)
+using mlir::SmallPtrSetImpl;  // NOLINT(misc-unused-using-decls)
+using mlir::SmallString;      // NOLINT(misc-unused-using-decls)
+using mlir::SmallVector;      // NOLINT(misc-unused-using-decls)
+using mlir::SmallVectorImpl;  // NOLINT(misc-unused-using-decls)
+using mlir::StringLiteral;    // NOLINT(misc-unused-using-decls)
+using mlir::StringRef;        // NOLINT(misc-unused-using-decls)
+using mlir::StringSet;        // NOLINT(misc-unused-using-decls)
+using mlir::TinyPtrVector;    // NOLINT(misc-unused-using-decls)
+using mlir::Twine;            // NOLINT(misc-unused-using-decls)
+using mlir::TypeSwitch;       // NOLINT(misc-unused-using-decls)
 } // namespace circt
 
 // Forward declarations of LLVM classes to be imported in to the circt
@@ -79,8 +80,8 @@ class SmallSet;
 
 // Import things we want into our namespace.
 namespace circt {
-using llvm::SmallDenseMap;
-using llvm::SmallSet;
+using llvm::SmallDenseMap; // NOLINT(misc-unused-using-decls)
+using llvm::SmallSet;      // NOLINT(misc-unused-using-decls)
 } // namespace circt
 
 // Forward declarations of classes to be imported in to the circt namespace.

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -114,6 +114,17 @@ LogicalResult DefineOp::verifyRegions() {
   return success();
 }
 
+bool DefineOp::isPassthrough() {
+  if (getNumArguments() != getNumResults())
+    return false;
+
+  return llvm::all_of(
+      llvm::zip(getArguments(), getBodyBlock().getTerminator()->getOperands()),
+      [](const auto &argAndRes) {
+        return std::get<0>(argAndRes) == std::get<1>(argAndRes);
+      });
+}
+
 //===----------------------------------------------------------------------===//
 // OutputOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   InferStateProperties.cpp
   InlineArcs.cpp
   InlineModules.cpp
+  LatencyRetiming.cpp
   LegalizeStateUpdate.cpp
   LowerClocksToFuncs.cpp
   LowerLUT.cpp

--- a/lib/Dialect/Arc/Transforms/InlineArcs.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineArcs.cpp
@@ -15,7 +15,6 @@
 
 using namespace circt;
 using namespace arc;
-using llvm::SetVector;
 using llvm::SmallDenseSet;
 using mlir::InlinerInterface;
 using mlir::SymbolUserMap;

--- a/lib/Dialect/Arc/Transforms/LatencyRetiming.cpp
+++ b/lib/Dialect/Arc/Transforms/LatencyRetiming.cpp
@@ -1,0 +1,138 @@
+//===- LatencyRetiming.cpp - Implement LatencyRetiming Pass ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Support/LLVM.h"
+#include "circt/Support/SymCache.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "arc-latency-retiming"
+
+using namespace circt;
+using namespace arc;
+
+//===----------------------------------------------------------------------===//
+// Patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LatencyRetimingStatistics {
+  unsigned numOpsRemoved = 0;
+  unsigned latencyUnitsSaved = 0;
+};
+
+/// Absorb the latencies from predecessor states to collapse shift registers and
+/// reduce the overall amount of latency units in the design.
+struct LatencyRetimingPattern : OpRewritePattern<StateOp> {
+  LatencyRetimingPattern(MLIRContext *context, SymbolCache &symCache,
+                         LatencyRetimingStatistics &statistics)
+      : OpRewritePattern<StateOp>(context), symCache(symCache),
+        statistics(statistics) {}
+
+  LogicalResult matchAndRewrite(StateOp op,
+                                PatternRewriter &rewriter) const final;
+
+private:
+  SymbolCache &symCache;
+  LatencyRetimingStatistics &statistics;
+};
+
+} // namespace
+
+LogicalResult
+LatencyRetimingPattern::matchAndRewrite(StateOp op,
+                                        PatternRewriter &rewriter) const {
+  unsigned minPrevLatency = UINT_MAX;
+  SetVector<StateOp> predecessors;
+
+  if (op.getReset() || op.getEnable())
+    return failure();
+
+  for (auto input : op.getInputs()) {
+    auto predState = input.getDefiningOp<StateOp>();
+    if (!predState)
+      return failure();
+
+    if (predState->hasAttr("name") || predState->hasAttr("names"))
+      return failure();
+
+    if (predState == op)
+      return failure();
+
+    if (predState.getLatency() != 0 && op.getLatency() != 0 &&
+        predState.getClock() != op.getClock())
+      return failure();
+
+    if (predState.getEnable() || predState.getReset())
+      return failure();
+
+    if (llvm::any_of(predState->getUsers(),
+                     [&](auto *user) { return user != op; }))
+      return failure();
+
+    predecessors.insert(predState);
+    minPrevLatency = std::min(minPrevLatency, predState.getLatency());
+  }
+
+  if (minPrevLatency == 0 || minPrevLatency == UINT_MAX)
+    return failure();
+
+  op.setLatency(op.getLatency() + minPrevLatency);
+  for (auto prevStateOp : predecessors) {
+    if (!op.getClock() && !op->getParentOfType<ClockDomainOp>())
+      op.getClockMutable().assign(prevStateOp.getClock());
+
+    statistics.latencyUnitsSaved += minPrevLatency;
+    auto newLatency = prevStateOp.getLatency() - minPrevLatency;
+    prevStateOp.setLatency(newLatency);
+
+    if (newLatency > 0)
+      continue;
+
+    prevStateOp.getClockMutable().clear();
+    if (cast<DefineOp>(symCache.getDefinition(prevStateOp.getArcAttr()))
+            .isPassthrough()) {
+      rewriter.replaceOp(prevStateOp, prevStateOp.getInputs());
+      ++statistics.numOpsRemoved;
+    }
+  }
+  statistics.latencyUnitsSaved -= minPrevLatency;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LatencyRetiming pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LatencyRetimingPass : LatencyRetimingBase<LatencyRetimingPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LatencyRetimingPass::runOnOperation() {
+  SymbolCache cache;
+  cache.addDefinitions(getOperation());
+
+  LatencyRetimingStatistics statistics;
+
+  RewritePatternSet patterns(&getContext());
+  patterns.add<LatencyRetimingPattern>(&getContext(), cache, statistics);
+
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    return signalPassFailure();
+
+  numOpsRemoved = statistics.numOpsRemoved;
+  latencyUnitsSaved = statistics.latencyUnitsSaved;
+}
+
+std::unique_ptr<Pass> arc::createLatencyRetimingPass() {
+  return std::make_unique<LatencyRetimingPass>();
+}

--- a/lib/Dialect/Arc/Transforms/SplitLoops.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitLoops.cpp
@@ -19,7 +19,6 @@ using namespace circt;
 using namespace arc;
 using namespace hw;
 
-using llvm::SetVector;
 using llvm::SmallSetVector;
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Arc/latency-retiming.mlir
+++ b/test/Dialect/Arc/latency-retiming.mlir
@@ -1,0 +1,95 @@
+// RUN: circt-opt %s --arc-latency-retiming | FileCheck %s
+
+// CHECK-LABEL: hw.module @Foo
+hw.module @Foo(%clk: i1, %clk2: i1, %en: i1, %rst: i1, %arg0: i32, %arg1: i32) -> (out0: i32, out1: i32, out2: i32, out3: i32, out4: i32, out5: i32, out6: i32, out7: i32, out8: i32, out9: i32, out10: i32, out11: i32) {
+  // COM: simple shift-register of depth 3 is merged to one arc.state
+  %0 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  %1 = arc.state @Bar(%0) clock %clk lat 1 : (i32) -> i32
+  %2 = arc.state @Bar(%1) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V0:%.+]] = arc.state @Bar(%arg0) clock %clk lat 3 :
+
+  // COM: looks like a shift register from the outside (and actually is), but
+  // COM: the arcs are not exactly passthroughs, so don't erase them
+  // COM: TODO: a canonicalization pattern could reorder the outputs such that
+  // COM:       this also folds to just one state, but inlining will get rid of
+  // COM:       them anyways.
+  // CHECK-NEXT: [[V1:%.+]]:2 = arc.state @Baz(%arg0, %arg1) lat 0 :
+  %3:2 = arc.state @Baz(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+  // CHECK-NEXT: [[V2:%.+]]:2 = arc.state @Baz([[V1]]#0, [[V1]]#1) lat 0 :
+  %4:2 = arc.state @Baz(%3#0, %3#1) clock %clk lat 2 : (i32, i32) -> (i32, i32)
+  // CHECK-NEXT: [[V3:%.+]]:2 = arc.state @Baz([[V2]]#0, [[V2]]#1) clock %clk lat 6 :
+  %5:2 = arc.state @Baz(%4#0, %4#1) clock %clk lat 3 : (i32, i32) -> (i32, i32)
+
+  // COM: a fan-in tree, op that gets the latencies starts with lat 0
+  %6 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  %7 = arc.state @Bar(%arg1) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V4:%.+]]:2 = arc.state @Baz(%arg0, %arg1) lat 0 :
+  %8:2 = arc.state @Baz(%6, %7) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+  %9 = arc.state @Bar(%arg1) clock %clk lat 2 : (i32) -> i32
+  // CHECK-NEXT: [[V5:%.+]]:2 = arc.state @Baz([[V4]]#0, %arg1) clock %clk lat 2 :
+  %10:2 = arc.state @Baz(%8#0, %9) lat 0 : (i32, i32) -> (i32, i32)
+
+  // COM: fan-out tree
+  // CHECK-NEXT: [[V6:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
+  %11 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk lat 1 :
+  %12 = arc.state @Bar(%11) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk lat 1 :
+  %13 = arc.state @Bar(%11) clock %clk lat 1 : (i32) -> i32
+
+  // COM: states with names attached are not touched
+  %14 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V7:%.+]] = arc.state @Bar(%arg0) clock %clk lat 2 {name = "reg"} :
+  %15 = arc.state @Bar(%14) clock %clk lat 1 {name = "reg"} : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V7]]) clock %clk lat 1 :
+  %16 = arc.state @Bar(%15) clock %clk lat 1 : (i32) -> i32
+
+  // COM: states with names attached are not touched
+  %17 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V8:%.+]] = arc.state @Bar(%arg0) clock %clk lat 2 {names = ["reg"]} :
+  %18 = arc.state @Bar(%17) clock %clk lat 1 {names = ["reg"]} : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V8]]) clock %clk lat 1 :
+  %19 = arc.state @Bar(%18) clock %clk lat 1 : (i32) -> i32
+
+  // COM: states with enables are not touched
+  // CHECK-NEXT: [[V9:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
+  %20 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V10:%.+]] = arc.state @Bar([[V9]]) clock %clk enable %en lat 1 :
+  %21 = arc.state @Bar(%20) clock %clk enable %en lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V10]]) clock %clk lat 1 :
+  %22 = arc.state @Bar(%21) clock %clk lat 1 : (i32) -> i32
+
+  // COM: states with resets are not touched
+  // CHECK-NEXT: [[V11:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
+  %23 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V12:%.+]] = arc.state @Bar([[V11]]) clock %clk reset %rst lat 1 :
+  %24 = arc.state @Bar(%23) clock %clk reset %rst lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V12]]) clock %clk lat 1 :
+  %25 = arc.state @Bar(%24) clock %clk lat 1 : (i32) -> i32
+
+  // COM: using own result value
+  // CHECK-NEXT: [[V13:%.+]] = arc.state @Bar([[V13]]) clock %clk lat 1 :
+  %26 = arc.state @Bar(%26) clock %clk lat 1 : (i32) -> i32
+
+  // COM: different clocks
+  // CHECK-NEXT: arc.state @Bar(%arg0) clock %clk lat 1 :
+  %27 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar({{.*}}) clock %clk2 lat 1 :
+  %28 = arc.state @Bar(%27) clock %clk2 lat 1 : (i32) -> i32
+
+  // COM: can only partially take over latencies
+  %29 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar(%arg1) clock %clk lat 1 :
+  %30 = arc.state @Bar(%arg1) clock %clk lat 2 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Baz(%arg0, {{.+}}) clock %clk lat 2 :
+  %31:2 = arc.state @Baz(%29, %30) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+
+  // CHECK-NEXT: hw.output [[V0]], [[V3]]#0, [[V3]]#1, [[V5]]#0
+  hw.output %2, %5#0, %5#1, %10#0, %12, %13, %16, %19, %22, %25, %28, %31 : i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+}
+arc.define @Bar(%arg0: i32) -> i32 {
+  arc.output %arg0 : i32
+}
+arc.define @Baz(%arg0: i32, %arg1: i32) -> (i32, i32) {
+  arc.output %arg1, %arg0 : i32, i32
+}


### PR DESCRIPTION
Currently, the latency attribute on the `arc.state` operations is not really used except for differentiating between 0 and 1 latency. This pass collapses sequences of `arc.state` operations that form a shift register into one state operation. It also aggregates the latencies of isolated fan-in trees. It's still very simple in its current form, but can be easily extended in the future. Since we don't have a proper benchmark running yet to assess performance, I gathered some statistics instead by ignoring the name attributes on the states (basically assuming that the user tells arcilator that they are only interested in the inputs and outputs, but not observing internal state and thus no taps are inserted). I don't add it to arcilator for now since we don't have a way to remove the name attributes in a controlled manner yet (it's also possible to apply these patterns in the presence of taps, but that's also not implemented yet and too much to add to this PR) and also no lowering support for states with >1 latency.

LargeBoomConfig statistics:
```
LatencyRetiming
  (S)  93 latency-units-saved - Number of latency units saved by merging them in a successor state
  (S) 245 num-ops-removed     - Number of zero-latency passthrough states removed
```

| latency | number of `arc.state` before | after |
|---|---|---|
| 0 | 25441 | 25572 |
| 1 | 27175 | 26596 |
| 2 | 0 | 123 |
| 3 | 0 | 80 |

Rocket statistics:
```
LatencyRetiming
  (S) 0 latency-units-saved - Number of latency units saved by merging them in a successor state
  (S) 5 num-ops-removed     - Number of zero-latency passthrough states removed
```