### PR TITLE
[ETC] Extract registers and instances if not in design

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -32,6 +32,7 @@ std::unique_ptr<mlir::Pass> createHWMemSimImplPass(
     bool addVivadoRAMAddressConflictSynthesisBugWorkaround = false);
 std::unique_ptr<mlir::Pass>
 createSVExtractTestCodePass(bool disableInstanceExtraction = false,
+                            bool disableRegisterExtraction = false,
                             bool disableModuleInlining = false);
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(std::optional<std::string> directory = {});

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -130,6 +130,8 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let options = [
     Option<"disableInstanceExtraction", "disable-instance-extraction", "bool",
            "false", "Disable extracting instances only that feed test code">,
+    Option<"disableRegisterExtraction", "disable-register-extraction", "bool",
+           "false", "Disable extracting registers only that feed test code">,
     Option<"disableModuleInlining", "disable-module-inlining", "bool",
            "false", "Disable inlining modules that only feed test code">
   ];

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -199,6 +199,11 @@ struct FirtoolOptions {
       llvm::cl::desc("Disable extracting instances only that feed test code"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
+  llvm::cl::opt<bool> etcDisableRegisterExtraction{
+      "etc-disable-register-extraction",
+      llvm::cl::desc("Disable extracting registers that only feed test code"),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
   llvm::cl::opt<bool> etcDisableModuleInlining{
       "etc-disable-module-inlining",
       llvm::cl::desc("Disable inlining modules that only feed test code"),

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -234,7 +234,7 @@ static void addOperationsToCloneSet(SetVector<Value> &inputs,
   }
 
   // Find operations we can extract and add them to the clone set.
-  for (auto operation : operationsToExtract) {
+  for (auto *operation : operationsToExtract) {
     // We know the forward dataflow for this operation ends in either
     // extractable test code or other operations that are handled speciall.
     // Check if all of the other operations are also marked for extraction.
@@ -251,7 +251,7 @@ static void addOperationsToCloneSet(SetVector<Value> &inputs,
   }
 
   // Perform the necessary IR mutations for extracted operations.
-  for (auto operation : operationsToExtract) {
+  for (auto *operation : operationsToExtract) {
     // Ensure this is one of the operations we actually want to clone.
     if (!opsToClone.contains(operation))
       continue;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -32,26 +32,15 @@ using namespace sv;
 
 using BindTable = DenseMap<Attribute, SmallDenseMap<Attribute, sv::BindOp>>;
 
-/// Track information about an Operation that might be extracted.
-struct OperationInfo {
-  // A set vector of this operation's forward dataflow slice.
-  SetVector<Operation *> forwardSlice;
-
-  // A vector of other operations that are dataflow sinks from this operation.
-  // This specifically tracks dataflow sinks that are handled specially, like
-  // instances and registers.
-  SmallVector<Operation *> operationSinks;
-};
-
 //===----------------------------------------------------------------------===//
 // StubExternalModules Helpers
 //===----------------------------------------------------------------------===//
 
 // Reimplemented from SliceAnalysis to use a worklist rather than recursion and
 // non-insert ordered set.
-static void getBackwardSliceSimple(Operation *rootOp,
-                                   SetVector<Operation *> &backwardSlice,
-                                   std::function<bool(Operation *)> filter) {
+static void
+getBackwardSliceSimple(Operation *rootOp, SetVector<Operation *> &backwardSlice,
+                       llvm::function_ref<bool(Operation *)> filter) {
   SmallVector<Operation *> worklist;
   worklist.push_back(rootOp);
 
@@ -96,65 +85,6 @@ static void getBackwardSliceSimple(Operation *rootOp,
   backwardSlice.remove(rootOp);
 }
 
-// Reimplemented and simplified from SliceAnalysis to use a worklist rather than
-// recursion and not consider nested regions. Also accepts a clone set
-// representing a backward dataflow slice. As soon as a use is found outside the
-// backward slice, return false. Otherwise, the whole forward slice is contained
-// in the backward slice, and return true.
-static bool getForwardSliceSimple(Operation *rootOp,
-                                  SetVector<Operation *> &opsToClone,
-                                  OperationInfo &operationInfo) {
-  SmallPtrSet<Operation *, 32> visited;
-  SmallVector<Operation *> worklist;
-  worklist.push_back(rootOp);
-  visited.insert(rootOp);
-
-  while (!worklist.empty()) {
-    Operation *op = worklist.pop_back_val();
-    operationInfo.forwardSlice.insert(op);
-
-    for (auto *user : op->getUsers()) {
-      // If the dataflow is into an instance, mark it and move along.
-      if (auto sinkInstance = dyn_cast<hw::InstanceOp>(user)) {
-        assert(!opsToClone.contains(sinkInstance) &&
-               "expected instances to not be present in opsToClone");
-        operationInfo.operationSinks.push_back(sinkInstance);
-        continue;
-      }
-
-      // If the dataflow is into a register, mark it and move along.
-      if (auto sinkRegister = dyn_cast<seq::FirRegOp>(user)) {
-        assert(!opsToClone.contains(sinkRegister) &&
-               "expected instances to not be present in opsToClone");
-        operationInfo.operationSinks.push_back(sinkRegister);
-        continue;
-      }
-
-      // If the dataflow is into an op that isn't in the clone set, we're done.
-      if (!opsToClone.contains(user))
-        return false;
-
-      // Otherwise, continue following the dataflow slice.
-      if (visited.insert(user).second)
-        worklist.push_back(user);
-    }
-  }
-
-  return true;
-}
-
-// Compute the dataflow for a set of ops.
-static void dataflowSlice(SetVector<Operation *> &ops,
-                          SetVector<Operation *> &results) {
-  for (auto op : ops) {
-    getBackwardSliceSimple(op, results, [](Operation *testOp) -> bool {
-      return !isa<seq::SeqDialect>(testOp->getDialect()) &&
-             !isa<sv::ReadInOutOp>(testOp) && !isa<hw::InstanceOp>(testOp) &&
-             !isa<sv::PAssignOp>(testOp) && !isa<sv::BPAssignOp>(testOp);
-    });
-  }
-}
-
 // Compute the ops defining the blocks a set of ops are in.
 static void blockSlice(SetVector<Operation *> &ops,
                        SetVector<Operation *> &blocks) {
@@ -166,13 +96,20 @@ static void blockSlice(SetVector<Operation *> &ops,
   }
 }
 
-// Aggressively mark operations to be moved to the new module.  This leaves
-// maximum flexibility for optimization after removal of the nodes from the
-// old module.
-static SetVector<Operation *> computeCloneSet(SetVector<Operation *> &roots) {
+static void computeSlice(SetVector<Operation *> &roots,
+                         SetVector<Operation *> &results,
+                         llvm::function_ref<bool(Operation *)> filter) {
+  for (auto *op : roots)
+    getBackwardSliceSimple(op, results, filter);
+}
+
+// Return a backward slice started from `roots` until dataflow reaches to an
+// operations for which `filter` returns false.
+static SetVector<Operation *>
+getBackwardSlice(SetVector<Operation *> &roots,
+                 llvm::function_ref<bool(Operation *)> filter) {
   SetVector<Operation *> results;
-  // Get Dataflow for roots
-  dataflowSlice(roots, results);
+  computeSlice(roots, results, filter);
 
   // Get Blocks
   SetVector<Operation *> blocks;
@@ -180,122 +117,25 @@ static SetVector<Operation *> computeCloneSet(SetVector<Operation *> &roots) {
   blockSlice(results, blocks);
 
   // Make sure dataflow to block args (if conds, etc) is included
-  dataflowSlice(blocks, results);
+  computeSlice(blocks, results, filter);
 
-  // include the blocks and roots to clone
   results.insert(roots.begin(), roots.end());
   results.insert(blocks.begin(), blocks.end());
-
   return results;
 }
 
-// Find operations that need special handling, like instances and registers,
-// that directly feed the clone set, and add them if possible. This also returns
-// a list of ops that should be erased, which includes such operations and their
-// forward dataflow slices. The template type is the concrete Operation subclass
-// to try to extract.
-template <typename T>
-static void addOperationsToCloneSet(SetVector<Value> &inputs,
-                                    SetVector<Operation *> &opsToClone,
-                                    SmallPtrSetImpl<Operation *> &opsToErase) {
-  // Track inputs to add, which are used by the operation that will be
-  // extracted.
-  SmallVector<Value> inputsToAdd;
-
-  // Track inputs to remove, which come from operations that will be extracted.
-  SmallVector<Value> inputsToRemove;
-
-  // Track operations to potentially extract.
-  llvm::SmallDenseSet<Operation *> operationsToExtract;
-
-  // Track info about operations to potentially extract.
-  SmallDenseMap<Operation *, OperationInfo> operationInfo;
-
-  // Check each input into the clone set.
-  for (auto value : inputs) {
-    // Check if the input comes from an operation of the requested type, and it
-    // isn't already added to the clone set.
-    auto operation = value.getDefiningOp<T>();
-    if (!operation)
-      continue;
-    if (opsToClone.contains(operation))
-      continue;
-
-    // If the operation had a symbol, we can't extract it without more work.
-    if (operation.getInnerSym().has_value())
-      continue;
-
-    // Compute the operation's forward slice. If it wasn't fully contained in
-    // the clone set, move along.
-    if (!getForwardSliceSimple(operation, opsToClone, operationInfo[operation]))
-      continue;
-
-    operationsToExtract.insert(operation);
-  }
-
-  // Find operations we can extract and add them to the clone set.
-  for (auto *operation : operationsToExtract) {
-    // We know the forward dataflow for this operation ends in either
-    // extractable test code or other operations that are handled speciall.
-    // Check if all of the other operations are also marked for extraction.
-    bool allOperationSinksExtractable = llvm::all_of(
-        operationInfo[operation].operationSinks, [&](Operation *sinkOperation) {
-          return operationsToExtract.contains(sinkOperation);
-        });
-
-    if (!allOperationSinksExtractable)
-      continue;
-
-    // Add the operation to the clone set.
-    opsToClone.insert(operation);
-  }
-
-  // Perform the necessary IR mutations for extracted operations.
-  for (auto *operation : operationsToExtract) {
-    // Ensure this is one of the operations we actually want to clone.
-    if (!opsToClone.contains(operation))
-      continue;
-
-    // Add any operation inputs to the input set.
-    for (auto operand : operation->getOperands()) {
-      // Don't add values to the input set if they are the result of an op we
-      // are already going to clone.
-      if (operand.getDefiningOp() &&
-          opsToClone.contains(operand.getDefiningOp()))
-        continue;
-
-      inputsToAdd.push_back(operand);
-    }
-
-    // Mark the operation results to be removed from the input set.
-    for (auto result : operation->getResults())
-      inputsToRemove.push_back(result);
-
-    // Mark the operation and its forward dataflow to be erased from the pass.
-    // Normally, ops in the clone set are canonicalized away later, but for
-    // this case, we have to proactively erase them. The operations must be
-    // erased because we can't canonicalize away operations with unused results
-    // in general. The forward dataflow must be erased because the operation is
-    // being erased, and we can't leave null operands after this pass. Also
-    // erase any intermediate parents of the forward slice.
-    SetVector<Operation *> forwardSlice = operationInfo[operation].forwardSlice;
-    opsToErase.insert(operation);
-    for (auto *forwardOp : forwardSlice)
-      opsToErase.insert(forwardOp);
-
-    SetVector<Operation *> forwardSliceParents;
-    blockSlice(forwardSlice, forwardSliceParents);
-    for (auto *forwardOpParent : forwardSliceParents)
-      opsToErase.insert(forwardOpParent);
-  }
-
-  // Remove any inputs marked for removal.
-  for (auto v : inputsToRemove)
-    inputs.remove(v);
-
-  // Add any inputs marked for addition.
-  for (auto v : inputsToAdd)
-    inputs.insert(v);
+// Return a backward slice started from opertaions for which `rootFn` returns
+// true.
+static SetVector<Operation *>
+getBackwardSlice(hw::HWModuleOp module,
+                 llvm::function_ref<bool(Operation *)> rootFn,
+                 llvm::function_ref<bool(Operation *)> filterFn) {
+  SetVector<Operation *> roots;
+  module.walk([&](Operation *op) {
+    if (!isa<hw::HWModuleOp>(op) && rootFn(op))
+      roots.insert(op);
+  });
+  return getBackwardSlice(roots, filterFn);
 }
 
 static StringAttr getNameForPort(Value val, ArrayAttr modulePorts) {
@@ -589,6 +429,92 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
   }
 }
 
+static bool isAssertOp(hw::HWSymbolCache &symCache, Operation *op) {
+  // Symbols not in the cache will only be fore instances added by an extract
+  // phase and are not instances that could possibly have extract flags on them.
+  if (auto inst = dyn_cast<hw::InstanceOp>(op))
+    if (auto *mod = symCache.getDefinition(inst.getModuleNameAttr()))
+      if (mod->getAttr("firrtl.extract.assert.extra"))
+        return true;
+
+  // If the format of assert is "ifElseFatal", PrintOp is lowered into
+  // ErrorOp. So we have to check message contents whether they encode
+  // verifications. See FIRParserAsserts for more details.
+  if (auto error = dyn_cast<ErrorOp>(op)) {
+    if (auto message = error.getMessage())
+      return message->startswith("assert:") ||
+             message->startswith("assert failed (verification library)") ||
+             message->startswith("Assertion failed") ||
+             message->startswith("assertNotX:") ||
+             message->contains("[verif-library-assert]");
+    return false;
+  }
+
+  return isa<AssertOp, FinishOp, FWriteOp, AssertConcurrentOp, FatalOp>(op);
+}
+
+static bool isCoverOp(hw::HWSymbolCache &symCache, Operation *op) {
+  // Symbols not in the cache will only be fore instances added by an extract
+  // phase and are not instances that could possibly have extract flags on them.
+  if (auto inst = dyn_cast<hw::InstanceOp>(op))
+    if (auto *mod = symCache.getDefinition(inst.getModuleNameAttr()))
+      if (mod->getAttr("firrtl.extract.cover.extra"))
+        return true;
+  return isa<CoverOp, CoverConcurrentOp>(op);
+}
+
+static bool isAssumeOp(hw::HWSymbolCache &symCache, Operation *op) {
+  // Symbols not in the cache will only be fore instances added by an extract
+  // phase and are not instances that could possibly have extract flags on them.
+  if (auto inst = dyn_cast<hw::InstanceOp>(op))
+    if (auto *mod = symCache.getDefinition(inst.getModuleNameAttr()))
+      if (mod->getAttr("firrtl.extract.assume.extra"))
+        return true;
+
+  return isa<AssumeOp, AssumeConcurrentOp>(op);
+}
+
+/// Return true if the operation belongs to the design.
+bool isInDesign(hw::HWSymbolCache &symCache, Operation *op,
+                bool disableInstanceExtraction = false,
+                bool disableRegisterExtraction = false) {
+
+  // Module outputs are marked as designs.
+  if (isa<hw::OutputOp>(op))
+    return true;
+
+  // If an op has an innner sym, don't extract.
+  if (auto innerSym = op->getAttrOfType<StringAttr>("inner_sym"))
+    if (!innerSym.getValue().empty())
+      return true;
+
+  // Check whether the operation is a verification construct. Instance op could
+  // be used as verification construct so make sure to check this property
+  // first.
+  if (isAssertOp(symCache, op) || isCoverOp(symCache, op) ||
+      isAssumeOp(symCache, op))
+    return false;
+
+  // For instances and regiseters, check by passed arguments.
+  if (isa<hw::InstanceOp>(op))
+    return disableInstanceExtraction;
+  if (isa<seq::FirRegOp>(op))
+    return disableRegisterExtraction;
+
+  // Since we are not tracking dataflow through SV assignments, and we don't
+  // extract SV declarations (e.g. wire, reg or logic), so just read is part of
+  // the design.
+  if (isa<sv::ReadInOutOp>(op))
+    return true;
+
+  // If the op has regions, we visit sub-regions later.
+  if (op->getNumRegions() > 0)
+    return false;
+
+  // Otherwise, operations with memory effects as a part design.
+  return !mlir::isMemoryEffectFree(op);
+}
+
 //===----------------------------------------------------------------------===//
 // StubExternalModules Pass
 //===----------------------------------------------------------------------===//
@@ -608,10 +534,10 @@ struct SVExtractTestCodeImplPass
 
 private:
   // Run the extraction on a module, and return true if test code was extracted.
-  bool doModule(hw::HWModuleOp module, std::function<bool(Operation *)> fn,
+  bool doModule(hw::HWModuleOp module, llvm::function_ref<bool(Operation *)> fn,
                 StringRef suffix, Attribute path, Attribute bindFile,
-                BindTable &bindTable,
-                SmallPtrSetImpl<Operation *> &opsToErase) {
+                BindTable &bindTable, SmallPtrSetImpl<Operation *> &opsToErase,
+                SetVector<Operation *> &opsInDesign) {
     bool hasError = false;
     // Find Operations of interest.
     SetVector<Operation *> roots;
@@ -633,29 +559,23 @@ private:
       return false;
 
     // Find the data-flow and structural ops to clone.  Result includes roots.
-    auto opsToClone = computeCloneSet(roots);
+    // Track dataflow until it reaches to design parts.
+    auto opsToClone = getBackwardSlice(
+        roots, [&](Operation *op) { return !opsInDesign.count(op); });
 
     // Find the dataflow into the clone set
     SetVector<Value> inputs;
-    for (auto op : opsToClone)
+    for (auto *op : opsToClone) {
       for (auto arg : op->getOperands()) {
         auto argOp = arg.getDefiningOp(); // may be null
         if (!opsToClone.count(argOp))
           inputs.insert(arg);
       }
-
-    // Find instances that directly feed the clone set, and add them if
-    // possible.
-    if (!disableInstanceExtraction)
-      addOperationsToCloneSet<hw::InstanceOp>(inputs, opsToClone, opsToErase);
-
-    // Find registers that directly feed the clone set, and add them if
-    // possible.
-    if (!disableRegisterExtraction)
-      addOperationsToCloneSet<seq::FirRegOp>(inputs, opsToClone, opsToErase);
+      // Erase cloned operations.
+      opsToErase.insert(op);
+    }
 
     numOpsExtracted += opsToClone.size();
-    numOpsErased += opsToErase.size();
 
     // Make a module to contain the clone set, with arguments being the cut
     IRMapping cutMap;
@@ -705,43 +625,16 @@ void SVExtractTestCodeImplPass::runOnOperation() {
   symCache.addDefinitions(top);
   symCache.freeze();
 
-  // Symbols not in the cache will only be fore instances added by an extract
-  // phase and are not instances that could possibly have extract flags on them.
   auto isAssert = [&symCache](Operation *op) -> bool {
-    if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
-        if (mod->getAttr("firrtl.extract.assert.extra"))
-          return true;
-
-    // If the format of assert is "ifElseFatal", PrintOp is lowered into
-    // ErrorOp. So we have to check message contents whether they encode
-    // verifications. See FIRParserAsserts for more details.
-    if (auto error = dyn_cast<ErrorOp>(op)) {
-      if (auto message = error.getMessage())
-        return message->startswith("assert:") ||
-               message->startswith("assert failed (verification library)") ||
-               message->startswith("Assertion failed") ||
-               message->startswith("assertNotX:") ||
-               message->contains("[verif-library-assert]");
-      return false;
-    }
-
-    return isa<AssertOp>(op) || isa<FinishOp>(op) || isa<FWriteOp>(op) ||
-           isa<AssertConcurrentOp>(op) || isa<FatalOp>(op);
+    return isAssertOp(symCache, op);
   };
+
   auto isAssume = [&symCache](Operation *op) -> bool {
-    if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
-        if (mod->getAttr("firrtl.extract.assume.extra"))
-          return true;
-    return isa<AssumeOp>(op) || isa<AssumeConcurrentOp>(op);
+    return isAssumeOp(symCache, op);
   };
+
   auto isCover = [&symCache](Operation *op) -> bool {
-    if (auto inst = dyn_cast<hw::InstanceOp>(op))
-      if (auto mod = symCache.getDefinition(inst.getModuleNameAttr()))
-        if (mod->getAttr("firrtl.extract.cover.extra"))
-          return true;
-    return isa<CoverOp>(op) || isa<CoverConcurrentOp>(op);
+    return isCoverOp(symCache, op);
   };
 
   // Collect modules that are already bound and add the bound instance(s) to the
@@ -766,24 +659,64 @@ void SVExtractTestCodeImplPass::runOnOperation() {
         continue;
       }
 
+      // Get a set for operations in the design. We can extract operations that
+      // don't belong to the design.
+      auto opsInDesign = getBackwardSlice(
+          rtlmod,
+          /*rootFn=*/
+          [&](Operation *op) {
+            return isInDesign(symCache, op, disableInstanceExtraction,
+                              disableRegisterExtraction);
+          },
+          /*filterFn=*/{});
+
       SmallPtrSet<Operation *, 32> opsToErase;
       bool anyThingExtracted = false;
-      anyThingExtracted |= doModule(rtlmod, isAssert, "_assert", assertDir,
-                                    assertBindFile, bindTable, opsToErase);
-      anyThingExtracted |= doModule(rtlmod, isAssume, "_assume", assumeDir,
-                                    assumeBindFile, bindTable, opsToErase);
-      anyThingExtracted |= doModule(rtlmod, isCover, "_cover", coverDir,
-                                    coverBindFile, bindTable, opsToErase);
+      anyThingExtracted |=
+          doModule(rtlmod, isAssert, "_assert", assertDir, assertBindFile,
+                   bindTable, opsToErase, opsInDesign);
+      anyThingExtracted |=
+          doModule(rtlmod, isAssume, "_assume", assumeDir, assumeBindFile,
+                   bindTable, opsToErase, opsInDesign);
+      anyThingExtracted |=
+          doModule(rtlmod, isCover, "_cover", coverDir, coverBindFile,
+                   bindTable, opsToErase, opsInDesign);
+
+      // If nothing is extracted, we are done.
+      if (!anyThingExtracted)
+        continue;
 
       // Inline any modules that only have inputs for test code.
       if (!disableModuleInlining && anyThingExtracted)
         inlineInputOnly(rtlmod, *instanceGraph, bindTable, opsToErase);
 
-      // Erase any instances that were extracted, and their forward dataflow.
-      // Also erase old instances that were inlined and can now be cleaned up.
-      // Parts of the forward dataflow may have been nested under other ops to
-      // erase, so as we visit ops to erase, we remove them and all their
-      // children from the set of ops to erase until nothing is left.
+      // Here, erase extracted operations as well as dead operations.
+      // `opsToErase` includes extracted operations but doesn't contain all
+      // dead operations. Even though it's not ideal to perform non-trivial DCE
+      // here but we have to delete dead operations that might be an user of an
+      // extracted operation.
+      auto opsAlive = getBackwardSlice(
+          rtlmod,
+          /*rootFn=*/
+          [&](Operation *op) {
+            // Don't remove instances not to eliminate extracted instances
+            // introduced above. However we do want to erase old instances in
+            // the original module extracted into verification parts so identify
+            // such instances by querying to `opsToErase`.
+            return isInDesign(symCache, op,
+                              /*disableInstanceExtraction=*/true,
+                              disableRegisterExtraction) &&
+                   !opsToErase.contains(op);
+          },
+          /*filterFn=*/{});
+
+      // Walk the module and add dead operations to `opsToErase`.
+      op.walk([&](Operation *operation) {
+        if (&op != operation && !opsAlive.count(operation))
+          opsToErase.insert(operation);
+      });
+
+      numOpsErased += opsToErase.size();
       while (!opsToErase.empty()) {
         Operation *op = *opsToErase.begin();
         op->walk([&](Operation *erasedOp) { opsToErase.erase(erasedOp); });

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -212,6 +212,11 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
 
 LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
                                       const FirtoolOptions &opt) {
+  if (opt.extractTestCode)
+    pm.addPass(sv::createSVExtractTestCodePass(opt.etcDisableInstanceExtraction,
+                                               opt.etcDisableRegisterExtraction,
+                                               opt.etcDisableModuleInlining));
+
   pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass(
       {/*disableRandomization=*/!opt.isRandomEnabled(
            FirtoolOptions::RandomKind::Reg),
@@ -222,10 +227,6 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
       !opt.isRandomEnabled(FirtoolOptions::RandomKind::Mem),
       !opt.isRandomEnabled(FirtoolOptions::RandomKind::Reg),
       opt.addVivadoRAMAddressConflictSynthesisBugWorkaround));
-
-  if (opt.extractTestCode)
-    pm.addPass(sv::createSVExtractTestCodePass(opt.etcDisableInstanceExtraction,
-                                               opt.etcDisableModuleInlining));
 
   // If enabled, run the optimizer.
   if (!opt.disableOptimization) {

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -406,3 +406,30 @@ module {
     hw.output %0 : i1
   }
 }
+
+// -----
+// Check instance extraction
+
+module {
+  // CHECK-LABEL: @RegExtracted_cover
+  // CHECK: %testCode1 = seq.firreg
+  // CHECK: %testCode2 = seq.firreg
+  // CHECK-NOT: seq.firreg
+
+  // CHECK-LABEL: @RegExtracted
+  // CHECK: %designAndTestCode = seq.firreg
+  // CHECK-NOT: seq.firreg
+  hw.module @RegExtracted(%clock: i1, %in: i1) -> (out: i1) {
+    %testCode1 = seq.firreg %in clock %clock : i1
+    %testCode2 = seq.firreg %testCode1 clock %clock : i1
+    %designAndTestCode = seq.firreg %in clock %clock : i1
+
+    sv.always posedge %clock {
+      sv.cover %testCode1, immediate
+      sv.cover %testCode2, immediate
+      sv.cover %designAndTestCode, immediate
+    }
+
+    hw.output %designAndTestCode : i1
+  }
+}


### PR DESCRIPTION
This commit extends ETC to extract registers on top of https://github.com/llvm/circt/pull/5294. As firreg registers introduce cycles in dataflow by nature, this commit changes extraction mechanism so that we can find and extract maximum subset of testcode. Previously we were tracking dataflow until it reaches least fixedpoint of verification parts, but instead we can first compute least fixepoint of design parts and substract it from entire modules.