### PR TITLE
[Arc] Pull value definitions into reset/enable `IfOp`s where possible

### DIFF
--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -147,14 +147,17 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
       Block &block = region->front();
       for (auto &op : block) {
         for (auto operand : op.getOperands()) {
-          // If the op is already in the region or the definition is outside the clock tree, skip
+          // If the op is already in the region or the definition is outside the
+          // clock tree, skip
           Operation *definition = operand.getDefiningOp();
-          if (definition->getParentRegion() == region || !clockTreeOp->isAncestor(definition))
+          if (definition->getParentRegion() == region ||
+              !clockTreeOp->isAncestor(definition))
             continue;
-          // If the operand is used more than once, check moving the assignment wouldn't cause non-domination
+          // If the operand is used more than once, check moving the assignment
+          // wouldn't cause non-domination
           if (!operand.hasOneUse()) {
             bool safeToMove = true;
-            for (auto *user: operand.getUsers()) {
+            for (auto *user : operand.getUsers()) {
               if (region->isAncestor(user->getParentRegion())) {
                 safeToMove = false;
                 break;
@@ -163,8 +166,8 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
             if (!safeToMove)
               break;
           }
-          rewriter.updateRootInPlace(
-              definition, [&]() { definition->moveBefore(&op); });
+          rewriter.updateRootInPlace(definition,
+                                     [&]() { definition->moveBefore(&op); });
           changed = true;
         }
       }

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "arc-group-resets-and-enables"
@@ -143,35 +144,47 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
     for (auto *region : groupingRegions) {
       if (region->empty())
         continue;
+
       // Since we only work with IfOp then/else regions, we have at most 1 block
+
       Block &block = region->front();
-      for (auto &op : block) {
-        for (auto operand : op.getOperands()) {
-          // If the op is already in the region or the definition is outside the
-          // clock tree, skip
-          Operation *definition = operand.getDefiningOp();
-          if (definition->getParentRegion() == region ||
-              !clockTreeOp->isAncestor(definition))
-            continue;
-          // If the operand is used more than once, check moving the assignment
-          // wouldn't cause non-domination
-          if (!operand.hasOneUse()) {
-            bool safeToMove = true;
-            for (auto *user : operand.getUsers()) {
-              if (!region->isAncestor(user->getParentRegion()) ||
-                  ((user->getBlock() == &block) &&
-                   user->isBeforeInBlock(&op))) {
-                safeToMove = false;
-                break;
+      SmallVector<Operation *> worklist;
+      // Don't walk as we don't want nested ops in order to restrict to IfOps
+      for (auto &op: block.getOperations()) {
+        worklist.push_back(&op);
+      }
+      while (!worklist.empty()) {
+        SmallVector<Operation *> theseOperands;
+        Operation *op = worklist.back();
+        for (auto operand : op->getOperands()) {
+          if (Operation *definition = operand.getDefiningOp()) {
+            if (definition->getBlock() == op->getBlock() ||
+                !clockTreeOp->isAncestor(definition))
+              continue;
+            if (!operand.hasOneUse()) {
+              bool safeToMove = true;
+              for (auto *user : operand.getUsers()) {
+                if (!op->getParentRegion()->isAncestor(
+                        user->getParentRegion()) ||
+                    (user->getBlock() == op->getBlock() &&
+                     user->isBeforeInBlock(op))) {
+                  safeToMove = false;
+                  break;
+                }
               }
+              if (!safeToMove)
+                break;
             }
-            if (!safeToMove)
-              break;
+            // For some unknown reason, just calling moveBefore has the same output but is much slower
+            rewriter.updateRootInPlace(definition,
+                                       [&]() { definition->moveBefore(op); });
+            changed = true;
+            theseOperands.push_back(definition);
           }
-          rewriter.updateRootInPlace(definition,
-                                     [&]() { definition->moveBefore(&op); });
-          changed = true;
         }
+        worklist.pop_back();
+        worklist.insert(worklist.end(), theseOperands.begin(),
+                        theseOperands.end());
       }
     }
     return success(changed);

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -127,14 +127,17 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
       groupingRegions.push_back(&resetIfOp.getThenRegion());
       groupingRegions.push_back(&resetIfOp.getElseRegion());
     }
-    // Gather then/else regions of all higher-level IfOps (e.g. enables within
+    // Gather then/else regions of all second-level IfOps (e.g. enables within
     // resets)
+    SmallVector<Region *> secondLevelRegions;
     for (auto *resetRegion : groupingRegions) {
       for (auto enableIfOp : resetRegion->getOps<scf::IfOp>()) {
-        groupingRegions.push_back(&enableIfOp.getThenRegion());
-        groupingRegions.push_back(&enableIfOp.getElseRegion());
+        secondLevelRegions.push_back(&enableIfOp.getThenRegion());
+        secondLevelRegions.push_back(&enableIfOp.getElseRegion());
       }
     }
+    groupingRegions.insert(groupingRegions.end(), secondLevelRegions.begin(),
+                           secondLevelRegions.end());
 
     bool changed = false;
     for (auto *region : groupingRegions) {

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -158,7 +158,7 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
           if (!operand.hasOneUse()) {
             bool safeToMove = true;
             for (auto *user : operand.getUsers()) {
-              if (region->isAncestor(user->getParentRegion())) {
+              if (!region->isAncestor(user->getParentRegion())) {
                 safeToMove = false;
                 break;
               }

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -150,7 +150,7 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
       Block &block = region->front();
       SmallVector<Operation *> worklist;
       // Don't walk as we don't want nested ops in order to restrict to IfOps
-      for (auto &op: block.getOperations()) {
+      for (auto &op : block.getOperations()) {
         worklist.push_back(&op);
       }
       while (!worklist.empty()) {
@@ -175,7 +175,8 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
               if (!safeToMove)
                 break;
             }
-            // For some unknown reason, just calling moveBefore has the same output but is much slower
+            // For some unknown reason, just calling moveBefore has the same
+            // output but is much slower
             rewriter.updateRootInPlace(definition,
                                        [&]() { definition->moveBefore(op); });
             changed = true;

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -158,7 +158,9 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
           if (!operand.hasOneUse()) {
             bool safeToMove = true;
             for (auto *user : operand.getUsers()) {
-              if (!region->isAncestor(user->getParentRegion())) {
+              if (!region->isAncestor(user->getParentRegion()) ||
+                  ((user->getBlock() == &block) &&
+                   user->isBeforeInBlock(&op))) {
                 safeToMove = false;
                 break;
               }

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -147,17 +147,25 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
       Block &block = region->front();
       for (auto &op : block) {
         for (auto operand : op.getOperands()) {
-          if (operand.hasOneUse()) {
-            Operation *definition = operand.getDefiningOp();
-            // Confirm that the operand isn't already in the right region and
-            // that it's inside the clock tree
-            if (definition->getParentRegion() != region &&
-                clockTreeOp->isAncestor(definition)) {
-              rewriter.updateRootInPlace(
-                  definition, [&]() { definition->moveBefore(&op); });
-              changed = true;
+          // If the op is already in the region or the definition is outside the clock tree, skip
+          Operation *definition = operand.getDefiningOp();
+          if (definition->getParentRegion() == region || !clockTreeOp->isAncestor(definition))
+            continue;
+          // If the operand is used more than once, check moving the assignment wouldn't cause non-domination
+          if (!operand.hasOneUse()) {
+            bool safeToMove = true;
+            for (auto *user: operand.getUsers()) {
+              if (region->isAncestor(user->getParentRegion())) {
+                safeToMove = false;
+                break;
+              }
             }
+            if (!safeToMove)
+              break;
           }
+          rewriter.updateRootInPlace(
+              definition, [&]() { definition->moveBefore(&op); });
+          changed = true;
         }
       }
     }

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -114,6 +114,54 @@ struct EnableGroupingPattern : public OpRewritePattern<ClockTreeOp> {
     return success(changed);
   }
 };
+
+struct GroupAssignmentsInIfPattern : public OpRewritePattern<ClockTreeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ClockTreeOp clockTreeOp,
+                                PatternRewriter &rewriter) const override {
+    // Pull values only used in certain reset/enable cases into the appropriate
+    // IfOps
+    SmallVector<Region *> groupingRegions;
+    // Gather then/else regions of all top-level IfOps
+    for (auto resetIfOp : clockTreeOp.getBody().getOps<scf::IfOp>()) {
+      groupingRegions.push_back(&resetIfOp.getThenRegion());
+      groupingRegions.push_back(&resetIfOp.getElseRegion());
+    }
+    // Gather then/else regions of all higher-level IfOps (e.g. enables within
+    // resets)
+    for (auto *resetRegion : groupingRegions) {
+      for (auto enableIfOp : resetRegion->getOps<scf::IfOp>()) {
+        groupingRegions.push_back(&enableIfOp.getThenRegion());
+        groupingRegions.push_back(&enableIfOp.getElseRegion());
+      }
+    }
+
+    bool changed = false;
+    for (auto *region : groupingRegions) {
+      if (region->empty())
+        continue;
+      // Since we only work with IfOp then/else regions, we have at most 1 block
+      Block &block = region->front();
+      for (auto &op : block) {
+        for (auto operand : op.getOperands()) {
+          if (operand.hasOneUse()) {
+            Operation *definition = operand.getDefiningOp();
+            // Confirm that the operand isn't already in the right region and
+            // that it's inside the clock tree
+            if (definition->getParentRegion() != region &&
+                clockTreeOp->isAncestor(definition)) {
+              rewriter.updateRootInPlace(
+                  definition, [&]() { definition->moveBefore(&op); });
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+    return success(changed);
+  };
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -143,6 +191,7 @@ LogicalResult GroupResetsAndEnablesPass::runOnModel(ModelOp modelOp) {
   RewritePatternSet patterns(&context);
   patterns.insert<ResetGroupingPattern>(&context);
   patterns.insert<EnableGroupingPattern>(&context);
+  patterns.insert<GroupAssignmentsInIfPattern>(&context);
   GreedyRewriteConfig config;
   config.strictMode = GreedyRewriteStrictness::ExistingOps;
   if (failed(

--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -164,7 +164,10 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<scf::IfOp> {
                 if (!safeToMove)
                   break;
               }
-              definition->moveBefore(op);
+              // For some currently unknown reason, just calling moveBefore
+              // directly has the same output but is much slower
+              rewriter.updateRootInPlace(definition,
+                                         [&]() { definition->moveBefore(op); });
               changed = true;
               theseOperands.push_back(definition);
             }

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -264,7 +264,7 @@ arc.model "ResetAndEnableGrouping" {
   %in_en0 = arc.root_input "en0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_en1 = arc.root_input "en1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
-  // Group enables inside resets:
+  // Group enables inside resets (and pull in reads):
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %3 = arc.state_read %in_reset : <i1>
@@ -292,7 +292,7 @@ arc.model "ResetAndEnableGrouping" {
     }
   // CHECK-NEXT: }
   }
-  // Group both resets and enables:
+  // Group both resets and enables (and pull in reads):
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %7 = arc.state_read %in_reset : <i1>
@@ -324,7 +324,7 @@ arc.model "ResetAndEnableGrouping" {
     }
     // CHECK-NEXT: }
   }
-  // Group resets that are separated by an enable read:
+  // Group resets that are separated by an enable read (and pull in reads):
   arc.clock_tree %0 {
     //  CHECK: [[IN_RESET:%.+]] = arc.state_read %in_reset
     %11 = arc.state_read %in_reset : <i1>
@@ -340,7 +340,7 @@ arc.model "ResetAndEnableGrouping" {
       %12 = arc.state_read %in_en0 : <i1>
       // CHECK-NEXT:  arc.state_write [[FOO_ALLOC]] = [[IN_I0]] if [[IN_EN0]]
       // CHECK-NEXT:  [[IN_I1:%.+]] = arc.state_read %in_i1
-      // CHECK-NEXT: [[IN_EN1:%.+]] = arc.state_read %in_en1
+      // CHECK-NEXT:  [[IN_EN1:%.+]] = arc.state_read %in_en1
       // CHECK-NEXT:  arc.state_write [[BAR_ALLOC]] = [[IN_I1]] if [[IN_EN1]]
       %13 = arc.state_read %in_i0 : <i4>
       arc.state_write %1 = %13 if %12 : <i4>

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -215,6 +215,7 @@ arc.model "GroupAssignmentsInIfTesting" {
 ^bb0(%arg0: !arc.storage):
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
+  %in_i2 = arc.root_input "i2", %arg0 : (!arc.storage) -> !arc.state<i4>
   %in_cond0 = arc.root_input "cond0", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_cond1 = arc.root_input "cond1", %arg0 : (!arc.storage) -> !arc.state<i1>
   %0 = arc.state_read %in_clock : <i1>
@@ -223,17 +224,19 @@ arc.model "GroupAssignmentsInIfTesting" {
     // CHECK: [[IN_COND0:%.+]] = arc.state_read %in_cond0
     %3 = arc.state_read %in_cond0 : <i1>
     %4 = arc.state_read %in_i1 : <i4>
+    %5 = arc.state_read %in_i2 : <i4>
     // CHECK-NEXT: scf.if [[IN_COND0]] {
     scf.if %3 {
       // CHECK-NEXT: [[IN_I1:%.+]] = arc.state_read %in_i1
       // CHECK-NEXT: arc.state_write [[FOO_ALLOC:%.+]] = [[IN_I1]]
       arc.state_write %1 = %4 : <i4>
       // CHECK: [[IN_COND1:%.+]] = arc.state_read %in_cond1
-      %5 = arc.state_read %in_cond1 : <i1>
+      %6 = arc.state_read %in_cond1 : <i1>
       // CHECK-NEXT: scf.if [[IN_COND1]] {
-      scf.if %5 {
-        // CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = [[IN_I1]]
-        arc.state_write %2 = %4 : <i4>
+      scf.if %6 {
+        // CHECK-NEXT: [[IN_I2:%.+]] = arc.state_read %in_i2
+        // CHECK-NEXT: arc.state_write [[BAR_ALLOC:%.+]] = [[IN_I2]]
+        arc.state_write %2 = %5 : <i4>
         // CHECK-NEXT: }
       }
       // CHECK-NEXT: }


### PR DESCRIPTION
This is an extension to the reset/enable grouping logic introduced in #5103, which pulls assignment of values that are used only inside reset/enable `IfOp`s  into the `IfOps` so that they are not unnecessarily fetched. This is also able to handle values that are only used either within a region or its ancestors.

~~I've tested the performance of this and haven't seen any significant performance regression (in fact, running arcilator on BOOM until after the state lowering ran about 8% faster with the pass - I assume this was some other incidental factor but good to know it's not hitting performance on large designs since there's a lot of iteration going on!)~~ (made a mistake when benchmarking!). If it does seem like performance is getting hit in other settings then restricting this to operands with single uses (as I did at first) should speed things up, but I'd imagine we'd lose a lot of simulation-time improvements in larger designs.