### PR TITLE
[Arc] Generalize InlineArcs pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -28,6 +28,7 @@ class ArcOp<string mnemonic, list<Trait> traits = []> :
 def DefineOp : ArcOp<"define", [
   IsolatedFromAbove,
   FunctionOpInterface,
+  CallableOpInterface,
   Symbol,
   RegionKindInterface,
   SingleBlockImplicitTerminator<"arc::OutputOp">,
@@ -100,6 +101,15 @@ def DefineOp : ArcOp<"define", [
     /// Returns true if the arc returns the inputs directly and in the same
     /// order, otherwise false.
     bool isPassthrough();
+
+    //===------------------------------------------------------------------===//
+    // CallableOpInterface
+    //===------------------------------------------------------------------===//
+
+    mlir::Region *getCallableRegion() { return &getBody(); }
+    ArrayRef<mlir::Type> getCallableResults() { return getResultTypes(); }
+    mlir::ArrayAttr getCallableArgAttrs() { return nullptr; }
+    mlir::ArrayAttr getCallableResAttrs() { return nullptr; }
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -55,6 +55,12 @@ def InlineArcs : Pass<"arc-inline" , "mlir::ModuleOp"> {
     Statistic<"numTrivialArcs", "trivial-arcs", "Arcs with very few ops">,
     Statistic<"numSingleUseArcs", "single-use-arcs", "Arcs with a single use">,
   ];
+  let options = [
+    Option<"intoArcsOnly", "into-arcs-only", "bool", "false",
+           "Call operations to inline">,
+    Option<"maxNonTrivialOpsInBody", "max-body-ops", "unsigned", "3",
+           "Max number of non-trivial ops in the region to be inlined">,
+  ];
 }
 
 def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {

--- a/lib/Dialect/Arc/Transforms/InlineArcs.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineArcs.cpp
@@ -15,18 +15,21 @@
 
 using namespace circt;
 using namespace arc;
-using llvm::SmallDenseSet;
 using mlir::InlinerInterface;
-using mlir::SymbolUserMap;
 
 namespace {
 
 struct InlineArcsPass : public InlineArcsBase<InlineArcsPass> {
   InlineArcsPass() = default;
+  InlineArcsPass(bool intoArcsOnly, unsigned maxNonTrivialOpsInBody)
+      : InlineArcsPass() {
+    this->intoArcsOnly.setInitialValue(intoArcsOnly);
+    this->maxNonTrivialOpsInBody.setInitialValue(maxNonTrivialOpsInBody);
+  }
   InlineArcsPass(const InlineArcsPass &pass) : InlineArcsPass() {}
 
   void runOnOperation() override;
-  bool shouldInline(DefineOp defOp, ArrayRef<Operation *> users);
+  bool shouldInline(DefineOp defOp, ArrayRef<mlir::CallOpInterface> users);
 };
 
 /// A simple implementation of the `InlinerInterface` that marks all inlining as
@@ -37,17 +40,11 @@ struct ArcInliner : public InlinerInterface {
 
   bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
                        IRMapping &valueMapping) const override {
-    return true;
+    return isa<DefineOp>(src->getParentOp());
   }
   bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
                        IRMapping &valueMapping) const override {
-    return true;
-  }
-  void handleTerminator(Operation *op,
-                        ArrayRef<Value> valuesToRepl) const override {
-    assert(isa<arc::OutputOp>(op));
-    for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
-      from.replaceAllUsesWith(to);
+    return op->getParentOfType<DefineOp>();
   }
 };
 
@@ -55,45 +52,125 @@ struct ArcInliner : public InlinerInterface {
 
 void InlineArcsPass::runOnOperation() {
   auto module = getOperation();
-  SymbolTableCollection symbolTable;
-  SymbolUserMap symbolUserMap(symbolTable, module);
 
-  for (auto defOp : llvm::make_early_inc_range(module.getOps<DefineOp>())) {
+  // Store the call hierarcy manually since we need to keep it updated and the
+  // provided datastructures do not seem to support this
+  DenseMap<DefineOp, DenseSet<DefineOp>> arcsCalledInBody;
+  DenseMap<DefineOp, DenseSet<mlir::CallOpInterface>> usersPerArc;
+
+  SymbolTableCollection symbolTable;
+  ArcInliner inliner(&getContext());
+
+  // Compute Arc call hierarchy
+  module->walk([&](Operation *op) {
+    if (auto defOp = dyn_cast<DefineOp>(op)) {
+      arcsCalledInBody.insert({defOp, {}});
+      usersPerArc.insert({defOp, {}});
+    }
+
+    if (auto callOp = dyn_cast<mlir::CallOpInterface>(op)) {
+      if (auto defOp =
+              dyn_cast<DefineOp>(callOp.resolveCallable(&symbolTable))) {
+        usersPerArc[defOp].insert(callOp);
+        if (auto parentOp = op->getParentOfType<DefineOp>())
+          arcsCalledInBody[parentOp].insert(defOp);
+      }
+    }
+  });
+
+  // Remove all unused arcs
+  SmallVector<DefineOp> removeList(module.getOps<DefineOp>());
+  while (!removeList.empty()) {
+    auto defOp = removeList.pop_back_val();
+    if (!defOp)
+      continue;
+
+    if (usersPerArc[defOp].empty()) {
+      usersPerArc.erase(defOp);
+      for (auto callee : arcsCalledInBody[defOp]) {
+        defOp->walk([&](mlir::CallOpInterface call) {
+          usersPerArc[callee].erase(call);
+        });
+        if (usersPerArc[callee].empty())
+          removeList.push_back(callee);
+      }
+      arcsCalledInBody.erase(defOp);
+      defOp.erase();
+      ++numRemovedArcs;
+    }
+  }
+
+  // It's a bit ugly that we have an intermediate datastructure here, but some
+  // attempts in using a datastructure with deterministic iteration over
+  // arcsCalledInBody have shown worse performance.
+  SmallVector<DefineOp> arcsWithoutFurtherCalls;
+  for (const auto &[defOp, list] : arcsCalledInBody)
+    if (defOp && list.empty())
+      arcsWithoutFurtherCalls.push_back(defOp);
+
+  // We need to sort here because we iterated over a hashmap above.
+  std::sort(arcsWithoutFurtherCalls.begin(), arcsWithoutFurtherCalls.end());
+  SetVector<DefineOp> worklist(arcsWithoutFurtherCalls.begin(),
+                               arcsWithoutFurtherCalls.end());
+
+  while (!worklist.empty()) {
+    auto defOp = worklist.pop_back_val();
+
+    // TODO: copying here and sorting is not ideal, we should use another
+    // datastructure than a DenseSet. We need to unique the initial set of
+    // elements, deterministic iteration and fast element deletion, so maybe a
+    // linked list?
+    SmallVector<mlir::CallOpInterface> users(usersPerArc[defOp].begin(),
+                                             usersPerArc[defOp].end());
+    std::sort(users.begin(), users.end());
+
+    // Update the worklist
+    for (auto caller : users) {
+      if (auto parentOp = caller->getParentOfType<DefineOp>()) {
+        arcsCalledInBody[parentOp].erase(defOp);
+        if (arcsCalledInBody[parentOp].empty())
+          worklist.insert(parentOp);
+      }
+    }
+
     // Check if we should inline the arc.
-    auto users = symbolUserMap.getUsers(defOp);
     if (!shouldInline(defOp, users))
       continue;
+
     LLVM_DEBUG(llvm::dbgs() << "Inlining " << defOp.getSymName() << "\n");
 
     // Inline all uses of the arc. Currently we inline all of them but in the
     // future we may decide per use site whether to inline or not.
     unsigned numUsersLeft = users.size();
-    for (auto *user : users) {
-      auto useOp = dyn_cast<StateOp>(user);
-      if (!useOp)
-        continue;
-      if (useOp.getLatency() > 0)
+    for (auto user : users) {
+      if (!user->getParentOfType<DefineOp>() && intoArcsOnly)
         continue;
 
-      bool isLastArcUse = --numUsersLeft == 0;
-      ArcInliner inliner(&getContext());
-      if (failed(mlir::inlineRegion(inliner, &defOp.getBody(), useOp,
-                                    useOp.getOperands(), useOp.getResults(),
-                                    std::nullopt, !isLastArcUse))) {
-        useOp.emitError("failed to inline arc '") << defOp.getName() << "'";
-        return signalPassFailure();
+      // Recursive calls of arcs are not allowed, but since we cannot verify
+      // that in the op verifier, we need to check check here just to be sure
+      if (defOp == user->getParentOfType<DefineOp>())
+        continue;
+
+      if (succeeded(mlir::inlineCall(inliner, user, defOp, &defOp.getBody(),
+                                     numUsersLeft > 1))) {
+        usersPerArc[defOp].erase(user);
+        user.erase();
+        --numUsersLeft;
+        ++numInlinedArcs;
       }
-      useOp.erase();
-      if (isLastArcUse) {
+
+      if (numUsersLeft == 0) {
+        arcsCalledInBody.erase(defOp);
+        usersPerArc.erase(defOp);
         defOp.erase();
         ++numRemovedArcs;
       }
-      ++numInlinedArcs;
     }
   }
 }
 
-bool InlineArcsPass::shouldInline(DefineOp defOp, ArrayRef<Operation *> users) {
+bool InlineArcsPass::shouldInline(DefineOp defOp,
+                                  ArrayRef<mlir::CallOpInterface> users) {
   // Count the number of non-trivial ops in the arc. If there are only a few,
   // inline the arc.
   unsigned numNonTrivialOps = 0;
@@ -101,7 +178,7 @@ bool InlineArcsPass::shouldInline(DefineOp defOp, ArrayRef<Operation *> users) {
     if (!op->hasTrait<OpTrait::ConstantLike>() && !isa<OutputOp>(op))
       ++numNonTrivialOps;
   });
-  if (numNonTrivialOps <= 3) {
+  if (numNonTrivialOps <= maxNonTrivialOpsInBody) {
     ++numTrivialArcs;
     return true;
   }


### PR DESCRIPTION
InlineArcs only considers `arc.state` operations at the moment. This adds support to also inline `arc.call` sites. While the callgraph of the state ops is entirely flat as they can only occur in a `hw.module` and there is no hierarchy of such modules, the callgraph including `arc.call` operations form a DAG. Arcs are not allowed to have recursions, but as this is not properly verified, this pass checks for that and leaves the recursive structure as is. In order to perform the least amount of calls to the inlining utility, this pass is extended to traverse the callgraph bottom-up. This way calls are inlined before they potentially get duplicated by inlining in multiple call-sites. Would be nice to have something like `InstanceGraph` for arcs to use the llvm graph iterators.
Additionally, this pass removes all arcs that are not used now. This also adds some options to the pass to control whether the pass should only inline into arcs (and not modules to keep the state op graph intact there) as well as the maximum number of non-primitive ops an arcs is allowed to have to still be eligible for inlining.