### PR TITLE
[FIRRTL] Clean up instances in ExtractClasses.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/OM/OMOps.h"
@@ -30,6 +31,10 @@ struct ExtractClassesPass : public ExtractClassesBase<ExtractClassesPass> {
 
 private:
   void extractClass(FModuleOp moduleOp);
+  void updateInstances(FModuleOp moduleOp);
+
+  InstanceGraph *instanceGraph;
+  DenseMap<Operation *, llvm::BitVector> portsToErase;
 };
 } // namespace
 
@@ -48,7 +53,7 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
   IRMapping mapping;
 
   // Remember ports and operations to clean up when done.
-  llvm::BitVector portsToErase(moduleOp.getNumPorts());
+  portsToErase[moduleOp] = llvm::BitVector(moduleOp.getNumPorts());
   SmallVector<Operation *> opsToErase;
 
   // Collect information about input and output properties. Mark property ports
@@ -59,7 +64,7 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
     if (!isa<PropertyType>(port.type))
       continue;
 
-    portsToErase.set(index);
+    portsToErase[moduleOp].set(index);
 
     if (port.isInput())
       inputProperties.push_back({index, port.name, port.type, port.loc});
@@ -108,7 +113,11 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
     if (!mapping.contains(originalValue)) {
       if (auto *op = originalValue.getDefiningOp()) {
         builder.clone(*op, mapping);
-        opsToErase.push_back(op);
+
+        // InstanceOps are handled specially for now, but any other property
+        // defining ops should be erased after being copied over.
+        if (!isa<InstanceOp>(op))
+          opsToErase.push_back(op);
       }
     }
 
@@ -126,7 +135,53 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
   // assignments are erased before value defining ops. Then it erases ports.
   for (auto *op : opsToErase)
     op->erase();
-  moduleOp.erasePorts(portsToErase);
+  moduleOp.erasePorts(portsToErase[moduleOp]);
+}
+
+/// Clean up InstanceOps of any FModuleOps with properties.
+void ExtractClassesPass::updateInstances(FModuleOp moduleOp) {
+  OpBuilder builder(&getContext());
+  llvm::BitVector modulePortsToErase = portsToErase[moduleOp];
+  InstanceGraphNode *instanceGraphNode = instanceGraph->lookup(moduleOp);
+
+  // If there are no ports to erase, nothing to do.
+  if (!modulePortsToErase.empty() && !modulePortsToErase.any())
+    return;
+
+  // Clean up instances of the FModuleOp.
+  for (InstanceRecord *node : instanceGraphNode->uses()) {
+    // Get the original InstanceOp.
+    InstanceOp oldInstance = cast<InstanceOp>(node->getInstance());
+    builder.setInsertionPointAfter(oldInstance);
+
+    // If some but not all ports are properties, create a new instance without
+    // the property pins.
+    if (!modulePortsToErase.all()) {
+      InstanceOp newInstance =
+          oldInstance.erasePorts(builder, portsToErase[moduleOp]);
+      instanceGraph->replaceInstance(oldInstance, newInstance);
+    }
+
+    // Clean up uses of property pins. This amounts to erasing property
+    // assignments for now.
+    for (int propertyIndex : modulePortsToErase.set_bits()) {
+      for (Operation *user : oldInstance.getResult(propertyIndex).getUsers()) {
+        assert(isa<FConnectLike>(user) &&
+               "expected property pins to be used in property assignments");
+        user->erase();
+      }
+    }
+
+    // Erase the original instance.
+    oldInstance.erase();
+    node->erase();
+  }
+
+  // If all ports are properties, remove the FModuleOp completely.
+  if (!modulePortsToErase.empty() && modulePortsToErase.all()) {
+    moduleOp.erase();
+    instanceGraph->erase(instanceGraphNode);
+  }
 }
 
 /// Extract OM classes from FIRRTL modules with properties.
