### PR TITLE
[OM] Add initial Python API for OM dialect evaluator.

### DIFF
--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -1,0 +1,68 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+from circt.dialects import om
+from circt.ir import Context, InsertionPoint, Location, Module
+from circt.support import var_to_attribute
+
+from dataclasses import dataclass
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  module = Module.parse("""
+  module {
+    om.class @Test(%param: i64) {
+      om.class.field @field, %param : i64
+    }
+  }
+  """)
+
+  evaluator = om.Evaluator(module)
+
+# Test instantiate failure.
+
+
+@dataclass
+class Test:
+  field: int
+
+
+try:
+  obj = evaluator.instantiate(Test, [])
+except ValueError as e:
+  # CHECK: actual parameter list length (0) does not match
+  # CHECK: actual parameters:
+  # CHECK: formal parameters:
+  # CHECK: unable to instantiate object, see previous error(s)
+  print(e)
+
+# Test get field failure.
+
+
+@dataclass
+class Test:
+  foo: int
+
+
+try:
+  obj = evaluator.instantiate(Test, [42])
+except ValueError as e:
+  # CHECK: field "foo" does not exist
+  # CHECK: see current operation:
+  # CHECK: unable to get field, see previous error(s)
+  print(e)
+
+# Test instantiate success.
+
+
+@dataclass
+class Test:
+  field: int
+
+
+obj = evaluator.instantiate(Test, [42])
+
+# CHECK: Test(field=42)
+print(obj)

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -30,7 +30,7 @@ class Test:
 
 
 try:
-  obj = evaluator.instantiate(Test, [])
+  obj = evaluator.instantiate(Test)
 except ValueError as e:
   # CHECK: actual parameter list length (0) does not match
   # CHECK: actual parameters:
@@ -47,7 +47,7 @@ class Test:
 
 
 try:
-  obj = evaluator.instantiate(Test, [42])
+  obj = evaluator.instantiate(Test, 42)
 except ValueError as e:
   # CHECK: field "foo" does not exist
   # CHECK: see current operation:
@@ -62,7 +62,7 @@ class Test:
   field: int
 
 
-obj = evaluator.instantiate(Test, [42])
+obj = evaluator.instantiate(Test, 42)
 
 # CHECK: Test(field=42)
 print(obj)

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -15,6 +15,7 @@
 #include "circt-c/Dialect/HWArith.h"
 #include "circt-c/Dialect/Handshake.h"
 #include "circt-c/Dialect/MSFT.h"
+#include "circt-c/Dialect/OM.h"
 #include "circt-c/Dialect/SV.h"
 #include "circt-c/Dialect/Seq.h"
 #include "circt-c/ExportVerilog.h"
@@ -73,6 +74,10 @@ PYBIND11_MODULE(_circt, m) {
         mlirDialectHandleRegisterDialect(hwarith, context);
         mlirDialectHandleLoadDialect(hwarith, context);
 
+        MlirDialectHandle om = mlirGetDialectHandle__om__();
+        mlirDialectHandleRegisterDialect(om, context);
+        mlirDialectHandleLoadDialect(om, context);
+
         MlirDialectHandle seq = mlirGetDialectHandle__seq__();
         mlirDialectHandleRegisterDialect(seq, context);
         mlirDialectHandleLoadDialect(seq, context);
@@ -108,6 +113,8 @@ PYBIND11_MODULE(_circt, m) {
   circt::python::populateDialectMSFTSubmodule(msft);
   py::module hw = m.def_submodule("_hw", "HW API");
   circt::python::populateDialectHWSubmodule(hw);
+  py::module om = m.def_submodule("_om", "OM API");
+  circt::python::populateDialectOMSubmodule(om);
   py::module sv = m.def_submodule("_sv", "SV API");
   circt::python::populateDialectSVSubmodule(sv);
 }

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -17,6 +17,7 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension
     CIRCTModule.cpp
     ESIModule.cpp
     HWModule.cpp
+    OMModule.cpp
     MSFTModule.cpp
     SVModule.cpp
   EMBED_CAPI_LINK_LIBS
@@ -25,6 +26,7 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension
     CIRCTCAPIMSFT
     CIRCTCAPIHW
     CIRCTCAPIHWArith
+    CIRCTCAPIOM
     CIRCTCAPISeq
     CIRCTCAPISV
     CIRCTCAPIExportVerilog
@@ -92,6 +94,14 @@ declare_mlir_dialect_python_bindings(
     dialects/msft.py
     dialects/_msft_ops_ext.py
   DIALECT_NAME msft)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  TD_FILE dialects/OMOps.td
+  SOURCES
+    dialects/om.py
+  DIALECT_NAME om)
 
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects

