### PR TITLE
[Seq] Add clock gate conversion to extern module

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -21,14 +21,17 @@ namespace seq {
 
 #define GEN_PASS_DECL_LOWERSEQTOSV
 #define GEN_PASS_DECL_LOWERSEQFIRRTLTOSV
+#define GEN_PASS_DECL_EXTERNALIZECLOCKGATE
 #include "circt/Dialect/Seq/SeqPasses.h.inc"
 
 std::unique_ptr<mlir::Pass>
 createSeqLowerToSVPass(std::optional<bool> lowerToAlwaysFF = {});
-std::unique_ptr<Pass> createLowerSeqFIRRTLInitToSV();
+std::unique_ptr<mlir::Pass> createLowerSeqFIRRTLInitToSV();
 std::unique_ptr<mlir::Pass>
 createSeqFIRRTLLowerToSVPass(const LowerSeqFIRRTLToSVOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
+std::unique_ptr<mlir::Pass>
+createExternalizeClockGatePass(const ExternalizeClockGateOptions &options = {});
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -53,4 +53,28 @@ def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def ExternalizeClockGate: Pass<"externalize-clock-gate", "mlir::ModuleOp"> {
+  let summary = "Convert seq.clock_gate ops into hw.module.extern instances";
+  let constructor = "circt::seq::createExternalizeClockGatePass()";
+  let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect"];
+  let options = [
+    Option<"moduleName", "name", "std::string", "\"CKG\"",
+           "Name of the external clock gate module">,
+    Option<"inputName", "input", "std::string", "\"I\"",
+           "Name of the clock input">,
+    Option<"outputName", "output", "std::string", "\"O\"",
+           "Name of the gated clock output">,
+    Option<"enableName", "enable", "std::string", "\"E\"",
+           "Name of the enable input">,
+    Option<"testEnableName", "test-enable", "std::string", "\"TE\"",
+           "Name of the optional test enable input">,
+    Option<"instName", "instance-name", "std::string", "\"ckg\"",
+           "Name of the generated instances">
+  ];
+  let statistics = [
+    Statistic<"numClockGatesConverted", "num-clock-gates-converted",
+      "Number of clock gates converted to external module instances">
+  ];
+}
+
 #endif // CIRCT_DIALECT_SEQ_SEQPASSES

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -14,6 +14,7 @@
 #define CIRCT_FIRTOOL_FIRTOOL_H
 
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/CommandLine.h"
@@ -217,6 +218,38 @@ struct FirtoolOptions {
           "for a vivado synthesis bug that incorrectly modifies "
           "address conflict behavivor of combinational memories"),
       llvm::cl::init(false), llvm::cl::cat(category)};
+
+  //===----------------------------------------------------------------------===
+  // External Clock Gate Options
+  //===----------------------------------------------------------------------===
+
+  seq::ExternalizeClockGateOptions clockGateOpts;
+
+  llvm::cl::opt<std::string, true> ckgModuleName{
+      "ckg-name", llvm::cl::desc("Clock gate module name"),
+      llvm::cl::location(clockGateOpts.moduleName),
+      llvm::cl::init("EICG_wrapper"), llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgInputName{
+      "ckg-input", llvm::cl::desc("Clock gate input port name"),
+      llvm::cl::location(clockGateOpts.inputName), llvm::cl::init("in"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgOutputName{
+      "ckg-output", llvm::cl::desc("Clock gate output port name"),
+      llvm::cl::location(clockGateOpts.outputName), llvm::cl::init("out"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgEnableName{
+      "ckg-enable", llvm::cl::desc("Clock gate enable port name"),
+      llvm::cl::location(clockGateOpts.enableName), llvm::cl::init("en"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgTestEnableName{
+      "ckg-test-enable",
+      llvm::cl::desc("Clock gate test enable port name (optional)"),
+      llvm::cl::location(clockGateOpts.testEnableName),
+      llvm::cl::init("test_en"), llvm::cl::cat(category)};
 
   bool isRandomEnabled(RandomKind kind) const {
     return disableRandom != RandomKind::All && disableRandom != kind;

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_circt_dialect_library(CIRCTSeqTransforms
-  LowerSeqToSV.cpp
+  ExternalizeClockGate.cpp
   LowerSeqHLMem.cpp
+  LowerSeqToSV.cpp
 
   DEPENDS
   CIRCTSeqTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTComb
   CIRCTHW
   CIRCTSeq
   CIRCTSupport

--- a/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
+++ b/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
@@ -1,0 +1,107 @@
+//===- ExternalizeClockGate.cpp - Convert clock gate to extern module -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+namespace circt {
+namespace seq {
+#define GEN_PASS_DEF_EXTERNALIZECLOCKGATE
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+} // namespace seq
+} // namespace circt
+
+using namespace circt;
+using namespace seq;
+using namespace hw;
+
+namespace {
+struct ExternalizeClockGatePass
+    : public impl::ExternalizeClockGateBase<ExternalizeClockGatePass> {
+  using ExternalizeClockGateBase<
+      ExternalizeClockGatePass>::ExternalizeClockGateBase;
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void ExternalizeClockGatePass::runOnOperation() {
+  SymbolTable &symtbl = getAnalysis<SymbolTable>();
+
+  // Collect all clock gate ops.
+  std::vector<ClockGateOp> clockGatesToReplace;
+  getOperation().walk(
+      [&](ClockGateOp op) { clockGatesToReplace.push_back(op); });
+
+  if (clockGatesToReplace.empty()) {
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  // Generate the external module declaration.
+  auto builder = OpBuilder::atBlockBegin(getOperation().getBody());
+  auto i1Type = builder.getI1Type();
+
+  SmallVector<PortInfo, 4> modulePorts;
+  modulePorts.push_back(
+      {builder.getStringAttr(inputName), PortDirection::INPUT, i1Type});
+  modulePorts.push_back(
+      {builder.getStringAttr(outputName), PortDirection::OUTPUT, i1Type});
+  modulePorts.push_back(
+      {builder.getStringAttr(enableName), PortDirection::INPUT, i1Type});
+  bool hasTestEnable = !testEnableName.empty();
+  if (hasTestEnable)
+    modulePorts.push_back(
+        {builder.getStringAttr(testEnableName), PortDirection::INPUT, i1Type});
+
+  auto moduleOp = builder.create<HWModuleExternOp>(
+      getOperation().getLoc(), builder.getStringAttr(moduleName), modulePorts,
+      moduleName);
+  symtbl.insert(moduleOp);
+
+  // Replace all clock gates with an instance of the external module.
+  SmallVector<Value, 4> instPorts;
+  for (auto ckgOp : clockGatesToReplace) {
+    ImplicitLocOpBuilder builder(ckgOp.getLoc(), ckgOp);
+
+    Value enable = ckgOp.getEnable();
+    Value testEnable = ckgOp.getTestEnable();
+
+    // If the clock gate has a test enable operand but the module does not, add
+    // a `comb.or` to merge the two enable conditions.
+    if (hasTestEnable && !testEnable)
+      testEnable = builder.create<ConstantOp>(i1Type, 0);
+
+    // If the clock gate has no test enable operand but the module does, add a
+    // constant 0 input.
+    if (!hasTestEnable && testEnable) {
+      enable = builder.createOrFold<comb::OrOp>(enable, testEnable, true);
+      testEnable = {};
+    }
+
+    instPorts.push_back(ckgOp.getInput());
+    instPorts.push_back(enable);
+    if (testEnable)
+      instPorts.push_back(testEnable);
+
+    auto instOp = builder.create<InstanceOp>(
+        moduleOp, builder.getStringAttr(instName), instPorts);
+    ckgOp.replaceAllUsesWith(instOp);
+    ckgOp.erase();
+
+    instPorts.clear();
+    ++numClockGatesConverted;
+  }
+}
+
+std::unique_ptr<Pass> circt::seq::createExternalizeClockGatePass(
+    const ExternalizeClockGateOptions &options) {
+  return std::make_unique<ExternalizeClockGatePass>(options);
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -217,6 +217,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
                                                opt.etcDisableRegisterExtraction,
                                                opt.etcDisableModuleInlining));
 
+  pm.addPass(seq::createExternalizeClockGatePass(opt.clockGateOpts));
   pm.nest<hw::HWModuleOp>().addPass(seq::createSeqFIRRTLLowerToSVPass(
       {/*disableRandomization=*/!opt.isRandomEnabled(
            FirtoolOptions::RandomKind::Reg),

--- a/test/Dialect/Seq/externalize-clock-gate.mlir
+++ b/test/Dialect/Seq/externalize-clock-gate.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt %s --externalize-clock-gate --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
+// RUN: circt-opt %s --externalize-clock-gate="name=SuchClock input=CI output=CO enable=EN test-enable=TEN instance-name=gated" --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-CUSTOM
+// RUN: circt-opt %s --externalize-clock-gate="name=VeryGate test-enable=" --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-WITHOUT-TESTENABLE
+
+// CHECK-DEFAULT: hw.module.extern @CKG(%I: i1, %E: i1, %TE: i1) -> (O: i1)
+// CHECK-CUSTOM: hw.module.extern @SuchClock(%CI: i1, %EN: i1, %TEN: i1) -> (CO: i1)
+// CHECK-WITHOUT-TESTENABLE: hw.module.extern @VeryGate(%I: i1, %E: i1) -> (O: i1)
+
+// CHECK-LABEL: hw.module @Foo
+hw.module @Foo(%clock: i1, %enable: i1, %test_enable: i1) {
+  // CHECK-NOT: seq.clock_gate
+  %cg0 = seq.clock_gate %clock, %enable
+  %cg1 = seq.clock_gate %clock, %enable, %test_enable
+
+  // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
+  // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %test_enable: i1) -> (O: i1)
+
+  // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
+  // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
+
+  // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: %clock: i1, E: %enable: i1) -> (O: i1)
+  // CHECK-WITHOUT-TESTENABLE: [[COMBINED_ENABLE:%.+]] = comb.or bin %enable, %test_enable : i1
+  // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: %clock: i1, E: [[COMBINED_ENABLE]]: i1) -> (O: i1)
+}

--- a/test/firtool/clock-gate.fir
+++ b/test/firtool/clock-gate.fir
@@ -1,0 +1,33 @@
+; RUN: firtool %s | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
+; RUN: firtool %s --ckg-name=MyClockGate --ckg-input=CI --ckg-output=CO --ckg-enable=E --ckg-test-enable=TE | FileCheck %s --check-prefixes=CHECK,CHECK-CUSTOM
+
+circuit Foo:
+  intmodule ClockGate:
+    input in: Clock
+    input en: UInt<1>
+    output out: Clock
+    intrinsic = circt_clock_gate
+
+  module Foo:
+    input clk: Clock
+    input enable: UInt<1>
+    output gated_clk: Clock
+
+    inst ckg of ClockGate
+    ckg.in <= clk
+    ckg.en <= enable
+    gated_clk <= ckg.out
+
+; CHECK-LABEL: module Foo(
+
+; CHECK-DEFAULT: EICG_wrapper ckg (
+; CHECK-DEFAULT: .in (clk)
+; CHECK-DEFAULT: .en (enable)
+; CHECK-DEFAULT: .test_en (1'h0)
+; CHECK-DEFAULT: .out (gated_clk)
+
+; CHECK-CUSTOM: MyClockGate ckg (
+; CHECK-CUSTOM: .CI (clk)
+; CHECK-CUSTOM: .E (enable)
+; CHECK-CUSTOM: .TE (1'h0)
+; CHECK-CUSTOM: .CO (gated_clk)


### PR DESCRIPTION
Add the `ExternalizeClockGate` pass which converts all `seq.clock_gate` ops in a design into instances of a `hw.module.extern`. The name and ports of the extern module can be configured through pass options. In case the module has no test enable port, the conversion adds a `comb.or` to fold the enable and test enable operands of the `seq.clock_gate` into a single enable port.