### PR TITLE
[FIRRTL] Add RefCastOp for reset/width/const differences in refs.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1035,6 +1035,29 @@ def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+def RefCastOp : FIRRTLOp<"ref.cast",
+    [HasCustomSSAName,
+     Pure,
+     CompatibleRefTypes<"result","input">]> {
+  let summary = "Cast between compatible reference types";
+  let description = [{
+    Losslessly cast between compatible reference types.
+    Source and destination must be recursively identical or destination
+    has uninferred variants of the corresponding element in source.
+    ```
+      %result = firrtl.ref.cast %ref : (t1) -> t2
+    ```
+    }];
+
+  let arguments = (ins RefType:$input);
+  let results = (outs RefType:$result);
+
+  let hasFolder = 1;
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+}
+
 def RefResolveOp: FIRRTLExprOp<"ref.resolve",
                               [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL Resolve a Reference";

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -224,6 +224,11 @@ bool areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
 bool areTypesConstCastable(FIRRTLType destType, FIRRTLType srcType,
                            bool srcOuterTypeIsConst = false);
 
+/// Return true if destination ref type can be cast from source ref type,
+/// per FIRRTL spec rules they must be identical or destination has
+/// more general versions of the corresponding type in the source.
+bool areTypesRefCastable(Type dstType, Type srcType);
+
 /// Returns true if the destination is at least as wide as a source.  The source
 /// and destination types must be equivalent non-analog types.  The types are
 /// recursively connected to ensure that the destination is larger than the

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -192,6 +192,11 @@ class RefResultTypeConstraint<string base, string ref>
                    base, ref,
                    "RefType::get($_self.cast<FIRRTLBaseType>().getPassiveType())">;
 
+class CompatibleRefTypes<string dst, string src>
+  : PredOpTrait<"reference " # dst # " must be compatible with reference " # src #
+                ": recursively same or uninferred of same and can only demote rwprobe to probe",
+                CPred<"circt::firrtl::areTypesRefCastable($" # dst # ".getType(), $" # src # ".getType())">>;
+
 //===----------------------------------------------------------------------===//
 // Property Types
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -58,9 +58,10 @@ public:
             RefResolveOp, RefSubOp,
             // Casts to deal with weird stuff
             UninferredResetCastOp, UninferredWidthCastOp, ConstCastOp,
-            mlir::UnrealizedConversionCastOp>([&](auto expr) -> ResultType {
-          return thisCast->visitExpr(expr, args...);
-        })
+            RefCastOp, mlir::UnrealizedConversionCastOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitExpr(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidExpr(op, args...);
         });
@@ -189,6 +190,7 @@ public:
   HANDLE(ConstCastOp, Unhandled);
   HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);
+  HANDLE(RefCastOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3126,7 +3126,7 @@ LogicalResult ClockGateIntrinsicOp::canonicalize(ClockGateIntrinsicOp op,
 }
 
 //===----------------------------------------------------------------------===//
-// RefOps
+// Reference Ops.
 //===----------------------------------------------------------------------===//
 
 // refresolve(forceable.ref) -> forceable.data
@@ -3145,4 +3145,11 @@ void RefResolveOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
   results.insert<patterns::RefResolveOfRefSend>(context);
   results.insert(canonicalizeRefResolveOfForceable);
+}
+
+OpFoldResult RefCastOp::fold(FoldAdaptor adaptor) {
+  // RefCast is unnecessary if types match.
+  if (getInput().getType() == getType())
+    return getInput();
+  return {};
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2526,6 +2526,9 @@ LogicalResult RefDefineOp::verify() {
     if (isa<RefSubOp>(op))
       return emitError(
           "destination reference cannot be a sub-element of a reference");
+    if (isa<RefCastOp>(op)) // Source flow, check anyway for now.
+      return emitError(
+          "destination reference cannot be a cast of another reference");
   }
 
   return success();
@@ -4587,6 +4590,22 @@ void ElementwiseAndPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // RefOps
 //===----------------------------------------------------------------------===//
 
+void RefCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
+void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
                                          std::optional<Location> loc) {
@@ -4607,18 +4626,6 @@ FIRRTLType RefSendOp::inferReturnType(ValueRange operands,
     return emitInferRetTypeError(
         loc, "ref.send operand must be base type, not ", inType);
   return RefType::get(inBaseType.getPassiveType());
-}
-
-void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSendOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
-void RefSubOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
 }
 
 FIRRTLType RefSubOp::inferReturnType(ValueRange operands,

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2968,4 +2968,13 @@ firrtl.module @DonotUpdateInstanceName(in %in: !firrtl.uint<1>, out %a: !firrtl.
   firrtl.strictconnect %a, %b : !firrtl.uint<1>
 }
 
+// CHECK-LABEL: @RefCastSame
+firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
+  // Drop no-op ref.cast's.
+  // CHECK-NEXT:  firrtl.ref.define %out, %in
+  // CHECK-NEXT:  }
+  %same_as_in = firrtl.ref.cast %in : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>>
+  firrtl.ref.define %out, %same_as_in : !firrtl.probe<uint<1>>
+}
+
 }


### PR DESCRIPTION
Per spec, need to allow define'ing refs into destinations that are less inferred than their sources.  Add an explicit ref.cast operation to express the change, keep define requiring identical types.

Future PR's will hook this up to parsing and add needed pass support.