### PR TITLE
[TypeAlias] Add LowerToHW support for lowering TypeAlias

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -232,8 +232,12 @@ mapBaseTypeNullable(FIRRTLType type,
 
 /// Given a type, return the corresponding lowered type for the HW dialect.
 /// Non-FIRRTL types are simply passed through. This returns a null type if it
-/// cannot be lowered.
-Type lowerType(Type type);
+/// cannot be lowered. The optional function is required to specify how to lower
+/// AliasTypes.
+Type lowerType(
+    Type type, std::optional<Location> loc = {},
+    llvm::function_ref<hw::TypeAliasType(Type, BaseTypeAliasType, Location)>
+        getTypeDeclFn = {});
 
 //===----------------------------------------------------------------------===//
 // Parser-related utilities

--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -83,24 +83,16 @@ public:
   }
 
   /// Return a unique name, derived from the input `name` and ensure the
-  /// returned name has the input `suffix` only if `allowNoSuffix` is false.
-  /// `allowNoSuffix` ensures that the original name without the suffix is
-  /// returned if there is no conflict. Also add the new name to the internal
-  /// namespace. There are two possible outcomes for the returned name:
-  /// 1. The original name if `allowNoSuffix` is true, else original name +
-  /// `_<suffix>` is returned.
+  /// returned name has the input `suffix`. Also add the new name to the
+  /// internal namespace.
+  /// There are two possible outcomes for the returned name:
+  /// 1. The original name + `_<suffix>` is returned.
   /// 2. The name is given a suffix `_<n>_<suffix>` where `<n>` is a number
   ///    starting from `0` and incrementing by one each time.
