### PR TITLE
[FIRRTL] Tweak naming

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -382,11 +382,12 @@ def FNamableOp : OpInterface<"FNamableOp"> {
              getAttrOfType<NameKindEnumAttr>("nameKind").getValue()
              == NameKindEnum::DroppableName;
     }]>,
-    InterfaceMethod<"Make the name droppable.",
+    InterfaceMethod<"Completely drop a name.",
     "void", "dropName", (ins), [{}], /*defaultImplementation=*/[{
       this->getOperation()->setAttr("nameKind",
         NameKindEnumAttr::get(this->getOperation()->getContext(),
                               NameKindEnum::DroppableName));
+      this->getOperation()->setAttr("name", StringAttr::get(this->getOperation()->getContext(), ""));
     }]>,
     InterfaceMethod<"Set a namekind.",
     "void", "setNameKindAttr", (ins "firrtl::NameKindEnumAttr":$nameKind),

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -602,6 +602,8 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
            }]>
   ];
   let statistics = [
+    Statistic<"numNamesDropped", "num-names-dropped",
+      "Number of names dropped">,
     Statistic<"numNamesConverted", "num-names-converted",
       "Number of interesting names made droppable">,
   ];

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -85,10 +85,10 @@ static bool isUInt1(Type type) {
   return true;
 }
 
-// Heuristic to pick the best name.  Always pick a name over no name.  Always
-// pick a good name over a useless name.  Always pick a good name over one which
-// starts with underscore.  Define the best name as the longest name.
-// This function deterministically favors the second name on ties.
+// Heuristic to pick the best name.
+// Good names are not useless, don't start with an underscore, minimize
+// underscores in them, and are short. This function deterministically favors
+// the second name on ties.
 static StringRef chooseName(StringRef a, StringRef b) {
   if (a.empty())
     return b;
@@ -102,7 +102,11 @@ static StringRef chooseName(StringRef a, StringRef b) {
     return b;
   if (b.starts_with("_"))
     return a;
-  if (a.size() < b.size())
+  if (b.count('_') < a.count('_'))
+    return b;
+  if (b.count('_') > a.count('_'))
+    return a;
+  if (a.size() > b.size())
     return b;
   return a;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -115,12 +115,12 @@ static StringRef chooseName(StringRef a, StringRef b) {
 /// the name passed in.
 static void updateName(PatternRewriter &rewriter, Operation *op,
                        StringAttr name) {
-  if (!name || name.getValue().empty() || name.getValue() == "")
+  if (!name || name.getValue().empty())
     return;
   auto newName = name.getValue(); // old name is interesting
   auto newOpName = op->getAttrOfType<StringAttr>("name");
   // new name might not be interesting
-  if (newOpName && !newOpName.getValue().empty() && newOpName.getValue() != "")
+  if (newOpName)
     newName = chooseName(newOpName.getValue(), name.getValue());
   // Only update if needed
   if (!newOpName || newOpName.getValue() != newName)

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -88,7 +88,7 @@ static bool isUInt1(Type type) {
 // Heuristic to pick the best name.  Always pick a name over no name.  Always
 // pick a good name over a useless name.  Always pick a good name over one which
 // starts with underscore.  Define the best name as the longest name.
-// This deterministically favors the second name on ties.
+// This function deterministically favors the second name on ties.
 static StringRef chooseName(StringRef a, StringRef b) {
   if (a.empty())
     return b;

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -54,9 +54,9 @@ struct DropNamesPass : public DropNameBase<DropNamesPass> {
           return ModAction::Demote;
         return ModAction::Keep;
       });
-      numNamesConverted += namesChanged;
-      numNamesDropped += namesDropped;
     }
+    numNamesConverted += namesChanged;
+    numNamesDropped += namesDropped;
   }
 
 private:

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -24,26 +24,59 @@ struct DropNamesPass : public DropNameBase<DropNamesPass> {
     this->preserveMode = preserveMode;
   }
 
+  enum ModAction { Drop, Keep, Demote };
+
   void runOnOperation() override {
+    size_t namesDropped = 0;
+    size_t namesChanged = 0;
     if (preserveMode == PreserveValues::None) {
       // Drop all names.
-      numNamesConverted += dropNamesIf([](FNamableOp) { return true; });
+      dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
+        if (isUselessName(op.getName()))
+          return ModAction::Drop;
+        if (op.getName().starts_with("_"))
+          return ModAction::Drop;
+        return ModAction::Demote;
+      });
     } else if (preserveMode == PreserveValues::Named) {
       // Drop the name if it isn't considered meaningful.
-      numNamesConverted += dropNamesIf(
-          [](FNamableOp op) { return isUselessName(op.getName()); });
+      dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
+        if (isUselessName(op.getName()))
+          return ModAction::Drop;
+        if (op.getName().starts_with("_"))
+          return ModAction::Demote;
+        return ModAction::Keep;
+      });
+    } else if (preserveMode == PreserveValues::All) {
+      // Drop the name if it isn't considered meaningful.
+      dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
+        if (isUselessName(op.getName()))
+          return ModAction::Demote;
+        return ModAction::Keep;
+      });
+      numNamesConverted += namesChanged;
+      numNamesDropped += namesDropped;
     }
   }
 
 private:
