### PR TITLE
[HWModuleLike] Add by-name port lookup

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_HW_HWOPINTERFACES_H
 
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Dialect/HW/ModuleImplementation.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -41,7 +41,21 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     "size_t", "getNumPorts">,
 
     InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
+
+    InterfaceMethod<"Returns the index of the input port with the specified name",
+    "FailureOr<size_t>", "getArgIndex", (ins "llvm::StringRef":$portName),
+    /*methodBody=*/"",
+    /*defaultImplementation=*/[{
+      return hw::module_like_impl::getModuleArgIndex(this->getOperation(), portName);
+    }]>,
+
+    InterfaceMethod<"Returns the index of the output port with the specified name",
+    "FailureOr<size_t>", "getResIndex", (ins "llvm::StringRef":$portName),
+    /*methodBody=*/"",
+    /*defaultImplementation=*/[{
+      return hw::module_like_impl::getModuleResIndex(this->getOperation(), portName);
+    }]>,
   ];
 
   let verify = [{

--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -42,6 +42,28 @@ void printModuleSignature(OpAsmPrinter &p, Operation *op,
                           ArrayRef<Type> argTypes, bool isVariadic,
                           ArrayRef<Type> resultTypes, bool &needArgNamesAttr);
 
+// Creates index mappings of a modules ports based on the provided arg
+// and result names.
+void updateModuleIndexMappings(OperationState &result,
+                               ArrayRef<Attribute> argNames,
+                               ArrayRef<Attribute> resultNames);
+
+// Refreshes the index mappings of the module's ports based on the current
+// arg and result names.
+LogicalResult updateModuleIndexMappings(Operation *op);
+
+// Verifies that a modules arg and result index maps are consistent with
+// the current arg and result names.
+LogicalResult verifyModuleIdxMap(Operation *mod);
+
+// Returns the index of the module's argument with the given name, using
+// the module's arg index map.
+FailureOr<size_t> getModuleArgIndex(Operation *op, StringRef name);
+
+// Returns the index of the module's result with the given name, using
+// the module's result index map.
+FailureOr<size_t> getModuleResIndex(Operation *op, StringRef name);
+
 } // namespace module_like_impl
 } // namespace hw
 } // namespace circt

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -204,9 +204,9 @@ public:
         buildPipelineLike(pipelineName, pipeline.getInputs().getTypes(),
                           pipeline.getResults().getTypes());
     pipelineClk = pipelineMod.getBody().front().getArgument(
-        pipelineMod.getBody().front().getNumArguments() - 2);
+        *cast<hw::HWModuleLike>(*pipelineMod).getArgIndex("clk"));
     pipelineRst = pipelineMod.getBody().front().getArgument(
-        pipelineMod.getBody().front().getNumArguments() - 1);
+        *cast<hw::HWModuleLike>(*pipelineMod).getArgIndex("rst"));
 
     // Instantiate the pipeline in the parent module.
     builder.setInsertionPoint(pipeline);

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -313,6 +313,7 @@ static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive) {
       updateLocAttribute(op, "argLocs", ioInfo.argStructs);
       updateLocAttribute(op, "resultLocs", ioInfo.resStructs);
       updateBlockLocations(op, "argLocs", ioInfo.argStructs);
+      (void)hw::module_like_impl::updateModuleIndexMappings(op);
     }
 
     // Break if we've only lowering a single level of structs.


### PR DESCRIPTION
Adds capabilities to the `HWModuleLike` interface to lookup in/output port indices by name. This is done by maintaining a mapping (`DictionaryAttr`) between port names and their indices.

The `arg/resIdxMap` attributes are not inherent attributes of module-like ops (not part of parsing). this makes sense to me to avoid duplicating information. Instead, the mappings are updated whenever:
1. a module-like op is parsed
2. a module-like op is built
3. a module-like op has its ports modified through `hw::modifyModulePorts` or any of the other functions which i managed to determine modifies ports.

If a user modifies the ports of a module outside the above locations, it is the responsability of the user to ensure that `updateModuleIndexMappings` is called.

The performance of this comes down to the performance of looking up a key in a `DictionaryAttr`.

A final detail is that these mappings will only be available if a module has unique in/output port names, given that it is currently legal to have duplicate names in the `argNames`/`resNames` attributes, as well as this being supported by exportVerilog.

Lastly, `FIRRTL` module-like ops do not implement this interface (for now) given the unified in/out port list.

As a first user, updates `PipelineToHW` to lookup clk/rst ports by name. I'm sure there's tons of other uses throughout the codebase.

**Note**: This is probably a fairly contentious way of implementing this, mainly regarding space overhead, issues as to how to ensure that the map is always up to date, computational overhead even if users don't want/need the capability.
 
Alternative implementations:
* MLIR properties: Helps with some of the computational complexity, wherein we'd store a `DenseMap` instead of a (uniqued) `DictionaryAttribute`
* Helper class: Make this fully optional with a helper class/function that wraps a `HWModuleLike` to provide a by-name lookup API.