### PR TITLE
[FIRRTL] CAPI Additions

### DIFF
--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -119,8 +119,11 @@ MLIR_CAPI_EXPORTED bool firrtlTypeBundleHasFieldName(MlirType type,
 MLIR_CAPI_EXPORTED MlirStringRef firrtlTypeBundleGetFieldName(MlirType type,
                                                               int32_t index);
 
-/// Return the number of fields for the provided vector type.
-MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumFields(MlirType type);
+/// Return the number of elements for the provided vector type.
+MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumElements(MlirType type);
+
+/// Return the type of all elements in the provided vector type.
+MLIR_CAPI_EXPORTED MlirType firrtlTypeVectorGetElementType(MlirType type);
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -17,7 +17,93 @@
 extern "C" {
 #endif
 
+/// Wraps a FIRRTL BundleType element.
+struct FirrtlBundleElement {
+  MlirIdentifier name;
+  bool isFlip;
+  MlirType type;
+};
+typedef struct FirrtlBundleElement FirrtlBundleElement;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+/// Return 'true' if this is any FIRRTL type.
+bool firrtlTypeIs(MlirType type);
+
+/// Return 'true' if this is a FIRRTL ground type.
+bool firrtlTypeIsGround(MlirType type);
+
+/// Return 'true' if this is a FIRRTL const type.
+bool firrtlTypeIsConst(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Clock type.
+bool firrtlTypeIsClock(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Reset type.
+bool firrtlTypeIsReset(MlirType type);
+
+/// Return 'true' if this is a FIRRTL AsyncReset type.
+bool firrtlTypeIsAsyncReset(MlirType type);
+
+/// Return 'true' if this is a FIRRTL SInt type.
+bool firrtlTypeIsSInt(MlirType type);
+
+/// Return 'true' if this is a FIRRTL UInt type.
+bool firrtlTypeIsUInt(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Analog type.
+bool firrtlTypeIsAnalog(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Bundle type.
+bool firrtlTypeIsBundle(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Vector type.
+bool firrtlTypeIsFVector(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Reference type.
+bool firrtlTypeIsRef(MlirType type);
+
+// bool firrtlTypeIsOpenBundle(MlirType type);
+// bool firrtlTypeIsOpenVector(MlirType type);
+// bool firrtlTypeIsFEnum(MlirType type);
+
+/// Return the bit-width of a type.
+int32_t firrtlTypeGetBitWidth(MlirType type, bool ignoreFlip);
+
+/// Return 'true' if the destination type is at least as wide as the source.
+bool firrtlTypeIsLarger(MlirType dst, MlirType src);
+
+/// Return 'true' if two types are equivalent.
+bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
+                              bool srcOuterTypeIsConst);
+
+/// Return the number of fields for the given bundle type.
+int32_t firrtlTypeBundleGetNumFields(MlirType type);
+
+/// Return the index of a named bundle field.
+int32_t firrtlTypeBundleGetElementIndex(MlirType type, MlirStringRef name);
+
+/// Return the name of the bundle field at the given index.
+MlirStringRef firrtlTypeBundleGetElementName(MlirType type, int32_t index);
+
+/// Return the bundle field at the given index.
+FirrtlBundleElement firrtlTypeBundleGetElementByIndex(MlirType type,
+                                                      int32_t index);
+
+/// Return the bundle field with the given name.
+FirrtlBundleElement firrtlTypeBundleGetElementByName(MlirType type,
+                                                     MlirStringRef name);
+
+/// Return the number of fields for this vector type.
+int32_t firrtlTypeVectorGetNumFields(MlirType type);
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -29,59 +29,60 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
 //===----------------------------------------------------------------------===//
 
 /// Return 'true' if this is any FIRRTL type.
-bool firrtlTypeIsFIRRTLType(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFIRRTLType(MlirType type);
 
 /// Return 'true' if this is a FIRRTL ground type.
-bool firrtlTypeIsGround(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsGround(MlirType type);
 
 /// Return 'true' if this is a FIRRTL const type.
-bool firrtlTypeIsConst(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsConst(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Clock type.
-bool firrtlTypeIsClock(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsClock(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Reset type.
-bool firrtlTypeIsReset(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsReset(MlirType type);
 
 /// Return 'true' if this is a FIRRTL AsyncReset type.
-bool firrtlTypeIsAsyncReset(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsAsyncReset(MlirType type);
 
 /// Return 'true' if this is a FIRRTL SInt type.
-bool firrtlTypeIsSInt(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsSInt(MlirType type);
 
 /// Return 'true' if this is a FIRRTL UInt type.
-bool firrtlTypeIsUInt(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsUInt(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Analog type.
-bool firrtlTypeIsAnalog(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsAnalog(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Bundle type.
-bool firrtlTypeIsBundle(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsBundle(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Vector type.
-bool firrtlTypeIsFVector(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFVector(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Reference type.
-bool firrtlTypeIsRef(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsRef(MlirType type);
 
 /// Return 'true' if this is a FIRRTL OpenBundle type.
-bool firrtlTypeIsOpenBundle(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsOpenBundle(MlirType type);
 
 /// Return 'true' if this is a FIRRTL OpenVector type.
-bool firrtlTypeIsOpenVector(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsOpenVector(MlirType type);
 
 /// Return 'true' if this is a FIRRTL Enum type.
-bool firrtlTypeIsFEnum(MlirType type);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFEnum(MlirType type);
 
 /// Return the bit-width of a type.
-int32_t firrtlTypeGetBitWidth(MlirType type, bool ignoreFlip);
+MLIR_CAPI_EXPORTED int32_t firrtlTypeGetBitWidth(MlirType type,
+                                                 bool ignoreFlip);
 
 /// Return 'true' if the destination type is at least as wide as the source.
-bool firrtlTypeIsLarger(MlirType dst, MlirType src);
+MLIR_CAPI_EXPORTED bool firrtlTypeIsLarger(MlirType dst, MlirType src);
 
 /// Return 'true' if two types are equivalent.
-bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
-                              bool srcOuterTypeIsConst);
+MLIR_CAPI_EXPORTED bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
+                                                 bool srcOuterTypeIsConst);
 
 //===----------------------------------------------------------------------===//
 // Aggregate Types
@@ -95,27 +96,31 @@ typedef struct {
 } FirrtlBundleField;
 
 /// Return the bundle field at the provided index.
-FirrtlBundleField firrtlTypeBundleGetFieldByIndex(MlirType type, int32_t index);
+MLIR_CAPI_EXPORTED FirrtlBundleField
+firrtlTypeBundleGetFieldByIndex(MlirType type, int32_t index);
 
 /// Return the bundle field with the provided name.
-FirrtlBundleField firrtlTypeBundleGetFieldByName(MlirType type,
-                                                 MlirStringRef name);
+MLIR_CAPI_EXPORTED FirrtlBundleField
+firrtlTypeBundleGetFieldByName(MlirType type, MlirStringRef name);
 
 /// Return the number of fields for the provided bundle type.
-int32_t firrtlTypeBundleGetNumFields(MlirType type);
+MLIR_CAPI_EXPORTED int32_t firrtlTypeBundleGetNumFields(MlirType type);
 
 /// Return the index of the bundle field with the provided name.
 /// Returns (-1) if the field does not exist.
-int32_t firrtlTypeBundleGetFieldIndex(MlirType type, MlirStringRef name);
+MLIR_CAPI_EXPORTED int32_t firrtlTypeBundleGetFieldIndex(MlirType type,
+                                                         MlirStringRef name);
 
 /// Returns 'true' if a bundle field exists with the provided name.
-bool firrtlTypeBundleHasFieldName(MlirType type, MlirStringRef name);
+MLIR_CAPI_EXPORTED bool firrtlTypeBundleHasFieldName(MlirType type,
+                                                     MlirStringRef name);
 
 /// Return the name of the bundle field at the provided index.
-MlirStringRef firrtlTypeBundleGetFieldName(MlirType type, int32_t index);
+MLIR_CAPI_EXPORTED MlirStringRef firrtlTypeBundleGetFieldName(MlirType type,
+                                                              int32_t index);
 
 /// Return the number of fields for the provided vector type.
-int32_t firrtlTypeVectorGetNumFields(MlirType type);
+MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumFields(MlirType type);
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -12,18 +12,11 @@
 #define CIRCT_C_DIALECT_FIRRTL_H
 
 #include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/// Wraps a FIRRTL BundleType element.
-struct FirrtlBundleElement {
-  MlirIdentifier name;
-  bool isFlip;
-  MlirType type;
-};
-typedef struct FirrtlBundleElement FirrtlBundleElement;
 
 //===----------------------------------------------------------------------===//
 // Dialect API.
@@ -36,7 +29,7 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
 //===----------------------------------------------------------------------===//
 
 /// Return 'true' if this is any FIRRTL type.
-bool firrtlTypeIs(MlirType type);
+bool firrtlTypeIsFIRRTLType(MlirType type);
 
 /// Return 'true' if this is a FIRRTL ground type.
 bool firrtlTypeIsGround(MlirType type);
@@ -71,9 +64,14 @@ bool firrtlTypeIsFVector(MlirType type);
 /// Return 'true' if this is a FIRRTL Reference type.
 bool firrtlTypeIsRef(MlirType type);
 
-// bool firrtlTypeIsOpenBundle(MlirType type);
-// bool firrtlTypeIsOpenVector(MlirType type);
-// bool firrtlTypeIsFEnum(MlirType type);
+/// Return 'true' if this is a FIRRTL OpenBundle type.
+bool firrtlTypeIsOpenBundle(MlirType type);
+
+/// Return 'true' if this is a FIRRTL OpenVector type.
+bool firrtlTypeIsOpenVector(MlirType type);
+
+/// Return 'true' if this is a FIRRTL Enum type.
+bool firrtlTypeIsFEnum(MlirType type);
 
 /// Return the bit-width of a type.
 int32_t firrtlTypeGetBitWidth(MlirType type, bool ignoreFlip);
@@ -85,24 +83,38 @@ bool firrtlTypeIsLarger(MlirType dst, MlirType src);
 bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
                               bool srcOuterTypeIsConst);
 
-/// Return the number of fields for the given bundle type.
+//===----------------------------------------------------------------------===//
+// Aggregate Types
+//===----------------------------------------------------------------------===//
+
+/// Wrapped version of BundleType::BundleElement
+typedef struct {
+  MlirIdentifier name;
+  bool isFlip;
+  MlirType type;
+} FirrtlBundleField;
+
+/// Return the bundle field at the provided index.
+FirrtlBundleField firrtlTypeBundleGetFieldByIndex(MlirType type, int32_t index);
+
+/// Return the bundle field with the provided name.
+FirrtlBundleField firrtlTypeBundleGetFieldByName(MlirType type,
+                                                 MlirStringRef name);
+
+/// Return the number of fields for the provided bundle type.
 int32_t firrtlTypeBundleGetNumFields(MlirType type);
 
-/// Return the index of a named bundle field.
-int32_t firrtlTypeBundleGetElementIndex(MlirType type, MlirStringRef name);
+/// Return the index of the bundle field with the provided name.
+/// Returns (-1) if the field does not exist.
+int32_t firrtlTypeBundleGetFieldIndex(MlirType type, MlirStringRef name);
 
-/// Return the name of the bundle field at the given index.
-MlirStringRef firrtlTypeBundleGetElementName(MlirType type, int32_t index);
+/// Returns 'true' if a bundle field exists with the provided name.
+bool firrtlTypeBundleHasFieldName(MlirType type, MlirStringRef name);
 
-/// Return the bundle field at the given index.
-FirrtlBundleElement firrtlTypeBundleGetElementByIndex(MlirType type,
-                                                      int32_t index);
+/// Return the name of the bundle field at the provided index.
+MlirStringRef firrtlTypeBundleGetFieldName(MlirType type, int32_t index);
 
-/// Return the bundle field with the given name.
-FirrtlBundleElement firrtlTypeBundleGetElementByName(MlirType type,
-                                                     MlirStringRef name);
-
-/// Return the number of fields for this vector type.
+/// Return the number of fields for the provided vector type.
 int32_t firrtlTypeVectorGetNumFields(MlirType type);
 
 #ifdef __cplusplus

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -4,9 +4,129 @@
 
 #include "circt-c/Dialect/FIRRTL.h"
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
 
+using namespace circt::firrtl;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl,
                                       circt::firrtl::FIRRTLDialect)
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+bool firrtlTypeIs(MlirType type) { return unwrap(type).isa<FIRRTLType>(); }
+
+bool firrtlTypeIsGround(MlirType type) {
+  return unwrap(type).cast<FIRRTLType>().isGround();
+}
+
+bool firrtlTypeIsConst(MlirType type) {
+  return unwrap(type).cast<FIRRTLType>().isConst();
+}
+
+bool firrtlTypeIsClock(MlirType type) { return unwrap(type).isa<ClockType>(); }
+
+bool firrtlTypeIsReset(MlirType type) { return unwrap(type).isa<ResetType>(); }
+
+bool firrtlTypeIsAsyncReset(MlirType type) {
+  return unwrap(type).isa<AsyncResetType>();
+}
+
+bool firrtlTypeIsSInt(MlirType type) { return unwrap(type).isa<SIntType>(); }
+
+bool firrtlTypeIsUInt(MlirType type) { return unwrap(type).isa<UIntType>(); }
+
+bool firrtlTypeIsAnalog(MlirType type) {
+  return unwrap(type).isa<AnalogType>();
+}
+
+bool firrtlTypeIsBundle(MlirType type) {
+  return unwrap(type).isa<BundleType>();
+}
+
+bool firrtlTypeIsFVector(MlirType type) {
+  return unwrap(type).isa<FVectorType>();
+}
+
+bool firrtlTypeIsOpenBundle(MlirType type) {
+  return unwrap(type).isa<OpenBundleType>();
+}
+
+bool firrtlTypeIsOpenVector(MlirType type) {
+  return unwrap(type).isa<OpenVectorType>();
+}
+
+bool firrtlTypeIsFEnum(MlirType type) { return unwrap(type).isa<FEnumType>(); }
+
+bool firrtlTypeIsRef(MlirType type) { return unwrap(type).isa<RefType>(); }
+
+bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
+                              bool srcOuterTypeIsConst) {
+  return circt::firrtl::areTypesEquivalent(unwrap(dest).cast<FIRRTLType>(),
+                                           unwrap(src).cast<FIRRTLType>(),
+                                           srcOuterTypeIsConst);
+}
+
+int32_t firrtlTypeGetBitWidth(MlirType type, bool ignoreFlip) {
+  return getBitWidth(unwrap(type).cast<FIRRTLBaseType>(), ignoreFlip)
+      .value_or(0);
+}
+
+bool firrtlTypeIsLarger(MlirType dst, MlirType src) {
+  return circt::firrtl::isTypeLarger(unwrap(dst).cast<FIRRTLBaseType>(),
+                                     unwrap(src).cast<FIRRTLBaseType>());
+}
+
+int32_t firrtlTypeBundleGetNumFields(MlirType type) {
+  return unwrap(type).cast<BundleType>().getNumElements();
+}
+
+int32_t firrtlTypeBundleGetElementIndex(MlirType type, MlirStringRef name) {
+  return unwrap(type)
+      .cast<BundleType>()
+      .getElementIndex(unwrap(name))
+      .value_or(-1);
+}
+
+MlirStringRef firrtlTypeBundleGetElementName(MlirType type, int32_t index) {
+  return wrap(unwrap(type).cast<BundleType>().getElementName(index));
+}
+
+FirrtlBundleElement firrtlTypeBundleGetElementByIndex(MlirType type,
+                                                      int32_t index) {
+  FirrtlBundleElement ret;
+  auto bundle = unwrap(type).cast<BundleType>();
+  auto field = bundle.getElement(index);
+  ret.name = wrap(field.name);
+  ret.type = wrap(field.type);
+  ret.isFlip = field.isFlip;
+  return ret;
+}
+
+FirrtlBundleElement firrtlTypeBundleGetElementByName(MlirType type,
+                                                     MlirStringRef name) {
+  FirrtlBundleElement ret;
+  auto bundle = unwrap(type).cast<BundleType>();
+  if (auto field = bundle.getElement(unwrap(name))) {
+    ret.name = wrap(field->name);
+    ret.type = wrap(field->type);
+    ret.isFlip = field->isFlip;
+  } else {
+    ret.name = {nullptr};
+    ret.type = {nullptr};
+  }
+  return ret;
+}
+
+int32_t firrtlTypeVectorGetNumFields(MlirType type) {
+  return unwrap(type).cast<FVectorType>().getNumElements();
+}

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -23,67 +23,80 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl,
 // Type API.
 //===----------------------------------------------------------------------===//
 
-bool firrtlTypeIsFIRRTLType(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFIRRTLType(MlirType type) {
   return unwrap(type).isa<FIRRTLType>();
 }
 
-bool firrtlTypeIsGround(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsGround(MlirType type) {
   return unwrap(type).cast<FIRRTLType>().isGround();
 }
 
-bool firrtlTypeIsConst(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsConst(MlirType type) {
   return unwrap(type).cast<FIRRTLType>().isConst();
 }
 
-bool firrtlTypeIsClock(MlirType type) { return unwrap(type).isa<ClockType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsClock(MlirType type) {
+  return unwrap(type).isa<ClockType>();
+}
 
-bool firrtlTypeIsReset(MlirType type) { return unwrap(type).isa<ResetType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsReset(MlirType type) {
+  return unwrap(type).isa<ResetType>();
+}
 
-bool firrtlTypeIsAsyncReset(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsAsyncReset(MlirType type) {
   return unwrap(type).isa<AsyncResetType>();
 }
 
-bool firrtlTypeIsSInt(MlirType type) { return unwrap(type).isa<SIntType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsSInt(MlirType type) {
+  return unwrap(type).isa<SIntType>();
+}
 
-bool firrtlTypeIsUInt(MlirType type) { return unwrap(type).isa<UIntType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsUInt(MlirType type) {
+  return unwrap(type).isa<UIntType>();
+}
 
-bool firrtlTypeIsAnalog(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsAnalog(MlirType type) {
   return unwrap(type).isa<AnalogType>();
 }
 
-bool firrtlTypeIsBundle(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsBundle(MlirType type) {
   return unwrap(type).isa<BundleType>();
 }
 
-bool firrtlTypeIsFVector(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFVector(MlirType type) {
   return unwrap(type).isa<FVectorType>();
 }
 
-bool firrtlTypeIsOpenBundle(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsOpenBundle(MlirType type) {
   return unwrap(type).isa<OpenBundleType>();
 }
 
-bool firrtlTypeIsOpenVector(MlirType type) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsOpenVector(MlirType type) {
   return unwrap(type).isa<OpenVectorType>();
 }
 
-bool firrtlTypeIsFEnum(MlirType type) { return unwrap(type).isa<FEnumType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsFEnum(MlirType type) {
+  return unwrap(type).isa<FEnumType>();
+}
 
-bool firrtlTypeIsRef(MlirType type) { return unwrap(type).isa<RefType>(); }
+MLIR_CAPI_EXPORTED bool firrtlTypeIsRef(MlirType type) {
+  return unwrap(type).isa<RefType>();
+}
 
-bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
-                              bool srcOuterTypeIsConst) {
+MLIR_CAPI_EXPORTED bool firrtlTypesAreEquivalent(MlirType dest, MlirType src,
+                                                 bool srcOuterTypeIsConst) {
   return circt::firrtl::areTypesEquivalent(unwrap(dest).cast<FIRRTLType>(),
                                            unwrap(src).cast<FIRRTLType>(),
                                            srcOuterTypeIsConst);
 }
 
-int32_t firrtlTypeGetBitWidth(MlirType type, bool ignoreFlip) {
+MLIR_CAPI_EXPORTED int32_t firrtlTypeGetBitWidth(MlirType type,
+                                                 bool ignoreFlip) {
   return getBitWidth(unwrap(type).cast<FIRRTLBaseType>(), ignoreFlip)
       .value_or(0);
 }
 
-bool firrtlTypeIsLarger(MlirType dst, MlirType src) {
+MLIR_CAPI_EXPORTED bool firrtlTypeIsLarger(MlirType dst, MlirType src) {
   return circt::firrtl::isTypeLarger(unwrap(dst).cast<FIRRTLBaseType>(),
                                      unwrap(src).cast<FIRRTLBaseType>());
 }
@@ -92,8 +105,8 @@ bool firrtlTypeIsLarger(MlirType dst, MlirType src) {
 // Aggregate Types
 //===----------------------------------------------------------------------===//
 
-FirrtlBundleField firrtlTypeBundleGetFieldByIndex(MlirType type,
-                                                  int32_t index) {
+MLIR_CAPI_EXPORTED FirrtlBundleField
+firrtlTypeBundleGetFieldByIndex(MlirType type, int32_t index) {
   FirrtlBundleField ret;
   auto bundle = unwrap(type).cast<BundleType>();
   auto field = bundle.getElement(index);
@@ -103,8 +116,8 @@ FirrtlBundleField firrtlTypeBundleGetFieldByIndex(MlirType type,
   return ret;
 }
 
-FirrtlBundleField firrtlTypeBundleGetFieldByName(MlirType type,
-                                                 MlirStringRef name) {
+MLIR_CAPI_EXPORTED FirrtlBundleField
+firrtlTypeBundleGetFieldByName(MlirType type, MlirStringRef name) {
   FirrtlBundleField ret;
   auto bundle = unwrap(type).cast<BundleType>();
   auto field = bundle.getElement(unwrap(name)).value();
@@ -114,27 +127,30 @@ FirrtlBundleField firrtlTypeBundleGetFieldByName(MlirType type,
   return ret;
 }
 
-int32_t firrtlTypeBundleGetNumFields(MlirType type) {
+MLIR_CAPI_EXPORTED int32_t firrtlTypeBundleGetNumFields(MlirType type) {
   return unwrap(type).cast<BundleType>().getNumElements();
 }
 
-int32_t firrtlTypeBundleGetFieldIndex(MlirType type, MlirStringRef name) {
+MLIR_CAPI_EXPORTED int32_t firrtlTypeBundleGetFieldIndex(MlirType type,
+                                                         MlirStringRef name) {
   return unwrap(type)
       .cast<BundleType>()
       .getElementIndex(unwrap(name))
       .value_or(-1);
 }
 
-bool firrtlTypeBundleHasFieldName(MlirType type, MlirStringRef name) {
+MLIR_CAPI_EXPORTED bool firrtlTypeBundleHasFieldName(MlirType type,
+                                                     MlirStringRef name) {
   auto bundle = unwrap(type).cast<BundleType>();
   auto field = bundle.getElement(unwrap(name));
   return field ? true : false;
 }
 
-MlirStringRef firrtlTypeBundleGetFieldName(MlirType type, int32_t index) {
+MLIR_CAPI_EXPORTED MlirStringRef firrtlTypeBundleGetFieldName(MlirType type,
+                                                              int32_t index) {
   return wrap(unwrap(type).cast<BundleType>().getElementName(index));
 }
 
-int32_t firrtlTypeVectorGetNumFields(MlirType type) {
+MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumFields(MlirType type) {
   return unwrap(type).cast<FVectorType>().getNumElements();
 }

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -151,6 +151,11 @@ MLIR_CAPI_EXPORTED MlirStringRef firrtlTypeBundleGetFieldName(MlirType type,
   return wrap(unwrap(type).cast<BundleType>().getElementName(index));
 }
 
-MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumFields(MlirType type) {
+MLIR_CAPI_EXPORTED int32_t firrtlTypeVectorGetNumElements(MlirType type) {
   return unwrap(type).cast<FVectorType>().getNumElements();
+}
+
+MLIR_CAPI_EXPORTED MlirType firrtlTypeVectorGetElementType(MlirType type) {
+  auto vector = unwrap(type).cast<FVectorType>();
+  return wrap(vector.getElementType());
 }

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -11,5 +11,6 @@ target_link_libraries(circt-capi-ir-test
   CIRCTCAPISeq
   CIRCTCAPISV
   CIRCTCAPIFSM
+  CIRCTCAPIFIRRTL
   CIRCTCAPIExportVerilog
 )

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -150,20 +150,29 @@ bool testFIRRTLBundle(MlirContext ctx) {
   bool isBundle = firrtlTypeIsBundle(ty);
   int numFields = firrtlTypeBundleGetNumFields(ty);
 
-  FirrtlBundleElement foo = firrtlTypeBundleGetElementByName(
-      ty, mlirStringRefCreateFromCString("foo"));
-  FirrtlBundleElement bar = firrtlTypeBundleGetElementByName(
-      ty, mlirStringRefCreateFromCString("bar"));
+  bool fieldFooExists =
+      firrtlTypeBundleHasFieldName(ty, mlirStringRefCreateFromCString("foo"));
+  bool fieldBarExists =
+      firrtlTypeBundleHasFieldName(ty, mlirStringRefCreateFromCString("bar"));
+  bool fieldBazExists =
+      firrtlTypeBundleHasFieldName(ty, mlirStringRefCreateFromCString("baz"));
+  bool namesOk = (fieldFooExists && fieldBarExists && !fieldBazExists);
 
-  bool fooIsUInt = firrtlTypeIsUInt(foo.type);
-  int fooWidth = firrtlTypeGetBitWidth(foo.type, false);
-  bool barIsSInt = firrtlTypeIsSInt(bar.type);
-  int barWidth = firrtlTypeGetBitWidth(bar.type, false);
+  FirrtlBundleField fieldFoo = firrtlTypeBundleGetFieldByIndex(ty, 0);
+  FirrtlBundleField fieldBar =
+      firrtlTypeBundleGetFieldByName(ty, mlirStringRefCreateFromCString("bar"));
+
+  bool fooIsUInt = firrtlTypeIsUInt(fieldFoo.type);
+  int fooWidth = firrtlTypeGetBitWidth(fieldFoo.type, false);
+  bool fooOk = (fooIsUInt && (fooWidth == 32) && (!fieldFoo.isFlip));
+
+  bool barIsSInt = firrtlTypeIsSInt(fieldBar.type);
+  int barWidth = firrtlTypeGetBitWidth(fieldBar.type, false);
+  bool barOk = (barIsSInt && (barWidth == 32) && fieldBar.isFlip);
 
   mlirOperationDestroy(op);
 
-  return (fooIsUInt && (fooWidth == 32) && barIsSInt && (barWidth == 32) &&
-          bar.isFlip && isBundle && (numFields == 2));
+  return (isBundle && (numFields == 2) && namesOk && fooOk && barOk);
 }
 
 int testFIRRTLTypes() {

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -175,6 +175,22 @@ bool testFIRRTLBundle(MlirContext ctx) {
   return (isBundle && (numFields == 2) && namesOk && fooOk && barOk);
 }
 
+bool testFIRRTLVector(MlirContext ctx) {
+  MlirOperation op =
+      parseFirrtlOp(ctx, "%res = firrtl.wire : !firrtl.vector<uint<32>, 16>");
+  MlirValue val = mlirOperationGetResult(op, 0);
+  MlirType ty = mlirValueGetType(val);
+  bool isVector = firrtlTypeIsFVector(ty);
+  int numElements = firrtlTypeVectorGetNumElements(ty);
+  MlirType elementType = firrtlTypeVectorGetElementType(ty);
+  bool elementIsUInt = firrtlTypeIsUInt(elementType);
+  int elementWidth = firrtlTypeGetBitWidth(elementType, false);
+  mlirOperationDestroy(op);
+
+  return (isVector && (numElements == 16) && elementIsUInt &&
+          (elementWidth == 32));
+}
+
 int testFIRRTLTypes() {
   MlirContext ctx = mlirContextCreate();
   MlirDialectHandle firrtlHandle = mlirGetDialectHandle__firrtl__();
@@ -185,6 +201,8 @@ int testFIRRTLTypes() {
     return 1;
   if (!testFIRRTLBundle(ctx))
     return 2;
+  if (!testFIRRTLVector(ctx))
+    return 3;
 
   mlirContextDestroy(ctx);
 


### PR DESCRIPTION
This adds CAPI functions for discriminating between FIRRTL types (similar to ones for the HW dialect).
I imagine there are other opportunities for adding things to the CAPI, but I haven't run across them quite yet.