### PR TITLE
[SV][ETC] Fix perf bug removing from a SetVector of slice results.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -79,10 +79,6 @@ getBackwardSliceSimple(Operation *rootOp, SetVector<Operation *> &backwardSlice,
 
     backwardSlice.insert(op);
   }
-
-  // Don't insert the top level operation, we just queried on it and don't
-  // want it in the results.
-  backwardSlice.remove(rootOp);
 }
 
 // Compute the ops defining the blocks a set of ops are in.


### PR DESCRIPTION
On one design (-Odebug), ETC was taking 600s / 1100s total, after this change only takes ~20s.

Just drop the `remove` entirely, as it'll avoid re-slicing through the same operation again (minor) and more to the point AFAICT we add the "rootOp" removed here back to the result sets in the end anyway.

Removing an element from SetVector does not scale well.