### PR TITLE
[FIRRTL] Add RefCastOp, support ref path becoming more general

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1035,6 +1035,29 @@ def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+def RefCastOp : FIRRTLOp<"ref.cast",
+    [HasCustomSSAName,
+     Pure,
+     CompatibleRefTypes<"result","input">]> {
+  let summary = "Cast between compatible reference types";
+  let description = [{
+    Losslessly cast between compatible reference types.
+    Source and destination must be recursively identical or destination
+    has uninferred variants of the corresponding element in source.
+    ```
+      %result = firrtl.ref.cast %ref : (t1) -> t2
+    ```
+    }];
+
+  let arguments = (ins RefType:$input);
+  let results = (outs RefType:$result);
+
+  let hasFolder = 1;
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+}
+
 def RefResolveOp: FIRRTLExprOp<"ref.resolve",
                               [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL Resolve a Reference";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -297,7 +297,7 @@ def ProbeOp : FIRRTLOp<"probe"> {
 class ForceRefTypeConstraint<string ref, string base>
   : TypesMatchWith<"reference type of " # ref # " should be RWProbe of " # base,
                    base, ref,
-                   "RefType::get($_self.cast<FIRRTLBaseType>(), true)">;
+                   "RefType::get($_self.cast<FIRRTLBaseType>().getAllConstDroppedType(), true)">;
 
 def RefForceOp : FIRRTLOp<"ref.force",[ForceRefTypeConstraint<"dest", "src">]> {
   let summary = "FIRRTL force statement";

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -224,6 +224,11 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
 bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
                            bool srcOuterTypeIsConst = false);
 
+/// Return true if destination ref type can be cast from source ref type,
+/// per FIRRTL spec rules they must be identical or destination has
+/// more general versions of the corresponding type in the source.
+bool areTypesRefCastable(Type dstType, Type srcType);
+
 /// Returns true if the destination is at least as wide as a source.  The source
 /// and destination types must be equivalent non-analog types.  The types are
 /// recursively connected to ensure that the destination is larger than the
@@ -232,10 +237,6 @@ bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
 /// field-by-field.  Types with unresolved widths are assumed to fit into or
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
-
-/// Return true if destination can be set using source ref type,
-/// e.g., in a ref.define or ref.cast.  Rejects if not ref types.
-bool isCompatibleRefType(Type dstType, Type srcType);
 
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -206,7 +206,7 @@ bool containsConst(Type type);
 /// definition of type equivalence in the FIRRTL spec.  If the types being
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
-bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
+bool areTypesEquivalent(FIRRTLType destFType, FIRRTLType srcFType,
                         bool destOuterTypeIsConst = false,
                         bool srcOuterTypeIsConst = false,
                         bool requireSameWidths = false,

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -206,11 +206,10 @@ bool containsConst(Type type);
 /// definition of type equivalence in the FIRRTL spec.  If the types being
 /// compared have any outer flips that encode FIRRTL module directions (input or
 /// output), these should be stripped before using this method.
-bool areTypesEquivalent(FIRRTLType destFType, FIRRTLType srcFType,
+bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
                         bool destOuterTypeIsConst = false,
                         bool srcOuterTypeIsConst = false,
-                        bool requireSameWidths = false,
-                        bool requireDestSameOrUninferred = false);
+                        bool requireSameWidths = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -209,7 +209,8 @@ bool containsConst(Type type);
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
                         bool destOuterTypeIsConst = false,
                         bool srcOuterTypeIsConst = false,
-                        bool requireSameWidths = false);
+                        bool requireSameWidths = false,
+                        bool requireDestSameOrUninferred = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types
@@ -232,6 +233,10 @@ bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
 /// field-by-field.  Types with unresolved widths are assumed to fit into or
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
+
+/// Return true if destination can be set using source ref type,
+/// e.g., in a ref.define or ref.cast.  Rejects if not ref types.
+bool isCompatibleRefType(Type dstType, Type srcType);
 
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -199,6 +199,6 @@ class RefResultTypeConstraint<string base, string ref>
 class CompatibleRefTypes<string dst, string src>
   : PredOpTrait<"reference " # dst # " must be compatible with reference " # src #
                 ": recursively same or uninferred of same and can only demote rwprobe to probe",
-                CPred<"circt::firrtl::isCompatibleRefType($" # dst # ".getType(), $" # src # ".getType())">>;
+                CPred<"circt::firrtl::areTypesRefCastable($" # dst # ".getType(), $" # src # ".getType())">>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -196,4 +196,9 @@ class RefResultTypeConstraint<string base, string ref>
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
 
+class CompatibleRefTypes<string dst, string src>
+  : PredOpTrait<"reference " # dst # " must be compatible with reference " # src #
+                ": recursively same or uninferred of same and can only demote rwprobe to probe",
+                CPred<"circt::firrtl::isCompatibleRefType($" # dst # ".getType(), $" # src # ".getType())">>;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -58,9 +58,10 @@ public:
             RefResolveOp, RefSubOp,
             // Casts to deal with weird stuff
             UninferredResetCastOp, UninferredWidthCastOp, ConstCastOp,
-            mlir::UnrealizedConversionCastOp>([&](auto expr) -> ResultType {
-          return thisCast->visitExpr(expr, args...);
-        })
+            RefCastOp, mlir::UnrealizedConversionCastOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitExpr(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidExpr(op, args...);
         });
