### PR TITLE
[Pipeline] Add "ext" inputs to pipelines

### DIFF
--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -54,14 +54,15 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset, Optional<I1>:$stall
+    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>: $body);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $inputs `)` (`stall` $stall^)? `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
+    `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
+      `clock` $clock `reset` $reset attr-dict `:`functional-type($inputs, results) $body
   }];
 
   let extraClassDeclaration = [{
@@ -98,34 +99,26 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, I1:$clock, I1:$reset, Optional<I1>:$stall
+    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region AnyRegion:$body);
-  let skipDefaultBuilders = 1;
   let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
 
   let builders = [
-    OpBuilder<(ins
-      "TypeRange":$results, "ValueRange":$inputs, "Value":$clock, "Value":$reset, CArg<"Value", "{}">:$stall)>
+    OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "ValueRange":$extInputs,
+      "Value":$clock, "Value":$reset, CArg<"Value", "{}">:$stall)>
   ];
 
   let assemblyFormat = [{
-    `(` $inputs `)` (`stall` $stall^)? `clock` $clock `reset` $reset attr-dict `:` functional-type($inputs, results) $body
+    `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
+      `clock` $clock `reset` $reset attr-dict `:`functional-type($inputs, results) $body
   }];
 
   let extraClassDeclaration = [{
     static mlir::RegionKind getRegionKind(unsigned index) {
       return mlir::RegionKind::SSACFG;
-    }
-
-    // Returns the internal inputs of this pipeline.
-    FailureOr<ValueRange> getInnerInputs() {
-      auto* firstStage = getStage(0);
-      if(!firstStage)
-        return emitOpError() << "Pipeline has no stages";
-      
-      return {firstStage->getArguments()};
     }
 
     // Returns all of the stages in this pipeline.
@@ -166,6 +159,22 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     // This enables certain invariants such as "all values used within a stage
     // must be defined within a stage".
     bool isMaterialized();
+
+    // Returns the arguments for a stage.
+    ValueRange getStageArguments(Block* stage) {
+      if(stage != getEntryStage())
+        return stage->getArguments();
+
+      // The entry block defines a lot of SSA values...
+      // drop everything but the 'input's to the stage
+      return stage->getArguments().take_front(getInputs().size());
+    }
+
+    size_t getNumStageArguments(Block* stage) {
+      if(stage != getEntryStage())
+        return stage->getNumArguments();
+      return getInputs().size();
+    }
   }];
 }
 

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -165,9 +165,9 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
       if(stage != getEntryStage())
         return stage->getArguments();
 
-      // The entry block defines a lot of SSA values...
-      // drop everything but the 'input's to the stage
-      return stage->getArguments().take_front(getInputs().size());
+      // The entry stage block mirrors the input argument order of the pipeline.
+      // Grab the arguments corresponding to the inputs.
+      return stage->getArguments().slice(getInputs().getBeginOperandIndex(), getInputs().size());
     }
 
     size_t getNumStageArguments(Block* stage) {

--- a/include/circt/Dialect/Pipeline/PipelineInterfaces.td
+++ b/include/circt/Dialect/Pipeline/PipelineInterfaces.td
@@ -44,6 +44,27 @@ def PipelineLike : OpInterface<"PipelineLike"> {
     InterfaceMethod<"Returns the pipeline inputs",
       "ValueRange",
       "getInputs", (ins)>,
+    InterfaceMethod<"Returns the inner pipeline inputs",
+      "ValueRange",
+      "getInnerInputs", (ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        Block* firstStage = $_op.getEntryStage();        
+        return firstStage->getArguments().take_front($_op.getInputs().size());
+      }]
+    >,
+    InterfaceMethod<"Returns the pipeline external inputs",
+      "ValueRange",
+      "getExtInputs", (ins)>,
+    InterfaceMethod<"Returns the inner external inputs",
+      "ValueRange",
+      "getInnerExtInputs", (ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        Block* firstStage = $_op.getEntryStage();
+        return firstStage->getArguments().take_back($_op.getExtInputs().size());
+      }]
+     >,
     InterfaceMethod<"Returns the first stage in the pipeline",
       "Block*",
       "getEntryStage",

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -243,7 +243,7 @@ public:
     pipelineRst = pipelineMod.getBody().front().getArgument(
         pipelineMod.getBody().front().getNumArguments() - 1);
 
-    if (pipeline.getExtInputs().size() != 0) {
+    if (pipeline.getExtInputs().empty()) {
       // Maintain a mapping between external inputs and their corresponding
       // block argument in the top-level pipeline.
       auto modInnerExtInputs =

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -243,7 +243,7 @@ public:
     pipelineRst = pipelineMod.getBody().front().getArgument(
         pipelineMod.getBody().front().getNumArguments() - 1);
 
-    if (pipeline.getExtInputs().empty()) {
+    if (!pipeline.getExtInputs().empty()) {
       // Maintain a mapping between external inputs and their corresponding
       // block argument in the top-level pipeline.
       auto modInnerExtInputs =

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -221,7 +221,7 @@ public:
   // module signatures.
   void gatherExtInputsToStages() {
     for (auto extIn : pipeline.getInnerExtInputs()) {
-      for (auto user : extIn.getUsers())
+      for (auto *user : extIn.getUsers())
         stageExtInputs[user->getBlock()].insert(extIn);
     }
   }

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -138,14 +138,19 @@ public:
 
     // Replace uses of the pipeline internal inputs with the pipeline inputs.
     for (auto [outer, inner] :
-         llvm::zip(pipeline.getInputs(), *pipeline.getInnerInputs()))
+         llvm::zip(pipeline.getInputs(), pipeline.getInnerInputs()))
+      inner.replaceAllUsesWith(outer);
+
+    // Replace uses of the external inputs with the inner external inputs.
+    for (auto [outer, inner] :
+         llvm::zip(pipeline.getExtInputs(), pipeline.getInnerExtInputs()))
       inner.replaceAllUsesWith(outer);
 
     // All operations should go directly before the pipeline op, into the
     // parent module.
     builder.setInsertionPoint(pipeline);
-    if (failed(lowerStage(pipeline.getEntryStage(), *pipeline.getInnerInputs(),
-                          0)))
+    if (failed(
+            lowerStage(pipeline.getEntryStage(), pipeline.getInnerInputs(), 0)))
       return failure();
 
     return success();
@@ -159,7 +164,7 @@ public:
     if (stage != pipeline.getEntryStage()) {
       // Replace the internal stage inputs with the provided arguments.
       for (auto [vInput, vArg] :
-           llvm::zip(stage->getArguments(), stageArguments))
+           llvm::zip(pipeline.getStageArguments(stage), stageArguments))
         vInput.replaceAllUsesWith(vArg);
     }
 
@@ -193,6 +198,34 @@ public:
     return builder.getStringAttr("s" + std::to_string(stageIdx));
   }
 
+  // Helper class to manage grabbing the various inputs for stage modules.
+  struct PipelineStageMod {
+    PipelineStageMod(PipelineOutlineLowering &parent, Block *block,
+                     hw::HWModuleOp mod) {
+      size_t nStageInputArgs = parent.pipeline.getNumStageArguments(block);
+      inputs = mod.getArguments().take_front(nStageInputArgs);
+      extInputs = mod.getArguments().slice(
+          nStageInputArgs, parent.getStageExtInputs(block).size());
+      clock = mod.getArgument(mod.getNumArguments() - 2);
+      reset = mod.getArgument(mod.getNumArguments() - 1);
+    }
+
+    ValueRange inputs;
+    ValueRange extInputs;
+    Value clock;
+    Value reset;
+  };
+
+  // Iterate over the external inputs to the pipeline, and determine which
+  // stages actually reference them. This will be used to generate the stage
+  // module signatures.
+  void gatherExtInputsToStages() {
+    for (auto extIn : pipeline.getInnerExtInputs()) {
+      for (auto user : extIn.getUsers())
+        stageExtInputs[user->getBlock()].insert(extIn);
+    }
+  }
+
   LogicalResult run() override {
     pipelineName =
         (parentModule.getName() + "_p" + std::to_string(pipelineID)).str();
@@ -200,13 +233,23 @@ public:
     cloneConstantsToStages();
 
     // Build the top-level pipeline module.
-    pipelineMod =
-        buildPipelineLike(pipelineName, pipeline.getInputs().getTypes(),
-                          pipeline.getResults().getTypes());
+    pipelineMod = buildPipelineLike(
+        pipelineName, pipeline.getInputs().getTypes(),
+        pipeline.getExtInputs().getTypes(), pipeline.getResults().getTypes());
     pipelineClk = pipelineMod.getBody().front().getArgument(
         pipelineMod.getBody().front().getNumArguments() - 2);
     pipelineRst = pipelineMod.getBody().front().getArgument(
         pipelineMod.getBody().front().getNumArguments() - 1);
+
+    // Maintain a mapping between external inputs and their corresponding
+    // block argument in the top-level pipeline.
+    for (auto [extIn, barg] :
+         llvm::zip(pipeline.getInnerExtInputs(),
+                   pipelineMod.getBody().front().getArguments().slice(
+                       pipeline.getInputs().size(),
+                       pipeline.getExtInputs().size()))) {
+      toplevelExtInputs[extIn] = barg;
+    }
 
     // Instantiate the pipeline in the parent module.
     builder.setInsertionPoint(pipeline);
@@ -220,13 +263,18 @@ public:
     // results.
     pipeline.replaceAllUsesWith(pipelineInst.getResults());
 
+    // Determine the external inputs to each stage.
+    gatherExtInputsToStages();
+
     // From now on, insertion point must point to the pipeline module body.
     // This ensures that pipeline stage instantiations and free-standing
     // operations are inserted into the pipeline module.
     builder.setInsertionPointToStart(pipelineMod.getBodyBlock());
 
-    if (failed(lowerStage(pipeline.getEntryStage(),
-                          pipelineMod.getArguments().drop_back(2), 0)))
+    if (failed(lowerStage(
+            pipeline.getEntryStage(),
+            pipelineMod.getArguments().take_front(pipeline.getInputs().size()),
+            0)))
       return failure();
 
     pipeline.erase();
@@ -243,27 +291,45 @@ public:
 
     if (auto stageOp = dyn_cast<StageOp>(stage->getTerminator())) {
       auto [mod, inst] = buildStage(stage, stageArguments, stageIndex);
+      auto pipelineStageMod = PipelineStageMod{*this, stage, mod};
 
       // Remap the internal inputs of the stage to the module block arguments.
-      for (auto [vInput, vBarg] :
-           llvm::zip(stage->getArguments(),
-                     mod.getBody().front().getArguments().drop_back(2)))
+      for (auto [vInput, vBarg] : llvm::zip(pipeline.getStageArguments(stage),
+                                            pipelineStageMod.inputs))
         vInput.replaceAllUsesWith(vBarg);
+
+      // Remap external inputs to the stage to the external inputs in the
+      // module block arguments.
+      for (auto [vExtInput, vExtBarg] :
+           llvm::zip(getStageExtInputs(stage), pipelineStageMod.extInputs)) {
+        vExtInput.replaceUsesWithIf(vExtBarg, [&](OpOperand &operand) {
+          return operand.getOwner()->getBlock() == stage;
+        });
+      }
 
       // Move stage operations into the module.
       builder.setInsertionPointToStart(&mod.getBody().front());
-      modClock = mod.getBody().front().getArgument(
-          mod.getBody().front().getNumArguments() - 2);
-      modReset = mod.getBody().front().getArgument(
-          mod.getBody().front().getNumArguments() - 1);
+      modClock = pipelineStageMod.clock;
+      modReset = pipelineStageMod.reset;
       stageOutputOp = cast<hw::OutputOp>(mod.getBody().front().getTerminator());
       nextStage = stageOp.getNextStage();
       nextStageArgs = inst.getResults();
     } else {
       // Remap the internal inputs of the stage to the stage arguments.
       for (auto [vInput, vBarg] :
-           llvm::zip(stage->getArguments(), stageArguments))
+           llvm::zip(pipeline.getStageArguments(stage), stageArguments))
         vInput.replaceAllUsesWith(vBarg);
+
+      // Remap external inputs with the top-level pipeline module external
+      // inputs.
+      for (auto [extIn, topLevelBarg] :
+           llvm::zip(pipeline.getInnerExtInputs(),
+                     pipelineMod.getArguments().slice(
+                         pipeline.getInputs().size(),
+                         pipeline.getExtInputs().size()))) {
+        extIn.replaceAllUsesWith(topLevelBarg);
+      }
+
       stageOutputOp =
           cast<hw::OutputOp>(pipelineMod.getBodyBlock()->getTerminator());
       // Move lingering operations into the top-level pipeline module.
@@ -320,7 +386,7 @@ private:
   }
 
   hw::HWModuleOp buildPipelineLike(Twine name, TypeRange inputs,
-                                   TypeRange outputs) {
+                                   TypeRange extInputs, TypeRange outputs) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(parentModule);
     llvm::SmallVector<hw::PortInfo> ports;
@@ -329,6 +395,12 @@ private:
     for (auto [idx, in] : llvm::enumerate(inputs))
       ports.push_back(
           hw::PortInfo{builder.getStringAttr("in" + std::to_string(idx)),
+                       hw::PortDirection::INPUT, in});
+
+    // External inputs
+    for (auto [idx, in] : llvm::enumerate(extInputs))
+      ports.push_back(
+          hw::PortInfo{builder.getStringAttr("extIn" + std::to_string(idx)),
                        hw::PortDirection::INPUT, in});
 
     // clock and reset
@@ -355,19 +427,28 @@ private:
 
     llvm::SmallVector<Type> outputTypes;
     if (auto stageOp = dyn_cast<StageOp>(stage->getTerminator()))
-      llvm::append_range(outputTypes,
-                         stageOp.getNextStage()->getArgumentTypes());
+      llvm::append_range(
+          outputTypes,
+          pipeline.getStageArguments(stageOp.getNextStage()).getTypes());
     else
       llvm::append_range(outputTypes, pipeline.getResultTypes());
 
+    auto stageExtInputs = getStageExtInputs(stage);
     hw::HWModuleOp mod =
-        buildPipelineLike(name, stageArguments.getTypes(), outputTypes);
+        buildPipelineLike(name, pipeline.getStageArguments(stage).getTypes(),
+                          ValueRange(stageExtInputs).getTypes(), outputTypes);
 
     // instantiate...
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(pipelineMod.getBodyBlock()->getTerminator());
     llvm::SmallVector<Value, 4> stageOperands;
     llvm::append_range(stageOperands, stageArguments);
+
+    // Gather external inputs for this stage from the top-level pipeline
+    // module.
+    for (auto extInput : stageExtInputs)
+      stageOperands.push_back(toplevelExtInputs[extInput]);
+
     stageOperands.push_back(pipelineClk);
     stageOperands.push_back(pipelineRst);
     auto inst = builder.create<hw::InstanceOp>(pipeline.getLoc(), mod,
@@ -385,6 +466,24 @@ private:
 
   // Handle to the instantiation of the last stage in the pipeline.
   hw::InstanceOp lastStageInst;
+
+  // A mapping between stages and the external inputs which they reference.
+  // A SetVector is used to ensure determinism in the order of the external
+  // inputs to a stage.
+  llvm::DenseMap<Block *, llvm::SetVector<Value>> stageExtInputs;
+
+  // A mapping between external inputs and their corresponding top-level
+  // input in the pipeline module.
+  llvm::DenseMap<Value, Value> toplevelExtInputs;
+
+  // Wrapper around stageExtInputs which returns a llvm::SmallVector<Value>,
+  // which in turn can be used to get a ValueRange (and by extension,
+  // TypeRange).
+  llvm::SmallVector<Value> getStageExtInputs(Block *stage) {
+    llvm::SmallVector<Value> extInputs;
+    llvm::append_range(extInputs, stageExtInputs[stage]);
+    return extInputs;
+  }
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -114,12 +114,6 @@ void ScheduledPipelineOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   auto *region = odsState.addRegion();
   odsState.addTypes(results);
 
-  odsState.addAttribute(
-      "operand_segment_sizes",
-      odsBuilder.getDenseI32ArrayAttr(
-          {static_cast<int32_t>(inputs.size()), static_cast<int32_t>(1),
-           static_cast<int32_t>(1), static_cast<int32_t>(stall ? 1 : 0)}));
-
   // Add the entry stage
   auto &entryBlock = region->emplaceBlock();
   llvm::SmallVector<Location> entryArgLocs(inputs.size(), odsState.location);

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -110,6 +110,11 @@ void ExplicitRegsPass::runOnOperation() {
   OpBuilder b(getOperation().getContext());
   bb = std::make_shared<BackedgeBuilder>(b, getOperation().getLoc());
 
+  // Cache external inputs in a set for fast lookup.
+  llvm::DenseSet<Value> extInputs;
+  for (auto extInput : pipeline.getInnerExtInputs())
+    extInputs.insert(extInput);
+
   // Iterate over the pipeline body in-order (!).
   stageMap = pipeline.getStageMap();
   for (Block *stage : pipeline.getOrderedStages()) {
@@ -119,6 +124,10 @@ void ExplicitRegsPass::runOnOperation() {
       // Check the operands of this operation to see if any of them cross a
       // stage boundary.
       for (OpOperand &operand : op->getOpOperands()) {
+        if (extInputs.contains(operand.get())) {
+          // Never route external inputs through a stage.
+          continue;
+        }
         if (getParentStageInPipeline(pipeline, operand.get()) == stage) {
           // The operand is defined by some operation or block which ultimately
           // resides within the current pipeline stage. No routing needed.

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -138,7 +138,8 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
   b.setInsertionPoint(pipeline);
   auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
       pipeline.getLoc(), pipeline->getResultTypes(), pipeline.getInputs(),
-      pipeline.getClock(), pipeline.getReset(), pipeline.getStall());
+      pipeline.getExtInputs(), pipeline.getClock(), pipeline.getReset(),
+      pipeline.getStall());
 
   Block *currentStage = schedPipeline.getStage(0);
 

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -116,11 +116,11 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
-// CHECK-SAME:            %[[ARG:.*]]: i32, %[[EXT:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant true
-// CHECK:           %[[VAL_5:.*]] = comb.sub %[[ARG]], %[[ARG]] : i32
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[EXT]] : i32
+// CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_7]], %[[VAL_2]] : i32
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_1]] : i32, i32
 // CHECK:         }

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -114,3 +114,31 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 
   hw.output %0#0, %0#1 : i32, i1
 }
+
+// CHECK-LABEL:   hw.module @testSingleWithExt(
+// CHECK-SAME:            %[[ARG:.*]]: i32, %[[EXT:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[ARG]], %[[ARG]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[EXT]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_7]], %[[VAL_2]] : i32
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_1]] : i32, i32
+// CHECK:         }
+hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
+  %0:2 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
+  ^bb0(%a0: i32, %a1 : i32, %ext0: i32):
+    %true = hw.constant true
+    %1 = comb.sub %a0, %a0 : i32
+    pipeline.stage ^bb1 regs(%1 : i32) enable %true
+
+  ^bb1(%6: i32):
+    // Use the external value inside a stage
+    %8 = comb.add %6, %ext0 : i32
+    pipeline.stage ^bb2 regs(%8 : i32) enable %true
+  
+  ^bb2(%9 : i32):
+  // Use the external value in the exit stage.
+    pipeline.return %9, %ext0  : i32, i32
+  }
+  hw.output %0#0, %0#1 : i32, i32
+}

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -197,3 +197,50 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 
   hw.output %0#0, %0#1 : i32, i1
 }
+
+// CHECK-LABEL:   hw.module @testSingleWithExt_p0(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_5:.*]] = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32)
+// CHECK:           %[[VAL_6:.*]] = hw.instance "testSingleWithExt_p0_s1" @testSingleWithExt_p0_s1(in0: %[[VAL_5]]: i32, extIn0: %[[VAL_2]]: i32, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32)
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_2]] : i32, i32
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testSingleWithExt_p0_s0(
+// CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           hw.output %[[VAL_6]] : i32
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           hw.output %[[VAL_6]] : i32
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testSingleWithExt(
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i32, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, out1: i32)
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_5]] : i32, i32
+// CHECK:         }
+hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
+  %0:2 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
+  ^bb0(%a0: i32, %a1 : i32, %ext0: i32):
+    %true = hw.constant true
+    %1 = comb.sub %a0, %a0 : i32
+    pipeline.stage ^bb1 regs(%1 : i32) enable %true
+
+  ^bb1(%6: i32):
+    // Use the external value inside a stage
+    %8 = comb.add %6, %ext0 : i32
+    pipeline.stage ^bb2 regs(%8 : i32) enable %true
+  
+  ^bb2(%9 : i32):
+  // Use the external value in the exit stage.
+    pipeline.return %9, %ext0  : i32, i32
+  }
+  hw.output %0#0, %0#1 : i32, i32
+}

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -232,6 +232,8 @@ hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1,
     pipeline.return %a0 : i32
   }
   hw.output %out : i32
+}
+
 // CHECK-LABEL:   hw.module @testExtInput(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_4:.*]]:2 = pipeline.scheduled(%[[VAL_0]]) ext(%[[VAL_1]] : i32) clock %[[VAL_2]] reset %[[VAL_3]] : (i32) -> (i32, i32) {


### PR DESCRIPTION
`ext` inputs are inputs which are accessible in any pipeline stage, and which will never be registered during register materialization. If you imagine a pipeline as signals going from left to right with registers in between, `ext` inputs are inputs that hook in from the top or bottom, into any pipeline stage.

In hardware (outlined) lowering, the external inputs are only provided to stages which actually reference them:
```mlir
hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
  %0:2 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
  ^bb0(%a0: i32, %a1 : i32, %ext0: i32):
    %true = hw.constant true
    %1 = comb.sub %a0, %a0 : i32
    pipeline.stage ^bb1 regs(%1 : i32) enable %true

  ^bb1(%6: i32):
    // Use the external value inside a stage
    %8 = comb.add %6, %ext0 : i32
    pipeline.stage ^bb2 regs(%8 : i32) enable %true
  
  ^bb2(%9 : i32):
  // Use the external value in the exit stage.
    pipeline.return %9, %ext0  : i32, i32
  }
  hw.output %0#0, %0#1 : i32, i32
}

