### PR TITLE
[FIRRTL] Fix connect verifier for enums

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -195,7 +195,8 @@ public:
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
-                        bool srcOuterTypeIsConst = false);
+                        bool srcOuterTypeIsConst = false,
+                        bool requireSameWidths = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -375,6 +375,28 @@ firrtl.module @test(out %a: !firrtl.bundle<a flip: bundle<a flip: uint<1>>>) {
 
 // -----
 
+// Check that different labels cause the enumeration to not match.
+
+firrtl.circuit "test"  {
+firrtl.module @test(in %a: !firrtl.enum<a: uint<1>>, out %b: !firrtl.enum<a: uint<2>>) {
+  // expected-error @below {{type mismatch between destination '!firrtl.enum<a: uint<2>>' and source '!firrtl.enum<a: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.enum<a: uint<2>>, !firrtl.enum<a: uint<1>>
+}
+}
+
+// -----
+
+// Check that different data types causes the enumeration to not match.
+
+firrtl.circuit "test"  {
+firrtl.module @test(in %a: !firrtl.enum<a: uint<0>>, out %b: !firrtl.enum<b: uint<0>>) {
+  // expected-error @below {{type mismatch between destination '!firrtl.enum<b: uint<0>>' and source '!firrtl.enum<a: uint<0>>'}}
+  firrtl.connect %b, %a : !firrtl.enum<b: uint<0>>, !firrtl.enum<a: uint<0>>
+}
+}
+
+// -----
+
 /// Check that the following is an invalid sink flow source.  This has to use a
 /// memory because all other sinks (module outputs or instance inputs) can
 /// legally be used as sources.


### PR DESCRIPTION
Enumerations can only be connected when all variants, compared in order, have the same name and type, modulo uninferred widths.  They do not, like bundle and array types, allow for implicit truncation or extension of the ground fields.  The original logic had a couple of bugs:

1. It was not comparing the variant name.
2. It was comparing the dest to the dest (instead of the src).
3. It was allowing implicit truncs/exts in the variant types.

This change fixes these problems and adds two tests.