### PR TITLE
[FIRRTL] Support EnumTypes in error messages

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -582,6 +582,13 @@ circt::firrtl::getFieldName(const FieldRef &fieldRef, bool nameSafe) {
       // Recurse in to the element type.
       type = vecType.getElementType();
       localID = localID - vecType.getFieldID(index);
+    } else if (auto enumType = dyn_cast<FEnumType>(type)) {
+      auto index = enumType.getIndexForFieldID(localID);
+      auto &element = enumType.getElements()[index];
+      name += nameSafe ? "_" : ".";
+      name += element.name.getValue();
+      type = element.type;
+      localID = localID - enumType.getFieldID(index);
     } else {
       // If we reach here, the field ref is pointing inside some aggregate type
       // that isn't a bundle or a vector. If the type is a ground type, then the

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -168,3 +168,12 @@ firrtl.circuit "Issue5002" {
     firrtl.ref.define %inst2_ref, %w2_ref : !firrtl.rwprobe<uint>
   }
 }
+
+// -----
+// https://github.com/llvm/circt/issues/5324
+
+firrtl.circuit "NoWidthEnum" {
+  // expected-error @below {{uninferred width: port "o.Some" is unconstrained}}
+  firrtl.module @NoWidthEnum(out %o: !firrtl.enum<Some: uint>) {
+  }
+}


### PR DESCRIPTION
This adds support for enumeration types to `getFieldName`, which is commonly used to print the access path to a field in an aggregate.  This function is used to report error messages in InferWidths.

Fixes #5324