### PR TITLE
Add StringType to FIRRTL dialect

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_TYPES_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypeInterfaces.h"
 #include "circt/Dialect/HW/HWTypeInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
@@ -43,6 +44,7 @@ class OpenVectorType;
 class FVectorType;
 class FEnumType;
 class RefType;
+class StringType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -151,7 +153,7 @@ public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
     return llvm::isa<FIRRTLDialect>(type.getDialect()) &&
-           !type.isa<RefType, OpenBundleType, OpenVectorType>();
+           !type.isa<RefType, OpenBundleType, OpenVectorType, StringType>();
   }
 
   /// Returns true if this is a non-const "passive" that which is not analog.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -78,6 +78,9 @@ def OpenVectorType : FIRRTLDialectType<CPred<"$_self.isa<OpenVectorType>()">,
 def FEnumType : FIRRTLDialectType<CPred<"$_self.isa<FEnumType>()">,
  "FEnumType", "::circt::firrtl::FEnumType">;
 
+def StringType : FIRRTLDialectType<CPred<"$_self.isa<StringType>()">,
+  "StringType", "::circt::firrtl::StringType">;
+
 def AggregateType : FIRRTLDialectType<
   Or<[
     CPred<"$_self.isa<FVectorType>()">,
@@ -112,7 +115,7 @@ def RWProbe : FIRRTLDialectType<
    "rwprobe type", "::circt::firrtl::RefType">;
 
 // TODO: When Refs can appear within Base, need to disallow that too.
-def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
+def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType, StringType]>;
 def StrictConnectableType : AnyTypeOf<[PassiveType, ForeignType]>;
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -472,4 +472,23 @@ def RefImpl : FIRRTLImplType<"Ref",
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Non-Hardware Type Definitions
+//===----------------------------------------------------------------------===//
+
+def StringImpl : FIRRTLImplType<
+  "String", [PhasedTypeInterface], "circt::firrtl::FIRRTLType"> {
+  let summary = [{
+    An unlimited length string type. Not representable in hardware.
+    Commonly used as omir properties.
+  }];
+  let parameters = (ins "Phase":$phase);
+  let genVerifyDecl = true;
+  let genStorageClass = true;
+  let genAccessors = true;
+  let extraClassDeclaration = [{
+    bool isLegalInPhase(Phase phase) const { return getPhase() == phase; }
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -104,6 +104,12 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         printNestedType(refType.getType(), os);
         os << '>';
       })
+      .Case<StringType>([&](auto stringType) {
+        auto phase = stringType.getPhase();
+        if (phase != Phase::Hardware)
+          os << stringifyPhase(phase) << ".";
+        os << "string";
+      })
       .Default([&](auto) { anyFailed = true; });
   return failure(anyFailed);
 }
@@ -121,6 +127,22 @@ void circt::firrtl::printNestedType(Type type, AsmPrinter &os) {
 //===----------------------------------------------------------------------===//
 // Type Parsing
 //===----------------------------------------------------------------------===//
+
+/// Parse a type that has a phase qualifier.
+/// ```plain
+/// firrtl-phased-type ::= string
+/// ```
+static OptionalParseResult parsePhaseQualifiedType(AsmParser &parser,
+                                                   StringRef name, Phase phase,
+                                                   Type &result) {
+  auto *context = parser.getContext();
+  if (name.equals("string")) {
+    result = StringType::get(context, phase);
+    return success();
+  }
+  parser.emitError(parser.getNameLoc(), "expected phase-qualified type");
+  return failure();
+}
 
 /// Parse a type with a custom parser implementation.
 ///
@@ -143,12 +165,16 @@ void circt::firrtl::printNestedType(Type type, AsmPrinter &os) {
 ///   ::= enum '<' (enum-elt (',' enum-elt)*)? '>'
 ///   ::= vector '<' type ',' int '>'
 ///   ::= const '.' type
-///
+///   ::= 'property.' firrtl-phased-type
 /// bundle-elt ::= identifier flip? ':' type
 /// enum-elt ::= identifier ':' type
 /// ```
 static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
                                             Type &result) {
+  if (name.consume_front("property.")) {
+    return parsePhaseQualifiedType(parser, name, Phase::Property, result);
+  }
+
   bool isConst = false;
   const char constPrefix[] = "const.";
   if (name.starts_with(constPrefix)) {
@@ -347,6 +373,18 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
       return failure();
 
     return result = RefType::get(type, true), success();
+  }
+  if (name.equals("string")) {
+    if (isConst) {
+      parser.emitError(parser.getNameLoc(), "strings cannot be const");
+      return failure();
+    }
+    auto type =
+        parser.getChecked<StringType>(parser.getContext(), Phase::Hardware);
+    if (!type)
+      return failure();
+    result = type;
+    return success();
   }
 
   return {};
@@ -1950,6 +1988,17 @@ AsyncResetType AsyncResetType::getConstType(bool isConst) {
 }
 
 //===----------------------------------------------------------------------===//
+// StringType
+//===----------------------------------------------------------------------===//
+
+LogicalResult StringType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                 Phase phase) {
+  if (phase == Phase::Hardware)
+    return emitError() << "strings are not representable in hardware";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // FIRRTLDialect
 //===----------------------------------------------------------------------===//
 
@@ -1957,7 +2006,7 @@ void FIRRTLDialect::registerTypes() {
   addTypes<SIntType, UIntType, ClockType, ResetType, AsyncResetType, AnalogType,
            // Derived Types
            BundleType, FVectorType, FEnumType, RefType, OpenBundleType,
-           OpenVectorType>();
+           OpenVectorType, StringType>();
 }
 
 // Get the bit width for this type, return None  if unknown. Unlike

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1462,3 +1462,19 @@ firrtl.module @EnumNestedConstRegReset(in %clock: !firrtl.clock, in %reset: !fir
   %r = firrtl.regreset %clock, %reset, %resetVal : !firrtl.clock, !firrtl.asyncreset, !firrtl.enum<a: const.uint<1>>, !firrtl.enum<a: const.uint<1>>
 }
 }
+
+// -----
+// hardware firrtl.string is invalid
+
+firrtl.circuit "HardwareString" {
+// expected-error @+1 {{strings are not representable in hardware}}
+firrtl.module @HardwareString(in %string: !firrtl.string) {}
+}
+
+// -----
+// const hardware firrtl.string is invalid
+
+firrtl.circuit "ConstHardwareString" {
+// expected-error @+1 {{strings cannot be const}}
+firrtl.module @ConstHardwareString(in %string: !firrtl.const.string) {}
+}

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -242,4 +242,10 @@ firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, 
   %b_1 = firrtl.opensubindex %b[1] : !firrtl.openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>
   %b_0_y = firrtl.opensubfield %b_0[y] : !firrtl.openbundle<x : uint<2>, y: probe<uint<2>>>
 }
+
+// CHECK-LABEL: StringTest
+// CHECK-SAME:  (in %in: !firrtl.property.string, out %out: !firrtl.property.string)
+firrtl.module @StringTest(in %in: !firrtl.property.string, out %out: !firrtl.property.string) {
+  firrtl.connect %out, %in : !firrtl.property.string, !firrtl.property.string
+}
 }


### PR DESCRIPTION
Add a new StringType to FIRRTL. Strings are used as metadata properties. Although string has an explicit phase, that phase must not be hardware (must be property phased). Ports with string types are input/output properties.