### PR TITLE
[Pipeline] Add `pipeline.latency` operation

### DIFF
--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -215,4 +215,59 @@ def ReturnOp : Op<Pipeline_Dialect, "return", [
   let assemblyFormat = [{ ($inputs^)? attr-dict (`:` type($inputs)^)? }];
 }
 
+def LatencyOp : Op<Pipeline_Dialect, "latency", [
+    SingleBlockImplicitTerminator<"LatencyReturnOp">,
+    RegionKindInterface,
+    HasOnlyGraphRegion,
+  ]> {
+  
+  let summary = "Pipeline dialect latency operation.";
+  let description = [{
+    The `pipeline.latency` operation represents an operation for wrapping
+    multi-cycle operations. The operation declares a single block
+    wherein any operation may be placed within. The operation is not
+    `IsolatedFromAbove` meaning that the operation can reference values
+    defined outside of the operation (subject to the materialization
+    phase of the parent pipeline).
+  }];
+
+  let arguments = (ins ConfinedAttr<I32Attr, [IntMinValue<1>]>:$latency);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region AnyRegion:$body);
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "unsigned":$latency)>
+  ];
+  let skipDefaultBuilders = 1;
+
+  let assemblyFormat = [{
+    attr-dict $latency `->` `(` type($results) `)` $body
+  }];
+
+  let extraClassDeclaration = [{
+    // Returns the body block of the latency operation.
+    Block* getBodyBlock() {
+      return &getBody().front();
+    }
+  }];
+}
+
+def LatencyReturnOp : Op<Pipeline_Dialect, "latency.return", [
+    Terminator,
+    HasParent<"LatencyOp">
+  ]> {
+  let summary = "Pipeline latency return operation.";
+  let description = [{
+    The `latency.return` operation represents a terminator of a `pipeline.latency`
+    operation.
+  }];
+
+  let hasVerifier = 1;
+  let arguments = (ins Variadic<AnyType>:$inputs);
+  let builders = [OpBuilder<(ins), [{ return; }]>];
+  let assemblyFormat = [{ ($inputs^)? attr-dict (`:` type($inputs)^)? }];
+}
+
+
 #endif // PIPELINE_OPS

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -264,8 +264,8 @@ def LatencyReturnOp : Op<Pipeline_Dialect, "latency.return", [
   ]> {
   let summary = "Pipeline latency return operation.";
   let description = [{
-    The `latency.return` operation represents a terminator of a `pipeline.latency`
-    operation.
+    The `pipeline.latency.return` operation represents a terminator of a
+    `pipeline.latency` operation.
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -138,6 +138,10 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     // Stages are ordered from first (entry) to last (exit).
     llvm::SmallVector<Block*> getOrderedStages();
 
+    // Returns a map of stages to their index in the pipeline - this is
+    // with respect to 'getOrderedStages'.
+    llvm::DenseMap<Block*, unsigned> getStageMap();
+
     // Gets the n'th stage of this pipeline
     Block* getStage(unsigned n) {
       auto& blocks = getRegion().getBlocks();
@@ -219,6 +223,7 @@ def LatencyOp : Op<Pipeline_Dialect, "latency", [
     SingleBlockImplicitTerminator<"LatencyReturnOp">,
     RegionKindInterface,
     HasOnlyGraphRegion,
+    ParentOneOf<["UnscheduledPipelineOp", "ScheduledPipelineOp"]>
   ]> {
   
   let summary = "Pipeline dialect latency operation.";
@@ -233,7 +238,7 @@ def LatencyOp : Op<Pipeline_Dialect, "latency", [
 
   let arguments = (ins ConfinedAttr<I32Attr, [IntMinValue<1>]>:$latency);
   let results = (outs Variadic<AnyType>:$results);
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
   let hasVerifier = 1;
 
   let builders = [

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -227,6 +227,81 @@ LogicalResult StageOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// LatencyOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LatencyOp::verify() {
+  // Verify that the resulting values aren't referenced before they are
+  // accessible.
+  size_t latency = getLatency();
+  Block *definingStage = getOperation()->getBlock();
+
+  llvm::SmallVector<Block *> orderedStages =
+      getOperation()->getParentOfType<ScheduledPipelineOp>().getOrderedStages();
+  auto stageDistance = [&](Block *from, Block *to) {
+    size_t fromIdx = std::distance(
+        orderedStages.begin(),
+        std::find(orderedStages.begin(), orderedStages.end(), from));
+    size_t toIdx = std::distance(
+        orderedStages.begin(),
+        std::find(orderedStages.begin(), orderedStages.end(), to));
+    return toIdx - fromIdx;
+  };
+
+  for (auto [i, res] : llvm::enumerate(getResults())) {
+    for (auto &use : res.getUses()) {
+      auto *user = use.getOwner();
+      Block *userStage = user->getBlock();
+      unsigned useDistance = stageDistance(definingStage, userStage);
+
+      // Is this a stage op and is the value passed through? if so, this is a
+      // legal use.
+      StageOp stageOp = dyn_cast<StageOp>(user);
+      if (userStage == definingStage && stageOp) {
+        if (llvm::is_contained(stageOp.getPassthroughs(), res))
+          continue;
+      }
+
+      // The use is not a passthrough. Check that the distance between
+      // the defining stage and the user stage is at least the latency of the
+      // result.
+      if (useDistance < latency) {
+        auto diag = emitOpError("result ")
+                    << i << " is used before it is available.";
+        diag.attachNote(user->getLoc())
+            << "use was operand " << use.getOperandNumber()
+            << ". The result is available " << latency - useDistance
+            << " stages later than this use.";
+        return diag;
+      }
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LatencyReturnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LatencyReturnOp::verify() {
+  LatencyOp parent = cast<LatencyOp>(getOperation()->getParentOp());
+  size_t nInputs = getInputs().size();
+  size_t nResults = parent->getNumResults();
+  if (nInputs != nResults)
+    return emitOpError("expected ")
+           << nResults << " return values, got " << nInputs << ".";
+
+  for (auto [inType, reqType] :
+       llvm::zip(getInputs().getTypes(), parent->getResultTypes())) {
+    if (inType != reqType)
+      return emitOpError("expected return value of type ")
+             << reqType << ", got " << inType << ".";
+  }
+
+  return success();
+}
+
 #include "circt/Dialect/Pipeline/PipelineInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -67,7 +67,7 @@ size_t ExplicitRegsPass::stageDistance(Block *from, Block *to) {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 Value ExplicitRegsPass::routeThroughStage(Value v, Block *stage) {
-  Value retVal = v.get();
+  Value retVal = v;
   Block *definingStage = retVal.getParentBlock();
 
   // Is the value defined in the current stage?

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -12,6 +12,35 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
   hw.output %0 : i1
 }
 
+// CHECK-LABEL:   hw.module @testLatency1(
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
+// CHECK:           %[[VAL_6:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
+// CHECK:           hw.output %[[VAL_8]] : i32
+// CHECK:         }
+hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
+  ^bb0(%arg0_0: i32):
+    %true = hw.constant true
+    %1 = pipeline.latency 2 -> (i32) {
+      %6 = comb.add %arg0_0, %arg0_0 : i32
+      pipeline.latency.return %6 : i32
+    }
+    pipeline.stage ^bb1 pass(%1 : i32) enable %true
+  ^bb1(%2: i32):  // pred: ^bb0
+    pipeline.stage ^bb2 pass(%2 : i32) enable %true
+  ^bb2(%3: i32):  // pred: ^bb1
+    pipeline.stage ^bb3 regs(%3 : i32) enable %true
+  ^bb3(%4: i32):  // pred: ^bb2
+    pipeline.stage ^bb4 regs(%4 : i32) enable %true
+  ^bb4(%5: i32):  // pred: ^bb3
+    pipeline.return %5 : i32
+  }
+  hw.output %0 : i32
+}
+
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs)))' %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @test3(
+// CHECK-LABEL:   hw.module @testRegsOnly(
 // CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]]:2 = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32, i32, i1) -> (i32, i1) {
 // CHECK:           ^bb0(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
@@ -15,9 +15,9 @@
 // CHECK:             pipeline.return %[[VAL_17]], %[[VAL_9]] : i32, i1
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_18:.*]]#0, %[[VAL_18]]#1 : i32, i1
-// CHECK:         }
+// CHECK:     }        
 
-hw.module @test3(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i1) {
+hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i1) {
   %out:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
     ^bb0(%a0 : i32, %a1: i32, %g : i1):
       %true = hw.constant true
@@ -35,3 +35,97 @@ hw.module @test3(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (o
   hw.output %out#0, %out#1 : i32, i1
 }
 
+
+// CHECK-LABEL:   hw.module @testLatency1(
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = hw.constant true
+// CHECK:             %[[VAL_8:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK:             }
+// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_10:.*]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb1(%[[VAL_11:.*]]: i32):
+// CHECK:             pipeline.stage ^bb2 pass(%[[VAL_11]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
+// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_12]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb3(%[[VAL_13:.*]]: i32):
+// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_13]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb4(%[[VAL_14:.*]]: i32):
+// CHECK:             pipeline.return %[[VAL_14]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_15:.*]] : i32
+// CHECK:         }
+hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
+  ^bb0(%a0 : i32):
+    %true = hw.constant true
+    %out = pipeline.latency 2 -> (i32) {
+      %r = comb.add %a0, %a0 : i32
+      pipeline.latency.return %r : i32
+    }
+    pipeline.stage ^bb1 enable %true
+  ^bb1:
+    pipeline.stage ^bb2 enable %true
+  ^bb2:
+    pipeline.stage ^bb3 enable %true
+  ^bb3:
+    pipeline.stage ^bb4 enable %true
+  ^bb4:
+    pipeline.return %out : i32
+  }
+  hw.output %out : i32
+}
+
+// CHECK-LABEL:   hw.module @testLatency2(
+// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = hw.constant true
+// CHECK:             %[[VAL_8:.*]] = pipeline.latency 1 -> (i32) {
+// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK:             }
+// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_10:.*]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb1(%[[VAL_11:.*]]: i32):
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_11]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
+// CHECK:             %[[VAL_13:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_14:.*]] = comb.sub %[[VAL_6]], %[[VAL_6]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_14]] : i32
+// CHECK:             }
+// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_12]] : i32) pass(%[[VAL_15:.*]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb3(%[[VAL_16:.*]]: i32, %[[VAL_17:.*]]: i32):
+// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_16]] : i32) pass(%[[VAL_17]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb4(%[[VAL_18:.*]]: i32, %[[VAL_19:.*]]: i32):
+// CHECK:             %[[VAL_20:.*]] = comb.add %[[VAL_18]], %[[VAL_19]] : i32
+// CHECK:             pipeline.return %[[VAL_18]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_21:.*]] : i32
+// CHECK:         }
+hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
+  ^bb0(%a0 : i32):
+    %true = hw.constant true
+    %out = pipeline.latency 1 -> (i32) {
+      %r = comb.add %a0, %a0 : i32
+      pipeline.latency.return %r : i32
+    }
+    pipeline.stage ^bb1 enable %true
+  ^bb1:
+    pipeline.stage ^bb2 enable %true
+  ^bb2:
+    %out2 = pipeline.latency 2 -> (i32) {
+      %r = comb.sub %a0, %a0 : i32
+      pipeline.latency.return %r : i32
+    }
+    pipeline.stage ^bb3 enable %true
+  ^bb3:
+    pipeline.stage ^bb4 enable %true
+  ^bb4:
+    %res = comb.add %out, %out2 : i32
+    pipeline.return %out : i32
+  }
+  hw.output %out : i32
+}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -4,7 +4,10 @@
 hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
