### PR TITLE
[FIRRTL] Donot create empty InnerSym name

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -133,6 +133,7 @@ def InnerSymAttr : AttrDef<HWDialect, "InnerSym"> {
   let parameters = (ins ArrayRefParameter<"InnerSymPropertiesAttr">:$props);
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$sym),[{
+      assert(!sym.getValue().empty() && "symbol name must be non-empty");
       return get(sym.getContext(),
       {InnerSymPropertiesAttr::get(sym.getContext(), sym, 0,
                         mlir::StringAttr::get(sym.getContext(), "public"))});

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -635,7 +635,8 @@ StringAttr circt::firrtl::getOrAddInnerSym(
   if (nameHint.empty()) {
     if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
       nameHint = nameAttr.getValue();
-    else
+    // Ensure if the op name is also empty, nameHint is initialized.
+    if (nameHint.empty())
       nameHint = "sym";
   }
   auto name = getNamespace(mod).newName(nameHint);


### PR DESCRIPTION
`firrtl::getOrAddInnerSym` was returning an `InnerSymAttr` with empty symbol name, if the name hint and the operation name were both empty. Add the checks to ensure empty symbol name attributes are not created.