### PR TITLE
[FIRRTL][CHIRRTL] C API rename and change some types

### DIFF
--- a/include/circt-c/Dialect/CHIRRTL.h
+++ b/include/circt-c/Dialect/CHIRRTL.h
@@ -27,11 +27,11 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(CHIRRTL, chirrtl);
 // Type API.
 //===----------------------------------------------------------------------===//
 
-MLIR_CAPI_EXPORTED MlirType chirrtlGetTypeCMemory(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirType chirrtlTypeGetCMemory(MlirContext ctx,
                                                   MlirType elementType,
                                                   uint64_t numElements);
 
-MLIR_CAPI_EXPORTED MlirType chirrtlGetTypeCMemoryPort(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType chirrtlTypeGetCMemoryPort(MlirContext ctx);
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -19,7 +19,7 @@ extern "C" {
 
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct FIRRTLBundleField {
-  MlirAttribute name;
+  MlirIdentifier name;
   bool isFlip;
   MlirType type;
 } FIRRTLBundleField;
@@ -102,7 +102,7 @@ MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetRUW(MlirContext ctx,
                                                   FIRRTLRUW ruw);
 
 MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetMemInit(MlirContext ctx,
-                                                      MlirStringRef filename,
+                                                      MlirIdentifier filename,
                                                       bool isBinary,
                                                       bool isInline);
 

--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -19,8 +19,8 @@ extern "C" {
 
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct FIRRTLBundleField {
-  bool flip;
   MlirAttribute name;
+  bool isFlip;
   MlirType type;
 } FIRRTLBundleField;
 
@@ -74,15 +74,15 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl);
 // Type API.
 //===----------------------------------------------------------------------===//
 
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeUInt(MlirContext ctx, int32_t width);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeSInt(MlirContext ctx, int32_t width);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeClock(MlirContext ctx);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeReset(MlirContext ctx);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeAsyncReset(MlirContext ctx);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeAnalog(MlirContext ctx, int32_t width);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeVector(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetUInt(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetSInt(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetClock(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetReset(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetAsyncReset(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetAnalog(MlirContext ctx, int32_t width);
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetVector(MlirContext ctx,
                                                 MlirType element, size_t count);
-MLIR_CAPI_EXPORTED MlirType firrtlGetTypeBundle(
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetBundle(
     MlirContext ctx, size_t count, const FIRRTLBundleField *fields);
 
 //===----------------------------------------------------------------------===//
@@ -90,27 +90,27 @@ MLIR_CAPI_EXPORTED MlirType firrtlGetTypeBundle(
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-firrtlGetAttrConvention(MlirContext ctx, FIRRTLConvention convention);
+firrtlAttrGetConvention(MlirContext ctx, FIRRTLConvention convention);
 
 MLIR_CAPI_EXPORTED MlirAttribute
-firrtlGetAttrPortDirs(MlirContext ctx, size_t count, const FIRRTLPortDir *dirs);
+firrtlAttrGetPortDirs(MlirContext ctx, size_t count, const FIRRTLPortDir *dirs);
 
-MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrNameKind(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetNameKind(MlirContext ctx,
                                                        FIRRTLNameKind nameKind);
 
-MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrRUW(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetRUW(MlirContext ctx,
                                                   FIRRTLRUW ruw);
 
-MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrMemInit(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetMemInit(MlirContext ctx,
                                                       MlirStringRef filename,
                                                       bool isBinary,
                                                       bool isInline);
 
-MLIR_CAPI_EXPORTED MlirAttribute firrtlGetAttrMemDir(MlirContext ctx,
+MLIR_CAPI_EXPORTED MlirAttribute firrtlAttrGetMemDir(MlirContext ctx,
                                                      FIRRTLMemDir dir);
 
 MLIR_CAPI_EXPORTED MlirAttribute
-firrtlGetAttrEventControl(MlirContext ctx, FIRRTLEventControl eventControl);
+firrtlAttrGetEventControl(MlirContext ctx, FIRRTLEventControl eventControl);
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/Dialect/CHIRRTL.cpp
+++ b/lib/CAPI/Dialect/CHIRRTL.cpp
@@ -22,7 +22,7 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(CHIRRTL, chirrtl,
 // Type API.
 //===----------------------------------------------------------------------===//
 
-MlirType chirrtlGetTypeCMemory(MlirContext ctx, MlirType elementType,
+MlirType chirrtlTypeGetCMemory(MlirContext ctx, MlirType elementType,
                                uint64_t numElements) {
   auto baseType = unwrap(elementType).cast<firrtl::FIRRTLBaseType>();
   assert(baseType && "element must be base type");
@@ -30,6 +30,6 @@ MlirType chirrtlGetTypeCMemory(MlirContext ctx, MlirType elementType,
   return wrap(CMemoryType::get(unwrap(ctx), baseType, numElements));
 }
 
-MlirType chirrtlGetTypeCMemoryPort(MlirContext ctx) {
+MlirType chirrtlTypeGetCMemoryPort(MlirContext ctx) {
   return wrap(CMemoryPortType::get(unwrap(ctx)));
 }

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -63,11 +63,10 @@ MlirType firrtlTypeGetBundle(MlirContext ctx, size_t count,
   for (size_t i = 0; i < count; i++) {
     auto field = fields[i];
 
-    auto name = unwrap(field.name).cast<StringAttr>();
     auto baseType = unwrap(field.type).dyn_cast<FIRRTLBaseType>();
     assert(baseType && "field must be base type");
 
-    bundleFields.emplace_back(name, field.isFlip, baseType);
+    bundleFields.emplace_back(unwrap(field.name), field.isFlip, baseType);
   }
   return wrap(BundleType::get(unwrap(ctx), bundleFields));
 }
@@ -144,12 +143,10 @@ MlirAttribute firrtlAttrGetRUW(MlirContext ctx, FIRRTLRUW ruw) {
   return wrap(RUWAttrAttr::get(unwrap(ctx), value));
 }
 
-MlirAttribute firrtlAttrGetMemInit(MlirContext ctx, MlirStringRef filename,
+MlirAttribute firrtlAttrGetMemInit(MlirContext ctx, MlirIdentifier filename,
                                    bool isBinary, bool isInline) {
-  MLIRContext *mlirCtx = unwrap(ctx);
-
-  return wrap(MemoryInitAttr::get(
-      mlirCtx, StringAttr::get(mlirCtx, unwrap(filename)), isBinary, isInline));
+  return wrap(
+      MemoryInitAttr::get(unwrap(ctx), unwrap(filename), isBinary, isInline));
 }
 
 MlirAttribute firrtlAttrGetMemDir(MlirContext ctx, FIRRTLMemDir dir) {

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -24,38 +24,38 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(FIRRTL, firrtl,
 // Type API.
 //===----------------------------------------------------------------------===//
 
-MlirType firrtlGetTypeUInt(MlirContext ctx, int32_t width) {
+MlirType firrtlTypeGetUInt(MlirContext ctx, int32_t width) {
   return wrap(UIntType::get(unwrap(ctx), width));
 }
 
-MlirType firrtlGetTypeSInt(MlirContext ctx, int32_t width) {
+MlirType firrtlTypeGetSInt(MlirContext ctx, int32_t width) {
   return wrap(SIntType::get(unwrap(ctx), width));
 }
 
-MlirType firrtlGetTypeClock(MlirContext ctx) {
+MlirType firrtlTypeGetClock(MlirContext ctx) {
   return wrap(ClockType::get(unwrap(ctx)));
 }
 
-MlirType firrtlGetTypeReset(MlirContext ctx) {
+MlirType firrtlTypeGetReset(MlirContext ctx) {
   return wrap(ResetType::get(unwrap(ctx)));
 }
 
-MlirType firrtlGetTypeAsyncReset(MlirContext ctx) {
+MlirType firrtlTypeGetAsyncReset(MlirContext ctx) {
   return wrap(AsyncResetType::get(unwrap(ctx)));
 }
 
-MlirType firrtlGetTypeAnalog(MlirContext ctx, int32_t width) {
+MlirType firrtlTypeGetAnalog(MlirContext ctx, int32_t width) {
   return wrap(AnalogType::get(unwrap(ctx), width));
 }
 
-MlirType firrtlGetTypeVector(MlirContext ctx, MlirType element, size_t count) {
+MlirType firrtlTypeGetVector(MlirContext ctx, MlirType element, size_t count) {
   auto baseType = unwrap(element).cast<FIRRTLBaseType>();
   assert(baseType && "element must be base type");
 
   return wrap(FVectorType::get(baseType, count));
 }
 
-MlirType firrtlGetTypeBundle(MlirContext ctx, size_t count,
+MlirType firrtlTypeGetBundle(MlirContext ctx, size_t count,
                              const FIRRTLBundleField *fields) {
   SmallVector<BundleType::BundleElement, 4> bundleFields;
   bundleFields.reserve(count);
@@ -67,7 +67,7 @@ MlirType firrtlGetTypeBundle(MlirContext ctx, size_t count,
     auto baseType = unwrap(field.type).dyn_cast<FIRRTLBaseType>();
     assert(baseType && "field must be base type");
 
-    bundleFields.emplace_back(name, field.flip, baseType);
+    bundleFields.emplace_back(name, field.isFlip, baseType);
   }
   return wrap(BundleType::get(unwrap(ctx), bundleFields));
 }
@@ -76,7 +76,7 @@ MlirType firrtlGetTypeBundle(MlirContext ctx, size_t count,
 // Attribute API.
 //===----------------------------------------------------------------------===//
 
-MlirAttribute firrtlGetAttrConvention(MlirContext ctx,
+MlirAttribute firrtlAttrGetConvention(MlirContext ctx,
                                       FIRRTLConvention convention) {
   Convention value;
 
@@ -94,7 +94,7 @@ MlirAttribute firrtlGetAttrConvention(MlirContext ctx,
   return wrap(ConventionAttr::get(unwrap(ctx), value));
 }
 
-MlirAttribute firrtlGetAttrPortDirs(MlirContext ctx, size_t count,
+MlirAttribute firrtlAttrGetPortDirs(MlirContext ctx, size_t count,
                                     const FIRRTLPortDir *dirs) {
   static_assert(FIRRTLPortDir::FIRRTL_PORT_DIR_INPUT ==
                 static_cast<std::underlying_type_t<Direction>>(Direction::In));
@@ -107,7 +107,7 @@ MlirAttribute firrtlGetAttrPortDirs(MlirContext ctx, size_t count,
       unwrap(ctx), ArrayRef(reinterpret_cast<const Direction *>(dirs), count)));
 }
 
-MlirAttribute firrtlGetAttrNameKind(MlirContext ctx, FIRRTLNameKind nameKind) {
+MlirAttribute firrtlAttrGetNameKind(MlirContext ctx, FIRRTLNameKind nameKind) {
   NameKindEnum value;
 
   switch (nameKind) {
@@ -124,7 +124,7 @@ MlirAttribute firrtlGetAttrNameKind(MlirContext ctx, FIRRTLNameKind nameKind) {
   return wrap(NameKindEnumAttr::get(unwrap(ctx), value));
 }
 
-MlirAttribute firrtlGetAttrRUW(MlirContext ctx, FIRRTLRUW ruw) {
+MlirAttribute firrtlAttrGetRUW(MlirContext ctx, FIRRTLRUW ruw) {
   RUWAttr value;
 
   switch (ruw) {
@@ -144,7 +144,7 @@ MlirAttribute firrtlGetAttrRUW(MlirContext ctx, FIRRTLRUW ruw) {
   return wrap(RUWAttrAttr::get(unwrap(ctx), value));
 }
 
-MlirAttribute firrtlGetAttrMemInit(MlirContext ctx, MlirStringRef filename,
+MlirAttribute firrtlAttrGetMemInit(MlirContext ctx, MlirStringRef filename,
                                    bool isBinary, bool isInline) {
   MLIRContext *mlirCtx = unwrap(ctx);
 
@@ -152,7 +152,7 @@ MlirAttribute firrtlGetAttrMemInit(MlirContext ctx, MlirStringRef filename,
       mlirCtx, StringAttr::get(mlirCtx, unwrap(filename)), isBinary, isInline));
 }
 
-MlirAttribute firrtlGetAttrMemDir(MlirContext ctx, FIRRTLMemDir dir) {
+MlirAttribute firrtlAttrGetMemDir(MlirContext ctx, FIRRTLMemDir dir) {
   MemDirAttr value;
 
   switch (dir) {
@@ -175,7 +175,7 @@ MlirAttribute firrtlGetAttrMemDir(MlirContext ctx, FIRRTLMemDir dir) {
   return wrap(MemDirAttrAttr::get(unwrap(ctx), value));
 }
 
-MlirAttribute firrtlGetAttrEventControl(MlirContext ctx,
+MlirAttribute firrtlAttrGetEventControl(MlirContext ctx,
                                         FIRRTLEventControl eventControl) {
   EventControl value;
 


### PR DESCRIPTION
Based on #5472:

- Make C API names more consistent with other dialects.

- Change some string types to `MlirIdentifier`.