### PR TITLE
Enum const support

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2592,7 +2592,7 @@ LogicalResult MatchOp::verify() {
                                      << " is matched more than once";
 
     // Check that the block argument type matches the tag's type.
-    auto expectedType = type.getElementType(tagIndex);
+    auto expectedType = type.getElementTypePreservingConst(tagIndex);
     auto regionType = region.getArgument(0).getType();
     if (regionType != expectedType)
       return emitOpError("region type ")
@@ -2676,7 +2676,7 @@ ParseResult MatchOp::parse(OpAsmParser &parser, OperationState &result) {
     tags.push_back(IntegerAttr::get(i32Type, *index));
 
     // Parse the region.
-    arg.type = enumType.getElementType(*index);
+    arg.type = enumType.getElementTypePreservingConst(*index);
     if (parser.parseRegion(*region, arg))
       return failure();
   }
@@ -3155,7 +3155,8 @@ ParseResult IsTagOp::parse(OpAsmParser &parser, OperationState &result) {
 FIRRTLType IsTagOp::inferReturnType(ValueRange operands,
                                     ArrayRef<NamedAttribute> attrs,
                                     std::optional<Location> loc) {
-  return UIntType::get(operands[0].getContext(), 1, /*isConst=*/false);
+  return UIntType::get(operands[0].getContext(), 1,
+                       isConst(operands[0].getType()));
 }
 
 template <typename OpTy>

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -293,6 +293,10 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
     if (parser.parseCommaSeparatedList(mlir::AsmParser::Delimiter::LessGreater,
                                        parseEnumElement))
       return failure();
+    if (failed(FEnumType::verify(
+            [&]() { return parser.emitError(parser.getNameLoc()); }, elements,
+            isConst)))
+      return failure();
 
     return result = FEnumType::get(context, elements, isConst), success();
   }
@@ -1984,6 +1988,8 @@ auto FEnumType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
       return emitErrorFn() << "enum field '" << elt.name << "' not passive";
     if (r.containsAnalog)
       return emitErrorFn() << "enum field '" << elt.name << "' contains analog";
+    if (r.containsConst && !isConst)
+      return emitErrorFn() << "enum with 'const' elements must be 'const'";
     // TODO: exclude reference containing
   }
   return success();

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -21,8 +21,8 @@ firrtl.module @ConstReset(in %a: !firrtl.const.reset) {}
 // CHECK-LABEL: firrtl.module @ConstAsyncReset(in %a: !firrtl.const.asyncreset) {
 firrtl.module @ConstAsyncReset(in %a: !firrtl.const.asyncreset) {}
 
-// CHECK-LABEL: firrtl.module @ConstEnum(in %a: !firrtl.enum<a: uint<1>, b: uint<2>>) {
-firrtl.module @ConstEnum(in %a: !firrtl.enum<a: uint<1>, b: uint<2>>) {}
+// CHECK-LABEL: firrtl.module @ConstEnum(in %a: !firrtl.const.enum<a: uint<1>, b: uint<2>>) {
+firrtl.module @ConstEnum(in %a: !firrtl.const.enum<a: uint<1>, b: uint<2>>) {}
 
 // CHECK-LABEL: firrtl.module @ConstVec(in %a: !firrtl.const.vector<uint<1>, 3>) {
 firrtl.module @ConstVec(in %a: !firrtl.const.vector<uint<1>, 3>) {}
