### PR TITLE
[Arc] Dedup: generalize to CallOpInterface

### DIFF
--- a/include/circt/Dialect/Arc/ArcInterfaces.td
+++ b/include/circt/Dialect/Arc/ArcInterfaces.td
@@ -10,8 +10,9 @@
 #define CIRCT_DIALECT_ARC_ARCINTERFACES_TD
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/CallInterfaces.td"
 
-def CallOpMutableInterface : OpInterface<"CallOpMutableInterface"> {
+def CallOpMutableInterface : OpInterface<"CallOpMutableInterface", [CallOpInterface]> {
   let description = [{
     Can be implemented in addition to `CallOpInterface` to allow mutation of the
     call operation.
@@ -23,8 +24,7 @@ def CallOpMutableInterface : OpInterface<"CallOpMutableInterface"> {
         Returns the operands within this call that are used as arguments to the
         callee as a mutable range.
       }],
-      "::mlir::MutableOperandRange", "getArgOperandsMutable"
-    >,
+      "::mlir::MutableOperandRange", "getArgOperandsMutable">,
   ];
 }
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -131,7 +131,7 @@ def OutputOp : ArcOp<"output", [
 }
 
 def StateOp : ArcOp<"state", [
-  CallOpInterface, MemRefsNormalizable,
+  MemRefsNormalizable,
   CallOpMutableInterface,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   AttrSizedOperandSegments,
@@ -213,7 +213,7 @@ def StateOp : ArcOp<"state", [
 
   let extraClassDeclaration = [{
     operand_range getArgOperands() {
-      return {operand_begin(), operand_end()};
+      return getInputs();
     }
     MutableOperandRange getArgOperandsMutable() {
       return getInputsMutable();
@@ -227,12 +227,11 @@ def StateOp : ArcOp<"state", [
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
     }
-
   }];
 }
 
 def CallOp : ArcOp<"call", [
-  CallOpInterface, MemRefsNormalizable, Pure,
+  MemRefsNormalizable, Pure,
   CallOpMutableInterface,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>
 ]> {
@@ -261,7 +260,6 @@ def CallOp : ArcOp<"call", [
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
     }
-
   }];
 }
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -11,6 +11,7 @@
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 using namespace circt;
@@ -297,6 +298,11 @@ LogicalResult LutOp::verify() {
            << "first operation with side-effects here";
 
   return success();
+}
+
+Operation *
+CallOpMutableInterface::resolveCallable(SymbolTableCollection *symbolTable) {
+  return static_cast<CallOpInterface>(*this).resolveCallable(symbolTable);
 }
 
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -35,6 +35,7 @@ add_circt_library(CIRCTArcReductions
   CIRCTArcTransforms
   CIRCTConvertToArcs
   MLIRIR
+  MLIRCallInterfaces
 )
 
 add_dependencies(circt-headers


### PR DESCRIPTION
Currently, the Dedup pass only considers StateOp as call operations to arcs because this was the only legal way to call an arc until recently. Because there is no additional check that no other operation calls an arc, the pass fails because it potentially dedups an arc that is called by a CallOp which is not updated accordingly. This generalizes to operations that implement the CallOpMutableInterface. It is assumed that all operations that can call an arc, implement this interface.