### PR TITLE
[ETC] Enable extracting registers similar to instances.

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -32,6 +32,7 @@ std::unique_ptr<mlir::Pass> createHWMemSimImplPass(
     bool addVivadoRAMAddressConflictSynthesisBugWorkaround = false);
 std::unique_ptr<mlir::Pass>
 createSVExtractTestCodePass(bool disableInstanceExtraction = false,
+                            bool disableRegisterExtraction = false,
                             bool disableModuleInlining = false);
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(std::optional<std::string> directory = {});

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -130,6 +130,8 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let options = [
     Option<"disableInstanceExtraction", "disable-instance-extraction", "bool",
            "false", "Disable extracting instances only that feed test code">,
+    Option<"disableRegisterExtraction", "disable-register-extraction", "bool",
+           "false", "Disable extracting registers only that feed test code">,
     Option<"disableModuleInlining", "disable-module-inlining", "bool",
            "false", "Disable inlining modules that only feed test code">
   ];

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -199,6 +199,11 @@ struct FirtoolOptions {
       llvm::cl::desc("Disable extracting instances only that feed test code"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
+  llvm::cl::opt<bool> etcDisableRegisterExtraction{
+      "etc-disable-register-extraction",
+      llvm::cl::desc("Disable extracting registers that only feed test code"),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
   llvm::cl::opt<bool> etcDisableModuleInlining{
       "etc-disable-module-inlining",
       llvm::cl::desc("Disable inlining modules that only feed test code"),

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -234,7 +234,7 @@ static void addOperationsToCloneSet(SetVector<Value> &inputs,
   }
 
   // Find operations we can extract and add them to the clone set.
-  for (auto operation : operationsToExtract) {
+  for (auto *operation : operationsToExtract) {
     // We know the forward dataflow for this operation ends in either
     // extractable test code or other operations that are handled speciall.
     // Check if all of the other operations are also marked for extraction.
@@ -251,7 +251,7 @@ static void addOperationsToCloneSet(SetVector<Value> &inputs,
   }
 
   // Perform the necessary IR mutations for extracted operations.
-  for (auto operation : operationsToExtract) {
+  for (auto *operation : operationsToExtract) {
     // Ensure this is one of the operations we actually want to clone.
     if (!opsToClone.contains(operation))
       continue;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -212,6 +212,11 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
 
 LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
                                       const FirtoolOptions &opt) {
+  if (opt.extractTestCode)
+    pm.addPass(sv::createSVExtractTestCodePass(opt.etcDisableInstanceExtraction,
+                                               opt.etcDisableRegisterExtraction,
+                                               opt.etcDisableModuleInlining));
+
   pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass(
       {/*disableRandomization=*/!opt.isRandomEnabled(
            FirtoolOptions::RandomKind::Reg),
@@ -222,10 +227,6 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
       !opt.isRandomEnabled(FirtoolOptions::RandomKind::Mem),
       !opt.isRandomEnabled(FirtoolOptions::RandomKind::Reg),
       opt.addVivadoRAMAddressConflictSynthesisBugWorkaround));
-
-  if (opt.extractTestCode)
-    pm.addPass(sv::createSVExtractTestCodePass(opt.etcDisableInstanceExtraction,
-                                               opt.etcDisableModuleInlining));
 
   // If enabled, run the optimizer.
   if (!opt.disableOptimization) {

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -406,3 +406,30 @@ module {
     hw.output %0 : i1
   }
 }
+
+// -----
+// Check instance extraction
+
+module {
+  // CHECK-LABEL: @RegExtracted_cover
+  // CHECK: %testCode1 = seq.firreg
+  // CHECK: %testCode2 = seq.firreg
+  // CHECK-NOT: seq.firreg
+
+  // CHECK-LABEL: @RegExtracted
+  // CHECK: %designAndTestCode = seq.firreg
+  // CHECK-NOT: seq.firreg
+  hw.module @RegExtracted(%clock: i1, %in: i1) -> (out: i1) {
+    %testCode1 = seq.firreg %in clock %clock : i1
+    %testCode2 = seq.firreg %testCode1 clock %clock : i1
+    %designAndTestCode = seq.firreg %in clock %clock : i1
+
+    sv.always posedge %clock {
+      sv.cover %testCode1, immediate
+      sv.cover %testCode2, immediate
+      sv.cover %designAndTestCode, immediate
+    }
+
+    hw.output %designAndTestCode : i1
+  }
+}


### PR DESCRIPTION
The existing logic for extracting instances is made generic by moving most of the helpers to work with Operation *, and templating the method based on the concrete Operation type to extract. There are a lot of changes in variable names and comments to reword things in terms of operations instead of specifically instances, but the logic is otherwise unchanged.

In order to enable the same generic logic to extract registers, the pass has been moved earlier in the firtool pipeline, so it can work at the seq.firreg level of abstraction, which behaves just like an instance. The dataflowSlice method was updated to stop dataflow slices at any of the Seq dialect ops.

Finally, a new call to the newly-renamed addOperationsToCloneSet was added for the seq::FirRegOp case.

A test case is added that demonstrates registers that feed test code and only test code can be extracted, including situations where test code registers feed other test code registers. Registers that feed both test code and design code are not extracted.

This logic is well-vetted in the instance case, so I think that should be fairly low risk. My only other concern is if we will encounter surprises by running the pass earlier in the firtool pipeline, but looking at the intervening passes that had previously been run before it, I don't have any concerns.