### PR TITLE
[Arc] MemoryReadPortOp: remove enable and clock operand, make it pure

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -275,9 +275,7 @@ def ClockGateOp : ArcOp<"clock_gate", [Pure]> {
 def MemoryOp : ArcOp<"memory", [MemoryEffects<[MemAlloc]>]> {
   let summary = "Memory";
   let results = (outs MemoryType:$memory);
-  let assemblyFormat = [{
-    type($memory) attr-dict
-  }];
+  let assemblyFormat = "type($memory) attr-dict";
 }
 
 class MemoryAndDataTypesMatch<string mem, string data> : TypesMatchWith<
@@ -285,27 +283,26 @@ class MemoryAndDataTypesMatch<string mem, string data> : TypesMatchWith<
   "$_self.cast<MemoryType>().getWordType()">;
 
 def MemoryReadPortOp : ArcOp<"memory_read_port", [
-  MemoryEffects<[MemRead]>,
-  MemoryAndDataTypesMatch<"memory", "data">,
-  AttrSizedOperandSegments,
-  ClockedOpInterface
+  Pure, MemoryAndDataTypesMatch<"memory", "data">
 ]> {
   let summary = "Read port from a memory";
+  let description = [{
+    Represents a combinatorial memory read port. No memory read side-effect
+    trait is necessary because at the stage of the Arc lowering where this
+    operation is legal to be present, it is guaranteed that all reads from the
+    same address produce the same output. This is because all writes are
+    reordered to happen at the end of the cycle in LegalizeStateUpdates (or
+    alternatively produce the necessary temporaries).
+  }];
   let arguments = (ins
     MemoryType:$memory,
-    AnyInteger:$address,
-    Optional<I1>:$clock,
-    Optional<I1>:$enable
+    AnyInteger:$address
   );
   let results = (outs AnyInteger:$data);
 
   let assemblyFormat = [{
-    $memory `[` $address `]` (`if` $enable^)? (`clock` $clock^)?
-    attr-dict `:` type($memory) `,` type($address)
+    $memory `[` $address `]` attr-dict `:` type($memory) `,` type($address)
   }];
-
-  let hasVerifier = 1;
-  let hasFolder = 1;
 }
 
 def MemoryWritePortOp : ArcOp<"memory_write_port", [

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -131,7 +131,10 @@ def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
 def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
   let summary = "Split state into read and write ops grouped by clock tree";
   let constructor = "circt::arc::createLowerStatePass()";
-  let dependentDialects = ["arc::ArcDialect", "mlir::scf::SCFDialect"];
+  let dependentDialects = [
+    "arc::ArcDialect", "mlir::scf::SCFDialect", "mlir::func::FuncDialect",
+    "mlir::LLVM::LLVMDialect"
+  ];
 }
 
 def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -27,9 +27,12 @@ def StateType : ArcTypeDef<"State"> {
 
 def MemoryType : ArcTypeDef<"Memory"> {
   let mnemonic = "memory";
-  let parameters = (ins "unsigned":$numWords, "::mlir::IntegerType":$wordType,
-    OptionalParameter<"unsigned">:$stride);
-  let assemblyFormat = "`<` $numWords `x` $wordType (`,` $stride^)? `>`";
+  let parameters = (ins "unsigned":$numWords, "::mlir::IntegerType":$wordType);
+  let assemblyFormat = "`<` $numWords `x` $wordType `>`";
+
+  let extraClassDeclaration = [{
+    unsigned getStride();
+  }];
 }
 
 def StorageType : ArcTypeDef<"Storage"> {

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -193,20 +193,6 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// MemoryReadPortOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult MemoryReadPortOp::verify() {
-  if (!getOperation()->getParentOfType<ClockDomainOp>() && !getClock())
-    return emitOpError("outside a clock domain requires a clock");
-
-  if (getOperation()->getParentOfType<ClockDomainOp>() && getClock())
-    return emitOpError("inside a clock domain cannot have a clock");
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // MemoryWritePortOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -19,6 +19,11 @@ using namespace mlir;
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.cpp.inc"
 
+unsigned MemoryType::getStride() {
+  unsigned stride = (getWordType().getWidth() + 7) / 8;
+  return llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 8U)));
+}
+
 void ArcDialect::registerTypes() {
   addTypes<
 #define GET_TYPEDEF_LIST

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -88,17 +88,11 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
 
     if (auto memOp = dyn_cast<AllocMemoryOp>(op)) {
       auto memType = memOp.getType();
-      auto intType = memType.getWordType();
-      unsigned stride = (intType.getWidth() + 7) / 8;
-      stride =
-          llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 8U)));
+      unsigned stride = memType.getStride();
       unsigned numBytes = memType.getNumWords() * stride;
       auto offset = builder.getI32IntegerAttr(allocBytes(numBytes));
       op->setAttr("offset", offset);
       op->setAttr("stride", builder.getI32IntegerAttr(stride));
