### PR TITLE
[circt-lec] Generalise LEC to handle non-SSA modules

### DIFF
--- a/include/circt/LogicalEquivalence/Circuit.h
+++ b/include/circt/LogicalEquivalence/Circuit.h
@@ -82,14 +82,13 @@ private:
       mlir::Value result, mlir::OperandRange operands,
       llvm::function_ref<z3::expr(const z3::expr &, const z3::expr &)>
           operation);
-  /// Allocates an IR value in the logical backend and returns its representing
-  /// expression.
-  z3::expr allocateValue(mlir::Value value);
+  /// Returns the expression allocated for the input value in the logical
+  /// backend if one has been allocated - otherwise allocates and returns a new
+  /// expression
+  z3::expr fetchOrAllocateExpr(mlir::Value value);
   /// Allocates a constant value in the logical backend and returns its
   /// representing expression.
   void allocateConstant(mlir::Value opResult, const mlir::APInt &opValue);
-  /// Fetches the corresponding logical expression for a given IR value.
-  z3::expr fetchExpr(mlir::Value &value);
   /// Constrains the result of a MLIR operation to be equal a given logical
   /// express, simulating an assignment.
   void constrainResult(mlir::Value &result, z3::expr &expr);

--- a/integration_test/circt-lec/hw.mlir
+++ b/integration_test/circt-lec/hw.mlir
@@ -41,7 +41,6 @@ hw.module @notnot(%in: i1) -> (out: i1) {
 //  RUN: circt-lec %s -c1=basic -c2=basic -v=false | FileCheck %s --check-prefix=HW_OUTPUT
 //  HW_OUTPUT: c1 == c2
 
-
 hw.module @constZeroZero(%in: i1) -> (o1: i1, o2: i1) {
   %zero = hw.constant 0 : i1
   hw.output %zero, %zero : i1, i1
@@ -65,3 +64,15 @@ hw.module @constZeroOne(%in: i1) -> (o1: i1, o2: i1) {
 // Modules with one equivalent and one non-equivalent output
 //  RUN: not circt-lec %s -c1=constZeroZero -c2=constZeroOne -v=false | FileCheck %s --check-prefix=TWOOUTPUTSFAIL
 //  TWOOUTPUTSFAIL: c1 != c2
+
+hw.module @onePlusTwoNonSSA() -> (out: i2) {
+  %three = comb.add bin %one, %two : i2
+  %one = hw.constant 1 : i2
+  %two = hw.constant 2 : i2
+  hw.output %three : i2
+}
+
+// hw.module graph region check
+//  RUN: circt-lec %s -c1=onePlusTwo -c2=onePlusTwoNonSSA -v=false | FileCheck %s --check-prefix=HW_MODULE_GRAPH
+//  HW_MODULE_GRAPH: c1 == c2
+

--- a/lib/LogicalEquivalence/Circuit.cpp
+++ b/lib/LogicalEquivalence/Circuit.cpp
@@ -401,7 +401,7 @@ z3::expr Solver::Circuit::fetchOrAllocateExpr(Value value) {
     // Technically allowed for the `hw` dialect but
     // disallowed for `comb` operations; should check separately.
     assert(width > 0 && "0-width integers are not supported"); // NOLINT
-    z3::expr expr = solver.context.bv_const(valueName.c_str(), width);
+    expr = solver.context.bv_const(valueName.c_str(), width);
     LLVM_DEBUG(lec::printExpr(expr));
     LLVM_DEBUG(lec::printValue(value));
     auto exprInsertion = exprTable.insert(std::pair(value, expr));
@@ -412,7 +412,6 @@ z3::expr Solver::Circuit::fetchOrAllocateExpr(Value value) {
     auto symInsertion = solver.symbolTable.insert(std::pair(symbol, value));
     (void)symInsertion; // Suppress Warning
     assert(symInsertion.second && "Value not inserted in symbol table");
-    return expr;
   }
   return expr;
 }


### PR DESCRIPTION
Currently, `circt-lec` can only handle `hw.module`s whose contents meet SSA constraints - this is because it allocates Z3 bitvecs for each value when it finds that value as the result of an assignment. As a result, if it has not yet seen an assignment to a value that is used as an operand, it throws an error as it cannot find the appropriate bitvec - not ideal in a graph region, and causes issues bringing in the `seq` dialect in #4647. Pretty simple fix here, it just makes the allocation of bitvecs conditional on one not having already been allocated (so that allocation can be called multiple times on a value without multiple variables being created) and then tries to allocate every operand it sees. If a `hw.constant` result has already been assigned a symbolic variable by the time it becomes clear that it is a `hw.constant` result, a constraint is just added to force the variable to equal the constant value.