### PR TITLE
[OM] Add a symbol reference attribute

### DIFF
--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -34,10 +34,10 @@ def ReferenceAttr : AttrDef<OMDialect, "Reference", [TypedAttrInterface]> {
   }];
 }
 
-def SymRefAttr : AttrDef<OMDialect, "SymRef", [TypedAttrInterface]> {
+def OMSymbolRefAttr : AttrDef<OMDialect, "SymbolRef", [TypedAttrInterface]> {
   let summary = "An attribute that wraps a FlatSymbolRefAttr type";
 
-  let mnemonic = "symRef";
+  let mnemonic = "sym_ref";
 
   let parameters = (ins
     "mlir::FlatSymbolRefAttr":$ref

--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -34,4 +34,22 @@ def ReferenceAttr : AttrDef<OMDialect, "Reference", [TypedAttrInterface]> {
   }];
 }
 
+def SymRefAttr : AttrDef<OMDialect, "SymRef", [TypedAttrInterface]> {
+  let summary = "An attribute that wraps a FlatSymbolRefAttr type";
+
+  let mnemonic = "symRef";
+
+  let parameters = (ins
+    "mlir::FlatSymbolRefAttr":$ref
+  );
+
+  let assemblyFormat = [{
+    `<` $ref `>`
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Type getType();
+  }];
+}
+
 #endif // CIRCT_DIALECT_OM_OMATTRIBUTES_TD

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -35,4 +35,11 @@ def ReferenceType : TypeDef<OMDialect, "Reference", []> {
   let mnemonic = "ref";
 }
 
+
+def SymRefType : TypeDef<OMDialect, "SymRef", []> {
+  let summary = "A type that represents a reference to a flat symbol reference.";
+
+  let mnemonic = "symRef";
+}
+
 #endif // CIRCT_DIALECT_OM_OMTYPES_TD

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -36,10 +36,10 @@ def ReferenceType : TypeDef<OMDialect, "Reference", []> {
 }
 
 
-def SymRefType : TypeDef<OMDialect, "SymRef", []> {
+def SymbolRefType : TypeDef<OMDialect, "SymbolRef", []> {
   let summary = "A type that represents a reference to a flat symbol reference.";
 
-  let mnemonic = "symRef";
+  let mnemonic = "sym_ref";
 }
 
 #endif // CIRCT_DIALECT_OM_OMTYPES_TD

--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -27,7 +27,9 @@ Type circt::om::ReferenceAttr::getType() {
   return ReferenceType::get(getContext());
 }
 
-Type circt::om::SymRefAttr::getType() { return SymRefType::get(getContext()); }
+Type circt::om::SymbolRefAttr::getType() {
+  return SymbolRefType::get(getContext());
+}
 
 void circt::om::OMDialect::registerAttributes() {
   addAttributes<

--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -27,6 +27,8 @@ Type circt::om::ReferenceAttr::getType() {
   return ReferenceType::get(getContext());
 }
 
+Type circt::om::SymRefAttr::getType() { return SymRefType::get(getContext()); }
+
 void circt::om::OMDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -80,12 +80,12 @@ om.class @NestedField4() {
 
 // CHECK-LABEL: @ReferenceParameter
 // CHECK-SAME: !om.ref
-// CHECK-SAME: !om.symRef
-om.class @ReferenceParameter(%arg0: !om.ref, %arg1: !om.symRef) {
+// CHECK-SAME: !om.sym_ref
+om.class @ReferenceParameter(%arg0: !om.ref, %arg1: !om.sym_ref) {
   // CHECK: om.class.field @myref
   om.class.field @myref, %arg0 : !om.ref
   // CHECK: om.class.field @sym
-  om.class.field @sym, %arg1 : !om.symRef
+  om.class.field @sym, %arg1 : !om.sym_ref
 }
 
 // CHECK-LABEL: @ReferenceConstant
@@ -95,8 +95,8 @@ om.class @ReferenceConstant() {
   // CHECK: om.class.field @myref, %[[const1]] : !om.ref
   om.class.field @myref, %0 : !om.ref
 
-  // CHECK: %[[const2:.+]] = om.constant #om.symRef<@A> : !om.symRef
-  %1 = om.constant #om.symRef<@A> : !om.symRef
-  // CHECK: om.class.field @sym, %[[const2]] : !om.symRef
-  om.class.field @sym, %1 : !om.symRef
+  // CHECK: %[[const2:.+]] = om.constant #om.sym_ref<@A> : !om.sym_ref
+  %1 = om.constant #om.sym_ref<@A> : !om.sym_ref
+  // CHECK: om.class.field @sym, %[[const2]] : !om.sym_ref
+  om.class.field @sym, %1 : !om.sym_ref
 }

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -80,14 +80,23 @@ om.class @NestedField4() {
 
 // CHECK-LABEL: @ReferenceParameter
 // CHECK-SAME: !om.ref
-om.class @ReferenceParameter(%arg0: !om.ref) {
+// CHECK-SAME: !om.symRef
+om.class @ReferenceParameter(%arg0: !om.ref, %arg1: !om.symRef) {
+  // CHECK: om.class.field @myref
   om.class.field @myref, %arg0 : !om.ref
+  // CHECK: om.class.field @sym
+  om.class.field @sym, %arg1 : !om.symRef
 }
 
 // CHECK-LABEL: @ReferenceConstant
 om.class @ReferenceConstant() {
-  // CHECK: %[[const:.+]] = om.constant #om.ref<<@A::@inst_1>> : !om.ref
+  // CHECK: %[[const1:.+]] = om.constant #om.ref<<@A::@inst_1>> : !om.ref
   %0 = om.constant #om.ref<#hw.innerNameRef<@A::@inst_1>> : !om.ref
-  // CHECK: om.class.field @myref, %[[const]] : !om.ref
+  // CHECK: om.class.field @myref, %[[const1]] : !om.ref
   om.class.field @myref, %0 : !om.ref
+
+  // CHECK: %[[const2:.+]] = om.constant #om.symRef<@A> : !om.symRef
+  %1 = om.constant #om.symRef<@A> : !om.symRef
+  // CHECK: om.class.field @sym, %[[const2]] : !om.symRef
+  om.class.field @sym, %1 : !om.symRef
 }


### PR DESCRIPTION
Add a flat symbol reference attribute to OM dialect. This is required in addition to the `InnerRefAttr` to store reference to modules.
This PR adds  the `Attribute`, the corresponding `Type` and a lit test.
We can bikeshed on the Attribute name, `symRef`.