### PR TITLE
[OM] Add initial CAPI for OM dialect Evaluator.

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -39,7 +39,8 @@ struct OMEvaluator {
   void *ptr;
 };
 
-// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// clang-tidy doesn't respect extern "C".
+// see https://github.com/llvm/llvm-project/issues/35272.
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMEvaluator OMEvaluator;
 
@@ -49,7 +50,8 @@ struct OMObject {
   void *ptr;
 };
 
-// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// clang-tidy doesn't respect extern "C".
+// see https://github.com/llvm/llvm-project/issues/35272.
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMObject OMObject;
 
@@ -61,7 +63,8 @@ struct OMObjectValue {
   OMObject object;
 };
 
-// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// clang-tidy doesn't respect extern "C".
+// see https://github.com/llvm/llvm-project/issues/35272.
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMObjectValue OMObjectValue;
 

--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -38,6 +38,9 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(OM, om);
 struct OMEvaluator {
   void *ptr;
 };
+
+// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMEvaluator OMEvaluator;
 
 /// A value type for use in C APIs that just wraps a pointer to an Object.
@@ -45,6 +48,9 @@ typedef struct OMEvaluator OMEvaluator;
 struct OMObject {
   void *ptr;
 };
+
+// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMObject OMObject;
 
 /// A value type for use in C APIs that represents an ObjectValue.
@@ -54,6 +60,9 @@ struct OMObjectValue {
   MlirAttribute primitive;
   OMObject object;
 };
+
+// For some reason clang-tidy thinks this is C++ and wants to use `using`.
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct OMObjectValue OMObjectValue;
 
 //===----------------------------------------------------------------------===//

--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -1,0 +1,113 @@
+//===-- circt-c/Dialect/OM.h - C API for OM dialect -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares the C interface for registering and accessing the
+// OM dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_OM_H
+#define CIRCT_C_DIALECT_OM_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(OM, om);
+
+//===----------------------------------------------------------------------===//
+// Evaluator data structures.
+//===----------------------------------------------------------------------===//
+
+/// A value type for use in C APIs that just wraps a pointer to an Evaluator.
+/// This is in line with the usual MLIR DEFINE_C_API_STRUCT.
+struct OMEvaluator {
+  void *ptr;
+};
+typedef struct OMEvaluator OMEvaluator;
+
+/// A value type for use in C APIs that just wraps a pointer to an Object.
+/// This is in line with the usual MLIR DEFINE_C_API_STRUCT.
+struct OMObject {
+  void *ptr;
+};
+typedef struct OMObject OMObject;
+
+/// A value type for use in C APIs that represents an ObjectValue.
+/// Because ObjectValue is a std::variant, which doesn't work well with C APIs,
+/// we use a struct with both fields, one of which will always be null.
+struct OMObjectValue {
+  MlirAttribute primitive;
+  OMObject object;
+};
+typedef struct OMObjectValue OMObjectValue;
+
+//===----------------------------------------------------------------------===//
+// Evaluator API.
+//===----------------------------------------------------------------------===//
+
+/// Construct an Evaluator with an IR module.
+MLIR_CAPI_EXPORTED OMEvaluator omEvaluatorNew(MlirModule mod);
+
+/// Use the Evaluator to Instantiate an Object from its class name and actual
+/// parameters.
+MLIR_CAPI_EXPORTED OMObject omEvaluatorInstantiate(
+    OMEvaluator evaluator, MlirAttribute className, intptr_t nActualParams,
+    MlirAttribute const *actualParams);
+
+/// Get the Module the Evaluator is built from.
+MLIR_CAPI_EXPORTED MlirModule omEvaluatorGetModule(OMEvaluator evaluator);
+
+//===----------------------------------------------------------------------===//
+// Object API.
+//===----------------------------------------------------------------------===//
+
+/// Query if the Object is null.
+MLIR_CAPI_EXPORTED bool omEvaluatorObjectIsNull(OMObject object);
+
+/// Get a field from an Object, which must contain a field of that name.
+MLIR_CAPI_EXPORTED OMObjectValue omEvaluatorObjectGetField(OMObject object,
+                                                           MlirAttribute name);
+
+//===----------------------------------------------------------------------===//
+// ObjectValue API.
+//===----------------------------------------------------------------------===//
+
+// Query if the ObjectValue is null.
+MLIR_CAPI_EXPORTED bool omEvaluatorObjectValueIsNull(OMObjectValue objectValue);
+
+/// Query if the ObjectValue is an Object.
+MLIR_CAPI_EXPORTED bool
+omEvaluatorObjectValueIsAObject(OMObjectValue objectValue);
+
+/// Get the Object from an  ObjectValue, which must contain an Object.
+MLIR_CAPI_EXPORTED OMObject
+omEvaluatorObjectValueGetObject(OMObjectValue objectValue);
+
+/// Query if the ObjectValue is a Primitive.
+MLIR_CAPI_EXPORTED bool
+omEvaluatorObjectValueIsAPrimitive(OMObjectValue objectValue);
+
+/// Get the Primitive from an  ObjectValue, which must contain a Primitive.
+MLIR_CAPI_EXPORTED MlirAttribute
+omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_OM_H

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LLVM_OPTIONAL_SOURCES
   HWArith.cpp
   LLHD.cpp
   Moore.cpp