-  StringRef newName(const Twine &name, const Twine &suffix,
-                    bool allowNoSuffix = false) {
+  StringRef newName(const Twine &name, const Twine &suffix) {
     // Special case the situation where there is no name collision to avoid
     // messing with the SmallString allocation below.
     llvm::SmallString<64> tryName;
-    if (allowNoSuffix) {
-      auto inserted = nextIndex.insert({name.toStringRef(tryName), 0});
-      if (inserted.second)
-        return inserted.first->getKey();
-    }
     auto inserted = nextIndex.insert(
         {name.concat("_").concat(suffix).toStringRef(tryName), 0});
     if (inserted.second)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -295,10 +295,8 @@ struct CircuitLoweringState {
     // Get a unique typedecl name.
     // The bundleName can conflict with other symbols, but must be unique within
     // the TypeScopeOp.
-    typeName = StringAttr::get(
-        typeName.getContext(),
-        typeDeclNamespace.newName(typeName.getValue(), suffix,
-                                  /* Use suffix only on name conflict */ true));
+    typeName = StringAttr::get(typeName.getContext(),
+                               typeDeclNamespace.newName(typeName.getValue()));
 
     auto typeScopeBuilder =
         ImplicitLocOpBuilder::atBlockEnd(typeLoc, typeScope.getBodyBlock());

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -276,7 +276,7 @@ struct CircuitLoweringState {
       return hwAlias;
     assert(!typeAliases.isFrozen() &&
            "type aliases cannot be generated after its frozen");
-    return typeAliases.addTypedecl(firAliasType, rawType, typeLoc);
+    return typeAliases.addTypedecl(rawType, firAliasType, typeLoc);
   }
 
   FModuleLike getDut() { return dut; }
@@ -366,7 +366,7 @@ private:
   /// deteministic TypeDecls inside the global TypeScopeOp.
   struct RecordTypeAlias {
 
-    RecordTypeAlias(CircuitOp &c) : circuitOp(c) {}
+    RecordTypeAlias(CircuitOp c) : circuitOp(c) {}
 
     hw::TypeAliasType getTypedecl(BaseTypeAliasType firAlias) const {
       auto iter = firrtlTypeToAliasTypeMap.find(firAlias);
@@ -379,7 +379,7 @@ private:
 
     void freeze() { frozen = true; }
 
-    hw::TypeAliasType addTypedecl(BaseTypeAliasType firAlias, Type rawType,
+    hw::TypeAliasType addTypedecl(Type rawType, BaseTypeAliasType firAlias,
                                   Location typeLoc) {
       assert(!frozen && "Record already frozen, cannot be updated");
 
@@ -423,7 +423,7 @@ private:
     /// Set to keep track of unique typedecl names.
     Namespace typeDeclNamespace;
 
-    CircuitOp &circuitOp;
+    CircuitOp circuitOp;
   };
 
   RecordTypeAlias typeAliases = RecordTypeAlias(circuitOp);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -895,18 +895,28 @@ circt::firrtl::maybeStringToLocation(StringRef spelling, bool skipParsing,
 /// Given a type, return the corresponding lowered type for the HW dialect.
 /// Non-FIRRTL types are simply passed through. This returns a null type if it
 /// cannot be lowered.
-Type circt::firrtl::lowerType(Type type) {
+Type circt::firrtl::lowerType(
+    Type type, std::optional<Location> loc,
+    llvm::function_ref<hw::TypeAliasType(Type, BaseTypeAliasType, Location)>
+        getTypeDeclFn) {
   auto firType = type_dyn_cast<FIRRTLBaseType>(type);
   if (!firType)
     return type;
 
+  if (BaseTypeAliasType aliasType = dyn_cast<BaseTypeAliasType>(firType)) {
+    type = lowerType(aliasType.getInnerType(), loc, getTypeDeclFn);
+    if (!loc)
+      loc = UnknownLoc::get(type.getContext());
+    if (getTypeDeclFn)
+      return getTypeDeclFn(type, aliasType, *loc);
+  }
   // Ignore flip types.
   firType = firType.getPassiveType();
 
   if (auto bundle = type_dyn_cast<BundleType>(firType)) {
     mlir::SmallVector<hw::StructType::FieldInfo, 8> hwfields;
     for (auto element : bundle) {
-      Type etype = lowerType(element.type);
+      Type etype = lowerType(element.type, loc, getTypeDeclFn);
       if (!etype)
         return {};
       hwfields.push_back(hw::StructType::FieldInfo{element.name, etype});
@@ -914,7 +924,7 @@ Type circt::firrtl::lowerType(Type type) {
     return hw::StructType::get(type.getContext(), hwfields);
   }
   if (auto vec = type_dyn_cast<FVectorType>(firType)) {
-    auto elemTy = lowerType(vec.getElementType());
+    auto elemTy = lowerType(vec.getElementType(), loc, getTypeDeclFn);
     if (!elemTy)
       return {};
     return hw::ArrayType::get(elemTy, vec.getNumElements());
@@ -924,7 +934,7 @@ Type circt::firrtl::lowerType(Type type) {
     SmallVector<Attribute> names;
     bool simple = true;
     for (auto element : fenum) {
-      Type etype = lowerType(element.type);
+      Type etype = lowerType(element.type, loc, getTypeDeclFn);
       if (!etype)
         return {};
       hwfields.push_back(hw::UnionType::FieldInfo{element.name, etype, 0});

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -903,13 +903,14 @@ Type circt::firrtl::lowerType(
   if (!firType)
     return type;
 
-  if (BaseTypeAliasType aliasType = dyn_cast<BaseTypeAliasType>(firType)) {
-    type = lowerType(aliasType.getInnerType(), loc, getTypeDeclFn);
-    if (!loc)
-      loc = UnknownLoc::get(type.getContext());
-    if (getTypeDeclFn)
+  // If not known how to lower alias types, then ignore the alias.
+  if (getTypeDeclFn)
+    if (BaseTypeAliasType aliasType = dyn_cast<BaseTypeAliasType>(firType)) {
+      if (!loc)
+        loc = UnknownLoc::get(type.getContext());
+      type = lowerType(aliasType.getInnerType(), loc, getTypeDeclFn);
       return getTypeDeclFn(type, aliasType, *loc);
-  }
+    }
   // Ignore flip types.
   firType = firType.getPassiveType();
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1435,9 +1435,9 @@ firrtl.circuit "TypeAlias" {
 // CHECK:    hw.typedecl @baz : i1
 // CHECK:    hw.typedecl @C : !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
 // CHECK:    hw.typedecl @D : i1
+// CHECK:    hw.typedecl @baf : i1
 // CHECK:    hw.typedecl @bar : !hw.struct<valid: i1, ready: i1, data: i64>
 // CHECK:    hw.typedecl @bar_0 : i64
-// CHECK:    hw.typedecl @baf : i1
 // CHECK:  }
 // CHECK:  hw.module @TypeAlias(
 // CHECK-SAME: %in: !hw.typealias<@TypeAlias__TYPESCOPE_::@A, i1>
@@ -1459,9 +1459,11 @@ firrtl.circuit "TypeAlias" {
 // CHECK:    %wire = hw.wire %0  : !hw.struct<valid: i1, ready: i1, data: i64>
 // CHECK:    %0 = hw.bitcast %source : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar, !hw.struct<valid: i1, ready: i1, data: i64>>) -> !hw.struct<valid: i1, ready: i1, data: i64>
 // CHECK:    %data = hw.struct_extract %wire["data"] : !hw.struct<valid: i1, ready: i1, data: i64>
-// CHECK:    %1 = hw.bitcast %data : (i64) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
-// CHECK:    hw.output %1 : !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
-// CHECK:  }
+// CHECK:    %wire2 = hw.wire %1  : !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
+// CHECK:    %valid = hw.struct_extract %wire["valid"] : !hw.struct<valid: i1, ready: i1, data: i64>
+// CHECK:    %1 = hw.bitcast %valid : (i1) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
+// CHECK:    %2 = hw.bitcast %data : (i64) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
+// CHECK:    hw.output %2 : !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
 
   firrtl.module @TypeAlias(in %in: !firrtl.alias<A, uint<1>>,
                            in %const: !firrtl.const.alias<B, const.uint<1>>,
@@ -1474,11 +1476,14 @@ firrtl.circuit "TypeAlias" {
     firrtl.strictconnect %wire2, %const :!firrtl.const.alias<baf, const.uint<1>> , !firrtl.const.alias<B, const.uint<1>>
     firrtl.strictconnect %out2, %wire2 :!firrtl.const.alias<D, const.uint<1>> , !firrtl.const.alias<baf, const.uint<1>>
   }
-  firrtl.module private @SimpleStruct(in %source: !firrtl.alias<bar, bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>,
+  firrtl.module private @SimpleStruct(in %source: !firrtl.alias<bar, bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>>,
                               out %fldout: !firrtl.alias<bar, uint<64>>) {
-    %wire = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-    firrtl.strictconnect %wire, %source : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.alias<bar, bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>
-    %2 = firrtl.subfield %wire[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    %wire = firrtl.wire : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>
+    firrtl.strictconnect %wire, %source : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.alias<bar, bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>>
+    %2 = firrtl.subfield %wire[data] : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>
+    %wire2 = firrtl.wire : !firrtl.const.alias<baf, const.uint<1>>
     firrtl.connect %fldout, %2 : !firrtl.alias<bar, uint<64>>, !firrtl.uint<64>
+    %0 = firrtl.subfield %wire[valid] : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>> 
+    firrtl.strictconnect %wire2, %0 : !firrtl.const.alias<baf, const.uint<1>>, !firrtl.const.uint<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1429,47 +1429,50 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 // -----
 
 firrtl.circuit "TypeAlias" {
-//CHECK:   hw.type_scope @TypeAlias__TYPESCOPE_ {
-//CHECK:     hw.typedecl @bar : i1
-//CHECK:     hw.typedecl @bar_TypeAlias : i1
-//CHECK:     hw.typedecl @baz : i1
-//CHECK:     hw.typedecl @bar_0_TypeAlias : !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
-//CHECK:     hw.typedecl @bar_SimpleStruct : !hw.struct<valid: i1, ready: i1, data: i64>
-//CHECK:     hw.typedecl @bar_0_SimpleStruct : i64
-//CHECK:     hw.typedecl @baf : i1
-//CHECK:   }
-//CHECK:   hw.module @TypeAlias
-//CHECK-SAME:   %in: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar, i1>
-//CHECK-SAME:   %const: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_TypeAlias, i1>)
-//CHECK-SAME:   out: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_TypeAlias, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>
-//CHECK-SAME:   out2: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_TypeAlias, i1>
-//CHECK:     %wire = hw.wire %[[v0:.+]]  : !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
-//CHECK:     %[[v0]] = hw.bitcast %in : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
-//CHECK:     %wire2 = hw.wire %[[v1:.+]]  : !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
-//CHECK:     %[[v1]] = hw.bitcast %const : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar_TypeAlias, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
-//CHECK:     %[[v2:.+]] = hw.bitcast %in : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_TypeAlias, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>
-//CHECK:     %[[v3:.+]] = hw.bitcast %wire2 : (!hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_TypeAlias, i1>
-//CHECK:     hw.output %[[v2]], %[[v3]] : !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_TypeAlias, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>, !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_TypeAlias, i1>
+// CHECK:  hw.type_scope @TypeAlias__TYPESCOPE_ {
+// CHECK:    hw.typedecl @A : i1
+// CHECK:    hw.typedecl @B : i1
+// CHECK:    hw.typedecl @baz : i1
+// CHECK:    hw.typedecl @C : !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
+// CHECK:    hw.typedecl @D : i1
+// CHECK:    hw.typedecl @bar : !hw.struct<valid: i1, ready: i1, data: i64>
+// CHECK:    hw.typedecl @bar_0 : i64
+// CHECK:    hw.typedecl @baf : i1
+// CHECK:  }
+// CHECK:  hw.module @TypeAlias(
+// CHECK-SAME: %in: !hw.typealias<@TypeAlias__TYPESCOPE_::@A, i1>
+// CHECK-SAME: %const: !hw.typealias<@TypeAlias__TYPESCOPE_::@B, i1>
+// CHECK-SAME: out: !hw.typealias<@TypeAlias__TYPESCOPE_::@C, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>
+// CHECK-SAME: out2: !hw.typealias<@TypeAlias__TYPESCOPE_::@D, i1>)
+// CHECK:    %wire = hw.wire %0  : !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
+// CHECK:    %0 = hw.bitcast %in : (!hw.typealias<@TypeAlias__TYPESCOPE_::@A, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>
+// CHECK:    %wire2 = hw.wire %1  : !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
+// CHECK:    %1 = hw.bitcast %const : (!hw.typealias<@TypeAlias__TYPESCOPE_::@B, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>
+// CHECK:    %2 = hw.bitcast %in : (!hw.typealias<@TypeAlias__TYPESCOPE_::@A, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@C, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>
+// CHECK:    %3 = hw.bitcast %wire2 : (!hw.typealias<@TypeAlias__TYPESCOPE_::@baf, i1>) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@D, i1>
+// CHECK:    hw.output %2, %3 : !hw.typealias<@TypeAlias__TYPESCOPE_::@C, !hw.typealias<@TypeAlias__TYPESCOPE_::@baz, i1>>, !hw.typealias<@TypeAlias__TYPESCOPE_::@D, i1>
+// CHECK:  }
 
-// CHECK:   hw.module private @SimpleStruct
-// CHECK-SAME: %source: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_SimpleStruct, !hw.struct<valid: i1, ready: i1, data: i64>>) -> 
-// CHECK-SAME: (fldout: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_SimpleStruct, i64>)
-// CHECK:     %wire = hw.wire %0  : !hw.struct<valid: i1, ready: i1, data: i64>
-// CHECK:     %0 = hw.bitcast %source : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar_SimpleStruct, !hw.struct<valid: i1, ready: i1, data: i64>>) -> !hw.struct<valid: i1, ready: i1, data: i64>
-// CHECK:     %data = hw.struct_extract %wire["data"] : !hw.struct<valid: i1, ready: i1, data: i64>
-// CHECK:     %1 = hw.bitcast %data : (i64) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_SimpleStruct, i64>
-// CHECK:     hw.output %1 : !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0_SimpleStruct, i64>
+// CHECK:  hw.module private @SimpleStruct(
+// CHECK-SAME: %source: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar, !hw.struct<valid: i1, ready: i1, data: i64>>
+// CHECK-SAME: fldout: !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
+// CHECK:    %wire = hw.wire %0  : !hw.struct<valid: i1, ready: i1, data: i64>
+// CHECK:    %0 = hw.bitcast %source : (!hw.typealias<@TypeAlias__TYPESCOPE_::@bar, !hw.struct<valid: i1, ready: i1, data: i64>>) -> !hw.struct<valid: i1, ready: i1, data: i64>
+// CHECK:    %data = hw.struct_extract %wire["data"] : !hw.struct<valid: i1, ready: i1, data: i64>
+// CHECK:    %1 = hw.bitcast %data : (i64) -> !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
+// CHECK:    hw.output %1 : !hw.typealias<@TypeAlias__TYPESCOPE_::@bar_0, i64>
+// CHECK:  }
 
-  firrtl.module @TypeAlias(in %in: !firrtl.alias<bar, uint<1>>,
-                           in %const: !firrtl.const.alias<bar, const.uint<1>>,
-                           out %out: !firrtl.alias<bar, alias<baz, uint<1>>>,
-                           out %out2: !firrtl.const.alias<bar, const.uint<1>>) {
-    firrtl.strictconnect %out, %in: !firrtl.alias<bar, alias<baz, uint<1>>>,!firrtl.alias<bar, uint<1>> 
+  firrtl.module @TypeAlias(in %in: !firrtl.alias<A, uint<1>>,
+                           in %const: !firrtl.const.alias<B, const.uint<1>>,
+                           out %out: !firrtl.alias<C, alias<baz, uint<1>>>,
+                           out %out2: !firrtl.const.alias<D, const.uint<1>>) {
+    firrtl.strictconnect %out, %in: !firrtl.alias<C, alias<baz, uint<1>>>,!firrtl.alias<A, uint<1>> 
     %wire = firrtl.wire : !firrtl.alias<baz, uint<1>>
-    firrtl.connect %wire, %in :!firrtl.alias<baz, uint<1>> , !firrtl.alias<bar, uint<1>>
+    firrtl.connect %wire, %in :!firrtl.alias<baz, uint<1>> , !firrtl.alias<A, uint<1>>
     %wire2 = firrtl.wire : !firrtl.const.alias<baf, const.uint<1>>
-    firrtl.strictconnect %wire2, %const :!firrtl.const.alias<baf, const.uint<1>> , !firrtl.const.alias<bar, const.uint<1>>
-    firrtl.strictconnect %out2, %wire2 :!firrtl.const.alias<bar, const.uint<1>> , !firrtl.const.alias<baf, const.uint<1>>
+    firrtl.strictconnect %wire2, %const :!firrtl.const.alias<baf, const.uint<1>> , !firrtl.const.alias<B, const.uint<1>>
+    firrtl.strictconnect %out2, %wire2 :!firrtl.const.alias<D, const.uint<1>> , !firrtl.const.alias<baf, const.uint<1>>
   }
   firrtl.module private @SimpleStruct(in %source: !firrtl.alias<bar, bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>,
                               out %fldout: !firrtl.alias<bar, uint<64>>) {


### PR DESCRIPTION
Lower `firrtl.alias` to `hw.typealias`. 
Create a global `hw.type_scope` and add the `hw.typedecl`s corresponding to all
the `firrtl.alias`s across  the `firrtl.module`s. 
This PR adds a pre-scan to the `LowerToHW` pass to lower all the `firrtl.alias`
types for all the modules, sequentially. This ensures that name conflict
resolution and declaration order of `typedecl` are deterministic. The
sequential pass records all the alias types and their corresponding lowering,
which is accessed during the parallel phase.