-  size_t dropNamesIf(llvm::function_ref<bool(FNamableOp)> pred) {
+  size_t dropNamesIf(size_t &namesChanged, size_t &namesDropped,
+                     llvm::function_ref<ModAction(FNamableOp)> pred) {
     size_t changedNames = 0;
     auto droppableNameAttr =
         NameKindEnumAttr::get(&getContext(), NameKindEnum::DroppableName);
     getOperation()->walk([&](FNamableOp op) {
-      if (pred(op) && !op.hasDroppableName()) {
-        ++changedNames;
+      switch (pred(op)) {
+      case ModAction::Drop:
+        op.dropName();
+        ++namesDropped;
+        break;
+      case ModAction::Demote:
         op.setNameKindAttr(droppableNameAttr);
+        ++namesChanged;
+        break;
+      default:
+        break;
       }
     });
     return changedNames;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -26,14 +26,14 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
                                                   StringRef inputFilename) {
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerIntrinsicsPass());
 
-  if (!opt.disableOptimization)
-    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        mlir::createCSEPass());
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInjectDUTHierarchyPass());
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createDropNamesPass(opt.getPreserveMode()));
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInjectDUTHierarchyPass());
+  if (!opt.disableOptimization)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        mlir::createCSEPass());
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createLowerCHIRRTLPass());

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2733,7 +2733,7 @@ firrtl.module @MultibitMux(in %a: !firrtl.vector<uint<1>, 3>, in %sel: !firrtl.u
 firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
   %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %_useless_name_1 = firrtl.node  %0  : !firrtl.uint<1>
-  %useful_name = firrtl.node  %_useless_name_1  : !firrtl.uint<1>
+  %useful_name = firrtl.node %_useless_name_1  : !firrtl.uint<1>
   %_useless_name_2 = firrtl.node  %useful_name  : !firrtl.uint<1>
   // CHECK-NEXT: %useful_name = firrtl.or %in0, %in1
   // CHECK-NEXT: firrtl.strictconnect %out, %useful_name

--- a/test/Dialect/FIRRTL/drop-name.mlir
+++ b/test/Dialect/FIRRTL/drop-name.mlir
@@ -11,7 +11,13 @@ firrtl.circuit "Foo" {
 
     // ALL:   %_a = firrtl.wire  interesting_name : !firrtl.uint<1>
     // NAMED: %_a = firrtl.wire  : !firrtl.uint<1>
-    // NONE:  %_a = firrtl.wire  : !firrtl.uint<1>
+    // NONE:  %0 = firrtl.wire  : !firrtl.uint<1>
     %_a = firrtl.wire interesting_name : !firrtl.uint<1>
+
+    // ALL:   %_T = firrtl.wire : !firrtl.uint<1>
+    // NAMED: %0 = firrtl.wire  : !firrtl.uint<1>
+    // NONE:  %1 = firrtl.wire  : !firrtl.uint<1>
+    %_T = firrtl.wire interesting_name : !firrtl.uint<1>
+
   }
 }


### PR DESCRIPTION
Lots of _T_ and _WIRE were appearing in the output.  These are quite useless.  We filter these out at all name preservation levels.  This also allows putting other names which start with '_' as droppable.

Also reorder a pass to increase parallelism [NFCI]