### PR TITLE
[Arc] Simulation specific optimization for comb.icmp

### DIFF
--- a/test/Dialect/Arc/arc-canonicalizer.mlir
+++ b/test/Dialect/Arc/arc-canonicalizer.mlir
@@ -38,7 +38,6 @@ hw.module @memoryWritePortCanonicalizations(%clk: i1, %addr: i1, %data: i32) {
   arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
   // CHECK-NEXT: arc.memory_write_port [[MEM]], @memArcTrue_0(%addr, %data) clock %clk lat 1 :
   arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
-  // CHECK-NEXT: arc.state
   %0:3 = arc.state @memArcTrue(%addr, %data) lat 0 : (i1, i32) -> (i1, i32, i1)
   // CHECK-NEXT: hw.output
   hw.output
@@ -53,4 +52,40 @@ arc.define @unusedArcIsDeleted(%arg0: i32, %arg1: i32) -> i32 {
 arc.define @nestedUnused(%arg0: i32, %arg1: i32) -> i32 {
   %0 = comb.add %arg0, %arg1 : i32
   arc.output %0 : i32
+}
+
+// CHECK-LABEL: hw.module @icmpEqCanonicalizer
+hw.module @icmpEqCanonicalizer(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i4, %arg5: i4, %arg6: i4, %arg7: i4) -> (out0: i1, out1: i1) {
+  // CHECK-NEXT: %c-1_i4 = hw.constant -1 : i4
+  // CHECK-NEXT: [[V0:%.+]] = comb.and bin %arg0, %arg1, %arg2, %arg3 : i1
+  %c-1_i4 = hw.constant -1 : i4
+  %0 = comb.concat %arg0, %arg1, %arg2, %arg3 : i1, i1, i1, i1
+  %1 = comb.icmp bin eq %0, %c-1_i4 : i4
+
+  // CHECK-NEXT: [[V1:%.+]] = comb.and bin %arg4, %arg5, %arg6, %arg7 : i4
+  // CHECK-NEXT: [[V2:%.+]] = comb.icmp bin eq [[V1]], %c-1_i4 : i4
+  %c-1_i16 = hw.constant -1 : i16
+  %2 = comb.concat %arg4, %arg5, %arg6, %arg7 : i4, i4, i4, i4
+  %3 = comb.icmp bin eq %2, %c-1_i16 : i16
+
+  // CHECK-NEXT: hw.output [[V0]], [[V2]] :
+  hw.output %1, %3 : i1, i1
+}
+
+// CHECK-LABEL: hw.module @icmpNeCanonicalizer
+hw.module @icmpNeCanonicalizer(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i4, %arg5: i4, %arg6: i4, %arg7: i4) -> (out0: i1, out1: i1) {
+  // CHECK-NEXT: %c0_i4 = hw.constant 0 : i4
+  // CHECK-NEXT: [[V0:%.+]] = comb.or bin %arg0, %arg1, %arg2, %arg3 : i1
+  %c0_i4 = hw.constant 0 : i4
+  %0 = comb.concat %arg0, %arg1, %arg2, %arg3 : i1, i1, i1, i1
+  %1 = comb.icmp bin ne %0, %c0_i4 : i4
+
+  // CHECK-NEXT: [[V1:%.+]] = comb.or bin %arg4, %arg5, %arg6, %arg7 : i4
+  // CHECK-NEXT: [[V2:%.+]] = comb.icmp bin ne [[V1]], %c0_i4 : i4
+  %c0_i16 = hw.constant 0 : i16
+  %2 = comb.concat %arg4, %arg5, %arg6, %arg7 : i4, i4, i4, i4
+  %3 = comb.icmp bin ne %2, %c0_i16 : i16
+
+  // CHECK-NEXT: hw.output [[V0]], [[V2]] :
+  hw.output %1, %3 : i1, i1
 }


### PR DESCRIPTION
On the HW/Comb level, the `comb.concat` operation is basically considered free. However, in simulation it is quite expensive. Instead of concatenating integers of the same width, we can do the AND/OR directly and do a reduction on the smaller result integer, effectively cutting the number of assembly instructions produced to almost half.