--- a/lib/Bindings/Python/DialectModules.h
+++ b/lib/Bindings/Python/DialectModules.h
@@ -21,6 +21,7 @@ namespace python {
 void populateDialectESISubmodule(pybind11::module &m);
 void populateDialectHWSubmodule(pybind11::module &m);
 void populateDialectMSFTSubmodule(pybind11::module &m);
+void populateDialectOMSubmodule(pybind11::module &m);
 void populateDialectSVSubmodule(pybind11::module &m);
 
 } // namespace python

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -1,0 +1,100 @@
+//===- OMModule.cpp - OM API pybind module --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DialectModules.h"
+#include "circt-c/Dialect/OM.h"
+#include "circt/Support/LLVM.h"
+#include "mlir-c/IR.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
+
+using namespace mlir;
+using namespace mlir::python;
+using namespace mlir::python::adaptors;
+
+/// Provides an Object class by simply wrapping the OMObject CAPI.
+struct Object {
+  // Instantiate an Object with a reference to the underlying OMObject.
+  Object(OMObject object) : object(object) {}
+
+  // Get a field from the Object, using pybind's support for variant to return a
+  // Python object that is either an Object or Attribute.
+  std::variant<Object, MlirAttribute> getField(MlirAttribute name) {
+    // Get the field's ObjectValue via the CAPI.
+    OMObjectValue result = omEvaluatorObjectGetField(object, name);
+
+    // If the ObjectValue is null, something failed. Diagnostic handling is
+    // implemented in pure Python, so nothing to do here besides throwing an
+    // error to halt execution.
+    if (omEvaluatorObjectValueIsNull(result))
+      throw py::value_error("unable to get field, see previous error(s)");
+
+    // If the field was an Object, return a new Object.
+    if (omEvaluatorObjectValueIsAObject(result))
+      return Object(omEvaluatorObjectValueGetObject(result));
+
+    // If the field was a primitive, return the Attribute.
+    assert(omEvaluatorObjectValueIsAPrimitive(result));
+    return omEvaluatorObjectValueGetPrimitive(result);
+  }
+
+private:
+  // The underlying CAPI OMObject.
+  OMObject object;
+};
+
+/// Provides an Evaluator class by simply wrapping the OMEvaluator CAPI.
+struct Evaluator {
+  // Instantiate an Evaluator with a reference to the underlying OMEvaluator.
+  Evaluator(MlirModule mod) : evaluator(omEvaluatorNew(mod)) {}
+
+  // Instantiate an Object.
+  Object instantiate(MlirAttribute className,
+                     std::vector<MlirAttribute> actualParams) {
+    // Instantiate the Object via the CAPI.
+    OMObject result = omEvaluatorInstantiate(
+        evaluator, className, actualParams.size(), actualParams.begin().base());
+
+    // If the Object is null, something failed. Diagnostic handling is
+    // implemented in pure Python, so nothing to do here besides throwing an
+    // error to halt execution.
+    if (omEvaluatorObjectIsNull(result))
+      throw py::value_error(
+          "unable to instantiate object, see previous error(s)");
+
+    // Return a new Object.
+    return Object(result);
+  }
+
+  // Get the Module the Evaluator is built from.
+  MlirModule getModule() { return omEvaluatorGetModule(evaluator); }
+
+private:
+  // The underlying CAPI OMEvaluator.
+  OMEvaluator evaluator;
+};
+
+/// Populate the OM Python module.
+void circt::python::populateDialectOMSubmodule(py::module &m) {
+  m.doc() = "OM dialect Python native extension";
+
+  // Add the Evaluator class definition.
+  py::class_<Evaluator>(m, "Evaluator")
+      .def(py::init<MlirModule>(), py::arg("module"))
+      .def("instantiate", &Evaluator::instantiate, "Instantiate an Object",
+           py::arg("class_name"), py::arg("actual_params"))
+      .def_property_readonly("module", &Evaluator::getModule,
+                             "The Module the Evaluator is built from");
+
+  // Add the Object class definition.
+  py::class_<Object>(m, "Object")
+      .def("get_field", &Object::getField, "Get a field from an Object",
+           py::arg("name"));
+}

