### PR TITLE
[Calyx to FSM]Fix the bug when calyx multi-component design lower to fsm.

### DIFF
--- a/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
@@ -286,9 +286,10 @@ void CalyxToFSMPass::runOnOperation() {
   // refer to the symbols and SSA values defined in the regions of the
   // ComponentOp. This makes for an intermediate step, which allows for
   // outlining the FSM (materializing FSM I/O) at a later point.
+  auto machineName = ("control_" + component.getName()).str();
   auto funcType = FunctionType::get(&getContext(), {}, {});
   auto machine =
-      builder.create<MachineOp>(ctrlOp.getLoc(), /*name=*/"control",
+      builder.create<MachineOp>(ctrlOp.getLoc(), machineName,
                                 /*initialState=*/"fsm_entry", funcType);
   auto graph = FSMGraph(machine);
 

--- a/test/Conversion/CalyxToFSM/lower-if.mlir
+++ b/test/Conversion/CalyxToFSM/lower-if.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
-// CHECK:      fsm.machine @control()
+// CHECK:      fsm.machine @control_main()
 // CHECK-NEXT:   fsm.state @fsm_entry output {
 // CHECK-NEXT:     fsm.output
 // CHECK-NEXT:   } transitions {

--- a/test/Conversion/CalyxToFSM/lower-seq.mlir
+++ b/test/Conversion/CalyxToFSM/lower-seq.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
-// CHECK:      fsm.machine @control()
+// CHECK:      fsm.machine @control_main()
 // CHECK-NEXT:   fsm.state @fsm_entry output {
 // CHECK-NEXT:     fsm.output
 // CHECK-NEXT:   } transitions {

--- a/test/Conversion/CalyxToFSM/lower-while.mlir
+++ b/test/Conversion/CalyxToFSM/lower-while.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt --split-input-file -pass-pipeline='builtin.module(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
 
-// CHECK:      fsm.machine @control()
+// CHECK:      fsm.machine @control_main()
 // CHECK-NEXT:   fsm.state @fsm_entry output {
 // CHECK-NEXT:     fsm.output
 // CHECK-NEXT:   } transitions {


### PR DESCRIPTION
I found this problem while learning circt during this time, and I have solved it.You can see it [here](https://github.com/llvm/circt/issues/5296).The names of the state machines generated in the calyx-to-fsm pass are all called control. This leads to a problem when designing with multiple components, where components may instantiate the state machines of other components.

