### PR TITLE
[firtool] Erase extra verbatim files before printing final MLIR.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -160,6 +160,8 @@ createResolveTracesPass(mlir::StringRef outputAnnotationFilename = "");
 
 std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
 
+std::unique_ptr<mlir::Pass> createFinalizeIRPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -691,4 +691,15 @@ def VBToBV : Pass<"firrtl-vb-to-bv", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createVBToBVPass()";
 }
 
+def FinalizeIR : Pass<"firrtl-finalize-ir", "mlir::ModuleOp"> {
+  let summary = "Perform final IR mutations after ExportVerilog";
+  let description = [{
+    This pass finalizes the IR after it has been exported with ExportVerilog,
+    and before firtool emits the final IR. This includes mutations like dropping
+    verbatim ops that represent sideband files and are not required in the IR.
+  }];
+  let constructor = "circt::firrtl::createFinalizeIRPass()";
+  let dependentDialects = ["hw::HWDialect", "sv::SVDialect"];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ExpandWhens.cpp
   ExtractInstances.cpp
   FlattenMemory.cpp
+  FinalizeIR.cpp
   GrandCentral.cpp
   IMConstProp.cpp
   IMDeadCodeElim.cpp

--- a/lib/Dialect/FIRRTL/Transforms/FinalizeIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FinalizeIR.cpp
@@ -1,0 +1,40 @@
+//===- FinalizeIR.cpp - Finalize IR after ExportVerilog -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FinalizeIR pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/SV/SVOps.h"
+
+using namespace circt;
+
+namespace {
+struct FinalizeIRPass : public firrtl::FinalizeIRBase<FinalizeIRPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Finalize the IR after ExportVerilog and before the final IR is emitted.
+void FinalizeIRPass::runOnOperation() {
+  // Erase any sv.verbatim ops for sideband files.
+  for (auto verbatim : llvm::make_early_inc_range(
+           getOperation().getBodyRegion().getOps<sv::VerbatimOp>()))
+    if (auto outputFile = verbatim->getAttrOfType<hw::OutputFileAttr>(
+            hw::OutputFileAttr::getMnemonic()))
+      if (!outputFile.isDirectory() &&
+          outputFile.getExcludeFromFilelist().getValue())
+        verbatim.erase();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createFinalizeIRPass() {
+  return std::make_unique<FinalizeIRPass>();
+}

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -2,7 +2,7 @@
 // RUN: firtool %s --format=mlir --ir-fir --emit-bytecode | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: circt-opt %s --emit-bytecode | firtool --ir-fir | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
-// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -omir-file %S/firtool.fir.omir.anno.json -output-omir meta.omir.json -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.mlirbc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
 // RUN: circt-opt %t.mlirbc | FileCheck %s --check-prefix=VERILOG-WITH-MLIR-OUT
@@ -30,6 +30,8 @@ firrtl.circuit "Top" {
 // VERILOG-WITH-MLIR-NEXT :   output [7:0] out);
 // VERILOG-WITH-MLIR-NEXT :   assign out = in;
 // VERILOG-WITH-MLIR-NEXT : endmodule
+
+// VERILOG-WITH-MLIR-OUT-NOT: sv.verbatim{{.*}}output_file = {{.*}}meta.omir.json
 
 // VERILOG-WITH-MLIR-OUT-LABEL: hw.module @Top(%in: i8) -> (out: i8) {
 // VERILOG-WITH-MLIR-OUT-NEXT:    hw.output %in : i8

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -22,6 +22,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
@@ -438,6 +439,37 @@ static LogicalResult printOp(Operation *op, raw_ostream &os) {
   return success();
 }
 
+// If requested, finalize and print the MLIR into mlirOutFile. The final MLIR
+// will erase any sv.verbatim ops that represented contents for sideband files,
+// so this should always be called after ExportVerilog.
+static LogicalResult finalizeAndPrintMlir(ModuleOp moduleOp) {
+  if (mlirOutFile.empty())
+    return success();
+
+  std::string mlirOutError;
+  auto mlirFile = openOutputFile(mlirOutFile, &mlirOutError);
+  if (!mlirFile) {
+    llvm::errs() << mlirOutError;
+    return failure();
+  }
+
+  // Finalize the MLIR by erasing any sv.verbatim ops for sideband files.
+  for (auto verbatim : llvm::make_early_inc_range(
+           moduleOp.getBodyRegion().getOps<sv::VerbatimOp>()))
+    if (auto outputFile = verbatim->getAttrOfType<hw::OutputFileAttr>(
+            hw::OutputFileAttr::getMnemonic()))
+      if (!outputFile.isDirectory() &&
+          outputFile.getExcludeFromFilelist().getValue())
+        verbatim.erase();
+
+  // Print the final MLIR.
+  if (failed(printOp(moduleOp, mlirFile->os())))
+    return failure();
+  mlirFile->keep();
+
+  return success();
+}
+
 /// Process a single buffer of the input.
 static LogicalResult processBuffer(
     MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
@@ -809,19 +841,9 @@ static LogicalResult processBuffer(
       return failure();
   }
 
-  // If requested, print the final MLIR into mlirOutFile.
-  if (!mlirOutFile.empty()) {
-    std::string mlirOutError;
-    auto mlirFile = openOutputFile(mlirOutFile, &mlirOutError);
-    if (!mlirFile) {
-      llvm::errs() << mlirOutError;
-      return failure();
-    }
-
-    if (failed(printOp(*module, mlirFile->os())))
-      return failure();
-    mlirFile->keep();
-  }
+  // If requested, finalize and print the MLIR into mlirOutFile.
+  if (failed(finalizeAndPrintMlir(*module)))
+    return failure();
 
   // We intentionally "leak" the Module into the MLIRContext instead of
   // deallocating it.  There is no need to deallocate it right before process


### PR DESCRIPTION
There may be several files generated during any given run of firtool, represented as sv.verbatim ops with output_file attributes. This information isn't needed in the final MLIR that is emitted, so erase those from the MLIR right before emitting it.