### PR TITLE
[FIRRTL] Make emit-metadata a mlir::ModuleOp pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -169,7 +169,7 @@ def AddSeqMemPorts : Pass<"firrtl-add-seqmem-ports", "firrtl::CircuitOp"> {
   ];
 }
 
-def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
+def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "mlir::ModuleOp"> {
   let summary = "Emit metadata of the FIRRTL modules";
   let description = [{
     This pass handles the emission of several different kinds of metadata.

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -125,7 +125,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCreateSiFiveMetadataPass(
+  pm.addPass(firrtl::createCreateSiFiveMetadataPass(
       opt.replSeqMem, opt.replSeqMemCircuit, opt.replSeqMemFile));
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());

--- a/test/Dialect/FIRRTL/emit-metadata-errors.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-metadata))' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --firrtl-emit-metadata="repl-seq-mem=true repl-seq-mem-file='dut.conf'" --verify-diagnostics -split-input-file %s
 
 //===----------------------------------------------------------------------===//
 // RetimeModules

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true repl-seq-mem-file="dut.conf"}))' %s | FileCheck %s
+// RUN: circt-opt --firrtl-emit-metadata="repl-seq-mem=true repl-seq-mem-file='dut.conf'" -split-input-file %s | FileCheck %s
 
 firrtl.circuit "empty" {
   firrtl.module @empty() {
@@ -8,6 +8,8 @@ firrtl.circuit "empty" {
 // CHECK-NEXT:    firrtl.module @empty() {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 // RetimeModules
@@ -36,6 +38,8 @@ firrtl.circuit "retime0" attributes { annotations = [{
 // CHECK-SAME:        output_file = #hw.output_file<"retime_modules.json", excludeFromFileList>
 // CHECK-SAME:        symbols = [@retime0, @retime2]
 
+// -----
+
 //===----------------------------------------------------------------------===//
 // SitestBlackbox
 //===----------------------------------------------------------------------===//
@@ -53,6 +57,8 @@ firrtl.circuit "DUTBlackboxes" attributes { annotations = [{
 // CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
 }
 
+// -----
+
 // CHECK-LABEL: firrtl.circuit "TestBlackboxes"  {
 firrtl.circuit "TestBlackboxes" attributes { annotations = [{
     class = "sifive.enterprise.firrtl.SitestTestHarnessBlackBoxAnnotation",
@@ -65,6 +71,8 @@ firrtl.circuit "TestBlackboxes" attributes { annotations = [{
 // CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>}
 // CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
 }
+
+// -----
 
 // CHECK-LABEL: firrtl.circuit "BasicBlackboxes"   {
 firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
@@ -107,6 +115,8 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   // CHECK: sv.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>}
 }
 
+// -----
+
 //===----------------------------------------------------------------------===//
 // MemoryMetadata
 //===----------------------------------------------------------------------===//
@@ -117,8 +127,10 @@ firrtl.circuit "top"
   firrtl.module @top() { }
   // When there are no memories, we still need to emit the memory metadata.
   // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>}
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList>}
 }
+
+// -----
 
 // CHECK-LABEL: firrtl.circuit "OneMemory"
 firrtl.circuit "OneMemory" {
@@ -127,8 +139,10 @@ firrtl.circuit "OneMemory" {
   }
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [{direction = "input", name = "user_input", width = 5 : ui32}], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   // CHECK: "[\0A {\0A \22module_name\22: \22MWrite_ext\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 0,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [\0A {\0A \22name\22: \22user_input\22,\0A \22direction\22: \22input\22,\0A \22width\22: 5\0A }\0A ],\0A \22hierarchy\22: [\0A \22OneMemory.MWrite_ext\22\0A ]\0A }\0A]"
-  // CHECK: sv.verbatim "name MWrite_ext depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"\22dut.conf\22"
+  // CHECK: sv.verbatim "name MWrite_ext depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"'dut.conf'"
 }
+
+// -----
 
 // CHECK-LABEL: firrtl.circuit "DualReadsSMem"
 firrtl.circuit "DualReadsSMem" {
@@ -138,8 +152,10 @@ firrtl.circuit "DualReadsSMem" {
   firrtl.memmodule @DualReads_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, in R0_data: !firrtl.uint<42>, in R1_addr: !firrtl.uint<4>, in R1_en: !firrtl.uint<1>, in R1_clk: !firrtl.clock, in R1_data: !firrtl.uint<42>, in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 2 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   // CHECK: sv.verbatim "[\0A {\0A \22module_name\22: \22DualReads_ext\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 2,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22DualReadsSMem.DualReads_ext\22\0A ]\0A }\0A]"
   // CHECK: {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>}
-  // CHECK: sv.verbatim "name DualReads_ext depth 12 width 42 ports write,read,read\0A" {output_file = #hw.output_file<"\22dut.conf\22"
+  // CHECK: sv.verbatim "name DualReads_ext depth 12 width 42 ports write,read,read\0A" {output_file = #hw.output_file<"'dut.conf'"
 }
+
+// -----
 
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" {
@@ -169,5 +185,5 @@ firrtl.circuit "top" {
     // CHECK: sv.verbatim "[\0A {\0A \22module_name\22: \22memory_ext\22,\0A \22depth\22: 16,\0A \22width\22: 8,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 1,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22DUT.mem1.memory_ext\22\0A ]\0A },\0A {\0A \22module_name\22: \22dumm_ext\22,\0A \22depth\22: 20,\0A \22width\22: 5,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22DUT.mem1.dumm_ext\22\0A ]\0A }\0A]"
     // CHECK-SAME: output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>
     // CHECK: sv.verbatim "name head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0Aname memory_ext depth 16 width 8 ports read,rw\0Aname dumm_ext depth 20 width 5 ports write,read\0A"
-    // CHECK-SAME: {output_file = #hw.output_file<"\22dut.conf\22", excludeFromFileList>}
+    // CHECK-SAME: {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList>}
 }


### PR DESCRIPTION
Make the `CreateSiFiveMetadata` a `mlir::ModuleOp` pass. 
This is required to generate `om` operations (https://github.com/llvm/circt/pull/5224). The `om::ClassOp` must have  `mlir::ModuleOp` as the parent.
This PR updates the Pass infrastructure and also the lit tests.