### PR TITLE
[FIRRTL] Explicitly reject rwprobe of types containing const.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -839,6 +839,9 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     if (!innerType.isPassive())
       return emitError(loc, "probe inner type must be passive");
 
+    if (forceable && innerType.containsConst())
+      return emitError(loc, "rwprobe cannot contain const");
+
     result = RefType::get(innerType, forceable);
     break;
   }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -630,6 +630,12 @@ circuit ForceWithLiteral:
 
 ;// -----
 
+circuit RWProbeConst:
+  extmodule RWProbeConst:
+    output p : RWProbe<{a: const UInt}> ; expected-error {{rwprobe cannot contain const}}
+
+;// -----
+
 FIRRTL version 2.0.0
 circuit PartialConnect_v2p0p0:
   module PartialConnect_v2p0p0:


### PR DESCRIPTION
Don't leave to verifier, better diagnostic this way.