### PR TITLE
[FIRRTL] Export named references as macros to Verilog files

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -622,7 +622,7 @@ def RandomizeRegisterInit :
   let constructor = "circt::firrtl::createRandomizeRegisterInitPass()";
 }
 
-def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
+def LowerXMR : Pass<"firrtl-lower-xmr", "mlir::ModuleOp"> {
   let summary = "Lower ref ports to XMR";
   let description = [{
     This pass lowers RefType ops and ports to verbatim encoded XMRs.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -862,7 +862,7 @@ def MacroDefOp : SVOp<"macro.def",
   ];
 
   let assemblyFormat = [{
-    $macroName $format_string attr-dict
+    $macroName $format_string (`(` $symbols^ `)`)? attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -857,7 +857,7 @@ def MacroDefOp : SVOp<"macro.def",
 
   let builders = [
     OpBuilder<(ins "StringRef":$macroName, "StringRef":$format_string),
-                "build(odsBuilder, odsState, macroName, format_string,"
+                "build($_builder, $_state, macroName, format_string,"
                 "odsBuilder.getArrayAttr({}));">
   ];
 

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -844,13 +844,22 @@ def MacroDefOp : SVOp<"macro.def",
     opaque (plain string).  Given the general power of macros, this op does not
     try to capture a return type.
   
-    This operation produces a definition for the macro declaration referened by 
+    This operation produces a definition for the macro declaration referenced by 
     `sym_name`.  Argument lists are picked up from that operation.
+
+    sv.macro.def allows operand substitutions with {{0}} syntax.
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$macroName, 
-                       StrAttr:$format_string);
+                       StrAttr:$format_string,
+                       DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
   let results = (outs);
+
+  let builders = [
+    OpBuilder<(ins "StringRef":$macroName, "StringRef":$format_string),
+                "build(odsBuilder, odsState, macroName, format_string,"
+                "odsBuilder.getArrayAttr({}));">
+  ];
 
   let assemblyFormat = [{
     $macroName $format_string attr-dict

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4461,8 +4461,11 @@ LogicalResult StmtEmitter::visitSV(MacroDefOp op) {
     });
     ps << ")";
   }
-  if (!op.getFormatString().empty())
-    ps << " " << op.getFormatStringAttr();
+  if (!op.getFormatString().empty()) {
+    ps << " ";
+    emitTextWithSubstitutions(ps, op.getFormatString(), op, {},
+                              op.getSymbols());
+  }
   ps << PP::newline;
   return success();
 }
@@ -5325,7 +5328,7 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
           else
             rootFile.ops.push_back(info);
         })
