### PR TITLE
[HWArithToHW] Restore access to HWArith-specific patterns.

### DIFF
--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -400,6 +400,15 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
 // Pass driver
 //===----------------------------------------------------------------------===//
 
+void circt::populateHWArithToHWConversionPatterns(
+    HWArithToHWTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  patterns.add<ConstantOpLowering, CastOpLowering, ICmpOpLowering,
+               BinaryOpLowering<AddOp, comb::AddOp>,
+               BinaryOpLowering<SubOp, comb::SubOp>,
+               BinaryOpLowering<MulOp, comb::MulOp>, DivOpLowering>(
+      typeConverter, patterns.getContext());
+}
+
 namespace {
 
 class HWArithToHWPass : public HWArithToHWBase<HWArithToHWPass> {
@@ -414,11 +423,7 @@ public:
     target.addIllegalDialect<HWArithDialect>();
 
     // Add HWArith-specific conversion patterns.
-    patterns.add<ConstantOpLowering, CastOpLowering, ICmpOpLowering,
-                 BinaryOpLowering<hwarith::AddOp, comb::AddOp>,
-                 BinaryOpLowering<hwarith::SubOp, comb::SubOp>,
-                 BinaryOpLowering<hwarith::MulOp, comb::MulOp>, DivOpLowering>(
-        typeConverter, patterns.getContext());
+    populateHWArithToHWConversionPatterns(typeConverter, patterns);
 
     // ALL other operations are converted via the TypeConversionPattern which
     // will replace an operation to an identical operation with replaced


### PR DESCRIPTION
I'd like to bring back this method which has been removed in #4898, as our OoT-flow has other `ui`/`si` ops that we need to convert alongside the `hwarith` patterns.