### PR TITLE
[MapArith] Introduce `--map-arith-to-comb` pass

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -23,6 +23,7 @@ namespace circt {
 // Passes
 //===----------------------------------------------------------------------===//
 
+std::unique_ptr<mlir::Pass> createMapArithToCombPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();
 std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -53,4 +53,17 @@ def StripDebugInfoWithPred : Pass<"strip-debuginfo-with-pred", "::mlir::ModuleOp
            "intended to be used for testing."> ];
 }
 
+def MapArithToCombPass : InterfacePass<"map-arith-to-comb", "circt::hw::HWModuleLike"> {
+  let summary = "Map arith ops to combinatorial logic";
+  let description = [{
+    A pass which does a simple `arith` to `comb` mapping wherever possible.
+    This **does not** intend to be the definitive lowering/HLS pass of `arith`
+    operations in CIRCT (hence the name "map" instead of e.g. "lower").
+    Rather, it provides a simple way (mostly for testing purposes) to map
+    `arith` operations.
+  }];
+  let constructor = "circt::createMapArithToCombPass()";
+  let dependentDialects = ["circt::hw::HWDialect, mlir::arith::ArithDialect, circt::comb::CombDialect"];
+}
+
 #endif // CIRCT_TRANSFORMS_PASSES

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -54,9 +54,13 @@ def StripDebugInfoWithPred : Pass<"strip-debuginfo-with-pred", "::mlir::ModuleOp
 }
 
 def MapArithToCombPass : InterfacePass<"map-arith-to-comb", "circt::hw::HWModuleLike"> {
-  let summary = "Map arith ops to combinatorial logic";
+  let summary = "Map arith ops to combinational logic";
   let description = [{
     A pass which does a simple `arith` to `comb` mapping wherever possible.
+    This pass will not convert:  
+    * floating point operations
+    * operations using `vector`-typed values
+
     This **does not** intend to be the definitive lowering/HLS pass of `arith`
     operations in CIRCT (hence the name "map" instead of e.g. "lower").
     Rather, it provides a simple way (mostly for testing purposes) to map

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_library(CIRCTTransforms
   FlattenMemRefs.cpp
   StripDebugInfoWithPred.cpp
+  MapArithToComb.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Transforms
@@ -11,6 +12,9 @@ add_circt_library(CIRCTTransforms
   MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
+  MLIRArithDialect
+  CIRCTHW
+  CIRCTComb
 
   DEPENDS
   CIRCTTransformsPassIncGen

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -19,8 +19,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "llvm/Support/Debug.h"
-
 using namespace mlir;
 using namespace circt;
 
@@ -67,8 +65,6 @@ public:
     auto loc = op.getLoc();
     size_t outWidth = op.getOut().getType().getIntOrFloatBitWidth();
     size_t inWidth = adaptor.getIn().getType().getIntOrFloatBitWidth();
-
-    llvm::dbgs() << "out: " << outWidth << " in: " << inWidth << "\n";
 
     rewriter.replaceOp(
         op,

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -1,0 +1,139 @@
+//===- MapArithToComb.cpp - Arith-to-comb mapping pass ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the MapArithToComb pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Transforms/Passes.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace circt;
+
+template <typename TFrom, typename TTo>
+class OneToOnePattern : public OpConversionPattern<TFrom> {
+public:
+  OneToOnePattern(MLIRContext *context) : OpConversionPattern<TFrom>(context) {}
+  using OpAdaptor = typename TFrom::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(TFrom op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TTo>(op, adaptor.getOperands(), op->getAttrs());
+    return success();
+  }
+};
+
+class ExtSConvertionPattern : public OpConversionPattern<arith::ExtSIOp> {
+public:
+  ExtSConvertionPattern(MLIRContext *context)
+      : OpConversionPattern<arith::ExtSIOp>(context) {}
+  using OpAdaptor = typename arith::ExtSIOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(arith::ExtSIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    size_t outWidth = op.getType().getIntOrFloatBitWidth();
+    rewriter.replaceOp(op, comb::createOrFoldSExt(
+                               op.getLoc(), op.getOperand(),
+                               rewriter.getIntegerType(outWidth), rewriter));
+    return success();
+  }
+};
+
+class ExtZConvertionPattern : public OpConversionPattern<arith::ExtUIOp> {
+public:
+  ExtZConvertionPattern(MLIRContext *context)
+      : OpConversionPattern<arith::ExtUIOp>(context) {}
+  using OpAdaptor = typename arith::ExtUIOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(arith::ExtUIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    size_t outWidth = op.getOut().getType().getIntOrFloatBitWidth();
+    size_t inWidth = adaptor.getIn().getType().getIntOrFloatBitWidth();
+
+    llvm::dbgs() << "out: " << outWidth << " in: " << inWidth << "\n";
+
+    rewriter.replaceOp(
+        op,
+        {rewriter.create<comb::ConcatOp>(
+            loc,
+            rewriter.create<hw::ConstantOp>(loc, APInt(outWidth - inWidth, 0)),
+            adaptor.getIn())});
+    return success();
+  }
+};
+
+class TruncateConversionPattern : public OpConversionPattern<arith::TruncIOp> {
+public:
+  TruncateConversionPattern(MLIRContext *context)
+      : OpConversionPattern<arith::TruncIOp>(context) {}
+  using OpAdaptor = typename arith::TruncIOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(arith::TruncIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    size_t outWidth = op.getType().getIntOrFloatBitWidth();
+    rewriter.replaceOpWithNewOp<comb::ExtractOp>(op, adaptor.getIn(), 0,
+                                                 outWidth);
+    return success();
+  }
+};
+
+namespace {
+struct MapArithToCombPass : public MapArithToCombPassBase<MapArithToCombPass> {
+public:
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+
+    ConversionTarget target(*ctx);
+    target.addLegalDialect<comb::CombDialect, hw::HWDialect>();
+    target.addIllegalDialect<arith::ArithDialect>();
+
+    RewritePatternSet patterns(ctx);
+
+    patterns.insert<OneToOnePattern<arith::AddIOp, comb::AddOp>,
+                    OneToOnePattern<arith::SubIOp, comb::SubOp>,
+                    OneToOnePattern<arith::MulIOp, comb::MulOp>,
+                    OneToOnePattern<arith::DivSIOp, comb::DivSOp>,
+                    OneToOnePattern<arith::DivUIOp, comb::DivUOp>,
+                    OneToOnePattern<arith::RemSIOp, comb::ModSOp>,
+                    OneToOnePattern<arith::RemUIOp, comb::ModUOp>,
+                    OneToOnePattern<arith::AndIOp, comb::AndOp>,
+                    OneToOnePattern<arith::OrIOp, comb::OrOp>,
+                    OneToOnePattern<arith::XOrIOp, comb::XorOp>,
+                    OneToOnePattern<arith::ShLIOp, comb::ShlOp>,
+                    OneToOnePattern<arith::ShRSIOp, comb::ShrSOp>,
+                    OneToOnePattern<arith::ShRUIOp, comb::ShrUOp>,
+                    OneToOnePattern<arith::CmpIOp, comb::ICmpOp>,
+                    OneToOnePattern<arith::SelectOp, comb::MuxOp>,
+                    ExtSConvertionPattern, ExtZConvertionPattern,
+                    TruncateConversionPattern>(ctx);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::createMapArithToCombPass() {
+  return std::make_unique<MapArithToCombPass>();
+}

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -104,37 +104,37 @@ public:
   }
 };
 
-static comb::ICmpPredicate
-arithToCombPredicate(arith::CmpIPredicate predicate) {
-  switch (predicate) {
-  case arith::CmpIPredicate::eq:
-    return comb::ICmpPredicate::eq;
-  case arith::CmpIPredicate::ne:
-    return comb::ICmpPredicate::ne;
-  case arith::CmpIPredicate::slt:
-    return comb::ICmpPredicate::slt;
-  case arith::CmpIPredicate::ult:
-    return comb::ICmpPredicate::ult;
-  case arith::CmpIPredicate::sle:
-    return comb::ICmpPredicate::sle;
-  case arith::CmpIPredicate::ule:
-    return comb::ICmpPredicate::ule;
-  case arith::CmpIPredicate::sgt:
-    return comb::ICmpPredicate::sgt;
-  case arith::CmpIPredicate::ugt:
-    return comb::ICmpPredicate::ugt;
-  case arith::CmpIPredicate::sge:
-    return comb::ICmpPredicate::sge;
-  case arith::CmpIPredicate::uge:
-    return comb::ICmpPredicate::uge;
-  }
-  llvm_unreachable("Unknown predicate");
-}
-
 class CompConversionPattern : public OpConversionPattern<arith::CmpIOp> {
 public:
   using OpConversionPattern<arith::CmpIOp>::OpConversionPattern;
   using OpAdaptor = typename arith::CmpIOp::Adaptor;
+
+  static comb::ICmpPredicate
+  arithToCombPredicate(arith::CmpIPredicate predicate) {
+    switch (predicate) {
+    case arith::CmpIPredicate::eq:
+      return comb::ICmpPredicate::eq;
+    case arith::CmpIPredicate::ne:
+      return comb::ICmpPredicate::ne;
+    case arith::CmpIPredicate::slt:
+      return comb::ICmpPredicate::slt;
+    case arith::CmpIPredicate::ult:
+      return comb::ICmpPredicate::ult;
+    case arith::CmpIPredicate::sle:
+      return comb::ICmpPredicate::sle;
+    case arith::CmpIPredicate::ule:
+      return comb::ICmpPredicate::ule;
+    case arith::CmpIPredicate::sgt:
+      return comb::ICmpPredicate::sgt;
+    case arith::CmpIPredicate::ugt:
+      return comb::ICmpPredicate::ugt;
+    case arith::CmpIPredicate::sge:
+      return comb::ICmpPredicate::sge;
+    case arith::CmpIPredicate::uge:
+      return comb::ICmpPredicate::uge;
+    }
+    llvm_unreachable("Unknown predicate");
+  }
 
   LogicalResult
   matchAndRewrite(arith::CmpIOp op, OpAdaptor adaptor,

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -23,7 +23,7 @@ void registerDialect(DialectRegistry &registry);
 
 namespace arith {
 class ArithDialect;
-}
+} // namespace arith
 
 namespace memref {
 class MemRefDialect;

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -17,10 +17,13 @@
 
 namespace mlir {
 class MemrefDialect;
-
 // Forward declaration from Dialect.h
 template <typename ConcreteDialect>
 void registerDialect(DialectRegistry &registry);
+
+namespace arith {
+class ArithDialect;
+}
 
 namespace memref {
 class MemRefDialect;
@@ -36,6 +39,15 @@ class FuncDialect;
 } // end namespace mlir
 
 namespace circt {
+namespace hw {
+class HWModuleLike;
+class HWDialect;
+} // namespace hw
+
+namespace comb {
+class CombDialect;
+} // namespace comb
+
 #define GEN_PASS_CLASSES
 #include "circt/Transforms/Passes.h.inc"
 

--- a/test/Transforms/map-arith-to-comb.mlir
+++ b/test/Transforms/map-arith-to-comb.mlir
@@ -1,5 +1,5 @@
 
-// RUN: circt-opt --pass-pipeline='builtin.module(any(map-arith-to-comb))' %s | FileCheck %s
+// RUN: circt-opt -split-input-file -verify-diagnostics --pass-pipeline='builtin.module(any(map-arith-to-comb))' %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @foo(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1) {
@@ -43,4 +43,12 @@ hw.module @foo(%arg0 : i32, %arg1 : i32, %arg2 : i1) -> () {
     %14 = arith.extsi %arg1 : i32 to i33
     %15 = arith.extui %arg1 : i32 to i35
     %16 = arith.trunci %arg1 : i32 to i16
+    %17 = arith.cmpi slt, %arg0, %arg1 : i32
+}
+
+// -----
+
+hw.module @invalidVector(%arg0 : vector<4xi32>) -> () {
+  // expected-error @+1 {{failed to legalize operation 'arith.extsi' that was explicitly marked illegal}}
+    %0 = arith.extsi %arg0 : vector<4xi32> to vector<4xi33>
 }

--- a/test/Transforms/map-arith-to-comb.mlir
+++ b/test/Transforms/map-arith-to-comb.mlir
@@ -1,0 +1,46 @@
+
+// RUN: circt-opt --pass-pipeline='builtin.module(any(map-arith-to-comb))' %s | FileCheck %s
+
+// CHECK-LABEL:   hw.module @foo(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1) {
+// CHECK:           %[[VAL_3:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = comb.mul %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = comb.divs %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_7:.*]] = comb.divu %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mods %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_9:.*]] = comb.modu %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_10:.*]] = comb.and %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_11:.*]] = comb.or %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_12:.*]] = comb.xor %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_13:.*]] = comb.shl %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_14:.*]] = comb.shrs %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_15:.*]] = comb.shru %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_16:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_17:.*]] = comb.extract %[[VAL_1]] from 31 : (i32) -> i1
+// CHECK:           %[[VAL_18:.*]] = comb.concat %[[VAL_17]], %[[VAL_1]] : i1, i32
+// CHECK:           %[[VAL_19:.*]] = hw.constant 0 : i3
+// CHECK:           %[[VAL_20:.*]] = comb.concat %[[VAL_19]], %[[VAL_1]] : i3, i32
+// CHECK:           %[[VAL_21:.*]] = comb.extract %[[VAL_1]] from 0 : (i32) -> i16
+// CHECK:           hw.output
+// CHECK:         }
+
+hw.module @foo(%arg0 : i32, %arg1 : i32, %arg2 : i1) -> () {
+    %0 = arith.addi %arg0, %arg1 : i32
+    %1 = arith.subi %arg0, %arg1 : i32
+    %2 = arith.muli %arg0, %arg1 : i32
+    %3 = arith.divsi %arg0, %arg1 : i32
+    %4 = arith.divui %arg0, %arg1 : i32
+    %5 = arith.remsi %arg0, %arg1 : i32
+    %6 = arith.remui %arg0, %arg1 : i32
+    %7 = arith.andi  %arg0, %arg1 : i32
+    %8 = arith.ori   %arg0, %arg1 : i32
+    %9 = arith.xori  %arg0, %arg1 : i32
+    %10 = arith.shli %arg0, %arg1 : i32
+    %11 = arith.shrsi %arg0, %arg1 : i32
+    %12 = arith.shrui %arg0, %arg1 : i32
+    %13 = arith.select %arg2, %arg0, %arg1 : i32
+    %14 = arith.extsi %arg1 : i32 to i33
+    %15 = arith.extui %arg1 : i32 to i35
+    %16 = arith.trunci %arg1 : i32 to i16
+}


### PR DESCRIPTION
Adds a pass which does a simple `arith` to `comb` mapping. The intention of this pass is mainly to get code out of Handshake (and wherever else we do some ad-hoc, simple arith-to-comb mapping/HLS), thus allowing integration testing of DC flows (refresher: handshake-to-dc lowers handshake ops to a combination of `dc` and `arith`).

This **does not** intend to be the definitive lowering/HLS pass of `arith` operations (hence the name "map" instead of e.g. "lower"). See it more as a temporary pass to provide this kind of functionality until we have an operator library + library mapping pass.

Currently, this pass strictly does operation mapping. If needed, `index`-type conversion could also be moved to this pass (e.g. setting `index` type width as a parameter of the pass).