### PR TITLE
[HW] Fix type casts for nested type alias

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -84,7 +84,7 @@ bool type_isa(Type type) {
 
   // Then check if it is a type alias wrapping the requested type.
   if (auto alias = type.dyn_cast<TypeAliasType>())
-    return alias.getInnerType().isa<BaseTy...>();
+    return type_isa<BaseTy...>(alias.getInnerType());
 
   return false;
 }
@@ -106,7 +106,7 @@ BaseTy type_cast(Type type) {
     return type.cast<BaseTy>();
 
   // Otherwise, it must be a type alias wrapping the requested type.
-  return type.cast<TypeAliasType>().getInnerType().cast<BaseTy>();
+  return type_cast<BaseTy>(type.cast<TypeAliasType>().getInnerType());
 }
 
 template <typename BaseTy>

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -7,6 +7,8 @@ hw.type_scope @__hw_typedecls {
   hw.typedecl @foo : i1
   // CHECK: typedef struct packed {logic a; logic b; } bar;
   hw.typedecl @bar : !hw.struct<a: i1, b: i1>
+  hw.typedecl @nest1 : !hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>
+  hw.typedecl @nest2 : !hw.typealias<@__hw_typedecls::@nest1, !hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
 
   // CHECK: typedef struct packed {logic a; logic [7:0] b[0:15]; } barArray;
   hw.typedecl @barArray : !hw.struct<a: i1, b: !hw.uarray<16xi8>>
@@ -80,6 +82,10 @@ hw.module @testAggregateCreate(%i: i1) -> (out1: i1, out2: i1) {
   // CHECK: [[NAME]].b
   %2 = hw.struct_extract %0["b"] : !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>
   hw.output %1, %2 : i1, i1
+}
+
+hw.module @testNestedAlias(%i: !hw.typealias<@__hw_typedecls::@nest2, !hw.typealias<@__hw_typedecls::@nest1, !hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>) -> () {
+  %0 = hw.struct_extract %i["a"] : !hw.typealias<@__hw_typedecls::@nest2, !hw.typealias<@__hw_typedecls::@nest1, !hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>
 }
 
 // CHECK-LABEL: module testAggregateInout


### PR DESCRIPTION
This fixes a small bug that alias-aware type casts are not recursively applied.