@@ -137,10 +192,25 @@ void ExtractClassesPass::runOnOperation() {
     return;
   CircuitOp circuit = *circuits.begin();
 
+  // Get the FIRRTL instance graph.
+  instanceGraph = &getAnalysis<InstanceGraph>();
+
   // Walk all FModuleOps to potentially extract an OM class if the FModuleOp
   // contains properties.
-  for (auto moduleOp : circuit.getOps<FModuleOp>())
+  for (auto moduleOp : llvm::make_early_inc_range(circuit.getOps<FModuleOp>()))
     extractClass(moduleOp);
+
+  // Clean up InstanceOps of any FModuleOps with properties. This is done after
+  // the classes are extracted to avoid extra bookeeping as InstanceOps are
+  // cleaned up.
+  for (auto moduleOp : llvm::make_early_inc_range(circuit.getOps<FModuleOp>()))
+    updateInstances(moduleOp);
+
+  // Mark analyses preserved, since we keep the instance graph up to date.
+  markAllAnalysesPreserved();
+
+  // Reset pass state.
+  instanceGraph = nullptr;
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createExtractClassesPass() {

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -1,7 +1,36 @@
 // RUN: circt-opt -firrtl-extract-classes %s | FileCheck %s
 
 firrtl.circuit "Top" {
-  firrtl.module @Top() {}
+  // CHECK-LABEL: firrtl.module @Top
+  firrtl.module @Top() {
+    // CHECK-NOT: firrtl.instance all
+    %all_in0, %all_out0 = firrtl.instance all @AllProperties(
+      in in0: !firrtl.string,
+      out out0: !firrtl.string)
+
+    // CHECK: %{{.+}}, %{{.+}} = firrtl.instance some
+    %some_in0, %some_in1, %some_out0, %some_out1, %some_out2 = firrtl.instance some @SomeProperties(
+      in in0: !firrtl.string,
+      in in1: !firrtl.uint<1>,
+      out out0: !firrtl.string,
+      out out1: !firrtl.string,
+      out out2: !firrtl.uint<1>)
+
+    // CHECK: %{{.+}}, %{{.+}} = firrtl.instance no
+    %no_in0, %no_out0 = firrtl.instance no @NoProperties(
+      in in0: !firrtl.uint<1>,
+      out out0: !firrtl.uint<1>)
+
+    // CHECK-NOT: firrtl.propassign
+    firrtl.propassign %some_in0, %all_out0 : !firrtl.string
+  }
+
+  // CHECK-NOT: @AllProperties
+  firrtl.module @AllProperties(
+      in %in0: !firrtl.string,
+      out %out0: !firrtl.string) {
+    firrtl.propassign %out0, %in0 : !firrtl.string
+  }
 
   // CHECK-LABEL: firrtl.module @SomeProperties
   // CHECK-SAME: (in %in1: !firrtl.uint<1>, out %out3: !firrtl.uint<1>)
@@ -19,7 +48,20 @@ firrtl.circuit "Top" {
     firrtl.propassign %out2, %in0 : !firrtl.string
     firrtl.connect %out3, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
+
+  // CHECK-LABEL: firrtl.module @NoProperties
+  // CHECK-SAME: (in %in0: !firrtl.uint<1>, out %out0: !firrtl.uint<1>)
+  // CHECK: firrtl.connect
+  firrtl.module @NoProperties(
+      in %in0: !firrtl.uint<1>,
+      out %out0: !firrtl.uint<1>) {
+    firrtl.connect %out0, %in0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
 }
+
+// CHECK-LABEL: om.class @AllProperties
+// CHECK-SAME: (%[[P0:.+]]: !firrtl.string)
+// CHECK: om.class.field @out0, %[[P0]] : !firrtl.string
 
 // CHECK-LABEL: om.class @SomeProperties
 // CHECK-SAME: (%[[P0:.+]]: !firrtl.string)

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -8,13 +8,14 @@ firrtl.circuit "Top" {
       in in0: !firrtl.string,
       out out0: !firrtl.string)
 
-    // CHECK: %some_in1, %some_out2 = firrtl.instance some
-    %some_in0, %some_in1, %some_out0, %some_out1, %some_out2 = firrtl.instance some @SomeProperties(
+    // CHECK: %some_in1, %some_out3 = firrtl.instance some
+    %some_in0, %some_in1, %some_out0, %some_out1, %some_out2, %some_out3 = firrtl.instance some @SomeProperties(
       in in0: !firrtl.string,
       in in1: !firrtl.uint<1>,
       out out0: !firrtl.string,
       out out1: !firrtl.string,
-      out out2: !firrtl.uint<1>)
+      out out2: !firrtl.string,
+      out out3: !firrtl.uint<1>)
 
     // CHECK: %no_in0, %no_out0 = firrtl.instance no
     %no_in0, %no_out0 = firrtl.instance no @NoProperties(

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -8,7 +8,7 @@ firrtl.circuit "Top" {
       in in0: !firrtl.string,
       out out0: !firrtl.string)
 
-    // CHECK: %{{.+}}, %{{.+}} = firrtl.instance some
+    // CHECK: %some_in1, %some_out2 = firrtl.instance some
     %some_in0, %some_in1, %some_out0, %some_out1, %some_out2 = firrtl.instance some @SomeProperties(
       in in0: !firrtl.string,
       in in1: !firrtl.uint<1>,
@@ -16,7 +16,7 @@ firrtl.circuit "Top" {
       out out1: !firrtl.string,
       out out2: !firrtl.uint<1>)
 
-    // CHECK: %{{.+}}, %{{.+}} = firrtl.instance no
+    // CHECK: %no_in0, %no_out0 = firrtl.instance no
     %no_in0, %no_out0 = firrtl.instance no @NoProperties(
       in in0: !firrtl.uint<1>,
       out out0: !firrtl.uint<1>)


### PR DESCRIPTION
After classes are extracted from FIRRTL modules, the property ports of the module are removed. This patch extends the pass to also update instances of mutated modules, so their instantiations remain correct. It also removes modules that only existed for properties.