### PR TITLE
[Comb] Introduce synopsys mux intrinsics

### DIFF
--- a/include/circt/Dialect/Comb/CombVisitors.h
+++ b/include/circt/Dialect/Comb/CombVisitors.h
@@ -104,6 +104,8 @@ public:
   HANDLE(ReplicateOp, Unhandled);
   HANDLE(ExtractOp, Unhandled);
   HANDLE(MuxOp, Unhandled);
+  HANDLE(SynopsysMux2IntrinsicOp, Unhandled);
+  HANDLE(SynopsysMux4IntrinsicOp, Unhandled);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -316,3 +316,46 @@ def TruthTableOp : CombOp<"truth_table", [Pure]> {
 
   let hasVerifier = 1;
 }
+
+
+//===----------------------------------------------------------------------===//
+// Targest Specific Intrinsics
+//===----------------------------------------------------------------------===//
+
+def SynopsysMux2IntrinsicOp : CombOp<"int.synopsys.mux2",
+ [Pure, AllTypesMatch<["trueValue", "falseValue", "result"]>]> {
+  let summary = "An intrinsic lowered into 2-to-1 MUX cell in the synopsys target";
+  let description = [{
+    ```
+      %0 = int.synopsys.mux2 %pred, %tvalue, %fvalue : i4
+    ```
+  }];
+
+  let arguments = (ins I1:$cond, AnyType:$trueValue,
+                       AnyType:$falseValue, UnitAttr:$twoState);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = [{
+    (`bin` $twoState^)? $cond `,` $trueValue `,` $falseValue
+      attr-dict `:` qualified(type($result))
+  }];
+}
+
+def SynopsysMux4IntrinsicOp : CombOp<"int.synopsys.mux4",
+ [Pure, AllTypesMatch<["v3", "v2", "v1", "v0", "result"]>]> {
+  let summary = "An intrinsic lowered into 4-to-1 MUX cell in the synopsys target";
+  let description = [{
+    ```
+      %0 = comb.int.synopsys.mux4 %sel, %v3, %v2, %v1, %v0 : i4
+    ```
+  }];
+
+  let arguments = (ins I<2>:$sel, AnyType:$v3, AnyType:$v2,
+                       AnyType:$v1, AnyType:$v0, UnitAttr:$twoState);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = [{
+    (`bin` $twoState^)? $sel `,` $v3 `,` $v2 `,` $v1 `,` $v0
+      attr-dict `:` qualified(type($result))
+  }];
+}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1063,6 +1063,20 @@ hw.module @structExplodeLowering(%a: !hw.struct<a: i1, b: i1>) -> (outA: i1, out
   hw.output %0#0, %0#1 : i1, i1
 }
 
+hw.module @SynopsysIntrinsic(%sel: i1, %sel2: i2, %high: i1, %low: i1) -> (out1: i1, out2: i1) {
+  // CHECK:      /* synopsys infer_mux_override */
+  // CHECK-NEXT: assign [[MUX2:.+]] = sel ? high : low;
+  // CHECK-NEXT: wire [3:0] [[ARRAY:.+]] =
+  // CHECK-SAME{LITERAL}: {{high}, {low}, {high}, {low}};
+  // CHECK:      /* synopsys infer_mux_override */
+  // CHECK-NEXT: assign [[MUX4:.+]] = [[ARRAY]][sel2];
+  // CHECK-NEXT: assign out1 = [[MUX2]];
+  // CHECK-NEXT: assign out2 = [[MUX4]];
+  %0 = comb.int.synopsys.mux2 bin %sel, %high, %low : i1
+  %1 = comb.int.synopsys.mux4 bin %sel2, %high, %low, %high, %low : i1
+  hw.output %0, %1 : i1, i1
+}
+
 
 // Rename field names
 // CHECK-LABEL: renameKeyword(


### PR DESCRIPTION
This commit adds two target specific intrincis `comb.int.synopsys.{mux4, mux2}`, which directly represent 4-to-1 and 2-to-1 MUX cells in the synopys target.

To preserve the operation cleanly, new operations are added instaed of adding new attributes to mux.

PrepareForEmission lowers these operations into wire + assign + mux pragma.