+  OM.cpp
   Seq.cpp
   SV.cpp
   FSM.cpp
@@ -73,6 +74,15 @@ add_mlir_public_c_api_library(CIRCTCAPIMoore
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTMoore
+)
+
+add_mlir_public_c_api_library(CIRCTCAPIOM
+  OM.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTOM
+  CIRCTOMEvaluator
 )
 
 add_mlir_public_c_api_library(CIRCTCAPISeq

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -1,0 +1,151 @@
+//===- OM.cpp - C Interface for the OM Dialect ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Implements a C Interface for the OM Dialect
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/OM.h"
+#include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "circt/Dialect/OM/OMDialect.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Wrap.h"
+
+using namespace mlir;
+using namespace circt::om;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(OM, om, OMDialect)
+
+//===----------------------------------------------------------------------===//
+// Evaluator data structures.
+//===----------------------------------------------------------------------===//
+
+DEFINE_C_API_PTR_METHODS(OMEvaluator, circt::om::Evaluator)
+DEFINE_C_API_PTR_METHODS(OMObject, std::shared_ptr<circt::om::Object>)
+
+//===----------------------------------------------------------------------===//
+// Evaluator API.
+//===----------------------------------------------------------------------===//
+
+/// Construct an Evaluator with an IR module.
+OMEvaluator omEvaluatorNew(MlirModule mod) {
+  // Just allocate and wrap the Evaluator.
+  return wrap(new Evaluator(unwrap(mod)));
+}
+
+/// Use the Evaluator to Instantiate an Object from its class name and actual
+/// parameters.
+OMObject omEvaluatorInstantiate(OMEvaluator evaluator, MlirAttribute className,
+                                intptr_t nActualParams,
+                                MlirAttribute const *actualParams) {
+  // Unwrap the Evaluator.
+  Evaluator *cppEvaluator = unwrap(evaluator);
+
+  // Unwrap the className, which the client must supply as a StringAttr.
+  StringAttr cppClassName = unwrap(className).cast<StringAttr>();
+
+  // Unwrap the actual parameters, which the client must supply as Attributes.
+  SmallVector<Attribute> actualParamsTmp;
+  SmallVector<ObjectValue> cppActualParams(
+      unwrapList(nActualParams, actualParams, actualParamsTmp));
+
+  // Invoke the Evaluator to instantiate the Object.
+  FailureOr<std::shared_ptr<Object>> result =
+      cppEvaluator->instantiate(cppClassName, cppActualParams);
+
+  // If instantiation failed, return a null Object. A Diagnostic will be emitted
+  // in this case.
+  if (failed(result))
+    return OMObject();
+
+  // Wrap and return a *new* shared pointer to the Object, to ensure the
+  // reference count is kept up to date.
+  return wrap(new std::shared_ptr<Object>(result.value()));
+}
+
+/// Get the Module the Evaluator is built from.
+MlirModule omEvaluatorGetModule(OMEvaluator evaluator) {
+  // Just unwrap the Evaluator, get the Module, and wrap it.
+  return wrap(unwrap(evaluator)->getModule());
+}
+
+//===----------------------------------------------------------------------===//
+// Object API.
+//===----------------------------------------------------------------------===//
+
+/// Query if the Object is null.
+bool omEvaluatorObjectIsNull(OMObject object) {
+  // Just check if the Object shared pointer is null.
+  return !object.ptr;
+}
+
+/// Get a field from an Object, which must contain a field of that name.
+OMObjectValue omEvaluatorObjectGetField(OMObject object, MlirAttribute name) {
+  // Unwrap the Object and get the field of the name, which the client must
+  // supply as a StringAttr.
+  FailureOr<ObjectValue> result =
+      (*unwrap(object))->getField(unwrap(name).cast<StringAttr>());
+
+  // If getField failed, return a null ObjectValue. A Diagnostic will be emitted
+  // in this case.
+  if (failed(result))
+    return OMObjectValue();
+
+  // If the field is an Object, return an ObjectValue with the Object set.
+  if (auto *object = std::get_if<std::shared_ptr<Object>>(&result.value()))
+    return OMObjectValue{MlirAttribute(), wrap(object)};
+
+  // If the field is an Attribute, return an ObjectValue with the Primitive set.
+  if (auto *primitive = std::get_if<Attribute>(&result.value()))
+    return OMObjectValue{wrap(*primitive), OMObject()};
+
+  // This case should never be hit, but return a null ObjectValue that is
+  // neither an Object nor a Primitive.
+  return OMObjectValue();
+}
+
+//===----------------------------------------------------------------------===//
+// ObjectValue API.
+//===----------------------------------------------------------------------===//
+
+// Query if the ObjectValue is null.
+bool omEvaluatorObjectValueIsNull(OMObjectValue objectValue) {
+  // Check if both Object and Attribute are null.
+  return !omEvaluatorObjectValueIsAObject(objectValue) &&
+         !omEvaluatorObjectValueIsAPrimitive(objectValue);
+}
+
+/// Query if the ObjectValue is an Object.
+bool omEvaluatorObjectValueIsAObject(OMObjectValue objectValue) {
+  // Check if the Object is non-null.
+  return !omEvaluatorObjectIsNull(objectValue.object);
+}
+
+/// Get the Object from an  ObjectValue, which must contain an Object.
+OMObject omEvaluatorObjectValueGetObject(OMObjectValue objectValue) {
+  // Assert the Object is non-null, and return it.
+  assert(omEvaluatorObjectValueIsAObject(objectValue));
+  return objectValue.object;
+}
+
+/// Query if the ObjectValue is a Primitive.
+bool omEvaluatorObjectValueIsAPrimitive(OMObjectValue objectValue) {
+  // Check if the Attribute is non-null.
+  return !mlirAttributeIsNull(objectValue.primitive);
+}
+
+/// Get the Primitive from an  ObjectValue, which must contain a Primitive.
+MlirAttribute omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue) {
+  // Assert the Attribute is non-null, and return it.
+  assert(omEvaluatorObjectValueIsAPrimitive(objectValue));
+  return objectValue.primitive;
+}

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_llvm_executable(circt-capi-ir-test
+  PARTIAL_SOURCES_INTENDED
   ir.c
 )
 llvm_update_compile_flags(circt-capi-ir-test)
