### PR TITLE
[OM] Support graph regions in OM dialect

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -16,6 +16,7 @@
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 class OMOp<string mnemonic, list<Trait> traits = []> :
@@ -27,7 +28,7 @@ class OMOp<string mnemonic, list<Trait> traits = []> :
 
 def ClassOp : OMOp<"class",
     [SingleBlock, NoTerminator, Symbol, SymbolTable,
-     HasParent<"mlir::ModuleOp">,
+     HasParent<"mlir::ModuleOp">, RegionKindInterface,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>
     ]> {
   let arguments = (ins
@@ -59,6 +60,11 @@ def ClassOp : OMOp<"class",
     mlir::ArrayRef<mlir::StringRef> formalParamNames,
     mlir::ArrayRef<mlir::StringRef> fieldNames,
     mlir::ArrayRef<mlir::Type> fieldTypes);
+
+    // Implement RegionKindInterface.
+    static mlir::RegionKind getRegionKind(unsigned index) {
+      return mlir::RegionKind::Graph;
+    }
   }];
 }
 

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -121,3 +121,29 @@ om.class @StringConstant() {
   // CHECK: om.class.field @string, %[[const1]] : !om.string
   om.class.field @string, %0 : !om.string
 }
+
+// CHECK-LABEL: @LinkedList
+om.class @LinkedList(%prev: !om.class.type<@LinkedList>) {
+  om.class.field @prev, %prev : !om.class.type<@LinkedList>
+}
+
+// CHECK-LABEL: @ReferenceEachOther
+om.class @ReferenceEachOther() {
+  // CHECK-NEXT: %[[obj1:.+]] = om.object @LinkedList(%[[obj2:.+]]) : (!om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+  // CHECK-NEXT: %[[obj2]] = om.object @LinkedList(%[[obj1]]) : (!om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+  %0 = om.object @LinkedList(%1) : (!om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+  %1 = om.object @LinkedList(%0) : (!om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+}
+
+// CHECK-LABEL: @RefecenceEachOthersField
+om.class @RefecenceEachOthersField(%blue_1: i8, %green_1: i32) {
+  // CHECK-NEXT: %[[obj1:.+]] = om.object @Widget(%blue_1, %[[field2:.+]]) : (i8, i32) -> !om.class.type<@Widget>
+  %0 = om.object @Widget(%blue_1, %3) : (i8, i32) -> !om.class.type<@Widget>
+  // CHECK-NEXT: %[[field1:.+]] = om.object.field %[[obj1]], [@blue_1] : (!om.class.type<@Widget>) -> i8
+  %1 = om.object.field %0, [@blue_1] : (!om.class.type<@Widget>) -> i8
+
+  // CHECK-NEXT: %[[obj2:.+]] = om.object @Widget(%[[field1]], %green_1) : (i8, i32) -> !om.class.type<@Widget>
+  %2 = om.object @Widget(%1, %green_1) : (i8, i32) -> !om.class.type<@Widget>
+  // CHECK-NEXT: %[[field2]] = om.object.field %[[obj2]], [@green_1] : (!om.class.type<@Widget>) -> i32
+  %3 = om.object.field %2, [@green_1] : (!om.class.type<@Widget>) -> i32
+}


### PR DESCRIPTION
This implements region kind interface for class op to support graph regions. Graph regions are useful to represent DAG or cyclic references between two objects. A follow up would be to make sure that OM evaluator works with cyclic references. 