### PR TITLE
[FIRRTL][InferResets] Fix reset inference through const cast.

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1026,6 +1026,44 @@ firrtl.circuit "ConstReset" {
 
 // -----
 
+// CHECK-LABEL "ConstAggReset"
+firrtl.circuit "ConstAggReset" {
+  // CHECK-LABEL: module @ConstAggReset
+  // CHECK-NOT: : reset
+  firrtl.module @ConstAggReset(in %in: !firrtl.const.bundle<a: reset, b: uint<1>>, out %out: !firrtl.bundle<a: asyncreset>, out %out2: !firrtl.bundle<a: reset, b: uint<1>>) {
+    %out_a = firrtl.subfield %out[a] : !firrtl.bundle<a: asyncreset>
+    %in_a = firrtl.subfield %in[a] : !firrtl.const.bundle<a: reset, b: uint<1>>
+    %in_a_asyncreset = firrtl.resetCast %in_a : (!firrtl.const.reset) -> !firrtl.const.asyncreset
+    %in_a_asyncreset_noconst = firrtl.constCast %in_a_asyncreset : (!firrtl.const.asyncreset) -> !firrtl.asyncreset
+    firrtl.strictconnect %out_a, %in_a_asyncreset_noconst : !firrtl.asyncreset
+
+    %in_noconst = firrtl.constCast %in : (!firrtl.const.bundle<a: reset, b: uint<1>>) -> !firrtl.bundle<a: reset, b : uint<1>>
+    firrtl.strictconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL "ConstAggCastReset"
+firrtl.circuit "ConstAggCastReset" {
+  // CHECK-LABEL: module @ConstAggCastReset
+  // CHECK-NOT: : reset
+  firrtl.module @ConstAggCastReset(in %in: !firrtl.const.bundle<a: reset, b: uint<1>>, out %out: !firrtl.bundle<a: asyncreset>, out %out2: !firrtl.bundle<a: reset, b: uint<1>>) {
+    %out_a = firrtl.subfield %out[a] : !firrtl.bundle<a: asyncreset>
+    %in_a = firrtl.subfield %in[a] : !firrtl.const.bundle<a: reset, b: uint<1>>
+    // CHECK: constCast %{{.+}} : (!firrtl.const.asyncreset) -> !firrtl.asyncreset
+    %in_a_noconst = firrtl.constCast %in_a : (!firrtl.const.reset) -> !firrtl.reset
+    %in_a_asyncreset = firrtl.resetCast %in_a_noconst : (!firrtl.reset) -> !firrtl.asyncreset
+    // CHECK-NEXT: strictconnect
+    firrtl.strictconnect %out_a, %in_a_asyncreset : !firrtl.asyncreset
+    // CHECK-NOT: : reset
+    %in_noconst = firrtl.constCast %in : (!firrtl.const.bundle<a: reset, b: uint<1>>) -> !firrtl.bundle<a: reset, b : uint<1>>
+    firrtl.strictconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
+  }
+}
+
+// -----
+
 // Check resets are inferred for forceable ops.
 
 // CHECK-LABEL: "InferToRWProbe"


### PR DESCRIPTION
Update these as operations that cannot have types inferred from inputs, drop (incomplete) code handling while propagating through SSA use/def graph.  In order to support updating in this way, we'd need to walk the source/dest type and update modulo the const structure present on each.

Luckily don't need to, this portion is for flowing through operations not explicitly handled as part of the traced network. ConstCast is handled this way, and so its destination type can be fixed up using `updateReset()` earlier in the function.

Fix reset inference of const-cast involving aggregates, add test.

Fixes #5333.