@@ -12,4 +13,17 @@ target_link_libraries(circt-capi-ir-test
   CIRCTCAPISV
   CIRCTCAPIFSM
   CIRCTCAPIExportVerilog
+)
+
+add_llvm_executable(circt-capi-om-test
+  PARTIAL_SOURCES_INTENDED
+  om.c
+)
+llvm_update_compile_flags(circt-capi-om-test)
+
+target_link_libraries(circt-capi-om-test
+  PRIVATE
+
+  MLIRCAPIIR
+  CIRCTCAPIOM
 )

--- a/test/CAPI/om.c
+++ b/test/CAPI/om.c
@@ -1,0 +1,90 @@
+/*===- om.c - Simple test of OM C APIs ------------------------------------===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+/* RUN: circt-capi-om-test 2>&1 | FileCheck %s
+ */
+
+#include "circt-c/Dialect/OM.h"
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+#include <mlir-c/Support.h>
+#include <stdio.h>
+
+void testEvaluator(MlirContext ctx) {
+  const char *testIR = "module {"
+                       "  om.class @Test(%param: i8) {"
+                       "    om.class.field @field, %param : i8"
+                       "  }"
+                       "}";
+
+  // Set up the Evaluator.
+  MlirModule testModule =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(testIR));
+
+  OMEvaluator evaluator = omEvaluatorNew(testModule);
+
+  MlirAttribute className =
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("Test"));
+
+  // Test instantiation failure.
+  OMObject failedObject = omEvaluatorInstantiate(evaluator, className, 0, 0);
+
+  // CHECK: error: actual parameter list length (0) does not match
+  // CHECK: object is null: 1
+  fprintf(stderr, "object is null: %d\n",
+          omEvaluatorObjectIsNull(failedObject));
+
+  // Test instantiation success.
+
+  MlirAttribute actualParam =
+      mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42);
+
+  OMObject object =
+      omEvaluatorInstantiate(evaluator, className, 1, &actualParam);
+
+  // Test get field failure.
+
+  MlirAttribute missingFieldName =
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("foo"));
+
+  OMObjectValue missingField =
+      omEvaluatorObjectGetField(object, missingFieldName);
+
+  // CHECK: error: field "foo" does not exist
+  // CHECK: field is null: 1
+  fprintf(stderr, "field is null: %d\n",
+          omEvaluatorObjectValueIsNull(missingField));
+
+  // Test get field success.
+
+  MlirAttribute fieldName =
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("field"));
+
+  OMObjectValue field = omEvaluatorObjectGetField(object, fieldName);
+
+  // CHECK: field is object: 0
+  fprintf(stderr, "field is object: %d\n",
+          omEvaluatorObjectValueIsAObject(field));
+  // CHECK: field is primitive: 1
+  fprintf(stderr, "field is primitive: %d\n",
+          omEvaluatorObjectValueIsAPrimitive(field));
+
+  MlirAttribute fieldValue = omEvaluatorObjectValueGetPrimitive(field);
+
+  // CHECK: 42 : i8
+  mlirAttributeDump(fieldValue);
+}
+
+int main() {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleRegisterDialect(mlirGetDialectHandle__om__(), ctx);
+  testEvaluator(ctx);
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CIRCT_TEST_DEPENDS
   split-file
   arcilator
   circt-capi-ir-test
+  circt-capi-om-test
   circt-as
   circt-dis
   circt-opt

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,8 +57,8 @@ tool_dirs = [
 ]
 tools = [
     'firtool', 'circt-as', 'circt-dis', 'circt-opt', 'circt-reduce',
-    'circt-translate', 'circt-capi-ir-test', 'esi-tester', 'hlstool',
-    'arcilator'
+    'circt-translate', 'circt-capi-ir-test', 'circt-capi-om-test', 'esi-tester',
+    'hlstool', 'arcilator'
 ]
 
 # Enable Verilator if it has been detected.


### PR DESCRIPTION
This adds the usual CAPI structure and dialect registration boilerplate, as well as CAPIs around the Evaluator library.

The APIs are intended to be as minimal and straightforward as possible, simply wrapping and unwrapping the C++ structures when possible.

One slight divergence is in the ObjectValue type, which is a std::variant between an Object shared pointer or an Attribute. The normal approach of casting to and from a void pointer does not work with std::variant, so a different representation of ObjectValue is used instead. The discriminated union is simply represented as a struct which only over has one field set. It might be possible to save some space using a struct with a C union and a flag, but the simplicity of the current approach seemed reasonable.

Another minor detail worth mentioning is that we must take some care to ensure the shared pointers to Objects have their reference count kept up to date. In the CAPI for the instantiate method, if we simply return the shared pointer, the reference will be lost as the Object pointer travels to C as a void pointer, so we allocate a new shared pointer in the CAPI, which ensures the reference count accurately reflect that we have handed out another reference.