### PR TITLE
[PyCDE] Fix parameterized extern mods

### DIFF
--- a/docs/PyCDE/basics.md
+++ b/docs/PyCDE/basics.md
@@ -247,6 +247,50 @@ PyCDE does not produce parameterized SystemVerilog modules! The specialization
 happens with Python code, which is far more powerful than SystemVerilog
 parameterization constructs.
 
+## External parameterized modules
+
+Just like internally defined parameterized modules, leave off the generator and
+PyCDE will output SystemVerilog instantations with the module parameters. The
+parameter types are best effort based on the first instantiation encountered.
+
+```python
+from pycde import modparams, Module
+
+@modparams
+def AddInts(width: int):
+
+  class AddInts(Module):
+    a = Input(UInt(width))
+    b = Input(UInt(width))
+    c = Output(UInt(width + 1))
+
+  return AddInts
+
+
+class Top(Module):
+  a = Input(UInt(32))
+  b = Input(UInt(32))
+  c = Output(UInt(33))
+
+  @generator
+  def construct(self):
+    add_ints_m = AddInts(32)
+    add_ints = add_ints_m(a=self.a, b=self.b)
+    self.c = add_ints.c
+```
+
+For the instantiation produces:
+
+```verilog
+  AddInts #(
+    .width(64'd32)
+  ) AddInts (
+    .a (a),
+    .b (b),
+    .c (c)
+  );
+```
+
 ## Using CIRCT dialects directly (instead of with PyCDE syntactic sugar)
 
 Generally speaking, don't.

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -307,7 +307,7 @@ class ModuleLikeBuilderBase(_PyProxy):
   def name(self):
     if hasattr(self.modcls, "module_name"):
       return self.modcls.module_name
-    elif self.parameters is not None:
+    elif self.parameters is not None and len(self.generators) > 0:
       return _create_module_name(self.modcls.__name__, self.parameters)
     else:
       return self.modcls.__name__
@@ -579,8 +579,7 @@ class modparams:
     if not issubclass(cls, Module):
       raise ValueError("Parameterization function must return Module class")
 
-    if len(cls._builder.generators) > 0:
-      cls._builder.parameters = cache_key[1]
+    cls._builder.parameters = cache_key[1]
     _MODULE_CACHE[cache_key] = cls
     return cls
 

--- a/frontends/PyCDE/test/test_polynomial.py
+++ b/frontends/PyCDE/test/test_polynomial.py
@@ -66,14 +66,14 @@ class CoolPolynomialCompute(Module):
 
 
 @modparams
-def ExternWithParams(a, b):
+def ExternWithParams(A: str, B: int):
 
   typedef1 = types.struct({"a": types.i1}, "exTypedef")
 
   class M(Module):
     module_name = "parameterized_extern"
     ignored_input = Input(types.i1)
-    used_input = Input(types.i4)
+    used_input = Input(types.int(B))
 
     @property
     def instance_name(self):
@@ -105,7 +105,7 @@ class PolynomialSystem(Module):
     CoolPolynomialCompute([4, 42], x=23)
 
     w1 = Wire(types.i4)
-    m = ExternWithParams({"foo": "bar"}, 3)(ignored_input=None, used_input=w1)
+    m = ExternWithParams("foo", 4)(ignored_input=None, used_input=w1)
     m.name = "pexternInst"
     w1.assign(0)
 
@@ -128,14 +128,14 @@ poly.print()
 # CHECK:         %example2_1.y = msft.instance @example2_1 @PolyComputeForCoeff__1__2__3__4__5_(%example.y) : (i32) -> i32
 # CHECK:         %CoolPolynomialCompute.y = msft.instance @CoolPolynomialCompute @supercooldevice(%{{.+}}) : (i32) -> i32
 # CHECK:         [[R0:%.+]] = hw.bitcast %false : (i1) -> i1
-# CHECK:         msft.instance @singleton @parameterized_extern([[R0]], %c0_i4)  : (i1, i4) -> ()
+# CHECK:         msft.instance @singleton @parameterized_extern(%0, %c0_i4) <A: none = "foo", B: i64 = 4> : (i1, i4) -> ()
 # CHECK:         %c0_i4 = hw.constant 0 : i4
 # CHECK:         msft.output %example.y : i32
 # CHECK:       }
 # CHECK:       msft.module @PolyComputeForCoeff__62__42__6_ {coefficients = {coeff = [62, 42, 6]}} (%x: i32) -> (y: i32)
 # CHECK:       msft.module @PolyComputeForCoeff__1__2__3__4__5_ {coefficients = {coeff = [1, 2, 3, 4, 5]}} (%x: i32) -> (y: i32)
 # CHECK:       msft.module.extern @supercooldevice(%x: i32) -> (y: i32) attributes {verilogName = "supercooldevice"}
-# CHECK:       msft.module.extern @parameterized_extern(%ignored_input: i1, %used_input: i4) attributes {verilogName = "parameterized_extern"}
+# CHECK:       msft.module.extern @parameterized_extern<A: none, B: i64>(%ignored_input: i1, %used_input: i4) attributes {verilogName = "parameterized_extern"}
 
 print("Generating rest...")
 poly.generate()


### PR DESCRIPTION
External modules with parameters were being instantiated without the parameters.