### PR TITLE
[WireDFT] Add support for wiring optional clock div bypass signal.

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -92,6 +92,8 @@ constexpr const char *metadataDirectoryAttrName =
 constexpr const char *noDedupAnnoClass = "firrtl.transforms.NoDedupAnnotation";
 constexpr const char *dftTestModeEnableAnnoClass =
     "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation";
+constexpr const char *dftClockDividerBypassAnnoClass =
+    "sifive.enterprise.firrtl.DFTClockDividerBypassAnnotation";
 
 // Grand Central Annotations
 constexpr const char *serializedViewAnnoClass =

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -546,6 +546,7 @@ static const llvm::StringMap<AnnoRecord> annotationRecords{{
     {extractAssumeAnnoClass, NoTargetAnnotation},
     {extractCoverageAnnoClass, NoTargetAnnotation},
     {dftTestModeEnableAnnoClass, {stdResolve, applyWithoutTarget<true>}},
+    {dftClockDividerBypassAnnoClass, {stdResolve, applyWithoutTarget<true>}},
     {runFIRRTLTransformAnnoClass, {noResolve, drop}},
     {mustDedupAnnoClass, NoTargetAnnotation},
     {addSeqMemPortAnnoClass, NoTargetAnnotation},

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -162,16 +162,17 @@ void WireDFTPass::runOnOperation() {
       }
       return false;
     };
+    auto handleAnnotationChecks = [&](Value value, Annotation anno) {
+      return handleAnnotation(value, anno, dftTestModeEnableAnnoClass,
+                              enableSignal, enableModule) ||
+             handleAnnotation(value, anno, dftClockDividerBypassAnnoClass,
+                              clockDivBypassSignal, clockDivBypassModule);
+    };
 
     // See if this module has any port marked as the DFT enable.
     AnnotationSet::removePortAnnotations(
         module, [&](unsigned i, Annotation anno) {
-          return handleAnnotation(module.getArgument(i), anno,
-                                  dftTestModeEnableAnnoClass, enableSignal,
-                                  enableModule) ||
-                 handleAnnotation(module.getArgument(i), anno,
-                                  dftClockDividerBypassAnnoClass,
-                                  clockDivBypassSignal, clockDivBypassModule);
+          return handleAnnotationChecks(module.getArgument(i), anno);
         });
     if (error)
       return signalPassFailure();
@@ -184,12 +185,7 @@ void WireDFTPass::runOnOperation() {
         return WalkResult::advance();
 
       AnnotationSet::removeAnnotations(op, [&](Annotation anno) {
-        return handleAnnotation(op->getResult(0), anno,
-                                dftTestModeEnableAnnoClass, enableSignal,
-                                enableModule) ||
-               handleAnnotation(op->getResult(0), anno,
-                                dftClockDividerBypassAnnoClass,
-                                clockDivBypassSignal, clockDivBypassModule);
+        return handleAnnotationChecks(op->getResult(0), anno);
       });
       if (error)
         return WalkResult::interrupt();

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -332,10 +332,15 @@ void WireDFTPass::runOnOperation() {
     // bypass wiring. Check name against magic as well for now.
     if (clockDivBypassSignal && ext.getNumPorts() > clockDivBypassPortNo) {
       if (ext.getPortDirection(clockDivBypassPortNo) == Direction::In &&
-          ext.getPortType(clockDivBypassPortNo) == uint1Type &&
-          ext.getPortName(clockDivBypassPortNo) ==
-              requiredClockDivBypassPortName)
-        clockGatesWithBypass.insert(cgnode);
+          ext.getPortType(clockDivBypassPortNo) == uint1Type) {
+        if (ext.getPortName(clockDivBypassPortNo) ==
+            requiredClockDivBypassPortName)
+          clockGatesWithBypass.insert(cgnode);
+        else
+          mlir::emitWarning(
+              ext.getPortLocation(clockDivBypassPortNo),
+              "compatible port in bypass position has wrong name, skipping");
+      }
     }
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -109,6 +109,10 @@ void WireDFTPass::runOnOperation() {
   Value enableSignal;
   FModuleOp enableModule;
 
+  // Optional extra signal: clockDivBypassSignal.
+  Value clockDivBypassSignal;
+  FModuleOp clockDivBypassModule;
+
   // Walk all modules looking for the DUT module and the annotated enable
   // signal.
   for (auto &op : *circuit.getBodyBlock()) {
@@ -135,25 +139,50 @@ void WireDFTPass::runOnOperation() {
     bool error = false;
     AnnotationSet::removePortAnnotations(module, [&](unsigned i,
                                                      Annotation anno) {
-      // If we have already encountered an error or this is not the right
-      // annotation kind, continue.
-      if (error || !anno.isClass(dftTestModeEnableAnnoClass))
+      // If we have already encountered an error, continue.
+      if (error)
         return false;
-      // If we have already found a DFT enable, emit an error.
-      if (enableSignal) {
-        auto diag =
-            module->emitError("more than one thing marked as a DFT enable");
-        diag.attachNote(enableSignal.getLoc()) << "first thing defined here";
-        error = true;
-        return false;
+
+      // Check for enable signal annotation.
+      if (anno.isClass(dftTestModeEnableAnnoClass)) {
+        // If we have already found a DFT enable, emit an error.
+        if (enableSignal) {
+          auto diag =
+              module->emitError("more than one thing marked as a DFT enable");
+          diag.attachNote(enableSignal.getLoc()) << "first thing defined here";
+          error = true;
+          return false;
+        }
+        // Grab the enable value and remove the annotation.
+        enableSignal =
+            getValueByFieldID(ImplicitLocOpBuilder::atBlockBegin(
+                                  module->getLoc(), module.getBodyBlock()),
+                              module.getArgument(i), anno.getFieldID());
+        enableModule = module;
+        return true;
       }
-      // Grab the enable value and remove the annotation.
-      enableSignal =
-          getValueByFieldID(ImplicitLocOpBuilder::atBlockBegin(
-                                module->getLoc(), module.getBodyBlock()),
-                            module.getArgument(i), anno.getFieldID());
-      enableModule = module;
-      return true;
+
+      // Check for clock div bypass signal.
+      if (anno.isClass(dftClockDividerBypassAnnoClass)) {
+        // If we have already found a DFT clock div bypass signal, emit an
+        // error.
+        if (clockDivBypassSignal) {
+          module->emitError(
+                    "more than one thing marked as a DFT clock div bypass")
+                  .attachNote(clockDivBypassSignal.getLoc())
+              << "first thing defined here";
+          error = true;
+          return false;
+        }
+        clockDivBypassSignal =
+            getValueByFieldID(ImplicitLocOpBuilder::atBlockBegin(
+                                  module->getLoc(), module.getBodyBlock()),
+                              module.getArgument(i), anno.getFieldID());
+        clockDivBypassModule = module;
+        return true;
+      }
+
+      return false;
     });
     if (error)
       return signalPassFailure();
@@ -161,23 +190,50 @@ void WireDFTPass::runOnOperation() {
     // Walk the module body looking for any operation marked as the DFT enable.
     auto walkResult = module->walk([&](Operation *op) {
       AnnotationSet::removeAnnotations(op, [&](Annotation anno) {
-        // If we have already encountered an error or this is not the right
-        // annotation kind, continue.
-        if (error || !anno.isClass(dftTestModeEnableAnnoClass))
+        // If we have already encountered an error, continue.
+        if (error)
           return false;
-        if (enableSignal) {
-          auto diag =
-              op->emitError("more than one thing marked as a DFT enable");
-          diag.attachNote(enableSignal.getLoc()) << "first thing defined here";
-          error = true;
-          return false;
+
+        // Check for enable signal annotation.
+        if (anno.isClass(dftTestModeEnableAnnoClass)) {
+          if (enableSignal) {
+            auto diag =
+                op->emitError("more than one thing marked as a DFT enable");
+            diag.attachNote(enableSignal.getLoc())
+                << "first thing defined here";
+            error = true;
+            return false;
+          }
+          // Grab the enable value and remove the annotation.
+          enableSignal = getValueByFieldID(
+              ImplicitLocOpBuilder::atBlockEnd(op->getLoc(), op->getBlock()),
+              op->getResult(0), anno.getFieldID());
+          enableModule = module;
+          return true;
         }
-        // Grab the enable value and remove the annotation.
-        enableSignal = getValueByFieldID(
-            ImplicitLocOpBuilder::atBlockEnd(op->getLoc(), op->getBlock()),
-            op->getResult(0), anno.getFieldID());
-        enableModule = module;
-        return true;
+
+        // Check for clock div bypass signal.
+        if (anno.isClass(dftClockDividerBypassAnnoClass)) {
+          // If we have already found a DFT clock div bypass signal, emit an
+          // error.
+          if (clockDivBypassSignal) {
+            op->emitError(
+                  "more than one thing marked as a DFT clock div bypass")
+                    .attachNote(clockDivBypassSignal.getLoc())
+                << "first thing defined here";
+            error = true;
+            return false;
+          }
+
+          // Grab the signal value and remove the annotation.
+          clockDivBypassSignal = getValueByFieldID(
+              ImplicitLocOpBuilder::atBlockEnd(op->getLoc(), op->getBlock()),
+              op->getResult(0), anno.getFieldID());
+          clockDivBypassModule = module;
+          return true;
+        }
+        // Not an annotation we're looking for.
+        return false;
       });
       if (error)
         return WalkResult::interrupt();
@@ -188,8 +244,15 @@ void WireDFTPass::runOnOperation() {
   }
 
   // No enable signal means we have no work to do.
-  if (!enableSignal)
+  if (!enableSignal) {
+    // Error if bypass is specified without enable.
+    if (clockDivBypassSignal) {
+      mlir::emitError(clockDivBypassSignal.getLoc(),
+                      "bypass signal specified without enable signal");
+      return signalPassFailure();
+    }
     return markAllAnalysesPreserved();
+  }
 
   // This pass requires a DUT.
   if (!dut) {
@@ -200,8 +263,9 @@ void WireDFTPass::runOnOperation() {
   auto &instanceGraph = getAnalysis<InstanceGraph>();
 
   // Find the LowestCommonAncestor node of all the nodes to be wired together,
-  // and collect all the ClockGate modules.
+  // and collect all the ClockGate modules.  Search under DUT.
   llvm::SetVector<InstanceRecord *> clockGates;
+  llvm::SetVector<InstanceRecord *> clockGatesWithBypass;
   auto *lca = lowestCommonAncestor(
       instanceGraph.lookup(dut), [&](InstanceRecord *node) {
         auto module = node->getTarget()->getModule();
@@ -210,8 +274,10 @@ void WireDFTPass::runOnOperation() {
           clockGates.insert(node);
           return true;
         }
-        // Return true if this is the module with the enable signal.
-        return node->getParent()->getModule() == enableModule;
+        // Return true if this is the module with the enable signal or the
+        // bypass signal.
+        return node->getParent()->getModule() == enableModule ||
+               node->getParent()->getModule() == clockDivBypassModule;
       });
 
   // If there are no clock gates under the DUT, we can stop now.
@@ -225,7 +291,13 @@ void WireDFTPass::runOnOperation() {
   // Language below reflects this as well.
   const unsigned testEnPortNo = 1;
 
+  const unsigned clockDivBypassPortNo = 3;
+
+  // Magic name for optional bypass signal.
+  StringRef requiredClockDivBypassPortName = "dft_clk_div_bypass";
+
   // Scan gathered clock gates and check for basic compatibility.
+  // Detect clock gates with bypass port while visiting each.
   for (auto *cgnode : clockGates) {
     auto module = cgnode->getTarget()->getModule();
     auto genErr = [&]() { return module.emitError("clock gate module "); };
@@ -255,6 +327,16 @@ void WireDFTPass::runOnOperation() {
       genErr() << "must have second port with input direction";
       return signalPassFailure();
     }
+
+    // If find expected port name + direction + type, this needs clock div
+    // bypass wiring. Check name against magic as well for now.
+    if (clockDivBypassSignal && ext.getNumPorts() > clockDivBypassPortNo) {
+      if (ext.getPortDirection(clockDivBypassPortNo) == Direction::In &&
+          ext.getPortType(clockDivBypassPortNo) == uint1Type &&
+          ext.getPortName(clockDivBypassPortNo) ==
+              requiredClockDivBypassPortName)
+        clockGatesWithBypass.insert(cgnode);
+    }
   }
 
   // Handle enable signal (only) outside DUT.
@@ -280,6 +362,35 @@ void WireDFTPass::runOnOperation() {
     }
   }
 
+  bool needsClockDivBypassWiring = !clockGatesWithBypass.empty();
+
+  // Handle bypass signal outside DUT (or the DUT+enable LCA).
+  // Compute separately for more specific diagnostic if unreachable,
+  // and use same LCA for wiring all signals.
+  if (needsClockDivBypassWiring &&
+      !instanceGraph.isAncestor(clockDivBypassModule, lca->getModule())) {
+    // Current LCA covers the clock gates we care about.
+    // Compute new LCA from bypass to that node.
+    lca = lowestCommonAncestor(
+        instanceGraph.getTopLevelNode(), [&](InstanceRecord *node) {
+          return node->getTarget() == lca ||
+                 node->getParent()->getModule() == clockDivBypassModule;
+        });
+    // Handle unreachable case.
+    if (!lca) {
+      auto diag = circuit.emitError(
+          "unable to connect bypass signal and DUT (and enable), may not "
+          "be reachable from top-level module");
+      diag.attachNote(clockDivBypassSignal.getLoc()) << "bypass signal here";
+      diag.attachNote(enableSignal.getLoc()) << "enable signal here";
+      diag.attachNote(dut.getLoc()) << "DUT here";
+      diag.attachNote(instanceGraph.getTopLevelModule().getLoc())
+          << "top-level module here";
+
+      return signalPassFailure();
+    }
+  }
+
   // Check all gates we're wiring are only within the DUT.
   if (!allUnder(clockGates.getArrayRef(), instanceGraph.lookup(dut))) {
     dut->emitError()
@@ -289,10 +400,6 @@ void WireDFTPass::runOnOperation() {
 
   // Stash some useful things.
   auto loc = lca->getModule().getLoc();
-  auto portName = StringAttr::get(&getContext(), "test_en");
-
-  // This maps an enable signal to each module.
-  DenseMap<InstanceGraphNode *, Value> signals;
 
   // Helper to insert a port into an instance op. We have to replace the whole
   // op and then keep the instance graph updated.
@@ -307,101 +414,123 @@ void WireDFTPass::runOnOperation() {
     return clone;
   };
 
-  // At this point we have found the enable signal, all important clock gates,
-  // and the ancestor of these. From here we need wire the enable signal
-  // upward to the LCA, and then wire the enable signal down to all clock
-  // gates.
+  // At this point we have found the enable and bypass signals, all important
+  // clock gates, and the ancestor of these. From here we need wire the
+  // enable/bypass signals upward to the LCA, and then wire those signals down
+  // to all clock gates.
 
-  // This first part wires the enable signal up ward to the LCA module.
-  auto *node = instanceGraph.lookup(enableModule);
-  auto signal = enableSignal;
-  PortInfo portInfo = {portName, uint1Type, Direction::Out, {}, loc};
-  while (node != lca) {
-    // If there is more than one parent the we are in trouble. We can't handle
-    // more than one enable signal to wire everywhere else.
-    if (!node->hasOneUse()) {
-      auto diag = emitError(enableSignal.getLoc(),
-                            "mutliple instantiations of the DFT enable signal");
-      auto it = node->usesBegin();
-      diag.attachNote((*it++)->getInstance()->getLoc())
-          << "first instance here";
-      diag.attachNote((*it)->getInstance()->getLoc()) << "second instance here";
-      return signalPassFailure();
-    }
+  auto wireUp = [&](Value startSignal, FModuleOp signalModule,
+                    StringAttr portName, StringRef portNameFriendly,
+                    unsigned targetPortNo, auto &targets) -> LogicalResult {
+    // This maps each module to its signal.
+    DenseMap<InstanceGraphNode *, Value> signals;
 
-    // Record the signal for this module.
-    signals[node] = signal;
+    // This first part wires the signal upward to the LCA module.
+    auto *node = instanceGraph.lookup(signalModule);
+    Value signal = startSignal;
+    PortInfo portInfo = {portName, uint1Type, Direction::Out, {}, loc};
+    while (node != lca) {
+      // If there is more than one parent the we are in trouble. We can't handle
+      // more than one enable signal to wire everywhere else.
+      if (!node->hasOneUse()) {
+        auto diag = emitError(startSignal.getLoc(),
+                              "multiple instantiations of the DFT ")
+                    << portNameFriendly << " signal";
+        auto it = node->usesBegin();
+        diag.attachNote((*it++)->getInstance()->getLoc())
+            << "first instance here";
+        diag.attachNote((*it)->getInstance()->getLoc())
+            << "second instance here";
+        return diag;
+      }
 
-    // Create an output port to this module.
-    auto module = cast<FModuleOp>(*node->getModule());
-    unsigned portNo = module.getNumPorts();
-    module.insertPorts({{portNo, portInfo}});
-    auto builder = ImplicitLocOpBuilder::atBlockEnd(module.getLoc(),
-                                                    module.getBodyBlock());
-    emitConnect(builder, module.getArgument(portNo), signal);
+      // Record the signal for this module.
+      signals[node] = signal;
 
-    // Add an output port to the instance of this module.
-    auto *instanceNode = (*node->usesBegin());
-    auto clone = insertPortIntoInstance(instanceNode, {portNo, portInfo});
+      // Create an output port to this module.
+      auto module = cast<FModuleOp>(*node->getModule());
+      unsigned portNo = module.getNumPorts();
+      module.insertPorts({{portNo, portInfo}});
+      auto builder = ImplicitLocOpBuilder::atBlockEnd(module.getLoc(),
+                                                      module.getBodyBlock());
+      emitConnect(builder, module.getArgument(portNo), signal);
 
-    // Set up for the next iteration.
-    signal = clone.getResult(portNo);
-    node = instanceNode->getParent();
-  }
-
-  // Record the enable signal in the LCA.
-  signals[node] = signal;
-
-  // Drill the enable signal to each of the leaf clock gates. We do this
-  // searching upward in the hiearchy until we find a module with the signal.
-  // This is a recursive function due to lazyness.
-  portInfo = {portName, uint1Type, Direction::In, {}, loc};
-  std::function<Value(InstanceGraphNode *)> getSignal =
-      [&](InstanceGraphNode *node) -> Value {
-    // Mutable signal reference.
-    auto &signal = signals[node];
-
-    // Early break if this module has already been wired.
-    if (signal)
-      return signal;
-
-    // Add an input signal to this module.
-    auto module = cast<FModuleOp>(*node->getModule());
-    unsigned portNo = module.getNumPorts();
-    module.insertPorts({{portNo, portInfo}});
-    auto arg = module.getArgument(portNo);
-
-    // Record the new signal.
-    signal = arg;
-
-    // Attach the input signal to each instance of this module.
-    for (auto *instanceNode : node->uses()) {
-      // Add an input signal to this instance op.
+      // Add an output port to the instance of this module.
+      auto *instanceNode = (*node->usesBegin());
       auto clone = insertPortIntoInstance(instanceNode, {portNo, portInfo});
 
-      // Wire the parent signal to the instance op.
-      auto *parent = instanceNode->getParent();
-      auto module = cast<FModuleOp>(*parent->getModule());
-      auto signal = getSignal(parent);
-      auto builder = ImplicitLocOpBuilder::atBlockEnd(module->getLoc(),
-                                                      module.getBodyBlock());
-      emitConnect(builder, clone.getResult(portNo), signal);
+      // Set up for the next iteration.
+      signal = clone.getResult(portNo);
+      node = instanceNode->getParent();
     }
 
-    return arg;
+    // Record the signal in the LCA.
+    signals[node] = signal;
+
+    // Drill the enable signal to each of the leaf clock gates. We do this
+    // searching upward in the hiearchy until we find a module with the signal.
+    // This is a recursive function due to lazyness.
+    portInfo = {portName, uint1Type, Direction::In, {}, loc};
+    std::function<Value(InstanceGraphNode *)> getSignal =
+        [&](InstanceGraphNode *node) -> Value {
+      // Mutable signal reference.
+      auto &signal = signals[node];
+
+      // Early break if this module has already been wired.
+      if (signal)
+        return signal;
+
+      // Add an input signal to this module.
+      auto module = cast<FModuleOp>(*node->getModule());
+      unsigned portNo = module.getNumPorts();
+      module.insertPorts({{portNo, portInfo}});
+      auto arg = module.getArgument(portNo);
+
+      // Record the new signal.
+      signal = arg;
+
+      // Attach the input signal to each instance of this module.
+      for (auto *instanceNode : node->uses()) {
+        // Add an input signal to this instance op.
+        auto clone = insertPortIntoInstance(instanceNode, {portNo, portInfo});
+
+        // Wire the parent signal to the instance op.
+        auto *parent = instanceNode->getParent();
+        auto module = cast<FModuleOp>(*parent->getModule());
+        auto signal = getSignal(parent);
+        auto builder = ImplicitLocOpBuilder::atBlockEnd(module->getLoc(),
+                                                        module.getBodyBlock());
+        emitConnect(builder, clone.getResult(portNo), signal);
+      }
+
+      return arg;
+    };
+
+    // Wire the signal to each clock gate using the helper above.
+    for (auto *instance : targets) {
+      auto *parent = instance->getParent();
+      auto module = cast<FModuleOp>(*parent->getModule());
+      auto builder = ImplicitLocOpBuilder::atBlockEnd(module->getLoc(),
+                                                      module.getBodyBlock());
+      emitConnect(
+          builder,
+          cast<InstanceOp>(*instance->getInstance()).getResult(targetPortNo),
+          getSignal(parent));
+    }
+    return success();
   };
 
-  // Wire the signal to each clock gate using the helper above.
-  for (auto *instance : clockGates) {
-    auto *parent = instance->getParent();
-    auto module = cast<FModuleOp>(*parent->getModule());
-    auto builder = ImplicitLocOpBuilder::atBlockEnd(module->getLoc(),
-                                                    module.getBodyBlock());
-    emitConnect(
-        builder,
-        cast<InstanceOp>(*instance->getInstance()).getResult(testEnPortNo),
-        getSignal(parent));
-  }
+  auto enablePortName = StringAttr::get(&getContext(), "test_en");
+  auto bypassPortName =
+      StringAttr::get(&getContext(), requiredClockDivBypassPortName);
+  if (failed(wireUp(enableSignal, enableModule, enablePortName, "enable",
+                    testEnPortNo, clockGates)))
+    return signalPassFailure();
+  if (needsClockDivBypassWiring &&
+      failed(wireUp(clockDivBypassSignal, clockDivBypassModule, bypassPortName,
+                    "clock divider bypass", clockDivBypassPortNo,
+                    clockGatesWithBypass)))
+    return signalPassFailure();
 
   // And we're done!
   markAnalysesPreserved<InstanceGraph>();

--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -20,7 +20,7 @@ firrtl.circuit "TwoDuts" {
 
 firrtl.circuit "TwoSignals" {
   firrtl.module @TwoSignals(in %test_en0: !firrtl.uint<1>) attributes {portAnnotations = [[{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]]} {
-    // expected-error @+2 {{more than one thing marked as a DFT enable}}
+    // expected-error @+2 {{more than one thing marked as sifive.enterprise.firrtl.DFTTestModeEnableAnnotation}}
     // expected-note  @-2 {{first thing defined here}}
     %test_en1 = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]}: !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -33,7 +33,7 @@ firrtl.circuit "TwoEnables" {
   firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
 
   firrtl.module @TestEn() {
-    // expected-error @+1 {{mutliple instantiations of the DFT enable signal}}
+    // expected-error @+1 {{multiple instantiations of the DFT enable signal}}
     %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
   }
   
@@ -62,6 +62,39 @@ firrtl.circuit "EnableNotReachable" {
   // expected-note @below {{top-level module here}}
   firrtl.module @EnableNotReachable() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+}
+
+// -----
+
+// Test bypass signal without enable.
+firrtl.circuit "BypassWithoutEnable" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  firrtl.module @BypassWithoutEnable() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // expected-error @below {{bypass signal specified without enable signal}}
+    %dft_clk_div_bypass = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTClockDividerBypassAnnotation"}]} : !firrtl.uint<1>
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_dft_clk_div_bypass, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+}
+
+// -----
+
+// Test bypass signal unreachable.
+// expected-error @below {{unable to connect bypass signal and DUT (and enable), may not be reachable from top-level module}}
+firrtl.circuit "BypassNotReachable" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  firrtl.module @Bypass() {
+    // expected-note @below {{bypass signal here}}
+    %dft_clk_div_bypass = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTClockDividerBypassAnnotation"}]} : !firrtl.uint<1>
+  }
+  // expected-note @below {{DUT here}}
+  // expected-note @below {{top-level module here}}
+  firrtl.module @BypassNotReachable() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // expected-note @below {{enable signal here}}
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    %eicg_in, %eicg_test_en, %eicg_en, %eicg_dft_clk_div_bypass, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock)
   }
 }
 

--- a/test/Dialect/FIRRTL/wire-dft.mlir
+++ b/test/Dialect/FIRRTL/wire-dft.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -firrtl-dft %s | FileCheck %s
+// RUN: circt-opt -firrtl-dft %s --verify-diagnostics | FileCheck %s
 
 // The clock gate corresponds to this FIRRTL external module:
 // ```firrtl
@@ -211,6 +211,8 @@ firrtl.circuit "EnableOutsideDUT2" {
 
 // Test ignore bypass with wrong port name or at different direction/type.
 firrtl.circuit "BypassWrong" {
+  // Warning if port is compatible but name doesn't match, conservatively skipping.
+  // expected-warning @below {{compatible port in bypass position has wrong name, skipping}}
   firrtl.extmodule @EICG_wrapper_wrongName(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in wrong_name: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_name"}
   firrtl.extmodule @EICG_wrapper_wrongType(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<3>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_type"}
   firrtl.extmodule @EICG_wrapper_wrongDirection(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_dir"}

--- a/test/Dialect/FIRRTL/wire-dft.mlir
+++ b/test/Dialect/FIRRTL/wire-dft.mlir
@@ -209,3 +209,28 @@ firrtl.circuit "EnableOutsideDUT2" {
   }
 }
 
+// Test ignore bypass with wrong port name or at different direction/type.
+firrtl.circuit "BypassWrong" {
+  firrtl.extmodule @EICG_wrapper_wrongName(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in wrong_name: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_name"}
+  firrtl.extmodule @EICG_wrapper_wrongType(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<3>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_type"}
+  firrtl.extmodule @EICG_wrapper_wrongDirection(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_dir"}
+
+  firrtl.extmodule @EICG_wrapper_right(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper_right"}
+
+  // No bypass wiring.
+  // CHECK-LABEL: @Gates(in %test_en: !firrtl.uint<1>)
+  firrtl.module private @Gates() {
+    %name_in, %name_test_en, %name_en, %name_wrong_name, %name_out = firrtl.instance name @EICG_wrapper_wrongName(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in wrong_name: !firrtl.uint<1>, out out: !firrtl.clock)
+    %type_in, %type_test_en, %type_en, %type_dft_clk_div_bypass, %type_out = firrtl.instance type @EICG_wrapper_wrongType(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, in dft_clk_div_bypass: !firrtl.uint<3>, out out: !firrtl.clock)
+
+    %dir_in, %dir_test_en, %dir_en, %dir_dft_clk_div_bypass, %dir_out = firrtl.instance dir @EICG_wrapper_wrongDirection(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out dft_clk_div_bypass: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+
+  firrtl.module @BypassWrong() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %test_en = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTTestModeEnableAnnotation"}]} : !firrtl.uint<1>
+    %dft_clk_div_bypass = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.DFTClockDividerBypassAnnotation"}]} : !firrtl.uint<1>
+
+    firrtl.instance g @Gates()
+  }
+}
+


### PR DESCRIPTION
If a signal is annotated as the clock divider bypass signal, wire it to clock gates that have the expected port.

Like `test_en` wiring the port number is hardcoded, but unlike test_en this ignores the "bypass" port if that port doesn't match the expected bypass port name/dir/type.

Warning is emitted if looks compatible but name doesn't match and bypass signal annotation is found.