### PR TITLE
[FIRRTL] Initial pass to extract OM classes from FIRRTL modules.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -164,6 +164,8 @@ std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
 
 std::unique_ptr<mlir::Pass> createFinalizeIRPass();
 
+std::unique_ptr<mlir::Pass> createExtractClassesPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -716,4 +716,18 @@ def FinalizeIR : Pass<"firrtl-finalize-ir", "mlir::ModuleOp"> {
   let dependentDialects = ["hw::HWDialect", "sv::SVDialect"];
 }
 
+def ExtractClasses : Pass<"firrtl-extract-classes", "mlir::ModuleOp"> {
+  let summary = "Extract OM classes from FIRRTL modules with properties";
+  let description = [{
+    This pass walks all FIRRTL modules and creates OM classes from their non-RTL
+    properties. OM classes are created with parameters corresponding to FIRRTL
+    input properties, and OM class fields corresponding to FIRRTL output
+    properties. FIRRTL operations are not converted to OM operations. A final
+    conversion pass is required, which can operate on the extracted OM classes
+    in parallel.
+  }];
+  let constructor = "circt::firrtl::createExtractClassesPass()";
+  let dependentDialects = ["om::OMDialect"];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   DropName.cpp
   EmitOMIR.cpp
   ExpandWhens.cpp
+  ExtractClasses.cpp
   ExtractInstances.cpp
   FlattenMemory.cpp
   FinalizeIR.cpp
@@ -47,6 +48,8 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
 
   DEPENDS
   CIRCTFIRRTLTransformsIncGen
+  MLIROMIncGen
+  MLIROMAttrIncGen
 
   LINK_LIBS PUBLIC
   CIRCTFIRRTL

--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -1,0 +1,146 @@
+//===- ExtractClasses.cpp - Extract OM classes ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ExtractClasses pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/Support/Parallel.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace circt::firrtl;
+using namespace circt::om;
+
+namespace {
+struct ExtractClassesPass : public ExtractClassesBase<ExtractClassesPass> {
+  void runOnOperation() override;
+
+private:
+  void extractClass(FModuleOp moduleOp);
+};
+} // namespace
+
+/// Helper class to capture details about a property.
+struct Property {
+  size_t index;
+  StringRef name;
+  Type type;
+  Location loc;
+};
+
+/// Potentiall extract an OM class from a FIRRTL module which may contain
+/// properties.
+void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
+  // Map from Values in the FModuleOp to Values in the ClassOp.
+  IRMapping mapping;
+
+  // Remember ports and operations to clean up when done.
+  llvm::BitVector portsToErase(moduleOp.getNumPorts());
+  SmallVector<Operation *> opsToErase;
+
+  // Collect information about input and output properties. Mark property ports
+  // to be erased.
+  SmallVector<Property> inputProperties;
+  SmallVector<Property> outputProperties;
+  for (auto [index, port] : llvm::enumerate(moduleOp.getPorts())) {
+    if (!isa<PropertyType>(port.type))
+      continue;
+
+    portsToErase.set(index);
+
+    if (port.isInput())
+      inputProperties.push_back({index, port.name, port.type, port.loc});
+
+    if (port.isOutput())
+      outputProperties.push_back({index, port.name, port.type, port.loc});
+  }
+
+  // If the FModuleOp has no properties, nothing to do.
+  if (inputProperties.empty() && outputProperties.empty())
+    return;
+
+  OpBuilder builder = OpBuilder::atBlockEnd(getOperation().getBody(0));
+
+  // Collect the parameter names from input properties.
+  SmallVector<StringRef> formalParamNames;
+  for (auto inputProperty : inputProperties)
+    formalParamNames.push_back(inputProperty.name);
+
+  // Construct the ClassOp with the FModuleOp name and parameter names.
+  auto classOp = builder.create<ClassOp>(moduleOp.getLoc(), moduleOp.getName(),
+                                         formalParamNames);
+
+  // Construct the ClassOp body with block arguments for each input property,
+  // updating the mapping to map from the input property to the block argument.
+  Block *classBody = &classOp.getRegion().emplaceBlock();
+  for (auto inputProperty : inputProperties) {
+    BlockArgument parameterValue =
+        classBody->addArgument(inputProperty.type, inputProperty.loc);
+    BlockArgument inputValue = moduleOp.getArgument(inputProperty.index);
+    mapping.map(inputValue, parameterValue);
+  }
+
+  // Construct ClassFieldOps for each output property.
+  builder.setInsertionPointToStart(classBody);
+  for (auto outputProperty : outputProperties) {
+    // Get the Value driven to the property to use for this ClassFieldOp.
+    auto outputValue =
+        cast<FIRRTLPropertyValue>(moduleOp.getArgument(outputProperty.index));
+    Value originalValue = getDriverFromConnect(outputValue);
+
+    // Mark the property assign to be erased.
+    opsToErase.push_back(getPropertyAssignment(outputValue));
+
+    // If the Value is defined by an Operation, copy that into the body, and
+    // map from the old Value to the new Value. This may need to walk property
+    // ops in order to copy them into the ClassOp, but for now only constant
+    // ops exist. Mark the property op to be erased.
+    if (auto *op = originalValue.getDefiningOp()) {
+      builder.clone(*op, mapping);
+      opsToErase.push_back(op);
+    }
+
+    // Create the ClassFieldOp using the mapping to find the appropriate Value.
+    Value fieldValue = mapping.lookup(originalValue);
+    builder.create<ClassFieldOp>(originalValue.getLoc(), outputProperty.name,
+                                 fieldValue);
+  }
+
+  // Clean up the FModuleOp by removing property ports and operations. This
+  // first erases opsToErase in the order they were added, so property
+  // assignments are erased before value defining ops. Then it erases ports.
+  for (auto *op : opsToErase)
+    op->erase();
+  moduleOp.erasePorts(portsToErase);
+}
+
+/// Extract OM classes from FIRRTL modules with properties.
+void ExtractClassesPass::runOnOperation() {
+  // Get the CircuitOp.
+  auto circuits = getOperation().getOps<CircuitOp>();
+  if (circuits.empty())
+    return;
+  CircuitOp circuit = *circuits.begin();
+
+  // Walk all FModuleOps to potentially extract an OM class if the FModuleOp
+  // contains properties.
+  for (auto moduleOp : circuit.getOps<FModuleOp>())
+    extractClass(moduleOp);
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createExtractClassesPass() {
+  return std::make_unique<ExtractClassesPass>();
+}

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt -firrtl-extract-classes %s | FileCheck %s
+
+firrtl.circuit "Top" {
+  firrtl.module @Top() {}
+
+  // CHECK-LABEL: firrtl.module @SomeProperties
+  // CHECK-SAME: (in %in1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>)
+  // CHECK-NOT: firrtl.propassign
+  firrtl.module @SomeProperties(
+      in %in0: !firrtl.string,
+      in %in1: !firrtl.uint<1>,
+      out %out0: !firrtl.string,
+      out %out1: !firrtl.string,
+      out %out2: !firrtl.uint<1>) {
+    %0 = firrtl.string "hello"
+    firrtl.propassign %out0, %0 : !firrtl.string
+    firrtl.propassign %out1, %in0 : !firrtl.string
+    firrtl.connect %out2, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+// CHECK-LABEL: om.class @SomeProperties
+// CHECK-SAME: (%[[P0:.+]]: !firrtl.string)
+// CHECK: %[[S0:.+]] = firrtl.string "hello"
+// CHECK: om.class.field @out0, %[[S0]] : !firrtl.string
+// CHECK: om.class.field @out1, %[[P0]] : !firrtl.string

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -4,18 +4,20 @@ firrtl.circuit "Top" {
   firrtl.module @Top() {}
 
   // CHECK-LABEL: firrtl.module @SomeProperties
-  // CHECK-SAME: (in %in1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>)
+  // CHECK-SAME: (in %in1: !firrtl.uint<1>, out %out3: !firrtl.uint<1>)
   // CHECK-NOT: firrtl.propassign
   firrtl.module @SomeProperties(
       in %in0: !firrtl.string,
       in %in1: !firrtl.uint<1>,
       out %out0: !firrtl.string,
       out %out1: !firrtl.string,
-      out %out2: !firrtl.uint<1>) {
+      out %out2: !firrtl.string,
+      out %out3: !firrtl.uint<1>) {
     %0 = firrtl.string "hello"
     firrtl.propassign %out0, %0 : !firrtl.string
-    firrtl.propassign %out1, %in0 : !firrtl.string
-    firrtl.connect %out2, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.propassign %out1, %0 : !firrtl.string
+    firrtl.propassign %out2, %in0 : !firrtl.string
+    firrtl.connect %out3, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -23,4 +25,5 @@ firrtl.circuit "Top" {
 // CHECK-SAME: (%[[P0:.+]]: !firrtl.string)
 // CHECK: %[[S0:.+]] = firrtl.string "hello"
 // CHECK: om.class.field @out0, %[[S0]] : !firrtl.string
-// CHECK: om.class.field @out1, %[[P0]] : !firrtl.string
+// CHECK: om.class.field @out1, %[[S0]] : !firrtl.string
+// CHECK: om.class.field @out2, %[[P0]] : !firrtl.string


### PR DESCRIPTION
Modules with input or output properties are converted to OM classes. The input properties become parameters, and the output properties become fields. The ops directly connected to output properties are moved over. As needed, this can be extended to move over whole dataflow slices, or adapted to work with ops besides connects.

The property ports and operations are removed from the FIRRTL modules, so after this pass runs, the modules only contain RTL.

This only handles the simplest cases: output properties driven from input properties and constants. Handling instances of property-containing modules will come in a future addition. This includes fixing up instantiations of mutated modules to match their declaration.

The OM type system is open, so this produces legal IR, but not IR that is usable with the Evaluator. A future addition will include a pass to convert to the operations, attributes, and types the OM dialect expects to work with in the Evaluator.