### PR TITLE
[Comb] Canonicalize a + c1 + c2 into a + (c1 + c2)

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -325,6 +325,17 @@ hw.module @subCst(%a: i4) -> (o1: i4) {
   hw.output %b : i4
 }
 
+// CHECK-LABEL: @addConstAndConst
+hw.module @addConstAndConst(%a: i4) -> (o1: i4) {
+// CHECK-NEXT: %c3_i4 = hw.constant 3 : i4
+// CHECK-NEXT: %0 = comb.add %a, %c3_i4 : i4
+  %c1 = hw.constant 1 : i4
+  %c2 = hw.constant 2 : i4
+  %b = comb.add %a, %c1 : i4
+  %c = comb.add %b, %c2 : i4
+  hw.output %c : i4
+}
+
 // Validates that when there is a matching suffix, and prefix, both of them are removed
 // appropriately, and strips of an unnecessary Cat where possible.
 // CHECK-LABEL: hw.module @compareStrengthReductionRemoveSuffixAndPrefix


### PR DESCRIPTION
Due to attempts to prevent logic duplication, the generic canonicalizers do not catch this case which is in general beneficial. A separate canonicalizer is added.