### PR TITLE
[OM] Simplify the Python instantiate API to just return Objects.

### DIFF
--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -30,14 +30,8 @@ with Context() as ctx, Location.unknown():
 
 # Test instantiate failure.
 
-
-@dataclass
-class Test:
-  field: int
-
-
 try:
-  obj = evaluator.instantiate(Test)
+  obj = evaluator.instantiate("Test")
 except ValueError as e:
   # CHECK: actual parameter list length (0) does not match
   # CHECK: actual parameters:
@@ -47,14 +41,9 @@ except ValueError as e:
 
 # Test get field failure.
 
-
-@dataclass
-class Test:
-  foo: int
-
-
 try:
-  obj = evaluator.instantiate(Test, 42)
+  obj = evaluator.instantiate("Test", 42)
+  obj.foo
 except ValueError as e:
   # CHECK: field "foo" does not exist
   # CHECK: see current operation:
@@ -63,19 +52,9 @@ except ValueError as e:
 
 # Test instantiate success.
 
+obj = evaluator.instantiate("Test", 42)
 
-@dataclass
-class Child:
-  foo: int
-
-
-@dataclass
-class Test:
-  field: int
-  child: Child
-
-
-obj = evaluator.instantiate(Test, 42)
-
-# CHECK: Test(field=42, child=Child(foo=14))
-print(obj)
+# CHECK: 42
+print(obj.field)
+# CHECK: 14
+print(obj.child.foo)

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object, ClassType
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, ClassType
 
 from circt.ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
 from circt.support import attribute_to_var, var_to_attribute
@@ -17,6 +17,25 @@ from typing import TYPE_CHECKING, Any, Sequence, TypeVar
 
 if TYPE_CHECKING:
   from _typeshed.stdlib.dataclass import DataclassInstance
+
+
+# Define the Object class by inheriting from the base implementation in C++.
+class Object(BaseObject):
+
+  def __init__(self, obj: BaseObject) -> None:
+    super().__init__(obj)
+
+  def __getattr__(self, name: str):
+    # Call the base method to get a field.
+    field = super().__getattr__(name)
+
+    # For primitives, return a Python value.
+    if isinstance(field, Attribute):
+      return attribute_to_var(field)
+
+    # For objects, return an Object, wrapping the base implementation.
+    assert isinstance(field, BaseObject)
+    return Object(field)
 
 
 # Define the Evaluator class by inheriting from the base implementation in C++.
@@ -40,15 +59,14 @@ class Evaluator(BaseEvaluator):
     # Attach our Diagnostic handler.
     mod.context.attach_diagnostic_handler(self._handle_diagnostic)
 
-  def instantiate(self, cls: type["DataclassInstance"],
-                  *args: Any) -> "DataclassInstance":
-    """Instantiate an Object with a dataclass type and actual parameters."""
+  def instantiate(self, cls: str, *args: Any) -> Object:
+    """Instantiate an Object with a class name and actual parameters."""
 
     # Convert the class name and actual parameters to Attributes within the
     # Evaluator's context.
     with self.module.context:
-      # Get the class name from the provided dataclass name.
-      class_name = StringAttr.get(cls.__name__)
+      # Get the class name from the class name.
+      class_name = StringAttr.get(cls)
 
       # Get the actual parameter Attributes from the supplied variadic
       # arguments. This relies on the circt.support helpers to convert from
@@ -58,41 +76,8 @@ class Evaluator(BaseEvaluator):
     # Call the base instantiate method.
     obj = super().instantiate(class_name, actual_params)
 
-    # Wrap the Object in the provided dataclass.
-    return self._instantiate_dataclass(cls, obj)
-
-  def _instantiate_dataclass(self, cls: type["DataclassInstance"],
-                             obj: Object) -> "DataclassInstance":
-    # Convert the field names of the class we are instantiating to StringAttrs
-    # within the Evaluator's context.
-    with self.module.context:
-      class_fields = [
-          (StringAttr.get(field.name), field.type) for field in fields(cls)
-      ]
-
-    # Convert the instantiated Object fields to Python objects.
-    object_fields = {}
-
-    for field_name, field_type in class_fields:
-      # Get the field from the object.
-      field = obj.get_field(field_name)
-
-      # Handle primitives represented as Attributes and nested Objects.
-      if isinstance(field, Attribute):
-        # Convert the field value to a Python object. This relies on the
-        # circt.support helpers to convert from Attribute to Python objects.
-        field_value = attribute_to_var(field)
-      else:
-        # Convert the field value to a Python dataclass for the Object.
-        assert isinstance(field, Object)
-        field_value = self._instantiate_dataclass(field_type, field)
-
-      # Save this field in the keyword argument dictionary that will be passed
-      # to the dataclass constructor.
-      object_fields[field_name.value] = field_value
-
-    # Instantiate a Python object of the requested class.
-    return cls(**object_fields)
+    # Return the Object, wrapping the base implementation.
+    return Object(obj)
 
   def _handle_diagnostic(self, diagnostic: Diagnostic) -> bool:
     """Handle MLIR Diagnostics by logging them."""


### PR DESCRIPTION
This API previously accepted a Python dataclass as input, and used it as a template to guide the logic to pull fields out of the instantiated Object and build an instance of the requested dataclass.

This allowed the API to be strongly typed, by accepting a dataclass type as input and returning an instance of that dataclass as output. However, this requires the user to specify a-priori what fields should be present in the resulting Object, and this may not always be known.

By simply returning an Object, and adding the appropriate Python conversions to Object's __getattr__, we can generically return Objects that behave just like the previous dataclasses, without specifying the fields up front. This also avoids rewrapping the Objects in dataclasses.

In the future, we can add back a similar form of type safety when this would be useful, potentially using Protocols similarly to how dataclasses were used as a template before.