### PR TITLE
[Support] Add a 'by-name' lookup for HWModuleLike ops

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -76,6 +76,51 @@ struct ModulePortInfo {
   SmallVector<PortInfo> outputs;
 };
 
+// This provides capability for looking up port indices based on port names.
+struct ModulePortLookupInfo {
+  FailureOr<unsigned>
+  lookupPortIndex(const llvm::DenseMap<StringAttr, unsigned> &portMap,
+                  StringAttr name) const {
+    auto it = portMap.find(name);
+    if (it == portMap.end())
+      return failure();
+    return it->second;
+  }
+
+public:
+  explicit ModulePortLookupInfo(MLIRContext *ctx, ModulePortInfo portInfo)
+      : ctx(ctx) {
+    for (auto &in : portInfo.inputs)
+      inputPortMap[in.name] = in.argNum;
+
+    for (auto &out : portInfo.outputs)
+      outputPortMap[out.name] = out.argNum;
+  }
+
+  // Return the index of the input port with the specified name.
+  FailureOr<unsigned> getInputPortIndex(StringAttr name) const {
+    return lookupPortIndex(inputPortMap, name);
+  }
+
+  // Return the index of the output port with the specified name.
+  FailureOr<unsigned> getOutputPortIndex(StringAttr name) const {
+    return lookupPortIndex(outputPortMap, name);
+  }
+
+  FailureOr<unsigned> getInputPortIndex(StringRef name) const {
+    return getInputPortIndex(StringAttr::get(ctx, name));
+  }
+
+  FailureOr<unsigned> getOutputPortIndex(StringRef name) const {
+    return getOutputPortIndex(StringAttr::get(ctx, name));
+  }
+
+private:
+  llvm::DenseMap<StringAttr, unsigned> inputPortMap;
+  llvm::DenseMap<StringAttr, unsigned> outputPortMap;
+  MLIRContext *ctx;
+};
+
 class InnerSymbolOpInterface;
 /// Verification hook for verifying InnerSym Attribute.
 LogicalResult verifyInnerSymAttr(InnerSymbolOpInterface op);

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -88,7 +88,8 @@ struct ModulePortLookupInfo {
   }
 
 public:
-  explicit ModulePortLookupInfo(MLIRContext *ctx, ModulePortInfo portInfo)
+  explicit ModulePortLookupInfo(MLIRContext *ctx,
+                                const ModulePortInfo &portInfo)
       : ctx(ctx) {
     for (auto &in : portInfo.inputs)
       inputPortMap[in.name] = in.argNum;

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -107,6 +107,15 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike"> {
       return getModulePortInfo($_op);
     }]>,
 
+    InterfaceMethod<"Get a handle to a utility class which provides by-name lookup of port indices. The returned object does _not_ update if the module is mutated.",
+    "::circt::hw::ModulePortLookupInfo", "getPortLookupInfo", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return hw::ModulePortLookupInfo(
+        $_op->getContext(),
+        this->getPorts());
+    }]>,
+
     /// Insert and remove input and output ports of this module. Does not modify
     /// the block arguments of the module body. The insertion and removal
     /// indices must be in ascending order. The indices refer to the port

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -285,11 +285,13 @@ public:
       parent.getStageExtInputs(block, stageExtInputs);
       extInputs =
           mod.getArguments().slice(nStageInputArgs, stageExtInputs.size());
-      valid = mod.getArgument(mod.getNumArguments() - (withStall ? 4 : 3));
+
+      auto portLookup = mod.getPortLookupInfo();
       if (withStall)
-        stall = mod.getArgument(mod.getNumArguments() - 3);
-      clock = mod.getArgument(mod.getNumArguments() - 2);
-      reset = mod.getArgument(mod.getNumArguments() - 1);
+        stall = mod.getArgument(*portLookup.getInputPortIndex("stall"));
+      valid = mod.getArgument(*portLookup.getInputPortIndex("enable"));
+      clock = mod.getArgument(*portLookup.getInputPortIndex("clk"));
+      reset = mod.getArgument(*portLookup.getInputPortIndex("rst"));
     }
 
     ValueRange inputs;
@@ -322,10 +324,11 @@ public:
         buildPipelineLike(pipelineName, pipeline.getInputs().getTypes(),
                           pipeline.getExtInputs().getTypes(),
                           pipeline.getResults().getTypes(), withStall);
+    auto portLookup = pipelineMod.getPortLookupInfo();
     pipelineClk = pipelineMod.getBody().front().getArgument(
-        pipelineMod.getBody().front().getNumArguments() - 2);
+        *portLookup.getInputPortIndex("clk"));
     pipelineRst = pipelineMod.getBody().front().getArgument(
-        pipelineMod.getBody().front().getNumArguments() - 1);
+        *portLookup.getInputPortIndex("rst"));
 
     if (!pipeline.getExtInputs().empty()) {
       // Maintain a mapping between external inputs and their corresponding


### PR DESCRIPTION
... based on a name-to-index `DenseMap` built from the `hw::ModulePortInfo` struct. Needed in various places, and not willing to wait for https://github.com/llvm/circt/pull/5350.