### PR TITLE
[FIRRTL] Add a type interface for querying phase compatibility

### DIFF
--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -24,6 +24,12 @@ mlir_tablegen(FIRRTLOpInterfaces.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(CIRCTFIRRTLOpInterfacesIncGen)
 add_dependencies(circt-headers CIRCTFIRRTLOpInterfacesIncGen)
 
+set(LLVM_TARGET_DEFINITIONS FIRRTLTypeInterfaces.td)
+mlir_tablegen(FIRRTLTypeInterfaces.h.inc -gen-type-interface-decls)
+mlir_tablegen(FIRRTLTypeInterfaces.cpp.inc -gen-type-interface-defs)
+add_public_tablegen_target(CIRCTFIRRTLTypeInterfacesIncGen)
+add_dependencies(circt-headers CIRCTFIRRTLTypeInterfacesIncGen)
+
 # Generate Dialect documentation.
 add_circt_doc(FIRRTLAttributes Dialects/FIRRTLAttributes -gen-attrdef-doc)
 add_circt_doc(FIRRTLStructure Dialects/FIRRTLStructureOps -gen-op-doc)
@@ -33,6 +39,7 @@ add_circt_doc(FIRRTLExpressions Dialects/FIRRTLExpressionOps -gen-op-doc)
 add_circt_doc(FIRRTLTypes Dialects/FIRRTLTypes -gen-typedef-doc)
 add_circt_doc(FIRRTLTypesImpl Dialects/FIRRTLTypesImpl -gen-typedef-doc)
 add_circt_doc(FIRRTLOpInterfaces Dialects/FIRRTLOpInterfaces -gen-op-interface-docs)
+add_circt_doc(FIRRTLTypeInterfaces Dialects/FIRRTLTypeInterfaces -gen-type-interface-docs)
 
 # Generate Pass documentation.
 add_circt_doc(Passes FIRRTLPasses -gen-pass-doc)

--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -17,6 +17,16 @@ include "FIRRTLDialect.td"
 include "mlir/IR/EnumAttr.td"
 
 //===----------------------------------------------------------------------===//
+// Value Phase Tracking
+//===----------------------------------------------------------------------===//
+
+def Phase : I32EnumAttr<"Phase", "value phase", [
+                        I32EnumAttrCase<"Hardware",  0, "hardware">,
+                        I32EnumAttrCase<"Property",  1, "property">]> {
+  let genSpecializedAttr = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // Name Kinds
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.h
@@ -1,0 +1,23 @@
+//===- FIRRTLTypeInterfaces.h - FIRRTL Type Interfaces ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the type interfaces of the FIRRTL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Support/LLVM.h"
+
+#include "mlir/IR/Types.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_H

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.td
@@ -1,0 +1,41 @@
+//===- FIRRTLTypeInterfaces.td - FIRRTL Type Interfaces ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file describes the type interfaces of the FIRRTL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_TD
+#define CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+/// Trait for types that can implicitly belong to a phase.
+def PhasedTypeInterface : TypeInterface<"PhasedTypeInterface"> {
+  let cppNamespace = "::circt::firrtl";
+  let methods = [
+    InterfaceMethod<"Is this type compatible with the given phase",
+      "bool", "isLegalInPhase", (ins "Phase":$phase)>,
+    InterfaceMethod<"Is this type fully compatible with the hardware phase.",
+      "bool", "isLegalHardware", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return static_cast<const ConcreteType *>(this)->isLegalInPhase(Phase::Hardware);
+      }]
+    >,
+    InterfaceMethod<"Is this type fully compatible with the property phase",
+      "bool", "isLegalProperty", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return static_cast<const ConcreteType *>(this)->isLegalInPhase(Phase::Property);
+      }]
+    >
+  ];
+}
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPEINTERFACES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -15,6 +15,7 @@
 
 include "FIRRTLDialect.td"
 include "circt/Dialect/HW/HWTypeInterfaces.td"
+include "FIRRTLTypeInterfaces.td"
 
 // Base class for other typedefs. Provides dialact-specific defaults.
 class FIRRTLImplType<string name,

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   FIRRTLInstanceGraph.cpp
   FIRRTLOpInterfaces.cpp
   FIRRTLOps.cpp
+  FIRRTLTypeInterfaces.cpp
   FIRRTLTypes.cpp
   FIRRTLUtils.cpp
   NLATable.cpp

--- a/lib/Dialect/FIRRTL/FIRRTLTypeInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypeInterfaces.cpp
@@ -1,0 +1,15 @@
+//===- FIRRTLTypeInterfaces.cpp - FIRRTL Type Interfaces --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the type interfaces of the FIRRTL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.cpp.inc"


### PR DESCRIPTION
Phases separate the values in a firrtl program into two worlds, the property
world and the hardware world. Eventually, a firrtl program will be compiled
into two artifacts:

1. The hardware design (verilog)
2. The metadata (om dialect mlir bytecode)

The property phased values will be erased from the hardware design and only
exist in the metadata artifact, while the hardware phased values will be erased
from the metadata and only exist in the hardware design.