### PR TITLE
[FIRRTL] Add Verif/LTL intrinsics

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -372,7 +372,8 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::createLowerFIRRTLToHWPass()";
   let dependentDialects = ["comb::CombDialect", "hw::HWDialect",
-                           "seq::SeqDialect", "sv::SVDialect"];
+                           "seq::SeqDialect", "sv::SVDialect",
+                           "ltl::LTLDialect", "verif::VerifDialect"];
   let options = [
     Option<"disableMemRandomization", "disable-mem-randomization", "bool", "false",
             "Disable emission of memory randomization code">,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -15,6 +15,7 @@
 
 include "FIRRTLDialect.td"
 include "FIRRTLTypes.td"
+include "FIRRTLEnums.td"
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Types.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -1062,5 +1063,60 @@ def RefSubOp : FIRRTLExprOp<"ref.sub"> {
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` qualified(type($input))";
 }
+
+//===----------------------------------------------------------------------===//
+// LTL Dialect Sequence and Property Intrinsics
+//===----------------------------------------------------------------------===//
+
+class LTLIntrinsicOp<string mnemonic, list<Trait> traits = []> :
+    FIRRTLOp<"int.ltl." # mnemonic, traits # [Pure]> {
+  let summary = "FIRRTL variant of `ltl." # mnemonic # "`";
+  let description = "See `ltl." # mnemonic # "` op in the LTL dialect.";
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+  let results = (outs UInt1Type:$result);
+}
+
+class UnaryLTLIntrinsicOp<string mnemonic, list<Trait> traits = []> :
+    LTLIntrinsicOp<mnemonic, traits> {
+  let arguments = (ins UInt1Type:$input);
+}
+
+class BinaryLTLIntrinsicOp<string mnemonic, list<Trait> traits = []> :
+    LTLIntrinsicOp<mnemonic, traits> {
+  let arguments = (ins UInt1Type:$lhs, UInt1Type:$rhs);
+}
+
+
+// Generic
+def LTLAndIntrinsicOp : BinaryLTLIntrinsicOp<"and", [Commutative]>;
+def LTLOrIntrinsicOp : BinaryLTLIntrinsicOp<"or", [Commutative]>;
+
+// Sequences
+def LTLDelayIntrinsicOp : LTLIntrinsicOp<"delay"> {
+  let arguments = (ins UInt1Type:$input,
+                       I64Attr:$delay,
+                       OptionalAttr<I64Attr>:$length);
+  let assemblyFormat = [{
+    $input `,` $delay (`,` $length^)? attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+def LTLConcatIntrinsicOp : BinaryLTLIntrinsicOp<"concat">;
+
+// Properties
+def LTLNotIntrinsicOp : UnaryLTLIntrinsicOp<"not">;
+def LTLImplicationIntrinsicOp : BinaryLTLIntrinsicOp<"implication">;
+def LTLEventuallyIntrinsicOp : UnaryLTLIntrinsicOp<"eventually">;
+
+// Clocking
+def LTLClockIntrinsicOp : LTLIntrinsicOp<"clock"> {
+  let arguments = (ins UInt1Type:$input, ClockType:$clock);
+  let assemblyFormat = [{
+    $input `,` $clock attr-dict `:` functional-type(operands, results)
+  }];
+}
+def LTLDisableIntrinsicOp : BinaryLTLIntrinsicOp<"disable">;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLEXPRESSIONS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -327,4 +327,22 @@ def RefReleaseInitialOp : FIRRTLOp<"ref.release_initial"> {
   let assemblyFormat = "$predicate `,` $dest attr-dict `:` type($predicate) `,` qualified(type($dest))";
 }
 
+//===----------------------------------------------------------------------===//
+// Verif Dialect Intrinsics
+//===----------------------------------------------------------------------===//
+
+class VerifIntrinsicOp<string mnemonic, list<Trait> traits = []> :
+    FIRRTLOp<"int.verif." # mnemonic, traits> {
+  let summary = "FIRRTL variant of `verif." # mnemonic # "`";
+  let description = "See `verif." # mnemonic # "` op in the Verif dialect.";
+  let arguments = (ins UInt1Type:$property, OptionalAttr<StrAttr>:$label);
+  let assemblyFormat = [{
+    operands attr-dict `:` type(operands)
+  }];
+}
+
+def VerifAssertIntrinsicOp : VerifIntrinsicOp<"assert">;
+def VerifAssumeIntrinsicOp : VerifIntrinsicOp<"assume">;
+def VerifCoverIntrinsicOp : VerifIntrinsicOp<"cover">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLSTATEMENTS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -48,7 +48,10 @@ public:
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
             // Intrinsic Expressions.
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
-            SizeOfIntrinsicOp,
+            SizeOfIntrinsicOp, LTLAndIntrinsicOp, LTLOrIntrinsicOp,
+            LTLDelayIntrinsicOp, LTLConcatIntrinsicOp, LTLNotIntrinsicOp,
+            LTLImplicationIntrinsicOp, LTLEventuallyIntrinsicOp,
+            LTLClockIntrinsicOp, LTLDisableIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -155,6 +158,15 @@ public:
   HANDLE(PlusArgsValueIntrinsicOp, Unhandled);
   HANDLE(PlusArgsTestIntrinsicOp, Unhandled);
   HANDLE(SizeOfIntrinsicOp, Unhandled);
+  HANDLE(LTLAndIntrinsicOp, Unhandled);
+  HANDLE(LTLOrIntrinsicOp, Unhandled);
+  HANDLE(LTLDelayIntrinsicOp, Unhandled);
+  HANDLE(LTLConcatIntrinsicOp, Unhandled);
+  HANDLE(LTLNotIntrinsicOp, Unhandled);
+  HANDLE(LTLImplicationIntrinsicOp, Unhandled);
+  HANDLE(LTLEventuallyIntrinsicOp, Unhandled);
+  HANDLE(LTLClockIntrinsicOp, Unhandled);
+  HANDLE(LTLDisableIntrinsicOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);
@@ -191,10 +203,11 @@ public:
         .template Case<AttachOp, ConnectOp, StrictConnectOp, RefDefineOp,
                        ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
                        AssumeOp, CoverOp, ProbeOp, RefForceOp,
-                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitStmt(opNode, args...);
-            })
+                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
+                       VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
+                       VerifCoverIntrinsicOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitStmt(opNode, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -234,6 +247,9 @@ public:
   HANDLE(RefForceInitialOp);
   HANDLE(RefReleaseOp);
   HANDLE(RefReleaseInitialOp);
+  HANDLE(VerifAssertIntrinsicOp);
+  HANDLE(VerifAssumeIntrinsicOp);
+  HANDLE(VerifCoverIntrinsicOp);
 
 #undef HANDLE
 };

--- a/lib/Conversion/FIRRTLToHW/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToHW/CMakeLists.txt
@@ -11,7 +11,9 @@ add_circt_conversion_library(CIRCTFIRRTLToHW
   CIRCTComb
   CIRCTFIRRTL
   CIRCTHW
+  CIRCTLTL
   CIRCTSeq
   CIRCTSV
+  CIRCTVerif
   MLIRTransforms
 )

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -88,6 +88,10 @@ namespace llhd {
 class LLHDDialect;
 } // namespace llhd
 
+namespace ltl {
+class LTLDialect;
+} // namespace ltl
+
 namespace loopschedule {
 class LoopScheduleDialect;
 } // namespace loopschedule
@@ -124,6 +128,10 @@ class FSMDialect;
 namespace systemc {
 class SystemCDialect;
 } // namespace systemc
+
+namespace verif {
+class VerifDialect;
+} // namespace verif
 
 // Generate the classes which represent the passes
 #define GEN_PASS_CLASSES

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -88,29 +88,56 @@ static ParseResult sizedPort(StringRef name, FModuleLike mod, unsigned n,
   return success();
 }
 
-static ParseResult hasNParam(StringRef name, FModuleLike mod, unsigned n) {
+static ParseResult hasNParam(StringRef name, FModuleLike mod, unsigned n,
+                             unsigned c = 0) {
   unsigned num = 0;
   if (mod.getParameters())
     num = mod.getParameters().size();
-  if (n != num) {
-    mod.emitError(name) << " has " << num << " parameters instead of " << n;
+  if (num < n || num > n + c) {
+    auto d = mod.emitError(name) << " has " << num << " parameters instead of ";
+    if (c == 0)
+      d << n;
+    else
+      d << " between " << n << " and " << (n + c);
     return failure();
   }
   return success();
 }
+
 static ParseResult namedParam(StringRef name, FModuleLike mod,
-                              StringRef paramName) {
+                              StringRef paramName, bool optional = false) {
   for (auto a : mod.getParameters()) {
     auto param = a.cast<ParamDeclAttr>();
     if (param.getName().getValue().equals(paramName)) {
       if (param.getValue().isa<StringAttr>())
         return success();
 
-      mod.emitError(name) << " test has parameter '" << param.getName()
+      mod.emitError(name) << " has parameter '" << param.getName()
                           << "' which should be a string but is not";
       return failure();
     }
   }
+  if (optional)
+    return success();
+  mod.emitError(name) << " is missing parameter " << paramName;
+  return failure();
+}
+
+static ParseResult namedIntParam(StringRef name, FModuleLike mod,
+                                 StringRef paramName, bool optional = false) {
+  for (auto a : mod.getParameters()) {
+    auto param = a.cast<ParamDeclAttr>();
+    if (param.getName().getValue().equals(paramName)) {
+      if (param.getValue().isa<IntegerAttr>())
+        return success();
+
+      mod.emitError(name) << " has parameter '" << param.getName()
+                          << "' which should be an integer but is not";
+      return failure();
+    }
+  }
+  if (optional)
+    return success();
   mod.emitError(name) << " is missing parameter " << paramName;
   return failure();
 }
@@ -237,6 +264,284 @@ static bool lowerCirctClockGate(InstancePathCache &instancePathCache,
   return true;
 }
 
+static bool lowerCirctLTLAnd(InstancePathCache &instancePathCache,
+                             FModuleLike mod) {
+  if (hasNPorts("circt.ltl.and", mod, 3) ||
+      namedPort("circt.ltl.and", mod, 0, "lhs") ||
+      namedPort("circt.ltl.and", mod, 1, "rhs") ||
+      namedPort("circt.ltl.and", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.and", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.and", mod, 1, 1) ||
+      sizedPort<UIntType>("circt.ltl.and", mod, 2, 1) ||
+      hasNParam("circt.ltl.and", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto lhs = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto rhs = builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(lhs);
+    inst.getResult(1).replaceAllUsesWith(rhs);
+    auto out = builder.create<LTLAndIntrinsicOp>(lhs.getType(), lhs, rhs);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLOr(InstancePathCache &instancePathCache,
+                            FModuleLike mod) {
+  if (hasNPorts("circt.ltl.or", mod, 3) ||
+      namedPort("circt.ltl.or", mod, 0, "lhs") ||
+      namedPort("circt.ltl.or", mod, 1, "rhs") ||
+      namedPort("circt.ltl.or", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.or", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.or", mod, 1, 1) ||
+      sizedPort<UIntType>("circt.ltl.or", mod, 2, 1) ||
+      hasNParam("circt.ltl.or", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto lhs = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto rhs = builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(lhs);
+    inst.getResult(1).replaceAllUsesWith(rhs);
+    auto out = builder.create<LTLOrIntrinsicOp>(lhs.getType(), lhs, rhs);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLDelay(InstancePathCache &instancePathCache,
+                               FModuleLike mod) {
+  if (hasNPorts("circt.ltl.delay", mod, 2) ||
+      namedPort("circt.ltl.delay", mod, 0, "in") ||
+      namedPort("circt.ltl.delay", mod, 1, "out") ||
+      sizedPort<UIntType>("circt.ltl.delay", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.delay", mod, 1, 1) ||
+      hasNParam("circt.ltl.delay", mod, 1, 2) ||
+      namedIntParam("circt.ltl.delay", mod, "delay") ||
+      namedIntParam("circt.ltl.delay", mod, "length", true))
+    return false;
+
+  auto getI64Attr = [&](int64_t value) {
+    return IntegerAttr::get(IntegerType::get(mod.getContext(), 64), value);
+  };
+  auto params = mod.getParameters();
+  auto delay = getI64Attr(params[0]
+                              .cast<ParamDeclAttr>()
+                              .getValue()
+                              .cast<IntegerAttr>()
+                              .getValue()
+                              .getZExtValue());
+  IntegerAttr length;
+  if (params.size() >= 2)
+    if (auto lengthDecl = params[1].cast<ParamDeclAttr>())
+      length = getI64Attr(
+          lengthDecl.getValue().cast<IntegerAttr>().getValue().getZExtValue());
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto in = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(in);
+    auto out =
+        builder.create<LTLDelayIntrinsicOp>(in.getType(), in, delay, length);
+    inst.getResult(1).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLConcat(InstancePathCache &instancePathCache,
+                                FModuleLike mod) {
+  if (hasNPorts("circt.ltl.concat", mod, 3) ||
+      namedPort("circt.ltl.concat", mod, 0, "lhs") ||
+      namedPort("circt.ltl.concat", mod, 1, "rhs") ||
+      namedPort("circt.ltl.concat", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.concat", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.concat", mod, 1, 1) ||
+      sizedPort<UIntType>("circt.ltl.concat", mod, 2, 1) ||
+      hasNParam("circt.ltl.concat", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto lhs = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto rhs = builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(lhs);
+    inst.getResult(1).replaceAllUsesWith(rhs);
+    auto out = builder.create<LTLConcatIntrinsicOp>(lhs.getType(), lhs, rhs);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLNot(InstancePathCache &instancePathCache,
+                             FModuleLike mod) {
+  if (hasNPorts("circt.ltl.not", mod, 2) ||
+      namedPort("circt.ltl.not", mod, 0, "in") ||
+      namedPort("circt.ltl.not", mod, 1, "out") ||
+      sizedPort<UIntType>("circt.ltl.not", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.not", mod, 1, 1) ||
+      hasNParam("circt.ltl.not", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto input =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(input);
+    auto out = builder.create<LTLNotIntrinsicOp>(input.getType(), input);
+    inst.getResult(1).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLImplication(InstancePathCache &instancePathCache,
+                                     FModuleLike mod) {
+  if (hasNPorts("circt.ltl.implication", mod, 3) ||
+      namedPort("circt.ltl.implication", mod, 0, "lhs") ||
+      namedPort("circt.ltl.implication", mod, 1, "rhs") ||
+      namedPort("circt.ltl.implication", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.implication", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.implication", mod, 1, 1) ||
+      sizedPort<UIntType>("circt.ltl.implication", mod, 2, 1) ||
+      hasNParam("circt.ltl.implication", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto lhs = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto rhs = builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(lhs);
+    inst.getResult(1).replaceAllUsesWith(rhs);
+    auto out =
+        builder.create<LTLImplicationIntrinsicOp>(lhs.getType(), lhs, rhs);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLEventually(InstancePathCache &instancePathCache,
+                                    FModuleLike mod) {
+  if (hasNPorts("circt.ltl.eventually", mod, 2) ||
+      namedPort("circt.ltl.eventually", mod, 0, "in") ||
+      namedPort("circt.ltl.eventually", mod, 1, "out") ||
+      sizedPort<UIntType>("circt.ltl.eventually", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.eventually", mod, 1, 1) ||
+      hasNParam("circt.ltl.eventually", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto input =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(input);
+    auto out = builder.create<LTLEventuallyIntrinsicOp>(input.getType(), input);
+    inst.getResult(1).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLClock(InstancePathCache &instancePathCache,
+                               FModuleLike mod) {
+  if (hasNPorts("circt.ltl.clock", mod, 3) ||
+      namedPort("circt.ltl.clock", mod, 0, "property") ||
+      namedPort("circt.ltl.clock", mod, 1, "clock") ||
+      namedPort("circt.ltl.clock", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.clock", mod, 0, 1) ||
+      typedPort<ClockType>("circt.ltl.clock", mod, 1) ||
+      sizedPort<UIntType>("circt.ltl.clock", mod, 2, 1) ||
+      hasNParam("circt.ltl.clock", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto property =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto clock =
+        builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(property);
+    inst.getResult(1).replaceAllUsesWith(clock);
+    auto out = builder.create<LTLClockIntrinsicOp>(property.getType(), property,
+                                                   clock);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerCirctLTLDisable(InstancePathCache &instancePathCache,
+                                 FModuleLike mod) {
+  if (hasNPorts("circt.ltl.disable", mod, 3) ||
+      namedPort("circt.ltl.disable", mod, 0, "property") ||
+      namedPort("circt.ltl.disable", mod, 1, "condition") ||
+      namedPort("circt.ltl.disable", mod, 2, "out") ||
+      sizedPort<UIntType>("circt.ltl.disable", mod, 0, 1) ||
+      sizedPort<UIntType>("circt.ltl.disable", mod, 1, 1) ||
+      sizedPort<UIntType>("circt.ltl.disable", mod, 2, 1) ||
+      hasNParam("circt.ltl.disable", mod, 0))
+    return false;
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto property =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto condition =
+        builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(property);
+    inst.getResult(1).replaceAllUsesWith(condition);
+    auto out = builder.create<LTLDisableIntrinsicOp>(property.getType(),
+                                                     property, condition);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+template <class Op>
+static bool lowerCirctVerif(InstancePathCache &instancePathCache,
+                            FModuleLike mod) {
+  if (hasNPorts("circt.verif.assert", mod, 1) ||
+      namedPort("circt.verif.assert", mod, 0, "property") ||
+      sizedPort<UIntType>("circt.verif.assert", mod, 0, 1) ||
+      hasNParam("circt.verif.assert", mod, 0, 1) ||
+      namedParam("circt.verif.assert", mod, "label", true))
+    return false;
+
+  auto params = mod.getParameters();
+  StringAttr label;
+  if (!params.empty())
+    if (auto labelDecl = params[0].cast<ParamDeclAttr>())
+      label = labelDecl.getValue().cast<StringAttr>();
+
+  for (auto *use : lookupInstNode(instancePathCache, mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto property =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(property);
+    builder.create<Op>(property, label);
+    inst.erase();
+  }
+  return true;
+}
+
 std::pair<const char *, std::function<bool(InstancePathCache &, FModuleLike)>>
     intrinsics[] = {
         {"circt.sizeof", lowerCirctSizeof},
@@ -249,6 +554,30 @@ std::pair<const char *, std::function<bool(InstancePathCache &, FModuleLike)>>
         {"circt_plusargs_value", lowerCirctPlusArgValue},
         {"circt.clock_gate", lowerCirctClockGate},
         {"circt_clock_gate", lowerCirctClockGate},
+        {"circt.ltl.and", lowerCirctLTLAnd},
+        {"circt_ltl_and", lowerCirctLTLAnd},
+        {"circt.ltl.or", lowerCirctLTLOr},
+        {"circt_ltl_or", lowerCirctLTLOr},
+        {"circt.ltl.delay", lowerCirctLTLDelay},
+        {"circt_ltl_delay", lowerCirctLTLDelay},
+        {"circt.ltl.concat", lowerCirctLTLConcat},
+        {"circt_ltl_concat", lowerCirctLTLConcat},
+        {"circt.ltl.not", lowerCirctLTLNot},
+        {"circt_ltl_not", lowerCirctLTLNot},
+        {"circt.ltl.implication", lowerCirctLTLImplication},
+        {"circt_ltl_implication", lowerCirctLTLImplication},
+        {"circt.ltl.eventually", lowerCirctLTLEventually},
+        {"circt_ltl_eventually", lowerCirctLTLEventually},
+        {"circt.ltl.clock", lowerCirctLTLClock},
+        {"circt_ltl_clock", lowerCirctLTLClock},
+        {"circt.ltl.disable", lowerCirctLTLDisable},
+        {"circt_ltl_disable", lowerCirctLTLDisable},
+        {"circt.verif.assert", lowerCirctVerif<VerifAssertIntrinsicOp>},
+        {"circt_verif_assert", lowerCirctVerif<VerifAssertIntrinsicOp>},
+        {"circt.verif.assume", lowerCirctVerif<VerifAssumeIntrinsicOp>},
+        {"circt_verif_assume", lowerCirctVerif<VerifAssumeIntrinsicOp>},
+        {"circt.verif.cover", lowerCirctVerif<VerifCoverIntrinsicOp>},
+        {"circt_verif_cover", lowerCirctVerif<VerifCoverIntrinsicOp>},
 };
 
 // This is the main entrypoint for the lowering pass.

--- a/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics --split-input-file %s
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    %0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // expected-error @below {{operand of type '!ltl.sequence' cannot be used as an integer}}
+    // expected-error @below {{couldn't handle this operation}}
+    %1 = firrtl.and %0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    %0 = firrtl.wire : !firrtl.uint<1>
+    // expected-note @below {{leaking outside verification context here}}
+    %1 = firrtl.and %0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // expected-error @below {{verification operation used in a non-verification context}}
+    %2 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %0, %2 : !firrtl.uint<1>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -1,0 +1,129 @@
+// RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics %s | FileCheck %s
+
+firrtl.circuit "Intrinsics" {
+  // CHECK-LABEL: hw.module @Intrinsics
+  firrtl.module @Intrinsics(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>) {
+    // CHECK-NEXT: %x_i1 = sv.constantX : i1
+    // CHECK-NEXT: [[T0:%.+]] = comb.icmp bin ceq %a, %x_i1
+    // CHECK-NEXT: [[T1:%.+]] = comb.icmp bin ceq %clk, %x_i1
+    // CHECK-NEXT: %x0 = hw.wire [[T0]]
+    // CHECK-NEXT: %x1 = hw.wire [[T1]]
+    %0 = firrtl.int.isX %a : !firrtl.uint<1>
+    %1 = firrtl.int.isX %clk : !firrtl.clock
+    %x0 = firrtl.node interesting_name %0 : !firrtl.uint<1>
+    %x1 = firrtl.node interesting_name %1 : !firrtl.uint<1>
+
+    // CHECK-NEXT: [[FOO_STR:%.*]] = sv.constantStr "foo"
+    // CHECK-NEXT: [[FOO_DECL:%.*]] = sv.reg : !hw.inout<i1>
+    // CHECK-NEXT: [[FOO:%.*]] = sv.read_inout [[FOO_DECL]]
+    // CHECK-NEXT: [[BAR_STR:%.*]] = sv.constantStr "bar"
+    // CHECK-NEXT: [[BAR_VALUE_DECL:%.*]] = sv.reg : !hw.inout<i5>
+    // CHECK-NEXT: [[BAR_FOUND_DECL:%.*]] = sv.reg : !hw.inout<i1>
+    // CHECK-NEXT: sv.initial {
+    // CHECK-NEXT:   [[TMP:%.*]] = sv.system "test$plusargs"([[FOO_STR]])
+    // CHECK-NEXT:   sv.passign [[FOO_DECL]], [[TMP]]
+    // CHECK-NEXT:   [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
+    // CHECK-NEXT:   sv.passign [[BAR_FOUND_DECL]], [[TMP]]
+    // CHECK-NEXT: }
+    // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]
+    // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.read_inout [[BAR_VALUE_DECL]]
+    // CHECK-NEXT: %x2 = hw.wire [[FOO]]
+    // CHECK-NEXT: %x3 = hw.wire [[BAR_FOUND]]
+    // CHECK-NEXT: %x4 = hw.wire [[BAR_VALUE]]
+    %2 = firrtl.int.plusargs.test "foo"
+    %3, %4 = firrtl.int.plusargs.value "bar" : !firrtl.uint<5>
+    %x2 = firrtl.node interesting_name %2 : !firrtl.uint<1>
+    %x3 = firrtl.node interesting_name %3 : !firrtl.uint<1>
+    %x4 = firrtl.node interesting_name %4 : !firrtl.uint<5>
+  }
+
+  // CHECK-LABEL: hw.module @LTLAndVerif
+  firrtl.module @LTLAndVerif(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    // CHECK-NEXT: [[D0:%.+]] = ltl.delay %a, 42 : i1
+    // CHECK-NEXT: [[D1:%.+]] = ltl.delay %b, 42, 1337 : i1
+    %d0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %d1 = firrtl.int.ltl.delay %b, 42, 1337 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[L0:%.+]] = ltl.and [[D0]], [[D1]] : !ltl.sequence, !ltl.sequence
+    // CHECK-NEXT: [[L1:%.+]] = ltl.or %a, [[L0]] : i1, !ltl.sequence
+    %l0 = firrtl.int.ltl.and %d0, %d1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %l1 = firrtl.int.ltl.or %a, %l0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[C0:%.+]] = ltl.concat [[D0]], [[L1]] : !ltl.sequence, !ltl.sequence
+    %c0 = firrtl.int.ltl.concat %d0, %l1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[N0:%.+]] = ltl.not [[C0]] : !ltl.sequence
+    %n0 = firrtl.int.ltl.not %c0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[I0:%.+]] = ltl.implication [[C0]], [[N0]] : !ltl.sequence, !ltl.property
+    %i0 = firrtl.int.ltl.implication %c0, %n0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[E0:%.+]] = ltl.eventually [[I0]] : !ltl.property
+    %e0 = firrtl.int.ltl.eventually %i0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[K0:%.+]] = ltl.clock [[I0]], posedge %clk : !ltl.property
+    %k0 = firrtl.int.ltl.clock %i0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[D2:%.+]] = ltl.disable [[K0]] if %b : !ltl.property
+    %d2 = firrtl.int.ltl.disable %k0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: verif.assert %a : i1
+    // CHECK-NEXT: verif.assert %a label "hello" : i1
+    // CHECK-NEXT: verif.assume [[C0]] : !ltl.sequence
+    // CHECK-NEXT: verif.assume [[C0]] label "hello" : !ltl.sequence
+    // CHECK-NEXT: verif.cover [[K0]] : !ltl.property
+    // CHECK-NEXT: verif.cover [[K0]] label "hello" : !ltl.property
+    firrtl.int.verif.assert %a : !firrtl.uint<1>
+    firrtl.int.verif.assert %a {label = "hello"} : !firrtl.uint<1>
+    firrtl.int.verif.assume %c0 : !firrtl.uint<1>
+    firrtl.int.verif.assume %c0 {label = "hello"} : !firrtl.uint<1>
+    firrtl.int.verif.cover %k0 : !firrtl.uint<1>
+    firrtl.int.verif.cover %k0 {label = "hello"} : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: hw.module @LowerIntrinsicStyle
+  firrtl.module @LowerIntrinsicStyle(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    // Wires can make the lowering really weird. Try some strange setup where
+    // the ops are totally backwards. This is tricky to lower since a lot of the
+    // LTL ops' result type depends on the inputs, and LowerToHW lowers them
+    // before their operands have been lowered (and have the correct LTL type).
+    // CHECK-NOT: hw.wire
+    %c = firrtl.wire : !firrtl.uint<1>
+    %d = firrtl.wire : !firrtl.uint<1>
+    %e = firrtl.wire : !firrtl.uint<1>
+    %f = firrtl.wire : !firrtl.uint<1>
+    %g = firrtl.wire : !firrtl.uint<1>
+
+    // CHECK-NEXT: verif.assert [[E:%.+]] : !ltl.sequence
+    // CHECK-NEXT: verif.assert [[F:%.+]] : !ltl.property
+    // CHECK-NEXT: verif.assert [[G:%.+]] : !ltl.property
+    firrtl.int.verif.assert %e : !firrtl.uint<1>
+    firrtl.int.verif.assert %f : !firrtl.uint<1>
+    firrtl.int.verif.assert %g : !firrtl.uint<1>
+
+    // !ltl.property
+    // CHECK-NEXT: [[G]] = ltl.implication [[E]], [[F]] : !ltl.sequence, !ltl.property
+    %4 = firrtl.int.ltl.implication %e, %f : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %g, %4 : !firrtl.uint<1>
+
+    // inferred as !ltl.property
+    // CHECK-NEXT: [[F]] = ltl.or %b, [[D:%.+]] : i1, !ltl.property
+    %3 = firrtl.int.ltl.or %b, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %f, %3 : !firrtl.uint<1>
+
+    // inferred as !ltl.sequence
+    // CHECK-NEXT: [[E]] = ltl.and %b, [[C:%.+]] : i1, !ltl.sequence
+    %2 = firrtl.int.ltl.and %b, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %e, %2 : !firrtl.uint<1>
+
+    // !ltl.property
+    // CHECK-NEXT: [[D]] = ltl.not %b : i1
+    %1 = firrtl.int.ltl.not %b : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %d, %1 : !firrtl.uint<1>
+
+    // !ltl.sequence
+    // CHECK-NEXT: [[C]] = ltl.delay %a, 42 : i1
+    %0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.strictconnect %c, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -238,9 +238,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: = comb.icmp bin eq {{.*}}, %c-1_i14 : i14
     %28 = firrtl.andr %18 : (!firrtl.uint<14>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: = comb.icmp bin ceq {{.*}}, %x_i1
-    %x28 = firrtl.int.isX %28 : !firrtl.uint<1>
-
     // CHECK-NEXT: [[XOREXT:%.+]] = comb.concat %c0_i11, [[XOR]]
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shru bin [[XOREXT]], [[VAL18]] : i14
     // CHECK-NEXT: [[DSHR:%.+]] = comb.extract [[SHIFT]] from 0 : (i14) -> i3
@@ -1509,34 +1506,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK{LITERAL}:   %0 = hw.aggregate_constant [[[3 : i8, 2 : i8], [1 : i8, 0 : i8]], [[7 : i8, 6 : i8], [5 : i8, 4 : i8]]]
     // CHECK-SAME: !hw.struct<a: !hw.array<2xarray<2xi8>>, b: !hw.array<2xarray<2xi8>>>
     // CHECK: hw.output %0
-  }
-
-  // CHECK-LABEL: hw.module @intrinsic
-  firrtl.module @intrinsic(in %clk: !firrtl.clock, out %io1: !firrtl.uint<1>, out %io2: !firrtl.uint<1>, out %io3: !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
-    %1 = firrtl.int.isX %clk : !firrtl.clock
-    firrtl.strictconnect %io1, %1 : !firrtl.uint<1>
-    // CHECK: %[[x:.*]] = sv.constantX
-    // CHECK: comb.icmp bin ceq %clk, %[[x]]
-
-    %2 = firrtl.int.plusargs.test "foo"
-    firrtl.strictconnect %io2, %2 : !firrtl.uint<1>
-    %3, %4 = firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
-    firrtl.strictconnect %io3, %3 : !firrtl.uint<1>
-    firrtl.strictconnect %io4, %4 : !firrtl.uint<5>
-
-    // CHECK: %[[foo:.*]] = sv.constantStr "foo"
-    // CHECK: %[[tst:.*]] = sv.reg : !hw.inout<i1>
-    // CHECK: %[[foo2:.*]] = sv.constantStr "foo"
-    // CHECK: %[[val:.*]] = sv.reg : !hw.inout<i5> 
-    // CHECK: %[[fnd:.*]] = sv.reg : !hw.inout<i1> 
-    // CHECK: sv.initial { 
-    // CHECK: %[[call:.*]] = sv.system "test$plusargs"(%[[foo]])
-    // CHECK: sv.passign %[[tst]], %[[call]]
-    // CHECK: %[[call:.*]] = sv.system "value$plusargs"(%[[foo2]], %[[val]])
-    // CHECK: sv.passign %[[fnd]], %[[call]]
-    // CHECK: }
-    // CHECK: %[[rfnd:.*]] = sv.read_inout %[[fnd]]
-    // CHECK: %[[rval:.*]] = sv.read_inout %[[val]]
   }
 
   // An internal-only analog connection between two instances should be implemented with a wire

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -99,4 +99,88 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %in2, %clk : !firrtl.clock
     firrtl.strictconnect %en2, %en : !firrtl.uint<1>
   }
+
+  // CHECK-NOT: LTLAnd
+  // CHECK-NOT: LTLOr
+  // CHECK-NOT: LTLDelay1
+  // CHECK-NOT: LTLDelay2
+  // CHECK-NOT: LTLConcat
+  // CHECK-NOT: LTLNot
+  // CHECK-NOT: LTLImplication
+  // CHECK-NOT: LTLEventually
+  // CHECK-NOT: LTLClock
+  // CHECK-NOT: LTLDisable
+  firrtl.intmodule @LTLAnd(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.and"}
+  firrtl.intmodule @LTLOr(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.or"}
+  firrtl.intmodule @LTLDelay1<delay: i64 = 42>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.delay"}
+  firrtl.intmodule @LTLDelay2<delay: i64 = 42, length: i64 = 1337>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.delay"}
+  firrtl.intmodule @LTLConcat(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.concat"}
+  firrtl.intmodule @LTLNot(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.not"}
+  firrtl.intmodule @LTLImplication(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.implication"}
+  firrtl.intmodule @LTLEventually(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.eventually"}
+  firrtl.intmodule @LTLClock(in property: !firrtl.uint<1>, in clock: !firrtl.clock, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.clock"}
+  firrtl.intmodule @LTLDisable(in property: !firrtl.uint<1>, in condition: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.disable"}
+
+  // CHECK: firrtl.module @LTL()
+  firrtl.module @LTL() {
+    // CHECK-NOT: LTLAnd
+    // CHECK-NOT: LTLOr
+    // CHECK: firrtl.int.ltl.and {{%.+}}, {{%.+}} :
+    // CHECK: firrtl.int.ltl.or {{%.+}}, {{%.+}} :
+    %and.lhs, %and.rhs, %and.out = firrtl.instance "and" @LTLAnd(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %or.lhs, %or.rhs, %or.out = firrtl.instance "or" @LTLOr(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+
+    // CHECK-NOT: LTLDelay1
+    // CHECK-NOT: LTLDelay2
+    // CHECK: firrtl.int.ltl.delay {{%.+}}, 42 :
+    // CHECK: firrtl.int.ltl.delay {{%.+}}, 42, 1337 :
+    %delay1.in, %delay1.out = firrtl.instance "delay1" @LTLDelay1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %delay2.in, %delay2.out = firrtl.instance "delay2" @LTLDelay2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+
+    // CHECK-NOT: LTLConcat
+    // CHECK-NOT: LTLNot
+    // CHECK-NOT: LTLImplication
+    // CHECK-NOT: LTLEventually
+    // CHECK: firrtl.int.ltl.concat {{%.+}}, {{%.+}} :
+    // CHECK: firrtl.int.ltl.not {{%.+}} :
+    // CHECK: firrtl.int.ltl.implication {{%.+}}, {{%.+}} :
+    // CHECK: firrtl.int.ltl.eventually {{%.+}} :
+    %concat.lhs, %concat.rhs, %concat.out = firrtl.instance "concat" @LTLConcat(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %not.in, %not.out = firrtl.instance "not" @LTLNot(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %implication.lhs, %implication.rhs, %implication.out = firrtl.instance "implication" @LTLImplication(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %eventually.in, %eventually.out = firrtl.instance "eventually" @LTLEventually(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+
+    // CHECK-NOT: LTLClock
+    // CHECK: firrtl.int.ltl.clock {{%.+}}, {{%.+}} :
+    %clock.property, %clock.clock, %clock.out = firrtl.instance "clock" @LTLClock(in property: !firrtl.uint<1>, in clock: !firrtl.clock, out out: !firrtl.uint<1>)
+
+    // CHECK-NOT: LTLDisable
+    // CHECK: firrtl.int.ltl.disable {{%.+}}, {{%.+}} :
+    %disable.property, %disable.condition, %disable.out = firrtl.instance "disable" @LTLDisable(in property: !firrtl.uint<1>, in condition: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+  }
+
+  // CHECK-NOT: VerifAssert1
+  // CHECK-NOT: VerifAssert2
+  // CHECK-NOT: VerifAssume
+  // CHECK-NOT: VerifCover
+  firrtl.intmodule @VerifAssert1(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assert"}
+  firrtl.intmodule @VerifAssert2<label: none = "hello">(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assert"}
+  firrtl.intmodule @VerifAssume(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assume"}
+  firrtl.intmodule @VerifCover(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.cover"}
+
+  // CHECK: firrtl.module @Verif()
+  firrtl.module @Verif() {
+    // CHECK-NOT: VerifAssert1
+    // CHECK-NOT: VerifAssert2
+    // CHECK-NOT: VerifAssume
+    // CHECK-NOT: VerifCover
+    // CHECK: firrtl.int.verif.assert {{%.+}} :
+    // CHECK: firrtl.int.verif.assert {{%.+}} {label = "hello"} :
+    // CHECK: firrtl.int.verif.assume {{%.+}} :
+    // CHECK: firrtl.int.verif.cover {{%.+}} :
+    %assert1.property = firrtl.instance "assert1" @VerifAssert1(in property: !firrtl.uint<1>)
+    %assert2.property = firrtl.instance "assert2" @VerifAssert2(in property: !firrtl.uint<1>)
+    %assume.property = firrtl.instance "assume" @VerifAssume(in property: !firrtl.uint<1>)
+    %cover.property = firrtl.instance "cover" @VerifCover(in property: !firrtl.uint<1>)
+  }
 }

--- a/test/firtool/verif.fir
+++ b/test/firtool/verif.fir
@@ -1,0 +1,55 @@
+; RUN: firtool %s | FileCheck %s
+
+circuit Foo:
+  intmodule LTLDelay:
+    input in: UInt<1>
+    output out: UInt<1>
+    intrinsic = circt_ltl_delay
+    parameter delay = 1
+    parameter length = 0
+
+  intmodule LTLConcat:
+    input lhs: UInt<1>
+    input rhs: UInt<1>
+    output out: UInt<1>
+    intrinsic = circt_ltl_concat
+
+  intmodule LTLImplication:
+    input lhs: UInt<1>
+    input rhs: UInt<1>
+    output out: UInt<1>
+    intrinsic = circt_ltl_implication
+
+  intmodule LTLEventually:
+    input in: UInt<1>
+    output out: UInt<1>
+    intrinsic = circt_ltl_eventually
+
+  intmodule VerifAssert:
+    input property: UInt<1>
+    intrinsic = circt_verif_assert
+    parameter label = "hello"
+
+  module Foo:
+    input clk: Clock
+    input a: UInt<1>
+    input b: UInt<1>
+
+    inst delay of LTLDelay
+    delay.in <= b
+
+    inst concat of LTLConcat
+    concat.lhs <= a
+    concat.rhs <= delay.out
+
+    inst implication of LTLImplication
+    implication.lhs <= a
+    implication.rhs <= concat.out
+
+    inst eventually of LTLEventually
+    eventually.in <= implication.out
+
+    ; CHECK: hello: assert property (s_eventually a |-> a ##1 b);
+    inst assert of VerifAssert
+    assert.property <= eventually.out
+


### PR DESCRIPTION
Add intrinsics to the FIRRTL dialect that lower directly to operations in the Verif and LTL dialects. This allows FIRRTL inputs to express temporal assert, assume, and cover operations without requiring native support for them in the FIRRTL spec.

This commit does the following:

- Add `firrtl.int.ltl.*` and `firrtl.int.verif.*` operations to `FIRRTLExpressions.td` and `FIRRTLStatements.td`
- Add intrinsic lowering support to `LowerIntrinsics`
- Add visitor support
- In LowerToHW, map the intrinsics to the corresponding `verif.*` and `ltl.*` operations.
- Since there are no opaque user-defined FIRRTL types yet, the intrinsics operate on `UInt<1>` where the LTL ops would operate on concrete `!ltl.sequence` and `!ltl.property` types. The LowerToHW change also includes a final `fixupLTLOps` step to ensure these types are propagate properly and don't leak into `i1` logic.
- Add tests for `LowerIntrinsics`, `LowerToHW`, and an end-to-end test with firtool to check for FIR-to-SVA output.

Now that the number of intrinsics starts to grow, we probably want to refactor the `LowerIntrinsics` pass a bit and create something like a pattern/intrinsic set and a few helpers to match for ports and parameters, with error reporting in one unified place. Future work.