### PR TITLE
[LowerToHW] Lower clock gate intrinsic to Seq dialect

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -48,10 +48,11 @@ public:
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
             // Intrinsic Expressions.
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
-            SizeOfIntrinsicOp, LTLAndIntrinsicOp, LTLOrIntrinsicOp,
-            LTLDelayIntrinsicOp, LTLConcatIntrinsicOp, LTLNotIntrinsicOp,
-            LTLImplicationIntrinsicOp, LTLEventuallyIntrinsicOp,
-            LTLClockIntrinsicOp, LTLDisableIntrinsicOp,
+            SizeOfIntrinsicOp, ClockGateIntrinsicOp, LTLAndIntrinsicOp,
+            LTLOrIntrinsicOp, LTLDelayIntrinsicOp, LTLConcatIntrinsicOp,
+            LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
+            LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
+            LTLDisableIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -158,6 +159,7 @@ public:
   HANDLE(PlusArgsValueIntrinsicOp, Unhandled);
   HANDLE(PlusArgsTestIntrinsicOp, Unhandled);
   HANDLE(SizeOfIntrinsicOp, Unhandled);
+  HANDLE(ClockGateIntrinsicOp, Unhandled);
   HANDLE(LTLAndIntrinsicOp, Unhandled);
   HANDLE(LTLOrIntrinsicOp, Unhandled);
   HANDLE(LTLDelayIntrinsicOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1684,6 +1684,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(PlusArgsTestIntrinsicOp op);
   LogicalResult visitExpr(PlusArgsValueIntrinsicOp op);
   LogicalResult visitExpr(SizeOfIntrinsicOp op);
+  LogicalResult visitExpr(ClockGateIntrinsicOp op);
   LogicalResult visitExpr(LTLAndIntrinsicOp op);
   LogicalResult visitExpr(LTLOrIntrinsicOp op);
   LogicalResult visitExpr(LTLDelayIntrinsicOp op);
@@ -3744,6 +3745,15 @@ LogicalResult FIRRTLLowering::visitExpr(PlusArgsValueIntrinsicOp op) {
 LogicalResult FIRRTLLowering::visitExpr(SizeOfIntrinsicOp op) {
   op.emitError("SizeOf should have been resolved.");
   return failure();
+}
+
+LogicalResult FIRRTLLowering::visitExpr(ClockGateIntrinsicOp op) {
+  Value testEnable;
+  if (op.getTestEnable())
+    testEnable = getLoweredValue(op.getTestEnable());
+  return setLoweringTo<seq::ClockGateOp>(op, getLoweredValue(op.getInput()),
+                                         getLoweredValue(op.getEnable()),
+                                         testEnable);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLAndIntrinsicOp op) {

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -37,6 +37,23 @@ firrtl.circuit "Intrinsics" {
     %x4 = firrtl.node interesting_name %4 : !firrtl.uint<5>
   }
 
+  // CHECK-LABEL: hw.module @ClockGate
+  firrtl.module @ClockGate(
+    in %clk: !firrtl.clock,
+    in %enable: !firrtl.uint<1>,
+    in %testEnable: !firrtl.uint<1>,
+    out %gated_clk0: !firrtl.clock,
+    out %gated_clk1: !firrtl.clock
+  ) {
+    // CHECK-NEXT: [[CLK0:%.+]] = seq.clock_gate %clk, %enable
+    // CHECK-NEXT: [[CLK1:%.+]] = seq.clock_gate %clk, %enable, %testEnable
+    // CHECK-NEXT: hw.output [[CLK0]], [[CLK1]]
+    %0 = firrtl.int.clock_gate %clk, %enable
+    %1 = firrtl.int.clock_gate %clk, %enable, %testEnable
+    firrtl.strictconnect %gated_clk0, %0 : !firrtl.clock
+    firrtl.strictconnect %gated_clk1, %1 : !firrtl.clock
+  }
+
   // CHECK-LABEL: hw.module @LTLAndVerif
   firrtl.module @LTLAndVerif(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
     // CHECK-NEXT: [[D0:%.+]] = ltl.delay %a, 42 : i1


### PR DESCRIPTION
Lower the `firrtl.int.clock_gate` intrinsic to a `seq.clock_gate` op.