### PR TITLE
[OM] Add ClassOp builders

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -40,9 +40,16 @@ def ClassOp : OMOp<"class",
   );
 
   let builders = [
+    OpBuilder<(ins "::mlir::Twine":$name)>,
     OpBuilder<(ins "::mlir::Twine":$name,
-                    "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames)>,
-    OpBuilder<(ins "::mlir::Twine":$name)>
+                   "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames)>,
+    OpBuilder<(ins "::mlir::Twine":$name,
+                   "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames,
+                   "::mlir::ArrayRef<::mlir::Type>":$fieldTypes)>,
+    OpBuilder<(ins "::mlir::Twine":$name,
+                   "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames,
+                   "::mlir::ArrayRef<::mlir::StringRef>":$fieldNames,
+                   "::mlir::ArrayRef<::mlir::Type>":$fieldTypes)>,
   ];
 
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -43,13 +43,6 @@ def ClassOp : OMOp<"class",
     OpBuilder<(ins "::mlir::Twine":$name)>,
     OpBuilder<(ins "::mlir::Twine":$name,
                    "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames)>,
-    OpBuilder<(ins "::mlir::Twine":$name,
-                   "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames,
-                   "::mlir::ArrayRef<::mlir::Type>":$fieldTypes)>,
-    OpBuilder<(ins "::mlir::Twine":$name,
-                   "::mlir::ArrayRef<::mlir::StringRef>":$formalParamNames,
-                   "::mlir::ArrayRef<::mlir::StringRef>":$fieldNames,
-                   "::mlir::ArrayRef<::mlir::Type>":$fieldTypes)>,
   ];
 
   let hasCustomAssemblyFormat = 1;
@@ -58,6 +51,14 @@ def ClassOp : OMOp<"class",
 
   let extraClassDeclaration = [{
     mlir::Block *getBodyBlock() { return &getBody().front(); }
+    // This builds a ClassOp, and populates it with the CLassFieldOps.
+    // Build the ClassOp with `name` and `formalParamNames`. Then add
+    // ClassFieldOps for each name and type in `fieldNames` and `fieldTypes`.
+    circt::om::ClassOp static buildSimpleClassOp(
+    mlir::OpBuilder &odsBuilder, mlir::Location loc, mlir::Twine name,
+    mlir::ArrayRef<mlir::StringRef> formalParamNames,
+    mlir::ArrayRef<mlir::StringRef> fieldNames,
+    mlir::ArrayRef<mlir::Type> fieldTypes);
   }];
 }
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -66,6 +66,30 @@ void circt::om::ClassOp::build(OpBuilder &odsBuilder, OperationState &odsState,
 }
 
 void circt::om::ClassOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                               Twine name, ArrayRef<StringRef> formalParamNames,
+                               ArrayRef<Type> fieldTypes) {
+
+  return build(odsBuilder, odsState, name, formalParamNames, formalParamNames,
+               fieldTypes);
+}
+
+void circt::om::ClassOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                               Twine name, ArrayRef<StringRef> formalParamNames,
+                               ArrayRef<StringRef> fieldNames,
+                               ArrayRef<Type> fieldTypes) {
+  build(odsBuilder, odsState, odsBuilder.getStringAttr(name),
+        odsBuilder.getStrArrayAttr(formalParamNames));
+  Block *body = &odsState.regions[0]->emplaceBlock();
+  auto loc = odsState.location;
+  OpBuilder bodyBuilder(odsState.getContext());
+  bodyBuilder.setInsertionPointToEnd(body);
+  for (auto [name, type] : llvm::zip(fieldNames, fieldTypes)) {
+    bodyBuilder.create<om::ClassFieldOp>(loc, name,
+                                         body->addArgument(type, loc));
+  }
+}
+
+void circt::om::ClassOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                                Twine name) {
   return build(odsBuilder, odsState, odsBuilder.getStringAttr(name),
                odsBuilder.getStrArrayAttr({}));

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -63,9 +63,9 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
-  StringRef fields[] = {"field"};
-  Type types[] = {builder.getIntegerType(32)};
-  builder.create<ClassOp>("MyClass", params, fields, types);
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
+                                           cls.getLoc());
 
   Evaluator evaluator(mod);
 
@@ -194,7 +194,7 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
   Type types[] = {builder.getIntegerType(32)};
