### PR TITLE
[Pipeline] Add `pipeline.stage` op and rename others accordingly

### DIFF
--- a/docs/Dialects/Pipeline/RationalePipeline.md
+++ b/docs/Dialects/Pipeline/RationalePipeline.md
@@ -1,0 +1,115 @@
+# Pipeline Dialect Rationale
+
+This document describes various design points of the `pipeline` dialect, why it is
+the way it is, and current status. This follows in the spirit of other [MLIR
+Rationale docs](https://mlir.llvm.org/docs/Rationale/).
+
+## Introduction
+
+## Pipeline Phases
+
+A `pipeline.pipeline` operation can be used in a sequence of phases, each
+of which incrementally transforms the pipeline from being unscheduled towards
+being an RTL representation of a pipeline. Each phase is mutually exlusive,
+meaning that the "phase-defining" operations
+(`pipeline.ss, pipeline.ss.reg, pipeline.stage`) are not allowed to co-exist.
+
+### Phase 1: Unscheduled
+
+The highest-level phase that a pipeline may be in is the unscheduled phase.
+In this case, the body of the pipeline simply consists of a feed-forward set of
+operations representing a dataflow graph.
+
+```mlir
+%out = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32) {
+  ^bb0(%a0 : i32, %a1: i32, %g : i1):
+    %add0 = comb.add %a0, %a1 : i32
+    %add1 = comb.add %add0, %a0 : i32
+    %add2 = comb.add %add1, %add0 : i32
+    pipeline.return %add2 valid %s1_valid : i32
+}
+```
+
+### Phase 2: Scheduled
+
+Uisng e.g. the `pipeline-schedule-linear` pass, a pipeline may be scheduled wrt.
+an operator library denoting the latency of each operation. The result of a scheduling
+problem is the insertion of `pipeline.ss` operations into the pipeline body.
+`pipeline.ss` are stage separating operations denoting the end of a stage and the
+beginning of the next. The semantics are thus that **any SSA def-use edge that
+crosses a stage boundary is a pipeline register**.  
+Note that we also intend to add support for attaching multi-cycle latencies to
+SSA values in the future, which will allow for more fine-grained control over
+the registers in the pipeline.  
+Given these semantics, this phase represents an abstraction for retiming a
+pipeline, seeing as additional `pipeline.ss` operations may be inserted or 
+moved around without changing the semantics of the computation, only the
+latency characteristics of the pipeline.
+
+```mlir
+%out = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32) {
+^bb0(%a0 : i32, %a1: i32, %g : i1):
+  %add0 = comb.add %a0, %a1 : i32
+
+  %s0_valid = pipeline.ss enable %g
+  %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
+
+  %s1_valid = pipeline.ss enable %s0_valid
+  %add2 = comb.add %add1, %add0 : i32 // %add0 crosses multiple stages.
+
+  pipeline.return %add2 valid %s1_valid : i32
+}
+```
+
+### Phase 3: Register materialized
+
+Once the prior phase has been completed, pipeline registers must be materialized.  
+This amounts to a dataflow analysis to check the phase 2 property of def-use edges
+across pipeline stages, performed by the `pipeline-explicit-regs` pass.  
+The result of this is the change of `pipeline.ss` to `pipeline.ss.reg` operations.
+
+```mlir
+%0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
+^bb0(%a0: i32, %a1: i32, %g: i1):
+  %1 = comb.add %a0, %a1 : i32
+
+  %1_s0, %a0_s0, %valid = pipeline.ss.reg enable %g regs %1, %a0 : i32, i32
+  %2 = comb.add %1_s0, %a0_s0 : i32
+
+  %2_s1, %1_s1 %valid_3 = pipeline.ss.reg enable %valid regs %2, %1_s0 : i32, i32
+  %3 = comb.add %2_s1, %1_s1 : i32 // %1 from the entry stage is chained through both stage 1 and 2.
+
+  pipeline.return %3 valid %valid_3 : i32
+}
+```
+
+### Phase 4: Staged
+
+The final phase of a pipeline is the staged phase. In this stage, we break with the notion
+of a dataflow graph, and instead make each pipeline stage explicit, performed by the
+`pipeline-ss-to-stage` pass.
+A `pipeline.stage` is an operation with an explicit enable signal, a set of
+inputs and outputs.  The internal of a `pipeline.stage` is isolated from above, 
+ensuring that stage internals can exclusively access values that have been fed
+into the stage. The `pipeline.stage.return` operation determines which values 
+are to be registered, and returned as the stage output.  
+
+From here, a pipeline is ready to be lowered to a hardware representation.
+
+```mlir
+%0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
+^bb0(%a0: i32, %a1: i32, %arg2: i1):
+  %outputs:2, %valid = pipeline.stage ins %a0, %a1 enable %g : (i32, i32, i1) -> (i32, i32) {
+  ^bb0(%arg3: i32, %arg4: i32, %arg6: i1):
+    %2 = comb.add %arg3, %arg4 : i32
+    pipeline.stage.return regs %2, %arg3 valid %arg6 : (i32, i32)
+  }
+  %outputs_2:2, %valid_3 = pipeline.stage ins %outputs#0, %outputs#1 enable %valid : (i32, i32) -> (i32, i32) {
+  ^bb0(%arg3: i32, %arg4: i32, %arg5: i1):
+    %2 = comb.add %arg3, %arg4 : i32
+    pipeline.stage.return regs %2, %arg3 valid %arg5 : (i32, i32)
+  }
+  %1 = comb.add %outputs_2#0, %outputs_2#1 : i32
+  pipeline.return %1 valid %valid_3 : i32
+}
+```

--- a/docs/Dialects/Pipeline/_index.md
+++ b/docs/Dialects/Pipeline/_index.md
@@ -1,0 +1,4 @@
+# 'pipeline' Dialect
+
+[include "Dialects/Pipeline.md"]
+

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -87,10 +87,10 @@ def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
       ^bb0:(%arg0 : i32, %arg1: i32):
         %add0 = comb.add %arg0, %arg1 : i32
 
-        %s0_valid, %add0_r = pipeline.stage.register when %go regs (%add0: i32)
+        %s0_valid, %add0_r = pipeline.ss.reg enable %go regs (%add0: i32)
         %add1 = comb.add %add0_r, %arg0 : i32
   
-        %s1_valid, %add1_r = pipeline.stage.register when %g1 regs (%add1: i32)
+        %s1_valid, %add1_r = pipeline.ss.reg enable %g1 regs (%add1: i32)
         %add2 = comb.add %add1_r, %arg1 : i32
 
         pipeline.return %add2 valid %s1_valid : i32
@@ -126,82 +126,170 @@ def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
       return &region->front();
     }
 
-  }];
-}
+    // Returns the internal inputs of this pipeline.
+    ValueRange getInnerInputs() { return getBodyBlock()->getArguments().drop_back(1); }
 
