### PR TITLE
[FIRRTL] Support instances of property modules in ExtractClasses.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -30,11 +30,19 @@ struct ExtractClassesPass : public ExtractClassesBase<ExtractClassesPass> {
   void runOnOperation() override;
 
 private:
+  Value getOrCreateObjectValue(OpResult instanceOutput, InstanceOp instance,
+                               OpBuilder &builder, IRMapping &mapping,
+                               SmallVectorImpl<Operation *> &opsToErase);
+  ObjectOp getOrCreateObject(InstanceOp instance, OpBuilder &builder,
+                             IRMapping &mapping,
+                             SmallVectorImpl<Operation *> &opsToErase);
   void extractClass(FModuleOp moduleOp);
   void updateInstances(FModuleOp moduleOp);
 
   InstanceGraph *instanceGraph;
   DenseMap<Operation *, llvm::BitVector> portsToErase;
+  DenseMap<OpResult, Value> cachedObjectValues;
+  DenseMap<InstanceOp, ObjectOp> cachedObjects;
 };
 } // namespace
 
@@ -45,6 +53,111 @@ struct Property {
   Type type;
   Location loc;
 };
+
+/// Helper to get or create a Value from an ObjectFieldOp. This consults a cache
+/// to avoid re-creating ObjectFieldOps. An ObjectOp is looked up or created,
+/// and the field corresponding to the instance output is accessed. Note that
+/// this is able to work locally with just the instance and the OpResult, and
+/// the rest of the pass ensures the correct ClassOp is created.
+Value ExtractClassesPass::getOrCreateObjectValue(
+    OpResult instanceOutput, InstanceOp instance, OpBuilder &builder,
+    IRMapping &mapping, SmallVectorImpl<Operation *> &opsToErase) {
+  // Check if this ObjectField has already been created, and return it if so.
+  auto cachedObjectValue = cachedObjectValues.find(instanceOutput);
+  if (cachedObjectValue != cachedObjectValues.end())
+    return cachedObjectValue->getSecond();
+
+  // Get the result number for the InstanceOp output.
+  unsigned resultNum = instanceOutput.getResultNumber();
+
+  // Get the field type.
+  Type fieldType = instance.getResult(resultNum).getType();
+
+  // Get the ObjectOp to extract a field from.
+  ObjectOp object = getOrCreateObject(instance, builder, mapping, opsToErase);
+
+  // Get the field path.
+  StringAttr resultName = instance.getPortName(resultNum);
+  ArrayAttr fieldPath =
+      builder.getArrayAttr(FlatSymbolRefAttr::get(resultName));
+
+  // Construct the ObjectFieldOp.
+  auto fieldValue = builder.create<ObjectFieldOp>(instance.getLoc(), fieldType,
+                                                  object, fieldPath);
+
+  // Cache it for potential future lookups.
+  cachedObjectValues[instanceOutput] = fieldValue;
+
+  return fieldValue;
+}
+
+/// Helper to get or create an ObjectOp. This consults a cache to avoid
+/// re-creating ObjectOps. The actual parameters are computed by finding the
+/// assignments to the InstanceOp's inputs. The property ops involved are
+/// cloned, mapped, and marked for erasure as appropriate. The ObjectOp is then
+/// created with the appropriate type, class name, and the actual parameters.
+/// Note that this is able to work locally with just the instance, and the rest
+/// of the pass ensures the correct ClassOp is created.
+ObjectOp ExtractClassesPass::getOrCreateObject(
+    InstanceOp instance, OpBuilder &builder, IRMapping &mapping,
+    SmallVectorImpl<Operation *> &opsToErase) {
+  // Check if this ObjectOp has already been created, and return it if so.
+  auto cachedObject = cachedObjects.find(instance);
+  if (cachedObject != cachedObjects.end())
+    return cachedObject->getSecond();
+
+  // Build up the ObjectOp's actual parameters.
+  SmallVector<Value> actualParams;
+  for (size_t i = 0; i < instance.getNumResults(); ++i) {
+    // Skip outputs and non-Property inputs.
+    if (instance.getPortDirection(i) == Direction::Out)
+      continue;
+    auto result = dyn_cast<FIRRTLPropertyValue>(instance.getResult(i));
+    if (!result)
+      continue;
+
+    // Get the assignment to the input property.
+    PropAssignOp propassign = getPropertyAssignment(result);
+
+    // The source value will be mapped into the actual parameter.
+    Value inputValue = propassign.getSrc();
+
+    // If the Value is defined by an Operation that has already been processed,
+    // there is nothing to do.
+    if (!mapping.contains(inputValue)) {
+      // If the property was assigned from a property op, copy that over to the
+      // ClassOp as well. This may need to walk property ops, but for now only
+      // constant ops exist. Mark the defining op to be erased.
+      if (auto *definingOp = inputValue.getDefiningOp()) {
+        builder.clone(*definingOp, mapping);
+        opsToErase.push_back(definingOp);
+      }
+    }
+
+    // Lookup the mapping for the input value, and use this as an actual
+    // parameter.
+    actualParams.push_back(mapping.lookup(inputValue));
+
+    // Eagerly erase the property assign, since it is done now.
+    propassign.erase();
+  }
+
+  // Get the Object type.
+  auto objectType =
+      ClassType::get(instance.getContext(), instance.getModuleNameAttr());
+
+  // Get the Object's class name.
+  auto objectClass = instance.getModuleNameAttr().getAttr();
+
+  // Construct the ObjectOp.
+  auto object = builder.create<ObjectOp>(instance.getLoc(), objectType,
+                                         objectClass, actualParams);
+
+  // Cache it for potential future lookups.
+  cachedObjects[instance] = object;
+
+  return object;
+}
 
 /// Potentially extract an OM class from a FIRRTL module which may contain
 /// properties.