-      memOp.getResult().setType(MemoryType::get(memOp.getContext(),
-                                                memType.getNumWords(),
-                                                memType.getWordType(), stride));
       gettersToCreate.emplace_back(memOp, memOp.getStorage(), offset);
       continue;
     }

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   CIRCTSeq
   CIRCTSupport
   MLIRFuncDialect
+  MLIRLLVMDialect
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/lib/Dialect/Arc/Transforms/PassDetails.h
+++ b/lib/Dialect/Arc/Transforms/PassDetails.h
@@ -20,6 +20,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
 

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -94,6 +94,8 @@ void StripSVPass::runOnOperation() {
     opsToDelete.push_back(verb);
   for (auto verb : mlirModule.getOps<sv::IfDefOp>())
     opsToDelete.push_back(verb);
+  for (auto verb : mlirModule.getOps<sv::MacroDeclOp>())
+    opsToDelete.push_back(verb);
 
   for (auto module : mlirModule.getOps<hw::HWModuleOp>()) {
     for (Operation &op : *module.getBodyBlock()) {

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
 
-// CHECK-LABEL: llvm.func @EmptyArc() {
+// CHECK-LABEL: llvm.func internal @EmptyArc() {
 arc.define @EmptyArc() {
   arc.output
   // CHECK-NEXT: llvm.return
@@ -10,7 +10,7 @@ arc.define @EmptyArc() {
 // CHECK-LABEL: llvm.func @Types(
 // CHECK-SAME:    %arg0: !llvm.ptr<i8>
 // CHECK-SAME:    %arg1: !llvm.ptr<i1>
-// CHECK-SAME:    %arg2: !llvm.ptr<i72>
+// CHECK-SAME:    %arg2: !llvm.ptr<i8>
 // CHECK-SAME:  ) -> !llvm.struct<(
 // CHECK-SAME:    ptr<i8>
 // CHECK-SAME:    ptr<i1>
@@ -18,32 +18,31 @@ arc.define @EmptyArc() {
 func.func @Types(
   %arg0: !arc.storage,
   %arg1: !arc.state<i1>,
-  %arg2: !arc.memory<4 x i7, 9>
+  %arg2: !arc.memory<4 x i7>
 ) -> (
   !arc.storage,
   !arc.state<i1>,
-  !arc.memory<4 x i7, 9>
+  !arc.memory<4 x i7>
 ) {
-  return %arg0, %arg1, %arg2 : !arc.storage, !arc.state<i1>, !arc.memory<4 x i7, 9>
+  return %arg0, %arg1, %arg2 : !arc.storage, !arc.state<i1>, !arc.memory<4 x i7>
   // CHECK: llvm.return
-  // CHECK-SAME: !llvm.struct<(ptr<i8>, ptr<i1>, ptr<i72>)>
+  // CHECK-SAME: !llvm.struct<(ptr<i8>, ptr<i1>, ptr<i8>)>
 }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: llvm.func @StorageTypes(%arg0: !llvm.ptr<i8>) -> !llvm.struct<(ptr<i1>, ptr<i24>, ptr<i8>)> {
-func.func @StorageTypes(%arg0: !arc.storage) -> (!arc.state<i1>, !arc.memory<4 x i1, 3>, !arc.storage) {
+// CHECK-LABEL: llvm.func @StorageTypes(%arg0: !llvm.ptr<i8>) -> !llvm.struct<(ptr<i1>, ptr<i8>, ptr<i8>)> {
+func.func @StorageTypes(%arg0: !arc.storage) -> (!arc.state<i1>, !arc.memory<4 x i1>, !arc.storage) {
   %0 = arc.storage.get %arg0[42] : !arc.storage -> !arc.state<i1>
   // CHECK-NEXT: [[OFFSET:%.+]] = llvm.mlir.constant(42 :
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[[[OFFSET]]]
   // CHECK-NEXT: llvm.bitcast [[PTR]] : !llvm.ptr<i8> to !llvm.ptr<i1>
-  %1 = arc.storage.get %arg0[43] : !arc.storage -> !arc.memory<4 x i1, 3>
+  %1 = arc.storage.get %arg0[43] : !arc.storage -> !arc.memory<4 x i1>
   // CHECK-NEXT: [[OFFSET:%.+]] = llvm.mlir.constant(43 :
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[[[OFFSET]]]
-  // CHECK-NEXT: llvm.bitcast [[PTR]] : !llvm.ptr<i8> to !llvm.ptr<i24>
   %2 = arc.storage.get %arg0[44] : !arc.storage -> !arc.storage
   // CHECK-NEXT: [[OFFSET:%.+]] = llvm.mlir.constant(44 :
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[[[OFFSET]]]
-  return %0, %1, %2 : !arc.state<i1>, !arc.memory<4 x i1, 3>, !arc.storage
+  return %0, %1, %2 : !arc.state<i1>, !arc.memory<4 x i1>, !arc.storage
   // CHECK: llvm.return
 }
 // CHECK-NEXT: }
@@ -59,12 +58,8 @@ func.func @StateAllocation(%arg0: !arc.storage<10>) {
   arc.alloc_state %arg0 {offset = 2} : (!arc.storage<10>) -> !arc.state<i3>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[2]
   // CHECK-NEXT: llvm.bitcast [[PTR]] : !llvm.ptr<i8> to !llvm.ptr<i3>
-  arc.alloc_memory %arg0 {offset = 3, stride = 1} : (!arc.storage<10>) -> !arc.memory<4 x i1, 1>
+  arc.alloc_memory %arg0 {offset = 3, stride = 1} : (!arc.storage<10>) -> !arc.memory<4 x i1>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[3]
-  // CHECK-NOT:  llvm.bitcast
-  arc.alloc_memory %arg0 {offset = 3, stride = 3} : (!arc.storage<10>) -> !arc.memory<4 x i1, 3>
-  // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[3]
-  // CHECK-NEXT: llvm.bitcast [[PTR]] : !llvm.ptr<i8> to !llvm.ptr<i24>
   arc.alloc_storage %arg0[7] : (!arc.storage<10>) -> !arc.storage<3>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[7]
   return
@@ -96,21 +91,21 @@ func.func @StateUpdates(%arg0: !arc.storage<1>) {
 
 // CHECK-LABEL: llvm.func @MemoryUpdates(%arg0: !llvm.ptr<i8>, %arg1: i1) {
 func.func @MemoryUpdates(%arg0: !arc.storage<24>, %enable: i1) {
-  %0 = arc.alloc_memory %arg0 {offset = 0, stride = 6} : (!arc.storage<24>) -> !arc.memory<4 x i42, 6>
+  %0 = arc.alloc_memory %arg0 {offset = 0, stride = 6} : (!arc.storage<24>) -> !arc.memory<4 x i42>
   // CHECK-NEXT: [[RAW_PTR:%.+]] = llvm.getelementptr %arg0[0]
-  // CHECK-NEXT: [[PTR:%.+]] = llvm.bitcast [[RAW_PTR]] : !llvm.ptr<i8> to !llvm.ptr<i48>
+  // CHECK-NEXT: [[PTR:%.+]] = llvm.bitcast [[RAW_PTR]] : !llvm.ptr<i8> to !llvm.ptr<i64>
 
   %clk = hw.constant true
   %c3_i19 = hw.constant 3 : i19
   // CHECK-NEXT: llvm.mlir.constant(true
   // CHECK-NEXT: [[THREE:%.+]] = llvm.mlir.constant(3
 
-  %1 = arc.memory_read %0[%c3_i19] : <4 x i42, 6>, i19
+  %1 = arc.memory_read %0[%c3_i19] : <4 x i42>, i19
   %2 = arith.addi %1, %1 : i42
   // CHECK-NEXT:   [[ADDR:%.+]] = llvm.zext [[THREE]] : i19 to i20
   // CHECK-NEXT:   [[FOUR:%.+]] = llvm.mlir.constant(4
   // CHECK-NEXT:   [[INBOUNDS:%.+]] = llvm.icmp "ult" [[ADDR]], [[FOUR]]
-  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i48>, i20) -> !llvm.ptr<i42>
+  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i64>, i20) -> !llvm.ptr<i42>
   // CHECK-NEXT:   llvm.cond_br [[INBOUNDS]], [[BB_LOAD:\^.+]], [[BB_SKIP:\^.+]]
   // CHECK-NEXT: [[BB_LOAD]]:
   // CHECK-NEXT:   [[TMP:%.+]] = llvm.load [[GEP]]
@@ -121,11 +116,11 @@ func.func @MemoryUpdates(%arg0: !arc.storage<24>, %enable: i1) {
   // CHECK-NEXT: [[BB_RESUME]]([[LOADED:%.+]]: i42):
   // CHECK:        [[ADDED:%.+]] = llvm.add [[LOADED]], [[LOADED]]
 
-  arc.memory_write %0[%c3_i19], %2 if %enable : <4 x i42, 6>, i19
+  arc.memory_write %0[%c3_i19], %2 if %enable : <4 x i42>, i19
   // CHECK-NEXT:   [[ADDR:%.+]] = llvm.zext [[THREE]] : i19 to i20
   // CHECK-NEXT:   [[FOUR:%.+]] = llvm.mlir.constant(4
   // CHECK-NEXT:   [[INBOUNDS:%.+]] = llvm.icmp "ult" [[ADDR]], [[FOUR]]
-  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i48>, i20) -> !llvm.ptr<i42>
+  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i64>, i20) -> !llvm.ptr<i42>
   // CHECK-NEXT:   [[COND:%.+]] = llvm.and %arg1, [[INBOUNDS]]
   // CHECK-NEXT:   llvm.cond_br [[COND]], [[BB_STORE:\^.+]], [[BB_RESUME:\^.+]]
   // CHECK-NEXT: [[BB_STORE]]:
@@ -133,11 +128,11 @@ func.func @MemoryUpdates(%arg0: !arc.storage<24>, %enable: i1) {
   // CHECK-NEXT:   llvm.br [[BB_RESUME]]
   // CHECK-NEXT: [[BB_RESUME]]:
 
-  arc.memory_write %0[%c3_i19], %2 : <4 x i42, 6>, i19
+  arc.memory_write %0[%c3_i19], %2 : <4 x i42>, i19
   // CHECK-NEXT:   [[ADDR:%.+]] = llvm.zext [[THREE]] : i19 to i20
   // CHECK-NEXT:   [[FOUR:%.+]] = llvm.mlir.constant(4
   // CHECK-NEXT:   [[INBOUNDS:%.+]] = llvm.icmp "ult" [[ADDR]], [[FOUR]]
-  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i48>, i20) -> !llvm.ptr<i42>
+  // CHECK-NEXT:   [[GEP:%.+]] = llvm.getelementptr [[PTR]][[[ADDR]]] : (!llvm.ptr<i64>, i20) -> !llvm.ptr<i42>
   // CHECK-NEXT:   llvm.cond_br [[INBOUNDS]], [[BB_STORE:\^.+]], [[BB_RESUME:\^.+]]
   // CHECK-NEXT: [[BB_STORE]]:
   // CHECK-NEXT:   llvm.store [[ADDED]], [[GEP]]
@@ -178,4 +173,20 @@ func.func @lowerCombParity(%arg0: i32) -> i1 {
   %0 = comb.parity %arg0 : i32
 
   return %0 : i1
+}
+
+// CHECK-LABEL: llvm.func @funcCallOp
+func.func @funcCallOp(%arg0: i32) -> (i32, i32) {
+  // CHECK-NEXT: [[V0:%.+]] = llvm.call @dummyFuncCallee(%arg0) : (i32) -> !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: [[V1:%.+]] = llvm.extractvalue [[V0]][0] : !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: [[V2:%.+]] = llvm.extractvalue [[V0]][1] : !llvm.struct<(i32, i32)>
+  %0:2 = func.call @dummyFuncCallee(%arg0) : (i32) -> (i32, i32)
+  // CHECK-NEXT: [[V3:%.+]] = llvm.mlir.undef : !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: [[V4:%.+]] = llvm.insertvalue [[V1]], [[V3]][0] : !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: [[V5:%.+]] = llvm.insertvalue [[V2]], [[V4]][1] : !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: llvm.return [[V5]] :
+  func.return %0#0, %0#1 : i32, i32
+}
+func.func @dummyFuncCallee(%arg0: i32) -> (i32, i32) {
+  func.return %arg0, %arg0 : i32, i32
 }

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -51,17 +51,17 @@ arc.model "test" {
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i9001>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 0 : i32, stride = 1 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i1, 1>
+    // CHECK-SAME: -> !arc.memory<4 x i1>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 4 : i32, stride = 1 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i8, 1>
+    // CHECK-SAME: -> !arc.memory<4 x i8>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 8 : i32, stride = 2 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i16, 2>
+    // CHECK-SAME: -> !arc.memory<4 x i16>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 16 : i32, stride = 4 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i32, 4>
+    // CHECK-SAME: -> !arc.memory<4 x i32>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 32 : i32, stride = 8 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i64, 8>
+    // CHECK-SAME: -> !arc.memory<4 x i64>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 64 : i32, stride = 1128 : i32}
-    // CHECK-SAME: -> !arc.memory<4 x i9001, 1128>
+    // CHECK-SAME: -> !arc.memory<4 x i9001>
     // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4576 : i32}
   }
   // CHECK-NEXT: }

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -177,7 +177,7 @@ arc.define @lutSideEffects () -> i32 {
     %true = hw.constant true
     // expected-note @+1 {{first operation with side-effects here}}
     %1 = arc.memory !arc.memory<20 x i32>
-    %2 = arc.memory_read_port %1[%true] clock %true : !arc.memory<20 x i32>, i1
+    %2 = arc.memory_read_port %1[%true] : !arc.memory<20 x i32>, i1
     arc.output %2 : i32
   }
   arc.output %0 : i32
@@ -260,19 +260,6 @@ arc.define @dummyArc() {
 
 // -----
 
-hw.module @memoryReadPortOpInsideClockDomain(%clk: i1) {
-  arc.clock_domain (%clk) clock %clk : (i1) -> () {
-  ^bb0(%arg0: i1):
-    %mem = arc.memory <4 x i32>
-    %c0_i32 = hw.constant 0 : i32
-    // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    %0 = arc.memory_read_port %mem[%c0_i32] if %arg0 clock %arg0 : !arc.memory<4 x i32>, i32
-    arc.output
-  }
-}
-
-// -----
-
 hw.module @memoryWritePortOpInsideClockDomain(%clk: i1) {
   arc.clock_domain (%clk) clock %clk : (i1) -> () {
   ^bb0(%arg0: i1):
@@ -282,15 +269,6 @@ hw.module @memoryWritePortOpInsideClockDomain(%clk: i1) {
     arc.memory_write_port %mem[%c0_i32], %c0_i32 if %arg0 clock %arg0 : !arc.memory<4 x i32>, i32
     arc.output
   }
-}
-
-// -----
-
-hw.module @memoryReadPortOpOutsideClockDomain(%en: i1) {
-  %mem = arc.memory <4 x i32>
-  %c0_i32 = hw.constant 0 : i32
-  // expected-error @+1 {{outside a clock domain requires a clock}}
-  %0 = arc.memory_read_port %mem[%c0_i32] if %en : !arc.memory<4 x i32>, i32
 }
 
 // -----

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -57,10 +57,10 @@ arc.define @LookupTable(%arg0: i32, %arg1: i8) -> () {
 // CHECK-LABEL: func.func @StorageAccess
 func.func @StorageAccess(%arg0: !arc.storage<10000>) {
   // CHECK-NEXT: arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
-  // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, 4>
+  // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19>
   // CHECK-NEXT: arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
   %0 = arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
-  %1 = arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, 4>
+  %1 = arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19>
   %2 = arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
   return
 }
@@ -113,13 +113,10 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
   // CHECK: [[MEM:%.+]] = arc.memory <4 x i32>
   %mem = arc.memory <4 x i32>
 
-  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] if %en clock %clk : <4 x i32>, i32
-  %0 = arc.memory_read_port %mem[%c0_i32] if %en clock %clk : <4 x i32>, i32
+  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] : <4 x i32>, i32
+  %0 = arc.memory_read_port %mem[%c0_i32] : <4 x i32>, i32
   // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 if %en clock %clk : <4 x i32>, i32
   arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en clock %clk : <4 x i32>, i32
-
-  // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] clock %clk : <4 x i32>, i32
-  %1 = arc.memory_read_port %mem[%c0_i32] clock %clk : <4 x i32>, i32
   // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 clock %clk : <4 x i32>, i32
   arc.memory_write_port %mem[%c0_i32], %c0_i32 clock %clk : <4 x i32>, i32
 
@@ -129,13 +126,10 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
     %c1_i32 = hw.constant 1 : i32
     // CHECK: [[MEM2:%.+]] = arc.memory <4 x i32>
     %mem2 = arc.memory <4 x i32>
-    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] if %arg0 : <4 x i32>, i32
-    %2 = arc.memory_read_port %mem2[%c1_i32] if %arg0 : <4 x i32>, i32
+    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32>, i32
+    %2 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32>, i32
     // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 if %arg0 : <4 x i32>, i32
     arc.memory_write_port %mem2[%c1_i32], %c1_i32 if %arg0 : <4 x i32>, i32
-
-    // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32>, i32
-    %3 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32>, i32
     // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 : <4 x i32>, i32
     arc.memory_write_port %mem2[%c1_i32], %c1_i32 : <4 x i32>, i32
   }

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -67,22 +67,16 @@ hw.module @clockDomainDCE(%clk: i1) {
 }
 
 // CHECK-LABEL: hw.module @memoryOps
-hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32>, %addr: i32, %data: i32) -> (out0: i32, out1: i32) {
+hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32>, %addr: i32, %data: i32) {
   %true = hw.constant true
-  // CHECK: [[RD:%.+]] = arc.memory_read_port %mem[%addr] clock %clk : <4 x i32>, i32
-  %0 = arc.memory_read_port %mem[%addr] if %true clock %clk : <4 x i32>, i32
-  // CHECK-NEXT: arc.memory_write_port %mem[%addr], %data clock %clk : <4 x i32>, i32
+  // CHECK: arc.memory_write_port %mem[%addr], %data clock %clk : <4 x i32>, i32
   arc.memory_write_port %mem[%addr], %data if %true clock %clk : <4 x i32>, i32
   // CHECK-NEXT: arc.memory_write %mem[%addr], %data : <4 x i32>, i32
   arc.memory_write %mem[%addr], %data if %true : <4 x i32>, i32
 
   %false = hw.constant false
-  %1 = arc.memory_read_port %mem[%addr] if %false clock %clk : <4 x i32>, i32
   arc.memory_write_port %mem[%addr], %data if %false clock %clk : <4 x i32>, i32
   arc.memory_write %mem[%addr], %data if %false : <4 x i32>, i32
-
-  // CHECK-NEXT: hw.output [[RD]], %c0_i32
-  hw.output %0, %1 : i32, i32
 }
 
 // CHECK-LABEL: hw.module @clockDomainCanonicalizer
@@ -92,16 +86,14 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
   %mem = arc.memory <4 x i32>
   // COM: check that memories only used in one clock domain are pulled in and
   // COM: constants are cloned when used in multiple clock domains.
-  // CHECK: [[V0:%.+]] = arc.clock_domain ()
+  // CHECK:      arc.clock_domain ()
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory
-  // CHECK-NEXT: arc.memory_read_port [[MEM]][[[C0]]] :
   // CHECK-NEXT: arc.memory_write_port [[MEM]][[[C0]]], [[C0]] :
   %0 = arc.clock_domain (%c0_i32, %mem, %true) clock %clk : (i32, !arc.memory<4 x i32>, i1) -> i32 {
   ^bb0(%arg0: i32, %arg1: !arc.memory<4 x i32>, %arg2: i1):
-    %1 = arc.memory_read_port %arg1[%arg0] if %arg2 : !arc.memory<4 x i32>, i32
     arc.memory_write_port %arg1[%arg0], %arg0 if %arg2 : !arc.memory<4 x i32>, i32
-    arc.output %1 : i32
+    arc.output %arg0 : i32
   }
   // COM: check that unused inputs are removed, and constants are cloned into it
   // CHECK: [[V1:%.+]] = arc.clock_domain ()
@@ -136,7 +128,7 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
     arc.output %arg0, %3, %4, %5 : i32, i32, i32, i32
   }
 
-  // CHECK: hw.output [[V0]], [[V1]], %data, %c0_i32, [[V5]] : i32, i1, i32, i32, i32
+  // CHECK: hw.output %c0_i32{{.*}}, [[V1]], %data, %c0_i32, [[V5]] : i32, i1, i32, i32, i32
   hw.output %0, %1, %3, %4, %5 : i32, i1, i32, i32, i32
 }
 arc.define @identityi1(%arg0: i1) -> i1 {

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -38,7 +38,7 @@ hw.module.generated @WOMemoryWithMask, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0
 hw.module @TestROMemory(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] if %enable clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8>, i10
   // CHECK-NEXT: hw.output [[RDATA]]
   %0 = hw.instance "foo" @ROMemory(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
   hw.output %0 : i8
@@ -52,7 +52,7 @@ hw.module.generated @ROMemory, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1
 hw.module @TestROMemoryWithLatency(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: [[D0:%.+]] = arc.memory_read_port [[FOO]][%addr] if %enable clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[D0:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8>, i10
   // CHECK-NEXT: [[D1:%.+]] = seq.compreg {{.+}} [[D0]], %clock
   // CHECK-NEXT: [[D2:%.+]] = seq.compreg {{.+}} [[D1]], %clock
   // CHECK-NEXT: [[D3:%.+]] = seq.compreg {{.+}} [[D2]], %clock
@@ -69,10 +69,7 @@ hw.module.generated @ROMemoryWithLatency, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, 
 hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata: i8) -> (rdata: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8> {name = "foo"}
-  // CHECK-NEXT: hw.constant true
-  // CHECK-NEXT: [[WMODE_INV:%.+]] = comb.xor %wmode, %true
-  // CHECK-NEXT: [[RENABLE:%.+]] = comb.and %enable, [[WMODE_INV]]
-  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] if [[RENABLE]] clock %clock : <1024 x i8>, i10
+  // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8>, i10
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
   // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %wdata if [[WENABLE]] clock %clock : <1024 x i8>, i10
   // CHECK-NEXT: hw.output [[RDATA]]

--- a/test/Dialect/Arc/isolate-clocks.mlir
+++ b/test/Dialect/Arc/isolate-clocks.mlir
@@ -8,7 +8,7 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
   %1 = arc.state @DummyArc(%in) clock %clk0 enable %0 reset %c1 lat 1 : (i32) -> i32
   %mem = arc.memory <2 x i32>
   arc.memory_write_port %mem[%c0], %2 clock %clk0 : <2 x i32>, i1
-  %2 = arc.memory_read_port %mem[%c0] clock %clk0 : <2 x i32>, i1
+  %2 = arc.state @DummyArc(%in) clock %clk0 lat 1 : (i32) -> i32
   arc.memory_write_port %mem[%c1], %1 clock %clk0 : <2 x i32>, i1
   %3 = arc.state @DummyArc(%4) clock %clk1 enable %0 reset %c1  lat 1 : (i32) -> i32
   %4 = arc.state @DummyArc(%2) lat 0 : (i32) -> i32
@@ -17,13 +17,13 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
 
   // CHECK-NEXT: [[V0:%.+]] = comb.and %c0, %c1 : i1
   // CHECK-NEXT: [[V1:%.+]] = arc.state @DummyArc([[V2:%.+]]) lat 0 : (i32) -> i32
-  // CHECK-NEXT: [[V2]] = arc.clock_domain (%c1, %c0, [[V0]], %in) clock %clk0 : (i1, i1, i1, i32) -> i32 {
-  // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i32):
+  // CHECK-NEXT: [[V2]] = arc.clock_domain (%c1, %in, %c0, [[V0]]) clock %clk0 : (i1, i32, i1, i1) -> i32 {
+  // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i32, %arg2: i1, %arg3: i1):
   // CHECK-NEXT:   [[MEM:%.+]] = arc.memory <2 x i32>
   // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg0], [[V7:%.+]] : <2 x i32>, i1
-  // CHECK-NEXT:   [[V6:%.+]] = arc.memory_read_port [[MEM]][%arg1] : <2 x i32>, i1
-  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg1], [[V6]] : <2 x i32>, i1
-  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg3) enable %arg2 reset %arg0 lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V6:%.+]] = arc.state @DummyArc(%arg1) lat 1 : (i32) -> i32
+  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg2], [[V6]] : <2 x i32>, i1
+  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg1) enable %arg3 reset %arg0 lat 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V6]] : i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V3:%.+]] = arc.clock_domain ([[V0]], %c1, [[V1]]) clock %clk1 : (i1, i1, i32) -> i32 {

--- a/test/Dialect/Arc/legalize-state-update-error.mlir
+++ b/test/Dialect/Arc/legalize-state-update-error.mlir
@@ -1,0 +1,22 @@
+// RUN: circt-opt %s --arc-legalize-state-update --split-input-file --verify-diagnostics
+
+arc.model "Memory" {
+^bb0(%arg0: !arc.storage):
+  %false = hw.constant false
+  arc.clock_tree %false attributes {ct4} {
+    %r1 = arc.state_read %s1 : <i32>
+    scf.if %false {
+      // expected-error @+1 {{could not be moved to be after all reads to the same memory}}
+      arc.memory_write %mem2[%false], %r1 : <2 x i32>, i1
+      %mr1 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+    }
+    scf.if %false {
+      arc.memory_write %mem1[%false], %r1 : <2 x i32>, i1
+      // expected-note @+1 {{could not be moved after this read}}
+      %mr1 = arc.memory_read %mem2[%false] : <2 x i32>, i1
+    }
+  }
+  %mem1 = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  %mem2 = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  %s1 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i32>
+}

--- a/test/Dialect/Arc/legalize-state-update.mlir
+++ b/test/Dialect/Arc/legalize-state-update.mlir
@@ -186,3 +186,68 @@ arc.model "DontLeakThroughClockTreeOrPassthrough" {
     arc.state_write %out_b = %1 : <i1>
   }
 }
