### PR TITLE
[ETC] Use name/namehint as a port name

### DIFF
--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -420,6 +420,7 @@ module {
 
 module {
   // CHECK-LABEL: @RegExtracted_cover
+  // CHECK-SAME: %designAndTestCode
   // CHECK: %testCode1 = seq.firreg
   // CHECK: %testCode2 = seq.firreg
   // CHECK-NOT: seq.firreg


### PR DESCRIPTION
Fix #5459. Use namehints and name attributes on module boundary as port names of extracted modules. Also improve instance op logic a bit to avoid unnecessary linear search.