### PR TITLE
[FIRRTL] Add StringConstantOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -990,6 +990,26 @@ def BitCastOp: FIRRTLOp<"bitcast", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Properties
+//===----------------------------------------------------------------------===//
+
+def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
+  let summary = "Produce a constant string value";
+  let description = [{
+    Produces a constant value of string type.
+
+    Example:
+    ```mlir
+    %0 = firrtl.string "hello world"
+    ```
+  }];
+  let arguments = (ins StrAttr:$value);
+  let results = (outs StringType:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$value attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // RefOperations: Operations on the RefType.
 //
 // The RefType is used to capture dataflow paths.

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -81,6 +81,12 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
       return builder.create<AggregateConstantOp>(loc, type, arrayAttr);
   }
 
+  // String constants.
+  if (auto stringAttr = value.dyn_cast<StringAttr>()) {
+    if (type.isa<StringType>())
+      return builder.create<StringConstantOp>(loc, type, stringAttr);
+  }
+
   return nullptr;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -401,6 +401,11 @@ OpFoldResult AggregateConstantOp::fold(FoldAdaptor adaptor) {
   return getFieldsAttr();
 }
 
+OpFoldResult StringConstantOp::fold(FoldAdaptor adaptor) {
+  assert(adaptor.getOperands().empty() && "constant has no operands");
+  return getValueAttr();
+}
+
 //===----------------------------------------------------------------------===//
 // Binary Operators
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -247,5 +247,7 @@ firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, 
 // CHECK-SAME:  (in %in: !firrtl.string, out %out: !firrtl.string)
 firrtl.module @StringTest(in %in: !firrtl.string, out %out: !firrtl.string) {
   firrtl.connect %out, %in : !firrtl.string, !firrtl.string
+  // CHECK: %0 = firrtl.string "hello"
+  %0 = firrtl.string "hello"
 }
 }


### PR DESCRIPTION
This add an operation to create a constant of string type, as well as a fold to StringAttr and a StringType materializer.