+
+// CHECK-LABEL: arc.model "Memory"
+arc.model "Memory" {
+^bb0(%arg0: !arc.storage):
+  %false = hw.constant false
+  // CHECK: arc.clock_tree %false attributes {ct1}
+  arc.clock_tree %false attributes {ct1} {
+    // CHECK-NEXT: arc.state_read
+    // CHECK-NEXT: arc.memory_read [[MEM1:%.+]][%false]
+    // CHECK-NEXT: arc.memory_write [[MEM1]]
+    // CHECK-NEXT: arc.memory_read [[MEM2:%.+]][%false]
+    // CHECK-NEXT: arc.memory_write [[MEM2]]
+    %r1 = arc.state_read %s1 : <i32>
+    arc.memory_write %mem2[%false], %r1 : <2 x i32>, i1
+    arc.memory_write %mem1[%false], %r1 : <2 x i32>, i1
+    %mr1 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+    %mr2 = arc.memory_read %mem2[%false] : <2 x i32>, i1
+  // CHECK-NEXT: }
+  }
+  // CHECK: arc.clock_tree %false attributes {ct2}
+  arc.clock_tree %false attributes {ct2} {
+    // CHECK-NEXT: arc.state_read
+    // CHECK-NEXT: arc.memory_read
+    // CHECK-NEXT: scf.if %false {
+    // CHECK-NEXT:   arc.memory_read
+    // CHECK-NEXT: }
+    // CHECK-NEXT: arc.memory_write
+    %r1 = arc.state_read %s1 : <i32>
+    arc.memory_write %mem1[%false], %r1 : <2 x i32>, i1
+    %mr1 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+    scf.if %false {
+      %mr2 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+    }
+  // CHECK-NEXT: }
+  }
+  // CHECK: arc.clock_tree %false attributes {ct3}
+  arc.clock_tree %false attributes {ct3} {
+    // CHECK-NEXT: arc.memory_read [[MEM1]]
+    // CHECK-NEXT: arc.memory_read [[MEM2]]
+    // CHECK-NEXT: scf.if %false {
+    // CHECK-NEXT:   arc.state_read
+    // CHECK-NEXT:   scf.if %false {
+    // CHECK-NEXT:     arc.memory_write [[MEM2]]
+    // CHECK-NEXT:     arc.memory_read [[MEM1]]
+    // CHECK-NEXT:   }
+    // CHECK-NEXT:   arc.memory_write [[MEM1]]
+    // CHECK-NEXT: }
+    scf.if %false {
+      %r1 = arc.state_read %s1 : <i32>
+      arc.memory_write %mem1[%false], %r1 : <2 x i32>, i1
+      scf.if %false {
+        arc.memory_write %mem2[%false], %r1 : <2 x i32>, i1
+        %mr3 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+      }
+    }
+    %mr1 = arc.memory_read %mem1[%false] : <2 x i32>, i1
+    %mr2 = arc.memory_read %mem2[%false] : <2 x i32>, i1
+  // CHECK-NEXT: }
+  }
+  // CHECK: [[MEM1]] = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  // CHECK: [[MEM2]] = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  %mem1 = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  %mem2 = arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<2 x i32>
+  %s1 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i32>
+}

