### PR TITLE
[FIRRTL] Support const "source" in forces, insert refcast as needed.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -319,7 +319,7 @@ def ProbeOp : FIRRTLOp<"probe"> {
 class ForceRefTypeConstraint<string ref, string base>
   : TypesMatchWith<"reference type of " # ref # " should be RWProbe of " # base,
                    base, ref,
-                   "RefType::get($_self.cast<FIRRTLBaseType>(), true)">;
+                   "RefType::get($_self.cast<FIRRTLBaseType>().getAllConstDroppedType(), true)">;
 
 def RefForceOp : FIRRTLOp<"ref.force",[ForceRefTypeConstraint<"dest", "src">]> {
   let summary = "FIRRTL force statement";

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2815,10 +2815,10 @@ ParseResult FIRStmtParser::parseProbe(Value &result) {
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  // Check probe expression is not a reference-type value.
-  if (isa<RefType>(staticRef.getType()))
+  // Check probe expression is base-type.
+  if (!isa<FIRRTLBaseType>(staticRef.getType()))
     return emitError(startTok.getLoc(),
-                     "expected non-reference-type expression in 'probe', got ")
+                     "expected base-type expression in 'probe', got ")
            << staticRef.getType();
 
   // Check for other unsupported reference sources.
@@ -2848,11 +2848,11 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
   // Checks:
   // Not public port (verifier)
 
-  // Check probe expression is not a reference-type value.
-  if (isa<RefType>(staticRef.getType()))
+  // Check probe expression is base-type.
+  if (!isa<FIRRTLBaseType>(staticRef.getType()))
     return emitError(
                startTok.getLoc(),
-               "expected non-reference-type expression in 'rwprobe', got ")
+               "expected base-type expression in 'rwprobe', got ")
            << staticRef.getType();
 
   // Check for other unsupported reference sources.
@@ -2902,7 +2902,7 @@ ParseResult FIRStmtParser::parseRefForce() {
   auto srcBaseType = dyn_cast<FIRRTLBaseType>(src.getType());
   if (!srcBaseType)
     return emitError(startTok.getLoc(),
-                     "expected non-reference-type for force source, got ")
+                     "expected base-type for force source, got ")
            << src.getType();
 
   locationProcessor.setLoc(startTok.getLoc());
@@ -2942,7 +2942,7 @@ ParseResult FIRStmtParser::parseRefForceInitial() {
   auto srcBaseType = dyn_cast<FIRRTLBaseType>(src.getType());
   if (!srcBaseType)
     return emitError(startTok.getLoc(),
-                     "expected non-reference-type expression for force_initial "
+                     "expected base-type expression for force_initial "
                      "source, got ")
            << src.getType();
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2850,9 +2850,8 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
 
   // Check probe expression is base-type.
   if (!isa<FIRRTLBaseType>(staticRef.getType()))
-    return emitError(
-               startTok.getLoc(),
-               "expected base-type expression in 'rwprobe', got ")
+    return emitError(startTok.getLoc(),
+                     "expected base-type expression in 'rwprobe', got ")
            << staticRef.getType();
 
   // Check for other unsupported reference sources.

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1272,10 +1272,13 @@ circuit EnumTypes:
     inst rc of RefsChild
     rc.in <= in
 
-    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW]], %{{.+}} : !firrtl.uint<1>, !firrtl.uint<1>
-    force_initial(rc.rw, UInt<1>(0))
+    ; Check (const) literal works, even if uninferred width.
+    ; Cast reference to more general form as needed.
+    ; CHECK: %[[RC_RW_CAST:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint>
+    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW_CAST]], %{{.+}} : !firrtl.uint<1>, !firrtl.const.uint
+    force_initial(rc.rw, UInt(0))
 
-    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.const.uint<1>
     force(clock, cond, rc.rw, UInt<1>(1))
     ; CHECK: %[[NOT_COND:.+]] = firrtl.not %cond
     ; CHECK: firrtl.ref.release %clock, %[[NOT_COND]], %[[RC_RW]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -358,7 +358,7 @@ circuit ProbeBase:
     output out : UInt
 
     inst pg of ProbeGen
-    out <= probe(pg.p) ; expected-error {{expected non-reference-type expression in 'probe', got}}
+    out <= probe(pg.p) ; expected-error {{expected base-type expression in 'probe', got}}
 
 ;// -----
 


### PR DESCRIPTION
Better support literal and literal/const-derived sources to "force", and use ref.cast to accommodate supported differences.

This is not required by the current FIRRTL spec, but makes using it a bit easier.

Also this handles various const scenarios re:aggregates, current code seems primarily to get ground types/literals accepted.