--- a/lib/Bindings/Python/dialects/OMOps.td
+++ b/lib/Bindings/Python/dialects/OMOps.td
@@ -1,0 +1,15 @@
+//===-- OMOps.td - Entry point for OM  bindings ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BINDINGS_PYTHON_OM_OPS
+#define BINDINGS_PYTHON_OM_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "circt/Dialect/OM/OM.td"
+
+#endif

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -1,0 +1,89 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._om_ops_gen import *
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object
+
+from circt.ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
+from circt.support import attribute_to_var, var_to_attribute
+
+import sys
+import logging
+from dataclasses import fields
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+  from _typeshed.stdlib.dataclass import DataclassInstance
+
+
+# Define the Evaluator class by inheriting from the base implementation in C++.
+class Evaluator(BaseEvaluator):
+
+  def __init__(self, mod: Module) -> None:
+    """Instantiate an Evaluator with a Module."""
+
+    # Call the base constructor.
+    super().__init__(mod)
+
+    # Set up logging for diagnostics.
+    logging.basicConfig(
+        format="[%(asctime)s] %(name)s (%(levelname)s) %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO,
+        stream=sys.stdout,
+    )
+    self._logger = logging.getLogger("Evaluator")
+
+    # Attach our Diagnostic handler.
+    mod.context.attach_diagnostic_handler(self._handle_diagnostic)
+
+  def instantiate(self, cls: type["DataclassInstance"],
+                  *args: Any) -> "DataclassInstance":
+    """Instantiate an Object with a dataclass type and actual parameters."""
+
+    # Convert the class name and actual parameters to Attributes within the
+    # Evaluator's context.
+    with self.module.context:
+      class_name = StringAttr.get(cls.__name__)
+      actual_params = var_to_attribute(*args)
+
+    # Call the base instantiate method.
+    obj = super().instantiate(class_name, actual_params)
+
+    # Convert the field names of the class we are instantiating to StringAttrs
+    # within the Evaluator's context.
+    with self.module.context:
+      field_names = [StringAttr.get(field.name) for field in fields(cls)]
+
+    # Convert the instantiated Object fields from Attributes to Python objects.
+    # This will be generalized to support Objects in fields soon.
+    object_fields = {}
+    for field_name in field_names:
+      field = obj.get_field(field_name)
+      field_value = attribute_to_var(field)
+      object_fields[field_name.value] = field_value
+
+    # Instantiate a Python object of the requested class.
+    return cls(**object_fields)
+
+  def _handle_diagnostic(self, diagnostic: Diagnostic) -> bool:
+    """Handle MLIR Diagnostics by logging them."""
+
+    # Log the diagnostic message at the appropriate level.
+    if diagnostic.severity == DiagnosticSeverity.ERROR:
+      self._logger.error(diagnostic.message)
+    elif diagnostic.severity == DiagnosticSeverity.ERROR:
+      self._logger.warning(diagnostic.message)
+    else:
+      self._logger.info(diagnostic.message)
+
+    # Log any diagnostic notes at the info level.
+    for note in diagnostic.notes:
+      self._logger.info(str(note))
+
+    # Flush the stderr stream to ensure logs appear when expected.
+    sys.stdout.flush()
+
+    # Return True, indicating this diagnostic has been fully handled.
+    return True


### PR DESCRIPTION
This adds the usual Python API structure and dialect registration boilerplate, as well as Python APIs around the Evaluator library.

The C++ implementations with pybind are intended to be as minimal and straightforward as possible, simply wrapping the CAPI.

In order to provide a handy user-facing API, a couple of the C++ implementations are wrapped in pure Python to provide a nicer interface:

The Evaluator constructor is wrapped in Python to also set up a logger and diagnostic handler that uses the logger. This allows the CAPI and C++ implementation to avoid dealing with Diagnostics. The CAPI simply returns null on failure, and the C++ implementation simply throws a Python error in this case. The pure Python diagnostic handler ensure the error and any notes are logged before the error is thrown.

The Evaluator instantiate method is also wrapped in Python to handle a few things required to provide a handy, type-safe API. It takes care of accepting Python objects for actual parameters, and converting these to Attributes using an existing helper function. It does a similar conversion back to Python objects for primitive fields. It also handles some minor metaprogramming to inspect an incoming dataclass to determine its fields, extract them from the instantiated Object, and return an instance of the dataclass.

Note that this initial implementation only supports Attributes in Object fields in the pure Python wrapper around instantiation. Support for Objects in Object fields will be added shortly in a subsequent patch.