### PR TITLE
[Reduce] Add missing build deps on HW/FIRRTL dialects.

### DIFF
--- a/lib/Reduce/CMakeLists.txt
+++ b/lib/Reduce/CMakeLists.txt
@@ -9,4 +9,8 @@ add_circt_library(CIRCTReduceLib
   MLIRSupport
   MLIRTransforms
   MLIRReduceLib
+
+  # Dialect dependencies.
+  CIRCTFIRRTL
+  CIRCTHW
 )


### PR DESCRIPTION
Primary motivation is to fix header-gen dependence (before this change, this includes header before they're gen'd) but since this uses both `firrtl::` and `hw::` bits link too.