### PR TITLE
[Arc] Add StorageGetOp canonicalizer

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -463,7 +463,7 @@ def RootOutputOp : ArcOp<"root_output", [
 
 def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType]>;
 
-def StorageGetOp : ArcOp<"storage.get", [MemoryEffects<[MemRead]>]> {
+def StorageGetOp : ArcOp<"storage.get", [Pure]> {
   let summary = "Access an allocated state, memory, or storage slice";
   let arguments = (ins StorageType:$storage, I32Attr:$offset);
   let results = (outs AllocatableType:$result);
@@ -471,6 +471,7 @@ def StorageGetOp : ArcOp<"storage.get", [MemoryEffects<[MemRead]>]> {
     $storage `[` $offset `]` attr-dict
     `:` qualified(type($storage)) `->` type($result)
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -124,6 +124,20 @@ LogicalResult MemoryWriteOp::canonicalize(MemoryWriteOp op,
 }
 
 //===----------------------------------------------------------------------===//
+// StorageGetOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StorageGetOp::canonicalize(StorageGetOp op,
+                                         PatternRewriter &rewriter) {
+  if (auto pred = op.getStorage().getDefiningOp<StorageGetOp>()) {
+    op.getStorageMutable().assign(pred.getStorage());
+    op.setOffset(op.getOffset() + pred.getOffset());
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
 // ClockDomainOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -142,3 +142,18 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
 arc.define @identityi1(%arg0: i1) -> i1 {
   arc.output %arg0 : i1
 }
+
+// CHECK-LABEL: arc.model "StorageGetCanonicalizers"
+arc.model "StorageGetCanonicalizers" {
+// CHECK-NEXT: ^bb
+^bb0(%arg0: !arc.storage<512>):
+  %0 = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.storage<16>
+  %1 = arc.storage.get %0[0] : !arc.storage<16> -> !arc.state<i64>
+  %2 = arc.storage.get %0[8] : !arc.storage<16> -> !arc.state<i64>
+  %3 = arc.state_read %1 : <i64>
+  arc.state_write %2 = %3 : <i64>
+  // CHECK-NEXT: [[V0:%.+]] = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.state<i64>
+  // CHECK-NEXT: [[V1:%.+]] = arc.storage.get %arg0[24] : !arc.storage<512> -> !arc.state<i64>
+  // CHECK-NEXT: [[V2:%.+]] = arc.state_read [[V0]] : <i64>
+  // CHECK-NEXT: arc.state_write [[V1]] = [[V2]] : <i64>
+}


### PR DESCRIPTION
* Since `arc.storage.get` does not access the storage, but just adds a constant to the pointer (like getelementpointer), it does not have to be constrained to a memory read.
* Add a canonicalizer to collapse sequences of such ops.