### PR TITLE
[FIRRTL] Handle flips in const connections

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -205,6 +205,7 @@ bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
 /// types with flips in different positions to be equivalent.
 bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
                               bool destFlip = false, bool srcFlip = false,
+                              bool destOuterTypeIsConst = false,
                               bool srcOuterTypeIsConst = false);
 
 /// Returns true if the destination is at least as wide as a source.  The source

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -195,6 +195,7 @@ public:
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
+                        bool destOuterTypeIsConst = false,
                         bool srcOuterTypeIsConst = false,
                         bool requireSameWidths = false);
 

--- a/test/Dialect/FIRRTL/connect-errors.fir
+++ b/test/Dialect/FIRRTL/connect-errors.fir
@@ -30,6 +30,16 @@ circuit PartialConnectMismatch:
 
 ;// -----
 
+circuit PartialConnectResetFlipMismatch:
+  module PartialConnectResetFlipMismatch:
+    output a: { flip a: Reset }
+    output b: { a: Reset }
+
+; expected-error @+1 {{cannot partially connect non-weakly-equivalent}}
+    b <- a
+
+;// -----
+
 circuit Bar:
   module Bar:
 ; expected-note @+1 {{destination}}

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -562,6 +562,18 @@ firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.const.uint<1>) {
 
 // -----
 
+// Non-const aggregates cannot be connected to const types.
+
+firrtl.circuit "test" {
+firrtl.module @test(in %in   : !firrtl.bundle<a: uint<1>>,
+                    out %out : !firrtl.const.bundle<a: uint<1>>) {
+  // expected-error @+1 {{type mismatch}}
+  firrtl.connect %out, %in : !firrtl.const.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
+}
+}
+
+// -----
+
 /// Const flip types cannot be connected to non-const flip types.
 
 firrtl.circuit "test" {
@@ -586,7 +598,7 @@ firrtl.module @test(in %in   : !firrtl.bundle<a flip: const.uint<1>>,
 
 // -----
 
-/// Non-const doube flip types cannot be connected to const.
+/// Non-const double flip types cannot be connected to const.
 
 firrtl.circuit "test" {
 firrtl.module @test(in %in   : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>,

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -551,11 +551,48 @@ firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.sint<1>) {
 
 // -----
 
-/// Non-const types cannot be connected to const types
+/// Non-const types cannot be connected to const types.
 
 firrtl.circuit "test" {
 firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.const.uint<1>) {
   // expected-error @+1 {{type mismatch}}
   firrtl.connect %b, %a : !firrtl.const.uint<1>, !firrtl.uint<1>
+}
+}
+
+// -----
+
+/// Const flip types cannot be connected to non-const flip types.
+
+firrtl.circuit "test" {
+firrtl.module @test(in %in   : !firrtl.const.bundle<a flip: uint<1>>,
+                    out %out : !firrtl.bundle<a flip: uint<1>>) {
+  // expected-error @+1 {{type mismatch}}
+  firrtl.connect %out, %in : !firrtl.bundle<a flip: uint<1>>, !firrtl.const.bundle<a flip: uint<1>>
+}
+}
+
+// -----
+
+/// Nested const flip types cannot be connected to non-const flip types.
+
+firrtl.circuit "test" {
+firrtl.module @test(in %in   : !firrtl.bundle<a flip: const.uint<1>>,
+                    out %out : !firrtl.bundle<a flip: uint<1>>) {
+  // expected-error @+1 {{type mismatch}}
+  firrtl.connect %out, %in : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: const.uint<1>>
+}
+}
+
+// -----
+
+/// Non-const doube flip types cannot be connected to const.
+
+firrtl.circuit "test" {
+firrtl.module @test(in %in   : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>,
+                    out %out : !firrtl.const.bundle<a flip: bundle<a flip: uint<1>>>) {
+  // expected-error @+1 {{type mismatch}}
+  firrtl.connect %out, %in : !firrtl.const.bundle<a flip: bundle<a flip: uint<1>>>, 
+                             !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
 }
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -226,4 +226,23 @@ firrtl.module @ConstToNonConstVec(in %in : !firrtl.const.vector<uint<1>, 3>, out
   firrtl.connect %out, %in : !firrtl.vector<uint<1>, 3>, !firrtl.const.vector<uint<1>, 3>
 }
 
+firrtl.module @NonConstToConstFlip(in %in   : !firrtl.bundle<a flip: uint<1>>,
+                                   out %out : !firrtl.const.bundle<a flip: uint<1>>) {
+  // CHECK: firrtl.connect %out, %in : !firrtl.const.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
+  firrtl.connect %out, %in : !firrtl.const.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
+}
+
+firrtl.module @NonConstToNestedConstFlip(in %in   : !firrtl.bundle<a flip: uint<1>>,
+                                         out %out : !firrtl.bundle<a flip: const.uint<1>>) {
+  // CHECK: firrtl.connect %out, %in : !firrtl.bundle<a flip: const.uint<1>>, !firrtl.bundle<a flip: uint<1>>
+  firrtl.connect %out, %in : !firrtl.bundle<a flip: const.uint<1>>, !firrtl.bundle<a flip: uint<1>>
+}
+
+firrtl.module @ConstToNonConstDoubleFlipp(in %in : !firrtl.const.bundle<a flip: bundle<a flip: uint<1>>>, 
+                                          out %out : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>) {
+  // CHECK: firrtl.connect %out, %in :
+  // CHECK-SAME: !firrtl.bundle<a flip: bundle<a flip: uint<1>>>, !firrtl.const.bundle<a flip: bundle<a flip: uint<1>>>
+  firrtl.connect %out, %in : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>, 
+                             !firrtl.const.bundle<a flip: bundle<a flip: uint<1>>>
+}
 }


### PR DESCRIPTION
Addresses #5209 

I can also update `areTypesWeaklyEquivalent`, although `const` types were introduced into the firrtl spec in the same version that removed partial connection, so I suppose I can leave it. Or I can remove all of the const logic it has to clean things up.