### PR TITLE
[Comb][ExportVerilog] Support SV attributes for MuxOp

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2769,9 +2769,6 @@ SubExprInfo ExprEmitter::visitSV(SampledOp op) {
 }
 
 SubExprInfo ExprEmitter::visitComb(MuxOp op) {
-  if (hasSVAttributes(op))
-    emitError(op, "SV attributes emission is unimplemented for the op");
-
   // The ?: operator is right associative.
 
   // Layout:
@@ -2790,7 +2787,9 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
       emitSubExpr(op.getCond(), VerilogPrecedence(Conditional - 1));
     });
     ps << BreakToken(1, 2);
-    ps << "? ";
+    ps << "?";
+    emitSVAttributes(op);
+    ps << " ";
     auto lhsInfo = ps.scopedBox(PP::ibox0, [&]() {
       return emitSubExpr(op.getTrueValue(), VerilogPrecedence(Conditional - 1));
     });

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -82,6 +82,13 @@ static OpTy replaceOpWithNewOpAndCopyName(PatternRewriter &rewriter,
   return newOp;
 }
 
+// Return true if the op has SV attributes. Note that we cannot use a helper
+// function `hasSVAttributes` defined under SV dialect because of a cyclic
+// dependency.
+static bool hasSVAttributes(Operation *op) {
+  return op->hasAttr("sv.attributes");
+}
+
 namespace {
 template <typename SubType>
 struct ComplementMatcher {
@@ -2228,6 +2235,9 @@ struct MuxRewriter : public mlir::OpRewritePattern<MuxOp> {
 
 LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
                                            PatternRewriter &rewriter) const {
+  // If the op has a SV attribute, don't optimize it.
+  if (hasSVAttributes(op))
+    return failure();
   APInt value;
 
   if (matchPattern(op.getTrueValue(), m_ConstantInt(&value))) {
@@ -2473,7 +2483,7 @@ static bool foldArrayOfMuxes(hw::ArrayCreateOp op, PatternRewriter &rewriter) {
   // Check the operands to the array create.  Ensure all of them are the
   // same op with the same number of operands.
   auto first = inputs[0].getDefiningOp<comb::MuxOp>();
-  if (!first)
+  if (!first || hasSVAttributes(first))
     return false;
 
   // Check whether all operands are muxes with the same condition.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -68,7 +68,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %arrCreated = hw.array_create %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone { sv.namehint="name_hint" } : i4
   %slice1 = hw.array_slice %arrCreated[%a] : (!hw.array<9xi4>) -> !hw.array<3xi4>
   %slice2 = hw.array_slice %arrCreated[%b] : (!hw.array<9xi4>) -> !hw.array<3xi4>
-  %35 = comb.mux %cond, %slice1, %slice2 : !hw.array<3xi4>
+  %35 = comb.mux %cond, %slice1, %slice2 {sv.attributes = [#sv.attribute<"svAttr">]} : !hw.array<3xi4>
 
   %ab = comb.add %a, %b : i4
   %subArr = hw.array_create %allone, %ab, %allone : i4
@@ -194,7 +194,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-NEXT:      assign r31 = {{[{}][{}]}}5{a[3]}}, a};
 // CHECK-NEXT:      assign r33 = cond ? a : b;
 // CHECK-NEXT:      assign r34 = ~a;
-// CHECK-NEXT:      assign r35 = cond ? name_hint[a +: 3] : name_hint[b +: 3];
+// CHECK-NEXT:      assign r35 = cond ? (* svAttr *) name_hint[a +: 3] : name_hint[b +: 3];
 // CHECK-NEXT:      assign r36 = {[[WIRE0]], [[WIRE0]]};
 // CHECK-NEXT:      assign r37 = array2d[a][b] (* svAttr *);
 // CHECK-NEXT:      assign r38 = {3{a}};


### PR DESCRIPTION
This adds SV attributes support for comb mux op. Mux canonicalization is disabled if there is SV attribute on the op. SV spec 11-1 defines SV attributes syntax for mux. 

<img width="785" alt="Screen Shot 2023-06-27 at 16 45 04" src="https://github.com/llvm/circt/assets/19691120/1f54e3c1-d7d7-47eb-91ec-b224ceb6607d">
