### PR TITLE
[ExportVerilog] Drop alignment, explore pretty-printing types/structs. (draft/experimenting)

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1443,7 +1443,7 @@ static bool printPackedTypeImpl(Type type, PPS &ps, Location loc,
             ps << ";";
           }
           if (!structType.getElements().empty())
-            ps << PP::nbsp;
+            ps << BreakToken(1, -2);
           ps << "}";
           emitDims(dims, ps, loc, emitter);
           // ps << PP::zerobreak;


### PR DESCRIPTION
WIP! Just sharing for visibility, quick attempt to get EV's types/etc going through our pretty-printer.

Whitespace is off due to hacking out the alignment code, so there are stray spaces before decl names sometimes and other issues such as port decl sharing alignment doesn't work.  If we didn't sometimes comment them out (zero-width), the pretty-printer could wrap port declarations for us, but this isn't done here yet.

Primary focus was on `struct packed` types, which currently end up looking something like:

```diff
<   input  struct packed {logic clock; logic reset; }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               auto_divider_only_clk_generator_in,
<   output struct packed {struct packed {struct packed {logic clock; logic reset; } allClocks_subsystem_cbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_mbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_fbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_pbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_sbus_1; struct packed {logic clock; logic reset; } allClocks_subsystem_sbus_0; struct packed {logic clock; logic reset; } allClocks_implicit_clock; } member; } auto_divider_only_clk_generator_out
< );
< 
<   wire
<     _bundleOut_0_member_allClocks_implicit_clock_clock_ClockDivideBy1_clk_out;	// DividerOnlyClockGenerator.scala:133:27
<   wire struct packed {logic clock; logic reset; }
<     _GEN =
<     '{clock: _bundleOut_0_member_allClocks_implicit_clock_clock_ClockDivideBy1_clk_out,
<       reset: auto_divider_only_clk_generator_in.reset};	// DividerOnlyClockGenerator.scala:133:27, :142:19, :144:19
<   wire
<     struct packed {struct packed {logic clock; logic reset; } allClocks_subsystem_cbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_mbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_fbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_pbus_0; struct packed {logic clock; logic reset; } allClocks_subsystem_sbus_1; struct packed {logic clock; logic reset; } allClocks_subsystem_sbus_0; struct packed {logic clock; logic reset; } allClocks_implicit_clock; }
<     _GEN_0 =
<     '{allClocks_subsystem_cbus_0: _GEN,
<       allClocks_subsystem_mbus_0: _GEN,
<       allClocks_subsystem_fbus_0: _GEN,
<       allClocks_subsystem_pbus_0: _GEN,
<       allClocks_subsystem_sbus_1: _GEN,
<       allClocks_subsystem_sbus_0: _GEN,
<       allClocks_implicit_clock: _GEN};	// DividerOnlyClockGenerator.scala:142:19
---
>   input  struct packed { logic clock; logic reset; } auto_divider_only_clk_generator_in,
>   output struct packed {
>            struct packed {
>              struct packed { logic clock; logic reset; } allClocks_subsystem_cbus_0;
>              struct packed { logic clock; logic reset; } allClocks_subsystem_mbus_0;
>              struct packed { logic clock; logic reset; } allClocks_subsystem_fbus_0;
>              struct packed { logic clock; logic reset; } allClocks_subsystem_pbus_0;
>              struct packed { logic clock; logic reset; } allClocks_subsystem_sbus_1;
>              struct packed { logic clock; logic reset; } allClocks_subsystem_sbus_0;
>              struct packed { logic clock; logic reset; } allClocks_implicit_clock;
>            } member;
>          } auto_divider_only_clk_generator_out
> );
> 
>   wire  _bundleOut_0_member_allClocks_implicit_clock_clock_ClockDivideBy1_clk_out;	// DividerOnlyClockGenerator.scala:133:27
>   wire struct packed { logic clock; logic reset; } _GEN
>     = '{clock: _bundleOut_0_member_allClocks_implicit_clock_clock_ClockDivideBy1_clk_out,
>         reset: auto_divider_only_clk_generator_in.reset};	// DividerOnlyClockGenerator.scala:133:27, :142:19, :144:19
>   wire
>     struct packed {
>       struct packed { logic clock; logic reset; } allClocks_subsystem_cbus_0;
>       struct packed { logic clock; logic reset; } allClocks_subsystem_mbus_0;
>       struct packed { logic clock; logic reset; } allClocks_subsystem_fbus_0;
>       struct packed { logic clock; logic reset; } allClocks_subsystem_pbus_0;
>       struct packed { logic clock; logic reset; } allClocks_subsystem_sbus_1;
>       struct packed { logic clock; logic reset; } allClocks_subsystem_sbus_0;
>       struct packed { logic clock; logic reset; } allClocks_implicit_clock;
>     } _GEN_0
>     = '{allClocks_subsystem_cbus_0: _GEN,
>         allClocks_subsystem_mbus_0: _GEN,
>         allClocks_subsystem_fbus_0: _GEN,
>         allClocks_subsystem_pbus_0: _GEN,
>         allClocks_subsystem_sbus_1: _GEN,
>         allClocks_subsystem_sbus_0: _GEN,
>         allClocks_implicit_clock: _GEN};	// DividerOnlyClockGenerator.scala:142:19
```