### PR TITLE
[arcilator] Convenience flag for printing debug info

### DIFF
--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -1,5 +1,6 @@
 // RUN: arcilator %s --inline=0 --until-before=llvm-lowering | FileCheck %s
 // RUN: arcilator %s | FileCheck %s --check-prefix=LLVM
+// RUN: arcilator --print-debug-info %s | FileCheck %s --check-prefix=LLVM-DEBUG
 
 // CHECK:      arc.define @[[XOR_ARC:.+]](
 // CHECK-NEXT:   comb.xor
@@ -68,3 +69,10 @@ hw.module @Top(%clock: i1, %i0: i4, %i1: i4) -> (out: i4) {
 // LLVM:   add i4
 // LLVM:   xor i4
 // LLVM:   xor i4
+
+// LLVM-DEBUG: define void @Top_passthrough(ptr %0){{.*}}!dbg
+// LLVM-DEBUG:   mul i4{{.*}}!dbg
+// LLVM-DEBUG: define void @Top_clock(ptr %0){{.*}}!dbg
+// LLVM-DEBUG:   add i4{{.*}}!dbg
+// LLVM-DEBUG:   xor i4{{.*}}!dbg
+// LLVM-DEBUG:   xor i4{{.*}}!dbg

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(arcilator
   CIRCTConvertToArcs
   CIRCTSupport
   MLIRParser
+  MLIRLLVMIRTransforms
   MLIRTargetLLVMIRExport
   MLIRBuiltinToLLVMIRTranslation
   MLIRLLVMToLLVMIRTranslation


### PR DESCRIPTION
To print debug info in MLIR output, the AsmPrinter CLI option mlir-print-debuginfo could be used. However, for printing debug info in the LLVM output, a pass to add the necessary DILocation attributes as to be called first. To make this process easy to use and uniform no matter whether MLIR or LLVM is printed, a print-debug-info CLI option is added