### PR TITLE
[FIRRTL] Reject ref statements for some ports but not all.

### DIFF
--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1211,7 +1211,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: ref.define %agg_out, %[[AGG3_PROBE]]
     define agg_out = probe(agg3)
 
-    ; CHECK: %{{.+}}, %[[REM_R:.+]], %{{.+}}, %[[REM_R2:.+]], %[[REM_UNUSED_REF:.+]] = firrtl.instance rem
+    ; CHECK: %{{.+}}, %[[REM_R:.+]], %{{.+}}, %[[REM_R2:.+]] = firrtl.instance rem
     ; CHECK-NEXT: %[[REM_R2_1:.+]] = firrtl.ref.sub %[[REM_R2]][1]
     ; CHECK-NEXT: %[[REM_R2_1_A:.+]] = firrtl.ref.sub %[[REM_R2_1]][0]
     ; CHECK-NEXT: %[[READ_REM_R2_1_A:.+]] = firrtl.ref.resolve %[[REM_R2_1_A]]
@@ -1268,9 +1268,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output r : Probe<UInt<1>>
     output data : UInt<3>
     output r2 : Probe<{a : UInt<3>}[3]>
-    output no_ref_for_this : Probe<UInt<1>>
     ref r2 is "in"
     ref r is "path.to.internal.signal"
+
+
+  ; CHECK-LABEL: extmodule private @RefExtABI
+  ; CHECK-NOT: internalPaths
+  extmodule RefExtABI :
+    input in : UInt<1>
+    output r : Probe<UInt<1>>
+    output data : UInt<3>
+    output r2 : Probe<{a : UInt<3>}[3]>
+
 
   ; CHECK-LABEL: module private @ProbeInvalidate
   ; CHECK-NEXT: }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -478,6 +478,15 @@ circuit RefDupe:
     ref p is "a.z" ; expected-error {{duplicate ref statement for 'p'}}
 
 ;// -----
+; Either use ref statements or ABI, can't partially use ref statements.
+
+circuit MissingRef:
+  extmodule MissingRef:
+    output p : Probe<UInt<2>> ; expected-error {{no ref statement found for ref port "p"}}
+    output q : Probe<UInt<2>>
+    ref q is "foo.bar"
+
+;// -----
 
 circuit UnusedRef:
   extmodule UnusedRef:


### PR DESCRIPTION
For use w/deferred linking or the new ABI, ref statements are not required.  However, if they're present they must cover all ref ports on the module.

cc #4909.