@@ -106,18 +219,30 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
         cast<FIRRTLPropertyValue>(moduleOp.getArgument(outputProperty.index));
     Value originalValue = getDriverFromConnect(outputValue);
 
-    // If the Value is defined by an Operation that hasn't been copied yet, copy
-    // that into the body, and map from the old Value to the new Value. This may
-    // need to walk property ops in order to copy them into the ClassOp, but for
-    // now only constant ops exist. Mark the property op to be erased.
+    // If the Value is defined by an Operation that has already been processed,
+    // there is nothing to do.
     if (!mapping.contains(originalValue)) {
       if (auto *op = originalValue.getDefiningOp()) {
-        builder.clone(*op, mapping);
+        // InstanceOps are handled specially, by creating ObjectOps and
+        // extracting an ObjectFieldOp. This will take care of re-using
+        // ObjectOps and ObjectFieldOps, updating the mapping, and keeping
+        // track of related ops that can be erased. The original value is
+        // mapped to the ObjectFieldOp.
+        if (auto instance = dyn_cast<InstanceOp>(op)) {
+          Value fieldValue =
+              getOrCreateObjectValue(cast<OpResult>(originalValue), instance,
+                                     builder, mapping, opsToErase);
+          mapping.map(originalValue, fieldValue);
+        } else {
+          // For all other ops, copy the defining op into the body, and
+          // map from the old Value to the new Value. This may need to walk
+          // property ops in order to copy them into the ClassOp, but for now
+          // only constant ops exist. Mark the property op to be erased.
+          builder.clone(*op, mapping);
 
-        // InstanceOps are handled specially for now, but any other property
-        // defining ops should be erased after being copied over.
-        if (!isa<InstanceOp>(op))
+          // Property defining ops should be erased after being copied over.
           opsToErase.push_back(op);
+        }
       }
     }
 

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -58,6 +58,55 @@ firrtl.circuit "Top" {
       out %out0: !firrtl.uint<1>) {
     firrtl.connect %out0, %in0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
+
+  // CHECK-LABEL: firrtl.module @NestedProperties
+  firrtl.module @NestedProperties(
+      in %in0: !firrtl.string,
+      in %in1: !firrtl.uint<1>,
+      out %out0: !firrtl.string,
+      out %out1: !firrtl.string,
+      out %out2: !firrtl.string,
+      out %out3: !firrtl.string,
+      out %out4: !firrtl.uint<1>) {
+    // CHECK-NOT: firrtl.instance all0
+    %all0_in0, %all0_out0 = firrtl.instance all0 @AllProperties(
+      in in0: !firrtl.string,
+      out out0: !firrtl.string)
+
+    // CHECK-NOT: firrtl.instance all1
+    %all1_in0, %all1_out0 = firrtl.instance all1 @AllProperties(
+      in in0: !firrtl.string,
+      out out0: !firrtl.string)
+
+    // CHECK: %some0_in1, %some0_out3 = firrtl.instance some0
+    %some0_in0, %some0_in1, %some0_out0, %some0_out1, %some0_out2, %some0_out3 = firrtl.instance some0 @SomeProperties(
+      in in0: !firrtl.string,
+      in in1: !firrtl.uint<1>,
+      out out0: !firrtl.string,
+      out out1: !firrtl.string,
+      out out2: !firrtl.string,
+      out out3: !firrtl.uint<1>)
+
+    // CHECK: %no0_in0, %no0_out0 = firrtl.instance no0
+    %no0_in0, %no0_out0 = firrtl.instance no0 @NoProperties(
+      in in0: !firrtl.uint<1>,
+      out out0: !firrtl.uint<1>)
+
+    // CHECK-NOT: firrtl.string
+    // CHECK-NOT: firrtl.propassign
+    // CHECK-COUNT-3: firrtl.connect
+    %0 = firrtl.string "hello"
+    firrtl.propassign %all0_in0, %0 : !firrtl.string
+    firrtl.propassign %all1_in0, %0 : !firrtl.string
+    firrtl.propassign %some0_in0, %in0 : !firrtl.string
+    firrtl.connect %some0_in1, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %no0_in0, %some0_out3 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.propassign %out0, %all0_out0 : !firrtl.string
+    firrtl.propassign %out1, %all0_out0 : !firrtl.string
+    firrtl.propassign %out2, %all1_out0 : !firrtl.string
+    firrtl.propassign %out3, %some0_out0 : !firrtl.string
+    firrtl.connect %out4, %no0_out0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
 }
 
 // CHECK-LABEL: om.class @AllProperties
@@ -70,3 +119,17 @@ firrtl.circuit "Top" {
 // CHECK: om.class.field @out0, %[[S0]] : !firrtl.string
 // CHECK: om.class.field @out1, %[[S0]] : !firrtl.string
 // CHECK: om.class.field @out2, %[[P0]] : !firrtl.string
+
+// CHECK-LABEL: om.class @NestedProperties
+// CHECK-SAME: (%[[P0:.+]]: !firrtl.string)
+// CHECK: %[[S0:.+]] = firrtl.string "hello"
+// CHECK: %[[O0:.+]] = om.object @AllProperties(%[[S0]])
+// CHECK: %[[F0:.+]] = om.object.field %[[O0]], [@out0]
+// CHECK: om.class.field @out0, %[[F0]]
+// CHECK: om.class.field @out1, %[[F0]]
+// CHECK: %[[O1:.+]] = om.object @AllProperties(%[[S0]])
+// CHECK: %[[F1:.+]] = om.object.field %[[O1]], [@out0]
+// CHECK: om.class.field @out2, %[[F1]]
+// CHECK: %[[O2:.+]] = om.object @SomeProperties(%[[P0]])
+// CHECK: %[[F2:.+]] = om.object.field %[[O2]], [@out0]
+// CHECK: om.class.field @out3, %[[F2]]

--- a/test/Dialect/FIRRTL/extract-classes.mlir
+++ b/test/Dialect/FIRRTL/extract-classes.mlir
@@ -78,6 +78,11 @@ firrtl.circuit "Top" {
       in in0: !firrtl.string,
       out out0: !firrtl.string)
 
+    // CHECK-NOT: firrtl.instance all2
+    %all2_in0, %all2_out0 = firrtl.instance all2 @AllProperties(
+      in in0: !firrtl.string,
+      out out0: !firrtl.string)
+
     // CHECK: %some0_in1, %some0_out3 = firrtl.instance some0
     %some0_in0, %some0_in1, %some0_out0, %some0_out1, %some0_out2, %some0_out3 = firrtl.instance some0 @SomeProperties(
       in in0: !firrtl.string,
@@ -98,12 +103,13 @@ firrtl.circuit "Top" {
     %0 = firrtl.string "hello"
     firrtl.propassign %all0_in0, %0 : !firrtl.string
     firrtl.propassign %all1_in0, %0 : !firrtl.string
+    firrtl.propassign %all2_in0, %all1_out0 : !firrtl.string
     firrtl.propassign %some0_in0, %in0 : !firrtl.string
     firrtl.connect %some0_in1, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %no0_in0, %some0_out3 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.propassign %out0, %all0_out0 : !firrtl.string
     firrtl.propassign %out1, %all0_out0 : !firrtl.string
-    firrtl.propassign %out2, %all1_out0 : !firrtl.string
+    firrtl.propassign %out2, %all2_out0 : !firrtl.string
     firrtl.propassign %out3, %some0_out0 : !firrtl.string
     firrtl.connect %out4, %no0_out0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -129,7 +135,9 @@ firrtl.circuit "Top" {
 // CHECK: om.class.field @out1, %[[F0]]
 // CHECK: %[[O1:.+]] = om.object @AllProperties(%[[S0]])
 // CHECK: %[[F1:.+]] = om.object.field %[[O1]], [@out0]
-// CHECK: om.class.field @out2, %[[F1]]
-// CHECK: %[[O2:.+]] = om.object @SomeProperties(%[[P0]])
+// CHECK: %[[O2:.+]] = om.object @AllProperties(%[[F1]])
 // CHECK: %[[F2:.+]] = om.object.field %[[O2]], [@out0]
-// CHECK: om.class.field @out3, %[[F2]]
+// CHECK: om.class.field @out2, %[[F2]]
+// CHECK: %[[O3:.+]] = om.object @SomeProperties(%[[P0]])
+// CHECK: %[[F3:.+]] = om.object.field %[[O3]], [@out0]
+// CHECK: om.class.field @out3, %[[F3]]


### PR DESCRIPTION
This finished support for handling InstanceOps with properties by converting them into ObjectOps. The existing traversal that builds up fields on ClassOps is maintained, but a special case is added for when the property comes from an InstanceOp.

Using a cache to allow re-use, ObjectOps are created, and ObjectFieldOps are created to extract their outputs. Some bookeeping is necessary to ensure the relevant property ops feeding the instance are cloned, the IRMapping is kept up to date, and the right property ops are cleaned up. Otherwise, the rest of the pass is unchanged.