### PR TITLE
[SystemC] integration tests: avoid compile_commands.json in clang-tidy.

### DIFF
--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: clang-tidy, systemc
 // RUN: circt-translate %s --export-systemc > %t.cpp
-// RUN: clang-tidy --extra-arg=-frtti %t.cpp
+// RUN: clang-tidy --extra-arg=-frtti %t.cpp --
 
 emitc.include <"systemc.h">
 emitc.include <"tuple">

--- a/integration_test/Target/ExportSystemC/func.mlir
+++ b/integration_test/Target/ExportSystemC/func.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: clang-tidy
 // RUN: circt-translate %s --export-systemc > %t.cpp
-// RUN: clang-tidy --extra-arg=-frtti %t.cpp
+// RUN: clang-tidy --extra-arg=-frtti %t.cpp --
 
 emitc.include <"stdint.h">
 emitc.include <"functional">


### PR DESCRIPTION
If CXX compiler is not clang (or not same clang as clang-tidy used), build flags may not be appropriate (or valid) for use by clang-tidy.

Workaround by adding trailing '--'.

Fixes #5236.

See upstream
https://github.com/llvm/llvm-project/commit/626849c71e85d546a004cc91866beab610222194 .