### PR TITLE
[FIRRTL] Add utility for getting the assignment to a property value.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -33,6 +33,9 @@ IntegerAttr getIntZerosAttr(Type type);
 /// Utility for generating a constant all ones attribute.
 IntegerAttr getIntOnesAttr(Type type);
 
+/// Return the single assignment to a Property value.
+PropAssignOp getPropertyAssignment(Value value);
+
 /// Return the module-scoped driver of a value only looking through one connect.
 Value getDriverFromConnect(Value val);
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -161,6 +161,21 @@ IntegerAttr circt::firrtl::getIntOnesAttr(Type type) {
   return getIntAttr(type, APInt(width, -1));
 }
 
+/// Return the single assignment to a Property value. It is assumed that the
+/// single assigment invariant is enforced elsewhere.
+PropAssignOp circt::firrtl::getPropertyAssignment(Value value) {
+  assert(isa<PropertyType>(value.getType()) && "expected a PropertyType value");
+  for (auto *user : value.getUsers())
+    if (auto propassign = dyn_cast<PropAssignOp>(user))
+      if (propassign.getDest() == value)
+        return propassign;
+
+  // The invariant that there is a single assignment should be enforced
+  // elsewhere. If for some reason a user called this on a Property value that
+  // is not assigned (like a module input port), just return null.
+  return nullptr;
+}
+
 /// Return the value that drives another FIRRTL value within module scope.  Only
 /// look backwards through one connection.  This is intended to be used in
 /// situations where you only need to look at the most recent connect, e.g., to


### PR DESCRIPTION
This adds a helper similar to getSingleConnectUserOf, except for PropAssignOp instead of StrictConnectOp. It is assumed the verifier will ensure there is in fact one assignment. No test is included, but this has been vetted already in a patch that will come in a future PR.