### PR TITLE
[FIRRTL] Add BaseTypeAliasType

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -481,6 +481,51 @@ def RefImpl : FIRRTLImplType<"Ref",
   }];
 }
 
+def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [FieldIDTypeInterface],
+                                        "::circt::firrtl::FIRRTLBaseType"> {
+  let summary = "type alias for firrtl base types";
+  let parameters =
+    (ins  "StringAttr":$name, TypeParameter<"::circt::firrtl::FIRRTLBaseType",
+                                            "An inner type">:$innerType);
+  let storageClass = "BaseTypeAliasStorage";
+  let genAccessors = true;
+  let skipDefaultBuilders = true;
+  let extraClassDeclaration = [{
+      // FIRRTLBaseType utils.
+      FIRRTLBaseType getAnonymousType();
+      FIRRTLBaseType getPassiveType();
+      FIRRTLBaseType getConstType(bool isConst);
+      FIRRTLBaseType getAllConstDroppedType();
+
+      /// Return the recursive properties of the type.
+      RecursiveTypeProperties getRecursiveTypeProperties() const;
+
+      // If a given `newInnerType` is identical to innerType, return `*this`
+      // because we can reuse the type alias. Otherwise return `newInnerType`.
+      FIRRTLBaseType getModifiedType(FIRRTLBaseType newInnerType);
+
+      /// Implement FieldIDTypeInterface.
+
+      /// Strip off a single layer of this type and return the sub-type and a
+      /// field ID targeting the same field, but rebased on the sub-type.
+      std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
+      getSubTypeByFieldID(uint64_t fieldID);
+
+      /// Get the maximum field ID.
+      uint64_t getMaxFieldID();
+
+      /// Returns the effective field id when treating the index field as the root
+      /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
+      /// op. Returns the new id and whether the id is in the given child.
+      std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
+  }];
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
+           "::circt::firrtl::FIRRTLBaseType":$innerType)>
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Non-Hardware Type Definitions
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -261,4 +261,14 @@ firrtl.module @BigIntTest(in %in: !firrtl.bigint, out %out: !firrtl.bigint) {
   // CHECK: %1 = firrtl.bigint -4
   %1 = firrtl.bigint -4
 }
+
+// CHECK-LABEL: TypeAlias
+// CHECK-SAME: %in: !firrtl.alias<bar, uint<1>>
+// CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>
+// CHECK-SAME: %r: !firrtl.openbundle<a: alias<baz, uint<1>>>
+firrtl.module @TypeAlias(in %in: !firrtl.alias<bar, uint<1>>,
+                         in %const: !firrtl.const.alias<baz, const.uint<1>>,
+                         out %r : !firrtl.openbundle<a: alias<baz, uint<1>>>) {
+}
+
 }


### PR DESCRIPTION
This commit adds minimal changes BaseTypeAliasType for base type alias.
Implement mlir parser/printer, storage and methods for FIRRTLBaseType and FieldIDTypeInterface.
Add a very simple round trip test since several changes are still required to use type alias in operations.

This doesn't include `RecursiveProperty` changes and `FIRRTLBaseType::getAnonnymousType` which requires more broader changes.