### PR TITLE
[DC] Add merge operation

### DIFF
--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -219,4 +219,16 @@ def UnpackOp : DCOp<"unpack", [InferTypeOpInterface]> {
     }];
 }
 
+def MergeOp : DCOp<"merge"> {
+  let summary = "Merge operation";
+  let description = [{
+    Non-deterministically selects one of the incoming tokens and emits an output
+    stating which token was selected.
+  }];
+
+  let arguments = (ins TokenType:$first, TokenType:$second);
+  let results = (outs I1ValueType:$output);
+  let assemblyFormat = "$first `,` $second attr-dict";
+}
+
 #endif // CIRCT_DIALECT_DC_OPS_TD

--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -222,8 +222,10 @@ def UnpackOp : DCOp<"unpack", [InferTypeOpInterface]> {
 def MergeOp : DCOp<"merge"> {
   let summary = "Merge operation";
   let description = [{
-    Non-deterministically selects one of the incoming tokens and emits an output
-    stating which token was selected.
+    Select one of the incoming tokens and emits an output stating which token
+    was selected. If multiple tokens are ready to transact at the same time,
+    the tokens are selected with priority, from first to last (i.e. left to right
+    in the IR). This property ensures deterministic behavior.
   }];
 
   let arguments = (ins TokenType:$first, TokenType:$second);

--- a/test/Dialect/DC/roundtrip.mlir
+++ b/test/Dialect/DC/roundtrip.mlir
@@ -8,7 +8,8 @@
 // CHECK:           %[[VAL_4:.*]] = dc.buffer[2] %[[VAL_1]] [1, 2] : !dc.value<i1>
 // CHECK:           %[[VAL_5:.*]]:2 = dc.fork [2] %[[VAL_0]]
 // CHECK:           %[[VAL_6:.*]] = dc.pack %[[VAL_0]]{{\[}}%[[VAL_2]]] : i32
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i1>
+// CHECK:           %[[VAL_7:.*]] = dc.merge %[[VAL_3]], %[[VAL_0]]
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i1>
 // CHECK:           hw.output
 // CHECK:         }
 hw.module @foo(%0 : !dc.token, %1 : !dc.value<i1>, %2 : i32) {
@@ -16,5 +17,6 @@ hw.module @foo(%0 : !dc.token, %1 : !dc.value<i1>, %2 : i32) {
   %bufferInit = dc.buffer [2] %1 [1, 2] : !dc.value<i1>
   %f1, %f2 = dc.fork [2] %0
   %pack = dc.pack %0 [%2] : i32
+  %merge = dc.merge %buffer, %0
   %unpack_token, %unpack_value = dc.unpack %1 : !dc.value<i1>
 }


### PR DESCRIPTION
Looks like we're going to have to introduce a possibility for non-determinism in DC to make it generally applicable.

`dc.merge` will non-deterministically select one of the incoming tokens and emit an output (`dc.value<i1>`) stating which token was selected.