@@ -189,6 +190,7 @@ public:
   HANDLE(ConstCastOp, Unhandled);
   HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);
+  HANDLE(RefCastOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3126,7 +3126,7 @@ LogicalResult ClockGateIntrinsicOp::canonicalize(ClockGateIntrinsicOp op,
 }
 
 //===----------------------------------------------------------------------===//
-// RefOps
+// Reference Ops.
 //===----------------------------------------------------------------------===//
 
 // refresolve(forceable.ref) -> forceable.data
@@ -3145,4 +3145,11 @@ void RefResolveOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
   results.insert<patterns::RefResolveOfRefSend>(context);
   results.insert(canonicalizeRefResolveOfForceable);
+}
+
+OpFoldResult RefCastOp::fold(FoldAdaptor adaptor) {
+  // RefCast is unnecessary if types match.
+  if (getInput().getType() == getType())
+    return getInput();
+  return {};
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2526,6 +2526,9 @@ LogicalResult RefDefineOp::verify() {
     if (isa<RefSubOp>(op))
       return emitError(
           "destination reference cannot be a sub-element of a reference");
+    if (isa<RefCastOp>(op)) // Source flow, check anyway for now.
+      return emitError(
+          "destination reference cannot be a cast of another reference");
   }
 
   return success();
@@ -4571,6 +4574,22 @@ void ElementwiseAndPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+void RefCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
                                          std::optional<Location> loc) {
@@ -4591,18 +4610,6 @@ FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
     return emitInferRetTypeError(
         loc, "ref.send operand must be base type, not ", inType);
   return RefType::get(inBaseType.getPassiveType());
-}
-
-void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
 }
 
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -723,6 +723,7 @@ bool firrtl::containsConst(Type type) {
       .Default(false);
 }
 
+// NOLINTBEGIN(misc-no-recursion)
 /// Helper to implement the equivalence logic for a pair of bundle elements.
 /// Note that the FIRRTL spec requires bundle elements to have the same
 /// orientation, but this only compares their passive types. The FIRRTL dialect
@@ -1003,6 +1004,7 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
         return destWidth <= -1 || srcWidth <= -1 || destWidth >= srcWidth;
       });
 }
