### PR TITLE
[Comb][FIRRTL][Seq] Fix fusing locations to append not add as metadata.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2386,8 +2386,8 @@ LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
       trueMux && falseMux && trueMux.getCond() == falseMux.getCond() &&
       trueMux.getTrueValue() == falseMux.getTrueValue()) {
     auto subMux = rewriter.create<MuxOp>(
-        rewriter.getFusedLoc(trueMux.getLoc(), falseMux.getLoc()), op.getCond(),
-        trueMux.getFalseValue(), falseMux.getFalseValue());
+        rewriter.getFusedLoc({trueMux.getLoc(), falseMux.getLoc()}),
+        op.getCond(), trueMux.getFalseValue(), falseMux.getFalseValue());
     replaceOpWithNewOpAndCopyName<MuxOp>(rewriter, op, trueMux.getCond(),
                                          trueMux.getTrueValue(), subMux,
                                          op.getTwoStateAttr());
@@ -2400,8 +2400,8 @@ LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
       trueMux && falseMux && trueMux.getCond() == falseMux.getCond() &&
       trueMux.getFalseValue() == falseMux.getFalseValue()) {
     auto subMux = rewriter.create<MuxOp>(
-        rewriter.getFusedLoc(trueMux.getLoc(), falseMux.getLoc()), op.getCond(),
-        trueMux.getTrueValue(), falseMux.getTrueValue());
+        rewriter.getFusedLoc({trueMux.getLoc(), falseMux.getLoc()}),
+        op.getCond(), trueMux.getTrueValue(), falseMux.getTrueValue());
     replaceOpWithNewOpAndCopyName<MuxOp>(rewriter, op, trueMux.getCond(),
                                          subMux, trueMux.getFalseValue(),
                                          op.getTwoStateAttr());

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -878,7 +878,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
     if (constIt != constPool.end()) {
       auto *cst = constIt->second;
       // Add location to the constant
-      cst->setLoc(builder.getFusedLoc(cst->getLoc(), loc));
+      cst->setLoc(builder.getFusedLoc({cst->getLoc(), loc}));
       return cst->getResult(0);
     }
     auto savedIP = builder.saveInsertionPoint();

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -184,7 +184,7 @@ private:
     OpBuilder builder(module.getBody());
     auto &constant = constantCache[value];
     if (constant) {
-      constant->setLoc(builder.getFusedLoc(constant->getLoc(), loc));
+      constant->setLoc(builder.getFusedLoc({constant->getLoc(), loc}));
       return constant;
     }
 

--- a/test/Dialect/FIRRTL/imcp-locations.mlir
+++ b/test/Dialect/FIRRTL/imcp-locations.mlir
@@ -1,0 +1,33 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-imconstprop))' --mlir-print-local-scope --mlir-print-debuginfo %s | FileCheck %s
+
+// CHECK-LABEL: circuit "Test"
+firrtl.circuit "Test" {
+  firrtl.module private @Consts(out %c2 : !firrtl.uint<3>, out %c4 : !firrtl.uint<3>) {
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
+    %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
+    firrtl.strictconnect %c2, %c2_ui3 : !firrtl.uint<3>
+    firrtl.strictconnect %c4, %c4_ui3 : !firrtl.uint<3>
+  }
+  // CHECK-LABEL: module @Test
+  firrtl.module @Test() {
+    // CHECK-NEXT: %[[SIX:.+]] = firrtl.constant 6 : !firrtl.uint<3>
+    // CHECK-SAME: loc(fused["test.txt":5:2, "test.txt":4:2])
+
+    %c2, %c4 = firrtl.instance consts @Consts(out c2: !firrtl.uint<3>, out c4: !firrtl.uint<3>)
+
+    %w_or = firrtl.wire : !firrtl.uint<3> loc("test.txt":4:2)
+    %w_add = firrtl.wire : !firrtl.uint<3> loc("test.txt":5:2)
+
+    %or = firrtl.or %c2, %c4: (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %add = firrtl.add %c2, %c4: (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<4>
+    %addtrunc = firrtl.bits %add 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+
+    firrtl.strictconnect %w_or, %or : !firrtl.uint<3>
+    firrtl.strictconnect %w_add, %addtrunc : !firrtl.uint<3>
+
+    // CHECK: %n_or = firrtl.node sym @n_or %[[SIX]]
+    // CHECK: %n_add = firrtl.node sym @n_add %[[SIX]]
+    %n_or = firrtl.node sym @n_or %w_or : !firrtl.uint<3>
+    %n_add = firrtl.node sym @n_add %w_add : !firrtl.uint<3>
+  }
+}


### PR DESCRIPTION
Previously we created a chain of FusedLocations that had metadata point to previous, instead append to it.

Leverage (and fix interaction with) `FusedLoc::get` behavior that decomposes/flattens (and unique's)  locs in child FusedLoc's if metadata matches (or doesn't exist, as here).

Add basic test.