-    %0 = comb.add %a0, %a1 : i32
+    %0 = pipeline.latency 2 -> (i32) {
+      %1 = comb.add %a0, %a1 : i32
+      pipeline.latency.return %1 : i32
+    }
     %c1_i1 = hw.constant 1 : i1
     pipeline.return %0 : i32
   }


### PR DESCRIPTION
The `pipeline.latency` operation represents an operation for wrapping multi-cycle operations. The operation declares a single block wherein any operation may be placed within. The operation is not `IsolatedFromAbove` meaning that the operation can reference values defined outside of the operation (subject to the materialization phase of the parent pipeline).

This commit includes changes to the register materialization pass (differentiating between `regs` and `pass` inputs to stages) and pipeline HW lowering. Currently, `pipeline.latency` operations are just inlined into the current insertion point.

an example pipeline:
```mlir
^bb1:
...
%out = pipeline.latency 2 -> (i32) {
  %dl1 = seq.compreg %in : i32
  %dl2 = seq.compreg %dl1 : i32
  pipeline.latency.return %dl2 : i32
}
pipeline.stage ^bb2
^bb2:
// It is illegal to reference %out here
pipeline.stage ^bb3
^bb3:
// It is legal to reference %out here
pipeline.stage ^bb4
^bb4:
// It is legal to reference %out here. This will also imply a register
// between stage bb3 and bb4.
foo.bar %out : i32
```

which will register materialize to:
```mlir
^bb1:
...
%out = pipeline.latency 2 -> (i32) {
  %dl1 = seq.compreg %in : i32
  %dl2 = seq.compreg %dl1 : i32
  pipeline.latency.return %dl2 : i32
}
pipeline.stage ^bb2 pass(%out : i32)
^bb2(%out_s2 : i32):
pipeline.stage ^bb3 pass(%out_s2 : i32)
^bb3(%out_s3 : i32):
pipeline.stage ^bb4 regs(%out_s3 : i32)
^bb4(%out_s4 : i32):
foo.bar %out_s4 : i32
```