-
-def PipelineStageOp : Op<Pipeline_Dialect, "stage", [
-    HasParent<"PipelineOp">
-  ]> {
-  let summary = "Pipeline pipeline stage.";
-  let description = [{
-    The `pipeline.stage` operation represents a stage separating register
-    in a pipeline. The stage does not define any explicit registers, but solely
-    defines a cut of a dataflow graph based on its lexical position in the
-    pipeline. Pipeline registers are made explicit through the register
-    materialization pass, wherein this op is replaced by
-    `pipeline.stage.register` operations.
-  }];
-
-  let arguments = (ins I1:$when);
-  let results = (outs I1:$valid);
-
-  let assemblyFormat = [{
-    `when` $when attr-dict
-  }];
-
-  let extraClassDeclaration = [{
-    // Returns the index of this stage in the pipeline.
-    unsigned index() {
-      auto stageOps = getOperation()->getParentOfType<PipelineOp>().getOps<PipelineStageOp>();
-      return std::distance(stageOps.begin(), llvm::find(stageOps, *this));
+    // Returns the internal enable signal of this pipeline.
+    Value getInnerEnable() {
+      return getBodyBlock()->getArguments().back();
     }
   }];
 }
 
-def PipelineStageRegisterOp : Op<Pipeline_Dialect, "stage.register", [
+
+def StageSeparatingOp : Op<Pipeline_Dialect, "ss", [
+    HasParent<"PipelineOp">
+  ]> {
+  let summary = "Pipeline **s**tage **s**eparating operation.";
+  let description = [{
+    The `pipeline.ss` operation represents a stage separation in a pipeline.
+    The delimiter does not define any explicit registers, but solely
+    defines a cut of a dataflow graph based on its lexical position in the
+    pipeline. Pipeline registers are made explicit through the register
+    materialization pass, wherein this op is replaced by `pipeline.stage`
+    operations.
+  }];
+
+  let arguments = (ins I1:$enable);
+  let results = (outs I1:$valid);
+
+  let assemblyFormat = [{
+    `enable` $enable attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    // Returns the index of this stage in the pipeline.
+    unsigned index();
+
+    ValueRange getInputs() { assert(false && "Unimplemented for `pipeline.ss`"); }
+    ValueRange getOutputs() { assert(false && "Unimplemented for `pipeline.ss`"); }
+  }];
+}
+
+def StageSeparatingRegOp : Op<Pipeline_Dialect, "ss.reg", [
     HasParent<"PipelineOp">,
-    RangedTypesMatchWith<"result type matches operand", "regIns", "regOuts",
+    RangedTypesMatchWith<"result type matches operand", "inputs", "outputs",
                          "llvm::make_range($_self.begin(), $_self.end())">
   ]> {
   let summary = "Pipeline pipeline stage.";
   let description = [{
-    The `pipeline.stage` operation represents a stage separating register
-    in a pipeline with materialized register values. `pipeline.stage` and
-    `pipeline.stage.register` operations are not allowed to co-exist in the
+    The `pipeline.ss.reg` operation represents a stage separating register
+    in a pipeline with materialized register values. `pipeline.ss` and
+    `pipeline.ss.reg` operations are not allowed to co-exist in the
     same pipeline body. This is because, once register values are materialized,
     all delays as well as knowledge about multicycle paths have been lowered
     away.
   }];
 
-  let arguments = (ins Variadic<AnyType>:$regIns, I1:$when);
-  let results = (outs Variadic<AnyType>:$regOuts, I1:$valid);
+  let arguments = (ins Variadic<AnyType>:$inputs, I1:$enable);
+  let results = (outs Variadic<AnyType>:$outputs, I1:$valid);
 
-  let builders = [OpBuilder<(ins "mlir::Value":$when, "mlir::ValueRange":$regIns)>];
+  let builders = [OpBuilder<(ins "mlir::Value":$enable, "mlir::ValueRange":$inputs)>];
 
   let assemblyFormat = [{
-    `when` $when (`regs` $regIns^)? attr-dict (`:` type($regIns)^)?
+    `enable` $enable (`regs` $inputs^)? attr-dict (`:` type($inputs)^)?
+  }];
+
+  let extraClassDeclaration = [{
+    // Returns the index of this stage in the pipeline.
+    unsigned index();
+  }];
+}
+
+
+def StageOp : Op<Pipeline_Dialect, "stage", [
+    HasParent<"PipelineOp">,
+    SingleBlockImplicitTerminator<"StageReturnOp">,
+    RegionKindInterface,
+    HasOnlyGraphRegion,
+    IsolatedFromAbove
+  ]> {
+  let summary = "Pipeline pipeline stage.";
+  let description = [{
+    The `pipeline.stage` operation represents a stage separating register
+    in a pipeline with materialized register values. `pipeline.ss` and
+    `pipeline.stage` operations are not allowed to co-exist in the
+    same pipeline body. This is because, once register values are materialized,
+    all delays as well as knowledge about multicycle paths have been lowered
+    away.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs, I1:$enable);
+  let results = (outs Variadic<AnyType>:$outputs, I1:$valid);
+  let regions = (region SizedRegion<1>: $body);
+  let hasVerifier = 1;
+
+
+  let skipDefaultBuilders = 1;
+  let builders = [OpBuilder<(ins 
+    "mlir::Value":$enable,
+    "mlir::ValueRange":$inputs,
+    "mlir::TypeRange":$outputs
+  )>];
+
+  let assemblyFormat = [{
+    `ins` ($inputs^)? `enable` $enable attr-dict `:` functional-type($inputs, $outputs) $body
   }];
 
   let extraClassDeclaration = [{
     // Returns the index of this stage in the pipeline.
     unsigned index() {
-      auto stageOps = getOperation()->getParentOfType<PipelineOp>().getOps<PipelineStageRegisterOp>();
+      auto stageOps = getOperation()->getParentOfType<PipelineOp>().getOps<StageOp>();
       return std::distance(stageOps.begin(), llvm::find(stageOps, *this));
+    }
+
+    /// Returns the body of a Pipeline stage.
+    Block *getBodyBlock() {
+      return &getOperation()->getRegion(0).front();
+    }
+
+    // Returns the internal `enable` signal.
+    Value getInnerEnable() {
+      return getBodyBlock()->getArguments().back();
+    }
+
+    // Returns the internal inputs of this stage.
+    ValueRange getInnerInputs() {
+      return getBodyBlock()->getArguments().drop_back(1);
     }
   }];
 }
 
-def ReturnOp : Op<Pipeline_Dialect, "return", [Terminator]> {
+def StageReturnOp : Op<Pipeline_Dialect, "stage.return", [
+    Terminator,
+    AttrSizedOperandSegments,
+    HasParent<"StageOp">
+  ]> {
+  let summary = "Pipeline stage return.";
+  let description = [{
+    The "stage.return" operation represents a terminator of a `pipeline.stage`.
+  }];
+
+  let hasVerifier = 1;
+  let arguments = (ins Variadic<AnyType>:$regs, Variadic<AnyType>:$passthroughs, I1:$valid);
+  let builders = [OpBuilder<(ins), [{ return; }]>];
+  let assemblyFormat = [{ (`regs` $regs^)? (`passthroughs` $passthroughs^)? `valid` $valid attr-dict (`:` `(` type($regs)^ `)`)? (`,` `(` type($passthroughs)^ `)` )? }];
+
+  let extraClassDeclaration = [{
+    // Assigns the operands of this stage return, as well as the required
+    // `operand_segment_sizes` attribute.
+    void setOperands(Value valid, ValueRange regs, ValueRange passthroughs);
+  }];
+}
+
+def ReturnOp : Op<Pipeline_Dialect, "return", [
+    Terminator,
+    HasParent<"PipelineOp">
+  ]> {
   let summary = "Pipeline dialect return.";
   let description = [{
     The "return" operation represents a terminator of a `pipeline.pipeline`.
   }];
 
   let hasVerifier = 1;
-  let arguments = (ins Variadic<AnyType>:$outputs, I1:$valid);
+  let arguments = (ins Variadic<AnyType>:$inputs, I1:$valid);
   let builders = [OpBuilder<(ins), [{ return; }]>];
-  let assemblyFormat = [{ ($outputs^)? `valid` $valid attr-dict (`:` type($outputs)^)? }];
+  let assemblyFormat = [{ ($inputs^)? `valid` $valid attr-dict (`:` type($inputs)^)? }];
 }
 
 #endif // PIPELINE_OPS

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -87,10 +87,10 @@ def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
       ^bb0:(%arg0 : i32, %arg1: i32):
         %add0 = comb.add %arg0, %arg1 : i32
 
-        %s0_valid, %add0_r = pipeline.ss.reg enable %go regs (%add0: i32)
+        %s0_valid, %add0_r = pipeline.stagesep.reg enable %go regs (%add0: i32)
         %add1 = comb.add %add0_r, %arg0 : i32
   
-        %s1_valid, %add1_r = pipeline.ss.reg enable %g1 regs (%add1: i32)
+        %s1_valid, %add1_r = pipeline.stagesep.reg enable %g1 regs (%add1: i32)
         %add2 = comb.add %add1_r, %arg1 : i32
 
         pipeline.return %add2 valid %s1_valid : i32
@@ -137,12 +137,12 @@ def PipelineOp : Op<Pipeline_Dialect, "pipeline", [
 }
 
 
-def StageSeparatingOp : Op<Pipeline_Dialect, "ss", [
+def StageSeparatingOp : Op<Pipeline_Dialect, "stagesep", [
     HasParent<"PipelineOp">
   ]> {
   let summary = "Pipeline **s**tage **s**eparating operation.";
   let description = [{
-    The `pipeline.ss` operation represents a stage separation in a pipeline.
+    The `pipeline.stagesep` operation represents a stage separation in a pipeline.
     The delimiter does not define any explicit registers, but solely
     defines a cut of a dataflow graph based on its lexical position in the
     pipeline. Pipeline registers are made explicit through the register
@@ -160,22 +160,19 @@ def StageSeparatingOp : Op<Pipeline_Dialect, "ss", [
   let extraClassDeclaration = [{
     // Returns the index of this stage in the pipeline.
     unsigned index();
-
-    ValueRange getInputs() { assert(false && "Unimplemented for `pipeline.ss`"); }
-    ValueRange getOutputs() { assert(false && "Unimplemented for `pipeline.ss`"); }
   }];
 }
 
-def StageSeparatingRegOp : Op<Pipeline_Dialect, "ss.reg", [
+def StageSeparatingRegOp : Op<Pipeline_Dialect, "stagesep.reg", [
     HasParent<"PipelineOp">,
     RangedTypesMatchWith<"result type matches operand", "inputs", "outputs",
                          "llvm::make_range($_self.begin(), $_self.end())">
   ]> {
   let summary = "Pipeline pipeline stage.";
   let description = [{
-    The `pipeline.ss.reg` operation represents a stage separating register
-    in a pipeline with materialized register values. `pipeline.ss` and
-    `pipeline.ss.reg` operations are not allowed to co-exist in the
+    The `pipeline.stagesep.reg` operation represents a stage separating register
+    in a pipeline with materialized register values. `pipeline.stagesep` and
+    `pipeline.stagesep.reg` operations are not allowed to co-exist in the
     same pipeline body. This is because, once register values are materialized,
     all delays as well as knowledge about multicycle paths have been lowered
     away.
@@ -207,7 +204,7 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
   let summary = "Pipeline pipeline stage.";
   let description = [{
     The `pipeline.stage` operation represents a stage separating register
-    in a pipeline with materialized register values. `pipeline.ss` and
+    in a pipeline with materialized register values. `pipeline.stagesep` and
     `pipeline.stage` operations are not allowed to co-exist in the
     same pipeline body. This is because, once register values are materialized,
     all delays as well as knowledge about multicycle paths have been lowered
@@ -268,7 +265,9 @@ def StageReturnOp : Op<Pipeline_Dialect, "stage.return", [
   let hasVerifier = 1;
   let arguments = (ins Variadic<AnyType>:$regs, Variadic<AnyType>:$passthroughs, I1:$valid);
   let builders = [OpBuilder<(ins), [{ return; }]>];
-  let assemblyFormat = [{ (`regs` $regs^)? (`passthroughs` $passthroughs^)? `valid` $valid attr-dict (`:` `(` type($regs)^ `)`)? (`,` `(` type($passthroughs)^ `)` )? }];
+  let assemblyFormat = [{ (`regs` $regs^)? (`passthroughs` $passthroughs^)?
+      `valid` $valid attr-dict (`:` `(` type($regs)^ `)`)?
+      (`,` `(` type($passthroughs)^ `)` )? }];
 
   let extraClassDeclaration = [{
     // Assigns the operands of this stage return, as well as the required

--- a/include/circt/Dialect/Pipeline/PipelinePasses.h
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.h
@@ -22,6 +22,7 @@ namespace circt {
 namespace pipeline {
 
 std::unique_ptr<mlir::Pass> createExplicitRegsPass();
+std::unique_ptr<mlir::Pass> createStageSeparatorToStagePass();
 std::unique_ptr<mlir::Pass> createScheduleLinearPipelinePass();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/Pipeline/PipelinePasses.td
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.td
@@ -25,6 +25,16 @@ def ExplicitRegs : Pass<"pipeline-explicit-regs", "pipeline::PipelineOp"> {
   let constructor = "circt::pipeline::createExplicitRegsPass()";
 }
 
+def StageSeparatorToStage : Pass<"pipeline-ss-to-stage", "pipeline::PipelineOp"> {
+  let summary = "Lowers pipeline stage separations (`pipeline.ss`) into explicit stages.";
+  let description = [{
+    Lowers pipeline stage separations (`pipeline.ss`) into explicit stages.
+  }];
+  let dependentDialects = ["hw::HWDialect"];
+  let constructor = "circt::pipeline::createStageSeparatorToStagePass()";
+}
+
+
 def ScheduleLinearPipeline : Pass<"pipeline-schedule-linear", "pipeline::PipelineOp"> {
   let summary = "Schedules a linear pipeline.";
   let description = [{

--- a/include/circt/Dialect/Pipeline/PipelinePasses.td
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.td
@@ -26,9 +26,9 @@ def ExplicitRegs : Pass<"pipeline-explicit-regs", "pipeline::PipelineOp"> {
 }
 
 def StageSeparatorToStage : Pass<"pipeline-ss-to-stage", "pipeline::PipelineOp"> {
-  let summary = "Lowers pipeline stage separations (`pipeline.ss`) into explicit stages.";
+  let summary = "Lowers pipeline stage separations (`pipeline.stagesep`) into explicit stages.";
   let description = [{
-    Lowers pipeline stage separations (`pipeline.ss`) into explicit stages.
+    Lowers pipeline stage separations (`pipeline.stagesep`) into explicit stages.
   }];
   let dependentDialects = ["hw::HWDialect"];
   let constructor = "circt::pipeline::createStageSeparatorToStagePass()";

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -58,15 +58,13 @@ LogicalResult PipelineOp::verify() {
              << ".";
   }
 
-  // Check mixing of `pipeline.stage` and `pipeline.stage.register` ops.
-  // This verifier thus ensures a proper phase ordering between stage ops
-  // and their materialized stage register op counterparts.
-  bool hasStageOps = !getOps<PipelineStageOp>().empty();
-  bool hasStageRegOps = !getOps<PipelineStageRegisterOp>().empty();
-
-  if (hasStageOps && hasStageRegOps)
-    return emitOpError("mixing `pipeline.stage` and `pipeline.stage.register` "
-                       "ops is illegal.");
+  // Check mixing of stage-like operations. These are not allowed to coexist.
+  bool hasDelimiterOps = !getOps<StageSeparatingOp>().empty();
+  bool hasDelimiterRegsOps = !getOps<StageSeparatingRegOp>().empty();
+  bool hasStageOps = !getOps<StageOp>().empty();
+  size_t phaseKinds = hasDelimiterOps + hasDelimiterRegsOps + hasStageOps;
+  if (phaseKinds > 1)
+    return emitOpError("pipeline contains a mix of stage-like operations.");
 
   return success();
 }
@@ -80,23 +78,56 @@ bool PipelineOp::isLatencyInsensitive() {
   return allInputsAreChannels && allOutputsAreChannels;
 }
 
+// ===----------------------------------------------------------------------===//
+// DelimiterOp
+// ===----------------------------------------------------------------------===//
+
+// Returns the index of this stage in the pipeline.
+unsigned StageSeparatingOp::index() {
+  auto stageOps =
+      getOperation()->getParentOfType<PipelineOp>().getOps<StageSeparatingOp>();
+  return std::distance(stageOps.begin(), llvm::find(stageOps, *this));
+}
+
+// ===----------------------------------------------------------------------===//
+// DelimiterRegisterOp
+// ===----------------------------------------------------------------------===//
+
+unsigned StageSeparatingRegOp::index() {
+  auto stageOps = getOperation()
+                      ->getParentOfType<PipelineOp>()
+                      .getOps<StageSeparatingRegOp>();
+  return std::distance(stageOps.begin(), llvm::find(stageOps, *this));
+}
+
+void StageSeparatingRegOp::build(OpBuilder &builder, OperationState &state,
+                                 Value enable, ValueRange inputs) {
+  StageSeparatingRegOp::build(builder, state, inputs.getTypes(), inputs,
+                              enable);
+  state.addTypes({enable.getType()});
+}
+
 //===----------------------------------------------------------------------===//
 // ReturnOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReturnOp::verify() {
   PipelineOp parent = getOperation()->getParentOfType<PipelineOp>();
-  if (getOutputs().size() != parent.getResults().size())
+  if (getInputs().size() != parent.getResults().size())
     return emitOpError("expected ")
            << parent.getResults().size() << " return values, got "
-           << getOutputs().size() << ".";
+           << getInputs().size() << ".";
 
   bool isLatencyInsensitive = parent.isLatencyInsensitive();
   for (size_t i = 0; i < parent.getResults().size(); i++) {
     Type expectedType = parent.getResultTypes()[i];
     Type actualType = getOperandTypes()[i];
-    if (isLatencyInsensitive)
-      expectedType = expectedType.cast<esi::ChannelType>().getInner();
+    if (isLatencyInsensitive) {
+      expectedType = expectedType.dyn_cast<esi::ChannelType>().getInner();
+      if (!expectedType)
+        return emitOpError("expected ESI channel type, got ")
+               << parent.getResultTypes()[i] << ".";
+    }
     if (expectedType != actualType)
       return emitOpError("expected argument ")
              << i << " to have type " << expectedType << ", got " << actualType
@@ -107,14 +138,88 @@ LogicalResult ReturnOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// PipelineStageRegisterOp
+// StageOp
 //===----------------------------------------------------------------------===//
 
-void PipelineStageRegisterOp::build(OpBuilder &builder, OperationState &state,
-                                    Value when, ValueRange regIns) {
-  PipelineStageRegisterOp::build(builder, state, regIns.getTypes(), regIns,
-                                 when);
-  state.addTypes({when.getType()});
+void StageOp::build(OpBuilder &builder, OperationState &odsState, Value enable,
+                    ValueRange inputs, TypeRange outputs) {
+  odsState.addOperands(inputs);
+  odsState.addOperands(enable);
+  odsState.addTypes(outputs);
+  // Valid output
+  odsState.addTypes(builder.getI1Type());
+
+  // Build inner region.
+  Region *region = odsState.addRegion();
+  Block *bodyBlock = new Block();
+  region->push_back(bodyBlock);
+  bodyBlock->addArguments(
+      inputs.getTypes(),
+      SmallVector<Location>(inputs.size(), odsState.location));
+  bodyBlock->addArguments({enable.getType()},
+                          SmallVector<Location>(1, odsState.location));
+  StageOp::ensureTerminator(*region, builder, odsState.location);
+}
+
+LogicalResult StageOp::verify() {
+  auto inputs = getInputs();
+  if (getBodyBlock()->getNumArguments() != (inputs.size() + /*valid*/ 1))
+    return emitOpError("expected ")
+           << inputs.size() + 1
+           << " arguments in the pipeline stage body block, got "
+           << getBodyBlock()->getNumArguments() << ".";
+
+  for (size_t i = 0; i < inputs.size(); i++) {
+    Type expectedInArg = inputs[i].getType();
+    Type bodyArg = getBodyBlock()->getArgument(i).getType();
+    if (expectedInArg != bodyArg)
+      return emitOpError("expected stage body block argument ")
+             << i << " to have type " << expectedInArg << ", got " << bodyArg
+             << ".";
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// StageReturnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StageReturnOp::verify() {
+  StageOp parent = getOperation()->getParentOfType<StageOp>();
+  size_t nRetVals = getRegs().size() + getPassthroughs().size();
+  if (nRetVals != parent.getOutputs().size())
+    return emitOpError("expected ")
+           << parent.getOutputs().size() << " return values, got " << nRetVals
+           << ".";
+
+  llvm::SmallVector<Type> retTypes;
+  llvm::append_range(retTypes, getRegs().getTypes());
+  llvm::append_range(retTypes, getPassthroughs().getTypes());
+  for (size_t i = 0; i < parent.getOutputs().size(); i++) {
+    Type expectedType = parent.getOutputs().getTypes()[i];
+    Type actualType = retTypes[i];
+    if (expectedType != actualType)
+      return emitOpError("expected argument ")
+             << i << " to have type " << expectedType << ", got " << actualType
+             << ".";
+  }
+
+  return success();
+}
+
+void StageReturnOp::setOperands(Value valid, ValueRange regs,
+                                ValueRange passthroughs) {
+  getOperation()->insertOperands(0, regs);
+  getOperation()->insertOperands(regs.size(), passthroughs);
+  getOperation()->insertOperands(regs.size() + passthroughs.size(), {valid});
+  llvm::SmallVector<int32_t, 3> operandSizes;
+  operandSizes.push_back(regs.size());
+  operandSizes.push_back(passthroughs.size());
+  operandSizes.push_back(1);
+  getOperation()->setAttr(
+      "operand_segment_sizes",
+      mlir::DenseI32ArrayAttr::get(getContext(), operandSizes));
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -79,7 +79,7 @@ bool PipelineOp::isLatencyInsensitive() {
 }
 
 // ===----------------------------------------------------------------------===//
-// DelimiterOp
+// StageSeparatingOp
 // ===----------------------------------------------------------------------===//
 
 // Returns the index of this stage in the pipeline.
@@ -90,7 +90,7 @@ unsigned StageSeparatingOp::index() {
 }
 
 // ===----------------------------------------------------------------------===//
-// DelimiterRegisterOp
+// StageSeparatingRegOp
 // ===----------------------------------------------------------------------===//
 
 unsigned StageSeparatingRegOp::index() {

--- a/lib/Dialect/Pipeline/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Pipeline/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTPipelineTransforms
   ExplicitRegs.cpp
   ScheduleLinearPipeline.cpp
+  StageSeparatorToStage.cpp
 
   DEPENDS
   CIRCTPipelineTransformsIncGen

--- a/lib/Dialect/Pipeline/Transforms/StageSeparatorToStage.cpp
+++ b/lib/Dialect/Pipeline/Transforms/StageSeparatorToStage.cpp
@@ -1,0 +1,148 @@
+//===- StageSeparatorToStage.cpp - Explicit regs pass ------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the delimiter-to-stage lowering pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Support/BackedgeBuilder.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace pipeline;
+
+namespace {
+
+class StageSeparatorToStagePass
+    : public StageSeparatorToStageBase<StageSeparatorToStagePass> {
+public:
+  void runOnOperation() override;
+
+private:
+  // Returns the operations which resides within each stage.
+  llvm::DenseMap<StageSeparatingRegOp, llvm::SmallVector<Operation *>>
+  gatherStageOps();
+
+  // The pipeline operation to be converted.
+  PipelineOp pipeline;
+};
+
+} // end anonymous namespace
+
+llvm::DenseMap<StageSeparatingRegOp, llvm::SmallVector<Operation *>>
+StageSeparatorToStagePass::gatherStageOps() {
+  auto stageSeparators = pipeline.getOps<StageSeparatingRegOp>();
+  StageSeparatingRegOp currentSeparator = *stageSeparators.begin();
+  auto setNextSeparator = [&]() {
+    auto next =
+        std::next(llvm::find_if(stageSeparators, [&](StageSeparatingRegOp op) {
+          return op == currentSeparator;
+        }));
+    if (next == stageSeparators.end()) {
+      currentSeparator = nullptr;
+      return;
+    }
+    currentSeparator = *next;
+  };
+
+  llvm::DenseMap<StageSeparatingRegOp, llvm::SmallVector<Operation *>> stageOps;
+  for (auto &op : pipeline.getBodyBlock()->getOperations()) {
+    if (!currentSeparator) {
+      // End of pipeline stages - 'op' is either a return value or
+      // operations residing in the output stage of the pipeline, which are
+      // not to be registered/placed in an explicit stage.
+      break;
+    }
+    if (auto separator = dyn_cast<StageSeparatingRegOp>(&op)) {
+      assert(currentSeparator == separator &&
+             "Expected to encounter the current stage like operation");
+      setNextSeparator();
+    } else
+      stageOps[currentSeparator].push_back(&op);
+  };
+  return stageOps;
+}
+
+void StageSeparatorToStagePass::runOnOperation() {
+  pipeline = getOperation();
+  OpBuilder b(getOperation().getContext());
+
+  auto stageOps = gatherStageOps();
+
+  // Maintain the set of constant operations in the pipeline - these
+  // eventually will need to be sunk into the stages which reference them.
+  llvm::SmallVector<Operation *> constants;
+
+  ValueRange currentStageInputs = pipeline.getInnerInputs();
+  Value currentStageEnable = pipeline.getInnerEnable();
+
+  // 1. iterate over stage delimiter operations
+  // 2. build stages
+  // 3. move operations in between stages into the new stage ops.
+  for (auto stageSep :
+       llvm::make_early_inc_range(pipeline.getOps<StageSeparatingRegOp>())) {
+    b.setInsertionPoint(stageSep);
+    StageOp currentStage =
+        b.create<StageOp>(stageSep->getLoc(), currentStageEnable,
+                          currentStageInputs, stageSep.getInputs().getTypes());
+
+    // Replace the stage separator with the new stage op.
+    stageSep->replaceAllUsesWith(currentStage);
+    stageSep.erase();
+
+    // Move non-constant ops from the stageOps map into the StageOp wherein
+    // they will reside.
+    auto stageReturn =
+        cast<StageReturnOp>(currentStage.getBodyBlock()->getTerminator());
+    for (auto *op : stageOps[stageSep]) {
+      if (op->hasTrait<OpTrait::ConstantLike>())
+        constants.push_back(op);
+      else
+        op->moveBefore(stageReturn);
+    }
+
+    // Finalize the current stage by adjusting the stage return value.
+    stageReturn.setOperands(currentStage.getInnerEnable(), stageSep.getInputs(),
+                            /*passthroughs=*/{});
+
+    // Replace usages of the stage inputs inside the stage with the stage
+    // inner inputs.
+    for (auto [stageInput, innerInput] :
+         llvm::zip(currentStageInputs, currentStage.getInnerInputs()))
+      stageInput.replaceAllUsesExcept(innerInput, currentStage);
+
+    // Update the outputs fed to the next stage.
+    currentStageInputs = currentStage.getOutputs();
+    currentStageEnable = currentStage.getValid();
+  }
+
+  // Constant sinking - copy constant ops into each stage that references
+  // them.
+  for (auto *op : constants) {
+    llvm::DenseMap<StageOp, llvm::SmallVector<OpOperand *>> stageUsers;
+    for (auto &use : op->getUses()) {
+      auto parentStage = dyn_cast<StageOp>(use.getOwner()->getParentOp());
+      if (!parentStage)
+        continue;
+
+      stageUsers[parentStage].push_back(&use);
+    }
+
+    for (auto [stage, uses] : stageUsers) {
+      auto *copiedConstant = op->clone();
+      copiedConstant->moveBefore(&stage.getBodyBlock()->front());
+      for (auto *use : uses)
+        use->set(copiedConstant->getResult(0));
+    }
+  }
+}
+
+std::unique_ptr<mlir::Pass> circt::pipeline::createStageSeparatorToStagePass() {
+  return std::make_unique<StageSeparatorToStagePass>();
+}

--- a/lib/Dialect/Pipeline/Transforms/StageSeparatorToStage.cpp
+++ b/lib/Dialect/Pipeline/Transforms/StageSeparatorToStage.cpp
@@ -63,8 +63,9 @@ StageSeparatorToStagePass::gatherStageOps() {
       assert(currentSeparator == separator &&
              "Expected to encounter the current stage like operation");
       setNextSeparator();
-    } else
+    } else {
       stageOps[currentSeparator].push_back(&op);
+    }
   };
   return stageOps;
 }

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -17,9 +17,9 @@ hw.module @test0(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i
   %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
     %1 = comb.add %arg0_0, %arg1_1 : i32
-    %regOuts:2, %valid = pipeline.stage.register when %arg2 regs %1, %arg0_0 : i32, i32
+    %regOuts:2, %valid = pipeline.ss.reg enable %arg2 regs %1, %arg0_0 : i32, i32
     %2 = comb.add %regOuts#0, %regOuts#1 : i32
-    %regOuts_2:2, %valid_3 = pipeline.stage.register when %valid regs %2, %regOuts#0 : i32, i32
+    %regOuts_2:2, %valid_3 = pipeline.ss.reg enable %valid regs %2, %regOuts#0 : i32, i32
     %3 = comb.add %regOuts_2#0, %regOuts_2#1 : i32
     pipeline.return %3 valid %valid_3 : i32
   }

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -17,9 +17,9 @@ hw.module @test0(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i
   %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
     %1 = comb.add %arg0_0, %arg1_1 : i32
-    %regOuts:2, %valid = pipeline.ss.reg enable %arg2 regs %1, %arg0_0 : i32, i32
+    %regOuts:2, %valid = pipeline.stagesep.reg enable %arg2 regs %1, %arg0_0 : i32, i32
     %2 = comb.add %regOuts#0, %regOuts#1 : i32
-    %regOuts_2:2, %valid_3 = pipeline.ss.reg enable %valid regs %2, %regOuts#0 : i32, i32
+    %regOuts_2:2, %valid_3 = pipeline.stagesep.reg enable %valid regs %2, %regOuts#0 : i32, i32
     %3 = comb.add %regOuts_2#0, %regOuts_2#1 : i32
     pipeline.return %3 valid %valid_3 : i32
   }

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,45 +1,11 @@
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.pipeline(pipeline-explicit-regs)))' | FileCheck %s
 
-// CHECK:      %[[PIPELINE_RES:.*]] = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> i32 {
-// CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i1):
-// CHECK-NEXT:     %[[ARG0_REG:.*]], %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG1]] regs %[[ARG0]] : i32
-// CHECK-NEXT:     pipeline.return %[[ARG0_REG]] valid %[[S0_VALID]] : i32
-// CHECK-NEXT: }
-
-hw.module @test1(%arg0 : i32,  %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %out = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> (i32) {
-    ^bb0(%a0 : i32, %g : i1):
-      %s0_valid = pipeline.stage when %g
-      pipeline.return %a0 valid %s0_valid : i32
-  }
-  hw.output %out : i32
-}
-
-// CHECK:      %0 = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> i32 {
-// CHECK-NEXT:   ^bb0(%[[ARG0]]: i32, %[[ARG1:.*]]: i1):
-// CHECK-NEXT:     %c1_i32 = hw.constant 1 : i32
-// CHECK-NEXT:     %[[S0_REG:.*]], %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG1]] regs %[[ARG0]] : i32
-// CHECK-NEXT:     %[[ADD0_OUT:.*]] = comb.add %[[S0_REG]], %c1_i32 : i32
-// CHECK-NEXT:     pipeline.return %[[ADD0_OUT]] valid %[[S0_VALID]] : i32
-// CHECK-NEXT: }
-
-hw.module @test2(%arg0 : i32,  %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %out = pipeline.pipeline(%arg0, %go) clock %clk reset %rst : (i32, i1) -> (i32) {
-    ^bb0(%a0 : i32, %g : i1):
-      %c1_i32 = hw.constant 1 : i32
-      %s0_valid = pipeline.stage when %g
-      %add = comb.add %a0, %c1_i32 : i32
-      pipeline.return %add valid %s0_valid : i32
-  }
-  hw.output %out : i32
-}
-
 // CHECK:      %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
 // CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i1):
 // CHECK-NEXT:     %[[ADD0_OUT:.*]] = comb.add %[[ARG0]], %[[ARG1]] : i32
-// CHECK-NEXT:     %[[S0_REGS:.*]]:2, %[[S0_VALID:.*]] = pipeline.stage.register when %[[ARG2]] regs %[[ADD0_OUT]], %[[ARG0]] : i32, i32
+// CHECK-NEXT:     %[[S0_REGS:.*]]:2, %[[S0_VALID:.*]] = pipeline.ss.reg enable %[[ARG2]] regs %[[ADD0_OUT]], %[[ARG0]] : i32, i32
 // CHECK-NEXT:     %[[ADD1_OUT:.*]] = comb.add %[[S0_REGS]]#0, %[[S0_REGS]]#1 : i32
-// CHECK-NEXT:     %[[S1_REGS:.*]]:2, %[[S1_VALID:.*]] = pipeline.stage.register when %[[S0_VALID]] regs %[[ADD1_OUT]], %[[S0_REGS]]#0 : i32, i32
+// CHECK-NEXT:     %[[S1_REGS:.*]]:2, %[[S1_VALID:.*]] = pipeline.ss.reg enable %[[S0_VALID]] regs %[[ADD1_OUT]], %[[S0_REGS]]#0 : i32, i32
 // CHECK-NEXT:     %[[ADD2_OUT:.*]] = comb.add %[[S1_REGS]]#0, %[[S1_REGS]]#1 : i32
 // CHECK-NEXT:     pipeline.return %[[ADD2_OUT]] valid %[[S1_VALID]] : i32
 // CHECK-NEXT: }
@@ -49,13 +15,14 @@ hw.module @test3(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (o
     ^bb0(%a0 : i32, %a1: i32, %g : i1):
       %add0 = comb.add %a0, %a1 : i32
 
-      %s0_valid = pipeline.stage when %g
+      %s0_valid = pipeline.ss enable %g
       %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
 
-      %s1_valid = pipeline.stage when %s0_valid
+      %s1_valid = pipeline.ss enable %s0_valid
       %add2 = comb.add %add1, %add0 : i32 // %add0 crosses multiple stages.
 
       pipeline.return %add2 valid %s1_valid : i32
   }
   hw.output %out : i32
 }
+

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -3,9 +3,9 @@
 // CHECK:      %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
 // CHECK-NEXT:   ^bb0(%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i1):
 // CHECK-NEXT:     %[[ADD0_OUT:.*]] = comb.add %[[ARG0]], %[[ARG1]] : i32
-// CHECK-NEXT:     %[[S0_REGS:.*]]:2, %[[S0_VALID:.*]] = pipeline.ss.reg enable %[[ARG2]] regs %[[ADD0_OUT]], %[[ARG0]] : i32, i32
+// CHECK-NEXT:     %[[S0_REGS:.*]]:2, %[[S0_VALID:.*]] = pipeline.stagesep.reg enable %[[ARG2]] regs %[[ADD0_OUT]], %[[ARG0]] : i32, i32
 // CHECK-NEXT:     %[[ADD1_OUT:.*]] = comb.add %[[S0_REGS]]#0, %[[S0_REGS]]#1 : i32
-// CHECK-NEXT:     %[[S1_REGS:.*]]:2, %[[S1_VALID:.*]] = pipeline.ss.reg enable %[[S0_VALID]] regs %[[ADD1_OUT]], %[[S0_REGS]]#0 : i32, i32
+// CHECK-NEXT:     %[[S1_REGS:.*]]:2, %[[S1_VALID:.*]] = pipeline.stagesep.reg enable %[[S0_VALID]] regs %[[ADD1_OUT]], %[[S0_REGS]]#0 : i32, i32
 // CHECK-NEXT:     %[[ADD2_OUT:.*]] = comb.add %[[S1_REGS]]#0, %[[S1_REGS]]#1 : i32
 // CHECK-NEXT:     pipeline.return %[[ADD2_OUT]] valid %[[S1_VALID]] : i32
 // CHECK-NEXT: }
@@ -15,10 +15,10 @@ hw.module @test3(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (o
     ^bb0(%a0 : i32, %a1: i32, %g : i1):
       %add0 = comb.add %a0, %a1 : i32
 
-      %s0_valid = pipeline.ss enable %g
+      %s0_valid = pipeline.stagesep enable %g
       %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
 
-      %s1_valid = pipeline.ss enable %s0_valid
+      %s1_valid = pipeline.stagesep enable %s0_valid
       %add2 = comb.add %add1, %add0 : i32 // %add0 crosses multiple stages.
 
       pipeline.return %add2 valid %s1_valid : i32

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -5,17 +5,18 @@
 // CHECK:           %[[VAL_4:.*]] = pipeline.pipeline(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] {operator_lib = @lib} : (i32, i32) -> i32 {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
 // CHECK:             %[[VAL_7:.*]] = hw.constant true
+// CHECK:             %[[VAL_8:.*]] = hw.constant true
 // CHECK:             %[[VAL_9:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] {ssp.operator_type = @add1} : i32
 // CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_5]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_11:.*]] = pipeline.stage when %[[VAL_7]]
-// CHECK:             %[[VAL_12:.*]] = pipeline.stage when %[[VAL_11]]
+// CHECK:             %[[VAL_11:.*]] = pipeline.ss enable %[[VAL_7]]
+// CHECK:             %[[VAL_12:.*]] = pipeline.ss enable %[[VAL_11]]
 // CHECK:             %[[VAL_13:.*]] = comb.mul %[[VAL_5]], %[[VAL_9]] {ssp.operator_type = @mul2} : i32
-// CHECK:             %[[VAL_14:.*]] = pipeline.stage when %[[VAL_12]]
-// CHECK:             %[[VAL_15:.*]] = pipeline.stage when %[[VAL_14]]
-// CHECK:             %[[VAL_16:.*]] = pipeline.stage when %[[VAL_15]]
+// CHECK:             %[[VAL_14:.*]] = pipeline.ss enable %[[VAL_12]]
+// CHECK:             %[[VAL_15:.*]] = pipeline.ss enable %[[VAL_14]]
+// CHECK:             %[[VAL_16:.*]] = pipeline.ss enable %[[VAL_15]]
 // CHECK:             %[[VAL_17:.*]] = comb.add %[[VAL_13]], %[[VAL_10]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_18:.*]] = pipeline.stage when %[[VAL_16]]
-// CHECK:             %[[VAL_19:.*]] = pipeline.stage when %[[VAL_18]]
+// CHECK:             %[[VAL_18:.*]] = pipeline.ss enable %[[VAL_16]]
+// CHECK:             %[[VAL_19:.*]] = pipeline.ss enable %[[VAL_18]]
 // CHECK:             pipeline.return %[[VAL_17]] valid %[[VAL_19]] : i32
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_20:.*]] : i32

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -8,15 +8,15 @@
 // CHECK:             %[[VAL_8:.*]] = hw.constant true
 // CHECK:             %[[VAL_9:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] {ssp.operator_type = @add1} : i32
 // CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_5]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_11:.*]] = pipeline.ss enable %[[VAL_7]]
-// CHECK:             %[[VAL_12:.*]] = pipeline.ss enable %[[VAL_11]]
+// CHECK:             %[[VAL_11:.*]] = pipeline.stagesep enable %[[VAL_7]]
+// CHECK:             %[[VAL_12:.*]] = pipeline.stagesep enable %[[VAL_11]]
 // CHECK:             %[[VAL_13:.*]] = comb.mul %[[VAL_5]], %[[VAL_9]] {ssp.operator_type = @mul2} : i32
-// CHECK:             %[[VAL_14:.*]] = pipeline.ss enable %[[VAL_12]]
-// CHECK:             %[[VAL_15:.*]] = pipeline.ss enable %[[VAL_14]]
-// CHECK:             %[[VAL_16:.*]] = pipeline.ss enable %[[VAL_15]]
+// CHECK:             %[[VAL_14:.*]] = pipeline.stagesep enable %[[VAL_12]]
+// CHECK:             %[[VAL_15:.*]] = pipeline.stagesep enable %[[VAL_14]]
+// CHECK:             %[[VAL_16:.*]] = pipeline.stagesep enable %[[VAL_15]]
 // CHECK:             %[[VAL_17:.*]] = comb.add %[[VAL_13]], %[[VAL_10]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_18:.*]] = pipeline.ss enable %[[VAL_16]]
-// CHECK:             %[[VAL_19:.*]] = pipeline.ss enable %[[VAL_18]]
+// CHECK:             %[[VAL_18:.*]] = pipeline.stagesep enable %[[VAL_16]]
+// CHECK:             %[[VAL_19:.*]] = pipeline.stagesep enable %[[VAL_18]]
 // CHECK:             pipeline.return %[[VAL_17]] valid %[[VAL_19]] : i32
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_20:.*]] : i32

--- a/test/Dialect/Pipeline/Transforms/ss-to-stages.mlir
+++ b/test/Dialect/Pipeline/Transforms/ss-to-stages.mlir
@@ -1,0 +1,34 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.pipeline(pipeline-ss-to-stage)))' %s | FileCheck %s
+
+// CHECK-LABEL:   hw.module @test1(
+// CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1,
+// CHECK-SAME:                     %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = pipeline.pipeline(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32, i32, i1) -> i32 {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]]:2, %[[VAL_10:.*]] = pipeline.stage ins %[[VAL_6]], %[[VAL_7]] enable %[[VAL_8]] : (i32, i32) -> (i32, i32) {
+// CHECK:             ^bb0(%[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
+// CHECK:               %[[VAL_14:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:               pipeline.stage.return regs %[[VAL_14]], %[[VAL_11]] valid %[[VAL_13]] : (i32, i32)
+// CHECK:             }
+// CHECK:             %[[VAL_15:.*]]:2, %[[VAL_16:.*]] = pipeline.stage ins %[[VAL_17:.*]]#0, %[[VAL_17]]#1 enable %[[VAL_18:.*]] : (i32, i32) -> (i32, i32) {
+// CHECK:             ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i32, %[[VAL_21:.*]]: i1):
+// CHECK:               %[[VAL_22:.*]] = comb.add %[[VAL_19]], %[[VAL_20]] : i32
+// CHECK:               pipeline.stage.return regs %[[VAL_22]], %[[VAL_19]] valid %[[VAL_21]] : (i32, i32)
+// CHECK:             }
+// CHECK:             %[[VAL_23:.*]] = comb.add %[[VAL_24:.*]]#0, %[[VAL_24]]#1 : i32
+// CHECK:             pipeline.return %[[VAL_23]] valid %[[VAL_25:.*]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_26:.*]] : i32
+// CHECK:         }
+hw.module @test1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
+    %1 = comb.add %arg0_0, %arg1_1 : i32
+    %regOuts:2, %valid = pipeline.ss.reg enable %arg2 regs %1, %arg0_0 : i32, i32
+    %2 = comb.add %regOuts#0, %regOuts#1 : i32
+    %regOuts_2:2, %valid_3 = pipeline.ss.reg enable %valid regs %2, %regOuts#0 : i32, i32
+    %3 = comb.add %regOuts_2#0, %regOuts_2#1 : i32
+    pipeline.return %3 valid %valid_3 : i32
+  }
+  hw.output %0 : i32
+}

--- a/test/Dialect/Pipeline/Transforms/ss-to-stages.mlir
+++ b/test/Dialect/Pipeline/Transforms/ss-to-stages.mlir
@@ -24,9 +24,9 @@ hw.module @test1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i
   %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
     %1 = comb.add %arg0_0, %arg1_1 : i32
-    %regOuts:2, %valid = pipeline.ss.reg enable %arg2 regs %1, %arg0_0 : i32, i32
+    %regOuts:2, %valid = pipeline.stagesep.reg enable %arg2 regs %1, %arg0_0 : i32, i32
     %2 = comb.add %regOuts#0, %regOuts#1 : i32
-    %regOuts_2:2, %valid_3 = pipeline.ss.reg enable %valid regs %2, %regOuts#0 : i32, i32
+    %regOuts_2:2, %valid_3 = pipeline.stagesep.reg enable %valid regs %2, %regOuts#0 : i32, i32
     %3 = comb.add %regOuts_2#0, %regOuts_2#1 : i32
     pipeline.return %3 valid %valid_3 : i32
   }

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -62,13 +62,13 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
 // -----
 
 hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  // expected-error @+1 {{'pipeline.pipeline' op mixing `pipeline.stage` and `pipeline.stage.register` ops is illegal.}}
+  // expected-error @+1 {{'pipeline.pipeline' op pipeline contains a mix of stage-like operations.}}
   %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
-    %c1_i1 = hw.constant 1 : i1
-    %r_0, %s0_valid = pipeline.stage.register when %c1_i1 regs %0 : i32
-    %s1_valid = pipeline.stage when %s0_valid
+    %c1_i1 = hw.constant true
+    %r_0, %s0_valid = pipeline.ss.reg enable %c1_i1 regs %0 : i32
+    %s1_valid = pipeline.ss enable %s0_valid
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : i32

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -67,8 +67,8 @@ hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out:
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant true
-    %r_0, %s0_valid = pipeline.ss.reg enable %c1_i1 regs %0 : i32
-    %s1_valid = pipeline.ss enable %s0_valid
+    %r_0, %s0_valid = pipeline.stagesep.reg enable %c1_i1 regs %0 : i32
+    %s1_valid = pipeline.stagesep enable %s0_valid
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : i32

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -6,23 +6,12 @@ hw.module @retimeable1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant 1 : i1
-    %s0_valid = pipeline.stage when %c1_i1
+    %s0_valid = pipeline.ss enable %c1_i1
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : i32
 }
 
-// CHECK-LABEL: hw.module @retimeable2
-hw.module @retimeable2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.pipeline(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %0 = comb.add %a0, %a1 : i32
-    %c1_i1 = hw.constant 1 : i1
-    %r_0, %s0_valid = pipeline.stage.register when %c1_i1 regs %0 : i32
-    pipeline.return %0 valid %s0_valid : i32
-  }
-  hw.output %0 : i32
-}
 
 // CHECK-LABEL: hw.module @retimeable3
 hw.module @retimeable3(%arg0 : !esi.channel<i32>, %arg1 : !esi.channel<i32>, %clk : i1, %rst: i1) -> (out: !esi.channel<i32>) {
@@ -30,8 +19,38 @@ hw.module @retimeable3(%arg0 : !esi.channel<i32>, %arg1 : !esi.channel<i32>, %cl
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant 1 : i1
-    %s0_valid = pipeline.stage when %c1_i1
+    %s0_valid = pipeline.ss enable %c1_i1
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : !esi.channel<i32>
+}
+
+// CHECK-LABEL: hw.module @stage
+hw.module @stage(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %gogo : i1):
+   %r_0, %s0_valid = pipeline.stage ins %a0, %a1 enable %gogo : (i32, i32) -> (i32) {
+      ^bb0(%in0 : i32, %in1: i32, %valid : i1):
+      %c1_i1 = hw.constant 1 : i1
+      %0 = comb.add %in0, %in1 : i32
+      pipeline.stage.return regs %0 valid %valid : (i32)
+   }
+    pipeline.return %r_0 valid %s0_valid : i32
+  }
+  hw.output %0 : i32
+}
+
+// CHECK-LABEL: hw.module @stageWithPassthrough
+hw.module @stageWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0, %1 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i32) {
+   ^bb0(%a0 : i32, %a1: i32, %gogo : i1):
+   %r_0, %pass_1, %s0_valid = pipeline.stage ins %a0, %a1 enable %gogo : (i32, i32) -> (i32, i32) {
+      ^bb0(%in0 : i32, %in1: i32, %valid : i1):
+      %c1_i1 = hw.constant 1 : i1
+      %0 = comb.add %in0, %in1 : i32
+      pipeline.stage.return regs %0 passthroughs %in1 valid %valid : (i32), (i32)
+   }
+    pipeline.return %r_0, %pass_1 valid %s0_valid : i32, i32
+  }
+  hw.output %0 : i32
 }

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -6,7 +6,7 @@ hw.module @retimeable1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant 1 : i1
-    %s0_valid = pipeline.ss enable %c1_i1
+    %s0_valid = pipeline.stagesep enable %c1_i1
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : i32
@@ -19,7 +19,7 @@ hw.module @retimeable3(%arg0 : !esi.channel<i32>, %arg1 : !esi.channel<i32>, %cl
    ^bb0(%a0 : i32, %a1: i32):
     %0 = comb.add %a0, %a1 : i32
     %c1_i1 = hw.constant 1 : i1
-    %s0_valid = pipeline.ss enable %c1_i1
+    %s0_valid = pipeline.stagesep enable %c1_i1
     pipeline.return %0 valid %s0_valid : i32
   }
   hw.output %0 : !esi.channel<i32>


### PR DESCRIPTION
This PR adds a new operation, `pipeline.stage` to the `Pipeline` dialect. This operation is used to make stages explicit - that is, a region-defining operation with inputs and outputs (much like the `loopschedule.pipeline.stage`). The motivation for this is that once a `pipeline.pipeline` has had registers materialized, a representational change to make the stages explicit allows for much cleaner RTL lowering whenever stages are _not_ to be lowered to hardware directly inline in the parent `hw.module`.
I see this as sort of the best-of-both worlds wrt. the earlier pipeline IR design discussions. I felt like i had to introduce this representation given that lowering the current `pipeline.stage.regs` to outlined modules felt extremely clunky, whereas stepping through this representation makes it much much simpler.

This thus allows us to transform:
```mlir
hw.module @test1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
  %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
    %1 = comb.add %arg0_0, %arg1_1 : i32
    %regOuts:2, %valid = pipeline.ss.reg enable %arg2 regs %1, %arg0_0 : i32, i32
    %2 = comb.add %regOuts#0, %regOuts#1 : i32
    %regOuts_2:2, %valid_3 = pipeline.ss.reg enable %valid regs %2, %regOuts#0 : i32, i32
    %3 = comb.add %regOuts_2#0, %regOuts_2#1 : i32
    pipeline.return %3 valid %valid_3 : i32
  }
  hw.output %0 : i32
}
```

into

```mlir
hw.module @test1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
    %0 = pipeline.pipeline(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> i32 {
    ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
      %outputs:2, %valid = pipeline.stage ins %arg0_0, %arg1_1 enable %arg2 : (i32, i32) -> (i32, i32) {
      ^bb0(%arg3: i32, %arg4: i32, %arg5: i1):
        %2 = comb.add %arg3, %arg4 : i32
        pipeline.stage.return regs %2, %arg3 valid %arg5 : (i32, i32)
      }
      %outputs_2:2, %valid_3 = pipeline.stage ins %outputs#0, %outputs#1 enable %valid : (i32, i32) -> (i32, i32) {
      ^bb0(%arg3: i32, %arg4: i32, %arg5: i1):
        %2 = comb.add %arg3, %arg4 : i32
        pipeline.stage.return regs %2, %arg3 valid %arg5 : (i32, i32)
      }
      %1 = comb.add %outputs_2#0, %outputs_2#1 : i32
      pipeline.return %1 valid %valid_3 : i32
    }
    hw.output %0 : i32
  }
```

To (hopefully) avoid confusion, this commit also renames some existing operations in the dialect:
* `pipeline.stage` becomes `pipeline.ss` - a *stage separating* operation. ... which is really what it is - it doesn't define a stage, it merely separates them.
* `pipeline.stage.regs` becomes `pipeline.ss.reg` - as above, it separates stages, but also defines the registers that are formed across the boundary.

A follow-up commit will rework HW lowering to be `pipeline.stage`-based.

Also introduces:
* `StageLike` - an interface for anything stage-like (this should may be named `BoundaryLike`. Allows us to iterate over `ss` ops, `pipeline.stage` ops and `pipeline.return`.
* Renames uses of `when` to `enable`
