### PR TITLE
[OM] Add `om.list_create` to create lists of objects

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -140,4 +140,22 @@ def ConstantOp : OMOp<"constant",
   let hasFolder = true;
 }
 
+def ListCreateOp : OMOp<"list_create", [Pure, SameTypeOperands]> {
+  let summary = "Create a list of values";
+  let description = [{
+    Creates a list from a sequence of inputs.
+
+    ```
+    %list = om.list_create %a, %b, %c : !om.ref
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs);
+  let results = (outs
+    ListType:$result
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 #endif // CIRCT_DIALECT_OM_OMOPS_TD

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -43,6 +43,12 @@ def ListType : TypeDef<OMDialect, "List", []> {
   let assemblyFormat = [{
     `<` $elementType `>`
   }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::Type":$elementType), [{
+      return $_get(elementType.getContext(), elementType);
+    }]>
+  ];
 }
 
 def SymbolRefType : TypeDef<OMDialect, "SymbolRef", []> {

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -281,6 +281,34 @@ OpFoldResult circt::om::ConstantOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// ListCreateOp
+//===----------------------------------------------------------------------===//
+
+void circt::om::ListCreateOp::print(OpAsmPrinter &p) {
+  p << " ";
+  p.printOperands(getInputs());
+  p.printOptionalAttrDict((*this)->getAttrs());
+  p << " : " << getType().getElementType();
+}
+
+ParseResult circt::om::ListCreateOp::parse(OpAsmParser &parser,
+                                           OperationState &result) {
+  llvm::SmallVector<OpAsmParser::UnresolvedOperand, 16> operands;
+  Type elemType;
+
+  if (parser.parseOperandList(operands) ||
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(elemType))
+    return failure();
+  result.addTypes({circt::om::ListType::get(elemType)});
+
+  for (auto operand : operands)
+    if (parser.resolveOperand(operand, elemType, result.operands))
+      return failure();
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -77,3 +77,14 @@ om.class @List() {
   %0 = om.constant #om.list< i32, [42 : i64]> : !om.list<i32>
   om.class.field @list, %0 : !om.list<i32>
 }
+
+// -----
+
+// CHECK-LABEL: @ListCreate
+om.class @ListCreate() {
+  %0 = om.constant 0 : i64
+  %1 = om.constant 1 : i32
+  // expected-error @+2 {{use of value '%1' expects different type than prior uses: 'i64' vs 'i32'}}
+  // expected-note @-2 {{prior use here}}
+  %lst = om.list_create %0, %1 : i64
+}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -114,6 +114,30 @@ om.class @ListConstant() {
   om.class.field @list_i32, %1 : !om.list<i32>
 }
 
+// CHECK-LABEL: @ListCreate
+om.class @ListCreate() {
+  // CHECK: [[cst5_i8:%.+]] = om.constant 5 : i8
+  %cst5_i8 = om.constant 5 : i8
+  // CHECK: [[cst6_i8:%.+]] = om.constant 6 : i8
+  %cst6_i8 = om.constant 6 : i8
+  // CHECK: [[cst5_i32:%.+]] = om.constant 5 : i32
+  %cst5_i32 = om.constant 5 : i32
+  // CHECK: [[cst6_i32:%.+]] = om.constant 6 : i32
+  %cst6_i32 = om.constant 6 : i32
+
+  // CHECK: [[obj0:%.+]] = om.object @Widget([[cst5_i8]], [[cst6_i32]]) : (i8, i32) -> !om.class.type<@Widget>
+  %obj0 = om.object @Widget(%cst5_i8, %cst6_i32) : (i8, i32) -> !om.class.type<@Widget>
+
+  // CHECK: [[obj1:%.+]] = om.object @Widget([[cst6_i8]], [[cst5_i32]]) : (i8, i32) -> !om.class.type<@Widget>
+  %obj1 = om.object @Widget(%cst6_i8, %cst5_i32) : (i8, i32) -> !om.class.type<@Widget>
+
+  // CHECK: [[list:%.+]] = om.list_create [[obj0]], [[obj1]] : !om.class.type<@Widget>
+  %list = om.list_create %obj0, %obj1 : !om.class.type<@Widget>
+
+  // CHECK: om.class.field @list_field, [[list]] : !om.list<!om.class.type<@Widget>>
+  om.class.field @list_field, %list : !om.list<!om.class.type<@Widget>>
+}
+
 // CHECK-LABEL: @String
 om.class @StringConstant() {
   // CHECK: %[[const1:.+]] = om.constant "foo" : !om.string


### PR DESCRIPTION
This PR adds the op to create lists of objects.

The Python bindings are not yet implemented as further discussion of the in-memory representation is required.