### PR TITLE
[FIRRTL][IMDCE] Remove some cached state

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -54,6 +54,7 @@ static bool isWeakReferencingAnnotation(Annotation anno) {
          (tpe == "OMReferenceTarget" || tpe == "OMMemberReferenceTarget" ||
           tpe == "OMMemberInstanceTarget");
 }
+
 namespace {
 struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
   void runOnOperation() override;
@@ -102,10 +103,6 @@ private:
   /// The set of blocks that are known to execute, or are intrinsically alive.
   DenseSet<Block *> executableBlocks;
 
-  /// This keeps track of users the instance results that correspond to output
-  /// ports.
-  DenseMap<BlockArgument, llvm::TinyPtrVector<mlir::OpResult>>
-      resultPortToInstanceResultMapping;
   InstanceGraph *instanceGraph;
 
   // The type with which we associate liveness.
@@ -122,10 +119,6 @@ private:
   /// the users need to be reprocessed.
   SmallVector<ElementType, 64> worklist;
   llvm::DenseSet<ElementType> liveElements;
-
-  /// This keeps track of input ports that need to be kept if the associated
-  /// instance is alive.
-  DenseMap<InstanceOp, SmallVector<mlir::OpResult>> lazyLiveInputPorts;
 
   /// A map from instances to hierpaths whose last path is the associated
   /// instance.
@@ -157,8 +150,12 @@ void IMDeadCodeElimPass::visitInstanceOp(InstanceOp instance) {
     markAlive(hierPath);
 
   // Input ports get alive only when the instance is alive.
-  for (auto inputPort : lazyLiveInputPorts[instance])
-    markAlive(inputPort);
+  for (auto &blockArg : module.getBody().getArguments()) {
+    auto portNo = blockArg.getArgNumber();
+    if (module.getPortDirection(portNo) == Direction::In &&
+        isKnownAlive(module.getArgument(portNo)))
+      markAlive(instance.getResult(portNo));
+  }
 }
 
 void IMDeadCodeElimPass::visitModuleOp(FModuleOp module) {
@@ -216,13 +213,12 @@ void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
   if (!isa<FModuleOp>(op)) {
     auto module = dyn_cast<FModuleLike>(op);
     for (auto resultNo : llvm::seq(0u, instance.getNumResults())) {
-      auto portVal = instance.getResult(resultNo);
       // If this is an output to the extmodule, we can ignore it.
       if (module.getPortDirection(resultNo) == Direction::Out)
         continue;
 
-      // Otherwise this is an inuput from it or an inout, mark it as alive.
-      markAlive(portVal);
+      // Otherwise this is an input from it or an inout, mark it as alive.
+      markAlive(instance.getResult(resultNo));
     }
     markAlive(instance);
 
@@ -232,18 +228,6 @@ void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
   // Otherwise this is a defined module.
   auto fModule = cast<FModuleOp>(op);
   markBlockExecutable(fModule.getBodyBlock());
-
-  // Ok, it is a normal internal module reference so populate
-  // resultPortToInstanceResultMapping.
-  for (auto resultNo : llvm::seq(0u, instance.getNumResults())) {
-    auto instancePortVal = instance.getResult(resultNo).cast<mlir::OpResult>();
-
-    // Otherwise we have a result from the instance.  We need to forward results
-    // from the body to this instance result's SSA value, so remember it.
-    BlockArgument modulePortVal = fModule.getArgument(resultNo);
-
-    resultPortToInstanceResultMapping[modulePortVal].push_back(instancePortVal);
-  }
 }
 
 void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
@@ -456,9 +440,7 @@ void IMDeadCodeElimPass::runOnOperation() {
 
   // Clean up data structures.
   executableBlocks.clear();
-  resultPortToInstanceResultMapping.clear();
   liveElements.clear();
-  lazyLiveInputPorts.clear();
   instanceToHierPaths.clear();
   hierPathToElements.clear();
 }
@@ -478,13 +460,10 @@ void IMDeadCodeElimPass::visitValue(Value value) {
     // instances as alive. We don't have to propagate the liveness of output
     // ports.
     if (portDirection == Direction::In) {
-      for (auto userOfResultPort :
-           resultPortToInstanceResultMapping[blockArg]) {
-        auto instance = userOfResultPort.getDefiningOp<InstanceOp>();
+      for (auto *instRec : instanceGraph->lookup(module)->uses()) {
+        auto instance = cast<InstanceOp>(instRec->getInstance());
         if (liveElements.contains(instance))
-          markAlive(userOfResultPort);
-        else
-          lazyLiveInputPorts[instance].push_back(userOfResultPort);
+          markAlive(instance.getResult(blockArg.getArgNumber()));
       }
     }
     return;
@@ -593,8 +572,7 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
   if (!isBlockExecutable(module.getBodyBlock()))
     return;
 
-  InstanceGraphNode *instanceGraphNode =
-      instanceGraph->lookup(module.getModuleNameAttr());
+  InstanceGraphNode *instanceGraphNode = instanceGraph->lookup(module);
   LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
                           << "\n");
 
@@ -603,8 +581,8 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
                                            InstanceOp instance) {
     auto result = instance.getResult(index);
     if (isAssumedDead(result)) {
-      // If the result is dead, replace the result with an unrealiazed
-      // conversion cast which works as a dummy placeholder.
+      // If the result is dead, replace the result with an unrealized conversion
+      // cast which works as a dummy placeholder.
       auto wire = builder
                       .create<mlir::UnrealizedConversionCastOp>(
                           ArrayRef<Type>{result.getType()}, ArrayRef<Value>{})
@@ -683,15 +661,20 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
     if (hasDontTouch(argument))
       continue;
 
-    // If the port is known alive, then we can't delete it except for write-only
-    // output ports.
     if (isKnownAlive(argument)) {
-      bool deadOutputPortAtAnyInstantiation =
-          module.getPortDirection(index) == Direction::Out &&
-          llvm::all_of(resultPortToInstanceResultMapping[argument],
-                       [&](Value result) { return isAssumedDead(result); });
 
-      if (!deadOutputPortAtAnyInstantiation)
+      // If an output port is only used internally in the module, then we can
+      // remove the port and replace it with a wire.
+      if (module.getPortDirection(index) == Direction::In)
+        continue;
+
+      // Check if the output port is demanded by any instance.  If not, then it
+      // is only demanded internally to the module.
+      if (llvm::any_of(instanceGraph->lookup(module)->uses(),
+                       [&](InstanceRecord *record) {
+                         return isKnownAlive(
+                             record->getInstance()->getResult(index));
+                       }))
         continue;
 
       // RefType can't be a wire, especially if it won't be erased.  Skip.


### PR DESCRIPTION
This change removes some cached information related to how module ports relate to instance results.

`resultPortToInstanceResultMapping`: This tracks a mapping from a block argument to all instance results that it corresponds to.  We can instead use the instance graph to go from a module to all instances of that module, and grab the instance result we are interested in.  There is a small difference in that instead of visiting only marked instances, we now visit every instance.  This is a NFC but it could be slower if there are many unreachable modules in the hierarchy with dead instances, but that is very uncommon and currently illegal in the FIRRTL spec.

`lazyLiveInputPorts`: This tracks which ports of an instance should be marked live if the instance op should be marked live. This corresponds to the input ports of a module, so it is not worth tracking, especially per-instance.  Instead we just mark the input ports of the instance when the instance is marked alive.