### PR TITLE
[HW][SV] Allow control of initial blocks setting memories

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -917,6 +917,13 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
       emitGuardedDefine("ENABLE_INITIAL_REG_", "ENABLE_INITIAL_REG_",
                         StringRef(), "");
     });
+
+    b.create<sv::VerbatimOp>("\n// Include rmemory initializers in init "
+                             "blocks unless synthesis is set");
+    emitGuard("SYNTHESIS", [&] {
+      emitGuardedDefine("ENABLE_INITIAL_MEM_", "ENABLE_INITIAL_MEM_",
+                        StringRef(), "");
+    });
   }
 
   if (state.used_RANDOMIZE_GARBAGE_ASSIGN) {

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -478,7 +478,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
           b.getStringAttr(moduleNamespace.newName(reg.getName())));
 
     if (mem.initIsInline) {
-      b.create<sv::IfDefOp>("SYNTHESIS", std::function<void()>(), [&]() {
+      b.create<sv::IfDefOp>("ENABLE_INITIAL_MEM_", [&]() {
         b.create<sv::InitialOp>([&]() {
           b.create<sv::ReadMemOp>(reg, mem.initFilename,
                                   mem.initIsBinary
@@ -543,7 +543,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
     return;
 
   constexpr unsigned randomWidth = 32;
-  b.create<sv::IfDefOp>("SYNTHESIS", std::function<void()>(), [&]() {
+  b.create<sv::IfDefOp>("ENABLE_INITIAL_MEM_", [&]() {
     sv::RegOp randReg;
     SmallVector<sv::RegOp> randRegs;
     if (!disableRegRandomization) {

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -112,8 +112,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:      sv.passign %[[wslot]], %wo_data_0
 //CHECK-NEXT:    }
 //CHECK-NEXT:  }
-//CHECK-NEXT:  sv.ifdef "SYNTHESIS" {
-//CHECK-NEXT:  } else {
+//CHECK-NEXT:  sv.ifdef "ENABLE_INITIAL_MEM_" {
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
 //CHECK-NEXT:    }
 //CHECK-NEXT:    %_RANDOM_MEM = sv.reg : !hw.inout<i32>


### PR DESCRIPTION
Added a separate macro to bypass synthesis and enable initial blocks setting memories lowered through `HWMemSimImpl`.