### PR TITLE
[FIRRTL][InferWidths] Handle foreign and prop types uniformly

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -138,11 +138,11 @@ getInnerRefTo(FModuleLike mod, size_t portIdx, StringRef nameHint,
 
 /// If it is a base type, return it as is. If reftype, return wrapped base type.
 /// Otherwise, return null.
-inline FIRRTLBaseType getBaseType(FIRRTLType type) {
-  return TypeSwitch<FIRRTLType, FIRRTLBaseType>(type)
+inline FIRRTLBaseType getBaseType(Type type) {
+  return TypeSwitch<Type, FIRRTLBaseType>(type)
       .Case<FIRRTLBaseType>([](auto base) { return base; })
       .Case<RefType>([](auto ref) { return ref.getType(); })
-      .Default([](FIRRTLType type) { return nullptr; });
+      .Default([](Type type) { return nullptr; });
 }
 
 /// Return base type or passthrough if FIRRTLType, else null.

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1740,7 +1740,7 @@ void InferenceMapping::declareVars(Value value, Location loc, bool isDerived) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  if (auto type = getBaseType(value.getType().cast<FIRRTLType>()))
+  if (auto type = getBaseType(value.getType()))
     declare(type);
 }
 
@@ -1775,8 +1775,8 @@ void InferenceMapping::maximumOfTypes(Value result, Value rhs, Value lhs) {
       llvm_unreachable("Unknown type inside a bundle!");
     }
   };
-  if (auto type = getBaseType(result.getType().cast<FIRRTLType>()))
-    maximize(getBaseType(type));
+  if (auto type = getBaseType(result.getType()))
+    maximize(type);
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater
@@ -1822,8 +1822,8 @@ void InferenceMapping::constrainTypes(Value larger, Value smaller) {
         }
       };
 
-  if (auto type = larger.getType().dyn_cast<FIRRTLType>())
-    constrain(getBaseType(type), larger, smaller);
+  if (auto type = getBaseType(larger.getType()))
+    constrain(type, larger, smaller);
 }
 
 /// Establishes constraints to ensure the sizes in the `larger` type are greater


### PR DESCRIPTION
This changes InferWidths to use a common pattern to filter out foreign and property types.  The `getBaseType(FIRRTLType)` function now takes a `Type` and returns null if it is not a `FIRRTLType`.  `declVars` and all three constrain functions now use `getBaseType` and a null-check to skip over foreign and property types.  This changes the behavior of `maximumOfTypes` and `unifyTypes`, but this is not a testable code path.