### PR TITLE
[CI] Migrate from set-output to using environment files.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -195,11 +195,11 @@ jobs:
       # Extract the LLVM submodule hash for use in the cache key.
       - name: Get LLVM Hash
         id: get-llvm-hash
-        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+        run: echo "hash=$(git rev-parse @:./llvm)" >> $GITHUB_OUTPUT
 
       - name: Get workflow spec hash
         id: get-workflow-hash
-        run: echo "::set-output name=hash::$(md5sum $GITHUB_WORKSPACE/.github/workflows/buildAndTest.yml | awk '{print $1}')"
+        run: echo "hash=$(md5sum $GITHUB_WORKSPACE/.github/workflows/buildAndTest.yml | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       # Try to fetch LLVM from the cache.
       - name: Cache LLVM

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -31,7 +31,7 @@ jobs:
       # Extract the LLVM submodule hash for use in the cache key.
       - name: Get LLVM Hash
         id: get-llvm-hash
-        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+        run: echo "hash=$(git rev-parse @:./llvm)" >> $GITHUB_OUTPUT
         shell: bash
 
       # Try to fetch LLVM from the cache.

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -49,7 +49,7 @@ jobs:
         id: build-current-llvm-commit
         run: |
           cd llvm
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           cmake --build ../build --config Debug --target check-circt --target check-circt-unit -- -j$(nproc)
 
       - name: Build latest LLVM commit
@@ -59,7 +59,7 @@ jobs:
           cd llvm
           git fetch origin main
           git checkout --detach origin/main
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           cmake --build ../build --config Debug --target check-circt --target check-circt-unit -- -j$(nproc)
 
       - name: Bisect commits


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands