### PR TITLE
[circt-lec] Clean up z3 includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ llvm_canonicalize_cmake_booleans(CIRCT_LLHD_SIM_ENABLED)
 #-------------------------------------------------------------------------------
 # circt-lec Configuration
 #-------------------------------------------------------------------------------
+
 # If circt-lec hasn't been explicitly disabled, find it.
 option(CIRCT_LEC_DISABLE "Disable the Logical Equivalence Checker" OFF)
 if(CIRCT_LEC_DISABLE)
@@ -489,15 +490,9 @@ else()
       get_target_property(Z3_LIB_LOCATION z3::libz3 IMPORTED_LOCATION_DEBUG)
       message(STATUS "Found Z3: ${Z3_LIB_LOCATION} (found version \"${Z3_VERSION_STRING}\")")
     endif()
-    # Link against the reported library and include locations.
-    list(APPEND CIRCT_LEC_LIBS ${Z3_LIBRARIES})
-    list(APPEND CIRCT_LEC_INCLUDES ${Z3_CXX_INCLUDE_DIRS})
   else()
     # Attempt initialising Z3 according to LLVM's `FindZ3` CMake module.
     find_package(Z3)
-    # Link against the reported library and include locations.
-    list(APPEND CIRCT_LEC_LIBS ${Z3_LIBRARIES})
-    list(APPEND CIRCT_LEC_INCLUDES ${Z3_INCLUDE_DIR})
   endif()
   
   if(Z3_FOUND)

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -1,23 +1,27 @@
 # circt-lec builds if a logic backend is found
 if(CIRCT_LEC_ENABLED)
-  list(APPEND CIRCT_LEC_SOURCES
+  add_llvm_tool(circt-lec
     circt-lec.cpp
     Circuit.cpp
     LogicExporter.cpp
     Solver.cpp
   )
 
-  list(APPEND CIRCT_LEC_LIBS
+  target_link_libraries(circt-lec
+    PRIVATE
     MLIRTransforms
     MLIRTranslateLib
     CIRCTComb
     CIRCTHW
     CIRCTSupport
+    ${Z3_LIBRARIES}
   )
 
-  add_llvm_tool(circt-lec ${CIRCT_LEC_SOURCES})
-  target_link_libraries(circt-lec PRIVATE ${CIRCT_LEC_LIBS})
-  target_include_directories(circt-lec PRIVATE ${CIRCT_LEC_INCLUDES})
+  target_include_directories(circt-lec SYSTEM
+    PRIVATE
+    ${Z3_INCLUDE_DIR}
+    ${Z3_CXX_INCLUDE_DIRS}
+  )
 
   # Correct the runpath when linking shared libraries.
   if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
Add the z3 include directories as system includes, not normal includes, to the circt-lec tool.  Including the z3 headers this way will prevent clang from putting out warnings on code in the z3 headers.

Also, remove some intermediate variables (`CIRCT_LEC_{INCLUDES,LIBS,SOURCES}`).