### PR TITLE
[Pipeline] Add verifiers and fix register materialization pass

### DIFF
--- a/include/circt/Dialect/Pipeline/Pipeline.h
+++ b/include/circt/Dialect/Pipeline/Pipeline.h
@@ -38,6 +38,23 @@
 namespace circt {
 namespace pipeline {
 class StageOp;
+class ScheduledPipelineOp;
+
+// Determines the stage which 'op' resides in within the pipeline. This is
+// useful for analysis of the pipeline, wherein ops may reside in nested
+// regions within different stages of the pipeline.
+Block *getParentStageInPipeline(ScheduledPipelineOp pipeline, Operation *op);
+
+// Determines the stage which 'block' resides in within the pipeline. This is
+// useful for analysis of the pipeline, wherein blocks may reside in nested
+// regions within different stages of the pipeline.
+Block *getParentStageInPipeline(ScheduledPipelineOp pipeline, Block *block);
+
+// Determines the stage which 'v' resides in within the pipeline. This is
+// useful for analysis of the pipeline, wherein values may reside in nested
+// regions within different stages of the pipeline.
+Block *getParentStageInPipeline(ScheduledPipelineOp pipeline, Value v);
+
 } // namespace pipeline
 } // namespace circt
 

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs)))' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs)))' --allow-unregistered-dialect %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testRegsOnly(
 // CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
@@ -92,7 +92,7 @@ hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK:             pipeline.stage ^bb2 regs(%[[VAL_11]] : i32) enable %[[VAL_7]]
 // CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
 // CHECK:             %[[VAL_13:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_14:.*]] = comb.sub %[[VAL_6]], %[[VAL_6]] : i32
+// CHECK:               %[[VAL_14:.*]] = comb.sub %[[VAL_12]], %[[VAL_12]] : i32
 // CHECK:               pipeline.latency.return %[[VAL_14]] : i32
 // CHECK:             }
 // CHECK:             pipeline.stage ^bb3 regs(%[[VAL_12]] : i32) pass(%[[VAL_15:.*]] : i32) enable %[[VAL_7]]
@@ -117,7 +117,7 @@ hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
     pipeline.stage ^bb2 enable %true
   ^bb2:
     %out2 = pipeline.latency 2 -> (i32) {
-      %r = comb.sub %a0, %a0 : i32
+      %r = comb.sub %out, %out : i32
       pipeline.latency.return %r : i32
     }
     pipeline.stage ^bb3 enable %true
@@ -126,6 +126,111 @@ hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
   ^bb4:
     %res = comb.add %out, %out2 : i32
     pipeline.return %out : i32
+  }
+  hw.output %out : i32
+}
+
+// CHECK-LABEL:   hw.module @testLatencyToLatency(
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = hw.constant true
+// CHECK:             %[[OUT1:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK:             }
+// CHECK:             pipeline.stage ^bb1 pass(%[[OUT1]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb1(%[[PASS1:.*]]: i32):
+// CHECK:             pipeline.stage ^bb2 pass(%[[PASS1]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb2(%[[PASS2:.*]]: i32):
+// CHECK:             %[[VAL_13:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_14:.*]] = hw.constant 1 : i32
+// CHECK:               %[[VAL_15:.*]] = comb.add %[[PASS2]], %[[VAL_14]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_15]] : i32
+// CHECK:             }
+// CHECK:             pipeline.stage ^bb3 pass(%[[VAL_16:.*]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb3(%[[VAL_17:.*]]: i32):
+// CHECK:             pipeline.stage ^bb4 pass(%[[VAL_17]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb4(%[[VAL_18:.*]]: i32):
+// CHECK:             pipeline.return %[[VAL_18]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_19:.*]] : i32
+// CHECK:         }
+hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
+  ^bb0(%arg0_0: i32):
+    %true = hw.constant true
+    %1 = pipeline.latency 2 -> (i32) {
+      %res = comb.add %arg0_0, %arg0_0 : i32
+      pipeline.latency.return %res : i32
+    }
+    pipeline.stage ^bb1 enable %true
+  ^bb1:
+    pipeline.stage ^bb2 enable %true
+
+  ^bb2:
+    %2 = pipeline.latency 2 -> (i32) {
+      %c1_i32 = hw.constant 1 : i32
+      %res2 = comb.add %1, %c1_i32 : i32
+      pipeline.latency.return %res2 : i32
+    }
+    pipeline.stage ^bb3 enable %true
+
+  ^bb3:
+    pipeline.stage ^bb4 enable %true
+
+  ^bb4:
+    pipeline.return %2 : i32
+  }
+  hw.output %0 : i32
+}
+
+// CHECK-LABEL:   hw.module @test_arbitrary_nesting(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_6]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb1(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = "foo.foo"(%[[VAL_8]]) : (i32) -> i32
+// CHECK:             "foo.bar"() ({
+// CHECK:               %[[VAL_10:.*]] = "foo.foo"(%[[VAL_8]]) : (i32) -> i32
+// CHECK:               "foo.baz"() ({
+// CHECK:               ^bb0(%[[VAL_11:.*]]: i32):
+// CHECK:                 "foo.foobar"(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (i32, i32, i32) -> ()
+// CHECK:                 "foo.foobar"(%[[VAL_8]]) : (i32) -> ()
+// CHECK:               }) : () -> ()
+// CHECK:             }) : () -> ()
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_8]] : i32) enable %[[VAL_7]]
+// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
+// CHECK:             pipeline.return %[[VAL_12]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_13:.*]] : i32
+// CHECK:         }
+hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
+  ^bb0(%a0 : i32):
+    %true = hw.constant true
+    pipeline.stage ^bb1 enable %true
+  ^bb1:
+    %foo = "foo.foo" (%a0) : (i32) -> (i32)
+    "foo.bar" () ({
+      ^bb0:
+      %foo2 = "foo.foo" (%a0) : (i32) -> (i32)
+      "foo.baz" () ({
+        ^bb0(%innerArg0 : i32):
+        // Reference all of the values defined above - none of these should
+        // be registered.
+        "foo.foobar" (%foo, %foo2, %innerArg0) : (i32, i32, i32) -> ()
+
+        // Reference %a0 - this should be registered.
+        "foo.foobar" (%a0) : (i32) -> ()
+      }) : () -> ()
+    }) : () -> ()
+
+    pipeline.stage ^bb2 enable %true
+  ^bb2:
+    pipeline.return %a0 : i32
   }
   hw.output %out : i32
 }

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -50,18 +50,79 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: 
 
 // -----
 
