### PR TITLE
[SVExtractTestCode] Clone constants even when used by designs as well

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -555,9 +555,12 @@ private:
       return false;
 
     // Find the data-flow and structural ops to clone.  Result includes roots.
-    // Track dataflow until it reaches to design parts.
-    auto opsToClone = getBackwardSlice(
-        roots, [&](Operation *op) { return !opsInDesign.count(op); });
+    // Track dataflow until it reaches to design parts except for constants that
+    // can be cloned freely.
+    auto opsToClone = getBackwardSlice(roots, [&](Operation *op) {
+      return !opsInDesign.count(op) ||
+             op->hasTrait<mlir::OpTrait::ConstantLike>();
+    });
 
     // Find the dataflow into the clone set
     SetVector<Value> inputs;

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -445,3 +445,22 @@ module {
     hw.output %designAndTestCode : i1
   }
 }
+
+// -----
+// Check that constants are cloned freely.
+
+module {
+  // CHECK-LABEL: @ConstantCloned_cover(%in: i1, %clock: i1)
+  // CHECK-NEXT:   %true = hw.constant true
+  // CHECK-NEXT:   comb.xor bin %in, %true : i1
+  hw.module @ConstantCloned(%clock: i1, %in: i1) -> (out: i1) {
+    %true = hw.constant true
+    %not = comb.xor bin %in, %true : i1
+
+    sv.always posedge %clock {
+      sv.cover %not, immediate
+    }
+
+    hw.output %true : i1
+  }
+}


### PR DESCRIPTION
Fix #5465. This fixes an issue that constants used by both designs and testcode.