### PR TITLE
Move cocotb driver to separate tool

### DIFF
--- a/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
+++ b/integration_test/Dialect/Handshake/buffer_init_none/buffer_init_none.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=buffer_init_none --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/buffer_initial_values/buffer_initial_values.mlir
+++ b/integration_test/Dialect/Handshake/buffer_initial_values/buffer_initial_values.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_initial_values --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=buffer_initial_values --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=buffer_initial_values --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=buffer_initial_values --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
+++ b/integration_test/Dialect/Handshake/conditional_modification/conditional_modification.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=conditional_modification --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST
 // CHECK-NEXT: ********************************

--- a/integration_test/Dialect/Handshake/dot/dot.mlir
+++ b/integration_test/Dialect/Handshake/dot/dot.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=dot --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=dot --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=dot --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=dot --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/lit.local.cfg.py
+++ b/integration_test/Dialect/Handshake/lit.local.cfg.py
@@ -6,5 +6,4 @@ for pyfile in glob.glob(os.path.join(dir_path, "**", "*.py")):
   # remove dir from pyfile
   config.excludes.add(os.path.basename(pyfile))
 
-config.excludes.add('cocotb_driver.py')
 config.excludes.add('helper.py')

--- a/integration_test/Dialect/Handshake/matmul/matmul.mlir
+++ b/integration_test/Dialect/Handshake/matmul/matmul.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=matmul --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=matmul --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=matmul --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=matmul --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/max/max.mlir
+++ b/integration_test/Dialect/Handshake/max/max.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=max --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=max --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=max --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=max --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST
 // CHECK-NEXT: ********************************

--- a/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.mlir
+++ b/integration_test/Dialect/Handshake/mix_std_hs/mix_std_hs.mlir
@@ -2,7 +2,7 @@
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --split-verilog --lowering-options=disallowLocalVariables,disallowPackedStructAssignments -o %T-cycles
 // RUN: hlstool %S/kernel.mlir --dynamic-hw --buffering-strategy=cycles --split-verilog --lowering-options=disallowLocalVariables,disallowPackedStructAssignments -o %T-cycles
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder=%S %T-cycles/*.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=mix_std_hs --pythonFolder="%S,%S/.." %T-cycles/*.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
+++ b/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.mlir
@@ -1,14 +1,14 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=multiple_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[NUM:.*]] PASS=[[NUM]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
+++ b/integration_test/Dialect/Handshake/nested_diamonds/nested_diamonds.mlir
@@ -2,16 +2,16 @@
 
 // RUN: circt-opt %s --insert-merge-blocks | \
 // RUN: hlstool --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // @mortbopet: this is currently disabled due to deadlocking.
 // RUN: circt-opt %s --insert-merge-blocks | \
 // RUN: hlstool --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv
-// DISABLED: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// DISABLED: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_diamonds --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[NUM:.*]] PASS=[[NUM]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
+++ b/integration_test/Dialect/Handshake/nested_loops/nested_loops.mlir
@@ -1,15 +1,15 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=nested_loops --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[NUM:.*]] PASS=[[NUM]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/sync_backedge/sync_backedge.mlir
+++ b/integration_test/Dialect/Handshake/sync_backedge/sync_backedge.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=sync_backedge --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=sync_backedge --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=sync_backedge --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=sync_backedge --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/sync_op/sync_op.mlir
+++ b/integration_test/Dialect/Handshake/sync_op/sync_op.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=sync_op --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=sync_op --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=sync_op --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=sync_op --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
+++ b/integration_test/Dialect/Handshake/task_pipelining/task_pipelining.mlir
@@ -1,14 +1,14 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=task_pipelining --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST
 // CHECK-NEXT: ********************************

--- a/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
+++ b/integration_test/Dialect/Handshake/tp_memory/tp_memory.mlir
@@ -1,14 +1,14 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --sv-trace-iverilog --dynamic-hw --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --sv-trace-iverilog --dynamic-hw --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // Locking the circt should yield the same result
 // RUN: hlstool %s --dynamic-hw --buffering-strategy=all --dynamic-parallelism=locking --verilog --lowering-options=disallowLocalVariables > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tp_memory --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK:      ** TEST
 // CHECK-NEXT: ********************************

--- a/integration_test/Dialect/Handshake/tuple_input/tuple_input.mlir
+++ b/integration_test/Dialect/Handshake/tuple_input/tuple_input.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables,disallowPackedStructAssignments > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_input --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tuple_input --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=all --verilog --lowering-options=disallowLocalVariables,disallowPackedStructAssignments > %t.sv && \
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_input --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tuple_input --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
+++ b/integration_test/Dialect/Handshake/tuple_packing/tuple_packing.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: iverilog,cocotb
 
 // RUN: hlstool %s --dynamic-hw --ir-input-level 1 --buffering-strategy=cycles --verilog --lowering-options=disallowLocalVariables,disallowPackedStructAssignments > %t.sv
-// RUN: %PYTHON% %S/../cocotb_driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder=%S %t.sv 2>&1 | FileCheck %s
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=top --pythonModule=tuple_packing --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(arcilator)
 add_subdirectory(circt-as)
+add_subdirectory(circt-cocotb-driver)
 add_subdirectory(circt-dis)
 add_subdirectory(circt-lec)
 add_subdirectory(circt-lsp-server)

--- a/tools/circt-cocotb-driver/CMakeLists.txt
+++ b/tools/circt-cocotb-driver/CMakeLists.txt
@@ -1,0 +1,12 @@
+# ===- CMakeLists.txt - Cocotb driver cmake -------------------*- cmake -*-===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===//
+
+# The Python script requires that it be configured.
+configure_file("circt-cocotb-driver.py.in" "${CIRCT_TOOLS_DIR}/circt-cocotb-driver.py")
+add_custom_target(circt-cocotb-driver
+  SOURCES "${CIRCT_TOOLS_DIR}/circt-cocotb-driver.py")

--- a/tools/circt-cocotb-driver/circt-cocotb-driver.py.in
+++ b/tools/circt-cocotb-driver/circt-cocotb-driver.py.in
@@ -1,9 +1,10 @@
+#!@Python3_EXECUTABLE@
+
 import argparse
 import os
 import subprocess
 import sys
 import re
-from pathlib import Path
 from cocotb_test.simulator import run
 
 
@@ -30,10 +31,10 @@ def parseArgs(args):
                          required=True,
                          help="Name of the python module.")
 
-  argparser.add_argument("--pythonFolder",
-                         type=str,
-                         default=os.getcwd(),
-                         help="The folder where the cocotb test file is.")
+  argparser.add_argument("--pythonFolders",
+                            type=str,
+                         default="",
+                         help="The folders where cocotb should include from, separated by commas.")
 
   argparser.add_argument(
       "sources",
@@ -114,7 +115,7 @@ def main():
       toplevel=args.topLevel,
       toplevel_lang="verilog",
       verilog_sources=sources,
-      python_search=[args.pythonFolder],
+      python_search=[f.strip() for f in args.pythonFolders.split(",")],
       work_dir=objDir,
       compile_args=compileArgs)
 


### PR DESCRIPTION
Turns out the cocotb driver is useful for things other than handshake... moves the cocotb driver to a separate tool folder, and modifies handshake tests accordingly.