### PR TITLE
[Arc] Change MemoryWritePortOp to also take an arc

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -312,29 +312,53 @@ def MemoryReadPortOp : ArcOp<"memory_read_port", [
 
 def MemoryWritePortOp : ArcOp<"memory_write_port", [
   MemoryEffects<[MemWrite]>,
-  MemoryAndDataTypesMatch<"memory", "data">,
-  MemoryAndAddressTypesMatch<"memory", "address">,
+  CallOpMutableInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   AttrSizedOperandSegments,
   ClockedOpInterface
 ]> {
   let summary = "Write port to a memory";
   let arguments = (ins
     MemoryType:$memory,
-    AnyInteger:$address,
+    FlatSymbolRefAttr:$arc,
+    Variadic<AnyType>:$inputs,
     Optional<I1>:$clock,
-    Optional<I1>:$enable,
-    AnyInteger:$data,
-    Optional<AnyInteger>:$mask
+    UnitAttr:$enable,
+    UnitAttr:$mask,
+    DefaultValuedAttr<I32Attr, "1">:$latency
   );
 
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` $data (`mask` `(` $mask^ `:` type($mask) `)`)?
-    (`if` $enable^)? (`clock` $clock^)? attr-dict `:` type($memory)
+    $memory `,` $arc  `(` $inputs `)` (`clock` $clock^)?  (`enable` $enable^)?
+    (`mask` $mask^)? `lat` $latency attr-dict `:`
+    type($memory) `,` type($inputs)
   }];
 
   let hasVerifier = 1;
-  let hasFolder = 1;
-  let hasCanonicalizeMethod = 1;
+
+  let extraClassDeclaration = [{
+    SmallVector<Type> getArcResultTypes();
+    static unsigned getAddressIdx() { return 0; }
+    static unsigned getDataIdx() { return 1; }
+    static unsigned getEnableIdx() { return 2; }
+    static unsigned getMaskIdx(bool hasEnable) { return hasEnable ? 3 : 2; }
+
+    operand_range getArgOperands() {
+      return getInputs();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getInputsMutable();
+    }
+
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("arc");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
+    }
+  }];
 }
 
 def MemoryReadOp : ArcOp<"memory_read", [

--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -74,24 +74,6 @@ LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
-// MemoryWritePortOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult MemoryWritePortOp::fold(FoldAdaptor adaptor,
-                                      SmallVectorImpl<OpFoldResult> &results) {
-  if (isAlways(adaptor.getEnable(), true))
-    return getEnableMutable().clear(), success();
-  return failure();
-}
-
-LogicalResult MemoryWritePortOp::canonicalize(MemoryWritePortOp op,
-                                              PatternRewriter &rewriter) {
-  if (isAlways(op.getEnable(), false))
-    return rewriter.eraseOp(op), success();
-  return failure();
-}
-
-//===----------------------------------------------------------------------===//
 // MemoryWriteOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -44,8 +44,8 @@ static LogicalResult verifyTypeListEquivalence(Operation *op,
   return success();
 }
 
-static LogicalResult verifyArcSymbolUse(Operation *op, ValueRange inputs,
-                                        ValueRange results,
+static LogicalResult verifyArcSymbolUse(Operation *op, TypeRange inputs,
+                                        TypeRange results,
                                         SymbolTableCollection &symbolTable) {
   // Check that the arc attribute was specified.
   auto arcName = op->getAttrOfType<FlatSymbolRefAttr>("arc");
@@ -59,12 +59,12 @@ static LogicalResult verifyArcSymbolUse(Operation *op, ValueRange inputs,
 
   // Verify that the operand and result types match the arc.
   auto type = arc.getFunctionType();
-  if (failed(verifyTypeListEquivalence(op, type.getInputs(), inputs.getTypes(),
-                                       "operand")))
+  if (failed(
+          verifyTypeListEquivalence(op, type.getInputs(), inputs, "operand")))
     return failure();
 
-  if (failed(verifyTypeListEquivalence(op, type.getResults(),
-                                       results.getTypes(), "result")))
+  if (failed(
+          verifyTypeListEquivalence(op, type.getResults(), results, "result")))
     return failure();
 
   return success();
@@ -145,7 +145,8 @@ LogicalResult OutputOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult StateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyArcSymbolUse(*this, getInputs(), getResults(), symbolTable);
+  return verifyArcSymbolUse(*this, getInputs().getTypes(),
+                            getResults().getTypes(), symbolTable);
 }
 
 LogicalResult StateOp::verify() {
@@ -176,16 +177,34 @@ bool StateOp::isClocked() { return getLatency() > 0; }
 //===----------------------------------------------------------------------===//
 
 LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyArcSymbolUse(*this, getInputs(), getResults(), symbolTable);
+  return verifyArcSymbolUse(*this, getInputs().getTypes(),
+                            getResults().getTypes(), symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
 // MemoryWritePortOp
 //===----------------------------------------------------------------------===//
 
+SmallVector<Type> MemoryWritePortOp::getArcResultTypes() {
+  auto memType = cast<MemoryType>(getMemory().getType());
+  SmallVector<Type> resultTypes{memType.getAddressType(),
+                                memType.getWordType()};
+  if (getEnable())
+    resultTypes.push_back(IntegerType::get(getContext(), 1));
+  if (getMask())
+    resultTypes.push_back(memType.getWordType());
+  return resultTypes;
+}
+
+LogicalResult
+MemoryWritePortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyArcSymbolUse(*this, getInputs().getTypes(), getArcResultTypes(),
+                            symbolTable);
+}
+
 LogicalResult MemoryWritePortOp::verify() {
-  if (getMask() && getMask().getType() != getData().getType())
-    return emitOpError("mask and data operand types do not match");
+  if (getLatency() < 1)
+    return emitOpError("latency must be at least 1");
 
   if (!getOperation()->getParentOfType<ClockDomainOp>() && !getClock())
     return emitOpError("outside a clock domain requires a clock");

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -289,9 +289,12 @@ hw.module @memoryWritePortOpInsideClockDomain(%clk: i1) {
     %mem = arc.memory <4 x i32, i32>
     %c0_i32 = hw.constant 0 : i32
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    arc.memory_write_port %mem[%c0_i32], %c0_i32 if %arg0 clock %arg0 : !arc.memory<4 x i32, i32>
+    arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %arg0) clock %arg0 enable lat 1: !arc.memory<4 x i32, i32>, i32, i32, i1
     arc.output
   }
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
 }
 
 // -----
@@ -300,7 +303,22 @@ hw.module @memoryWritePortOpOutsideClockDomain(%en: i1) {
   %mem = arc.memory <4 x i32, i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{outside a clock domain requires a clock}}
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en : !arc.memory<4 x i32, i32>
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
+}
+
+// -----
+
+hw.module @memoryWritePortOpLatZero(%en: i1) {
+  %mem = arc.memory <4 x i32, i32>
+  %c0_i32 = hw.constant 0 : i32
+  // expected-error @+1 {{latency must be at least 1}}
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 0 : !arc.memory<4 x i32, i32>, i32, i32, i1
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
 }
 
 // -----

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -108,17 +108,21 @@ hw.module @clockDomainTest(%clk: i1, %in0: i32, %in1: i16) {
 }
 
 // CHECK-LABEL: hw.module @memoryOps
-hw.module @memoryOps(%clk: i1, %en: i1) {
+hw.module @memoryOps(%clk: i1, %en: i1, %mask: i32) {
   %c0_i32 = hw.constant 0 : i32
   // CHECK: [[MEM:%.+]] = arc.memory <4 x i32, i32>
   %mem = arc.memory <4 x i32, i32>
 
   // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] : <4 x i32, i32>
   %0 = arc.memory_read_port %mem[%c0_i32] : <4 x i32, i32>
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 if %en clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en clock %clk : <4 x i32, i32>
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 clock %clk : <4 x i32, i32>
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
+  arc.memory_write_port %mem, @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
+  arc.memory_write_port %mem, @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
+  arc.memory_write_port %mem, @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
 
   // CHECK-NEXT: arc.clock_domain
   arc.clock_domain (%clk) clock %clk : (i1) -> () {
@@ -128,10 +132,10 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
     %mem2 = arc.memory <4 x i32, i32>
     // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32, i32>
     %2 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32, i32>
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 if %arg0 : <4 x i32, i32>
-    arc.memory_write_port %mem2[%c1_i32], %c1_i32 if %arg0 : <4 x i32, i32>
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 : <4 x i32, i32>
-    arc.memory_write_port %mem2[%c1_i32], %c1_i32 : <4 x i32, i32>
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
+    arc.memory_write_port %mem2, @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
+    arc.memory_write_port %mem2, @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
   }
 
   // CHECK: %{{.+}} = arc.memory_read [[MEM]][%c0_i32] : <4 x i32, i32>
@@ -141,4 +145,16 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
 
   // CHECK-NEXT: arc.memory_write [[MEM]][%c0_i32], %c0_i32 : <4 x i32, i32>
   arc.memory_write %mem[%c0_i32], %c0_i32 : <4 x i32, i32>
+}
+arc.define @identity(%arg0: i32, %arg1: i32) -> (i32, i32) {
+  arc.output %arg0, %arg1 : i32, i32
+}
+arc.define @identity1(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i1
+}
+arc.define @identity2(%arg0: i32, %arg1: i32, %arg2: i1, %arg3: i32) -> (i32, i32, i1, i32) {
+  arc.output %arg0, %arg1, %arg2, %arg3 : i32, i32, i1, i32
+}
+arc.define @identity3(%arg0: i32, %arg1: i32, %arg2: i32) -> (i32, i32, i32) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i32
 }

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -69,13 +69,10 @@ hw.module @clockDomainDCE(%clk: i1) {
 // CHECK-LABEL: hw.module @memoryOps
 hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32, i32>, %addr: i32, %data: i32) {
   %true = hw.constant true
-  // CHECK: arc.memory_write_port %mem[%addr], %data clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%addr], %data if %true clock %clk : <4 x i32, i32>
   // CHECK-NEXT: arc.memory_write %mem[%addr], %data : <4 x i32, i32>
   arc.memory_write %mem[%addr], %data if %true : <4 x i32, i32>
 
   %false = hw.constant false
-  arc.memory_write_port %mem[%addr], %data if %false clock %clk : <4 x i32, i32>
   arc.memory_write %mem[%addr], %data if %false : <4 x i32, i32>
 }
 
@@ -86,13 +83,14 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
   %mem = arc.memory <4 x i32, i32>
   // COM: check that memories only used in one clock domain are pulled in and
   // COM: constants are cloned when used in multiple clock domains.
-  // CHECK:      arc.clock_domain ()
+  // CHECK: arc.clock_domain ()
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0
+  // CHECK-NEXT: [[T:%.+]] = hw.constant true
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][[[C0]]], [[C0]] :
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memWrite([[C0]], [[C0]], [[T]]) enable lat 1 :
   %0 = arc.clock_domain (%c0_i32, %mem, %true) clock %clk : (i32, !arc.memory<4 x i32, i32>, i1) -> i32 {
   ^bb0(%arg0: i32, %arg1: !arc.memory<4 x i32, i32>, %arg2: i1):
-    arc.memory_write_port %arg1[%arg0], %arg0 if %arg2 : !arc.memory<4 x i32, i32>
+    arc.memory_write_port %arg1, @memWrite(%arg0, %arg0, %arg2) enable lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
     arc.output %arg0 : i32
   }
   // COM: check that unused inputs are removed, and constants are cloned into it
@@ -133,6 +131,9 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
 }
 arc.define @identityi1(%arg0: i1) -> i1 {
   arc.output %arg0 : i1
+}
+arc.define @memWrite(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i1
 }
 
 // CHECK-LABEL: arc.model "StorageGetCanonicalizers"

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -7,7 +7,7 @@ hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numW
 hw.module @TestWOMemory(%clock: i1, %addr: i10, %enable: i1, %data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data if %enable clock %clock : <1024 x i8, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i8) -> ()
 }
@@ -25,7 +25,7 @@ hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16,
   // CHECK-NEXT: [[MASK_BIT1:%.+]] = comb.extract %mask from 1 : (i2) -> i1
   // CHECK-NEXT: [[MASK_BYTE1:%.+]] = comb.replicate [[MASK_BIT1]] : (i1) -> i8
   // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE0]], [[MASK_BYTE1]]
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data mask([[MASK]] : i16) if %enable clock %clock : <1024 x i16, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable, [[MASK]]) clock %clock enable mask lat 1 : <1024 x i16, i10>, i10, i16, i1, i16
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
 }
@@ -71,7 +71,7 @@ hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata:
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8, i10>
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %wdata if [[WENABLE]] clock %clock : <1024 x i8, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %wdata, [[WENABLE]]) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output [[RDATA]]
   %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
   hw.output %0 : i8

--- a/test/Dialect/Arc/isolate-clocks.mlir
+++ b/test/Dialect/Arc/isolate-clocks.mlir
@@ -7,24 +7,23 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
   %0 = comb.and %c0, %c1 : i1
   %1 = arc.state @DummyArc(%in) clock %clk0 enable %0 reset %c1 lat 1 : (i32) -> i32
   %mem = arc.memory <2 x i32, i1>
-  arc.memory_write_port %mem[%c0], %2 clock %clk0 : <2 x i32, i1>
-  %2 = arc.state @DummyArc(%in) clock %clk0 lat 1 : (i32) -> i32
-  arc.memory_write_port %mem[%c1], %1 clock %clk0 : <2 x i32, i1>
+  arc.memory_write_port %mem, @identity(%c0, %2) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
+  %2 = arc.memory_read_port %mem[%c0] : <2 x i32, i1>
+  arc.memory_write_port %mem, @identity(%c1, %1) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
   %3 = arc.state @DummyArc(%4) clock %clk1 enable %0 reset %c1  lat 1 : (i32) -> i32
   %4 = arc.state @DummyArc(%2) lat 0 : (i32) -> i32
   %5 = arc.state @DummyArc(%4) clock %clk2 lat 1 : (i32) -> i32
   hw.output %3, %5 : i32, i32
 
   // CHECK-NEXT: [[V0:%.+]] = comb.and %c0, %c1 : i1
-  // CHECK-NEXT: [[V1:%.+]] = arc.state @DummyArc([[V2:%.+]]) lat 0 : (i32) -> i32
-  // CHECK-NEXT: [[V2]] = arc.clock_domain (%c1, %in, %c0, [[V0]]) clock %clk0 : (i1, i32, i1, i1) -> i32 {
-  // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i32, %arg2: i1, %arg3: i1):
-  // CHECK-NEXT:   [[MEM:%.+]] = arc.memory <2 x i32, i1>
-  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg0], [[V7:%.+]] : <2 x i32, i1>
-  // CHECK-NEXT:   [[V6:%.+]] = arc.state @DummyArc(%arg1) lat 1 : (i32) -> i32
-  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg2], [[V6]] : <2 x i32, i1>
-  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg1) enable %arg3 reset %arg0 lat 1 : (i32) -> i32
-  // CHECK-NEXT:   arc.output [[V6]] : i32
+  // CHECK-NEXT: [[MEM:%.+]] = arc.memory <2 x i32, i1>
+  // CHECK-NEXT: [[V6:%.+]] = arc.memory_read_port [[MEM]][%c0] : <2 x i32, i1>
+  // CHECK-NEXT: [[V1:%.+]] = arc.state @DummyArc([[V6]]) lat 0 : (i32) -> i32
+  // CHECK-NEXT: arc.clock_domain ([[MEM]], %c1, %c0, [[V6]], [[V0]], %in) clock %clk0 : (!arc.memory<2 x i32, i1>, i1, i1, i32, i1, i32) -> () {
+  // CHECK-NEXT: ^bb0(%arg0: !arc.memory<2 x i32, i1>, %arg1: i1, %arg2: i1, %arg3: i32, %arg4: i1, %arg5: i32):
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg1, [[V7:%.+]]) lat 1 :
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg2, %arg3) lat 1 :
+  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg5) enable %arg4 reset %arg1 lat 1 : (i32) -> i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V3:%.+]] = arc.clock_domain ([[V0]], %c1, [[V1]]) clock %clk1 : (i1, i1, i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i1, %arg2: i32):
@@ -40,6 +39,9 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
 }
 arc.define @DummyArc(%arg0: i32) -> i32 {
   arc.output %arg0 : i32
+}
+arc.define @identity(%arg0: i1, %arg1: i32) -> (i1, i32) {
+  arc.output %arg0, %arg1 : i1, i32
 }
 
 // CHECK-LABEL: hw.module @preexistingClockDomain

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -80,15 +80,19 @@ hw.module @NonMaskedMemoryWrite(%clk0: i1) {
   %c0_i2 = hw.constant 0 : i2
   %c9001_i42 = hw.constant 9001 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem[%c0_i2], %c9001_i42 clock %clk0 : <4 x i42, i2>
+  arc.memory_write_port %mem, @identity(%c0_i2, %c9001_i42) clock %clk0 lat 1 : <4 x i42, i2>, i2, i42
 
   // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
   // CHECK-NEXT: [[INCLK0:%.+]] = arc.root_input "clk0", [[PTR]] : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[MEM:%.+]] = arc.alloc_memory [[PTR]] : (!arc.storage) -> !arc.memory<4 x i42, i2>
   // CHECK-NEXT: [[CLK0:%.+]] = arc.state_read [[INCLK0]] : <i1>
   // CHECK-NEXT: arc.clock_tree [[CLK0]] {
-  // CHECK:        arc.memory_write [[MEM]][%c0_i2], %c9001_i42 : <4 x i42, i2>
+  // CHECK:        [[RES:%.+]]:2 = arc.call @identity(%c0_i2, %c9001_i42) : (i2, i42) -> (i2, i42)
+  // CHECK:        arc.memory_write [[MEM]][[[RES]]#0], [[RES]]#1 : <4 x i42, i2>
   // CHECK-NEXT: }
+}
+arc.define @identity(%arg0: i2, %arg1: i42) -> (i2, i42) {
+  arc.output %arg0, %arg1 : i2, i42
 }
 
 // CHECK-LABEL: arc.model "lowerMemoryReadPorts"
@@ -118,17 +122,21 @@ hw.module @maskedMemoryWrite(%clk: i1) {
   %c9001_i42 = hw.constant 9001 : i42
   %c1010_i42 = hw.constant 1010 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem[%c0_i2], %c9001_i42 mask (%c1010_i42 : i42) if %true clock %clk : <4 x i42, i2>
+  arc.memory_write_port %mem, @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) clock %clk enable mask lat 1 : <4 x i42, i2>, i2, i42, i1, i42
+}
+arc.define @identity2(%arg0: i2, %arg1: i42, %arg2: i1, %arg3: i42) -> (i2, i42, i1, i42) {
+  arc.output %arg0, %arg1, %arg2, %arg3 : i2, i42, i1, i42
 }
 // CHECK:      %c9001_i42 = hw.constant 9001 : i42
 // CHECK:      %c1010_i42 = hw.constant 1010 : i42
-// CHECK:      [[RD:%.+]] = arc.memory_read [[MEM:%.+]][%c0_i2] : <4 x i42, i2>
+// CHECK:      [[RES:%.+]]:4 = arc.call @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) : (i2, i42, i1, i42) -> (i2, i42, i1, i42)
+// CHECK:      [[RD:%.+]] = arc.memory_read [[MEM:%.+]][[[RES]]#0] : <4 x i42, i2>
 // CHECK:      %c-1_i42 = hw.constant -1 : i42
-// CHECK:      [[NEG_MASK:%.+]] = comb.xor bin %c1010_i42, %c-1_i42 : i42
+// CHECK:      [[NEG_MASK:%.+]] = comb.xor bin [[RES]]#3, %c-1_i42 : i42
 // CHECK:      [[OLD_MASKED:%.+]] = comb.and bin [[NEG_MASK]], [[RD]] : i42
-// CHECK:      [[NEW_MASKED:%.+]] = comb.and bin %c1010_i42, %c9001_i42 : i42
+// CHECK:      [[NEW_MASKED:%.+]] = comb.and bin [[RES]]#3, [[RES]]#1 : i42
 // CHECK:      [[DATA:%.+]] = comb.or bin [[OLD_MASKED]], [[NEW_MASKED]] : i42
-// CHECK:      arc.memory_write [[MEM]][%c0_i2], [[DATA]] if %true : <4 x i42, i2>
+// CHECK:      arc.memory_write [[MEM]][[[RES]]#0], [[DATA]] if [[RES]]#2 : <4 x i42, i2>
 
 // CHECK-LABEL: arc.model "Taps"
 hw.module @Taps() {
@@ -275,10 +283,13 @@ arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
 hw.module private @MemoryPortRegression(%clock: i1, %reset: i1, %in: i3) -> (x: i3) {
   %0 = arc.memory <2 x i3, i1> {name = "ram_ext"}
   %1 = arc.memory_read_port %0[%3] : <2 x i3, i1>
-  arc.memory_write_port %0[%3], %in clock %clock : <2 x i3, i1>
-  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 {names = ["value"]} : (i1) -> i1
+  arc.memory_write_port %0, @identity3(%3, %in) clock %clock lat 1 : <2 x i3, i1>, i1, i3
+  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 : (i1) -> i1
   %4 = arc.state @Queue_arc_1(%1) lat 0 : (i3) -> i3
   hw.output %4 : i3
+}
+arc.define @identity3(%arg0: i1, %arg1: i3) -> (i1, i3) {
+  arc.output %arg0, %arg1 : i1, i3
 }
 arc.define @Queue_arc_0(%arg0: i1) -> i1 {
   arc.output %arg0 : i1


### PR DESCRIPTION
The `arc.state` operation computes the fan-in of the register(s) it represents inside an arc which allows a simpler IR structure because only one operation is required to represent this instead calls + state operations making it easier to iterate the predecessor registers, etc. There are the exceptions of the enable and reset operands though. While the reset is mostly the reset signal provided by the root module input (like for the clock operand) and thus not really an issue to represent as an operand, the enable operand typically requires a call operation as predecessor to compute the fan-in. As discussed last week, it might be nice to also compute this fan-in inside the arc that already computes the data inputs plus adding a unit attribute on the state operation to indicate that that is the case and to verify that the last arc output has `i1` type.

This PR attempts to implement a similar structure for the `arc.memory_write_port` operation to see how this concept would generalize over memory operations, potentially providing a more uniform IR structure overall.

The canonicalizations had to be removed because they require a symbol lookup now, which is impossible to do efficiently inside the regular canonicalizer. The plan here is to introduce an ArcCanonicalizer that has access to a SymbolCache which has to be kept up-to-date by the patterns inside that canoicalizer. This new pass then allows us to collect patterns like the ones removed in this PR, removing calls to passthrough arcs, but also patterns on operations not from the arc dialect (e.g., the mux sequence to zero_count pattern).