### PR TITLE
[FIRRTL] Add BigInt property type

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -43,7 +43,9 @@ class OpenVectorType;
 class FVectorType;
 class FEnumType;
 class RefType;
+class PropertyType;
 class StringType;
+class BigIntType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -155,7 +157,7 @@ public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
     return llvm::isa<FIRRTLDialect>(type.getDialect()) &&
-           !type.isa<RefType, OpenBundleType, OpenVectorType, StringType>();
+           !type.isa<PropertyType, RefType, OpenBundleType, OpenVectorType>();
   }
 
   /// Returns true if this is a non-const "passive" that which is not analog.
@@ -307,7 +309,9 @@ public:
 class PropertyType : public FIRRTLType {
 public:
   /// Support method to enable LLVM-style type casting.
-  static bool classof(Type type) { return llvm::isa<StringType>(type); }
+  static bool classof(Type type) {
+    return llvm::isa<StringType, BigIntType>(type);
+  }
 
 protected:
   using FIRRTLType::FIRRTLType;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -211,4 +211,8 @@ def StringType : FIRRTLDialectType<CPred<"$_self.isa<StringType>()">,
   "StringType", "::circt::firrtl::StringType">,
   BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;
 
+def BigIntType : FIRRTLDialectType<CPred<"$_self.isa<BigIntType>()">,
+  "BigIntType", "::circt::firrtl::BigIntType">,
+  BuildableType<"::circt::firrtl::BigIntType::get($_builder.getContext())">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -493,4 +493,12 @@ def StringImpl : FIRRTLImplType<"String", [], "circt::firrtl::FIRRTLType"> {
   let genStorageClass = true;
 }
 
+def BigIntImpl : FIRRTLImplType<"BigInt", [], "circt::firrtl::FIRRTLType"> {
+  let summary = [{
+    An unlimited length signed integer type.  Not representable in hardware.
+  }];
+  let parameters = (ins);
+  let genStorageClass = true;
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -250,4 +250,10 @@ firrtl.module @StringTest(in %in: !firrtl.string, out %out: !firrtl.string) {
   // CHECK: %0 = firrtl.string "hello"
   %0 = firrtl.string "hello"
 }
+
+// CHECK-LABEL: BigIntTest
+// CHECK-SAME:  (in %in: !firrtl.bigint, out %out: !firrtl.bigint)
+firrtl.module @BigIntTest(in %in: !firrtl.bigint, out %out: !firrtl.bigint) {
+  firrtl.propassign %out, %in : !firrtl.bigint
+}
 }


### PR DESCRIPTION
This adds a new type to the FIRRTL dialect, BigInt.  A BigInt is a signed integer of arbitrary length.