### PR TITLE
[Verif] Add assert/assume/cover labels

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -21,9 +21,10 @@ class VerifOp<string mnemonic, list<Trait> traits = []> :
 
 class AssertLikeOp<string mnemonic, list<Trait> traits = []> :
   VerifOp<mnemonic, traits> {
-  let arguments = (ins LTLAnyPropertyType:$property);
+  let arguments = (ins LTLAnyPropertyType:$property,
+                       OptionalAttr<StrAttr>:$label);
   let assemblyFormat = [{
-    $property attr-dict `:` type($property)
+    $property (`label` $label^)? attr-dict `:` type($property)
   }];
 }
 

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -1,4 +1,19 @@
-// RUN: circt-opt %s --test-apply-lowering-options="options=emittedLineLength=9001" --export-verilog --verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --test-apply-lowering-options="options=emittedLineLength=9001,verifLabels" --export-verilog --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: module Labels
+hw.module @Labels(%a: i1) {
+  // CHECK: foo1: assert property (a);
+  // CHECK: foo2: assume property (a);
+  // CHECK: foo3: cover property (a);
+  verif.assert %a {label = "foo1"} : i1
+  verif.assume %a {label = "foo2"} : i1
+  verif.cover %a {label = "foo3"} : i1
+
+  // CHECK: bar: assert property (a);
+  // CHECK: bar_0: assert property (a);
+  verif.assert %a {label = "bar"} : i1
+  verif.assert %a {label = "bar"} : i1
+}
 
 // CHECK-LABEL: module BasicEmissionNonTemporal
 hw.module @BasicEmissionNonTemporal(%a: i1, %b: i1) {
@@ -22,7 +37,6 @@ hw.module @BasicEmissionNonTemporal(%a: i1, %b: i1) {
     verif.assume %2 : i1
     verif.cover %3 : i1
   }
-  // CHECK: end
 }
 
 // CHECK-LABEL: module BasicEmissionTemporal
@@ -44,7 +58,6 @@ hw.module @BasicEmissionTemporal(%a: i1) {
     verif.assume %p : !ltl.property
     verif.cover %p : !ltl.property
   }
-  // CHECK: end
 }
 
 // CHECK-LABEL: module Sequences

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -9,22 +9,28 @@
 //===----------------------------------------------------------------------===//
 
 // CHECK: verif.assert {{%.+}} : i1
+// CHECK: verif.assert {{%.+}} label "foo1" : i1
 // CHECK: verif.assert {{%.+}} : !ltl.sequence
 // CHECK: verif.assert {{%.+}} : !ltl.property
 verif.assert %true : i1
+verif.assert %true label "foo1" : i1
 verif.assert %s : !ltl.sequence
 verif.assert %p : !ltl.property
 
 // CHECK: verif.assume {{%.+}} : i1
+// CHECK: verif.assume {{%.+}} label "foo2" : i1
 // CHECK: verif.assume {{%.+}} : !ltl.sequence
 // CHECK: verif.assume {{%.+}} : !ltl.property
 verif.assume %true : i1
+verif.assume %true label "foo2" : i1
 verif.assume %s : !ltl.sequence
 verif.assume %p : !ltl.property
 
 // CHECK: verif.cover {{%.+}} : i1
+// CHECK: verif.cover {{%.+}} label "foo3" : i1
 // CHECK: verif.cover {{%.+}} : !ltl.sequence
 // CHECK: verif.cover {{%.+}} : !ltl.property
 verif.cover %true : i1
+verif.cover %true label "foo3" : i1
 verif.cover %s : !ltl.sequence
 verif.cover %p : !ltl.property


### PR DESCRIPTION
Allow `verif.{assert,assume,cover}` ops to carry a label that gets picked up by `LegalizeNames` and is properly emitted. All the machinery is already there, this just makes "label" part of the verif op semantics and ensures that `LegalizeNames` does the right thing.