### PR TITLE
[OMIR] Mark OMDontTouchedReferenceTarget dontTouch

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -253,6 +253,16 @@ static std::optional<Attribute> scatterOMIR(Attribute original,
           tracker.append("id", idAttr);
           tracker.append("target", StringAttr::get(ctx, value));
 
+          // Add the dontTouch annotation to the target for
+          // OMDontTouchedReferenceTarget.
+          if (tpe == "OMDontTouchedReferenceTarget") {
+            NamedAttrList dontTouchAnno;
+            dontTouchAnno.append("class",
+                                 StringAttr::get(ctx, dontTouchAnnoClass));
+            dontTouchAnno.append("target", StringAttr::get(ctx, value));
+            state.addToWorklistFn(DictionaryAttr::get(ctx, dontTouchAnno));
+          }
+
           state.addToWorklistFn(DictionaryAttr::get(ctx, tracker));
 
           return addID(tpe, value, idAttr);

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -32,7 +32,7 @@ circuit Foo : %[[
           {"info": "", "name": "b", "value": "OMInstanceTarget:~Foo|Foo"},
           {"info": "", "name": "c", "value": "OMMemberReferenceTarget:~Foo|Foo"},
           {"info": "", "name": "d", "value": "OMMemberInstanceTarget:~Foo|Foo"},
-          {"info": "", "name": "e", "value": "OMDontTouchedReferenceTarget:~Foo|Foo"},
+          {"info": "", "name": "e", "value": "OMDontTouchedReferenceTarget:~Foo|Foo>unsigned"},
           {"info": "", "name": "f", "value": "OMReferenceTarget:~Foo|Bar"},
           {"info": "", "name": "g", "value": "OMReferenceTarget:~Foo|Foo>signed"}
         ]
@@ -124,7 +124,7 @@ circuit Foo : %[[
 ; CHECK:       "name": "d"
 ; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo"
 ; CHECK:       "name": "e"
-; CHECK-NEXT:  "value": "OMDontTouchedReferenceTarget:~Foo|Foo"
+; CHECK-NEXT:  "value": "OMDontTouchedReferenceTarget:~Foo|Foo>unsigned_0"
 ; CHECK:       "name": "f"
 ; CHECK-NEXT:  "value": "OMReferenceTarget:~Foo|Bar"
 ; CHECK:       "name": "g",

--- a/test/Dialect/FIRRTL/omir.mlir
+++ b/test/Dialect/FIRRTL/omir.mlir
@@ -286,3 +286,4 @@ firrtl.circuit "Foo"  attributes {rawAnnotations = [
 // CHECK-SAME:    {class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[bID]] : i64}
 // CHECK-NEXT:  %g = firrtl.wire
 // CHECK-SAME:    {class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[gID]] : i64}
+// CHECK-SAME:    {class = "firrtl.transforms.DontTouchAnnotation"}


### PR DESCRIPTION
FIRRTL extensively uses "hasDontTouch" helper to check optimization block property but
it only checks symbols and dontTouchAnnotation.  Hence previously `OMDontTouchedReferenceTarget` 
did behave as an optimization blocker. This PR adds dontTouchAnnotation along with OMIRTracker so that 
we can get expected behavior.  