### PR TITLE
[FIRRTL] Improve PropAssignOp verifiers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -285,6 +285,7 @@ def PropAssignOp : FIRRTLOp<"propassign", [FConnectLike, SameTypeOperands,
     }];
   let arguments = (ins PropertyType:$dest, PropertyType:$src);
   let results = (outs);
+  let hasVerifier = 1;
   let assemblyFormat = "$dest `,` $src attr-dict `:` qualified(type($dest))";
   let extraClassDeclaration = [{
     static ConnectBehaviorKind getConnectBehaviorKind() {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2547,7 +2547,6 @@ LogicalResult PropAssignOp::verify() {
   return success();
 }
 
-
 void WhenOp::createElseRegion() {
   assert(!hasElseRegion() && "already has an else region");
   getElseRegion().push_back(new Block());

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2531,6 +2531,23 @@ LogicalResult RefDefineOp::verify() {
   return success();
 }
 
+LogicalResult PropAssignOp::verify() {
+  // Check that the flows make sense.
+  if (failed(checkConnectFlow(*this)))
+    return failure();
+
+  // Verify that there is a single value driving the destination.
+  for (auto *user : getDest().getUsers()) {
+    if (auto conn = dyn_cast<FConnectLike>(user);
+        conn && conn.getDest() == getDest() && conn != *this)
+      return emitError("destination property cannot be reused by multiple "
+                       "operations, it can only capture a unique dataflow");
+  }
+
+  return success();
+}
+
+
 void WhenOp::createElseRegion() {
   assert(!hasElseRegion() && "already has an else region");
   getElseRegion().push_back(new Block());

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1185,6 +1185,30 @@ firrtl.circuit "NoDefineIntoRefSub" {
 }
 
 // -----
+// Check that you can't drive a source.
+
+firrtl.circuit "PropertyDriveSource" {
+  // @expected-note @below {{the destination was defined here}}
+  firrtl.module @PropertyDriveSource(in %in: !firrtl.string) {
+    %0 = firrtl.string "hello"
+    // expected-error @below {{connect has invalid flow: the destination expression "in" has source flow, expected sink or duplex flow}}
+    firrtl.propassign %in, %0 : !firrtl.string
+  }
+}
+
+// -----
+// Check that you can't drive a sink more than once.
+
+firrtl.circuit "PropertyDoubleDrive" {
+  firrtl.module @PropertyDriveSource(out %out: !firrtl.string) {
+    %0 = firrtl.string "hello"
+    // expected-error @below {{destination property cannot be reused by multiple operations, it can only capture a unique dataflow}}
+    firrtl.propassign %out, %0 : !firrtl.string
+    firrtl.propassign %out, %0 : !firrtl.string
+  }
+}
+
+// -----
 // Issue 4174-- handle duplicate module names.
 
 firrtl.circuit "hi" {


### PR DESCRIPTION
This adds verifiers which:
1. check that a source is not a destination.
2. check that a sink if not driven more than once.