### PR TITLE
[Pipeline] add 'go' signal to pipeline

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -211,7 +211,9 @@ def PipelineToHW : Pass<"lower-pipeline-to-hw", "hw::HWModuleOp"> {
   ];
   let options = [
     Option<"outlineStages", "outline-stages", "bool", "false",
-      "Outline each stage to a separate `hw.module`.">
+      "Outline each stage to a separate `hw.module`.">,
+    Option<"clockGateRegs", "clock-gate-regs", "bool", "false",
+      "Clock gate each register instead of (default) input muxing  (ASIC optimization).">
   ];
 }
 

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -80,7 +80,6 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     RegionKindInterface,
     PipelineLike,
     AttrSizedOperandSegments,
-    OpAsmOpInterface,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
   let summary = "Scheduled pipeline operation";

--- a/include/circt/Dialect/Pipeline/Pipeline.td
+++ b/include/circt/Dialect/Pipeline/Pipeline.td
@@ -24,6 +24,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 include "circt/Dialect/Pipeline/PipelineInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
 
 def Pipeline_Dialect : Dialect {
   let name = "pipeline";
@@ -46,23 +47,21 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
     operations to-be-scheduled into a pipeline.
     Mainly serves as a container and entrypoint for scheduling.
 
-    A `pipeline.unscheduled` supports a `stall` input. This signal is intended to
-    connect to all stages within the pipeline, and is used to stall the entirety
-    of the pipeline. It is lowering defined how stages choose to use this signal,
-    although in the common case, a `stall` signal would typically connect to
-    the clock-enable input of the stage-separating registers.
+    The interface of a `pipeline.unscheduled` is similar to that of a
+    `pipeline.scheduled`. Please refer to this op for further documentation
+    about the interface signals.
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, Optional<I1>:$stall
+    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs, I1:$go, I1:$clock, I1:$reset, Optional<I1>:$stall
   );
-  let results = (outs Variadic<AnyType>:$results);
+  let results = (outs Variadic<AnyType>:$results, I1:$done);
   let regions = (region SizedRegion<1>: $body);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
