### PR TITLE
[LowerSeqToSV] Make `createTree` iterative, NFCI

### DIFF
--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -486,17 +486,38 @@ FirRegLower::tryRestoringSubaccess(OpBuilder &builder, Value reg, Value term,
 
 void FirRegLower::createTree(OpBuilder &builder, Value reg, Value term,
                              Value next) {
-  // If term and next values are equivalent, we don't have to create an
-  // assignment.
-  if (areEquivalentValues(term, next))
-    return;
-  auto mux = next.getDefiningOp<comb::MuxOp>();
-  if (mux && mux.getTwoState()) {
-    addToIfBlock(
-        builder, mux.getCond(),
-        [&]() { createTree(builder, reg, term, mux.getTrueValue()); },
-        [&]() { createTree(builder, reg, term, mux.getFalseValue()); });
-  } else {
+
+  SmallVector<std::tuple<Block *, Value, Value, Value>> worklist;
+  auto addToWorklist = [&](Value reg, Value term, Value next) {
+    worklist.push_back({builder.getBlock(), reg, term, next});
+  };
+
+  auto getArrayIndex = [&](Value reg, Value idx) {
+    // Create an array index op just after `reg`.
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointAfterValue(reg);
+    return builder.create<sv::ArrayIndexInOutOp>(reg.getLoc(), reg, idx);
+  };
+
+  SmallVector<Value, 8> opsToDelete;
+  addToWorklist(reg, term, next);
+  while (!worklist.empty()) {
+    OpBuilder::InsertionGuard guard(builder);
+    Block *block;
+    Value reg, term, next;
+    std::tie(block, reg, term, next) = worklist.pop_back_val();
+    builder.setInsertionPointToEnd(block);
+    if (areEquivalentValues(term, next))
+      continue;
+
+    auto mux = next.getDefiningOp<comb::MuxOp>();
+    if (mux && mux.getTwoState()) {
+      addToIfBlock(
+          builder, mux.getCond(),
+          [&]() { addToWorklist(reg, term, mux.getTrueValue()); },
+          [&]() { addToWorklist(reg, term, mux.getFalseValue()); });
+      continue;
+    }
     // If the next value is an array creation, split the value into
     // invidial elements and construct trees recursively.
     if (auto array = next.getDefiningOp<hw::ArrayCreateOp>()) {
@@ -508,28 +529,21 @@ void FirRegLower::createTree(OpBuilder &builder, Value reg, Value term,
         addToIfBlock(
             builder, cond,
             [&]() {
-              Value nextReg;
-              {
-                // Create an array index op just after `reg`.
-                OpBuilder::InsertionGuard guard(builder);
-                builder.setInsertionPointAfterValue(reg);
-                nextReg = builder.create<sv::ArrayIndexInOutOp>(reg.getLoc(),
-                                                                reg, index);
-              }
+              Value nextReg = getArrayIndex(reg, index);
               auto termElement =
                   builder.create<hw::ArrayGetOp>(term.getLoc(), term, index);
-              createTree(builder, nextReg, termElement, trueValue);
-              termElement.erase();
+              opsToDelete.push_back(termElement);
+              addToWorklist(nextReg, termElement, trueValue);
             },
             []() {});
         ++numSubaccessRestored;
-        return;
+        continue;
       }
       // Compat fix for GCC12's libstdc++, cannot use
       // llvm::enumerate(llvm::reverse(OperandRange)).  See #4900.
-      SmallVector<Value> reverseOpValues(llvm::reverse(array.getOperands()));
-      for (auto [idx, value] : llvm::enumerate(reverseOpValues)) {
-
+      // SmallVector<Value> reverseOpValues(llvm::reverse(array.getOperands()));
+      for (auto [idx, value] : llvm::enumerate(array.getOperands())) {
+        idx = array.getOperands().size() - idx - 1;
         // Create an index constant.
         auto idxVal = getOrCreateConstant(
             array.getLoc(),
@@ -537,24 +551,24 @@ void FirRegLower::createTree(OpBuilder &builder, Value reg, Value term,
                   idx));
 
         auto &index = arrayIndexCache[{reg, idx}];
-        if (!index) {
-          // Create an array index op just after `reg`.
-          OpBuilder::InsertionGuard guard(builder);
-          builder.setInsertionPointAfterValue(reg);
-          index =
-              builder.create<sv::ArrayIndexInOutOp>(reg.getLoc(), reg, idxVal);
-        }
+        if (!index)
+          index = getArrayIndex(reg, idxVal);
 
         auto termElement =
             builder.create<hw::ArrayGetOp>(term.getLoc(), term, idxVal);
-        createTree(builder, index, termElement, value);
-        // This value was used to check the equivalence of elements so useless
-        // anymore.
-        termElement.erase();
+        opsToDelete.push_back(termElement);
+        addToWorklist(index, termElement, value);
       }
-      return;
+      continue;
     }
+
     builder.create<sv::PAssignOp>(term.getLoc(), reg, next);
+  }
+
+  while (!opsToDelete.empty()) {
+    auto value = opsToDelete.pop_back_val();
+    assert(value.use_empty());
+    value.getDefiningOp()->erase();
   }
 }
 

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -585,8 +585,8 @@ hw.module @ArrayElements(%a: !hw.array<2xi1>, %clock: i1, %cond: i1) -> (b: !hw.
   %5 = comb.mux bin %cond, %0, %2 : i1
   %6 = hw.array_create %5, %4 : i1
   hw.output %r : !hw.array<2xi1>
-  // CHECK:      %[[r2:.+]] = sv.array_index_inout %r[%true] : !hw.inout<array<2xi1>>, i1
-  // CHECK-NEXT: %[[r1:.+]] = sv.array_index_inout %r[%false] : !hw.inout<array<2xi1>>, i1
+  // CHECK:      %[[r1:.+]] = sv.array_index_inout %r[%false] : !hw.inout<array<2xi1>>, i1
+  // CHECK-NEXT: %[[r2:.+]] = sv.array_index_inout %r[%true] : !hw.inout<array<2xi1>>, i1
   // CHECK:      sv.always posedge %clock {
   // CHECK-NEXT:   sv.if %cond {
   // CHECK-NEXT:     sv.passign %[[r1]], %1 : i1
@@ -694,10 +694,10 @@ hw.module @NestedSubaccess(%clock: i1, %en_0: i1, %en_1: i1, %en_2: i1, %addr_0:
   %31 = comb.mux bin %en_1, %27, %30 : !hw.array<3xi32>
   %32 = hw.array_create %26, %24, %22 : i32
   %33 = comb.mux bin %en_0, %31, %32 : !hw.array<3xi32>
-  // CHECK:        %[[IDX4:.+]] = sv.array_index_inout %r[%addr_3] : !hw.inout<array<3xi32>>, i2
-  // CHECK:        %[[IDX3:.+]] = sv.array_index_inout %r[%addr_2] : !hw.inout<array<3xi32>>, i2
-  // CHECK:        %[[IDX2:.+]] = sv.array_index_inout %r[%addr_1] : !hw.inout<array<3xi32>>, i2
   // CHECK:        %[[IDX1:.+]] = sv.array_index_inout %r[%addr_0] : !hw.inout<array<3xi32>>, i2
+  // CHECK:        %[[IDX2:.+]] = sv.array_index_inout %r[%addr_1] : !hw.inout<array<3xi32>>, i2
+  // CHECK:        %[[IDX3:.+]] = sv.array_index_inout %r[%addr_2] : !hw.inout<array<3xi32>>, i2
+  // CHECK:        %[[IDX4:.+]] = sv.array_index_inout %r[%addr_3] : !hw.inout<array<3xi32>>, i2
   // CHECK:        sv.always posedge %clock {
   // CHECK-NEXT:   sv.if %en_0 {
   // CHECK-NEXT:     sv.if %en_1 {


### PR DESCRIPTION
As we expand mux into nested-if, the nest level could reach to O(10000). To avoid stack overflow this PR changes `createTree` to iterative algorithm. 