### PR TITLE
[FIRRTL] Add v2.4.0 Radix-specified Integer Literals

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -49,12 +49,13 @@ TOK_IDENTIFIER(identifier)         // foo
 TOK_IDENTIFIER(literal_identifier) // `42`
 
 // Literals
-TOK_LITERAL(integer)        // 42
-TOK_LITERAL(signed_integer) // -42 and +42
-TOK_LITERAL(floatingpoint)  // 42.0
-TOK_LITERAL(version)        // 1.2.3
-TOK_LITERAL(string)         // "foo"
-TOK_LITERAL(raw_string)     // 'foo'
+TOK_LITERAL(integer)                 // 42
+TOK_LITERAL(signed_integer)          // -42 and +42
+TOK_LITERAL(radix_specified_integer) // 0b101010, 0o52, 0d42, 0h2a and negations
+TOK_LITERAL(floatingpoint)           // 42.0
+TOK_LITERAL(version)                 // 1.2.3
+TOK_LITERAL(string)                  // "foo"
+TOK_LITERAL(raw_string)              // 'foo'
 
 TOK_LITERAL(fileinfo)
 TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1488,3 +1488,80 @@ circuit Probes_refexprs:
     force_initial(rwprobe(`test`), `test`)
     ; CHECK: force_initial
     force_initial(`9`.`0`.rwprobe, `test`.`0`)
+
+;// -----
+
+; CHECK-LABEL: firrtl.circuit "RadixEncodedIntegerLiterals"
+FIRRTL version 2.4.0
+circuit RadixEncodedIntegerLiterals:
+  module RadixEncodedIntegerLiterals:
+    output bu: UInt<8>
+    output ou: UInt<8>
+    output du0: UInt<8>
+    output du1: UInt<8>
+    output hu: UInt<8>
+    output bs: SInt<8>
+    output os: SInt<8>
+    output dus0: SInt<8>
+    output dus1: SInt<8>
+    output hs: SInt<8>
+
+    ; CHECK:      %[[c42_ui7:[-a-zA-Z_0-9]+]] = firrtl.constant 42
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %bu, %[[c_constCast]]
+    bu <= UInt(0b101010)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %ou, %[[c_constCast]]
+    ou <= UInt(0o052)
+
+    ; Note: this creates a second constant because the width of a parsed
+    ; constant is dependent on the overestimation of LLVM::StringRef.
+    ;
+    ; CHECK:      %[[c42_ui8:[-a-zA-Z_0-9]+]] = firrtl.constant 42
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui8]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %du0, %[[c_constCast]]
+    du0 <= UInt(42)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui8]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %du1, %[[c_constCast]]
+    du1 <= UInt(0d42)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %hu, %[[c_constCast]]
+    hu <= UInt(0h2a)
+
+    ; CHECK:      %[[cn42_si7:[-a-zA-Z_0-9]+]] = firrtl.constant -42
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %bs, %[[c_constCast]]
+    bs <= SInt(-0b101010)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %os, %[[c_constCast]]
+    os <= SInt(-0o52)
+
+    ; Note: this creates a second constant because the width of a parsed
+    ; constant is dependent on the overestimation of LLVM::StringRef.
+    ;
+    ; CHECK:      %[[cn42_si8:[-a-zA-Z_0-9]+]] = firrtl.constant -42
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si8]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %dus0, %[[c_constCast]]
+    dus0 <= SInt(-42)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si8]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %dus1, %[[c_constCast]]
+    dus1 <= SInt(-0d42)
+
+    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
+    ; CHECK-NEXT: firrtl.strictconnect %hs, %[[c_constCast]]
+    hs <= SInt(-0h2a)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -694,3 +694,57 @@ circuit PropAssignNonProperty:
     input x : UInt<1>
     output y : UInt<1>
     propassign x, y ; expected-error {{can only propassign property types}}
+
+;// -----
+
+FIRRTL version 2.3.9
+circuit UnsupportedRadixSpecifiedIntegerLiterals:
+  module UnsupportedRadixSpecifiedIntegerLiterals:
+    output foo: UInt<8>
+    ; expected-error @below {{Radix-specified integer literals are a FIRRTL 2.4.0 feature, but the specified FIRRTL version was 2.3.9}}
+    foo <= UInt(0b101010)
+
+;// -----
+
+FIRRTL version 2.4.0
+circuit InvalidBinaryRadixSpecifiedIntegerLiteral:
+  module InvalidBinaryRadixSpecifiedIntegerLiteral:
+    output foo: UInt<8>
+    ; expected-error @below {{invalid character in integer literal}}
+    foo <= UInt(0b2)
+
+;// -----
+
+FIRRTL version 2.4.0
+circuit InvalidOctalRadixSpecifiedIntegerLiteral:
+  module InvalidOctalRadixSpecifiedIntegerLiteral:
+    output foo: UInt<8>
+    ; expected-error @below {{invalid character in integer literal}}
+    foo <= UInt(0o8)
+
+;// -----
+
+FIRRTL version 2.4.0
+circuit InvalidDecimalRadixSpecifiedIntegerLiteral:
+  module InvalidDecimalRadixSpecifiedIntegerLiteral:
+    output foo: UInt<8>
+    ; expected-error @below {{invalid character in integer literal}}
+    foo <= UInt(0da)
+
+;// -----
+
+FIRRTL version 2.4.0
+circuit InvalidHexadecimalRadixSpecifiedIntegerLiteral:
+  module InvalidHexadecimalRadixSpecifiedIntegerLiteral:
+    output foo: UInt<8>
+    ; expected-error @below {{invalid character in integer literal}}
+    foo <= UInt(0hg)
+
+;// -----
+
+FIRRTL version 3.0.0
+circuit UnsupportedStringEncodedIntegerLiterals:
+  module UnsupportedStringEncodedIntegerLiterals:
+    output foo: UInt<8>
+    ; expected-error @below {{String-encoded integer literals are unsupported after FIRRTL 3.0.0}}
+    connect foo, UInt("h2a")


### PR DESCRIPTION
Add parsing support for FIRRTL 3.0.0 radix-specified integer literals. These are a replacement for string-encoded integer literals.  E.g., the following is the new syntax:

    connect foo, UInt(0b101010)

And the following is the old syntax:

    connect foo, UInt("b101010")

Gate this parsing support on being in a circuit which is marked as being 3.0.0 or later.