-        .Case<VerbatimOp, IfDefOp>([&](Operation *op) {
+        .Case<VerbatimOp, IfDefOp, MacroDefOp>([&](Operation *op) {
           // Emit into a separate file using the specified file name or
           // replicate the operation in each outputfile.
           if (!attr) {
@@ -5357,7 +5360,6 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
             separateFile(op);
           }
         })
-        .Case<MacroDefOp>([&](auto op) { replicatedOps.push_back(op); })
         .Case<MacroDeclOp>([&](auto op) {
           symbolCache.addDefinition(op.getSymNameAttr(), op);
         })

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -272,11 +272,13 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   LogicalResult resolveReferencePath(mlir::TypedValue<RefType> refVal,
-                                     SmallVectorImpl<Attribute> &refSendPath,
+                                     ImplicitLocOpBuilder builder,
+                                     Attribute &ref,
                                      SmallString<128> &stringLeaf) {
     auto remoteOpPath = getRemoteRefSend(refVal);
     if (!remoteOpPath)
       return failure();
+    SmallVector<Attribute> refSendPath;
     size_t lastIndex;
     while (remoteOpPath) {
       lastIndex = *remoteOpPath;
@@ -297,6 +299,16 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       stringLeaf.append(iter->getSecond());
     }
 
+    // Compute the reference attribute.  If the path is size 1,
+    // then this is just an InnerRefAttr (module--component pair).  Otherwise,
+    // we need to use the symbol of a HierPathOp that stores the path.
+    if (refSendPath.size() == 1)
+      ref = refSendPath.front();
+    else if (!refSendPath.empty())
+      ref = FlatSymbolRefAttr::get(
+          getOrCreatePath(builder.getArrayAttr(refSendPath), builder)
+              .getSymNameAttr());
+
     return success();
   }
 
@@ -307,22 +319,11 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     if (!remoteOpPath)
       return failure();
 
-    SmallVector<Attribute> refSendPath;
-    SmallString<128> xmrString;
-    if (failed(resolveReferencePath(refVal, refSendPath, xmrString)))
-      return failure();
-
-    // Compute the reference given to the SVXMRRefOp.  If the path is size 1,
-    // then this is just an InnerRefAttr (module--component pair).  Otehrwise,
-    // we need to use the symbol of a HierPathOp that stores the path.
     ImplicitLocOpBuilder builder(loc, insertBefore);
     Attribute ref;
-    if (refSendPath.size() == 1)
-      ref = refSendPath.front();
-    else
-      ref = FlatSymbolRefAttr::get(
-          getOrCreatePath(builder.getArrayAttr(refSendPath), builder)
-              .getSymNameAttr());
+    SmallString<128> xmrString;
+    if (failed(resolveReferencePath(refVal, builder, ref, xmrString)))
+      return failure();
 
     // Create the XMR op and convert it to the referenced FIRRTL type.
     auto referentType = refVal.getType().getType();
@@ -453,8 +454,11 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   LogicalResult handlePublicModuleRefPorts(FModuleOp module) {
+    // Decls must be at the top mlir module scope
+    auto declBuilder = ImplicitLocOpBuilder::atBlockBegin(
+        module.getLoc(), getOperation().getBody());
     auto builder = ImplicitLocOpBuilder::atBlockBegin(module.getLoc(),
-                                                      getOperation().getBody());
+                                                      circuitOp.getBodyBlock());
 
     for (size_t portIndex = 0, numPorts = module.getNumPorts();
          portIndex != numPorts; ++portIndex) {
@@ -465,21 +469,14 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       auto portValue =
           module.getArgument(portIndex).cast<mlir::TypedValue<RefType>>();
 
-      SmallVector<Attribute> refSendPath;
+      Attribute ref;
       SmallString<128> stringLeaf;
-      if (failed(resolveReferencePath(portValue, refSendPath, stringLeaf)))
+      if (failed(resolveReferencePath(portValue, builder, ref, stringLeaf)))
         return failure();
 
       SmallString<128> formatString;
-      for (size_t pathIndex = 0, pathSize = refSendPath.size();
-           pathIndex < pathSize; ++pathIndex) {
-        if (pathIndex > 0)
-          formatString.append(".");
-        formatString.append("{{");
-        formatString.append(std::to_string(pathIndex));
-        formatString.append("}}");
-      }
-
+      if (ref)
+        formatString += "{{0}}";
       formatString += stringLeaf;
 
       // Insert a macro with the format:
@@ -488,11 +485,12 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       auto macroName = builder.getStringAttr("ref_" + circuitOp.getName() +
                                              "_" + module.getName() + "_" +
                                              module.getPortName(portIndex));
-      builder.create<sv::MacroDeclOp>(macroName, ArrayAttr(), StringAttr());
-      auto macroDefOp =
-          builder.create<sv::MacroDefOp>(FlatSymbolRefAttr::get(macroName),
-                                         builder.getStringAttr(formatString),
-                                         builder.getArrayAttr(refSendPath));
+      declBuilder.create<sv::MacroDeclOp>(macroName, ArrayAttr(), StringAttr());
+
+      auto macroDefOp = builder.create<sv::MacroDefOp>(
+          FlatSymbolRefAttr::get(macroName),
+          builder.getStringAttr(formatString),
+          builder.getArrayAttr(ref ? ref : ArrayRef<Attribute>{}));
 
       // The macro will be exported to a file with the format:
       // ref_<circuit name>_<module name>.sv

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -480,8 +480,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       formatString += stringLeaf;
 
       // Insert a macro with the format:
-      // ref_<circuit name>_<module name>_<ref name> <internal path
-      // from module>
+      // ref_<circuit-name>_<module-name>_<ref-name> <path>
       auto macroName = builder.getStringAttr("ref_" + circuitOp.getName() +
                                              "_" + module.getName() + "_" +
                                              module.getPortName(portIndex));
@@ -493,7 +492,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
           builder.getArrayAttr(ref ? ref : ArrayRef<Attribute>{}));
 
       // The macro will be exported to a file with the format:
-      // ref_<circuit name>_<module name>.sv
+      // ref_<circuit-name>_<module-name>.sv
       macroDefOp->setAttr(
           "output_file", hw::OutputFileAttr::getFromFilename(
                              &getContext(), "ref_" + circuitOp.getName() + "_" +

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -481,8 +481,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
       // Insert a macro with the format:
       // ref_<circuit-name>_<module-name>_<ref-name> <path>
-      auto macroName = builder.getStringAttr("ref_" + circuitOp.getName() +
-                                             "_" + module.getName() + "_" +
+      SmallString<128> refCircuitModulePrefix{"ref_", circuitOp.getName(), "_",
+                                              module.getName()};
+      auto macroName = builder.getStringAttr(refCircuitModulePrefix + "_" +
                                              module.getPortName(portIndex));
       declBuilder.create<sv::MacroDeclOp>(macroName, ArrayAttr(), StringAttr());
 
@@ -493,10 +494,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
       // The macro will be exported to a file with the format:
       // ref_<circuit-name>_<module-name>.sv
-      macroDefOp->setAttr(
-          "output_file", hw::OutputFileAttr::getFromFilename(
-                             &getContext(), "ref_" + circuitOp.getName() + "_" +
-                                                module.getName() + ".sv"));
+      macroDefOp->setAttr("output_file",
+                          hw::OutputFileAttr::getFromFilename(
+                              &getContext(), refCircuitModulePrefix + ".sv"));
     }
 
     return success();

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -706,13 +706,26 @@ firrtl.circuit "ForceRelease" {
 
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" {
-  // CHECK-LABEL: hw.hierpath private @xmrPath [@Top::@foo, @Foo::@x]
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_a "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@w>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_b "{{[{][{]0[}][}]}}"([@xmrPath]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_c "{{[{][{]0[}][}]}}.internal.path"([#hw.innerNameRef<@Top::@foo>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_d "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@xmr_sym>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Foo_x "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Foo::@x>]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
-  // CHECK-NEXT:  sv.macro.def @ref_Top_Foo_y "internal.path" {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+  // CHECK-LABEL:        hw.hierpath private @xmrPath [@Top::@foo, @Foo::@x]
+
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Top_a "{{0}}"
+  // CHECK-SAME:          ([#hw.innerNameRef<@Top::@w>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Top_b "{{0}}"
+  // CHECK-SAME:          ([@xmrPath]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Top_c "{{0}}.internal.path"
+  // CHECK-SAME:          ([#hw.innerNameRef<@Top::@foo>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Top_d "{{0}}"
+  // CHECK-SAME:          ([#hw.innerNameRef<@Top::@xmr_sym>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Foo_x "{{0}}"
+  // CHECK-SAME:          ([#hw.innerNameRef<@Foo::@x>]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+
+  // CHECK-NEXT:          sv.macro.def @ref_Top_Foo_y "internal.path" 
+  // CHECK-NOT:           ([
+  // CHECK-SAME:          {output_file = #hw.output_file<"ref_Top_Foo.sv">}
 
   // CHECK-LABEL: firrtl.module @Top()
   firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, 

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -700,18 +700,23 @@ firrtl.circuit "ForceRelease" {
 // CHECK-LABEL: sv.macro.def @ref_Top_Top_a "{{[{][{]0[}][}]}}" {output_file = #hw.output_file<"ref_Top_Top.sv">, symbols = [#hw.innerNameRef<@Top::@w>]}
 // CHECK-LABEL: sv.macro.decl @ref_Top_Top_b
 // CHECK-LABEL: sv.macro.def @ref_Top_Top_b "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}" {output_file = #hw.output_file<"ref_Top_Top.sv">, symbols = [#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@x>]}
-// CHECK-NOT:   sv.macro.decl @ref_Top_Top_c
-// CHECK-NOT:   sv.macro.def @ref_Top_Top_c
+// CHECK-LABEL: sv.macro.decl @ref_Top_Top_c
+// CHECK-LABEL: sv.macro.def @ref_Top_Top_c "{{[{][{]0[}][}]}}" {output_file = #hw.output_file<"ref_Top_Top.sv">, symbols = [#hw.innerNameRef<@Top::@xmr_sym>]}
+// CHECK-NOT:   sv.macro.decl @ref_Top_Top_d
+// CHECK-NOT:   sv.macro.def @ref_Top_Top_d
 
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Top()
-  firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, out %b: !firrtl.probe<uint<1>>, in %c: !firrtl.probe<uint<1>>) {
+  firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, out %b: !firrtl.probe<uint<1>>, out %c: !firrtl.probe<uint<1>>, in %d: !firrtl.probe<uint<1>>) {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
     %0 = firrtl.ref.send %w : !firrtl.uint<1>
     firrtl.ref.define %a, %0 : !firrtl.probe<uint<1>>
     %x = firrtl.instance foo sym @foo @Foo(out x: !firrtl.probe<uint<1>>)
     firrtl.ref.define %b, %x : !firrtl.probe<uint<1>>
+    %constant = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.ref.send %constant : !firrtl.uint<1>
+    firrtl.ref.define %c, %1 : !firrtl.probe<uint<1>>
   }
 
   // CHECK-LABEL: firrtl.module @Foo()

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -697,25 +697,23 @@ firrtl.circuit "ForceRelease" {
 // Check tracking of public output refs as sv.macro.decl and sv.macro.def
 
 // CHECK-LABEL: sv.macro.decl @ref_Top_Top_a
-// CHECK-LABEL: sv.macro.def @ref_Top_Top_a "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@w>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-
-// CHECK-LABEL: sv.macro.decl @ref_Top_Top_b
-// CHECK-LABEL: sv.macro.def @ref_Top_Top_b "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}"([#hw.innerNameRef<@Top::@foo>, #hw.innerNameRef<@Foo::@x>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-// CHECK-LABEL: sv.macro.decl @ref_Top_Top_c
-// CHECK-LABEL: sv.macro.def @ref_Top_Top_c "{{[{][{]0[}][}]}}.internal.path"([#hw.innerNameRef<@Top::@foo>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
-
-// CHECK-LABEL: sv.macro.decl @ref_Top_Top_d
-// CHECK-LABEL: sv.macro.def @ref_Top_Top_d "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@xmr_sym>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+// CHECK-NEXT:  sv.macro.decl @ref_Top_Top_b
+// CHECK-NEXT:  sv.macro.decl @ref_Top_Top_c
+// CHECK-NEXT:  sv.macro.decl @ref_Top_Top_d
 // CHECK-NOT:   sv.macro.decl @ref_Top_Top_e
-// CHECK-NOT:   sv.macro.def @ref_Top_Top_e
-
-// CHECK-LABEL: sv.macro.decl @ref_Top_Foo_x
-// CHECK-LABEL: sv.macro.def @ref_Top_Foo_x "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Foo::@x>]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
-// CHECK-LABEL: sv.macro.decl @ref_Top_Foo_y
-// CHECK-LABEL: sv.macro.def @ref_Top_Foo_y "internal.path" {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+// CHECK-NEXT:  sv.macro.decl @ref_Top_Foo_x
+// CHECK-NEXT:  sv.macro.decl @ref_Top_Foo_y
 
 // CHECK-LABEL: firrtl.circuit "Top"
 firrtl.circuit "Top" {
+  // CHECK-LABEL: hw.hierpath private @xmrPath [@Top::@foo, @Foo::@x]
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_a "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@w>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_b "{{[{][{]0[}][}]}}"([@xmrPath]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_c "{{[{][{]0[}][}]}}.internal.path"([#hw.innerNameRef<@Top::@foo>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Top_d "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Top::@xmr_sym>]) {output_file = #hw.output_file<"ref_Top_Top.sv">}
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Foo_x "{{[{][{]0[}][}]}}"([#hw.innerNameRef<@Foo::@x>]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+  // CHECK-NEXT:  sv.macro.def @ref_Top_Foo_y "internal.path" {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+
   // CHECK-LABEL: firrtl.module @Top()
   firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, 
                      out %b: !firrtl.probe<uint<1>>, 

--- a/test/firtool/export-ref.fir
+++ b/test/firtool/export-ref.fir
@@ -1,0 +1,30 @@
+; RUN: firtool %s -split-verilog -o %t
+; RUN: cat %t/ref_Top_Top.sv | FileCheck %s
+
+; CHECK:      `define ref_Top_Top_direct_probe direct
+; CHECK-NEXT: `define ref_Top_Top_inner_probe inner.x
+; CHECK-NEXT: `define ref_Top_Top_keyword_probe always_0
+
+FIRRTL version 3.0.0
+circuit Top:
+  module Top:
+    output direct_probe: Probe<UInt<1>>
+    output inner_probe: Probe<UInt<2>>
+    output keyword_probe: Probe<UInt<3>>
+
+    wire direct: UInt<1>
+    invalidate direct
+    define direct_probe = probe(direct)
+
+    inst inner of Inner
+    define inner_probe = inner.x_probe
+
+    wire always: UInt<3>
+    invalidate always
+    define keyword_probe = probe(always)
+
+  module Inner:
+    output x_probe: Probe<UInt<2>>
+    wire x: UInt<2>
+    invalidate x
+    define x_probe = probe(x)

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -692,7 +692,7 @@ static LogicalResult processBuffer(
     // Lower the ref.resolve and ref.send ops and remove the RefType ports.
     // LowerToHW cannot handle RefType so, this pass must be run to remove all
     // RefType ports and ops.
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
+    pm.addPass(firrtl::createLowerXMRPass());
 
     pm.addPass(createLowerFIRRTLToHWPass(
         enableAnnotationWarning.getValue(), emitChiselAssertsAsSVA.getValue(),


### PR DESCRIPTION
This implements the [proposed lowering of ref ports in the firrtl abi spec](https://github.com/chipsalliance/firrtl-spec/pull/103).

During the `LowerXMR` pass, for each public output ref port,  an `hw.exportableRef` op is created to track the ref. This op is a symbolic namepath for the ref. During the `ExportVerilog` pass, `sv.macro.decl` and `sv.macro.def` ops are created with the fully resolved namepath based on the legalized verilog names.

Although the semantics are fairly firrtl specific, the exportable-ref op is part of the `hw` dialect since it needs to hang around until `ExportVerilog`.