@@ -127,20 +127,6 @@ firrtl.module @ConstSubtag(in %in : !firrtl.const.enum<a: uint<1>, b: uint<2>>,
   // CHECK-NEXT: firrtl.connect %out, [[VAL]] : !firrtl.const.uint<2>, !firrtl.const.uint<2>
   %0 = firrtl.subtag %in[b] : !firrtl.const.enum<a: uint<1>, b: uint<2>>
   firrtl.connect %out, %0 : !firrtl.const.uint<2>, !firrtl.const.uint<2>
-}
-
-// CHECK-LABEL: firrtl.module @MixedConstSubtag
-firrtl.module @MixedConstSubtag(in %in : !firrtl.enum<a: uint<1>, b: const.uint<2>>,
-                                out %a : !firrtl.uint<1>,
-                                out %b : !firrtl.const.uint<2>) {
-  // CHECK-NEXT: [[VAL0:%.+]] = firrtl.subtag %in[a] : !firrtl.enum<a: uint<1>, b: const.uint<2>>
-  // CHECK-NEXT: [[VAL1:%.+]] = firrtl.subtag %in[b] : !firrtl.enum<a: uint<1>, b: const.uint<2>>
-  // CHECK-NEXT: firrtl.connect %a, [[VAL0]] : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %b, [[VAL1]] : !firrtl.const.uint<2>, !firrtl.const.uint<2>
-  %0 = firrtl.subtag %in[a] : !firrtl.enum<a: uint<1>, b: const.uint<2>>
-  %1 = firrtl.subtag %in[b] : !firrtl.enum<a: uint<1>, b: const.uint<2>>
-  firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %b, %1 : !firrtl.const.uint<2>, !firrtl.const.uint<2>
 }
 
 // CHECK-LABEL: firrtl.module @ConstRegResetValue

--- a/test/Dialect/FIRRTL/drop-const.mlir
+++ b/test/Dialect/FIRRTL/drop-const.mlir
@@ -10,8 +10,7 @@ firrtl.module @DropConst() {}
 // CHECK-SAME: in d: !firrtl.vector<uint<1>, 3>,
 // CHECK-SAME: in e: !firrtl.vector<uint<1>, 3>,
 // CHECK-SAME: in f: !firrtl.enum<a: uint<2>, b: uint<1>>,