// lowers to
  hw.module @testSingleWithExt_p0(%in0: i32, %in1: i32, %extIn0: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
    %testSingleWithExt_p0_s0.out0 = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(in0: %in0: i32, in1: %in1: i32, clk: %clk: i1, rst: %rst: i1) -> (out0: i32)
    %testSingleWithExt_p0_s1.out0 = hw.instance "testSingleWithExt_p0_s1" @testSingleWithExt_p0_s1(in0: %testSingleWithExt_p0_s0.out0: i32, extIn0: %extIn0: i32, clk: %clk: i1, rst: %rst: i1) -> (out0: i32)
    hw.output %testSingleWithExt_p0_s1.out0, %extIn0 : i32, i32
  }
  hw.module @testSingleWithExt_p0_s0(%in0: i32, %in1: i32, %clk: i1, %rst: i1) -> (out0: i32) {
    %true = hw.constant true
    %0 = comb.sub %in0, %in0 : i32
    %s0_reg0 = seq.compreg %0, %clk : i32
    hw.output %s0_reg0 : i32
  }
  hw.module @testSingleWithExt_p0_s1(%in0: i32, %extIn0: i32, %clk: i1, %rst: i1) -> (out0: i32) {
    %true = hw.constant true
    %0 = comb.add %in0, %extIn0 : i32
    %s1_reg0 = seq.compreg %0, %clk : i32
    hw.output %s1_reg0 : i32
  }
  hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
    %testSingleWithExt_p0.out0, %testSingleWithExt_p0.out1 = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %arg0: i32, in1: %arg0: i32, extIn0: %ext1: i32, clk: %clk: i1, rst: %rst: i1) -> (out0: i32, out1: i32)
    hw.output %testSingleWithExt_p0.out0, %testSingleWithExt_p0.out1 : i32, i32
  }
```

**Note**: The pipeline op signature is getting unruly, given that all inputs are bundled into the single `^bb0` definition. In a future commit, i plan to specialize the printer/parser for the pipeline op to mimick something like the `scf` ops, such that we have a bit more sane format.

```mlir
  %out:2 = pipeline.scheduled(%arg0) ext(%arg1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
    ^bb0(%a0 : i32, %ext0: i32):

// vs

%out:2 = pipeline.scheduled(%a0 : i32 = %arg0) ext(%ext0 = %arg1 : i32) clock %clk reset %rst -> (i32, i32) {
```