-  builder.create<ClassOp>("MyClass", params, fields, types);
+  ClassOp::buildSimpleClassOp(builder, loc, "MyClass", params, fields, types);
 
   Evaluator evaluator(mod);
 
@@ -262,8 +262,8 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
   Type types[] = {builder.getIntegerType(32)};
-  auto innerCls =
-      builder.create<ClassOp>("MyInnerClass", params, fields, types);
+  auto innerCls = ClassOp::buildSimpleClassOp(builder, loc, "MyInnerClass",
+                                              params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);
@@ -310,8 +310,8 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
   Type types[] = {builder.getIntegerType(32)};
-  auto innerCls =
-      builder.create<ClassOp>("MyInnerClass", params, fields, types);
+  auto innerCls = ClassOp::buildSimpleClassOp(builder, loc, "MyInnerClass",
+                                              params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -63,9 +63,9 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
-  auto cls = builder.create<ClassOp>("MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
-                                           cls.getLoc());
+  StringRef fields[] = {"field"};
+  Type types[] = {builder.getIntegerType(32)};
+  builder.create<ClassOp>("MyClass", params, fields, types);
 
   Evaluator evaluator(mod);
 
@@ -192,11 +192,9 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
-  auto cls = builder.create<ClassOp>("MyClass", params);
-  auto &body = cls.getBody().emplaceBlock();
-  body.addArgument(builder.getIntegerType(32), cls.getLoc());
-  builder.setInsertionPointToStart(&body);
-  builder.create<ClassFieldOp>("field", body.getArgument(0));
+  StringRef fields[] = {"field"};
+  Type types[] = {builder.getIntegerType(32)};
+  builder.create<ClassOp>("MyClass", params, fields, types);
 
   Evaluator evaluator(mod);
 
@@ -262,11 +260,10 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
-  auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
-  auto &innerBody = innerCls.getBody().emplaceBlock();
-  innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());
-  builder.setInsertionPointToStart(&innerBody);
-  builder.create<ClassFieldOp>("field", innerBody.getArgument(0));
+  StringRef fields[] = {"field"};
+  Type types[] = {builder.getIntegerType(32)};
+  auto innerCls =
+      builder.create<ClassOp>("MyInnerClass", params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);
@@ -311,11 +308,10 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
-  auto innerCls = builder.create<ClassOp>("MyInnerClass", params);
-  auto &innerBody = innerCls.getBody().emplaceBlock();
-  innerBody.addArgument(builder.getIntegerType(32), innerCls.getLoc());
-  builder.setInsertionPointToStart(&innerBody);
-  builder.create<ClassFieldOp>("field", innerBody.getArgument(0));
+  StringRef fields[] = {"field"};
+  Type types[] = {builder.getIntegerType(32)};
+  auto innerCls =
+      builder.create<ClassOp>("MyInnerClass", params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);


### PR DESCRIPTION
Add convenient builders to `om::ClassOp` that given the parameter names, and field names and types, will create the body of the `ClassOp` with all the `ClassFieldOp` initialized.

Pasting a use case here, 
```cpp

  StringRef paramNames[] = {"name",           "depth",        "width",
                            "maskBits",       "readPorts",    "writePorts",
                            "readwritePorts", "writeLatency", "readLatency"};
  mlir::Type classFieldTypes[] = {
      om::SymbolRefType::get(context),
      mlir::IntegerType::get(context, 64, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned),
      mlir::IntegerType::get(context, 32, IntegerType::Unsigned)};

      // Memory metadata class.
 auto   memorySchemaClass = builderOM.create<circt::om::ClassOp>(
        "MemorySchema", paramNames, classFieldTypes);
```
will generate : 

```mlir 
om.class @MemorySchema(%name: !om.sym_ref, %depth: ui64, %width: ui32, %maskBits: ui32, %readPorts: ui32, %writePorts: ui32, %readwritePorts: ui32, %writeLatency: ui32, %readLatency: ui32) {
    om.class.field @name, %name : !om.sym_ref
    om.class.field @depth, %depth : ui64
    om.class.field @width, %width : ui32
    om.class.field @maskBits, %maskBits : ui32
    om.class.field @readPorts, %readPorts : ui32
    om.class.field @writePorts, %writePorts : ui32
    om.class.field @readwritePorts, %readwritePorts : ui32
    om.class.field @writeLatency, %writeLatency : ui32
    om.class.field @readLatency, %readLatency : ui32
  }
```