### PR TITLE
[FIRRTL] Add property assign op instead of using connect

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -272,6 +272,27 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
   }];
 }
 
+def PropAssignOp : FIRRTLOp<"passign", [FConnectLike, SameTypeOperands,
+                                        HasParent<"FModuleOp">]> {
+  let summary = "Assign to a sink property value.";
+  let description = [{
+    Assign an output property value. The types must match exactly.
+
+    Example:
+    ```mlir
+      firrtl.passign %dest, %src : !firrtl.string
+    ```
+    }];
+  let arguments = (ins PropertyType:$dest, PropertyType:$src);
+  let results = (outs);
+  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+  let extraClassDeclaration = [{
+    static ConnectBehaviorKind getConnectBehaviorKind() {
+      return ConnectBehaviorKind::StaticSingleConnect;
+    }
+  }];
+}
+
 def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
   let summary = "Force procedural statement";
   let description = "Maps to the corresponding `sv.force` operation.";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -272,15 +272,15 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
   }];
 }
 
-def PropAssignOp : FIRRTLOp<"passign", [FConnectLike, SameTypeOperands,
-                                        HasParent<"FModuleOp">]> {
+def PropAssignOp : FIRRTLOp<"propassign", [FConnectLike, SameTypeOperands,
+                                           HasParent<"FModuleOp">]> {
   let summary = "Assign to a sink property value.";
   let description = [{
     Assign an output property value. The types must match exactly.
 
     Example:
     ```mlir
-      firrtl.passign %dest, %src : !firrtl.string
+      firrtl.propassign %dest, %src : !firrtl.string
     ```
     }];
   let arguments = (ins PropertyType:$dest, PropertyType:$src);

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -285,7 +285,7 @@ def PropAssignOp : FIRRTLOp<"passign", [FConnectLike, SameTypeOperands,
     }];
   let arguments = (ins PropertyType:$dest, PropertyType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+  let assemblyFormat = "$dest `,` $src attr-dict `:` qualified(type($dest))";
   let extraClassDeclaration = [{
     static ConnectBehaviorKind getConnectBehaviorKind() {
       return ConnectBehaviorKind::StaticSingleConnect;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -296,6 +296,19 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// PropertyTypes
+//===----------------------------------------------------------------------===//
+
+class PropertyType : public FIRRTLType {
+public:
+  /// Support method to enable LLVM-style type casting.
+  static bool classof(Type type) { return llvm::isa<StringType>(type); }
+
+protected:
+  using FIRRTLType::FIRRTLType;
+};
+
+//===----------------------------------------------------------------------===//
 // Type helpers
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -78,10 +78,6 @@ def OpenVectorType : FIRRTLDialectType<CPred<"$_self.isa<OpenVectorType>()">,
 def FEnumType : FIRRTLDialectType<CPred<"$_self.isa<FEnumType>()">,
  "FEnumType", "::circt::firrtl::FEnumType">;
 
-def StringType : FIRRTLDialectType<CPred<"$_self.isa<StringType>()">,
-  "StringType", "::circt::firrtl::StringType">,
-  BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;
-
 def AggregateType : FIRRTLDialectType<
   Or<[
     CPred<"$_self.isa<FVectorType>()">,
@@ -116,7 +112,7 @@ def RWProbe : FIRRTLDialectType<
    "rwprobe type", "::circt::firrtl::RefType">;
 
 // TODO: When Refs can appear within Base, need to disallow that too.
-def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType, StringType]>;
+def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
 def StrictConnectableType : AnyTypeOf<[PassiveType, ForeignType]>;
 
 //===----------------------------------------------------------------------===//
@@ -195,5 +191,19 @@ class RefResultTypeConstraint<string base, string ref>
   : TypesMatchWith<"reference base type should match",
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
+
+//===----------------------------------------------------------------------===//
+// Property Types
+//===----------------------------------------------------------------------===//
+
+def PropertyType : FIRRTLDialectType<
+  CPred<"$_self.isa<PropertyType>()">,
+  "a property type", "::circt::firrtl::PropertyType", [{
+    A FIRRTL property type, such as a string.
+  }]>;
+
+def StringType : FIRRTLDialectType<CPred<"$_self.isa<StringType>()">,
+  "StringType", "::circt::firrtl::StringType">,
+  BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -246,7 +246,7 @@ firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, 
 // CHECK-LABEL: StringTest
 // CHECK-SAME:  (in %in: !firrtl.string, out %out: !firrtl.string)
 firrtl.module @StringTest(in %in: !firrtl.string, out %out: !firrtl.string) {
-  firrtl.passign %out, %in : !firrtl.string
+  firrtl.propassign %out, %in : !firrtl.string
   // CHECK: %0 = firrtl.string "hello"
   %0 = firrtl.string "hello"
 }

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -246,7 +246,7 @@ firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, 
 // CHECK-LABEL: StringTest
 // CHECK-SAME:  (in %in: !firrtl.string, out %out: !firrtl.string)
 firrtl.module @StringTest(in %in: !firrtl.string, out %out: !firrtl.string) {
-  firrtl.connect %out, %in : !firrtl.string, !firrtl.string
+  firrtl.passign %out, %in : !firrtl.string
   // CHECK: %0 = firrtl.string "hello"
   %0 = firrtl.string "hello"
 }


### PR DESCRIPTION
This adds a new statement to FIRRTL to assign a property to a property sink.  We stop allowing properties to be connected with a ConnectOp. This new operation enforces that the parent operation is a FModuleOp, and that it has static single connects, which is a good limitation to keep from using this operation inside a WhenOp.