### PR TITLE
[Python] Fix import path

### DIFF
--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from ._om_ops_gen import *
 from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, ClassType, ReferenceAttr
 
-from circt.ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
-from circt.support import attribute_to_var, var_to_attribute
+from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
+from ..support import attribute_to_var, var_to_attribute
 
 import sys
 import logging


### PR DESCRIPTION
Absolute paths break PyCDE (and theoretically any other lib which embeds CIRCT in its own namespace).