### PR TITLE
[FIRRTL][InferWidths] Skip over property types

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -133,11 +133,13 @@ getInnerRefTo(FModuleLike mod, size_t portIdx, StringRef nameHint,
 // Type utilities
 //===----------------------------------------------------------------------===//
 
-/// If reftype, return wrapped base type.  Otherwise (if base), return as-is.
+/// If it is a base type, return it as is. If reftype, return wrapped base type.
+/// Otherwise, return null.
 inline FIRRTLBaseType getBaseType(FIRRTLType type) {
   return TypeSwitch<FIRRTLType, FIRRTLBaseType>(type)
       .Case<FIRRTLBaseType>([](auto base) { return base; })
-      .Case<RefType>([](auto ref) { return ref.getType(); });
+      .Case<RefType>([](auto ref) { return ref.getType(); })
+      .Default([](FIRRTLType type) { return nullptr; });
 }
 
 /// Return base type or passthrough if FIRRTLType, else null.

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1702,8 +1702,6 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
 /// Declare free variables for the type of a value, and associate the resulting
 /// set of variables with that value.
 void InferenceMapping::declareVars(Value value, Location loc, bool isDerived) {
-  auto ftype = value.getType().cast<FIRRTLType>();
-
   // Declare a variable for every unknown width in the type. If this is a Bundle
   // type or a FVector type, we will have to potentially create many variables.
   unsigned fieldID = 0;
@@ -1742,7 +1740,8 @@ void InferenceMapping::declareVars(Value value, Location loc, bool isDerived) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  declare(getBaseType(ftype));
+  if (auto type = getBaseType(value.getType().cast<FIRRTLType>()))
+    declare(type);
 }
 
 /// Assign the constraint expressions of the fields in the `result` argument as
@@ -1776,8 +1775,8 @@ void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  auto type = result.getType().cast<FIRRTLType>();
-  maximize(getBaseType(type));
+  if (auto type = getBaseType(result.getType().cast<FIRRTLType>()))
+    maximize(getBaseType(type));
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
@@ -1789,9 +1788,6 @@ void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
 void InferenceMapping::constrainTypes(Value larger, Value smaller) {
   // Recurse to every leaf element and set larger >= smaller. Ignore foreign
   // types as these do not participate in width inference.
-  auto type = larger.getType().dyn_cast<FIRRTLType>();
-  if (!type)
-    return;
 
   auto fieldID = 0;
   std::function<void(FIRRTLBaseType, Value, Value)> constrain =
@@ -1826,7 +1822,8 @@ void InferenceMapping::constrainTypes(Value larger, Value smaller) {
         }
       };
 
-  constrain(getBaseType(type), larger, smaller);
+  if (auto type = larger.getType().dyn_cast<FIRRTLType>())
+    constrain(getBaseType(type), larger, smaller);
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
@@ -1921,7 +1918,8 @@ void InferenceMapping::unifyTypes(FieldRef lhs, FieldRef rhs, FIRRTLType type) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  unify(getBaseType(type));
+  if (auto ftype = getBaseType(type))
+    unify(ftype);
 }
 
 /// Get the constraint expression for a value.

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -928,4 +928,8 @@ firrtl.circuit "Foo" {
     firrtl.attach %2, %c : !firrtl.const.analog, !firrtl.const.analog<3>
     firrtl.connect %3, %d : !firrtl.const.vector<uint, 2>, !firrtl.const.vector<uint<4>, 2>
   }
+  
+  // Should not crash when encountering property types.
+  // CHECK: firrtl.module @Property(in %a: !firrtl.string)
+  firrtl.module @Property(in %a: !firrtl.string) { }
 }


### PR DESCRIPTION
No property types have inferrable widths, so we need to teach InferWidths to gracefully ignore them. InferWidths assumes that every type is convertible to a base type by `getBaseType(FIRRTLType)`.  This function will now return null when the type is not convertible to a base type, which includes property types. Inferwidths now checks to see if the conversion to a base type was successful.