### PR TITLE
[OM] Add initial implementation of Evaluator.

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -1,0 +1,106 @@
+//===- Evaluator.h - Object Model dialect evaluator -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the Object Model dialect declaration.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_OM_EVALUATOR_EVALUATOR_H
+#define CIRCT_DIALECT_OM_EVALUATOR_EVALUATOR_H
+
+#include "circt/Dialect/OM/OMOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace circt {
+namespace om {
+
+/// A value of an object in memory. It is either a composite Object, or a
+/// primitive Attribute. Further refinement is expected.
+using ObjectValue = std::variant<std::shared_ptr<struct Object>, Attribute>;
+
+/// The fields of a composite Object, currently represented as a map. Further
+/// refinement is expected.
+using ObjectFields = SmallDenseMap<StringAttr, ObjectValue>;
+
+/// An Evaluator, which is constructed with an IR module and can instantiate
+/// Objects. Further refinement is expected.
+struct Evaluator {
+  /// Construct an Evaluator with an IR module.
+  Evaluator(ModuleOp mod);
+
+  /// Instantiate an Object with its class name and actual parameters.
+  FailureOr<std::shared_ptr<Object>>
+  instantiate(StringAttr className, ArrayRef<ObjectValue> actualParams);
+
+private:
+  /// Evaluate a Value in a Class body according to the small expression grammar
+  /// described in the rationale document. The actual parameters are the values
+  /// supplied at the current instantiation of the Class being evaluated.
+  FailureOr<ObjectValue> evaluateValue(Value value,
+                                       ArrayRef<ObjectValue> actualParams);
+
+  /// Evaluator dispatch functions for the small expression grammar.
+  FailureOr<ObjectValue> evaluateParameter(BlockArgument formalParam,
+                                           ArrayRef<ObjectValue> actualParams);
+  FailureOr<ObjectValue> evaluateConstant(ConstantOp op,
+                                          ArrayRef<ObjectValue> actualParams);
+  FailureOr<ObjectValue>
+  evaluateObjectInstance(ObjectOp op, ArrayRef<ObjectValue> actualParams);
+  FailureOr<ObjectValue>
+  evaluateObjectField(ObjectFieldOp op, ArrayRef<ObjectValue> actualParams);
+
+  /// The symbol table for the IR module the Evaluator was constructed with.
+  /// Used to look up class definitions.
+  SymbolTable symbolTable;
+
+  /// Object storage. Currently used for memoizing calls to evaluateValue.
+  /// Further refinement is expected.
+  mlir::DenseMap<Value, std::shared_ptr<Object>> objects;
+};
+
+/// A composite Object, which has a type and fields.
+struct Object {
+  /// Get the type of the Object.
+  mlir::Type getType();
+
+  /// Get a field of the Object by name.
+  FailureOr<ObjectValue> getField(StringAttr name);
+
+private:
+  /// Allow the instantiate method as a friend to construct Objects.
+  friend FailureOr<std::shared_ptr<Object>>
+      Evaluator::instantiate(StringAttr, ArrayRef<ObjectValue>);
+
+  /// Construct an Object of the given Class with the given fields.
+  Object(ClassOp cls, ObjectFields &fields);
+
+  /// The Class of the Object.
+  ClassOp cls;
+
+  /// The fields of the Object.
+  ObjectFields fields;
+};
+
+/// Helper to enable printing objects in Diagnostics.
+static inline mlir::Diagnostic &operator<<(mlir::Diagnostic &diag,
+                                           const ObjectValue &objectValue) {
+  if (auto *object = std::get_if<std::shared_ptr<Object>>(&objectValue))
+    diag << *object;
+  if (auto *attribute = std::get_if<Attribute>(&objectValue))
+    diag << *attribute;
+  return diag;
+}
+
+} // namespace om
+} // namespace circt
+
+#endif // CIRCT_DIALECT_OM_EVALUATOR_EVALUATOR_H