--- a/test/Dialect/Arc/print-state-info.mlir
+++ b/test/Dialect/Arc/print-state-info.mlir
@@ -37,7 +37,7 @@ arc.model "Bar" {
   // CHECK-NEXT: "type": "memory"
   // CHECK-NEXT: "stride": 3
   // CHECK-NEXT: "depth": 5
-  arc.alloc_memory %arg0 {name = "y", offset = 48, stride = 3} : (!arc.storage<9001>) -> !arc.memory<5 x i17, 3>
+  arc.alloc_memory %arg0 {name = "y", offset = 48, stride = 3} : (!arc.storage<9001>) -> !arc.memory<5 x i17>
 
   // CHECK:      "name": "z"
   // CHECK-NEXT: "offset": 92

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -49,3 +49,6 @@ hw.module @Top() {
   // CHECK: %int_rtc_tick_value = seq.compreg [[RST]], %subsystem_pbus.clock : i7
   %int_rtc_tick_value = seq.firreg %int_rtc_tick_value clock %subsystem_pbus.clock reset sync %subsystem_pbus.reset, %c0_i7 : i7
 }
+
+// CHECK-NOT: sv.macro.decl
+sv.macro.decl @RANDOM


### PR DESCRIPTION
* Remove the optional enable and clock operands from `arc.memory_read_port` making it a combinatorial read port. Latencies can be added using the `arc.state` operation.
* Adjust InferMemories accordingly
* Make `arc.memory_read_port` pure to allow it to be moved into `arc.define` ops. This means the memory value has to be passed via argument. This will be considered to pass the whole memory as a value (like `hw.array`) at this stage of the lowering. The LegalizeStateUpdates pass should make it easy to switch to pointer semantics for memories.
* Remove top-level `sv.macro.decl` ops in StripSV (sorry for this unrelated change, but it's just 4 lines :) )
* Remove the optional stride parameter from the `!arc.memory` type and add a member function to conveniently compute the stride on-demand. Not removing it led to some issues in the lowering to LLVM which would have required bigger changes to AllocateState otherwise.
* Fix a bug in the ClockDomainOp canonicalizer revealed by the change to the regression test required by the removal of the `memory_read_port` operands
* Change the memory read port lowering in LowerState such that it does not reorder read ops anymore, but just converts them and also lowers Arcs that contain reads to functions early on because arcs don't allow ops with memory side effects. Alternatively we could split the arcs and pull the read ops out again.
* Add the memory read/write reordering to LegalizeStateUpdates instead. This is just a temporary implementation and fails on more complex cases, but we need to re-implement this pass anyways as it is very slow (~4 sec on rocket, 100s of sec on largeBoom)
* Add support for `func.call` op lowering in LowerArcToLLVM and lower arcs with LLVM internal linkage such that LLVM can remove those functions when getting inlined to reduce the objfile size to almost a third for rocket.

Sorry for touching a lot of things in this PR. Let me know if I should try to split it up a bit more.