+// NOLINTEND(misc-no-recursion)
 
 bool firrtl::isCompatibleRefType(Type dstType, Type srcType) {
   auto dstRefType = dyn_cast<RefType>(dstType);

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1007,11 +1007,11 @@ bool firrtl::isCompatibleRefType(Type dstType, Type srcType) {
   if (dstRefType.getForceable() && !srcRefType.getForceable())
     return false;
 
-  // Okay, duplicate majority of the type equivalence logic.
-  // Primary change is to require types are (recursively) the same OR
-  // destination is uninferred version of the source.  So along ref path width
-  // information can be lost but not added, similarly resets can become more
-  // general but not more specific.
+  // Okay walk the types recursively.  They must be identical "structurally"
+  // with exception leaf (ground) types of destination can be uninferred
+  // versions of the corresponding source type. (can lose width information or
+  // become a more general reset type)
+
   // NOLINTBEGIN(misc-no-recursion)
   auto recurse = [&](auto &&f, FIRRTLBaseType dest,
                      FIRRTLBaseType src) -> bool {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1012,6 +1012,7 @@ bool firrtl::isCompatibleRefType(Type dstType, Type srcType) {
   // destination is uninferred version of the source.  So along ref path width
   // information can be lost but not added, similarly resets can become more
   // general but not more specific.
+  // NOLINTBEGIN(misc-no-recursion)
   auto recurse = [&](auto &&f, FIRRTLBaseType dest,
                      FIRRTLBaseType src) -> bool {
     // Fast-path for identical types.
@@ -1077,6 +1078,7 @@ bool firrtl::isCompatibleRefType(Type dstType, Type srcType) {
   };
 
   return recurse(recurse, dstRefType.getType(), srcRefType.getType());
+  // NOLINTEND(misc-no-recursion)
 }
 
 /// Return the passive version of a firrtl type

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1052,6 +1052,7 @@ bool firrtl::areTypesRefCastable(Type dstType, Type srcType) {
   // NOLINTEND(misc-no-recursion)
 }
 
+// NOLINTBEGIN(misc-no-recursion)
 /// Returns true if the destination is at least as wide as an equivalent source.
 bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
   return TypeSwitch<FIRRTLBaseType, bool>(dstType)
@@ -1080,6 +1081,7 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
         return destWidth <= -1 || srcWidth <= -1 || destWidth >= srcWidth;
       });
 }
+// NOLINTEND(misc-no-recursion)
 
 /// Return the passive version of a firrtl type
 /// top level for ODS constraint usage

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1046,9 +1046,10 @@ bool firrtl::areTypesRefCastable(Type dstType, Type srcType) {
                  });
     }
 
+    // XXX: Disable support for reset differences until InferResets support.
     // Reset types can be driven by UInt<1>, AsyncReset, or Reset types.
-    if (dest.isa<ResetType>())
-      return src.isResetType();
+    // if (dest.isa<ResetType>())
+    //   return src.isResetType();
     // (but don't allow the other direction, can only become more general)
 
     // Compare against const src if dest is const.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -986,8 +986,8 @@ bool firrtl::areTypesRefCastable(Type dstType, Type srcType) {
   // to have const cast away, especially for probes of literals and expressions
   // derived from them.  Check const as with const cast.
   // NOLINTBEGIN(misc-no-recursion)