--- a/lib/Dialect/OM/CMakeLists.txt
+++ b/lib/Dialect/OM/CMakeLists.txt
@@ -27,3 +27,5 @@ add_circt_dialect_library(
 )
 
 add_dependencies(circt-headers MLIROMIncGen)
+
+add_subdirectory(Evaluator)

--- a/lib/Dialect/OM/Evaluator/CMakeLists.txt
+++ b/lib/Dialect/OM/Evaluator/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_circt_library(CIRCTOMEvaluator
+  Evaluator.cpp
+
+  LINK_LIBS
+  CIRCTOM
+  MLIRIR
+)

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace circt::om;
 
 /// Construct an Evaluator with an IR module.
-circt::om::Evaluator::Evaluator(ModuleOp mod) : symbolTable(SymbolTable(mod)) {}
+circt::om::Evaluator::Evaluator(ModuleOp mod) : symbolTable(mod) {}
 
 /// Instantiate an Object with its class name and actual parameters.
 FailureOr<std::shared_ptr<Object>>
@@ -52,7 +52,11 @@ circt::om::Evaluator::instantiate(StringAttr className,
     if (auto *object = std::get_if<std::shared_ptr<Object>>(&actualParam))
       actualParamType = object->get()->getType();
 
-    if (!actualParamType || actualParamType != formalParamType) {
+    if (!actualParamType)
+      return cls.emitError("actual parameter for ")
+             << formalParamName << " is null";
+
+    if (actualParamType != formalParamType) {
       auto error = cls.emitError("actual parameter for ")
                    << formalParamName << " has invalid type";
       error.attachNote() << "actual parameter: " << actualParam;

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -1,0 +1,196 @@
+//===- Evaluator.cpp - Object Model dialect evaluator ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the Object Model dialect Evaluator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/SymbolTable.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt::om;
+
+/// Construct an Evaluator with an IR module.
+circt::om::Evaluator::Evaluator(ModuleOp mod) : symbolTable(SymbolTable(mod)) {}
+
+/// Instantiate an Object with its class name and actual parameters.
+FailureOr<std::shared_ptr<Object>>
+circt::om::Evaluator::instantiate(StringAttr className,
+                                  ArrayRef<ObjectValue> actualParams) {
+  ClassOp cls = symbolTable.lookup<ClassOp>(className);
+  if (!cls)
+    return symbolTable.getOp()->emitError("unknown class name ") << className;
+
+  auto formalParamNames = cls.getFormalParamNames().getAsRange<StringAttr>();
+  auto formalParamTypes = cls.getBodyBlock()->getArgumentTypes();
+
+  // Verify the actual parameters are the right size and types for this class.
+  if (actualParams.size() != formalParamTypes.size()) {
+    auto error = cls.emitError("actual parameter list length (")
+                 << actualParams.size() << ") does not match formal "
+                 << "parameter list length (" << formalParamTypes.size() << ")";
+    error.attachNote() << "actual parameters: " << actualParams;
+    error.attachNote(cls.getLoc()) << "formal parameters: " << formalParamTypes;
+    return error;
+  }
+
+  // Verify the actual parameter types match.
+  for (auto [actualParam, formalParamName, formalParamType] :
+       llvm::zip(actualParams, formalParamNames, formalParamTypes)) {
+    Type actualParamType;
+    if (auto *attr = std::get_if<Attribute>(&actualParam))
+      if (auto typedActualParam = attr->dyn_cast_or_null<TypedAttr>())
+        actualParamType = typedActualParam.getType();
+    if (auto *object = std::get_if<std::shared_ptr<Object>>(&actualParam))
+      actualParamType = object->get()->getType();
+
+    if (!actualParamType || actualParamType != formalParamType) {
+      auto error = cls.emitError("actual parameter for ")
+                   << formalParamName << " has invalid type";
+      error.attachNote() << "actual parameter: " << actualParam;
+      error.attachNote() << "format parameter type: " << formalParamType;
+      return error;
+    }
+  }
+
+  // Instantiate the fields.
+  ObjectFields fields;
+  for (auto field : cls.getOps<ClassFieldOp>()) {
+    StringAttr name = field.getSymNameAttr();
+    Value value = field.getValue();
+
+    FailureOr<ObjectValue> result = evaluateValue(value, actualParams);
+    if (failed(result))
+      return failure();
+
+    fields[name] = result.value();
+  }
+
+  // Allocate the Object. Further refinement is expected.
+  auto *object = new Object(cls, fields);
+
+  return success(std::shared_ptr<Object>(object));
+}
+
+/// Evaluate a Value in a Class body according to the semantics of the IR. The
+/// actual parameters are the values supplied at the current instantiation of
+/// the Class being evaluated.
+FailureOr<ObjectValue>
+circt::om::Evaluator::evaluateValue(Value value,
+                                    ArrayRef<ObjectValue> actualParams) {
+  return TypeSwitch<Value, FailureOr<ObjectValue>>(value)
+      .Case([&](BlockArgument arg) {
+        return evaluateParameter(arg, actualParams);
+      })
+      .Case([&](OpResult result) {
+        return TypeSwitch<Operation *, FailureOr<ObjectValue>>(
+                   result.getDefiningOp())
+            .Case([&](ConstantOp op) {
+              return evaluateConstant(op, actualParams);
+            })
+            .Case([&](ObjectOp op) {
+              return evaluateObjectInstance(op, actualParams);
+            })
+            .Case([&](ObjectFieldOp op) {
+              return evaluateObjectField(op, actualParams);
+            })
+            .Default([&](Operation *op) {
+              auto error = op->emitError("unable to evaluate value");
+              error.attachNote() << "value: " << value;
+              return error;
+            });
+      });
+}
+
+/// Evaluator dispatch function for parameters.
+FailureOr<ObjectValue>
+circt::om::Evaluator::evaluateParameter(BlockArgument formalParam,
+                                        ArrayRef<ObjectValue> actualParams) {
+  return success(actualParams[formalParam.getArgNumber()]);
+}
+
+/// Evaluator dispatch function for constants.
+FailureOr<ObjectValue>
+circt::om::Evaluator::evaluateConstant(ConstantOp op,
+                                       ArrayRef<ObjectValue> actualParams) {
+  return success(op.getValue());
+}
+
+/// Evaluator dispatch function for Object instances.
+FailureOr<ObjectValue> circt::om::Evaluator::evaluateObjectInstance(
+    ObjectOp op, ArrayRef<ObjectValue> actualParams) {
+  // First, check if we have already evaluated this object, and return it if so.
+  auto existingInstance = objects.find(op);
+  if (existingInstance != objects.end())
+    return success(existingInstance->second);
+
+  // If we need to instantiate a new object, evaluate values for all of its
+  // actual parameters. Note that this is eager evaluation, which precludes
+  // creating cycles in the object model. Further refinement is expected.
+  SmallVector<ObjectValue> objectParams;
+  for (auto param : op.getActualParams()) {
+    FailureOr<ObjectValue> result = evaluateValue(param, actualParams);
+    if (failed(result))
+      return result;
+    objectParams.push_back(result.value());
+  }
+
+  // Instantiate and return the new Object, saving the instance for later.
+  auto newInstance = instantiate(op.getClassNameAttr(), objectParams);
+  if (succeeded(newInstance))
+    objects[op.getResult()] = newInstance.value();
+  return newInstance;
+}
+
+/// Evaluator dispatch function for Object fields.
+FailureOr<ObjectValue>
+circt::om::Evaluator::evaluateObjectField(ObjectFieldOp op,
+                                          ArrayRef<ObjectValue> actualParams) {
+  // Evaluate the Object itself, in case it hasn't been evaluated yet.
+  FailureOr<ObjectValue> currentObjectResult =
+      evaluateValue(op.getObject(), actualParams);
+  if (failed(currentObjectResult))
+    return currentObjectResult;
+
+  std::shared_ptr<Object> currentObject =
+      std::get<std::shared_ptr<Object>>(currentObjectResult.value());
+
+  // Iteratively access nested fields through the path until we reach the final
+  // field in the path.
+  ObjectValue finalField;
+  for (auto field : op.getFieldPath().getAsRange<FlatSymbolRefAttr>()) {
+    auto currentField = currentObject->getField(field.getAttr());
+    finalField = currentField.value();
+    if (auto *nextObject = std::get_if<std::shared_ptr<Object>>(&finalField))
+      currentObject = *nextObject;
+  }
+
+  // Return the field being accessed.
+  return finalField;
+}
+
+/// Construct an Object of the given type with the given fields.
+circt::om::Object::Object(ClassOp cls, ObjectFields &fields)
+    : cls(cls), fields(fields) {}
+
+/// Get the type of the Object.
+Type circt::om::Object::getType() {
+  return ClassType::get(cls.getContext(),
+                        FlatSymbolRefAttr::get(cls.getNameAttr()));
+}
+
+/// Get a field of the Object by name.
+FailureOr<ObjectValue> circt::om::Object::getField(StringAttr name) {
+  auto field = fields.find(name);
+  if (field == fields.end())
+    return cls.emitError("field ") << name << " does not exist";
+  return success(fields[name]);
+}

--- a/unittests/Dialect/CMakeLists.txt
+++ b/unittests/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Moore)
 add_subdirectory(FIRRTL)
 add_subdirectory(HW)
+add_subdirectory(OM)

--- a/unittests/Dialect/OM/CMakeLists.txt
+++ b/unittests/Dialect/OM/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Evaluator)

--- a/unittests/Dialect/OM/Evaluator/CMakeLists.txt
+++ b/unittests/Dialect/OM/Evaluator/CMakeLists.txt
@@ -5,4 +5,6 @@ add_circt_unittest(CIRCTOMEvaluatorTests
 target_link_libraries(CIRCTOMEvaluatorTests
   PRIVATE
   CIRCTOMEvaluator
+  CIRCTOM
+  MLIRIR
 )

--- a/unittests/Dialect/OM/Evaluator/CMakeLists.txt
+++ b/unittests/Dialect/OM/Evaluator/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_circt_unittest(CIRCTOMEvaluatorTests
+  EvaluatorTests.cpp
+)
+
+target_link_libraries(CIRCTOMEvaluatorTests
+  PRIVATE
+  CIRCTOMEvaluator
+)

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -1,0 +1,377 @@
+//===- EvaluatorTest.cpp - Object Model evaluator tests -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Location.h"
+#include "llvm/Support/Debug.h"
+#include "gtest/gtest.h"
+#include <mlir/IR/BuiltinAttributes.h>
+
+using namespace mlir;
+using namespace circt::om;
+
+namespace {
+
+/// Failure scenarios.
+
+TEST(EvaluatorTests, InstantiateInvalidClassName) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  Evaluator evaluator(mod);
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(diag.str(), "unknown class name \"MyClass\"");
+  });
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_FALSE(succeeded(result));
+}
+
+TEST(EvaluatorTests, InstantiateInvalidParamSize) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
+                                           cls.getLoc());
+
+  Evaluator evaluator(mod);
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(
+        diag.str(),
+        "actual parameter list length (0) does not match formal parameter "
+        "list length (1)");
+  });
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_FALSE(succeeded(result));
+}
+
+TEST(EvaluatorTests, InstantiateInvalidParamType) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
+                                           cls.getLoc());
+
+  Evaluator evaluator(mod);
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(diag.str(), "actual parameter for \"param\" has invalid type");
+  });
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"),
+                                      {builder.getF32FloatAttr(42)});
+
+  ASSERT_FALSE(succeeded(result));
+}
+
+TEST(EvaluatorTests, GetFieldInvalidName) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass", builder.getArrayAttr({}));
+  cls.getBody().emplaceBlock();
+
+  Evaluator evaluator(mod);
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(diag.str(), "field \"foo\" does not exist");
+  });
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue = result.value()->getField(builder.getStringAttr("foo"));
+
+  ASSERT_FALSE(succeeded(fieldValue));
+}
+
+/// Success scenarios.
+
+TEST(EvaluatorTests, InstantiateObjectWithParamField) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(builder.getIntegerType(32), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  builder.create<ClassFieldOp>("field", body.getArgument(0));
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"),
+                                      {builder.getI32IntegerAttr(42)});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue =
+      std::get<Attribute>(
+          result.value()->getField(builder.getStringAttr("field")).value())
+          .dyn_cast<IntegerAttr>();
+  ASSERT_TRUE(fieldValue);
+  ASSERT_EQ(fieldValue.getValue(), 42);
+}
+
+TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass", builder.getArrayAttr({}));
+  auto &body = cls.getBody().emplaceBlock();
+  builder.setInsertionPointToStart(&body);
+  auto constant = builder.create<ConstantOp>(builder.getIntegerType(32),
+                                             builder.getI32IntegerAttr(42));
+  builder.create<ClassFieldOp>("field", constant);
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue =
+      std::get<Attribute>(
+          result.value()->getField(builder.getStringAttr("field")).value())
+          .dyn_cast<IntegerAttr>();
+  ASSERT_TRUE(fieldValue);
+  ASSERT_EQ(fieldValue.getValue(), 42);
+}
+
+TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
+  auto &innerBody = innerCls.getBody().emplaceBlock();
+  innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());
+  builder.setInsertionPointToStart(&innerBody);
+  builder.create<ClassFieldOp>("field", innerBody.getArgument(0));
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(builder.getIntegerType(32), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  auto innerClsType = ClassType::get(
+      builder.getContext(),
+      FlatSymbolRefAttr::get(builder.getStringAttr("MyInnerClass")));
+  auto innerClsName = builder.getStringAttr("MyInnerClass");
+  auto object =
+      builder.create<ObjectOp>(innerClsType, innerClsName, body.getArguments());
+  builder.create<ClassFieldOp>("field", object);
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"),
+                                      {builder.getI32IntegerAttr(42)});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue = std::get<std::shared_ptr<Object>>(
+      result.value()->getField(builder.getStringAttr("field")).value());
+
+  ASSERT_TRUE(fieldValue);
+
+  auto innerFieldValue =
+      std::get<Attribute>(
+          fieldValue->getField(builder.getStringAttr("field")).value())
+          .cast<IntegerAttr>();
+
+  ASSERT_EQ(innerFieldValue.getValue(), 42);
+}
+
+TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
+  auto &innerBody = innerCls.getBody().emplaceBlock();
+  innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());
+  builder.setInsertionPointToStart(&innerBody);
+  builder.create<ClassFieldOp>("field", innerBody.getArgument(0));
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(builder.getIntegerType(32), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  auto innerClsType = ClassType::get(
+      builder.getContext(),
+      FlatSymbolRefAttr::get(builder.getStringAttr("MyInnerClass")));
+  auto innerClsName = builder.getStringAttr("MyInnerClass");
+  auto object =
+      builder.create<ObjectOp>(innerClsType, innerClsName, body.getArguments());
+  auto field =
+      builder.create<ObjectFieldOp>(builder.getI32Type(), object,
+                                    builder.getArrayAttr(FlatSymbolRefAttr::get(
+                                        builder.getStringAttr("field"))));
+  builder.create<ClassFieldOp>("field", field);
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"),
+                                      {builder.getI32IntegerAttr(42)});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue =
+      std::get<Attribute>(
+          result.value()->getField(builder.getStringAttr("field")).value())
+          .cast<IntegerAttr>();
+
+  ASSERT_TRUE(fieldValue);
+  ASSERT_EQ(fieldValue.getValue(), 42);
+}
+
+TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto innerCls =
+      builder.create<ClassOp>("MyInnerClass", builder.getArrayAttr({}));
+  innerCls.getBody().emplaceBlock();
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass", builder.getArrayAttr({}));
+  auto &body = cls.getBody().emplaceBlock();
+  builder.setInsertionPointToStart(&body);
+  auto innerClsType = ClassType::get(
+      builder.getContext(),
+      FlatSymbolRefAttr::get(builder.getStringAttr("MyInnerClass")));
+  auto innerClsName = builder.getStringAttr("MyInnerClass");
+  auto object =
+      builder.create<ObjectOp>(innerClsType, innerClsName, body.getArguments());
+  builder.create<ClassFieldOp>("field1", object);
+  builder.create<ClassFieldOp>("field2", object);
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto field1Value = std::get<std::shared_ptr<Object>>(
+      result.value()->getField(builder.getStringAttr("field1")).value());
+
+  auto field2Value = std::get<std::shared_ptr<Object>>(
+      result.value()->getField(builder.getStringAttr("field2")).value());
+
+  ASSERT_TRUE(field1Value);
+  ASSERT_TRUE(field2Value);
+
+  ASSERT_EQ(field1Value, field2Value);
+}
+
+} // namespace

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -62,7 +62,7 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
   auto mod = builder.create<ModuleOp>(loc);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
   auto cls = builder.create<ClassOp>("MyClass", params);
   cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
                                            cls.getLoc());
