### PR TITLE
[FIRRTL][IMCP] Skip over non-base types

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -626,6 +626,11 @@ void circt::firrtl::walkGroundTypes(
     FIRRTLType firrtlType,
     llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn) {
   auto type = getBaseType(firrtlType);
+  
+  // If this is not a base type, return.
+  if (!type)
+    return;
+
   // If this is a ground type, don't call recursive functions.
   if (type.isGround())
     return fn(0, type);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -626,7 +626,7 @@ void circt::firrtl::walkGroundTypes(
     FIRRTLType firrtlType,
     llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn) {
   auto type = getBaseType(firrtlType);
-  
+
   // If this is not a base type, return.
   if (!type)
     return;

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -553,6 +553,17 @@ firrtl.circuit "SendThroughRWProbe" {
 
 // -----
 
+// Should not crash when there are properties.
+
+// CHECK-LABEL: firrtl.circuit "Properties"
+firrtl.circuit "Properties" {
+  firrtl.module @Properties(in %in : !firrtl.string, out %out : !firrtl.string) {
+    firrtl.propassign %out, %in : !firrtl.string
+  }
+}
+
+// -----
+
 // Verbatim expressions should not be optimized away.
 firrtl.circuit "Verbatim"  {
   firrtl.module @Verbatim() {


### PR DESCRIPTION
IMCP uses a helper `walkGroundTypes` to iterate over all the leaf elements of a FIRRTLType.  This change makes `walkGroundTypes` skip over property types.  In the future we will probably want to augment IMCP to perform constant propagation on property types.