+hw.module @unterminated(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.scheduled' op all blocks must be terminated with a `pipeline.stage` or `pipeline.return` op.}}
+  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %c1_i1 = hw.constant true
+    %0 = comb.add %a0, %a1 : i32
+
+  ^bb1:
+    pipeline.stage ^bb2 regs(%0, %c1_i1 : i32, i1) enable %c1_i1
+
+  ^bb2(%s2_s0 : i32, %s2_valid : i1):
+    pipeline.return %s2_s0 : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
 hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
   %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
    ^bb0(%a0 : i32, %a1: i32):
     %c1_i1 = hw.constant true
     %0 = comb.add %a0, %a1 : i32
-  
+    pipeline.stage ^bb1 enable %c1_i1
+
+
   ^bb1:
   // expected-error @+1 {{'pipeline.stage' op Pipeline is in register materialized mode - operand 0 is defined in a different stage, which is illegal.}}
     pipeline.stage ^bb2 regs(%0, %c1_i1 : i32, i1) enable %c1_i1
-  
+
   ^bb2(%s2_s0 : i32, %s2_valid : i1):
     pipeline.return %s2_s0 : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
+  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %c1_i1 = hw.constant true
+    %0 = comb.add %a0, %a1 : i32
+    pipeline.stage ^bb1 enable %c1_i1
+
+  ^bb1:
+    pipeline.stage ^bb2 enable %c1_i1
+
+  ^bb2:
+    pipeline.stage ^bb1 enable %c1_i1
+
+  ^bb3:
+    pipeline.return %0 : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
+  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32):
+    %c1_i1 = hw.constant true
+    %0 = comb.add %a0, %a1 : i32
+    pipeline.stage ^bb1 enable %c1_i1
+
+  ^bb1:
+    pipeline.stage ^bb1 enable %c1_i1
+
+  ^bb3:
+    pipeline.return %0 : i32
   }
   hw.output %0 : i32
 }
@@ -81,6 +142,39 @@ hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (
   ^bb1:
     // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
     pipeline.return %1 : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+// Test which verifies that the values referenced within the body of a
+// latency operation also adhere to the latency constraints.
+hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
+  ^bb0(%arg0_0: i32):
+    %true = hw.constant true
+    // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
+    %1 = pipeline.latency 2 -> (i32) {
+      %res = comb.add %arg0_0, %arg0_0 : i32
+      pipeline.latency.return %res : i32
+    }
+    pipeline.stage ^bb1 enable %true
+
+  ^bb1:
+    %2 = pipeline.latency 2 -> (i32) {
+      %c1_i32 = hw.constant 1 : i32
+      // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
+      %res2 = comb.add %1, %c1_i32 : i32
+      pipeline.latency.return %res2 : i32
+    }
+    pipeline.stage ^bb2 enable %true
+
+  ^bb2:
+    pipeline.stage ^bb3 enable %true
+
+  ^bb3:
+    pipeline.return %2 : i32
   }
   hw.output %0 : i32
 }


### PR DESCRIPTION
Adds a bunch more verification to the `pipeline.scheduled` and `pipeline.latency` ops, as well as fixing the register materialization pass:
* The register materialization pass has now been modified to  accomodate arbitrarily nested operations within each stage, which is a superset of the support required for `pipeline.latency`, in case operations in the inner body of the `pipeline.latency` op references values defined outside of its stage.