### PR TITLE
[Arc] Add ArcCanonicalizer pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -312,29 +312,53 @@ def MemoryReadPortOp : ArcOp<"memory_read_port", [
 
 def MemoryWritePortOp : ArcOp<"memory_write_port", [
   MemoryEffects<[MemWrite]>,
-  MemoryAndDataTypesMatch<"memory", "data">,
-  MemoryAndAddressTypesMatch<"memory", "address">,
+  CallOpMutableInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   AttrSizedOperandSegments,
   ClockedOpInterface
 ]> {
   let summary = "Write port to a memory";
   let arguments = (ins
     MemoryType:$memory,
-    AnyInteger:$address,
+    FlatSymbolRefAttr:$arc,
+    Variadic<AnyType>:$inputs,
     Optional<I1>:$clock,
-    Optional<I1>:$enable,
-    AnyInteger:$data,
-    Optional<AnyInteger>:$mask
+    UnitAttr:$enable,
+    UnitAttr:$mask,
+    DefaultValuedAttr<I32Attr, "1">:$latency
   );
 
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` $data (`mask` `(` $mask^ `:` type($mask) `)`)?
-    (`if` $enable^)? (`clock` $clock^)? attr-dict `:` type($memory)
+    $memory `,` $arc  `(` $inputs `)` (`clock` $clock^)?  (`enable` $enable^)?
+    (`mask` $mask^)? `lat` $latency attr-dict `:`
+    type($memory) `,` type($inputs)
   }];
 
   let hasVerifier = 1;
-  let hasFolder = 1;
-  let hasCanonicalizeMethod = 1;
+
+  let extraClassDeclaration = [{
+    SmallVector<Type> getArcResultTypes();
+    static unsigned getAddressIdx() { return 0; }
+    static unsigned getDataIdx() { return 1; }
+    static unsigned getEnableIdx() { return 2; }
+    static unsigned getMaskIdx(bool hasEnable) { return hasEnable ? 3 : 2; }
+
+    operand_range getArgOperands() {
+      return getInputs();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getInputsMutable();
+    }
+
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("arc");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
+    }
+  }];
 }
 
 def MemoryReadOp : ArcOp<"memory_read", [

--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -23,6 +23,7 @@ std::unique_ptr<mlir::Pass>
 createAddTapsPass(llvm::Optional<bool> tapPorts = {},
                   llvm::Optional<bool> tapWires = {});
 std::unique_ptr<mlir::Pass> createAllocateStatePass();
+std::unique_ptr<mlir::Pass> createArcCanonicalizerPass();
 std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createGroupResetsAndEnablesPass();
 std::unique_ptr<mlir::Pass> createInferMemoriesPass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -27,6 +27,14 @@ def AllocateState : Pass<"arc-allocate-state", "arc::ModelOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def ArcCanonicalizer : Pass<"arc-canonicalizer", "mlir::ModuleOp"> {
+  let summary = "Simulation centric canonicalizations";
+  let constructor = "createArcCanonicalizerPass()";
+  let dependentDialects = ["hw::HWDialect",
+                           "comb::CombDialect",
+                           "arc::ArcDialect"];
+}
+
 def Dedup : Pass<"arc-dedup", "mlir::ModuleOp"> {
   let summary = "Deduplicate identical arc definitions";
   let description = [{

--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -74,24 +74,6 @@ LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
-// MemoryWritePortOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult MemoryWritePortOp::fold(FoldAdaptor adaptor,
-                                      SmallVectorImpl<OpFoldResult> &results) {
-  if (isAlways(adaptor.getEnable(), true))
-    return getEnableMutable().clear(), success();
-  return failure();
-}
-
-LogicalResult MemoryWritePortOp::canonicalize(MemoryWritePortOp op,
-                                              PatternRewriter &rewriter) {
-  if (isAlways(op.getEnable(), false))
-    return rewriter.eraseOp(op), success();
-  return failure();
-}
-
-//===----------------------------------------------------------------------===//
 // MemoryWriteOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -44,8 +44,8 @@ static LogicalResult verifyTypeListEquivalence(Operation *op,
   return success();
 }
 
-static LogicalResult verifyArcSymbolUse(Operation *op, ValueRange inputs,
-                                        ValueRange results,
+static LogicalResult verifyArcSymbolUse(Operation *op, TypeRange inputs,
+                                        TypeRange results,
                                         SymbolTableCollection &symbolTable) {
   // Check that the arc attribute was specified.
   auto arcName = op->getAttrOfType<FlatSymbolRefAttr>("arc");
@@ -59,12 +59,12 @@ static LogicalResult verifyArcSymbolUse(Operation *op, ValueRange inputs,
 
   // Verify that the operand and result types match the arc.
   auto type = arc.getFunctionType();
-  if (failed(verifyTypeListEquivalence(op, type.getInputs(), inputs.getTypes(),
-                                       "operand")))
+  if (failed(
+          verifyTypeListEquivalence(op, type.getInputs(), inputs, "operand")))
     return failure();
 
-  if (failed(verifyTypeListEquivalence(op, type.getResults(),
-                                       results.getTypes(), "result")))
+  if (failed(
+          verifyTypeListEquivalence(op, type.getResults(), results, "result")))
     return failure();
 
   return success();
@@ -145,7 +145,8 @@ LogicalResult OutputOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult StateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyArcSymbolUse(*this, getInputs(), getResults(), symbolTable);
+  return verifyArcSymbolUse(*this, getInputs().getTypes(),
+                            getResults().getTypes(), symbolTable);
 }
 
 LogicalResult StateOp::verify() {
@@ -176,16 +177,34 @@ bool StateOp::isClocked() { return getLatency() > 0; }
 //===----------------------------------------------------------------------===//
 
 LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyArcSymbolUse(*this, getInputs(), getResults(), symbolTable);
+  return verifyArcSymbolUse(*this, getInputs().getTypes(),
+                            getResults().getTypes(), symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
 // MemoryWritePortOp
 //===----------------------------------------------------------------------===//
 
+SmallVector<Type> MemoryWritePortOp::getArcResultTypes() {
+  auto memType = cast<MemoryType>(getMemory().getType());
+  SmallVector<Type> resultTypes{memType.getAddressType(),
+                                memType.getWordType()};
+  if (getEnable())
+    resultTypes.push_back(IntegerType::get(getContext(), 1));
+  if (getMask())
+    resultTypes.push_back(memType.getWordType());
+  return resultTypes;
+}
+
+LogicalResult
+MemoryWritePortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyArcSymbolUse(*this, getInputs().getTypes(), getArcResultTypes(),
+                            symbolTable);
+}
+
 LogicalResult MemoryWritePortOp::verify() {
-  if (getMask() && getMask().getType() != getData().getType())
-    return emitOpError("mask and data operand types do not match");
+  if (getLatency() < 1)
+    return emitOpError("latency must be at least 1");
 
   if (!getOperation()->getParentOfType<ClockDomainOp>() && !getClock())
     return emitOpError("outside a clock domain requires a clock");

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -1,0 +1,323 @@
+//===- ArcCanonicalizer.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Simulation centric canonicalizations for non-arc operations and
+// canonicalizations that require efficient symbol lookups.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Support/SymCache.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-canonicalizer"
+
+using namespace circt;
+using namespace arc;
+
+//===----------------------------------------------------------------------===//
+// Datastructures
+//===----------------------------------------------------------------------===//
+
+/// A combination of SymbolCache and SymbolUserMap that also allows to add users
+/// and remove symbols on-demand.
+class SymbolHandler : public SymbolCache {
+public:
+  /// Return the users of the provided symbol operation.
+  ArrayRef<Operation *> getUsers(Operation *symbol) const {
+    auto it = userMap.find(symbol);
+    return it != userMap.end() ? it->second.getArrayRef() : std::nullopt;
+  }
+
+  /// Return true if the given symbol has no uses.
+  bool useEmpty(Operation *symbol) {
+    return !userMap.count(symbol) || userMap[symbol].empty();
+  }
+
+  void addUser(Operation *def, Operation *user) {
+    assert(isa<mlir::SymbolOpInterface>(def));
+    if (!symbolCache.contains(cast<mlir::SymbolOpInterface>(def).getNameAttr()))
+      symbolCache.insert(
+          {cast<mlir::SymbolOpInterface>(def).getNameAttr(), def});
+    userMap[def].insert(user);
+  }
+
+  void removeUser(Operation *def, Operation *user) {
+    assert(isa<mlir::SymbolOpInterface>(def));
+    if (symbolCache.contains(cast<mlir::SymbolOpInterface>(def).getNameAttr()))
+      userMap[def].remove(user);
+    if (userMap[def].empty())
+      userMap.erase(def);
+  }
+
+  void removeDefinitionAndAllUsers(Operation *def) {
+    assert(isa<mlir::SymbolOpInterface>(def));
+    symbolCache.erase(cast<mlir::SymbolOpInterface>(def).getNameAttr());
+    userMap.erase(def);
+  }
+
+  void collectAllSymbolUses(Operation *symbolTableOp,
+                            SymbolTableCollection &symbolTable) {
+    // NOTE: the following is almost 1-1 taken from the SymbolUserMap
+    // constructor. They made it difficult to extend the implementation by
+    // having a lot of members private and non-virtual methods.
+    SmallVector<Operation *> symbols;
+    auto walkFn = [&](Operation *symbolTableOp, bool allUsesVisible) {
+      for (Operation &nestedOp : symbolTableOp->getRegion(0).getOps()) {
+        auto symbolUses = SymbolTable::getSymbolUses(&nestedOp);
+        assert(symbolUses && "expected uses to be valid");
+
+        for (const SymbolTable::SymbolUse &use : *symbolUses) {
+          symbols.clear();
+          (void)symbolTable.lookupSymbolIn(symbolTableOp, use.getSymbolRef(),
+                                           symbols);
+          for (Operation *symbolOp : symbols)
+            userMap[symbolOp].insert(use.getUser());
+        }
+      }
+    };
+    // We just set `allSymUsesVisible` to false here because it isn't necessary
+    // for building the user map.
+    SymbolTable::walkSymbolTables(symbolTableOp, /*allSymUsesVisible=*/false,
+                                  walkFn);
+  }
+
+private:
+  DenseMap<Operation *, SetVector<Operation *>> userMap;
+};
+
+//===----------------------------------------------------------------------===//
+// Canonicalization patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// A rewrite pattern that has access to a symbol cache to access and modify the
+/// symbol-defining op and symbol users as well as a namespace to query new
+/// names. Each pattern has to make sure that the symbol handler is kept
+/// up-to-date no matter whether the pattern succeeds of fails.
+template <typename SourceOp>
+class SymOpRewritePattern : public OpRewritePattern<SourceOp> {
+public:
+  SymOpRewritePattern(MLIRContext *ctxt, SymbolHandler &symbolCache,
+                      Namespace &names, mlir::PatternBenefit benefit = 1,
+                      ArrayRef<StringRef> generatedNames = {})
+      : OpRewritePattern<SourceOp>(ctxt, benefit, generatedNames), names(names),
+        symbolCache(symbolCache) {}
+
+protected:
+  Namespace &names;
+  SymbolHandler &symbolCache;
+};
+
+class MemWritePortEnableAndMaskCanonicalizer
+    : public SymOpRewritePattern<MemoryWritePortOp> {
+public:
+  MemWritePortEnableAndMaskCanonicalizer(
+      MLIRContext *ctxt, SymbolHandler &symbolCache, Namespace &names,
+      DenseMap<StringAttr, StringAttr> &arcMapping)
+      : SymOpRewritePattern<MemoryWritePortOp>(ctxt, symbolCache, names),
+        arcMapping(arcMapping) {}
+  LogicalResult matchAndRewrite(MemoryWritePortOp op,
+                                PatternRewriter &rewriter) const final;
+
+private:
+  DenseMap<StringAttr, StringAttr> &arcMapping;
+};
+
+struct CallPassthroughArc : public SymOpRewritePattern<CallOp> {
+  using SymOpRewritePattern::SymOpRewritePattern;
+  LogicalResult matchAndRewrite(CallOp op,
+                                PatternRewriter &rewriter) const final;
+};
+
+struct StatePassthroughArc : public SymOpRewritePattern<StateOp> {
+  using SymOpRewritePattern::SymOpRewritePattern;
+  LogicalResult matchAndRewrite(StateOp op,
+                                PatternRewriter &rewriter) const final;
+};
+
+struct RemoveUnusedArcs : public SymOpRewritePattern<DefineOp> {
+  using SymOpRewritePattern::SymOpRewritePattern;
+  LogicalResult matchAndRewrite(DefineOp op,
+                                PatternRewriter &rewriter) const final;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+LogicalResult canonicalizePassthoughCall(mlir::CallOpInterface callOp,
+                                         SymbolHandler &symbolCache,
+                                         PatternRewriter &rewriter) {
+  auto defOp = cast<DefineOp>(symbolCache.getDefinition(
+      callOp.getCallableForCallee().get<SymbolRefAttr>().getLeafReference()));
+  if (defOp.isPassthrough()) {
+    symbolCache.removeUser(defOp, callOp);
+    rewriter.replaceOp(callOp, callOp.getArgOperands());
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// Canonicalization pattern implementations
+//===----------------------------------------------------------------------===//
+
+LogicalResult MemWritePortEnableAndMaskCanonicalizer::matchAndRewrite(
+    MemoryWritePortOp op, PatternRewriter &rewriter) const {
+  auto defOp = cast<DefineOp>(symbolCache.getDefinition(op.getArcAttr()));
+  APInt enable;
+
+  if (op.getEnable() &&
+      mlir::matchPattern(
+          defOp.getBodyBlock().getTerminator()->getOperand(op.getEnableIdx()),
+          mlir::m_ConstantInt(&enable))) {
+    if (enable.isZero()) {
+      symbolCache.removeUser(defOp, op);
+      rewriter.eraseOp(op);
+      if (symbolCache.useEmpty(defOp)) {
+        symbolCache.removeDefinitionAndAllUsers(defOp);
+        rewriter.eraseOp(defOp);
+      }
+      return success();
+    }
+    if (enable.isAllOnes()) {
+      if (arcMapping.count(defOp.getNameAttr())) {
+        auto arcWithoutEnable = arcMapping[defOp.getNameAttr()];
+        // Remove the enable attribute
+        rewriter.updateRootInPlace(op, [&]() {
+          op.setEnable(false);
+          op.setArc(arcWithoutEnable.getValue());
+        });
+        symbolCache.removeUser(defOp, op);
+        symbolCache.addUser(symbolCache.getDefinition(arcWithoutEnable), op);
+        return success();
+      }
+
+      auto newName = names.newName(defOp.getName());
+      auto users = SmallVector<Operation *>(symbolCache.getUsers(defOp));
+      symbolCache.removeDefinitionAndAllUsers(defOp);
+
+      // Remove the enable attribute
+      rewriter.updateRootInPlace(op, [&]() {
+        op.setEnable(false);
+        op.setArc(newName);
+      });
+
+      auto newResultTypes = op.getArcResultTypes();
+
+      // Create a new arc that acts as replacement for other users
+      rewriter.setInsertionPoint(defOp);
+      auto newDefOp = rewriter.cloneWithoutRegions(defOp);
+      auto *block = rewriter.createBlock(
+          &newDefOp.getBody(), newDefOp.getBody().end(),
+          newDefOp.getArgumentTypes(),
+          SmallVector<Location>(newDefOp.getNumArguments(), defOp.getLoc()));
+      auto callOp = rewriter.create<CallOp>(newDefOp.getLoc(), newResultTypes,
+                                            newName, block->getArguments());
+      SmallVector<Value> results(callOp->getResults());
+      Value constTrue = rewriter.create<hw::ConstantOp>(
+          newDefOp.getLoc(), rewriter.getI1Type(), 1);
+      results.insert(results.begin() + op.getEnableIdx(), constTrue);
+      rewriter.create<OutputOp>(newDefOp.getLoc(), results);
+
+      // Remove the enable output from the current arc
+      auto *terminator = defOp.getBodyBlock().getTerminator();
+      rewriter.updateRootInPlace(
+          terminator, [&]() { terminator->eraseOperand(op.getEnableIdx()); });
+      rewriter.updateRootInPlace(defOp, [&]() {
+        defOp.setName(newName);
+        defOp.setFunctionType(
+            rewriter.getFunctionType(defOp.getArgumentTypes(), newResultTypes));
+      });
+
+      // Update symbol cache
+      symbolCache.addDefinition(defOp.getNameAttr(), defOp);
+      symbolCache.addDefinition(newDefOp.getNameAttr(), newDefOp);
+      symbolCache.addUser(defOp, callOp);
+      for (auto *user : users)
+        symbolCache.addUser(user == op ? defOp : newDefOp, user);
+
+      arcMapping[newDefOp.getNameAttr()] = defOp.getNameAttr();
+      return success();
+    }
+  }
+  return failure();
+}
+
+LogicalResult
+CallPassthroughArc::matchAndRewrite(CallOp op,
+                                    PatternRewriter &rewriter) const {
+  return canonicalizePassthoughCall(op, symbolCache, rewriter);
+}
+
+LogicalResult
+StatePassthroughArc::matchAndRewrite(StateOp op,
+                                     PatternRewriter &rewriter) const {
+  if (op.getLatency() == 0)
+    return canonicalizePassthoughCall(op, symbolCache, rewriter);
+  return failure();
+}
+
+LogicalResult
+RemoveUnusedArcs::matchAndRewrite(DefineOp op,
+                                  PatternRewriter &rewriter) const {
+  if (symbolCache.useEmpty(op)) {
+    op.getBody().walk([&](mlir::CallOpInterface user) {
+      if (auto symbol = user.getCallableForCallee().dyn_cast<SymbolRefAttr>())
+        if (auto *defOp = symbolCache.getDefinition(symbol.getLeafReference()))
+          symbolCache.removeUser(defOp, user);
+    });
+    symbolCache.removeDefinitionAndAllUsers(op);
+    rewriter.eraseOp(op);
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// ArcCanonicalizerPass implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct ArcCanonicalizerPass
+    : public ArcCanonicalizerBase<ArcCanonicalizerPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void ArcCanonicalizerPass::runOnOperation() {
+  SymbolTableCollection symbolTable;
+  SymbolHandler cache;
+  cache.addDefinitions(getOperation());
+  cache.collectAllSymbolUses(getOperation(), symbolTable);
+  Namespace names;
+  names.add(cache);
+  DenseMap<StringAttr, StringAttr> arcMapping;
+
+  RewritePatternSet symbolPatterns(&getContext());
+  symbolPatterns.add<CallPassthroughArc, StatePassthroughArc, RemoveUnusedArcs>(
+      &getContext(), cache, names);
+  symbolPatterns.add<MemWritePortEnableAndMaskCanonicalizer>(
+      &getContext(), cache, names, arcMapping);
+
+  if (failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                std::move(symbolPatterns))))
+    return signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> arc::createArcCanonicalizerPass() {
+  return std::make_unique<ArcCanonicalizerPass>();
+}

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTArcTransforms
   AddTaps.cpp
   AllocateState.cpp
+  ArcCanonicalizer.cpp
   Dedup.cpp
   GroupResetsAndEnables.cpp
   InferMemories.cpp

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -289,9 +289,12 @@ hw.module @memoryWritePortOpInsideClockDomain(%clk: i1) {
     %mem = arc.memory <4 x i32, i32>
     %c0_i32 = hw.constant 0 : i32
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    arc.memory_write_port %mem[%c0_i32], %c0_i32 if %arg0 clock %arg0 : !arc.memory<4 x i32, i32>
+    arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %arg0) clock %arg0 enable lat 1: !arc.memory<4 x i32, i32>, i32, i32, i1
     arc.output
   }
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
 }
 
 // -----
@@ -300,7 +303,22 @@ hw.module @memoryWritePortOpOutsideClockDomain(%en: i1) {
   %mem = arc.memory <4 x i32, i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{outside a clock domain requires a clock}}
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en : !arc.memory<4 x i32, i32>
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
+}
+
+// -----
+
+hw.module @memoryWritePortOpLatZero(%en: i1) {
+  %mem = arc.memory <4 x i32, i32>
+  %c0_i32 = hw.constant 0 : i32
+  // expected-error @+1 {{latency must be at least 1}}
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 0 : !arc.memory<4 x i32, i32>, i32, i32, i1
+}
+arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
+  arc.output %addr, %data, %enable : i32, i32, i1
 }
 
 // -----

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -108,17 +108,21 @@ hw.module @clockDomainTest(%clk: i1, %in0: i32, %in1: i16) {
 }
 
 // CHECK-LABEL: hw.module @memoryOps
-hw.module @memoryOps(%clk: i1, %en: i1) {
+hw.module @memoryOps(%clk: i1, %en: i1, %mask: i32) {
   %c0_i32 = hw.constant 0 : i32
   // CHECK: [[MEM:%.+]] = arc.memory <4 x i32, i32>
   %mem = arc.memory <4 x i32, i32>
 
   // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] : <4 x i32, i32>
   %0 = arc.memory_read_port %mem[%c0_i32] : <4 x i32, i32>
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 if %en clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 if %en clock %clk : <4 x i32, i32>
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][%c0_i32], %c0_i32 clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%c0_i32], %c0_i32 clock %clk : <4 x i32, i32>
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
+  arc.memory_write_port %mem, @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
+  arc.memory_write_port %mem, @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
+  arc.memory_write_port %mem, @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
 
   // CHECK-NEXT: arc.clock_domain
   arc.clock_domain (%clk) clock %clk : (i1) -> () {
@@ -128,10 +132,10 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
     %mem2 = arc.memory <4 x i32, i32>
     // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32, i32>
     %2 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32, i32>
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 if %arg0 : <4 x i32, i32>
-    arc.memory_write_port %mem2[%c1_i32], %c1_i32 if %arg0 : <4 x i32, i32>
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]][%c1_i32], %c1_i32 : <4 x i32, i32>
-    arc.memory_write_port %mem2[%c1_i32], %c1_i32 : <4 x i32, i32>
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
+    arc.memory_write_port %mem2, @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
+    arc.memory_write_port %mem2, @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
   }
 
   // CHECK: %{{.+}} = arc.memory_read [[MEM]][%c0_i32] : <4 x i32, i32>
@@ -141,4 +145,16 @@ hw.module @memoryOps(%clk: i1, %en: i1) {
 
   // CHECK-NEXT: arc.memory_write [[MEM]][%c0_i32], %c0_i32 : <4 x i32, i32>
   arc.memory_write %mem[%c0_i32], %c0_i32 : <4 x i32, i32>
+}
+arc.define @identity(%arg0: i32, %arg1: i32) -> (i32, i32) {
+  arc.output %arg0, %arg1 : i32, i32
+}
+arc.define @identity1(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i1
+}
+arc.define @identity2(%arg0: i32, %arg1: i32, %arg2: i1, %arg3: i32) -> (i32, i32, i1, i32) {
+  arc.output %arg0, %arg1, %arg2, %arg3 : i32, i32, i1, i32
+}
+arc.define @identity3(%arg0: i32, %arg1: i32, %arg2: i32) -> (i32, i32, i32) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i32
 }

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -69,13 +69,10 @@ hw.module @clockDomainDCE(%clk: i1) {
 // CHECK-LABEL: hw.module @memoryOps
 hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32, i32>, %addr: i32, %data: i32) {
   %true = hw.constant true
-  // CHECK: arc.memory_write_port %mem[%addr], %data clock %clk : <4 x i32, i32>
-  arc.memory_write_port %mem[%addr], %data if %true clock %clk : <4 x i32, i32>
   // CHECK-NEXT: arc.memory_write %mem[%addr], %data : <4 x i32, i32>
   arc.memory_write %mem[%addr], %data if %true : <4 x i32, i32>
 
   %false = hw.constant false
-  arc.memory_write_port %mem[%addr], %data if %false clock %clk : <4 x i32, i32>
   arc.memory_write %mem[%addr], %data if %false : <4 x i32, i32>
 }
 
@@ -86,13 +83,14 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
   %mem = arc.memory <4 x i32, i32>
   // COM: check that memories only used in one clock domain are pulled in and
   // COM: constants are cloned when used in multiple clock domains.
-  // CHECK:      arc.clock_domain ()
+  // CHECK: arc.clock_domain ()
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0
+  // CHECK-NEXT: [[T:%.+]] = hw.constant true
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory
-  // CHECK-NEXT: arc.memory_write_port [[MEM]][[[C0]]], [[C0]] :
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memWrite([[C0]], [[C0]], [[T]]) enable lat 1 :
   %0 = arc.clock_domain (%c0_i32, %mem, %true) clock %clk : (i32, !arc.memory<4 x i32, i32>, i1) -> i32 {
   ^bb0(%arg0: i32, %arg1: !arc.memory<4 x i32, i32>, %arg2: i1):
-    arc.memory_write_port %arg1[%arg0], %arg0 if %arg2 : !arc.memory<4 x i32, i32>
+    arc.memory_write_port %arg1, @memWrite(%arg0, %arg0, %arg2) enable lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
     arc.output %arg0 : i32
   }
   // COM: check that unused inputs are removed, and constants are cloned into it
@@ -133,6 +131,9 @@ hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i
 }
 arc.define @identityi1(%arg0: i1) -> i1 {
   arc.output %arg0 : i1
+}
+arc.define @memWrite(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
+  arc.output %arg0, %arg1, %arg2 : i32, i32, i1
 }
 
 // CHECK-LABEL: arc.model "StorageGetCanonicalizers"

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -7,7 +7,7 @@ hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numW
 hw.module @TestWOMemory(%clock: i1, %addr: i10, %enable: i1, %data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data if %enable clock %clock : <1024 x i8, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i8) -> ()
 }
@@ -25,7 +25,7 @@ hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16,
   // CHECK-NEXT: [[MASK_BIT1:%.+]] = comb.extract %mask from 1 : (i2) -> i1
   // CHECK-NEXT: [[MASK_BYTE1:%.+]] = comb.replicate [[MASK_BIT1]] : (i1) -> i8
   // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE0]], [[MASK_BYTE1]]
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %data mask([[MASK]] : i16) if %enable clock %clock : <1024 x i16, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable, [[MASK]]) clock %clock enable mask lat 1 : <1024 x i16, i10>, i10, i16, i1, i16
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
 }
@@ -71,7 +71,7 @@ hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata:
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8, i10>
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
-  // CHECK-NEXT: arc.memory_write_port [[FOO]][%addr], %wdata if [[WENABLE]] clock %clock : <1024 x i8, i10>
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %wdata, [[WENABLE]]) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output [[RDATA]]
   %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
   hw.output %0 : i8

--- a/test/Dialect/Arc/isolate-clocks.mlir
+++ b/test/Dialect/Arc/isolate-clocks.mlir
@@ -7,24 +7,23 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
   %0 = comb.and %c0, %c1 : i1
   %1 = arc.state @DummyArc(%in) clock %clk0 enable %0 reset %c1 lat 1 : (i32) -> i32
   %mem = arc.memory <2 x i32, i1>
-  arc.memory_write_port %mem[%c0], %2 clock %clk0 : <2 x i32, i1>
-  %2 = arc.state @DummyArc(%in) clock %clk0 lat 1 : (i32) -> i32
-  arc.memory_write_port %mem[%c1], %1 clock %clk0 : <2 x i32, i1>
+  arc.memory_write_port %mem, @identity(%c0, %2) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
+  %2 = arc.memory_read_port %mem[%c0] : <2 x i32, i1>
+  arc.memory_write_port %mem, @identity(%c1, %1) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
   %3 = arc.state @DummyArc(%4) clock %clk1 enable %0 reset %c1  lat 1 : (i32) -> i32
   %4 = arc.state @DummyArc(%2) lat 0 : (i32) -> i32
   %5 = arc.state @DummyArc(%4) clock %clk2 lat 1 : (i32) -> i32
   hw.output %3, %5 : i32, i32
 
   // CHECK-NEXT: [[V0:%.+]] = comb.and %c0, %c1 : i1
-  // CHECK-NEXT: [[V1:%.+]] = arc.state @DummyArc([[V2:%.+]]) lat 0 : (i32) -> i32
-  // CHECK-NEXT: [[V2]] = arc.clock_domain (%c1, %in, %c0, [[V0]]) clock %clk0 : (i1, i32, i1, i1) -> i32 {
-  // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i32, %arg2: i1, %arg3: i1):
-  // CHECK-NEXT:   [[MEM:%.+]] = arc.memory <2 x i32, i1>
-  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg0], [[V7:%.+]] : <2 x i32, i1>
-  // CHECK-NEXT:   [[V6:%.+]] = arc.state @DummyArc(%arg1) lat 1 : (i32) -> i32
-  // CHECK-NEXT:   arc.memory_write_port [[MEM]][%arg2], [[V6]] : <2 x i32, i1>
-  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg1) enable %arg3 reset %arg0 lat 1 : (i32) -> i32
-  // CHECK-NEXT:   arc.output [[V6]] : i32
+  // CHECK-NEXT: [[MEM:%.+]] = arc.memory <2 x i32, i1>
+  // CHECK-NEXT: [[V6:%.+]] = arc.memory_read_port [[MEM]][%c0] : <2 x i32, i1>
+  // CHECK-NEXT: [[V1:%.+]] = arc.state @DummyArc([[V6]]) lat 0 : (i32) -> i32
+  // CHECK-NEXT: arc.clock_domain ([[MEM]], %c1, %c0, [[V6]], [[V0]], %in) clock %clk0 : (!arc.memory<2 x i32, i1>, i1, i1, i32, i1, i32) -> () {
+  // CHECK-NEXT: ^bb0(%arg0: !arc.memory<2 x i32, i1>, %arg1: i1, %arg2: i1, %arg3: i32, %arg4: i1, %arg5: i32):
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg1, [[V7:%.+]]) lat 1 :
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg2, %arg3) lat 1 :
+  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg5) enable %arg4 reset %arg1 lat 1 : (i32) -> i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V3:%.+]] = arc.clock_domain ([[V0]], %c1, [[V1]]) clock %clk1 : (i1, i1, i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i1, %arg2: i32):
@@ -40,6 +39,9 @@ hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -
 }
 arc.define @DummyArc(%arg0: i32) -> i32 {
   arc.output %arg0 : i32
+}
+arc.define @identity(%arg0: i1, %arg1: i32) -> (i1, i32) {
+  arc.output %arg0, %arg1 : i1, i32
 }
 
 // CHECK-LABEL: hw.module @preexistingClockDomain

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -80,15 +80,19 @@ hw.module @NonMaskedMemoryWrite(%clk0: i1) {
   %c0_i2 = hw.constant 0 : i2
   %c9001_i42 = hw.constant 9001 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem[%c0_i2], %c9001_i42 clock %clk0 : <4 x i42, i2>
+  arc.memory_write_port %mem, @identity(%c0_i2, %c9001_i42) clock %clk0 lat 1 : <4 x i42, i2>, i2, i42
 
   // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
   // CHECK-NEXT: [[INCLK0:%.+]] = arc.root_input "clk0", [[PTR]] : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[MEM:%.+]] = arc.alloc_memory [[PTR]] : (!arc.storage) -> !arc.memory<4 x i42, i2>
   // CHECK-NEXT: [[CLK0:%.+]] = arc.state_read [[INCLK0]] : <i1>
   // CHECK-NEXT: arc.clock_tree [[CLK0]] {
-  // CHECK:        arc.memory_write [[MEM]][%c0_i2], %c9001_i42 : <4 x i42, i2>
+  // CHECK:        [[RES:%.+]]:2 = arc.call @identity(%c0_i2, %c9001_i42) : (i2, i42) -> (i2, i42)
+  // CHECK:        arc.memory_write [[MEM]][[[RES]]#0], [[RES]]#1 : <4 x i42, i2>
   // CHECK-NEXT: }
+}
+arc.define @identity(%arg0: i2, %arg1: i42) -> (i2, i42) {
+  arc.output %arg0, %arg1 : i2, i42
 }
 
 // CHECK-LABEL: arc.model "lowerMemoryReadPorts"
@@ -118,17 +122,21 @@ hw.module @maskedMemoryWrite(%clk: i1) {
   %c9001_i42 = hw.constant 9001 : i42
   %c1010_i42 = hw.constant 1010 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem[%c0_i2], %c9001_i42 mask (%c1010_i42 : i42) if %true clock %clk : <4 x i42, i2>
+  arc.memory_write_port %mem, @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) clock %clk enable mask lat 1 : <4 x i42, i2>, i2, i42, i1, i42
+}
+arc.define @identity2(%arg0: i2, %arg1: i42, %arg2: i1, %arg3: i42) -> (i2, i42, i1, i42) {
+  arc.output %arg0, %arg1, %arg2, %arg3 : i2, i42, i1, i42
 }
 // CHECK:      %c9001_i42 = hw.constant 9001 : i42
 // CHECK:      %c1010_i42 = hw.constant 1010 : i42
-// CHECK:      [[RD:%.+]] = arc.memory_read [[MEM:%.+]][%c0_i2] : <4 x i42, i2>
+// CHECK:      [[RES:%.+]]:4 = arc.call @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) : (i2, i42, i1, i42) -> (i2, i42, i1, i42)
+// CHECK:      [[RD:%.+]] = arc.memory_read [[MEM:%.+]][[[RES]]#0] : <4 x i42, i2>
 // CHECK:      %c-1_i42 = hw.constant -1 : i42
-// CHECK:      [[NEG_MASK:%.+]] = comb.xor bin %c1010_i42, %c-1_i42 : i42
+// CHECK:      [[NEG_MASK:%.+]] = comb.xor bin [[RES]]#3, %c-1_i42 : i42
 // CHECK:      [[OLD_MASKED:%.+]] = comb.and bin [[NEG_MASK]], [[RD]] : i42
-// CHECK:      [[NEW_MASKED:%.+]] = comb.and bin %c1010_i42, %c9001_i42 : i42
+// CHECK:      [[NEW_MASKED:%.+]] = comb.and bin [[RES]]#3, [[RES]]#1 : i42
 // CHECK:      [[DATA:%.+]] = comb.or bin [[OLD_MASKED]], [[NEW_MASKED]] : i42
-// CHECK:      arc.memory_write [[MEM]][%c0_i2], [[DATA]] if %true : <4 x i42, i2>
+// CHECK:      arc.memory_write [[MEM]][[[RES]]#0], [[DATA]] if [[RES]]#2 : <4 x i42, i2>
 
 // CHECK-LABEL: arc.model "Taps"
 hw.module @Taps() {
@@ -275,10 +283,13 @@ arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
 hw.module private @MemoryPortRegression(%clock: i1, %reset: i1, %in: i3) -> (x: i3) {
   %0 = arc.memory <2 x i3, i1> {name = "ram_ext"}
   %1 = arc.memory_read_port %0[%3] : <2 x i3, i1>
-  arc.memory_write_port %0[%3], %in clock %clock : <2 x i3, i1>
-  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 {names = ["value"]} : (i1) -> i1
+  arc.memory_write_port %0, @identity3(%3, %in) clock %clock lat 1 : <2 x i3, i1>, i1, i3
+  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 : (i1) -> i1
   %4 = arc.state @Queue_arc_1(%1) lat 0 : (i3) -> i3
   hw.output %4 : i3
+}
+arc.define @identity3(%arg0: i1, %arg1: i3) -> (i1, i3) {
+  arc.output %arg0, %arg1 : i1, i3
 }
 arc.define @Queue_arc_0(%arg0: i1) -> i1 {
   arc.output %arg0 : i1


### PR DESCRIPTION
Add a pass that allows us to implement canonicalization patterns that require a symbol cache to work efficiently (as regular canonicalization patterns don't get one provided). But also allows us to add canonicalizations to operations from other dialects that are simulation specific and thus not desirable to be added to that other dialect directly.