-  auto recurse = [&](auto &&f, FIRRTLBaseType dest,
-                     FIRRTLBaseType src, bool srcOuterTypeIsConst) -> bool {
+  auto recurse = [&](auto &&f, FIRRTLBaseType dest, FIRRTLBaseType src,
+                     bool srcOuterTypeIsConst) -> bool {
     // Fast-path for identical types.
     if (dest == src)
       return true;

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -35,10 +35,12 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // Special Connects (non-base, foreign):
   if (!dstType) {
-    // References use ref.define.  Types should match, leave to verifier if not.
-    if (isa<RefType>(dstFType))
+    // References use ref.define.  Add cast if types don't match.
+    if (isa<RefType>(dstFType)) {
+      if (dstFType != srcFType)
+        src = builder.create<RefCastOp>(dstFType, src);
       builder.create<RefDefineOp>(dst, src);
-    else // Other types, give up and leave a connect
+    } else // Other types, give up and leave a connect
       builder.create<ConnectOp>(dst, src);
     return;
   }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2870,16 +2870,22 @@ ParseResult FIRStmtParser::parseRefForce() {
                startTok.getLoc(),
                "expected rwprobe-type expression for force destination, got ")
            << dest.getType();
-  if (isa<RefType>(src.getType()))
+  auto srcBaseType = dyn_cast<FIRRTLBaseType>(src.getType());
+  if (!srcBaseType)
     return emitError(startTok.getLoc(),
                      "expected non-reference-type for force source, got ")
            << src.getType();
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  // Add a const cast if needed
-  if (src.getType() != ref.getType() && containsConst(src.getType()))
-    src = builder.create<ConstCastOp>(ref.getType(), src).getResult();
+  // Cast ref to accomodate uninferred sources.
+  auto noConstSrcType = srcBaseType.getAllConstDroppedType();
+  if (noConstSrcType != ref.getType()) {
+    // Try to cast destination to rwprobe of source type (dropping const).
+    auto compatibleRWProbe = RefType::get(noConstSrcType, true);
+    if (areTypesRefCastable(compatibleRWProbe, ref))
+      dest = builder.create<RefCastOp>(compatibleRWProbe, dest);
+  }
 
   builder.create<RefForceOp>(clock, pred, dest, src);
 
@@ -2904,7 +2910,8 @@ ParseResult FIRStmtParser::parseRefForceInitial() {
     return emitError(startTok.getLoc(), "expected rwprobe-type expression for "
                                         "force_initial destination, got ")
            << dest.getType();
-  if (isa<RefType>(src.getType()))
+  auto srcBaseType = dyn_cast<FIRRTLBaseType>(src.getType());
+  if (!srcBaseType)
     return emitError(startTok.getLoc(),
                      "expected non-reference-type expression for force_initial "
                      "source, got ")
@@ -2912,9 +2919,14 @@ ParseResult FIRStmtParser::parseRefForceInitial() {
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  // Add a const cast if needed
-  if (src.getType() != ref.getType() && containsConst(src.getType()))
-    src = builder.create<ConstCastOp>(ref.getType(), src).getResult();
+  // Cast ref to accomodate uninferred sources.
+  auto noConstSrcType = srcBaseType.getAllConstDroppedType();
+  if (noConstSrcType != ref.getType()) {
+    // Try to cast destination to rwprobe of source type (dropping const).
+    auto compatibleRWProbe = RefType::get(noConstSrcType, true);
+    if (areTypesRefCastable(compatibleRWProbe, ref))
+      dest = builder.create<RefCastOp>(compatibleRWProbe, dest);
+  }
 
   auto value = APInt::getAllOnes(1);
   auto type = UIntType::get(builder.getContext(), 1);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2741,6 +2741,11 @@ ParseResult FIRStmtParser::parseRefDefine() {
 
   locationProcessor.setLoc(startTok.getLoc());
 
+  if (!areTypesRefCastable(target.getType(), src.getType()))
+    return emitError(startTok.getLoc(), "cannot define reference of type ")
+           << target.getType() << " with incompatible reference of type "
+           << src.getType();
+
   emitConnect(builder, target, src);
 
   return success();

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -626,13 +626,16 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
       auto rd = getRefDefine(result);
       assert(rd && "input ref port to instance is alive, but no driver?");
       assert(isKnownAlive(rd.getSrc()));
-      auto *srcDefOp = rd.getSrc().getDefiningOp();
+      auto source = rd.getSrc();
+      auto *srcDefOp = source.getDefiningOp();
       if (srcDefOp && llvm::any_of(result.getUsers(), [&](auto user) {
-            return user->getBlock() != rd.getSrc().getParentBlock() ||
-                   user->isBeforeInBlock(rd.getSrc().getDefiningOp());
+            return user->getBlock() != source.getParentBlock() ||
+                   user->isBeforeInBlock(source.getDefiningOp());
           }))
         llvm::report_fatal_error("unsupported IR with references in IMDCE");
-      result.replaceAllUsesWith(rd.getSrc());
+      result.replaceAllUsesWith(source);
+      liveElements.erase(result);
+      liveElements.insert(source);
       ++numErasedOps;
       rd.erase();
       return;

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1678,6 +1678,10 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         declareVars(op.getResult(), op.getLoc());
         constrainTypes(op.getResult(), op.getRef());
       })
+      .Case<RefCastOp>([&](auto op) {
+        declareVars(op.getResult(), op.getLoc());
+        constrainTypes(op.getResult(), op.getInput());
+      })
       .Case<mlir::UnrealizedConversionCastOp>([&](auto op) {
         for (Value result : op.getResults()) {
           auto ty = result.getType();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -400,6 +400,7 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitExpr(BitCastOp op);
   bool visitExpr(RefSendOp op);
   bool visitExpr(RefResolveOp op);
+  bool visitExpr(RefCastOp op);
   bool visitStmt(ConnectOp op);
   bool visitStmt(StrictConnectOp op);
   bool visitStmt(RefDefineOp op);
@@ -1271,6 +1272,15 @@ bool TypeLoweringVisitor::visitExpr(RefResolveOp op) {
   // Lower according to lowering of the reference.
   // Particularly, preserve if rwprobe.
   return lowerProducer(op, clone, op.getRef().getType());
+}
+
+bool TypeLoweringVisitor::visitExpr(RefCastOp op) {
+  auto clone = [&](const FlatBundleFieldEntry &field,
+                   ArrayAttr attrs) -> Value {
+    auto input = getSubWhatever(op.getInput(), field.index);
+    return builder->create<RefCastOp>(RefType::get(field.type), input);
+  };
+  return lowerProducer(op, clone);
 }
 
 bool TypeLoweringVisitor::visitDecl(InstanceOp op) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -203,7 +203,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             if (!isZeroWidth(op.getType().getType()))
               dataFlowClasses->unionSets(op.getInput(), op.getResult());
             return success();
-           })
+          })
           .Case<Forceable>([&](Forceable op) {
             if (!op.isForceable() || op.getDataRef().use_empty())
               return success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -198,6 +198,12 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             resolveOps.push_back(resolve);
             return success();
           })
+          .Case<RefCastOp>([&](RefCastOp op) {
+            markForRemoval(op);
+            if (!isZeroWidth(op.getType().getType()))
+              dataFlowClasses->unionSets(op.getInput(), op.getResult());
+            return success();
+           })
           .Case<Forceable>([&](Forceable op) {
             if (!op.isForceable() || op.getDataRef().use_empty())
               return success();

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2968,4 +2968,13 @@ firrtl.module @DonotUpdateInstanceName(in %in: !firrtl.uint<1>, out %a: !firrtl.
   firrtl.strictconnect %a, %b : !firrtl.uint<1>
 }
 
+// CHECK-LABEL: @RefCastSame
+firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
+  // Drop no-op ref.cast's.
+  // CHECK-NEXT:  firrtl.ref.define %out, %in
+  // CHECK-NEXT:  }
+  %same_as_in = firrtl.ref.cast %in : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>>
+  firrtl.ref.define %out, %same_as_in : !firrtl.probe<uint<1>>
+}
+
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -853,7 +853,8 @@ firrtl.circuit "Foo" {
     firrtl.ref.define %bov_ref, %bov_rw : !firrtl.rwprobe<bundle<a: vector<uint, 2>, b : uint>>
 
     %ref_w = firrtl.ref.send %w : !firrtl.uint
-    firrtl.ref.define %x, %ref_w : !firrtl.probe<uint>
+    %cast_ref_w = firrtl.ref.cast %ref_w : (!firrtl.probe<uint>) -> !firrtl.probe<uint>
+    firrtl.ref.define %x, %cast_ref_w : !firrtl.probe<uint>
     firrtl.ref.define %y, %w_rw : !firrtl.rwprobe<uint>
 
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -144,16 +144,16 @@ firrtl.circuit "Refs" attributes {
   } {
 
   firrtl.module private @DUT(
-    in %in: !firrtl.uint<1>, out %out: !firrtl.ref<uint<1>>
+    in %in: !firrtl.uint<1>, out %out: !firrtl.probe<uint<1>>
   ) attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
     ]}
   {
     %ref = firrtl.ref.send %in : !firrtl.uint<1>
-    firrtl.ref.define %out, %ref : !firrtl.ref<uint<1>>
+    firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>
   }
   firrtl.module @Refs() {
-    %dut_in, %dut_tap = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>, out out: !firrtl.ref<uint<1>>)
+    %dut_in, %dut_tap = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>, out out: !firrtl.probe<uint<1>>)
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1125,7 +1125,7 @@ firrtl.module private @is1436_FOO() {
 
     // Define using forceable ref preserved.
     // CHECK-NEXT: firrtl.ref.define %{{.+}}, %[[X_REF]] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
-    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1> ,2>, b: uint<2>>>
+    firrtl.ref.define %bov_ref, %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
 
     // Preserve ref.sub uses.
     // CHECK-NEXT: %[[X_REF_A:.+]] = firrtl.ref.sub %[[X_REF]][0]
@@ -1150,8 +1150,10 @@ firrtl.module private @is1436_FOO() {
     %x_ref_b = firrtl.ref.sub %x_ref[1] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     %x_b = firrtl.ref.resolve %x_ref_b : !firrtl.rwprobe<uint<2>>
 
-    // TODO: Handle rwprobe --> probe define, enable this.
-    // firrtl.ref.define %probe, %x_ref_b : !firrtl.probe<uint<2>>
+    // CHECK-NEXT: %[[X_B_REF_PROBE:.+]] = firrtl.ref.cast %[[X_B_REF]]
+    // CHECK-NEXT: firrtl.ref.define %probe, %[[X_B_REF_PROBE]] : !firrtl.probe<uint<2>>
+    %x_ref_b_probe = firrtl.ref.cast %x_ref_b : (!firrtl.rwprobe<uint<2>>) -> !firrtl.probe<uint<2>>
+    firrtl.ref.define %probe, %x_ref_b_probe : !firrtl.probe<uint<2>>
 
     // Check resolve of rwprobe is preserved.
     // CHECK-NEXT: = firrtl.ref.resolve %[[X_REF]]

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -658,6 +658,25 @@ firrtl.circuit "ReadForceable" {
 }
 
 // -----
+// Check resolution through a ref cast.
+
+// CHECK-LABEL: firrtl.circuit "RefCast"
+firrtl.circuit "RefCast" {
+  // CHECK: hw.hierpath private @xmrPath [@RefCast::@[[wSym:.+]]]
+  // CHECK-LABEL: firrtl.module @RefCast(out %o: !firrtl.uint<2>)
+  firrtl.module @RefCast(out %o: !firrtl.uint<2>) {
+    %w, %w_ref = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    %w_ro = firrtl.ref.cast %w_ref : (!firrtl.rwprobe<uint<2>>) -> !firrtl.probe<uint<2>>
+    %x = firrtl.ref.resolve %w_ro : !firrtl.probe<uint<2>>
+    firrtl.strictconnect %o, %x : !firrtl.uint<2>
+    // CHECK-NEXT: %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
+    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
+    // CHECK-NEXT: firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
+  }
+}
+
+// -----
 
 // CHECK-LABEL: firrtl.circuit "ForceRelease"
 firrtl.circuit "ForceRelease" {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1193,8 +1193,9 @@ circuit EnumTypes:
   ; CHECK-LABEL: module private @Refs(
   module Refs :
     input in : UInt<1>
-    output r : Probe<UInt<1>>
-    output rw : RWProbe<UInt<1>>
+    output r : Probe<UInt>
+    output rw : RWProbe<UInt>
+    output notrw : Probe<UInt>
     output out : UInt<1>
     output out2 : UInt<1>
     output out3 : UInt<3>
@@ -1205,11 +1206,18 @@ circuit EnumTypes:
     inst rc of RefsChild
     rc.in <= in
     ; CHECK: %[[OUTREF:.+]] = firrtl.ref.send %out
-    ; CHECK-NEXT: ref.define %r, %[[OUTREF]]
+    ; CHECK-NEXT: %[[OUTREF_CAST:.+]] = firrtl.ref.cast %[[OUTREF]] : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint>
+    ; CHECK-NEXT: ref.define %r, %[[OUTREF_CAST]]
     define r = probe(out)
-    ; CHECK-NEXT: ref.define %rw, %[[RC_RW]]
-    ; CHECK-SAME: rwprobe
+    ; CHECK-NEXT: %[[RC_RW_CAST:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint>
+    ; CHECK-NEXT: ref.define %rw, %[[RC_RW_CAST]]
+    ; CHECK-SAME: rwprobe<uint>
     define rw = rc.rw
+
+    ; CHECK-NEXT: %[[RC_RW_CAST_PROBE:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.probe<uint>
+    ; CHECK-NEXT: ref.define %notrw, %[[RC_RW_CAST_PROBE]]
+    ; CHECK-SAME: firrtl.probe
+    define notrw = rc.rw
 
     ; CHECK-NEXT: %[[READ_RC_R:.+]] = firrtl.ref.resolve %[[RC_R]]
     ; CHECK-NEXT: connect %out, %[[READ_RC_R]]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1192,23 +1192,24 @@ circuit EnumTypes:
 
   ; CHECK-LABEL: module private @Refs(
   module Refs :
-    input in : UInt<1>
-    output r : Probe<UInt>
+    input in : const UInt<1>
+    output r : Probe<const UInt>
     output rw : RWProbe<UInt>
     output notrw : Probe<UInt>
     output out : UInt<1>
     output out2 : UInt<1>
     output out3 : UInt<3>
-    ; CHECK-SAME: out %agg_out: !firrtl.probe<bundle<a: uint<1>, b: uint>>
-    output agg_out : Probe<{a: UInt<1>, b: UInt}>
+    output outconst : const UInt<1>
+    ; CHECK-SAME: out %agg_out: !firrtl.probe<bundle<a: uint<1>, b: const.uint>>
+    output agg_out : Probe<{a: UInt<1>, b: const UInt}>
 
     ; CHECK-NEXT: %[[RC_IN:.+]], %[[RC_R:.+]], %[[RC_RW:.+]] = firrtl.instance rc
     inst rc of RefsChild
     rc.in <= in
-    ; CHECK: %[[OUTREF:.+]] = firrtl.ref.send %out
-    ; CHECK-NEXT: %[[OUTREF_CAST:.+]] = firrtl.ref.cast %[[OUTREF]] : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint>
+    ; CHECK: %[[OUTREF:.+]] = firrtl.ref.send %outconst
+    ; CHECK-NEXT: %[[OUTREF_CAST:.+]] = firrtl.ref.cast %[[OUTREF]] : (!firrtl.probe<const.uint<1>>) -> !firrtl.probe<const.uint>
     ; CHECK-NEXT: ref.define %r, %[[OUTREF_CAST]]
-    define r = probe(out)
+    define r = probe(outconst)
     ; CHECK-NEXT: %[[RC_RW_CAST:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint>
     ; CHECK-NEXT: ref.define %rw, %[[RC_RW_CAST]]
     ; CHECK-SAME: rwprobe<uint>
@@ -1227,9 +1228,9 @@ circuit EnumTypes:
     out <= read(rc.rw)
 
     ; ref.sub parsing
-    ; CHECK-DAG: %[[AGG:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a flip: uint<1>, b: uint>
+    ; CHECK-DAG: %[[AGG:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a flip: const.uint<1>, b: uint>
     ; CHECK-DAG: %[[AGG2:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a: uint, b flip: uint<1>>
-    wire agg : { flip a : UInt<1>, b : UInt }
+    wire agg : { flip a : const UInt<1>, b : UInt }
     wire agg2 : { a : UInt, flip b : UInt<1> }
     ; CHECK-DAG: %[[AGG_B:.+]] = firrtl.subfield %[[AGG]][b]
     ; CHECK-DAG: %[[AGG_B_PROBE:.+]] = firrtl.ref.send %[[AGG_B]]
@@ -1244,9 +1245,10 @@ circuit EnumTypes:
     out2 <= read(probe(agg2)).b
 
     ; CHECK: %[[AGG3:.+]] = firrtl.wire
-    wire agg3 : { a : UInt<1>, b : UInt }
+    wire agg3 : const { a : UInt<1>, b : UInt }
     ; CHECK-NEXT: %[[AGG3_PROBE:.+]] = firrtl.ref.send %[[AGG3]]
-    ; CHECK-NEXT: ref.define %agg_out, %[[AGG3_PROBE]]
+    ; CHECK-NEXT: %[[AGG3_PROBE_CAST:.+]] = firrtl.ref.cast %[[AGG3_PROBE]] : (!firrtl.probe<const.bundle<a: uint<1>, b: uint>>) -> !firrtl.probe<bundle<a: uint<1>, b: const.uint>> 
+    ; CHECK-NEXT: ref.define %agg_out, %[[AGG3_PROBE_CAST]]
     define agg_out = probe(agg3)
 
     ; CHECK: %{{.+}}, %[[REM_R:.+]], %{{.+}}, %[[REM_R2:.+]] = firrtl.instance rem
@@ -1260,7 +1262,7 @@ circuit EnumTypes:
     ; CHECK: %[[PROBE_IN:.+]] = firrtl.ref.send %in
     ; CHECK-DAG: %[[READ_PROBE_IN:.+]] = firrtl.ref.resolve %[[PROBE_IN]]
     ; CHECK-DAG: %[[SUM:.+]] = firrtl.and %[[READ_PROBE_IN]],
-    out <= and(read(probe(in)), UInt(1))
+    outconst <= and(read(probe(in)), UInt(1))
 
   ; CHECK-LABEL: module private @ForceRelease(
   module ForceRelease :

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1274,10 +1274,13 @@ circuit EnumTypes:
     inst rc of RefsChild
     rc.in <= in
 
-    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW]], %{{.+}} : !firrtl.uint<1>, !firrtl.uint<1>
-    force_initial(rc.rw, UInt<1>(0))
+    ; Check (const) literal works, even if uninferred width.
+    ; Cast reference to more general form as needed.
+    ; CHECK: %[[RC_RW_CAST:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint>
+    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW_CAST]], %{{.+}} : !firrtl.uint<1>, !firrtl.const.uint
+    force_initial(rc.rw, UInt(0))
 
-    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.const.uint<1>
     force(clock, cond, rc.rw, UInt<1>(1))
     ; CHECK: %[[NOT_COND:.+]] = firrtl.not %cond
     ; CHECK: firrtl.ref.release %clock, %[[NOT_COND]], %[[RC_RW]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -605,16 +605,6 @@ circuit LeadingProbe:
 
 ;// -----
 
-; This should be supported, needs internal support to land first.
-circuit DefineWidths:
-  module DefineWidths:
-    input in : UInt<1>
-    output p : Probe<UInt>
-    define p = probe(in) ; expected-error {{'firrtl.ref.define' op requires all operands to have the same type}}
-
-
-;// -----
-
 circuit ForceProbe:
   module ForceProbe:
     input in : UInt<1>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -670,3 +670,14 @@ circuit ConstProbe:
 circuit MultiConst:
   module MultiConst:
     output x : const const UInt<1> ; expected-error {{'const' can only be specified once on a type}}
+
+;// -----
+
+circuit DefinePromoteToRW:
+  extmodule Ref:
+    output ro : Probe<UInt<1>>
+  module DefinePromoteToRW:
+    output rw : RWProbe<UInt<1>>
+    inst r of Ref
+    ; expected-error @below {{cannot define reference of type '!firrtl.rwprobe<uint<1>>' with incompatible reference of type '!firrtl.probe<uint<1>>'}}
+    define rw = r.ro

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -229,3 +229,12 @@ firrtl.circuit "Forceable" {
   }
 }
 
+// -----
+
+firrtl.circuit "RefDefineAndCastWidths" {
+  firrtl.module @RefDefineAndCastWidths(in %x: !firrtl.uint<2>, out %p : !firrtl.probe<uint>) {
+    %ref = firrtl.ref.send %x : !firrtl.uint<2>
+    %cast = firrtl.ref.cast %ref : (!firrtl.probe<uint<2>>) -> !firrtl.probe<uint>
+    firrtl.ref.define %p, %cast : !firrtl.probe<uint>
+  }
+}


### PR DESCRIPTION
Want to support inference along reference path, add support for define destination to have more general type than source (pending inference).  Handle this with an explicit ref.cast operation, keep define SameTypeOperands.

Replaces #4825.