### PR TITLE
[HWCleanUp] Remove always_comb

### DIFF
--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -155,7 +155,6 @@ void HWCleanupPass::runOnGraphRegion(Region &region) {
   DenseSet<Operation *, AlwaysLikeOpInfo> alwaysFFOpsSeen;
   llvm::SmallDenseMap<Attribute, Operation *, 4> ifdefOps;
   sv::InitialOp initialOpSeen;
-  sv::AlwaysCombOp alwaysCombOpSeen;
 
   for (Operation &op : llvm::make_early_inc_range(body)) {
     // Merge alwaysff and always operations by hashing them to check to see if
@@ -187,14 +186,6 @@ void HWCleanupPass::runOnGraphRegion(Region &region) {
       if (initialOpSeen)
         mergeOperationsIntoFrom(initialOp, initialOpSeen);
       initialOpSeen = initialOp;
-      continue;
-    }
-
-    // Merge always_comb ops anywhere in the module.
-    if (auto alwaysComb = dyn_cast<sv::AlwaysCombOp>(op)) {
-      if (alwaysCombOpSeen)
-        mergeOperationsIntoFrom(alwaysComb, alwaysCombOpSeen);
-      alwaysCombOpSeen = alwaysComb;
       continue;
     }
   }

--- a/test/Dialect/SV/hw-cleanup.mlir
+++ b/test/Dialect/SV/hw-cleanup.mlir
@@ -280,28 +280,6 @@ hw.module @always_basic(%arg0: i1, %arg1: i1) {
 }
 
 
-// CHECK-LABEL: hw.module @alwayscomb_basic(
-hw.module @alwayscomb_basic(%a: i1, %b: i1) -> (x: i1, y: i1) {
-  %w1 = sv.reg : !hw.inout<i1>
-  %w2 = sv.reg : !hw.inout<i1>
-  // CHECK: sv.alwayscomb {
-  sv.alwayscomb {
-    // CHECK-NEXT: sv.bpassign %w1, %a : i1
-    sv.bpassign %w1, %a : i1
-  }
-
-  %out1 = sv.read_inout %w1 : !hw.inout<i1>
-
-  sv.alwayscomb {
-    // CHECK-NEXT: sv.bpassign %w2, %b : i1
-    sv.bpassign %w2, %b : i1
-  } // CHECK-NEXT: }
-
-  %out2 = sv.read_inout %w1 : !hw.inout<i1>
-
-  hw.output %out1, %out2 : i1, i1
-}
-
 // CHECK-LABEL: hw.module @nested_regions(
 // CHECK-NEXT:  [[FD:%.*]] = hw.constant -2147483646 : i32
 // CHECK-NEXT:  sv.initial  {


### PR DESCRIPTION
It's illegal to merge different always_comb as it might implicitly have data dependency each other.  Fix https://github.com/llvm/circt/issues/5171