### PR TITLE
[FIRRTL][CHIRRTL] Add dialect C API

### DIFF
--- a/include/circt-c/Dialect/CHIRRTL.h
+++ b/include/circt-c/Dialect/CHIRRTL.h
@@ -1,0 +1,40 @@
+//===-- circt-c/Dialect/CHIRRTL.h - C API for CHIRRTL dialect -----*- C -*-===//
+//
+// This header declares the C interface for registering and accessing the
+// CHIRRTL dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_CHIRRTL_H
+#define CIRCT_C_DIALECT_CHIRRTL_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(CHIRRTL, chirrtl);
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirType chirrtlGetTypeCMemory(MlirContext ctx,
+                                                  MlirType elementType,
+                                                  uint64_t numElements);
+
+MLIR_CAPI_EXPORTED MlirType chirrtlGetTypeCMemoryPort(MlirContext ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_CHIRRTL_H

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -17,7 +17,100 @@
 extern "C" {
 #endif
 
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct FIRRTLBundleField {
+  bool flip;
+  MlirAttribute name;
+  MlirType type;
+} FIRRTLBundleField;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLConvention {
+  FIRRTL_CONVENTION_INTERNAL,
+  FIRRTL_CONVENTION_SCALARIZED,
+} FIRRTLConvention;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLPortDir {
+  FIRRTL_PORT_DIR_INPUT,
+  FIRRTL_PORT_DIR_OUTPUT,
+} FIRRTLPortDir;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLNameKind {
+  FIRRTL_NAME_KIND_DROPPABLE_NAME,
+  FIRRTL_NAME_KIND_INTERESTING_NAME,
+} FIRRTLNameKind;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLRUW {
+  FIRRTL_RUW_UNDEFINED,
+  FIRRTL_RUW_OLD,
+  FIRRTL_RUW_NEW,
+} FIRRTLRUW;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLMemDir {
+  FIRRTL_MEM_DIR_INFER,
+  FIRRTL_MEM_DIR_READ,
+  FIRRTL_MEM_DIR_WRITE,
+  FIRRTL_MEM_DIR_READ_WRITE,
+} FIRRTLMemDir;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum FIRRTLEventControl {
+  FIRRTL_EVENT_CONTROL_AT_POS_EDGE,
+  FIRRTL_EVENT_CONTROL_AT_NEG_EDGE,
+  FIRRTL_EVENT_CONTROL_AT_EDGE,
+} FIRRTLEventControl;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeUInt(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeSInt(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeClock(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeReset(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeAsyncReset(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeAnalog(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeVector(MlirContext ctx,
+                                                MlirType element, size_t count);
+MLIR_CAPI_EXPORTED MlirType firrtlGetTypeBundle(
+    MlirContext ctx, size_t count, const FIRRTLBundleField *fields);
+
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+firrtlGetAttrConvention(MlirContext ctx, FIRRTLConvention convention);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+firrtlGetAttrPortDirs(MlirContext ctx, size_t count, const FIRRTLPortDir *dirs);
+
+MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrNameKind(MlirContext ctx,
+                                                       FIRRTLNameKind nameKind);
+
+MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrRUW(MlirContext ctx,
+                                                  FIRRTLRUW ruw);
+
+MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrMemInit(MlirContext ctx,
+                                                      MlirStringRef filename,
+                                                      bool isBinary,
+                                                      bool isInline);
+
+MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrMemDir(MlirContext ctx,
+                                                     FIRRTLMemDir dir);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+firrtlGetAttrEventControl(MlirContext ctx, FIRRTLEventControl eventControl);
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/Dialect/CHIRRTL.cpp
+++ b/lib/CAPI/Dialect/CHIRRTL.cpp
@@ -1,0 +1,35 @@
+//===- CHIRRTL.cpp - C Interface for the CHIRRTL Dialect ------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/CHIRRTL.h"
+#include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+using namespace circt;
+using namespace chirrtl;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(CHIRRTL, chirrtl,
+                                      circt::chirrtl::CHIRRTLDialect)
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+MlirType chirrtlGetTypeCMemory(MlirContext ctx, MlirType elementType,
+                               uint64_t numElements) {
+  auto baseType = unwrap(elementType).cast<firrtl::FIRRTLBaseType>();
+  assert(baseType && "element must be base type");
+
+  return wrap(CMemoryType::get(unwrap(ctx), baseType, numElements));
+}
+
+MlirType chirrtlGetTypeCMemoryPort(MlirContext ctx) {
+  return wrap(CMemoryPortType::get(unwrap(ctx)));
+}

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_OPTIONAL_SOURCES
   Comb.cpp
   ESI.cpp
   FIRRTL.cpp
+  CHIRRTL.cpp
   MSFT.cpp
   HW.cpp
   HWArith.cpp
@@ -33,6 +34,14 @@ add_mlir_public_c_api_library(CIRCTCAPIESI
 
 add_mlir_public_c_api_library(CIRCTCAPIFIRRTL
   FIRRTL.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTFIRRTL
+)
+
+add_mlir_public_c_api_library(CIRCTCAPICHIRRTL
+  CHIRRTL.cpp
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -3,10 +3,195 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt-c/Dialect/FIRRTL.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
 
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Dialect API.
+//===----------------------------------------------------------------------===//
+
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl,
                                       circt::firrtl::FIRRTLDialect)
+
+//===----------------------------------------------------------------------===//
+// Type API.
+//===----------------------------------------------------------------------===//
+
+MlirType firrtlGetTypeUInt(MlirContext ctx, int32_t width) {
+  return wrap(UIntType::get(unwrap(ctx), width));
+}
+
+MlirType firrtlGetTypeSInt(MlirContext ctx, int32_t width) {
+  return wrap(SIntType::get(unwrap(ctx), width));
+}
+
+MlirType firrtlGetTypeClock(MlirContext ctx) {
+  return wrap(ClockType::get(unwrap(ctx)));
+}
+
+MlirType firrtlGetTypeReset(MlirContext ctx) {
+  return wrap(ResetType::get(unwrap(ctx)));
+}
+
+MlirType firrtlGetTypeAsyncReset(MlirContext ctx) {
+  return wrap(AsyncResetType::get(unwrap(ctx)));
+}
+
+MlirType firrtlGetTypeAnalog(MlirContext ctx, int32_t width) {
+  return wrap(AnalogType::get(unwrap(ctx), width));
+}
+
+MlirType firrtlGetTypeVector(MlirContext ctx, MlirType element, size_t count) {
+  auto baseType = unwrap(element).cast<FIRRTLBaseType>();
+  assert(baseType && "element must be base type");
+
+  return wrap(FVectorType::get(baseType, count));
+}
+
+MlirType firrtlGetTypeBundle(MlirContext ctx, size_t count,
+                             const FIRRTLBundleField *fields) {
+  SmallVector<BundleType::BundleElement, 4> bundleFields;
+  bundleFields.reserve(count);
+
+  for (size_t i = 0; i < count; i++) {
+    auto field = fields[i];
+
+    auto name = unwrap(field.name).cast<StringAttr>();
+    auto baseType = unwrap(field.type).dyn_cast<FIRRTLBaseType>();
+    assert(baseType && "field must be base type");
+
+    bundleFields.emplace_back(name, field.flip, baseType);
+  }
+  return wrap(BundleType::get(unwrap(ctx), bundleFields));
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+MlirAttribute firrtlGetAttrConvention(MlirContext ctx,
+                                      FIRRTLConvention convention) {
+  Convention value;
+
+  switch (convention) {
+  case FIRRTL_CONVENTION_INTERNAL:
+    value = Convention::Internal;
+    break;
+  case FIRRTL_CONVENTION_SCALARIZED:
+    value = Convention::Scalarized;
+    break;
+  default: // NOLINT(clang-diagnostic-covered-switch-default)
+    llvm_unreachable("unknown convention");
+  }
+
+  return wrap(ConventionAttr::get(unwrap(ctx), value));
+}
+
+MlirAttribute firrtlGetAttrPortDirs(MlirContext ctx, size_t count,
+                                    const FIRRTLPortDir *dirs) {
+  static_assert(FIRRTLPortDir::FIRRTL_PORT_DIR_INPUT ==
+                static_cast<std::underlying_type_t<Direction>>(Direction::In));
+  static_assert(FIRRTLPortDir::FIRRTL_PORT_DIR_OUTPUT ==
+                static_cast<std::underlying_type_t<Direction>>(Direction::Out));
+
+  // FIXME: The `reinterpret_cast` here may voilate strict aliasing rule. Is
+  // there a better way?
+  return wrap(direction::packAttribute(
+      unwrap(ctx), ArrayRef(reinterpret_cast<const Direction *>(dirs), count)));
+}
+
+MlirAttribute firrtlGetAttrNameKind(MlirContext ctx, FIRRTLNameKind nameKind) {
+  NameKindEnum value;
+
+  switch (nameKind) {
+  case FIRRTL_NAME_KIND_DROPPABLE_NAME:
+    value = NameKindEnum::DroppableName;
+    break;
+  case FIRRTL_NAME_KIND_INTERESTING_NAME:
+    value = NameKindEnum::InterestingName;
+    break;
+  default: // NOLINT(clang-diagnostic-covered-switch-default)
+    llvm_unreachable("unknown name kind");
+  }
+
+  return wrap(NameKindEnumAttr::get(unwrap(ctx), value));
+}
+
+MlirAttribute firrtlGetAttrRUW(MlirContext ctx, FIRRTLRUW ruw) {
+  RUWAttr value;
+
+  switch (ruw) {
+  case FIRRTL_RUW_UNDEFINED:
+    value = RUWAttr::Undefined;
+    break;
+  case FIRRTL_RUW_OLD:
+    value = RUWAttr::Old;
+    break;
+  case FIRRTL_RUW_NEW:
+    value = RUWAttr::New;
+    break;
+  default: // NOLINT(clang-diagnostic-covered-switch-default)
+    llvm_unreachable("unknown ruw");
+  }
+
+  return wrap(RUWAttrAttr::get(unwrap(ctx), value));
+}
+
+MlirAttribute firrtlGetAttrMemInit(MlirContext ctx, MlirStringRef filename,
+                                   bool isBinary, bool isInline) {
+  MLIRContext *mlirCtx = unwrap(ctx);
+
+  return wrap(MemoryInitAttr::get(
+      mlirCtx, StringAttr::get(mlirCtx, unwrap(filename)), isBinary, isInline));
+}
+
+MlirAttribute firrtlGetAttrMemDir(MlirContext ctx, FIRRTLMemDir dir) {
+  MemDirAttr value;
+
+  switch (dir) {
+  case FIRRTL_MEM_DIR_INFER:
+    value = MemDirAttr::Infer;
+    break;
+  case FIRRTL_MEM_DIR_READ:
+    value = MemDirAttr::Read;
+    break;
+  case FIRRTL_MEM_DIR_WRITE:
+    value = MemDirAttr::Write;
+    break;
+  case FIRRTL_MEM_DIR_READ_WRITE:
+    value = MemDirAttr::ReadWrite;
+    break;
+  default: // NOLINT(clang-diagnostic-covered-switch-default)
+    llvm_unreachable("unknown memory direction");
+  }
+
+  return wrap(MemDirAttrAttr::get(unwrap(ctx), value));
+}
+
+MlirAttribute firrtlGetAttrEventControl(MlirContext ctx,
+                                        FIRRTLEventControl eventControl) {
+  EventControl value;
+
+  switch (eventControl) {
+  case FIRRTL_EVENT_CONTROL_AT_POS_EDGE:
+    value = EventControl::AtPosEdge;
+    break;
+  case FIRRTL_EVENT_CONTROL_AT_NEG_EDGE:
+    value = EventControl::AtNegEdge;
+    break;
+  case FIRRTL_EVENT_CONTROL_AT_EDGE:
+    value = EventControl::AtEdge;
+    break;
+  default: // NOLINT(clang-diagnostic-covered-switch-default)
+    llvm_unreachable("unknown event control");
+  }
+
+  return wrap(EventControlAttr::get(unwrap(ctx), value));
+}


### PR DESCRIPTION
This PR adds C API for FIRRTL and CHIRRTL dialects, which allows foreign languages to construct FIRRTL through MLIR C API. 