-// CHECK-SAME: in g: !firrtl.enum<a: uint<2>, b: uint<1>>,
-// CHECK-SAME: out h: !firrtl.probe<uint<1>>)
+// CHECK-SAME: out g: !firrtl.probe<uint<1>>)
 firrtl.extmodule @ConstPortExtModule(
   in a: !firrtl.const.uint<1>, 
   in b: !firrtl.const.bundle<a: uint<1>>,
@@ -19,8 +18,7 @@ firrtl.extmodule @ConstPortExtModule(
   in d: !firrtl.const.vector<uint<1>, 3>,
   in e: !firrtl.vector<const.uint<1>, 3>,
   in f: !firrtl.const.enum<a: uint<2>, b: uint<1>>,
-  in g: !firrtl.enum<a: uint<2>, b: const.uint<1>>,
-  out h: !firrtl.probe<const.uint<1>>
+  out g: !firrtl.probe<const.uint<1>>
 )
 
 // Const is dropped from module signature and ops
@@ -31,8 +29,7 @@ firrtl.extmodule @ConstPortExtModule(
 // CHECK-SAME: in %d: !firrtl.vector<uint<1>, 3>,
 // CHECK-SAME: in %e: !firrtl.vector<uint<1>, 3>,
 // CHECK-SAME: in %f: !firrtl.enum<a: uint<2>, b: uint<1>>,
-// CHECK-SAME: in %g: !firrtl.enum<a: uint<2>, b: uint<1>>,
-// CHECK-SAME: out %h: !firrtl.probe<uint<1>>)
+// CHECK-SAME: out %g: !firrtl.probe<uint<1>>)
 firrtl.module @ConstPortModule(
   in %a: !firrtl.const.uint<1>, 
   in %b: !firrtl.const.bundle<a: uint<1>>,
@@ -40,8 +37,7 @@ firrtl.module @ConstPortModule(
   in %d: !firrtl.const.vector<uint<1>, 3>,
   in %e: !firrtl.vector<const.uint<1>, 3>,
   in %f: !firrtl.const.enum<a: uint<2>, b: uint<1>>,
-  in %g: !firrtl.enum<a: uint<2>, b: const.uint<1>>,
-  out %h: !firrtl.probe<const.uint<1>>
+  out %g: !firrtl.probe<const.uint<1>>
 ) {
   // CHECK-NEXT: firrtl.instance inst @ConstPortExtModule(
   // CHECK-SAME: in a: !firrtl.uint<1>
@@ -50,17 +46,15 @@ firrtl.module @ConstPortModule(
   // CHECK-SAME: in d: !firrtl.vector<uint<1>, 3>,
   // CHECK-SAME: in e: !firrtl.vector<uint<1>, 3>,
   // CHECK-SAME: in f: !firrtl.enum<a: uint<2>, b: uint<1>>,
-  // CHECK-SAME: in g: !firrtl.enum<a: uint<2>, b: uint<1>>,
-  // CHECK-SAME: out h: !firrtl.probe<uint<1>>)
-  %a2, %b2, %c2, %d2, %e2, %f2, %g2, %h2 = firrtl.instance inst @ConstPortExtModule(
+  // CHECK-SAME: out g: !firrtl.probe<uint<1>>)
+  %a2, %b2, %c2, %d2, %e2, %f2, %g2 = firrtl.instance inst @ConstPortExtModule(
     in a: !firrtl.const.uint<1>, 
     in b: !firrtl.const.bundle<a: uint<1>>,
     in c: !firrtl.bundle<a: const.uint<1>>,
     in d: !firrtl.const.vector<uint<1>, 3>,
     in e: !firrtl.vector<const.uint<1>, 3>,
     in f: !firrtl.const.enum<a: uint<2>, b: uint<1>>,
-    in g: !firrtl.enum<a: uint<2>, b: const.uint<1>>,
-    out h: !firrtl.probe<const.uint<1>>
+    out g: !firrtl.probe<const.uint<1>>
   )
 
   firrtl.strictconnect %a2, %a : !firrtl.const.uint<1>
@@ -69,8 +63,7 @@ firrtl.module @ConstPortModule(
   firrtl.strictconnect %d2, %d : !firrtl.const.vector<uint<1>, 3>
   firrtl.strictconnect %e2, %e : !firrtl.vector<const.uint<1>, 3>
   firrtl.strictconnect %f2, %f : !firrtl.const.enum<a: uint<2>, b: uint<1>>
-  firrtl.strictconnect %g2, %g : !firrtl.enum<a: uint<2>, b: const.uint<1>>
-  firrtl.ref.define %h, %h2 : !firrtl.probe<const.uint<1>>
+  firrtl.ref.define %g, %g2 : !firrtl.probe<const.uint<1>>
 }
 
 // Const-cast ops are erased

--- a/test/Dialect/FIRRTL/lower-matches.mlir
+++ b/test/Dialect/FIRRTL/lower-matches.mlir
@@ -50,4 +50,35 @@ firrtl.module @LowerMatches(in %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: u
   }
 
 }
+
+// CHECK-LABEL: firrtl.module @ConstLowerMatches
+firrtl.module @ConstLowerMatches(in %enum : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>, out %out : !firrtl.const.uint<8>) {
+
+   // CHECK-NEXT: %0 = firrtl.istag %enum a : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT: firrtl.when %0 : !firrtl.const.uint<1> {
+   // CHECK-NEXT:   %1 = firrtl.subtag %enum[a] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:   firrtl.strictconnect %out, %1 : !firrtl.const.uint<8>
+   // CHECK-NEXT: } else {
+   // CHECK-NEXT:   %1 = firrtl.istag %enum b : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:   firrtl.when %1 : !firrtl.const.uint<1> {
+   // CHECK-NEXT:     %2 = firrtl.subtag %enum[b] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.const.uint<8>
+   // CHECK-NEXT:   } else {
+   // CHECK-NEXT:     %2 = firrtl.subtag %enum[c] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
+   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.const.uint<8>
+   // CHECK-NEXT:   }
+   // CHECK-NEXT: }
+  firrtl.match %enum : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>> {
+    case a(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+    }
+    case b(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+    }
+    case c(%arg0) {
+      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+    }
+  }
+
+}
 }


### PR DESCRIPTION
This pr ties up loose ends regarding enums and const.
MatchOp now takes const into account.
Non-const enums cannot contain const in their elements.
Verifier tests for enums have been added.