### PR TITLE
[FIRRTL][CheckCombLoops] Support property types

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -493,7 +493,7 @@ bool FIRRTLType::isGround() {
       .Case<BundleType, FVectorType, FEnumType, OpenBundleType, OpenVectorType>(
           [](Type) { return false; })
       // Not ground per spec, but leaf of aggregate.
-      .Case<RefType>([](Type) { return false; })
+      .Case<PropertyType, RefType>([](Type) { return false; })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return false;

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -202,7 +202,7 @@ public:
                           return op->getResult(0);
                         return {};
                       });
-              if (childVal && childVal.getType().isa<FIRRTLBaseType>())
+              if (childVal && childVal.getType().isa<FIRRTLType>())
                 children.push_back(childVal);
             }
           }
@@ -248,12 +248,12 @@ public:
   void preprocess(SmallVector<Value> &worklist) {
     // All the input ports are added to the worklist.
     for (BlockArgument arg : module.getArguments()) {
-      auto argType = arg.getType();
+      auto argType = cast<FIRRTLType>(arg.getType());
       if (argType.isa<RefType>())
         continue;
       if (module.getPortDirection(arg.getArgNumber()) == Direction::In)
         worklist.push_back(arg);
-      if (!argType.cast<FIRRTLBaseType>().isGround())
+      if (!argType.isGround())
         setValRefsTo(arg, FieldRef(arg, 0));
     }
     DenseSet<Value> memPorts;
@@ -365,6 +365,8 @@ public:
         worklist.push_back(port);
         if (!type.isGround())
           setValRefsTo(port, FieldRef(port, 0));
+      } else if (auto type = port.getType().dyn_cast<PropertyType>()) {
+        worklist.push_back(port);
       }
     }
   }

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -584,3 +584,16 @@ firrtl.circuit "CycleThroughForceable"   {
     firrtl.strictconnect %w, %n : !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "Properties"   {
+  firrtl.module @Child(in %in: !firrtl.string, out %out: !firrtl.string) {
+    firrtl.propassign %out, %in : !firrtl.string
+  }
+  // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: Properties.{child0.in <- child0.out <- child0.in}}}
+  firrtl.module @Properties() {
+    %in, %out = firrtl.instance child0 @Child(in in: !firrtl.string, out out: !firrtl.string)
+    firrtl.propassign %in, %out : !firrtl.string
+  }
+}


### PR DESCRIPTION
This change adds support for property types to CheckCombLoops.  Right now property types show up as regular ports on instances and modules, and are assigned the through the PropAssignOp, which implements the ConnectLike interface. Module ports, instance ports, and connect like operations had to be updated to support FIRRTLTypes instead of just FIRRTLBaseTypes.