### PR TITLE
[comb] Minor correction to `comb.icmp` td docs

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -122,7 +122,7 @@ def ICmpOp : CombOp<"icmp", [Pure, SameTypeOperands]> {
     bit wide result.
 
     ```
-        %r = hw.icmp eq %a, %b : i4
+        %r = comb.icmp eq %a, %b : i4
     ```
   }];
 


### PR DESCRIPTION
Very minor docs fix, usage example of `comb.icmp` incorrectly (unless I've missed something?) says `hw.icmp`.