### PR TITLE
[Comb] Lower comb pass boilerplate

### DIFF
--- a/include/circt/Dialect/Comb/CMakeLists.txt
+++ b/include/circt/Dialect/Comb/CMakeLists.txt
@@ -5,3 +5,10 @@ set(LLVM_TARGET_DEFINITIONS Comb.td)
 mlir_tablegen(CombEnums.h.inc -gen-enum-decls)
 mlir_tablegen(CombEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRCombEnumsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTCombTransformsIncGen)
+
+# Generate Pass documentation.
+add_circt_doc(Passes CombPasses -gen-pass-doc)

--- a/include/circt/Dialect/Comb/CombPasses.h
+++ b/include/circt/Dialect/Comb/CombPasses.h
@@ -1,4 +1,4 @@
-//===- Passes.h - HW pass entry points --------------------------*- C++ -*-===//
+//===- Passes.h - Comb pass entry points ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/circt/Dialect/Comb/CombPasses.h
+++ b/include/circt/Dialect/Comb/CombPasses.h
@@ -1,0 +1,32 @@
+//===- Passes.h - HW pass entry points --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_COMB_COMBPASSES_H
+#define CIRCT_DIALECT_COMB_COMBPASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include <memory>
+#include <optional>
+
+namespace circt {
+namespace comb {
+
+/// Generate the code for registering passes.
+#define GEN_PASS_DECL
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/Comb/Passes.h.inc"
+
+} // namespace comb
+} // namespace circt
+
+#endif // CIRCT_DIALECT_COMB_COMBPASSES_H

--- a/include/circt/Dialect/Comb/Passes.td
+++ b/include/circt/Dialect/Comb/Passes.td
@@ -1,0 +1,25 @@
+//===-- Passes.td - Comb pass definition file --------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_COMB_PASSES_TD
+#define CIRCT_DIALECT_COMB_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def LowerComb : Pass<"lower-comb", "mlir::ModuleOp"> {
+  let summary = "Lowers the some of the comb ops";
+  let description = [{
+    Some operations in the comb dialect (e.g. `comb.truth_table`) are not
+    directly supported by ExportVerilog. They need to be lowered into ops which
+    are supported. There are many ways to lower these ops so we do this in a
+    separate pass. This also allows the lowered form to participate in
+    optimizations like the comb canonicalizers.
+  }];
+}
+
+#endif // CIRCT_DIALECT_COMB_PASSES_TD

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -18,6 +18,7 @@
 #include "circt/Conversion/Passes.h"
 #include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Dialect/Comb/CombPasses.h"
 #include "circt/Dialect/DC/DCPasses.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
@@ -45,6 +46,7 @@ inline void registerAllPasses() {
   // Standard Passes
   arc::registerPasses();
   calyx::registerPasses();
+  comb::registerPasses();
   dc::registerPasses();
   esi::registerESIPasses();
   firrtl::registerPasses();

--- a/lib/Dialect/Comb/CMakeLists.txt
+++ b/lib/Dialect/Comb/CMakeLists.txt
@@ -22,3 +22,5 @@ add_circt_dialect_library(CIRCTComb
    )
 
 add_dependencies(circt-headers MLIRCombIncGen MLIRCombEnumsIncGen)
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/Comb/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Comb/Transforms/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_circt_dialect_library(CIRCTCombTransforms
+  LowerComb.cpp
+
+  DEPENDS
+  CIRCTCombTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTHW
+  CIRCTSV
+  CIRCTComb
+  CIRCTSupport
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Comb/Transforms/LowerComb.cpp
+++ b/lib/Dialect/Comb/Transforms/LowerComb.cpp
@@ -1,0 +1,34 @@
+//===- LowerComb.cpp - Lower some ops in comb -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Comb/CombPasses.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace circt::comb;
+
+namespace circt {
+namespace comb {
+#define GEN_PASS_DEF_LOWERCOMB
+#include "circt/Dialect/Comb/Passes.h.inc"
+} // namespace comb
+} // namespace circt
+
+namespace {
+class LowerCombPass : public impl::LowerCombBase<LowerCombPass> {
+public:
+  using LowerCombBase::LowerCombBase;
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerCombPass::runOnOperation() {}

--- a/lib/Dialect/Comb/Transforms/PassDetails.h
+++ b/lib/Dialect/Comb/Transforms/PassDetails.h
@@ -1,0 +1,27 @@
+//===- PassDetails.h - Comb pass class details ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_COMB_TRANSFORMS_PASSDETAILS_H
+#define DIALECT_COMB_TRANSFORMS_PASSDETAILS_H
+
+#include "circt/Dialect/HW/HWOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace comb {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/Comb/Passes.h.inc"
+
+} // namespace comb
+} // namespace circt
+
+#endif // DIALECT_COMB_TRANSFORMS_PASSDETAILS_H

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -17,6 +17,8 @@ target_link_libraries(circt-opt
   CIRCTCalyxToHW
   CIRCTCalyxToFSM
   CIRCTCalyxTransforms
+  CIRCTComb
+  CIRCTCombTransforms
   CIRCTConvertToArcs
   CIRCTDC
   CIRCTDCToHW


### PR DESCRIPTION
Some operations in the comb dialect (e.g. `comb.truth_table`) are not directly supported by ExportVerilog. They need to be lowered into ops which are supported. There are many ways to lower these ops so we do this in a separate pass. This also allows the lowered form to participate in optimizations like the comb canonicalizers. This change is just to introduce the pass boilerplate. It currently doesn't do anything.