### PR TITLE
[OM] Use standard API for getting the base pointer from a vector.

### DIFF
--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -63,7 +63,7 @@ struct Evaluator {
                      std::vector<MlirAttribute> actualParams) {
     // Instantiate the Object via the CAPI.
     OMObject result = omEvaluatorInstantiate(
-        evaluator, className, actualParams.size(), actualParams.begin().base());
+        evaluator, className, actualParams.size(), actualParams.data());
 
     // If the Object is null, something failed. Diagnostic handling is
     // implemented in pure Python, so nothing to do here besides throwing an


### PR DESCRIPTION
This switches to use the `data()` API, which is how the upstream Python bindings do it. Using `begin().base()` is
implementation-specific and doesn't work on Windows.

This should fix https://github.com/llvm/circt/issues/5336.