### PR TITLE
[FIRParser] Support keywords and literal identifiers as static ref exprs.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2461,9 +2461,11 @@ ParseResult FIRStmtParser::parseRefExp(Value &result, const Twine &message) {
     return parseProbe(result);
   if (token == FIRToken::lp_rwprobe)
     return parseRWProbe(result);
-  if (token == FIRToken::identifier)
-    return parseStaticRefExp(result, message);
-  return emitError(getToken().getLoc(), message);
+
+  // Default to parsing as static reference expression.
+  // Don't check token kind, we need to support literal_identifier and keywords,
+  // let parseId handle this.
+  return parseStaticRefExp(result, message);
 }
 
 /// static_reference ::= id

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1373,3 +1373,41 @@ circuit Foo_v1p9p9:
     ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
     auto <- out_0.member.0.reset @[Field 173:49]
+
+;// -----
+; Check reference expressions using literal identifiers or keywords.
+
+; CHECK-LABEL: firrtl.circuit "Probes_refexprs"
+FIRRTL version 3.0.0
+circuit Probes_refexprs:
+  extmodule refs:
+    output `0`: {`1`: Probe<{`2`: UInt<1>}>, rwprobe: RWProbe<UInt<1>>}
+    output ref: {module: Probe<{when: UInt<1>}>}
+
+  module Probes_refexprs:
+    output `0`: {`1`: Probe<{`2`: UInt<1>}>}
+    output out: UInt<1>
+
+    inst `9` of refs
+    inst ref of refs
+
+    ; CHECK: firrtl.ref.define
+    define `0`.`1` = `9`.`0`.`1`
+
+    ; CHECK-COUNT-4: firrtl.ref.resolve
+    node a = read(`9`.`0`.`1`).`2`
+    node b = read(`9`.`0`.`1`.`2`)
+    node c = read(`9`.ref.module).when
+    ; Keyword as leading part of static ref expression:
+    node d = read(ref.`0`.`1`.`2`)
+
+    out <= and(and(a, b), and(c, d))
+
+    ; CHECK: %[[TEST:.+]], %[[TEST_REF:.+]] = firrtl.wire
+    wire `test`: {`0`: UInt<1>, `b`: UInt<1>}
+    `test`.`0` <= a
+    `test`.`b` <= b
+     ; CHECK: force_initial %{{.+}}, %[[TEST_REF]], %[[TEST]]
+    force_initial(rwprobe(`test`), `test`)
+    ; CHECK: force_initial
+    force_initial(`9`.`0`.rwprobe, `test`.`0`)


### PR DESCRIPTION
Add test.