### PR TITLE
Update FIRRTLAnnotations.md to remove reference to tb_seq_mems.json [NFC]

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -801,7 +801,7 @@ Example:
 | target     | string | Reference target                             								|
 
 This annotation attaches metadata to the firrtl.mem operation. The `data` is
-emitted onto the `seq_mems.json` and `tb_seq_mems.json` file. It is required
+emitted onto the `seq_mems.json` file. It is required
 for verification only and used by memory generator tools for simulation.
 
 Example:

--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -801,8 +801,8 @@ Example:
 | target     | string | Reference target                             								|
 
 This annotation attaches metadata to the firrtl.mem operation. The `data` is
-emitted onto the `seq_mems.json` file. It is required
-for verification only and used by memory generator tools for simulation.
+emitted onto the `seq_mems.json` file. It is required for verification only and
+used by memory generator tools for simulation.
 
 Example:
 ```json


### PR DESCRIPTION
As of 5e6d68af872235203bd93e469746f91df8391020  we no longer emit the tb_seq_mems.json file. Remove mention of it from the docs.