### PR TITLE
[OM] Expose ReferenceAttr to Python

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -133,6 +133,14 @@ omEvaluatorObjectValueIsAPrimitive(OMObjectValue objectValue);
 MLIR_CAPI_EXPORTED MlirAttribute
 omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue);
 
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool omAttrIsAReferenceAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute omReferenceAttrGetInnerRef(MlirAttribute attr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -126,6 +126,12 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
       .def_property_readonly("type", &Object::getType,
                              "The Type of the Object");
 
+  // Add the ReferenceAttr definition
+  mlir_attribute_subclass(m, "ReferenceAttr", omAttrIsAReferenceAttr)
+      .def_property_readonly("inner_ref", [](MlirAttribute self) {
+        return omReferenceAttrGetInnerRef(self);
+      });
+
   // Add the ClassType class definition.
   mlir_type_subclass(m, "ClassType", omTypeIsAClassType);
 }

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, ClassType
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, ClassType, ReferenceAttr
 
 from circt.ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
 from circt.support import attribute_to_var, var_to_attribute

--- a/lib/Bindings/Python/support.py
+++ b/lib/Bindings/Python/support.py
@@ -134,6 +134,7 @@ def attribute_to_var(attr):
   if attr.__class__ != ir.Attribute:
     return attr
 
+  from .dialects import hw, om
   try:
     return ir.BoolAttr(attr).value
   except ValueError:
@@ -162,6 +163,19 @@ def attribute_to_var(attr):
   try:
     dict = ir.DictAttr(attr)
     return {i.name: attribute_to_var(i.attr) for i in dict}
+  except ValueError:
+    pass
+
+  from .dialects import om
+  try:
+    return attribute_to_var(om.ReferenceAttr(attr).inner_ref)
+  except ValueError:
+    pass
+
+  from .dialects import hw
+  try:
+    ref = hw.InnerRefAttr(attr)
+    return (ir.StringAttr(ref.module).value, ir.StringAttr(ref.name).value)
   except ValueError:
     pass
 

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -12,6 +12,7 @@
 
 #include "circt-c/Dialect/OM.h"
 #include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
@@ -179,4 +180,17 @@ MlirAttribute omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue) {
   // Assert the Attribute is non-null, and return it.
   assert(omEvaluatorObjectValueIsAPrimitive(objectValue));
   return objectValue.primitive;
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+bool omAttrIsAReferenceAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<ReferenceAttr>();
+}
+
+MlirAttribute omReferenceAttrGetInnerRef(MlirAttribute referenceAttr) {
+  return wrap(
+      (Attribute)unwrap(referenceAttr).cast<ReferenceAttr>().getInnerRef());
 }


### PR DESCRIPTION
Converted the reference attribute and inner name ref chain to a Python tuple for OM object evaluation.