@@ -81,6 +81,37 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
   ASSERT_FALSE(succeeded(result));
 }
 
+TEST(EvaluatorTests, InstantiateNullParam) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
+                                           cls.getLoc());
+
+  Evaluator evaluator(mod);
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(diag.str(), "actual parameter for \"param\" is null");
+  });
+
+  auto result =
+      evaluator.instantiate(builder.getStringAttr("MyClass"), {IntegerAttr()});
+
+  ASSERT_FALSE(succeeded(result));
+}
+
 TEST(EvaluatorTests, InstantiateInvalidParamType) {
   DialectRegistry registry;
   registry.insert<OMDialect>();
@@ -95,7 +126,7 @@ TEST(EvaluatorTests, InstantiateInvalidParamType) {
   auto mod = builder.create<ModuleOp>(loc);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
   auto cls = builder.create<ClassOp>("MyClass", params);
   cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
                                            cls.getLoc());
@@ -160,7 +191,7 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
   auto mod = builder.create<ModuleOp>(loc);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
   auto cls = builder.create<ClassOp>("MyClass", params);
   auto &body = cls.getBody().emplaceBlock();
   body.addArgument(builder.getIntegerType(32), cls.getLoc());
@@ -231,7 +262,7 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
   auto mod = builder.create<ModuleOp>(loc);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
   auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
   auto &innerBody = innerCls.getBody().emplaceBlock();
   innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());
@@ -285,7 +316,7 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
   auto mod = builder.create<ModuleOp>(loc);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  ArrayAttr params = builder.getArrayAttr({builder.getStringAttr("param")});
+  ArrayAttr params = builder.getStrArrayAttr({"param"});
   auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
   auto &innerBody = innerCls.getBody().emplaceBlock();
   innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());


### PR DESCRIPTION
The Evaluator is responsible for evaluating the object model according to the semantics defined by the rationale. It can be constructed from an IR module, and Objects can be instantiated by supplying a Class name and actual parameters.

Under the hood, it implements the small expression grammar outlined in the rationale document. The entire grammar defined so far is implemented in this initial version. Instantiations are currently evaluated eagerly, which precludes cycles.

Objects are defined using a variant that is either a pointer to a simple Object struct, or an typed Attribute for primitives. The fields of an Object struct are stored in a simple map.

This is sufficient for an initial implementation, but lots of opportunities exist to improve the evaluator, Object representation, and storage.

Unit tests have been added that exercise all failure and success modes.