### PR TITLE
[Python] Add CMake for MacOS C++17 compatibility in wheel build.

### DIFF
--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -67,7 +67,7 @@ class CMakeBuild(build_py):
     cmake_args = [
         "-DCMAKE_BUILD_TYPE=Release",  # not used on MSVC, but no harm
         "-DCMAKE_INSTALL_PREFIX={}".format(os.path.abspath(cmake_install_dir)),
-        "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14", # on OSX, min target for C++17
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14",  # on OSX, min target for C++17
         "-DPython3_EXECUTABLE={}".format(sys.executable.replace("\\", "/")),
         "-DLLVM_ENABLE_PROJECTS=mlir",
         "-DLLVM_EXTERNAL_PROJECTS=circt",

--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -67,6 +67,7 @@ class CMakeBuild(build_py):
     cmake_args = [
         "-DCMAKE_BUILD_TYPE=Release",  # not used on MSVC, but no harm
         "-DCMAKE_INSTALL_PREFIX={}".format(os.path.abspath(cmake_install_dir)),
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14", # on OSX, min target for C++17
         "-DPython3_EXECUTABLE={}".format(sys.executable.replace("\\", "/")),
         "-DLLVM_ENABLE_PROJECTS=mlir",
         "-DLLVM_EXTERNAL_PROJECTS=circt",


### PR DESCRIPTION
We are using C++17, and a recent addition to the Python bindings for the OM dialect relies on a C++17 feature. For this to compile with pybind11, we need to ensure we set the -mmacosx-version-min flag to at least version 10.14, which is where support for these C++17 features became available. By default, CMake was detecting an older version, so explicitly set this when building the wheel.