### PR TITLE
[FIRRTL] Remove `getBaseTypeOrNull`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -145,18 +145,10 @@ inline FIRRTLBaseType getBaseType(Type type) {
       .Default([](Type type) { return nullptr; });
 }
 
-/// Return base type or passthrough if FIRRTLType, else null.
-inline FIRRTLBaseType getBaseTypeOrNull(Type type) {
-  auto ftype = dyn_cast_or_null<FIRRTLType>(type);
-  if (!ftype)
-    return {};
-  return getBaseType(ftype);
-}
-
 /// Get base type if isa<> the requested type, else null.
 template <typename T>
 inline T getBaseOfType(Type type) {
-  return dyn_cast_or_null<T>(getBaseTypeOrNull(type));
+  return dyn_cast_or_null<T>(getBaseType(type));
 }
 
 /// Return a FIRRTLType with its base type component mutated by the given


### PR DESCRIPTION
Now that `getBaseType` handles all types, there is no need for `getBaseTypeOrNull`.