### PR TITLE
[FIRRTL] Const handling in cast ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -915,8 +915,9 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 
 // This assumes operands are ground types without explicitly checking
 class SameGroundTypeOperandConstness<string a, string b> 
-  : PredOpTrait<"operand constness must match",
-                 CPred<"isConst($" # a # ".getType()) == isConst($" # b # ".getType())">>;
+  : PredOpTrait<
+      "operand constness must match",
+      CPred<"isConst($" # a # ".getType()) == isConst($" # b # ".getType())">>;
 
 def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameGroundTypeOperandConstness<"input", "result">]> {
   let description = [{
@@ -946,9 +947,12 @@ def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure, SameG
 def ConstCastOp : FIRRTLOp<"constCast", [HasCustomSSAName, Pure]> {
   let description = [{
     Cast from a 'const' to a non-'const' type.
+    ```
+    %result = firrtl.constCast %in : (!firrtl.const.t1) -> !firrtl.t1
+    ```
   }];
-  let arguments = (ins FIRRTLBaseType:$input);
-  let results = (outs FIRRTLBaseType:$result);
+  let arguments = (ins PassiveType:$input);
+  let results = (outs PassiveType:$result);
   let hasVerifier = 1;
   let assemblyFormat =
     "$input attr-dict `:` functional-type($input, $result)";

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -913,7 +913,11 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 // Special inference Operations
 //===----------------------------------------------------------------------===//
 
-def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure]> {
+class SameOperandConstness<string a, string b> 
+  : PredOpTrait<"operand constness must match",
+                 CPred<"isConst($" # a # ".getType()) == isConst($" # b # ".getType())">>;
+
+def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameOperandConstness<"input", "result">]> {
   let description = [{
     Cast between reset types.  This is used to enable strictconnects early in
     the pipeline by isolating all uninferred reset connections to a single op.
@@ -925,7 +929,7 @@ def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure]> {
     "$input attr-dict `:` functional-type($input, $result)";
 }
 
-def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure]> {
+def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure, SameOperandConstness<"input", "result">]> {
   let description = [{
     Cast between sized and unsized integer types.  This is used to enable
     strictconnects early in the pipeline by isolating all uninferred width
@@ -934,6 +938,17 @@ def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure]> {
   let arguments = (ins IntType:$input);
   let results = (outs IntType:$result);
   let hasFolder = 1;
+  let assemblyFormat =
+    "$input attr-dict `:` functional-type($input, $result)";
+}
+
+def ConstCastOp : FIRRTLOp<"constCast", [HasCustomSSAName, Pure]> {
+  let description = [{
+    Cast from a 'const' to a non-'const' type.
+  }];
+  let arguments = (ins FIRRTLBaseType:$input);
+  let results = (outs FIRRTLBaseType:$result);
+  let hasVerifier = 1;
   let assemblyFormat =
     "$input attr-dict `:` functional-type($input, $result)";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -913,11 +913,12 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 // Special inference Operations
 //===----------------------------------------------------------------------===//
 
-class SameOperandConstness<string a, string b> 
+// This assumes operands are ground types without explicitly checking
+class SameGroundTypeOperandConstness<string a, string b> 
   : PredOpTrait<"operand constness must match",
                  CPred<"isConst($" # a # ".getType()) == isConst($" # b # ".getType())">>;
 
-def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameOperandConstness<"input", "result">]> {
+def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameGroundTypeOperandConstness<"input", "result">]> {
   let description = [{
     Cast between reset types.  This is used to enable strictconnects early in
     the pipeline by isolating all uninferred reset connections to a single op.
@@ -929,7 +930,7 @@ def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameO
     "$input attr-dict `:` functional-type($input, $result)";
 }
 
-def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure, SameOperandConstness<"input", "result">]> {
+def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure, SameGroundTypeOperandConstness<"input", "result">]> {
   let description = [{
     Cast between sized and unsized integer types.  This is used to enable
     strictconnects early in the pipeline by isolating all uninferred width

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -55,6 +55,9 @@ bool isConstant(Value value);
 /// constant values
 bool isConst(Type type);
 
+/// Returns true if the type is or contains a 'const' type.
+bool containsConst(Type type);
+
 /// Returns true if the value results from an expression with duplex flow.
 /// Duplex values have special treatment in bundle connect operations, and
 /// their flip orientation is not used to determine the direction of each

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -51,13 +51,6 @@ size_t getNumPorts(Operation *op);
 bool isConstant(Operation *op);
 bool isConstant(Value value);
 
-/// Returns true if this is a 'const' type that can only hold compile-time
-/// constant values
-bool isConst(Type type);
-
-/// Returns true if the type is or contains a 'const' type.
-bool containsConst(Type type);
-
 /// Returns true if the value results from an expression with duplex flow.
 /// Duplex values have special treatment in bundle connect operations, and
 /// their flip orientation is not used to determine the direction of each

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -210,6 +210,10 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
                               bool destOuterTypeIsConst = false,
                               bool srcOuterTypeIsConst = false);
 
+/// Returns whether the srcType can be const-casted to the destType.
+bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
+                           bool srcOuterTypeIsConst = false);
+
 /// Returns true if the destination is at least as wide as a source.  The source
 /// and destination types must be equivalent non-analog types.  The types are
 /// recursively connected to ensure that the destination is larger than the

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -192,6 +192,14 @@ public:
   std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
 };
 
+/// Returns true if this is a 'const' type whose value is guaranteed to be
+/// unchanging at circuit execution time
+bool isConst(Type type);
+
+/// Returns true if the type is or contains a 'const' type whose value is
+/// guaranteed to be unchanging at circuit execution time
+bool containsConst(Type type);
+
 /// Returns whether the two types are equivalent.  This implements the exact
 /// definition of type equivalence in the FIRRTL spec.  If the types being
 /// compared have any outer flips that encode FIRRTL module directions (input or

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3206,6 +3206,21 @@ bool firrtl::isConst(Type type) {
       .Default(false);
 }
 
+bool firrtl::containsConst(Type type) {
+  return TypeSwitch<Type, bool>(type)
+      .Case<FIRRTLBaseType, OpenBundleType, OpenVectorType>(
+          [](auto base) { return base.containsConst(); })
+      .Default(false);
+}
+
+LogicalResult ConstCastOp::verify() {
+  if (!areTypesConstCastable(getResult().getType(), getInput().getType()))
+    return emitOpError() << getInput().getType()
+                         << " is not 'const'-castable to "
+                         << getResult().getType();
+  return success();
+}
+
 FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        std::optional<Location> loc) {
@@ -4009,8 +4024,14 @@ LogicalResult BitCastOp::verify() {
   auto resTypeBits = getBitWidth(getType());
   if (inTypeBits.has_value() && resTypeBits.has_value()) {
     // Bitwidths must match for valid bit
-    if (*inTypeBits == *resTypeBits)
+    if (*inTypeBits == *resTypeBits) {
+      // non-'const' cannot be casted to 'const'
+      if (containsConst(getType()) && !isConst(getOperand().getType()))
+        return emitError("cannot cast non-'const' input type ")
+               << getOperand().getType() << " to 'const' result type "
+               << getType();
       return success();
+    }
     return emitError("the bitwidth of input (")
            << *inTypeBits << ") and result (" << *resTypeBits
            << ") don't match";
@@ -4368,6 +4389,10 @@ void UninferredResetCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 void UninferredWidthCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void ConstCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3199,20 +3199,6 @@ bool firrtl::isConstant(Value value) {
   return false;
 }
 
-bool firrtl::isConst(Type type) {
-  return TypeSwitch<Type, bool>(type)
-      .Case<FIRRTLBaseType, OpenBundleType, OpenVectorType>(
-          [](auto base) { return base.isConst(); })
-      .Default(false);
-}
-
-bool firrtl::containsConst(Type type) {
-  return TypeSwitch<Type, bool>(type)
-      .Case<FIRRTLBaseType, OpenBundleType, OpenVectorType>(
-          [](auto base) { return base.containsConst(); })
-      .Default(false);
-}
-
 LogicalResult ConstCastOp::verify() {
   if (!areTypesConstCastable(getResult().getType(), getInput().getType()))
     return emitOpError() << getInput().getType()

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -721,6 +721,20 @@ std::pair<uint64_t, bool> FIRRTLBaseType::rootChildFieldID(uint64_t fieldID,
       });
 }
 
+bool firrtl::isConst(Type type) {
+  return TypeSwitch<Type, bool>(type)
+      .Case<FIRRTLBaseType, OpenBundleType, OpenVectorType>(
+          [](auto base) { return base.isConst(); })
+      .Default(false);
+}
+
+bool firrtl::containsConst(Type type) {
+  return TypeSwitch<Type, bool>(type)
+      .Case<FIRRTLBaseType, OpenBundleType, OpenVectorType>(
+          [](auto base) { return base.containsConst(); })
+      .Default(false);
+}
+
 /// Helper to implement the equivalence logic for a pair of bundle elements.
 /// Note that the FIRRTL spec requires bundle elements to have the same
 /// orientation, but this only compares their passive types. The FIRRTL dialect

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -964,14 +964,13 @@ bool firrtl::areTypesConstCastable(FIRRTLType destFType, FIRRTLType srcFType,
     if (numDestElements != srcElements.size())
       return false;
 
-    return llvm::all_of_zip(destElements, srcElements,
-                            [&](const BundleType::BundleElement &destElement,
-                                const BundleType::BundleElement &srcElement) {
-                              return destElement.name == srcElement.name &&
-                                     areTypesConstCastable(destElement.type,
-                                                           srcElement.type,
-                                                           srcIsConst);
-                            });
+    return llvm::all_of_zip(
+        destElements, srcElements,
+        [&](const auto &destElement, const auto &srcElement) {
+          return destElement.name == srcElement.name &&
+                 areTypesConstCastable(destElement.type, srcElement.type,
+                                       srcIsConst);
+        });
   }
   if (destBundleType != srcBundleType)
     return false;

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -932,6 +932,10 @@ bool firrtl::areTypesConstCastable(FIRRTLType destFType, FIRRTLType srcFType,
   if (!destType || !srcType)
     return false;
 
+  // Types must be passive
+  if (!destType.isPassive() || !srcType.isPassive())
+    return false;
+
   bool srcIsConst = srcType.isConst() || srcOuterTypeIsConst;
 
   // Cannot cast non-'const' src to 'const' dest
@@ -964,7 +968,6 @@ bool firrtl::areTypesConstCastable(FIRRTLType destFType, FIRRTLType srcFType,
                             [&](const BundleType::BundleElement &destElement,
                                 const BundleType::BundleElement &srcElement) {
                               return destElement.name == srcElement.name &&
-                                     destElement.isFlip == srcElement.isFlip &&
                                      areTypesConstCastable(destElement.type,
                                                            srcElement.type,
                                                            srcIsConst);

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -133,4 +133,22 @@ firrtl.module @ConstRegResetValue(in %clock: !firrtl.clock, in %reset: !firrtl.a
   %0 = firrtl.regreset %clock, %reset, %resetValue : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.sint<1>, !firrtl.sint<1>
 }
 
+// CHECK-LABEL: firrtl.module @ConstCast
+firrtl.module @ConstCast(in %in: !firrtl.const.uint<1>, out %out: !firrtl.uint<1>) {
+  %0 = firrtl.constCast %in : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out, %0 : !firrtl.uint<1> 
+}
+
+// CHECK-LABEL: firrtl.module @ConstCastToMixedConstBundle
+firrtl.module @ConstCastToMixedConstBundle(in %in: !firrtl.const.bundle<a: uint<1>>, out %out: !firrtl.bundle<a: const.uint<1>>) {
+  %0 = firrtl.constCast %in : (!firrtl.const.bundle<a: uint<1>>) -> !firrtl.bundle<a: const.uint<1>>
+  firrtl.strictconnect %out, %0 : !firrtl.bundle<a: const.uint<1>>
+}
+
+// CHECK-LABEL: firrtl.module @ConstCastToMixedConstVector
+firrtl.module @ConstCastToMixedConstVector(in %in: !firrtl.const.vector<uint<1>, 2>, out %out: !firrtl.vector<const.uint<1>, 2>) {
+  %0 = firrtl.constCast %in : (!firrtl.const.vector<uint<1>, 2>) -> !firrtl.vector<const.uint<1>, 2>
+  firrtl.strictconnect %out, %0 : !firrtl.vector<const.uint<1>, 2>
+}
+
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1478,3 +1478,74 @@ firrtl.circuit "ConstHardwareString" {
 // expected-error @+1 {{strings cannot be const}}
 firrtl.module @ConstHardwareString(in %string: !firrtl.const.string) {}
 }
+
+// -----
+
+// Constcast non-const to const
+firrtl.circuit "ConstcastNonConstToConst" {
+  firrtl.module @ConstcastNonConstToConst(in %a: !firrtl.uint<1>) {
+    // expected-error @+1 {{'!firrtl.uint<1>' is not 'const'-castable to '!firrtl.const.uint<1>'}}
+    %b = firrtl.constCast %a : (!firrtl.uint<1>) -> !firrtl.const.uint<1>
+  }
+}
+
+// -----
+
+// Constcast non-const to const-containing
+firrtl.circuit "ConstcastNonConstToConst" {
+  firrtl.module @ConstcastNonConstToConst(in %a: !firrtl.bundle<a: uint<1>>) {
+    // expected-error @+1 {{'!firrtl.bundle<a: uint<1>>' is not 'const'-castable to '!firrtl.bundle<a: const.uint<1>>'}}
+    %b = firrtl.constCast %a : (!firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: const.uint<1>>
+  }
+}
+
+// -----
+
+// Constcast different types
+firrtl.circuit "ConstcastDifferentTypes" {
+  firrtl.module @ConstcastDifferentTypes(in %a: !firrtl.const.uint<1>) {
+    // expected-error @+1 {{'!firrtl.const.uint<1>' is not 'const'-castable to '!firrtl.sint<1>'}}
+    %b = firrtl.constCast %a : (!firrtl.const.uint<1>) -> !firrtl.sint<1>
+  }
+}
+
+// -----
+
+// Bitcast non-const to const
+firrtl.circuit "BitcastNonConstToConst" {
+  firrtl.module @BitcastNonConstToConst(in %a: !firrtl.uint<1>) {
+    // expected-error @+1 {{cannot cast non-'const' input type '!firrtl.uint<1>' to 'const' result type '!firrtl.const.sint<1>'}}
+    %b = firrtl.bitcast %a : (!firrtl.uint<1>) -> !firrtl.const.sint<1>
+  }
+}
+
+// -----
+
+// Bitcast non-const to const-containing
+firrtl.circuit "BitcastNonConstToConstContaining" {
+  firrtl.module @BitcastNonConstToConstContaining(in %a: !firrtl.bundle<a: uint<1>>) {
+    // expected-error @+1 {{cannot cast non-'const' input type '!firrtl.bundle<a: uint<1>>' to 'const' result type '!firrtl.bundle<a: const.sint<1>>'}}
+    %b = firrtl.bitcast %a : (!firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: const.sint<1>>
+  }
+}
+
+// -----
+
+// Uninferred width cast non-const to const
+firrtl.circuit "UninferredWidthCastNonConstToConst" {
+  firrtl.module @UninferredWidthCastNonConstToConst(in %a: !firrtl.uint) {
+    // expected-error @+1 {{operand constness must match}}
+    %b = firrtl.widthCast %a : (!firrtl.uint) -> !firrtl.const.uint<1>
+  }
+}
+
+// -----
+
+// Uninferred reset cast non-const to const
+firrtl.circuit "UninferredWidthCastNonConstToConst" {
+  firrtl.module @UninferredWidthCastNonConstToConst(in %a: !firrtl.reset) {
+    // expected-error @+1 {{operand constness must match}}
+    %b = firrtl.resetCast %a : (!firrtl.reset) -> !firrtl.const.asyncreset
+  }
+}
+


### PR DESCRIPTION
This commit adds a ConstCastOp for casting away constness from types. This op and const types will be dropped early in the firrtl pipeline in a followup commit.

Verification has been added to other casting ops to ensure that type constness is taken into account.