-      `clock` $clock `reset` $reset attr-dict `:`functional-type($inputs, results) $body
+      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $results) $body
   }];
 
   let extraClassDeclaration = [{
@@ -80,7 +79,9 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     Pure,
     RegionKindInterface,
     PipelineLike,
-    AttrSizedOperandSegments
+    AttrSizedOperandSegments,
+    OpAsmOpInterface,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
   let summary = "Scheduled pipeline operation";
   let description = [{
@@ -96,24 +97,31 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     of the pipeline. It is lowering defined how stages choose to use this signal,
     although in the common case, a `stall` signal would typically connect to
     the clock-enable input of the stage-separating registers.
+
+    The `go` input is used to start the pipeline. This value is fed through
+    the stages as the stage valid signal.
+    Note: the op is currently only designed for pipelines with II=1. For
+    pipelines with II>1, a user must themselves maintain state about when
+    the pipeline is ready to accept new inputs. We plan to add support for
+    head-of-pipeline backpressure in the future.
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, Optional<I1>:$stall
+    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, I1:$go, Optional<I1>:$stall
   );
-  let results = (outs Variadic<AnyType>:$results);
+  let results = (outs Variadic<AnyType>:$results, I1:$done);
   let regions = (region AnyRegion:$body);
   let hasVerifier = 1;
   let skipDefaultBuilders = 1;
 
   let builders = [
     OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "ValueRange":$extInputs,
-      "Value":$clock, "Value":$reset, CArg<"Value", "{}">:$stall)>
+      "Value":$clock, "Value":$reset, "Value":$go, CArg<"Value", "{}">:$stall)>
   ];
 
   let assemblyFormat = [{
     `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
-      `clock` $clock `reset` $reset attr-dict `:`functional-type($inputs, results) $body
+      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $results) $body
   }];
 
   let extraClassDeclaration = [{
@@ -125,6 +133,16 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     llvm::iplist<mlir::Block>& getStages() {
       return getRegion().getBlocks();
     }
+
+    // Returns the valid signal of the given pipeline stage. This is always
+    // the last block argument of a stage.
+    Value getStageValidSignal(size_t stageIdx) {
+      Block* stage = getStage(stageIdx);
+      return stage->getArguments().back();
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                        mlir::OpAsmSetValueNameFn setNameFn);
 
     // Returns all of the stages in this pipeline. The stages are ordered
     // with respect to their position in the pipeline as determined by the
@@ -160,19 +178,26 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
     // must be defined within a stage".
     bool isMaterialized();
 
-    // Returns the arguments for a stage.
+    // Returns the arguments for a stage. The stage valid signal is _not_ part
+    // of the returned values.
     ValueRange getStageArguments(Block* stage) {
       if(stage != getEntryStage())
-        return stage->getArguments();
+        return stage->getArguments().drop_back();
 
       // The entry stage block mirrors the input argument order of the pipeline.
       // Grab the arguments corresponding to the inputs.
       return stage->getArguments().slice(getInputs().getBeginOperandIndex(), getInputs().size());
     }
 
+    // Returns the valid signal for the given stage. The valid signal is always
+    // the last signal in the stage argument list.
+    Value getStageValidSignal(Block* stage) {
+      return stage->getArguments().back();
+    }
+
     size_t getNumStageArguments(Block* stage) {
       if(stage != getEntryStage())
-        return stage->getNumArguments();
+        return stage->getNumArguments() - /*stage valid*/1;
       return getInputs().size();
     }
   }];
@@ -182,7 +207,6 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
 def StageOp : Op<Pipeline_Dialect, "stage", [
     AttrSizedOperandSegments,
     HasParent<"ScheduledPipelineOp">,
-    DeclareOpInterfaceMethods<BranchOpInterface, ["getSuccessorForOperands"]>,
     Pure,
     Terminator
   ]> {
@@ -195,14 +219,14 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     3. which values to pass through to the next stage without registering
   }];
 
-  let arguments = (ins Variadic<AnyType>:$registers, Variadic<AnyType>:$passthroughs, I1:$enable);
+  let arguments = (ins Variadic<AnyType>:$registers, Variadic<AnyType>:$passthroughs);
   let successors = (successor AnySuccessor:$nextStage);
   let results = (outs);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     $nextStage (`regs` `(` $registers^ `:` type($registers) `)`)?
-      (`pass` `(` $passthroughs^ `:` type($passthroughs) `)` )? `enable` $enable attr-dict
+      (`pass` `(` $passthroughs^ `:` type($passthroughs) `)` )? attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Pipeline/PipelineInterfaces.td
+++ b/include/circt/Dialect/Pipeline/PipelineInterfaces.td
@@ -50,7 +50,13 @@ def PipelineLike : OpInterface<"PipelineLike"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         Block* firstStage = $_op.getEntryStage();        
-        return firstStage->getArguments().take_front($_op.getInputs().size());
+        auto inputs = $_op.getInputs();
+        if(inputs.empty())
+          return ValueRange();
+        
+        return firstStage->getArguments().slice(
+          inputs.getBeginOperandIndex(),
+          inputs.size());
       }]
     >,
     InterfaceMethod<"Returns the pipeline external inputs",
@@ -62,7 +68,13 @@ def PipelineLike : OpInterface<"PipelineLike"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         Block* firstStage = $_op.getEntryStage();
-        return firstStage->getArguments().take_back($_op.getExtInputs().size());
+        auto extInputs = $_op.getExtInputs();
+        if(extInputs.empty())
+          return ValueRange();
+
+        return firstStage->getArguments().slice(
+          extInputs.getBeginOperandIndex(),
+          extInputs.size());
       }]
      >,
     InterfaceMethod<"Returns the first stage in the pipeline",

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -1,10 +1,21 @@
 // REQUIRES: iverilog,cocotb
 
+// Test 1: default lowering
+
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
 // RUN:     -o %t.mlir > %t.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \
 // RUN:     --pythonModule=simple --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
+
+// Test 2: Clock-gate implementation
+
+// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages,clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN:     -o %t.mlir > %t.sv
+
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \
+// RUN:     --pythonModule=simple --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
+
 
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -9,19 +9,19 @@
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
-hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : i1, %reset : i1) -> (out: i32) {
-  %out = pipeline.scheduled(%arg0, %arg1, %go) clock %clock reset %reset : (i32, i32, i1) -> (i32) {
-    ^bb0(%a0 : i32, %a1: i32, %g : i1):
+hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : i1, %reset : i1) -> (out: i32, done : i1) {
+  %out, %done = pipeline.scheduled(%arg0, %arg1) clock %clock reset %reset go %go : (i32, i32) -> (i32) {
+    ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
       %add0 = comb.add %a0, %a1 : i32
-      pipeline.stage ^bb1 enable %g
+      pipeline.stage ^bb1
 
-    ^bb1:
+    ^bb1(%s1_valid : i1):
       %add1 = comb.add %add0, %a0 : i32
-      pipeline.stage ^bb2 enable %g
+      pipeline.stage ^bb2
 
-    ^bb2:
+    ^bb2(%s2_valid : i1):
       %add2 = comb.add %add1, %add0 : i32
       pipeline.return %add2 : i32
   }
-  hw.output %out : i32
+  hw.output %out, %done : i32, i1
 }

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -10,7 +10,7 @@
 
 // Test 2: Clock-gate implementation
 
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages,clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
 // RUN:     -o %t.mlir > %t.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \

--- a/integration_test/Dialect/Pipeline/simple/simple.py
+++ b/integration_test/Dialect/Pipeline/simple/simple.py
@@ -24,6 +24,7 @@ async def initDut(dut):
 
 @cocotb.test()
 async def test1(dut):
+  dut.go.value = 0
   await initDut(dut)
 
   dut.arg0.value = 42

--- a/integration_test/Dialect/Pipeline/simple/simple.py
+++ b/integration_test/Dialect/Pipeline/simple/simple.py
@@ -30,7 +30,10 @@ async def test1(dut):
   dut.arg1.value = 24
   dut.go.value = 1
 
-  for i in range(3):
+  while dut.done != 1:
     await clock(dut)
+    dut.go.value = 0
+    dut.arg0.value = 0
+    dut.arg1.value = 0
 
   assert dut.out == 174, f"Expected 174, got {dut.out}"

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -285,7 +285,12 @@ public:
     // Instantiate the pipeline in the parent module.
     builder.setInsertionPoint(pipeline);
     llvm::SmallVector<Value, 4> pipelineOperands;
-    llvm::append_range(pipelineOperands, pipeline.getOperands());
+    llvm::append_range(pipelineOperands, pipeline.getInputs());
+    llvm::append_range(pipelineOperands, pipeline.getExtInputs());
+    llvm::append_range(
+        pipelineOperands,
+        ValueRange{pipeline.getGo(), pipeline.getClock(), pipeline.getReset()});
+
     auto pipelineInst = builder.create<hw::InstanceOp>(
         pipeline.getLoc(), pipelineMod,
         builder.getStringAttr(pipelineMod.getName()), pipelineOperands);

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -16,6 +16,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace mlir;
 using namespace circt;
@@ -160,17 +161,18 @@ void ScheduledPipelineOp::getAsmBlockArgumentNames(
       size_t nExternalInputs = getExtInputs().size();
       for (auto [argi, arg] :
            llvm::enumerate(block.getArguments().slice(0, nRegularInputs)))
-        setNameFn(arg, "s0_arg" + std::to_string(argi));
+        setNameFn(arg, llvm::formatv("s0_arg{0}", argi).str());
 
       for (auto [argi, arg] : llvm::enumerate(
                block.getArguments().slice(nRegularInputs, nExternalInputs)))
-        setNameFn(arg, "ext" + std::to_string(argi));
+        setNameFn(arg, llvm::formatv("ext{0}", argi).str());
     } else {
       for (auto [argi, arg] : llvm::enumerate(block.getArguments().drop_back()))
-        setNameFn(arg, "s" + std::to_string(i) + "_arg" + std::to_string(argi));
+        setNameFn(arg, llvm::formatv("s{0}_arg{1}", i, argi).str());
     }
 
-    setNameFn(block.getArguments().back(), "s" + std::to_string(i) + "_valid");
+    setNameFn(block.getArguments().back(),
+              llvm::formatv("s{0}_valid", i).str());
   }
 }
 void ScheduledPipelineOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -275,7 +275,9 @@ LogicalResult ScheduledPipelineOp::verify() {
           if (extInputs.contains(operand)) {
             // This is an external input; legal to reference everywhere.
             continue;
-          } else if (auto *definingOp = operand.getDefiningOp()) {
+          }
+
+          if (auto *definingOp = operand.getDefiningOp()) {
             // Constants are allowed to be used across stages.
             if (definingOp->hasTrait<OpTrait::ConstantLike>())
               continue;

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -278,10 +278,10 @@ LogicalResult ScheduledPipelineOp::verify() {
             if (definingOp->hasTrait<OpTrait::ConstantLike>())
               continue;
             err = definingOp->getBlock() != &stage;
+          } else {
+            // This is a block argument;
+            err = !llvm::is_contained(stage.getArguments(), operand);
           }
-
-          // This is a block argument;
-          err = !llvm::is_contained(stage.getArguments(), operand);
 
           if (err)
             return op.emitOpError(

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -278,10 +278,10 @@ LogicalResult ScheduledPipelineOp::verify() {
             if (definingOp->hasTrait<OpTrait::ConstantLike>())
               continue;
             err = definingOp->getBlock() != &stage;
-          } else {
-            // This is a block argument;
-            err = !llvm::is_contained(stage.getArguments(), operand);
           }
+
+          // This is a block argument;
+          err = !llvm::is_contained(stage.getArguments(), operand);
 
           if (err)
             return op.emitOpError(

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -182,9 +182,8 @@ void ExplicitRegsPass::runOnOperation() {
     llvm::SmallVector<Type> regAndPassTypes;
     llvm::append_range(regAndPassTypes, ValueRange(regIns).getTypes());
     llvm::append_range(regAndPassTypes, ValueRange(passIns).getTypes());
-    stage->addArguments(regAndPassTypes,
-                        llvm::SmallVector<Location>(regAndPassTypes.size(),
-                                                    UnknownLoc::get(ctx)));
+    for (auto [i, type] : llvm::enumerate(regAndPassTypes))
+      stage->insertArgument(i, type, UnknownLoc::get(ctx));
 
     // Replace backedges for the next stage with the new arguments.
     for (auto it : llvm::enumerate(regMap)) {

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -12,7 +12,6 @@
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
-
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt --lower-pipeline-to-hw="clock-gate-regs" %s | FileCheck %s
+
+
+// CHECK-LABEL:   hw.module @testSingle(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
+// CHECK:         }
+
+
+hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
+    %1 = comb.sub %arg0_0, %arg1_1 : i32
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+    %8 = comb.add %6, %7 : i32
+    pipeline.return %8 : i32
+  }
+  hw.output %0#0, %0#1 : i32, i1
+}

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -19,13 +19,15 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
+// CHECK:           %[[VAL_10:.*]] = comb.mux %[[VAL_9]], %[[VAL_5]], %[[VAL_11:.*]] : i32
+// CHECK:           %[[VAL_11]] = seq.compreg %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_14:.*]] = comb.mux %[[VAL_13]], %[[VAL_11]], %[[VAL_15:.*]] : i32
+// CHECK:           %[[VAL_15]] = seq.compreg %[[VAL_14]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_16:.*]] = hw.constant false
+// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_13]], %[[VAL_3]], %[[VAL_4]], %[[VAL_16]]  : i1
+// CHECK:           hw.output %[[VAL_15]], %[[VAL_17]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
@@ -50,12 +52,14 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_9]] : i32
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -72,28 +76,36 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
-// CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.compreg.ce %[[VAL_16]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_18:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
-// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_3]], %[[VAL_20]] : i32
-// CHECK:           %[[VAL_23:.*]] = seq.compreg.ce %[[VAL_17]], %[[VAL_3]], %[[VAL_20]] : i32
-// CHECK:           %[[VAL_24:.*]] = hw.constant false
-// CHECK:           %[[VAL_25:.*]] = seq.compreg %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
-// CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
-// CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_13:.*]] = comb.mux %[[VAL_11]], %[[VAL_12]], %[[VAL_14:.*]] : i32
+// CHECK:           %[[VAL_14]] = seq.compreg %[[VAL_13]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_15:.*]] = comb.mux %[[VAL_11]], %[[VAL_7]], %[[VAL_16:.*]] : i32
+// CHECK:           %[[VAL_16]] = seq.compreg %[[VAL_15]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_17:.*]] = hw.constant false
+// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_19:.*]] = comb.mul %[[VAL_14]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_20:.*]] = comb.sub %[[VAL_19]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_21:.*]] = comb.mux %[[VAL_2]], %[[VAL_20]], %[[VAL_22:.*]] : i32
+// CHECK:           %[[VAL_22]] = seq.compreg %[[VAL_21]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_23:.*]] = comb.mux %[[VAL_2]], %[[VAL_19]], %[[VAL_24:.*]] : i32
+// CHECK:           %[[VAL_24]] = seq.compreg %[[VAL_23]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_25:.*]] = hw.constant false
+// CHECK:           %[[VAL_26:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_25]]  : i1
+// CHECK:           %[[VAL_27:.*]] = comb.add %[[VAL_22]], %[[VAL_24]] : i32
+// CHECK:           %[[VAL_28:.*]] = comb.mux %[[VAL_26]], %[[VAL_27]], %[[VAL_29:.*]] : i32
+// CHECK:           %[[VAL_29]] = seq.compreg %[[VAL_28]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_30:.*]] = comb.mux %[[VAL_26]], %[[VAL_22]], %[[VAL_31:.*]] : i32
+// CHECK:           %[[VAL_31]] = seq.compreg %[[VAL_30]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_32:.*]] = hw.constant false
+// CHECK:           %[[VAL_33:.*]] = seq.compreg %[[VAL_26]], %[[VAL_3]], %[[VAL_4]], %[[VAL_32]]  : i1
+// CHECK:           %[[VAL_34:.*]] = comb.mul %[[VAL_29]], %[[VAL_31]] : i32
+// CHECK:           hw.output %[[VAL_19]], %[[VAL_18]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -127,14 +139,16 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
-// CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
+// CHECK:           %[[VAL_7:.*]] = comb.mux %[[VAL_2]], %[[VAL_6]], %[[VAL_8:.*]] : i32
+// CHECK:           %[[VAL_8]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_12:.*]] = comb.mux %[[VAL_10]], %[[VAL_11]], %[[VAL_13:.*]] : i32
+// CHECK:           %[[VAL_13]] = seq.compreg %[[VAL_12]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_14:.*]] = hw.constant false
+// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
   %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
@@ -163,23 +177,25 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
-// CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
-// CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_11]] : i32
-// CHECK:           %[[VAL_17:.*]] = hw.constant false
-// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
-// CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
-// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_2]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
-// CHECK:           hw.output %[[VAL_22]] : i32
+// CHECK:           %[[VAL_9:.*]] = comb.mux %[[VAL_1]], %[[VAL_8]], %[[VAL_10:.*]] : i32
+// CHECK:           %[[VAL_10]] = seq.compreg %[[VAL_9]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_11:.*]] = hw.constant false
+// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i32>
+// CHECK:           %[[VAL_15:.*]] = comb.add %[[VAL_14]], %[[VAL_10]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_12]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_13]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_17:.*]] = comb.mux %[[VAL_12]], %[[VAL_16]], %[[VAL_18:.*]] : i32
+// CHECK:           %[[VAL_18]] = seq.compreg %[[VAL_17]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_19:.*]] = hw.constant false
+// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_12]], %[[VAL_2]], %[[VAL_3]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_21:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_22:.*]] = sv.read_inout %[[VAL_21]] : !hw.inout<i32>
+// CHECK:           %[[VAL_23:.*]] = comb.add %[[VAL_22]], %[[VAL_18]] : i32
+// CHECK:           %[[VAL_24:.*]] = seq.compreg.ce %[[VAL_23]], %[[VAL_2]], %[[VAL_20]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_21]], %[[VAL_24]] : i32
+// CHECK:           hw.output %[[VAL_24]] : i32
 // CHECK:         }
 hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
   %0:2 = pipeline.scheduled(%arg0) ext (%clk, %rst : i1, i1) clock %clk reset %rst go %go : (i32) -> (i32) {

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -15,21 +15,17 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK-LABEL:   hw.module @testLatency1(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
-// CHECK:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_8]]
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_8]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_11]]
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_5]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = hw.constant false
+// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_12]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           %[[VAL_16:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_15]]
-// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_13]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_18:.*]] = hw.constant false
-// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_15]], %[[VAL_3]], %[[VAL_4]], %[[VAL_18]]  : i1
-// CHECK:           hw.output %[[VAL_17]], %[[VAL_19]] : i32, i1
+// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
@@ -54,13 +50,12 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -77,32 +72,28 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_10]]
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_7]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_15:.*]] = hw.constant false
-// CHECK:           %[[VAL_16:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_15]]  : i1
-// CHECK:           %[[VAL_17:.*]] = comb.mul %[[VAL_13]], %[[VAL_14]] : i32
-// CHECK:           %[[VAL_18:.*]] = comb.sub %[[VAL_17]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_19:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_18]], %[[VAL_19]] : i32
-// CHECK:           %[[VAL_21:.*]] = seq.compreg %[[VAL_17]], %[[VAL_19]] : i32
-// CHECK:           %[[VAL_22:.*]] = hw.constant false
-// CHECK:           %[[VAL_23:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_22]]  : i1
-// CHECK:           %[[VAL_24:.*]] = comb.add %[[VAL_20]], %[[VAL_21]] : i32
-// CHECK:           %[[VAL_25:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_23]]
-// CHECK:           %[[VAL_26:.*]] = seq.compreg %[[VAL_24]], %[[VAL_25]] : i32
-// CHECK:           %[[VAL_27:.*]] = seq.compreg %[[VAL_20]], %[[VAL_25]] : i32
-// CHECK:           %[[VAL_28:.*]] = hw.constant false
-// CHECK:           %[[VAL_29:.*]] = seq.compreg %[[VAL_23]], %[[VAL_3]], %[[VAL_4]], %[[VAL_28]]  : i1
-// CHECK:           %[[VAL_30:.*]] = comb.mul %[[VAL_26]], %[[VAL_27]] : i32
-// CHECK:           hw.output %[[VAL_17]], %[[VAL_16]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.compreg.ce %[[VAL_16]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_18:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_19:.*]] = hw.constant false
+// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_3]], %[[VAL_20]] : i32
+// CHECK:           %[[VAL_23:.*]] = seq.compreg.ce %[[VAL_17]], %[[VAL_3]], %[[VAL_20]] : i32
+// CHECK:           %[[VAL_24:.*]] = hw.constant false
+// CHECK:           %[[VAL_25:.*]] = seq.compreg %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
+// CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
+// CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -134,17 +125,16 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_10]]
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32, i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
   %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
@@ -173,25 +163,23 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_8]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i32>
-// CHECK:           %[[VAL_15:.*]] = comb.add %[[VAL_14]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_12]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_13]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_12]]
-// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_16]], %[[VAL_17]] : i32
-// CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_12]], %[[VAL_2]], %[[VAL_3]], %[[VAL_19]]  : i1
-// CHECK:           %[[VAL_21:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_22:.*]] = sv.read_inout %[[VAL_21]] : !hw.inout<i32>
-// CHECK:           %[[VAL_23:.*]] = comb.add %[[VAL_22]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_24:.*]] = seq.compreg.ce %[[VAL_23]], %[[VAL_2]], %[[VAL_20]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_21]], %[[VAL_24]] : i32
-// CHECK:           hw.output %[[VAL_24]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
+// CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_17:.*]] = hw.constant false
+// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
+// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_2]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
+// CHECK:           hw.output %[[VAL_22]] : i32
 // CHECK:         }
 hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
   %0:2 = pipeline.scheduled(%arg0) ext (%clk, %rst : i1, i1) clock %clk reset %rst go %go : (i32) -> (i32) {

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -5,140 +5,221 @@
 // CHECK:           hw.output %[[VAL_0]] : i1
 // CHECK:         }
 hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i1) -> (i1) {
-  ^bb0(%a0: i1):
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %arg0 : (i1) -> (i1) {
+  ^bb0(%a0: i1, %s0_valid: i1):
     pipeline.return %a0 : i1
   }
-  hw.output %0 : i1
+  hw.output %0#0 : i1
 }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           hw.output %[[VAL_8]] : i32
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = hw.constant false
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_8]]
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_8]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_11]]
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_5]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_14:.*]] = hw.constant false
+// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_16:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_15]]
+// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_13]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_18:.*]] = hw.constant false
+// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_15]], %[[VAL_3]], %[[VAL_4]], %[[VAL_18]]  : i1
+// CHECK:           hw.output %[[VAL_17]], %[[VAL_19]] : i32, i1
 // CHECK:         }
-hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
-    %true = hw.constant true
+hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
+  %out, %done = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid: i1):
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %6 : i32
     }
-    pipeline.stage ^bb1 pass(%1 : i32) enable %true
-  ^bb1(%2: i32):  // pred: ^bb0
-    pipeline.stage ^bb2 pass(%2 : i32) enable %true
-  ^bb2(%3: i32):  // pred: ^bb1
-    pipeline.stage ^bb3 regs(%3 : i32) enable %true
-  ^bb3(%4: i32):  // pred: ^bb2
-    pipeline.stage ^bb4 regs(%4 : i32) enable %true
-  ^bb4(%5: i32):  // pred: ^bb3
+    pipeline.stage ^bb1 pass(%1 : i32)
+  ^bb1(%2: i32, %s1_valid: i1):  // pred: ^bb0
+    pipeline.stage ^bb2 pass(%2 : i32)
+  ^bb2(%3: i32, %s2_valid: i1):  // pred: ^bb1
+    pipeline.stage ^bb3 regs(%3 : i32)
+  ^bb3(%4: i32, %s3_valid: i1):  // pred: ^bb2
+    pipeline.stage ^bb4 regs(%4 : i32)
+  ^bb4(%5: i32, %s4_valid: i1):  // pred: ^bb3
     pipeline.return %5 : i32
   }
-  hw.output %0 : i32
+  hw.output %out, %done : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           hw.output %[[VAL_9]], %[[VAL_5]] : i32, i1
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32) enable %arg2
-  ^bb1(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
   hw.output %0#0, %0#1 : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]] : i1
-// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_13:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:           %[[VAL_14:.*]] = hw.constant true
-// CHECK:           %[[VAL_15:.*]] = comb.sub %[[VAL_13]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg %[[VAL_15]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_13]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]] : i1
-// CHECK:           %[[VAL_19:.*]] = comb.add %[[VAL_16]], %[[VAL_17]] : i32
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_19]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_21:.*]] = seq.compreg %[[VAL_16]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_22:.*]] = comb.mul %[[VAL_20]], %[[VAL_21]] : i32
-// CHECK:           hw.output %[[VAL_13]], %[[VAL_5]] : i32, i1
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_10]]
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_7]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_15:.*]] = hw.constant false
+// CHECK:           %[[VAL_16:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_15]]  : i1
+// CHECK:           %[[VAL_17:.*]] = comb.mul %[[VAL_13]], %[[VAL_14]] : i32
+// CHECK:           %[[VAL_18:.*]] = comb.sub %[[VAL_17]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_19:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_18]], %[[VAL_19]] : i32
+// CHECK:           %[[VAL_21:.*]] = seq.compreg %[[VAL_17]], %[[VAL_19]] : i32
+// CHECK:           %[[VAL_22:.*]] = hw.constant false
+// CHECK:           %[[VAL_23:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_22]]  : i1
+// CHECK:           %[[VAL_24:.*]] = comb.add %[[VAL_20]], %[[VAL_21]] : i32
+// CHECK:           %[[VAL_25:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_23]]
+// CHECK:           %[[VAL_26:.*]] = seq.compreg %[[VAL_24]], %[[VAL_25]] : i32
+// CHECK:           %[[VAL_27:.*]] = seq.compreg %[[VAL_20]], %[[VAL_25]] : i32
+// CHECK:           %[[VAL_28:.*]] = hw.constant false
+// CHECK:           %[[VAL_29:.*]] = seq.compreg %[[VAL_23]], %[[VAL_3]], %[[VAL_4]], %[[VAL_28]]  : i1
+// CHECK:           %[[VAL_30:.*]] = comb.mul %[[VAL_26]], %[[VAL_27]] : i32
+// CHECK:           hw.output %[[VAL_17]], %[[VAL_16]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0, %arg2 : i32, i32, i1) enable %arg2
-  ^bb1(%2: i32, %3: i32, %4: i1):  // pred: ^bb0
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32) enable %4
-  ^bb2(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
 
-  %1:2 = pipeline.scheduled(%0#0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %1:2 = pipeline.scheduled(%0#0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0, %arg2 : i32, i32, i1) enable %arg2
-  ^bb1(%2: i32, %3: i32, %4: i1):  // pred: ^bb0
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32) enable %4
-  ^bb2(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
 
   hw.output %0#0, %0#1 : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_4:.*]] = hw.constant true
-// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_7]], %[[VAL_2]] : i32
-// CHECK:           hw.output %[[VAL_8]], %[[VAL_1]] : i32, i32
+// CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_10]]
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_14:.*]] = hw.constant false
+// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32, i32
 // CHECK:         }
-hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
-  %0:2 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
-  ^bb0(%a0: i32, %a1 : i32, %ext0: i32):
+hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
+  ^bb0(%a0: i32, %a1 : i32, %ext0: i32, %s0_valid: i1):
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
-    pipeline.stage ^bb1 regs(%1 : i32) enable %true
+    pipeline.stage ^bb1 regs(%1 : i32)
 
-  ^bb1(%6: i32):
+  ^bb1(%6: i32, %s1_valid: i1):
     // Use the external value inside a stage
     %8 = comb.add %6, %ext0 : i32
-    pipeline.stage ^bb2 regs(%8 : i32) enable %true
+    pipeline.stage ^bb2 regs(%8 : i32)
   
-  ^bb2(%9 : i32):
+  ^bb2(%9 : i32, %s2_valid: i1):
   // Use the external value in the exit stage.
     pipeline.return %9, %ext0  : i32, i32
   }
   hw.output %0#0, %0#1 : i32, i32
+}
+
+// CHECK-LABEL:   hw.module @testControlUsage(
+// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_5:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !hw.inout<i32>
+// CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = hw.constant false
+// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i32>
+// CHECK:           %[[VAL_15:.*]] = comb.add %[[VAL_14]], %[[VAL_10]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_12]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_13]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_12]]
+// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_16]], %[[VAL_17]] : i32
+// CHECK:           %[[VAL_19:.*]] = hw.constant false
+// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_12]], %[[VAL_2]], %[[VAL_3]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_21:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_22:.*]] = sv.read_inout %[[VAL_21]] : !hw.inout<i32>
+// CHECK:           %[[VAL_23:.*]] = comb.add %[[VAL_22]], %[[VAL_18]] : i32
+// CHECK:           %[[VAL_24:.*]] = seq.compreg.ce %[[VAL_23]], %[[VAL_2]], %[[VAL_20]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_21]], %[[VAL_24]] : i32
+// CHECK:           hw.output %[[VAL_24]] : i32
+// CHECK:         }
+hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
+  %0:2 = pipeline.scheduled(%arg0) ext (%clk, %rst : i1, i1) clock %clk reset %rst go %go : (i32) -> (i32) {
+  ^bb0(%a0: i32, %ext_clk: i1, %ext_rst : i1, %s0_valid: i1):
+    %zero = hw.constant 0 : i32
+    %reg_out_wire = sv.wire : !hw.inout<i32>
+    %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
+    %add0 = comb.add %reg_out, %a0 : i32
+    %out = seq.compreg.ce %add0, %ext_clk, %s0_valid, %ext_rst, %zero : i32
+    sv.assign %reg_out_wire, %out : i32
+    pipeline.stage ^bb1 regs(%out : i32)
+
+  ^bb1(%6: i32, %s1_valid: i1):
+    %reg1_out_wire = sv.wire : !hw.inout<i32>
+    %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
+    %add1 = comb.add %reg1_out, %6 : i32
+    %out1 = seq.compreg.ce %add1, %ext_clk, %s1_valid, %ext_rst, %zero : i32
+    sv.assign %reg1_out_wire, %out1 : i32
+
+    pipeline.stage ^bb2 regs(%out1 : i32)
+  
+  ^bb2(%9 : i32, %s2_valid: i1):
+    %reg2_out_wire = sv.wire : !hw.inout<i32>
+    %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
+    %add2 = comb.add %reg2_out, %9 : i32
+    %out2 = seq.compreg.ce %add2, %ext_clk, %s2_valid, %ext_rst, %zero : i32
+    sv.assign %reg2_out_wire, %out2 : i32
+    pipeline.return %out2  : i32
+  }
+  hw.output %0#0 : i32
 }

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -44,18 +44,20 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
 // CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
-// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = comb.mux %[[VAL_1]], %[[VAL_0]], %[[VAL_5:.*]] : i32
+// CHECK:           %[[VAL_5]] = seq.compreg %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
-// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = comb.mux %[[VAL_1]], %[[VAL_0]], %[[VAL_5:.*]] : i32
+// CHECK:           %[[VAL_5]] = seq.compreg %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1(
@@ -93,11 +95,13 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle(
@@ -128,21 +132,25 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1(
@@ -156,21 +164,25 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
+// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple(
@@ -218,19 +230,21 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
+// CHECK:           %[[VAL_7:.*]] = comb.mux %[[VAL_2]], %[[VAL_6]], %[[VAL_8:.*]] : i32
+// CHECK:           %[[VAL_8]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_8]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
+// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
@@ -278,10 +292,11 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
-// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_3]], %[[VAL_10]], %[[VAL_12:.*]] : i32
+// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage_p0_s1(
@@ -292,10 +307,11 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
-// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_3]], %[[VAL_10]], %[[VAL_12:.*]] : i32
+// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage(

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -7,10 +7,9 @@
 
 // CHECK-LABEL:   hw.module @testBasic(
 // CHECK-SAME:                         %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out: i1) {
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = hw.instance "testBasic_p0" @testBasic_p0(in0: %[[VAL_0]]: i1, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_0]]: i1) -> (out0: i1, valid: i1)
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = hw.instance "testBasic_p0" @testBasic_p0(in0: %[[VAL_0]]: i1, enable: %[[VAL_0]]: i1, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i1, valid: i1)
 // CHECK:           hw.output %[[VAL_3]] : i1
 // CHECK:         }
-
 hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
   %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %arg0 : (i1) -> (i1) {
   ^bb0(%a0: i1, %s0_valid: i1):
@@ -31,41 +30,37 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK-LABEL:   hw.module @testLatency1_p0_s0(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1,  %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_5:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
-// CHECK:           hw.output %[[VAL_4]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s1(
 // CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
-// CHECK:           hw.output %[[VAL_0]], %[[VAL_6]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = hw.constant false
+// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]  : i1
+// CHECK:           hw.output %[[VAL_0]], %[[VAL_5]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
 // CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_0]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
-// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_0]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
-// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testLatency1_p0" @testLatency1_p0(in0: %[[VAL_0]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testLatency1_p0" @testLatency1_p0(in0: %[[VAL_0]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
@@ -98,17 +93,16 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:                          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testSingle_p0" @testSingle_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testSingle_p0" @testSingle_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
@@ -134,23 +128,21 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1(
@@ -164,29 +156,27 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:                            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testMultiple_p0" @testMultiple_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = hw.instance "testMultiple_p1" @testMultiple_p1(in0: %[[VAL_5]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testMultiple_p0" @testMultiple_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = hw.instance "testMultiple_p1" @testMultiple_p1(in0: %[[VAL_5]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
@@ -228,26 +218,24 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
-// CHECK:         }
-
-// CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
+// CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
+// CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant false
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_8]] : i32, i1
+// CHECK:         }
+
 // CHECK-LABEL:   hw.module @testSingleWithExt(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
@@ -290,11 +278,10 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.clock_gate %[[VAL_4]], %[[VAL_3]]
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_10]], %[[VAL_11]] : i32
-// CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
-// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage_p0_s1(
@@ -305,16 +292,15 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.clock_gate %[[VAL_4]], %[[VAL_3]]
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_10]], %[[VAL_11]] : i32
-// CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
-// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testControlUsage_p0" @testControlUsage_p0(in0: %[[VAL_0]]: i32, extIn0: %[[VAL_2]]: i1, extIn1: %[[VAL_3]]: i1, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_1]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testControlUsage_p0" @testControlUsage_p0(in0: %[[VAL_0]]: i32, extIn0: %[[VAL_2]]: i1, extIn1: %[[VAL_3]]: i1, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_4]] : i32
 // CHECK:         }
 hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -1,246 +1,349 @@
 // RUN: circt-opt --lower-pipeline-to-hw="outline-stages" %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testBasic_p0(
-// CHECK-SAME:          %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i1) {
-// CHECK:           hw.output %[[VAL_0]] : i1
+// CHECK-SAME:                            %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i1, valid: i1) {
+// CHECK:           hw.output %[[VAL_0]], %[[VAL_1]] : i1, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testBasic(
-// CHECK-SAME:          %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out: i1) {
-// CHECK:           %[[VAL_3:.*]] = hw.instance "testBasic_p0" @testBasic_p0(in0: %[[VAL_0]]: i1, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i1)
+// CHECK-SAME:                         %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out: i1) {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = hw.instance "testBasic_p0" @testBasic_p0(in0: %[[VAL_0]]: i1, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_0]]: i1) -> (out0: i1, valid: i1)
 // CHECK:           hw.output %[[VAL_3]] : i1
 // CHECK:         }
 
 hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i1) -> (i1) {
-  ^bb0(%a0: i1):
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %arg0 : (i1) -> (i1) {
+  ^bb0(%a0: i1, %s0_valid: i1):
     pipeline.return %a0 : i1
   }
-  hw.output %0 : i1
+  hw.output %0#0 : i1
 }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_3:.*]] = hw.instance "testLatency1_p0_s0" @testLatency1_p0_s0(in0: %[[VAL_0]]: i32, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32)
-// CHECK:           %[[VAL_4:.*]] = hw.instance "testLatency1_p0_s1" @testLatency1_p0_s1(in0: %[[VAL_3]]: i32, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32)
-// CHECK:           %[[VAL_5:.*]] = hw.instance "testLatency1_p0_s2" @testLatency1_p0_s2(in0: %[[VAL_4]]: i32, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32)
-// CHECK:           %[[VAL_6:.*]] = hw.instance "testLatency1_p0_s3" @testLatency1_p0_s3(in0: %[[VAL_5]]: i32, clk: %[[VAL_1]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32)
-// CHECK:           hw.output %[[VAL_6]] : i32
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testLatency1_p0_s0" @testLatency1_p0_s0(in0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testLatency1_p0_s1" @testLatency1_p0_s1(in0: %[[VAL_4]]: i32, enable: %[[VAL_5]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testLatency1_p0_s2" @testLatency1_p0_s2(in0: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = hw.instance "testLatency1_p0_s3" @testLatency1_p0_s3(in0: %[[VAL_8]]: i32, enable: %[[VAL_9]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s0(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_3:.*]] = hw.constant true
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1,  %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           hw.output %[[VAL_4]] : i32
+// CHECK:           %[[VAL_5:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s1(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_3:.*]] = hw.constant true
-// CHECK:           hw.output %[[VAL_0]] : i32
+// CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_0]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
-// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_3:.*]] = hw.constant true
-// CHECK:           %[[VAL_4:.*]] = seq.compreg %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           hw.output %[[VAL_4]] : i32
+// CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
+// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_0]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_3:.*]] = hw.constant true
-// CHECK:           %[[VAL_4:.*]] = seq.compreg %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           hw.output %[[VAL_4]] : i32
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_4:.*]] = seq.clock_gate %[[VAL_2]], %[[VAL_1]]
+// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_0]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = hw.instance "testLatency1_p0" @testLatency1_p0(in0: %[[VAL_0]]: i32, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32)
-// CHECK:           hw.output %[[VAL_5]] : i32
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testLatency1_p0" @testLatency1_p0(in0: %[[VAL_0]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
-hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
-    %true = hw.constant true
+hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
+  %out, %done = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid: i1):
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %6 : i32
     }
-    pipeline.stage ^bb1 pass(%1 : i32) enable %true
-  ^bb1(%2: i32):  // pred: ^bb0
-    pipeline.stage ^bb2 pass(%2 : i32) enable %true
-  ^bb2(%3: i32):  // pred: ^bb1
-    pipeline.stage ^bb3 regs(%3 : i32) enable %true
-  ^bb3(%4: i32):  // pred: ^bb2
-    pipeline.stage ^bb4 regs(%4 : i32) enable %true
-  ^bb4(%5: i32):  // pred: ^bb3
+    pipeline.stage ^bb1 pass(%1 : i32)
+  ^bb1(%2: i32, %s1_valid: i1):  // pred: ^bb0
+    pipeline.stage ^bb2 pass(%2 : i32)
+  ^bb2(%3: i32, %s2_valid: i1):  // pred: ^bb1
+    pipeline.stage ^bb3 regs(%3 : i32)
+  ^bb3(%4: i32, %s3_valid: i1):  // pred: ^bb2
+    pipeline.stage ^bb4 regs(%4 : i32)
+  ^bb4(%5: i32, %s4_valid: i1):  // pred: ^bb3
     pipeline.return %5 : i32
   }
-  hw.output %0 : i32
+  hw.output %out, %done : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testSingle_p0(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testSingle_p0_s0" @testSingle_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32)
-// CHECK:           %[[VAL_7:.*]] = hw.constant true
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingle_p0_s0" @testSingle_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           %[[VAL_8:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_7]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]] : i32, i32
+// CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle(
-// CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testSingle_p0" @testSingle_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i1)
+// CHECK-SAME:                          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testSingle_p0" @testSingle_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32) enable %arg2
-  ^bb1(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
   hw.output %0#0, %0#1 : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p0_s0" @testMultiple_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, out2: i1)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testMultiple_p0_s1" @testMultiple_p0_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, in2: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32)
-// CHECK:           %[[VAL_10:.*]] = hw.constant true
+// CHECK-SAME:                               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p0_s0" @testMultiple_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = hw.instance "testMultiple_p0_s1" @testMultiple_p0_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           %[[VAL_11:.*]] = comb.mul %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, out2: i1) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]] : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : i32, i32, i1
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
-// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]] : i32, i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p1_s0" @testMultiple_p1_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, out2: i1)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testMultiple_p1_s1" @testMultiple_p1_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, in2: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32)
-// CHECK:           %[[VAL_10:.*]] = hw.constant true
+// CHECK-SAME:                               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p1_s0" @testMultiple_p1_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = hw.instance "testMultiple_p1_s1" @testMultiple_p1_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           %[[VAL_11:.*]] = comb.mul %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, out2: i1) {
-// CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]] : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : i32, i32, i1
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testMultiple_p1_s1(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_8]], %[[VAL_10]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testMultiple_p0" @testMultiple_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i1)
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = hw.instance "testMultiple_p1" @testMultiple_p1(in0: %[[VAL_5]]: i32, in1: %[[VAL_1]]: i32, in2: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i1)
+// CHECK-SAME:                            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testMultiple_p0" @testMultiple_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = hw.instance "testMultiple_p1" @testMultiple_p1(in0: %[[VAL_5]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0, %arg2 : i32, i32, i1) enable %arg2
-  ^bb1(%2: i32, %3: i32, %4: i1):  // pred: ^bb0
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32) enable %4
-  ^bb2(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
 
-  %1:2 = pipeline.scheduled(%0#0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
-  ^bb0(%arg0_0: i32, %arg1_1: i32, %arg2: i1):
-    %true = hw.constant true
+  %1:2 = pipeline.scheduled(%0#0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0, %arg2 : i32, i32, i1) enable %arg2
-  ^bb1(%2: i32, %3: i32, %4: i1):  // pred: ^bb0
+    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32) enable %4
-  ^bb2(%6: i32, %7: i32):  // pred: ^bb1
+    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
-    pipeline.return %8, %true : i32, i1
+    pipeline.return %8 : i32
   }
 
   hw.output %0#0, %0#1 : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_5:.*]] = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32)
-// CHECK:           %[[VAL_6:.*]] = hw.instance "testSingleWithExt_p0_s1" @testSingleWithExt_p0_s1(in0: %[[VAL_5]]: i32, extIn0: %[[VAL_2]]: i32, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32)
-// CHECK:           hw.output %[[VAL_6]], %[[VAL_2]] : i32, i32
+// CHECK-SAME:                                    %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testSingleWithExt_p0_s1" @testSingleWithExt_p0_s1(in0: %[[VAL_6]]: i32, extIn0: %[[VAL_2]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_2]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s0(
-// CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_4:.*]] = hw.constant true
-// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           hw.output %[[VAL_6]] : i32
+// CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
+// CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
-// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           hw.output %[[VAL_6]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i32, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, out1: i32)
-// CHECK:           hw.output %[[VAL_4]], %[[VAL_5]] : i32, i32
+// CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0" @testSingleWithExt_p0(in0: %[[VAL_0]]: i32, in1: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_2]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i32
 // CHECK:         }
-hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
-  %0:2 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
-  ^bb0(%a0: i32, %a1 : i32, %ext0: i32):
+hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
+  ^bb0(%a0: i32, %a1 : i32, %ext0: i32, %s0_valid: i1):
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
-    pipeline.stage ^bb1 regs(%1 : i32) enable %true
+    pipeline.stage ^bb1 regs(%1 : i32)
 
-  ^bb1(%6: i32):
+  ^bb1(%6: i32, %s1_valid: i1):
     // Use the external value inside a stage
     %8 = comb.add %6, %ext0 : i32
-    pipeline.stage ^bb2 regs(%8 : i32) enable %true
+    pipeline.stage ^bb2 regs(%8 : i32)
   
-  ^bb2(%9 : i32):
+  ^bb2(%9 : i32, %s2_valid: i1):
   // Use the external value in the exit stage.
     pipeline.return %9, %ext0  : i32, i32
   }
   hw.output %0#0, %0#1 : i32, i32
+}
+
+// CHECK-LABEL:   hw.module @testControlUsage_p0(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testControlUsage_p0_s0" @testControlUsage_p0_s0(in0: %[[VAL_0]]: i32, extIn0: %[[VAL_1]]: i1, extIn1: %[[VAL_2]]: i1, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testControlUsage_p0_s1" @testControlUsage_p0_s1(in0: %[[VAL_6]]: i32, extIn0: %[[VAL_1]]: i1, extIn1: %[[VAL_2]]: i1, enable: %[[VAL_7]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_10:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_11:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_12:.*]] = sv.read_inout %[[VAL_11]] : !hw.inout<i32>
+// CHECK:           %[[VAL_13:.*]] = comb.add %[[VAL_12]], %[[VAL_8]] : i32
+// CHECK:           %[[VAL_14:.*]] = seq.compreg.ce %[[VAL_13]], %[[VAL_1]], %[[VAL_9]], %[[VAL_2]], %[[VAL_10]]  : i32
+// CHECK:           sv.assign %[[VAL_11]], %[[VAL_14]] : i32
+// CHECK:           hw.output %[[VAL_14]], %[[VAL_9]] : i32, i1
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testControlUsage_p0_s0(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_7:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_8:.*]] = sv.read_inout %[[VAL_7]] : !hw.inout<i32>
+// CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
+// CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.clock_gate %[[VAL_4]], %[[VAL_3]]
+// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_10]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testControlUsage_p0_s1(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_7:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_8:.*]] = sv.read_inout %[[VAL_7]] : !hw.inout<i32>
+// CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
+// CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.clock_gate %[[VAL_4]], %[[VAL_3]]
+// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_10]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:         }
+
+// CHECK-LABEL:   hw.module @testControlUsage(
+// CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testControlUsage_p0" @testControlUsage_p0(in0: %[[VAL_0]]: i32, extIn0: %[[VAL_2]]: i1, extIn1: %[[VAL_3]]: i1, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_1]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           hw.output %[[VAL_4]] : i32
+// CHECK:         }
+hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
+  %0:2 = pipeline.scheduled(%arg0) ext (%clk, %rst : i1, i1) clock %clk reset %rst go %go : (i32) -> (i32) {
+  ^bb0(%a0: i32, %ext_clk: i1, %ext_rst : i1, %s0_valid: i1):
+    %zero = hw.constant 0 : i32
+    %reg_out_wire = sv.wire : !hw.inout<i32>
+    %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
+    %add0 = comb.add %reg_out, %a0 : i32
+    %out = seq.compreg.ce %add0, %ext_clk, %s0_valid, %ext_rst, %zero : i32
+    sv.assign %reg_out_wire, %out : i32
+    pipeline.stage ^bb1 regs(%out : i32)
+
+  ^bb1(%6: i32, %s1_valid: i1):
+    %reg1_out_wire = sv.wire : !hw.inout<i32>
+    %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
+    %add1 = comb.add %reg1_out, %6 : i32
+    %out1 = seq.compreg.ce %add1, %ext_clk, %s1_valid, %ext_rst, %zero : i32
+    sv.assign %reg1_out_wire, %out1 : i32
+
+    pipeline.stage ^bb2 regs(%out1 : i32)
+  
+  ^bb2(%9 : i32, %s2_valid: i1):
+    %reg2_out_wire = sv.wire : !hw.inout<i32>
+    %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
+    %add2 = comb.add %reg2_out, %9 : i32
+    %out2 = seq.compreg.ce %add2, %ext_clk, %s2_valid, %ext_rst, %zero : i32
+    sv.assign %reg2_out_wire, %out2 : i32
+    pipeline.return %out2  : i32
+  }
+  hw.output %0#0 : i32
 }

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,217 +1,215 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs)))' --allow-unregistered-dialect %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testRegsOnly(
-// CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]]:2 = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32, i32, i1) -> (i32, i1) {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
-// CHECK:             %[[VAL_9:.*]] = hw.constant true
-// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]], %[[VAL_6]], %[[VAL_8]] : i32, i32, i1) enable %[[VAL_8]]
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]], %[[VAL_7]] : i32, i32)
 // CHECK:           ^bb1(%[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
 // CHECK:             %[[VAL_14:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_14]], %[[VAL_11]] : i32, i32) enable %[[VAL_13]]
-// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i32):
-// CHECK:             %[[VAL_17:.*]] = comb.add %[[VAL_15]], %[[VAL_16]] : i32
-// CHECK:             pipeline.return %[[VAL_17]], %[[VAL_9]] : i32, i1
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_14]], %[[VAL_11]] : i32, i32)
+// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i32, %[[VAL_17:.*]]: i1):
+// CHECK:             %[[VAL_18:.*]] = comb.add %[[VAL_15]], %[[VAL_16]] : i32
+// CHECK:             pipeline.return %[[VAL_18]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_18:.*]]#0, %[[VAL_18]]#1 : i32, i1
-// CHECK:     }        
+// CHECK:           hw.output %[[VAL_19:.*]], %[[VAL_20:.*]] : i32, i1
+// CHECK:         }
 
 hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i1) {
-  %out:2 = pipeline.scheduled(%arg0, %arg1, %go) clock %clk reset %rst : (i32, i32, i1) -> (i32, i1) {
+  %out:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
     ^bb0(%a0 : i32, %a1: i32, %g : i1):
-      %true = hw.constant true
       %add0 = comb.add %a0, %a1 : i32
-      pipeline.stage ^bb1 enable %g
+      pipeline.stage ^bb1
     
-    ^bb1:
+    ^bb1(%s1_valid : i1):
       %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
-      pipeline.stage ^bb2 enable %g
+      pipeline.stage ^bb2
 
-    ^bb2:
+    ^bb2(%s2_valid : i1):
       %add2 = comb.add %add1, %add0 : i32 // %add0 crosses multiple stages.
-      pipeline.return %add2, %true : i32, i1
+      pipeline.return %add2 : i32
   }
   hw.output %out#0, %out#1 : i32, i1
 }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = hw.constant true
-// CHECK:             %[[VAL_8:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = hw.constant true
+// CHECK:             %[[VAL_10:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_11]] : i32
 // CHECK:             }
-// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_10:.*]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb1(%[[VAL_11:.*]]: i32):
-// CHECK:             pipeline.stage ^bb2 pass(%[[VAL_11]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
-// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_12]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb3(%[[VAL_13:.*]]: i32):
-// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_13]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb4(%[[VAL_14:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_14]] : i32
+// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_12:.*]] : i32)
+// CHECK:           ^bb1(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i1):
+// CHECK:             pipeline.stage ^bb2 pass(%[[VAL_13]] : i32)
+// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i1):
+// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_15]] : i32)
+// CHECK:           ^bb3(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i1):
+// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_17]] : i32)
+// CHECK:           ^bb4(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_19]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_15:.*]] : i32
+// CHECK:           hw.output %[[VAL_21:.*]] : i32
 // CHECK:         }
 hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
-  ^bb0(%a0 : i32):
+  %out:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> (i32) {
+  ^bb0(%a0 : i32, %s0_valid : i1):
     %true = hw.constant true
     %out = pipeline.latency 2 -> (i32) {
       %r = comb.add %a0, %a0 : i32
       pipeline.latency.return %r : i32
     }
-    pipeline.stage ^bb1 enable %true
-  ^bb1:
-    pipeline.stage ^bb2 enable %true
-  ^bb2:
-    pipeline.stage ^bb3 enable %true
-  ^bb3:
-    pipeline.stage ^bb4 enable %true
-  ^bb4:
+    pipeline.stage ^bb1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb2
+  ^bb2(%s2_valid : i1):
+    pipeline.stage ^bb3
+  ^bb3(%s3_valid : i1):
+    pipeline.stage ^bb4
+  ^bb4(%s4_valid : i1):
     pipeline.return %out : i32
   }
-  hw.output %out : i32
+  hw.output %out#0 : i32
 }
 
 // CHECK-LABEL:   hw.module @testLatency2(
-// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = hw.constant true
-// CHECK:             %[[VAL_8:.*]] = pipeline.latency 1 -> (i32) {
-// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = hw.constant true
+// CHECK:             %[[VAL_10:.*]] = pipeline.latency 1 -> (i32) {
+// CHECK:               %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_11]] : i32
 // CHECK:             }
-// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_10:.*]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb1(%[[VAL_11:.*]]: i32):
-// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_11]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
-// CHECK:             %[[VAL_13:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_14:.*]] = comb.sub %[[VAL_12]], %[[VAL_12]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_14]] : i32
+// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_12:.*]] : i32)
+// CHECK:           ^bb1(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i1):
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_13]] : i32)
+// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i1):
+// CHECK:             %[[VAL_17:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_18:.*]] = comb.sub %[[VAL_15]], %[[VAL_15]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_18]] : i32
 // CHECK:             }
-// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_12]] : i32) pass(%[[VAL_15:.*]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb3(%[[VAL_16:.*]]: i32, %[[VAL_17:.*]]: i32):
-// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_16]] : i32) pass(%[[VAL_17]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb4(%[[VAL_18:.*]]: i32, %[[VAL_19:.*]]: i32):
-// CHECK:             %[[VAL_20:.*]] = comb.add %[[VAL_18]], %[[VAL_19]] : i32
-// CHECK:             pipeline.return %[[VAL_18]] : i32
+// CHECK:             pipeline.stage ^bb3 regs(%[[VAL_15]] : i32) pass(%[[VAL_19:.*]] : i32)
+// CHECK:           ^bb3(%[[VAL_20:.*]]: i32, %[[VAL_21:.*]]: i32, %[[VAL_22:.*]]: i1):
+// CHECK:             pipeline.stage ^bb4 regs(%[[VAL_20]] : i32) pass(%[[VAL_21]] : i32)
+// CHECK:           ^bb4(%[[VAL_23:.*]]: i32, %[[VAL_24:.*]]: i32, %[[VAL_25:.*]]: i1):
+// CHECK:             %[[VAL_26:.*]] = comb.add %[[VAL_23]], %[[VAL_24]] : i32
+// CHECK:             pipeline.return %[[VAL_23]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_21:.*]] : i32
+// CHECK:           hw.output %[[VAL_27:.*]] : i32
 // CHECK:         }
 hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
-  ^bb0(%a0 : i32):
+  %out:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> (i32) {
+  ^bb0(%a0 : i32, %s0_valid : i1):
     %true = hw.constant true
     %out = pipeline.latency 1 -> (i32) {
       %r = comb.add %a0, %a0 : i32
       pipeline.latency.return %r : i32
     }
-    pipeline.stage ^bb1 enable %true
-  ^bb1:
-    pipeline.stage ^bb2 enable %true
-  ^bb2:
+    pipeline.stage ^bb1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb2
+  ^bb2(%s2_valid : i1):
     %out2 = pipeline.latency 2 -> (i32) {
       %r = comb.sub %out, %out : i32
       pipeline.latency.return %r : i32
     }
-    pipeline.stage ^bb3 enable %true
-  ^bb3:
-    pipeline.stage ^bb4 enable %true
-  ^bb4:
+    pipeline.stage ^bb3
+  ^bb3(%s3_valid : i1):
+    pipeline.stage ^bb4
+  ^bb4(%s4_valid : i1):
     %res = comb.add %out, %out2 : i32
     pipeline.return %out : i32
   }
-  hw.output %out : i32
+  hw.output %out#0 : i32
 }
 
 // CHECK-LABEL:   hw.module @testLatencyToLatency(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = hw.constant true
-// CHECK:             %[[OUT1:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_6]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_9]] : i32
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = hw.constant true
+// CHECK:             %[[VAL_10:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_11]] : i32
 // CHECK:             }
-// CHECK:             pipeline.stage ^bb1 pass(%[[OUT1]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb1(%[[PASS1:.*]]: i32):
-// CHECK:             pipeline.stage ^bb2 pass(%[[PASS1]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb2(%[[PASS2:.*]]: i32):
-// CHECK:             %[[VAL_13:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_14:.*]] = hw.constant 1 : i32
-// CHECK:               %[[VAL_15:.*]] = comb.add %[[PASS2]], %[[VAL_14]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_15]] : i32
+// CHECK:             pipeline.stage ^bb1 pass(%[[VAL_12:.*]] : i32)
+// CHECK:           ^bb1(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i1):
+// CHECK:             pipeline.stage ^bb2 pass(%[[VAL_13]] : i32)
+// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i1):
+// CHECK:             %[[VAL_17:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_18:.*]] = hw.constant 1 : i32
+// CHECK:               %[[VAL_19:.*]] = comb.add %[[VAL_15]], %[[VAL_18]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_19]] : i32
 // CHECK:             }
-// CHECK:             pipeline.stage ^bb3 pass(%[[VAL_16:.*]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb3(%[[VAL_17:.*]]: i32):
-// CHECK:             pipeline.stage ^bb4 pass(%[[VAL_17]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb4(%[[VAL_18:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_18]] : i32
+// CHECK:             pipeline.stage ^bb3 pass(%[[VAL_20:.*]] : i32)
+// CHECK:           ^bb3(%[[VAL_21:.*]]: i32, %[[VAL_22:.*]]: i1):
+// CHECK:             pipeline.stage ^bb4 pass(%[[VAL_21]] : i32)
+// CHECK:           ^bb4(%[[VAL_23:.*]]: i32, %[[VAL_24:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_23]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_19:.*]] : i32
+// CHECK:           hw.output %[[VAL_25:.*]] : i32
 // CHECK:         }
 hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid : i1):
     %true = hw.constant true
     %1 = pipeline.latency 2 -> (i32) {
       %res = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %res : i32
     }
-    pipeline.stage ^bb1 enable %true
-  ^bb1:
-    pipeline.stage ^bb2 enable %true
+    pipeline.stage ^bb1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb2
 
-  ^bb2:
+  ^bb2(%s2_valid : i1):
     %2 = pipeline.latency 2 -> (i32) {
       %c1_i32 = hw.constant 1 : i32
       %res2 = comb.add %1, %c1_i32 : i32
       pipeline.latency.return %res2 : i32
     }
-    pipeline.stage ^bb3 enable %true
+    pipeline.stage ^bb3
 
-  ^bb3:
-    pipeline.stage ^bb4 enable %true
+  ^bb3(%s3_valid : i1):
+    pipeline.stage ^bb4
 
-  ^bb4:
+  ^bb4(%s4_valid : i1):
     pipeline.return %2 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // CHECK-LABEL:   hw.module @test_arbitrary_nesting(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = hw.constant true
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_6]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb1(%[[VAL_8:.*]]: i32):
-// CHECK:             %[[VAL_9:.*]] = "foo.foo"(%[[VAL_8]]) : (i32) -> i32
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]] : i32)
+// CHECK:           ^bb1(%[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: i1):
+// CHECK:             %[[VAL_12:.*]] = "foo.foo"(%[[VAL_10]]) : (i32) -> i32
 // CHECK:             "foo.bar"() ({
-// CHECK:               %[[VAL_10:.*]] = "foo.foo"(%[[VAL_8]]) : (i32) -> i32
+// CHECK:               %[[VAL_13:.*]] = "foo.foo"(%[[VAL_10]]) : (i32) -> i32
 // CHECK:               "foo.baz"() ({
-// CHECK:               ^bb0(%[[VAL_11:.*]]: i32):
-// CHECK:                 "foo.foobar"(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (i32, i32, i32) -> ()
-// CHECK:                 "foo.foobar"(%[[VAL_8]]) : (i32) -> ()
+// CHECK:               ^bb0(%[[VAL_14:.*]]: i32):
+// CHECK:                 "foo.foobar"(%[[VAL_12]], %[[VAL_13]], %[[VAL_14]]) : (i32, i32, i32) -> ()
+// CHECK:                 "foo.foobar"(%[[VAL_10]]) : (i32) -> ()
 // CHECK:               }) : () -> ()
 // CHECK:             }) : () -> ()
-// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_8]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb2(%[[VAL_12:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_12]] : i32
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_10]] : i32)
+// CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_15]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_13:.*]] : i32
+// CHECK:           hw.output %[[VAL_17:.*]] : i32
 // CHECK:         }
 hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %out = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> (i32) {
-  ^bb0(%a0 : i32):
+  %out:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> (i32) {
+  ^bb0(%a0 : i32, %s0_valid : i1):
     %true = hw.constant true
-    pipeline.stage ^bb1 enable %true
-  ^bb1:
+    pipeline.stage ^bb1
+  ^bb1(%s1_valid : i1):
     %foo = "foo.foo" (%a0) : (i32) -> (i32)
     "foo.bar" () ({
       ^bb0:
@@ -227,33 +225,33 @@ hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1,
       }) : () -> ()
     }) : () -> ()
 
-    pipeline.stage ^bb2 enable %true
-  ^bb2:
+    pipeline.stage ^bb2
+  ^bb2(%s2_valid : i1):
     pipeline.return %a0 : i32
   }
-  hw.output %out : i32
+  hw.output %out#0 : i32
 }
 
 // CHECK-LABEL:   hw.module @testExtInput(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_4:.*]]:2 = pipeline.scheduled(%[[VAL_0]]) ext(%[[VAL_1]] : i32) clock %[[VAL_2]] reset %[[VAL_3]] : (i32) -> (i32, i32) {
-// CHECK:           ^bb0(%[[ARG_IN:.*]]: i32, %[[EXT_IN:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = hw.constant true
-// CHECK:             %[[VAL_8:.*]] = comb.add %[[ARG_IN]], %[[EXT_IN]] : i32
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_8]] : i32) enable %[[VAL_7]]
-// CHECK:           ^bb1(%[[VAL_9:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_9]], %[[EXT_IN]] : i32, i32
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_5:.*]]:2, %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) ext(%[[VAL_1]] : i32) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> (i32, i32) {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = hw.constant true
+// CHECK:             %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_11]] : i32)
+// CHECK:           ^bb1(%[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_12]], %[[VAL_8]] : i32, i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_10:.*]]#0, %[[VAL_10]]#1 : i32, i32
+// CHECK:           hw.output %[[VAL_14:.*]]#0, %[[VAL_14]]#1 : i32, i32
 // CHECK:         }
-hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %clk : i1, %rst : i1) -> (out0: i32, out1: i32) {
-  %out:2 = pipeline.scheduled(%arg0) ext(%ext1 : i32) clock %clk reset %rst : (i32) -> (i32, i32) {
-    ^bb0(%a0 : i32, %e0: i32):
+hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i32) {
+  %out:3 = pipeline.scheduled(%arg0) ext(%ext1 : i32) clock %clk reset %rst go %go: (i32) -> (i32, i32) {
+    ^bb0(%a0 : i32, %e0: i32, %s0_valid : i1):
       %true = hw.constant true
       %add0 = comb.add %a0, %e0 : i32
-      pipeline.stage ^bb1 enable %true
+      pipeline.stage ^bb1
 
-    ^bb1:
+    ^bb1(%s1_valid : i1):
       pipeline.return %add0, %e0 : i32, i32
   }
   hw.output %out#0, %out#1 : i32, i32

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -2,30 +2,29 @@
 
 // CHECK-LABEL:   hw.module @pipeline(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] : (i32, i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32):
-// CHECK:             %[[VAL_8:.*]] = hw.constant true
-// CHECK:             %[[VAL_9:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_6]] {ssp.operator_type = @add1} : i32
-// CHECK:             pipeline.stage ^bb1 enable %[[VAL_8]]
-// CHECK:           ^bb1:
-// CHECK:             pipeline.stage ^bb2 enable %[[VAL_8]]
-// CHECK:           ^bb2:
-// CHECK:             %[[VAL_11:.*]] = comb.mul %[[VAL_6]], %[[VAL_9]] {ssp.operator_type = @mul2} : i32
-// CHECK:             pipeline.stage ^bb3 enable %[[VAL_8]]
-// CHECK:           ^bb3:
-// CHECK:             pipeline.stage ^bb4 enable %[[VAL_8]]
-// CHECK:           ^bb4:
-// CHECK:             pipeline.stage ^bb5 enable %[[VAL_8]]
-// CHECK:           ^bb5:
-// CHECK:             %[[VAL_12:.*]] = comb.add %[[VAL_11]], %[[VAL_10]] {ssp.operator_type = @add1} : i32
-// CHECK:             pipeline.stage ^bb6 enable %[[VAL_8]]
-// CHECK:           ^bb6:
-// CHECK:             pipeline.stage ^bb7 enable %[[VAL_8]]
-// CHECK:           ^bb7:
-// CHECK:             pipeline.return %[[VAL_12]] : i32
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] {ssp.operator_type = @add1} : i32
+// CHECK:             %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
+// CHECK:             pipeline.stage ^bb1
+// CHECK:           ^bb1(%[[VAL_12:.*]]: i1):
+// CHECK:             pipeline.stage ^bb2
+// CHECK:           ^bb2(%[[VAL_13:.*]]: i1):
+// CHECK:             %[[VAL_14:.*]] = comb.mul %[[VAL_7]], %[[VAL_10]] {ssp.operator_type = @mul2} : i32
+// CHECK:             pipeline.stage ^bb3
+// CHECK:           ^bb3(%[[VAL_15:.*]]: i1):
+// CHECK:             pipeline.stage ^bb4
+// CHECK:           ^bb4(%[[VAL_16:.*]]: i1):
+// CHECK:             pipeline.stage ^bb5
+// CHECK:           ^bb5(%[[VAL_17:.*]]: i1):
+// CHECK:             %[[VAL_18:.*]] = comb.add %[[VAL_14]], %[[VAL_11]] {ssp.operator_type = @add1} : i32
+// CHECK:             pipeline.stage ^bb6
+// CHECK:           ^bb6(%[[VAL_19:.*]]: i1):
+// CHECK:             pipeline.stage ^bb7
+// CHECK:           ^bb7(%[[VAL_20:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_18]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_13:.*]] : i32
+// CHECK:           hw.output %[[VAL_21:.*]] : i32
 // CHECK:         }
 
 module {
@@ -35,16 +34,16 @@ module {
   }
 
   hw.module @pipeline(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
-    %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst
+    %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go
       {operator_lib = @lib}
     : (i32, i32) -> (i32) {
-    ^bb0(%a0 : i32, %a1: i32):
+    ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
       %0 = comb.add %a0, %a1 {ssp.operator_type = @add1} : i32
       %1 = comb.mul %a0, %0 {ssp.operator_type = @mul2} : i32
       %2 = comb.add %a1, %a0 {ssp.operator_type = @add1} : i32
       %3 = comb.add %1, %2 {ssp.operator_type = @add1} : i32
       pipeline.return %3 : i32
     }
-    hw.output %0 : i32
+    hw.output %0#0 : i32
   }
 }

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -1,149 +1,138 @@
-// RUN: circt-opt %s -split-input-file -verify-diagnostics
+// RUN: circt-opt -split-input-file -verify-diagnostics %s
 
-// -----
-
-hw.module @body_argn(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  // expected-error @+1 {{'pipeline.unscheduled' op expected 2 arguments in the pipeline body block, got 1.}}
-  %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32):
-    %valid = hw.constant 1 : i1
+hw.module @body_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  // expected-error @+1 {{'pipeline.unscheduled' op expected 3 arguments in the pipeline entry block, got 2.}}
+  %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %s0_valid : i1):
     pipeline.return %a0 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @res_argn(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %valid = hw.constant 1 : i1
+hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     // expected-error @+1 {{'pipeline.return' op expected 1 return values, got 0.}}
     pipeline.return
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @body_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @body_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.unscheduled' op expected body block argument 0 to have type 'i32', got 'i31'.}}
-  %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i31, %a1 : i32):
-    %valid = hw.constant 1 : i1
+  %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i31, %a1 : i32, %s0_valid : i1):
     pipeline.return %a1 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i31) {
-  %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i31) {
-   ^bb0(%a0 : i32, %a1 : i32):
-    %valid = hw.constant 1 : i1
+hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i31) {
+  %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i31) {
+   ^bb0(%a0 : i32, %a1 : i32, %s0_valid : i1):
     // expected-error @+1 {{'pipeline.return' op expected return value of type 'i31', got 'i32'.}}
     pipeline.return %a0 : i32
   }
-  hw.output %0 : i31
+  hw.output %0#0 : i31
 }
 
 // -----
 
-hw.module @unterminated(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op all blocks must be terminated with a `pipeline.stage` or `pipeline.return` op.}}
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %c1_i1 = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
 
-  ^bb1:
-    pipeline.stage ^bb2 regs(%0, %c1_i1 : i32, i1) enable %c1_i1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb2 regs(%0 : i32)
 
   ^bb2(%s2_s0 : i32, %s2_valid : i1):
     pipeline.return %s2_s0 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %c1_i1 = hw.constant true
+hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    pipeline.stage ^bb1 enable %c1_i1
+    pipeline.stage ^bb1
 
 
-  ^bb1:
+  ^bb1(%s1_valid : i1):
   // expected-error @+1 {{'pipeline.stage' op Pipeline is in register materialized mode - operand 0 is defined in a different stage, which is illegal.}}
-    pipeline.stage ^bb2 regs(%0, %c1_i1 : i32, i1) enable %c1_i1
+    pipeline.stage ^bb2 regs(%0: i32)
 
   ^bb2(%s2_s0 : i32, %s2_valid : i1):
     pipeline.return %s2_s0 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %c1_i1 = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    pipeline.stage ^bb1 enable %c1_i1
+    pipeline.stage ^bb1
 
-  ^bb1:
-    pipeline.stage ^bb2 enable %c1_i1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb2
 
-  ^bb2:
-    pipeline.stage ^bb1 enable %c1_i1
+  ^bb2(%s2_valid : i1):
+    pipeline.stage ^bb1
 
-  ^bb3:
+  ^bb3(%s3_valid : i1):
     pipeline.return %0 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
-hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
-    %c1_i1 = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    pipeline.stage ^bb1 enable %c1_i1
+    pipeline.stage ^bb1
 
-  ^bb1:
-    pipeline.stage ^bb1 enable %c1_i1
+  ^bb1(%s1_valid : i1):
+    pipeline.stage ^bb1
 
-  ^bb3:
+  ^bb3(%s3_valid : i1):
     pipeline.return %0 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
 hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid : i1):
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %6 : i32
     }
-    pipeline.stage ^bb1 enable %true
-  ^bb1:
+    pipeline.stage ^bb1
+  ^bb1(%s1_valid : i1):
     // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
     pipeline.return %1 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
@@ -151,50 +140,81 @@ hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (
 // Test which verifies that the values referenced within the body of a
 // latency operation also adhere to the latency constraints.
 hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid : i1):
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %res = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %res : i32
     }
-    pipeline.stage ^bb1 enable %true
+    pipeline.stage ^bb1
 
-  ^bb1:
+  ^bb1(%s1_valid : i1):
     %2 = pipeline.latency 2 -> (i32) {
       %c1_i32 = hw.constant 1 : i32
       // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
       %res2 = comb.add %1, %c1_i32 : i32
       pipeline.latency.return %res2 : i32
     }
-    pipeline.stage ^bb2 enable %true
+    pipeline.stage ^bb2
 
-  ^bb2:
-    pipeline.stage ^bb3 enable %true
+  ^bb2(%s2_valid : i1):
+    pipeline.stage ^bb3
 
-  ^bb3:
+  ^bb3(%s3_valid : i1):
     pipeline.return %2 : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // -----
 
 
 hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) clock %clk reset %rst : (i32) -> i32 {
-  ^bb0(%arg0_0: i32):
-    %true = hw.constant true
+  %0:2 = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
+  ^bb0(%arg0_0: i32, %s0_valid : i1):
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %arg0_0, %arg0_0 : i32
       pipeline.latency.return %6 : i32
     }
     // expected-note@+1 {{use was operand 0. The result is available 2 stages later than this use.}}
-    pipeline.stage ^bb1 regs(%1 : i32) enable %true
-  ^bb1(%v : i32):
+    pipeline.stage ^bb1 regs(%1 : i32)
+  ^bb1(%v : i32, %s1_valid : i1):
     pipeline.return %v : i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
+}
+
+// -----
+
+hw.module @missing_valid_entry1(%go : i1, %clk : i1, %rst : i1) -> () {
+  // expected-error @+1 {{'pipeline.unscheduled' op expected 1 arguments in the pipeline entry block, got 0.}}
+  %done = pipeline.unscheduled() clock %clk reset %rst go %go : () -> () {
+   ^bb0:
+  }
+  hw.output
+}
+
+// -----
+
+hw.module @missing_valid_entry2(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () {
+  // expected-error @+1 {{'pipeline.unscheduled' op expected last argument to the entry stage to be an i1 signal (stage valid signal).}}
+  %done = pipeline.unscheduled(%arg) clock %clk reset %rst go %go : (i32) -> () {
+   ^bb0(%a0 : i32, %a1 : i32):
+  }
+  hw.output
+}
+
+// -----
+
+hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () {
+  // expected-error @+1 {{'pipeline.scheduled' op block 1 must have an i1 argument as the last block argument (stage valid signal).}}
+  %done = pipeline.scheduled(%arg) clock %clk reset %rst go %go : (i32) -> () {
+   ^bb0(%a0 : i32, %s0_valid : i1):
+     pipeline.stage ^bb1
+   ^bb1:
+      pipeline.return
+  }
+  hw.output
 }

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -1,51 +1,47 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL:   hw.module @unscheduled1(
-// CHECK-SAME:         %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_4:.*]] = pipeline.unscheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = pipeline.latency 2 -> (i32) {
-// CHECK:               %[[VAL_8:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:               pipeline.latency.return %[[VAL_8]] : i32
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.unscheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = pipeline.latency 2 -> (i32) {
+// CHECK:               %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:               pipeline.latency.return %[[VAL_11]] : i32
 // CHECK:             }
-// CHECK:             %[[VAL_9:.*]] = hw.constant true
-// CHECK:             pipeline.return %[[VAL_10:.*]] : i32
+// CHECK:             pipeline.return %[[VAL_12:.*]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_11:.*]] : i32
+// CHECK:           hw.output %[[VAL_13:.*]] : i32
 // CHECK:         }
-hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
+hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.unscheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = pipeline.latency 2 -> (i32) {
       %1 = comb.add %a0, %a1 : i32
       pipeline.latency.return %1 : i32
     }
-    %c1_i1 = hw.constant 1 : i1
     pipeline.return %0 : i32
   }
   hw.output %0 : i32
 }
 
 // CHECK-LABEL:   hw.module @scheduled1(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_8:.*]] = hw.constant true
-// CHECK:             pipeline.stage ^bb1 enable %[[VAL_8]]
-// CHECK:           ^bb1:
-// CHECK:             pipeline.return %[[VAL_7]] : i32
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:             pipeline.stage ^bb1
+// CHECK:           ^bb1(%[[VAL_11:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_10]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_9:.*]] : i32
+// CHECK:           hw.output %[[VAL_12:.*]] : i32
 // CHECK:         }
-hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
+hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    %c1_i1 = hw.constant 1 : i1
-    pipeline.stage ^bb1 enable %c1_i1
+    pipeline.stage ^bb1
 
-   ^bb1:
+   ^bb1(%s1_valid : i1):
     pipeline.return %0 : i32
   }
   hw.output %0 : i32
@@ -53,66 +49,62 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i
 
 
 // CHECK-LABEL:   hw.module @scheduled2(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_8:.*]] = hw.constant true
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]], %[[VAL_8]] : i32, i1) enable %[[VAL_8]]
-// CHECK:           ^bb1(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i1):
-// CHECK:             pipeline.return %[[VAL_9]] : i32
+// CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]] : i32)
+// CHECK:           ^bb1(%[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_11]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_11:.*]] : i32
+// CHECK:           hw.output %[[VAL_13:.*]] : i32
 // CHECK:         }
-hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32) {
-   ^bb0(%a0 : i32, %a1: i32):
+hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %g : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %g : (i32, i32) -> (i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    %c1_i1 = hw.constant 1 : i1
-    pipeline.stage ^bb1 regs(%0, %c1_i1 : i32, i1) enable %c1_i1
+    pipeline.stage ^bb1 regs(%0 : i32)
 
-   ^bb1(%s0_0 : i32, %s0_valid : i1):
+   ^bb1(%s0_0 : i32, %s1_valid : i1):
     pipeline.return %s0_0 : i32
   }
   hw.output %0 : i32
 }
 
 // CHECK-LABEL:   hw.module @scheduledWithPassthrough(
-// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_4:.*]]:2 = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_2]] reset %[[VAL_3]] : (i32, i32) -> (i32, i32) {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:             %[[VAL_8:.*]] = hw.constant true
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]], %[[VAL_8]] : i32, i1) pass(%[[VAL_6]] : i32) enable %[[VAL_8]]
-// CHECK:           ^bb1(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i1, %[[VAL_11:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_9]], %[[VAL_11]] : i32, i32
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]]:2, %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> (i32, i32) {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]] : i32) pass(%[[VAL_8]] : i32)
+// CHECK:           ^bb1(%[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_11]], %[[VAL_12]] : i32, i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_12:.*]]#0 : i32
+// CHECK:           hw.output %[[VAL_14:.*]]#0 : i32
 // CHECK:         }
-hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %clk : i1, %rst : i1) -> (out: i32) {
-  %0, %1 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst : (i32, i32) -> (i32, i32) {
-   ^bb0(%a0 : i32, %a1: i32):
+hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %g : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:3 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %g : (i32, i32) -> (i32, i32) {
+   ^bb0(%a0 : i32, %a1: i32, %s0_valid : i1):
     %0 = comb.add %a0, %a1 : i32
-    %c1_i1 = hw.constant 1 : i1
-    pipeline.stage ^bb1 regs(%0, %c1_i1 : i32, i1) pass(%a1 : i32) enable %c1_i1
+    pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
 
-   ^bb1(%s0_0 : i32, %s0_valid : i1, %s0_pass_a1 : i32):
+   ^bb1(%s0_0 : i32, %s0_pass_a1 : i32, %s1_valid : i1):
     pipeline.return %s0_0, %s0_pass_a1 : i32, i32
   }
-  hw.output %0 : i32
+  hw.output %0#0 : i32
 }
 
 // CHECK-LABEL:   hw.module @withStall(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_4:.*]] = pipeline.scheduled(%[[VAL_0]]) stall %[[VAL_1]] clock %[[VAL_2]] reset %[[VAL_3]] : (i32) -> i32 {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: i32):
-// CHECK:             pipeline.return %[[VAL_5]] : i32
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) stall %[[VAL_1]] clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_7]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_6:.*]] : i32
+// CHECK:           hw.output %[[VAL_9:.*]] : i32
 // CHECK:         }
-hw.module @withStall(%arg0 : i32, %stall : i1, %clk : i1, %rst : i1) -> (out: i32) {
-  %0 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst : (i32) -> (i32) {
-   ^bb0(%a0 : i32):
+hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst go %go : (i32) -> (i32) {
+   ^bb0(%a0 : i32, %s0_valid : i1):
     pipeline.return %a0 : i32
   }
   hw.output %0 : i32


### PR DESCRIPTION
This commit adds an explicit 'go' signal to the pipeline abstraction. This signal is used to indicate when the pipeline should start. The signal will propagate through each stage as the stage valid signal. As a result of this, each stage now has a `s#_valid : i1` signal as the last value in its block argument list. This value can be used within each stage for any operations which requires access to the pipeline control circuitry.
Given that pipeline stage validity is now explicit within the block arguments of a stage, a `pipeline.stage` operation no longer has an `enable` signal. As a small 'bugfix' here, a `seq.clock_gate` is emitted to gate the pipeline stage separating registers on the pipeline stage valid signal.