### PR TITLE
[Pipeline] Add optional `stall` signal to pipelines

### DIFF
--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -44,17 +44,23 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
     been scheduled. It contains a single block representing a graph region of
     operations to-be-scheduled into a pipeline.
     Mainly serves as a container and entrypoint for scheduling.
+
+    A `pipeline.pipeline` supports a `stall` input. This signal is intended to
+    connect to all stages within the pipeline, and is used to stall the entirety
+    of the pipeline. It is lowering defined how stages choose to use this signal,
+    although in the common case, a `stall` signal would typically connect to
+    the clock-enable input of the stage-separating registers.
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset
+    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>: $body);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $inputs `)` `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
+    `(` $inputs `)` (`stall` $stall^)? `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
   }];
 
   let extraClassDeclaration = [{
@@ -95,6 +101,13 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     The internal representation of the pipeline is agnostic to the latency
     insensitivity of the I/O. This is by design - allowing us a single source
     of truth for lowering either latency sensitive or latency insensitive pipelines.
+
+
+    A `pipeline.pipeline` supports a `stall` input. This signal is intended to
+    connect to all stages within the pipeline, and is used to stall the entirety
+    of the pipeline. It is lowering defined how stages choose to use this signal,
+    although in the common case, a `stall` signal would typically connect to
+    the clock-enable input of the stage-separating registers.
   }];
 
   let arguments = (ins
@@ -106,11 +119,12 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "Value":$clock, "Value":$reset)>
+    OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "Value":$clock,
+      "Value":$reset, Optional<I1>:$stall)>
   ];
 
   let assemblyFormat = [{
-    `(` $inputs `)` `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
+    `(` $inputs `)` (`stall` $stall^)? `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -35,7 +35,8 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
     SingleBlockImplicitTerminator<"ReturnOp">,
     RegionKindInterface,
     HasOnlyGraphRegion,
-    PipelineLike
+    PipelineLike,
+    AttrSizedOperandSegments
   ]> {
   
   let summary = "unscheduled pipeline operation";
@@ -84,7 +85,8 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     IsolatedFromAbove,
     Pure,
     RegionKindInterface,
-    PipelineLike
+    PipelineLike,
+    AttrSizedOperandSegments
   ]> {
   let summary = "Scheduled pipeline operation";
   let description = [{
@@ -111,7 +113,7 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset
+    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region AnyRegion:$body);
@@ -119,8 +121,8 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "Value":$clock,
-      "Value":$reset, Optional<I1>:$stall)>
+    OpBuilder<(ins
+      "TypeRange":$results, "ValueRange":$inputs, "Value":$clock, "Value":$reset, CArg<"Value", "{}">:$stall)>
   ];
 
   let assemblyFormat = [{

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -83,12 +83,20 @@ void ScheduledPipelineOp::build(mlir::OpBuilder &odsBuilder,
                                 mlir::OperationState &odsState,
                                 ::mlir::TypeRange results,
                                 mlir::ValueRange inputs, mlir::Value clock,
-                                mlir::Value reset) {
+                                mlir::Value reset, mlir::Value stall) {
   odsState.addOperands(inputs);
   odsState.addOperands(clock);
   odsState.addOperands(reset);
+  if (stall)
+    odsState.addOperands(stall);
   auto *region = odsState.addRegion();
   odsState.addTypes(results);
+
+  odsState.addAttribute(
+      "operand_segment_sizes",
+      odsBuilder.getDenseI32ArrayAttr(
+          {static_cast<int32_t>(inputs.size()), static_cast<int32_t>(1),
+           static_cast<int32_t>(1), static_cast<int32_t>(stall ? 1 : 0)}));
 
   // Add the entry stage
   auto &entryBlock = region->emplaceBlock();

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -138,7 +138,7 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
   b.setInsertionPoint(pipeline);
   auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
       pipeline.getLoc(), pipeline->getResultTypes(), pipeline.getInputs(),
-      pipeline.getClock(), pipeline.getReset());
+      pipeline.getClock(), pipeline.getReset(), pipeline.getStall());
 
   Block *currentStage = schedPipeline.getStage(0);
 

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -53,3 +53,12 @@ hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : 
   }
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: hw.module @withStall
+hw.module @withStall(%arg0 : i32, %go : i1, %stall : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.pipeline(%arg0, %go) stall %stall clock %clk reset %rst : (i32, i1) -> (i32) {
+   ^bb0(%a0 : i32, %gogo: i1):
+    pipeline.return %a0 valid %gogo : i32
+  }
+  hw.output %0 : i32
+}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -1,6 +1,15 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: hw.module @unscheduled1
+// CHECK-LABEL:   hw.module @unscheduled1(
+// CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_4:.*]] = pipeline.unscheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             %[[VAL_8:.*]] = hw.constant true
+// CHECK:             pipeline.return %[[VAL_7]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_9:.*]] : i32
+// CHECK:         }
 hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
@@ -11,7 +20,18 @@ hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out:
   hw.output %0 : i32
 }
 
