### PR TITLE
[CMake] Make cmake config more reliable?

### DIFF
--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -1,12 +1,17 @@
-set(LLVM_OPTIONAL_SOURCES
-  ArcReductions.cpp
-)
-
-add_circt_dialect_library(CIRCTArc
+set(srcs
   ArcDialect.cpp
   ArcFolds.cpp
   ArcOps.cpp
   ArcTypes.cpp
+)
+
+set(LLVM_OPTIONAL_SOURCES
+  ${srcs}
+  ArcReductions.cpp
+)
+
+add_circt_dialect_library(CIRCTArc
+  ${srcs}
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -1,9 +1,4 @@
-set(LLVM_OPTIONAL_SOURCES
-  FIRRTLReductions.cpp
-)
-
-include_directories(.)
-add_circt_dialect_library(CIRCTFIRRTL
+set(srcs
   CHIRRTLDialect.cpp
   FIRRTLAnnotationHelper.cpp
   FIRRTLAnnotations.cpp
@@ -17,6 +12,16 @@ add_circt_dialect_library(CIRCTFIRRTL
   FIRRTLTypes.cpp
   FIRRTLUtils.cpp
   NLATable.cpp
+)
+
+set(LLVM_OPTIONAL_SOURCES
+  ${srcs}
+  FIRRTLReductions.cpp
+)
+
+include_directories(.)
+add_circt_dialect_library(CIRCTFIRRTL
+  ${srcs}
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/FIRRTL

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -1,8 +1,4 @@
-set(LLVM_OPTIONAL_SOURCES
-  HWReductions.cpp
-)
-
-add_circt_dialect_library(CIRCTHW
+set(srcs
   CustomDirectiveImpl.cpp
   HWAttributes.cpp
   HWDialect.cpp
@@ -15,6 +11,15 @@ add_circt_dialect_library(CIRCTHW
   InstanceImplementation.cpp
   ModuleImplementation.cpp
   InnerSymbolTable.cpp
+)
+
+set(LLVM_OPTIONAL_SOURCES
+  ${srcs}
+  HWReductions.cpp
+)
+
+add_circt_dialect_library(CIRCTHW
+  ${srcs}
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/HW


### PR DESCRIPTION
I've heard from someone who ported CIRCT main to work with mlir-16 that the LLVM cmake checks complain that there are cpp files not included in any library. I'm not sure if that's caused by changes in the LLVM cmake config since then or if generally all cpp files in that directory should be marked optional when there are multiple libraries declared in a CMakeLists.txt.

Could someone with more CMake knowledge take a look if that change makes sense?