### PR TITLE
Update GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -9,10 +9,10 @@ Welcome to the CIRCT project!
 methodology to the domain of hardware design tools.
 
 Take a look at the following diagram, which gives a brief overview of the 
-current [dialects and how they interact](/includes/img/dialects.svg):
+current [dialects and how they interact](includes/img/dialects.svg):
 
-<p align="center"><img src="/includes/img/dialectlegend.svg"/></p>
-<p align="center"><img src="/includes/img/dialects.svg"/></p>
+<p align="center"><img src="includes/img/dialectlegend.svg"/></p>
+<p align="center"><img src="includes/img/dialects.svg"/></p>
 
 ## Setting this up
 


### PR DESCRIPTION
Fixed links to dialect images. A previous commit (b142ded) changed the links to root-relative links instead of relative links, breaking the images. I have changed the links back to relative.