### PR TITLE
[IMCP] Mark overdefined for the operations with large number of operands

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -709,7 +709,7 @@ void IMConstPropPass::visitOperation(Operation *op) {
 
   // To prevent regressions, mark values as overdefined when they are defined
   // by operations with a large number of operands.
-  if (op->getNumOperands() >= 128) {
+  if (op->getNumOperands() > 128) {
     for (auto value : op->getResults())
       markOverdefined(value);
     return;

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -707,6 +707,14 @@ void IMConstPropPass::visitOperation(Operation *op) {
   if (llvm::all_of(op->getResults(), isOverdefinedFn))
     return;
 
+  // To prevent regressions, mark values as overdefined when they are defined
+  // by operations with a large number of operands.
+  if (op->getNumOperands() >= 128) {
+    for (auto value : op->getResults())
+      markOverdefined(value);
+    return;
+  }
+
   // Collect all of the constant operands feeding into this operation. If any
   // are not ready to be resolved, bail out and wait for them to resolve.
   SmallVector<Attribute, 8> operandConstants;


### PR DESCRIPTION
We don't mark overdefined if there exists an operand with unknown state. This was required to get optimal results, but it also means that we have to try folding every time operand state was changed. It could cause regressions for operations with large number of operands. Actually in the internal designs there are operations with 65536 operands which caused regression in IMCP. This PR fixes the issue by just giving up such operations, especially when there are more than 128 operands since the success rate of folder should be much less. Maybe we can improve by specializing a folder for IMCP so that we don't have to get all operand lattice states.