### PR TITLE
[FIRRTL] ExtractClasses: Fix use-after-free.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -175,14 +175,14 @@ void ExtractClassesPass::updateInstances(FModuleOp moduleOp) {
     }
 
     // Erase the original instance.
-    oldInstance.erase();
     node->erase();
+    oldInstance.erase();
   }
 
   // If all ports are properties, remove the FModuleOp completely.
   if (!modulePortsToErase.empty() && modulePortsToErase.all()) {
-    moduleOp.erase();
     instanceGraph->erase(instanceGraphNode);
+    moduleOp.erase();
   }
 }
 


### PR DESCRIPTION
Fixes #5425.

This was on the module, but similarly don't erase
the IR until after removing from data-structure referring to it, as general good practice.