-// CHECK-LABEL: hw.module @scheduled1
+// CHECK-LABEL:   hw.module @scheduled1(
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             %[[VAL_8:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 enable %[[VAL_8]]
+// CHECK:           ^bb1:
+// CHECK:             pipeline.return %[[VAL_7]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_9:.*]] : i32
+// CHECK:         }
 hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
@@ -26,7 +46,18 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i
 }
 
 
-// CHECK-LABEL: hw.module @scheduled2
+// CHECK-LABEL:   hw.module @scheduled2(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             %[[VAL_8:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]], %[[VAL_8]] : i32, i1) enable %[[VAL_8]]
+// CHECK:           ^bb1(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_11:.*]] : i32
+// CHECK:         }
 hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
@@ -40,7 +71,18 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i
   hw.output %0 : i32
 }
 
-// CHECK-LABEL: hw.module @scheduledWithPassthrough
+// CHECK-LABEL:   hw.module @scheduledWithPassthrough(
+// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_4:.*]]:2 = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> (i32, i32) {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             %[[VAL_8:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]], %[[VAL_8]] : i32, i1) pass(%[[VAL_6]] : i32) enable %[[VAL_8]]
+// CHECK:           ^bb1(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i1, %[[VAL_11:.*]]: i32):
+// CHECK:             pipeline.return %[[VAL_9]], %[[VAL_11]] : i32, i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_12:.*]]#0 : i32
+// CHECK:         }
 hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0, %1 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
    ^bb0(%a0 : i32, %a1: i32):
@@ -54,11 +96,18 @@ hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : 
   hw.output %0 : i32
 }
 
-// CHECK-LABEL: hw.module @withStall
-hw.module @withStall(%arg0 : i32, %go : i1, %stall : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.pipeline(%arg0, %go) stall %stall clock %clk reset %rst : (i32, i1) -> (i32) {
-   ^bb0(%a0 : i32, %gogo: i1):
-    pipeline.return %a0 valid %gogo : i32
+// CHECK-LABEL:   hw.module @withStall(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]]) stall %[[VAL_1]] clock %[[VAL_2]] reset %[[VAL_3]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32):
+// CHECK:             pipeline.return %[[VAL_5]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_6:.*]] : i32
+// CHECK:         }
+hw.module @withStall(%arg0 : i32, %stall : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst : (i32) -> (i32) {
+   ^bb0(%a0 : i32):
+    pipeline.return %a0 : i32
   }
   hw.output %0 : i32
 }


### PR DESCRIPTION
This signal is intended to connect to all stages within the pipeline, and is used to stall the entirety of the pipeline. It is lowering defined how stages choose to use this signal, although in the common case, a `stall` signal would typically connect to the clock-enable input of the stage-separating registers.

Future PRs will implement hardware lowerings - blocked by #5234.