### PR TITLE
[Pipeline] Add per-register clock gating

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -207,12 +207,13 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     to communicate:
     1. which stage (block) to transition to next
     2. which registers to build at this stage boundary
-    3. An optional hierarchy of boolean values to be used for clock gates for
+    3. which values to pass through to the next stage without registering
+    4. An optional hierarchy of boolean values to be used for clock gates for
        each register.
       - The implicit '!stalled' gate will always be the first signal in the
         hierarchy. Further signals are added to the hierarchy from left to
         right.
-    4. which values to pass through to the next stage without registering
+
 
     Example:
     ```mlir

--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -207,16 +207,31 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     to communicate:
     1. which stage (block) to transition to next
     2. which registers to build at this stage boundary
-    3. which values to pass through to the next stage without registering
+    3. An optional hierarchy of boolean values to be used for clock gates for
+       each register.
+      - The implicit '!stalled' gate will always be the first signal in the
+        hierarchy. Further signals are added to the hierarchy from left to
+        right.
+    4. which values to pass through to the next stage without registering
+
+    Example:
+    ```mlir
+    pipeline.stage ^bb1 regs(%a : i32 gated by [%foo, %bar], %b : i1) pass(%c : i32)
+    ```
   }];
 
-  let arguments = (ins Variadic<AnyType>:$registers, Variadic<AnyType>:$passthroughs);
+  let arguments = (ins
+    Variadic<AnyType>:$registers,
+    Variadic<AnyType>:$passthroughs,
+    Variadic<I1>:$clockGates,
+    I64ArrayAttr:$clockGatesPerRegister);
   let successors = (successor AnySuccessor:$nextStage);
   let results = (outs);
   let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
 
   let assemblyFormat = [{
-    $nextStage (`regs` `(` $registers^ `:` type($registers) `)`)?
+    $nextStage custom<StageRegisters>($registers, type($registers), $clockGates, $clockGatesPerRegister)
       (`pass` `(` $passthroughs^ `:` type($passthroughs) `)` )? attr-dict
   }];
 
@@ -225,9 +240,19 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     void setNextStage(Block *block) {
       setSuccessor(block);
     }
-  }];
-}
 
+    // Returns the list of clock gates for the given register.
+    ValueRange getClockGatesForReg(unsigned regIdx);
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Block*":$dest, "ValueRange":$registers, "ValueRange":$passthroughs)>,
+    // Clock gate builder, which takes a mapping between the registers and
+    // and their clock gate hierarchy.
+    OpBuilder<(ins "Block*":$dest, "ValueRange":$registers, "ValueRange":$passthroughs,
+      "const llvm::DenseMap<Value, llvm::SmallVector<Value>>&":$clockGates)>
+  ];
+}
 
 def ReturnOp : Op<Pipeline_Dialect, "return", [
     Terminator,

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -466,11 +466,10 @@ ValueRange StageOp::getClockGatesForReg(unsigned regIdx) {
     if (index == regIdx) {
       // This is the register we are looking for.
       return getClockGates().slice(clockGateStartIdx, nClockGates);
-    } else {
-      // Increment the start index by the number of clock gates for this
-      // register.
-      clockGateStartIdx += nClockGates;
     }
+    // Increment the start index by the number of clock gates for this
+    // register.
+    clockGateStartIdx += nClockGates;
   }
 
   llvm_unreachable("register index out of bounds.");

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -327,6 +327,155 @@ LogicalResult ReturnOp::verify() {
 // StageOp
 //===----------------------------------------------------------------------===//
 
+static ParseResult parseSingleStageRegister(
+    OpAsmParser &parser, OpAsmParser::UnresolvedOperand &v, Type &t,
+    llvm::SmallVector<OpAsmParser::UnresolvedOperand> &clockGates) {
+
+  if (failed(parser.parseOperand(v)) || failed(parser.parseColonType(t)))
+    return failure();
+
+  if (failed(parser.parseOptionalKeyword("gated")))
+    return success();
+
+  if (failed(parser.parseKeyword("by")) ||
+      failed(
+          parser.parseOperandList(clockGates, OpAsmParser::Delimiter::Square)))
+    return failure();
+
+  return success();
+}
+
+// Parses the form:
+// regs($register : type($register) (`gated by` `[` $clockGates `]`)?, ...)
+ParseResult parseStageRegisters(
+    OpAsmParser &parser,
+    llvm::SmallVector<OpAsmParser::UnresolvedOperand, 4> &registers,
+    llvm::SmallVector<mlir::Type, 1> &registerTypes,
+    llvm::SmallVector<OpAsmParser::UnresolvedOperand, 4> &clockGates,
+    ArrayAttr &clockGatesPerRegister) {
+
+  if (failed(parser.parseOptionalKeyword("regs"))) {
+    clockGatesPerRegister = parser.getBuilder().getI64ArrayAttr({});
+    return success(); // no registers to parse.
+  }
+
+  llvm::SmallVector<int64_t> clockGatesPerRegisterList;
+  if (failed(parser.parseCommaSeparatedList(AsmParser::Delimiter::Paren, [&]() {
+        OpAsmParser::UnresolvedOperand v;
+        Type t;
+        llvm::SmallVector<OpAsmParser::UnresolvedOperand> cgs;
+        if (parseSingleStageRegister(parser, v, t, cgs))
+          return failure();
+        registers.push_back(v);
+        registerTypes.push_back(t);
+        llvm::append_range(clockGates, cgs);
+        clockGatesPerRegisterList.push_back(cgs.size());
+        return success();
+      })))
+    return failure();
+
+  clockGatesPerRegister =
+      parser.getBuilder().getI64ArrayAttr(clockGatesPerRegisterList);
+
+  return success();
+}
+
+void printStageRegisters(OpAsmPrinter &p, Operation *op, ValueRange registers,
+                         TypeRange registerTypes, ValueRange clockGates,
+                         ArrayAttr clockGatesPerRegister) {
+  if (registers.empty())
+    return;
+
+  p << "regs(";
+  size_t clockGateStartIdx = 0;
+  llvm::interleaveComma(
+      llvm::zip(registers, registerTypes, clockGatesPerRegister), p,
+      [&](auto it) {
+        auto &[reg, type, nClockGatesAttr] = it;
+        p << reg << " : " << type;
+        int64_t nClockGates =
+            nClockGatesAttr.template cast<IntegerAttr>().getInt();
+        if (nClockGates == 0)
+          return;
+        p << " gated by [";
+        llvm::interleaveComma(clockGates.slice(clockGateStartIdx, nClockGates),
+                              p);
+        p << "]";
+        clockGateStartIdx += nClockGates;
+      });
+  p << ")";
+}
+
+void StageOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                    Block *dest, ValueRange registers,
+                    ValueRange passthroughs) {
+  odsState.addSuccessors(dest);
+  odsState.addOperands(registers);
+  odsState.addOperands(passthroughs);
+  odsState.addAttribute("operand_segment_sizes",
+                        odsBuilder.getDenseI32ArrayAttr(
+                            {static_cast<int32_t>(registers.size()),
+                             static_cast<int32_t>(passthroughs.size()),
+                             /*clock gates*/ static_cast<int32_t>(0)}));
+  llvm::SmallVector<int64_t> clockGatesPerRegister(registers.size(), 0);
+  odsState.addAttribute("clockGatesPerRegister",
+                        odsBuilder.getI64ArrayAttr(clockGatesPerRegister));
+}
+
+void StageOp::build(
+    OpBuilder &odsBuilder, OperationState &odsState, Block *dest,
+    ValueRange registers, ValueRange passthroughs,
+    const llvm::DenseMap<Value, llvm::SmallVector<Value>> &clockGates) {
+  odsState.addSuccessors(dest);
+  odsState.addOperands(registers);
+  odsState.addOperands(passthroughs);
+
+  // Get a sorted list of clock gates wrt. the registers.
+  llvm::SmallVector<int64_t> clockGatesPerRegister;
+  llvm::SmallVector<Value> sortedClockGates;
+  for (Value reg : registers) {
+    size_t nClockGates = 0;
+    if (auto it = clockGates.find(reg); it != clockGates.end()) {
+      llvm::append_range(sortedClockGates, it->second);
+      nClockGates = it->second.size();
+    }
+    clockGatesPerRegister.push_back(nClockGates);
+  }
+  odsState.addOperands(sortedClockGates);
+  odsState.addAttribute(
+      "operand_segment_sizes",
+      odsBuilder.getDenseI32ArrayAttr(
+          {static_cast<int32_t>(registers.size()),
+           static_cast<int32_t>(passthroughs.size()),
+           /*clock gates*/ static_cast<int32_t>(sortedClockGates.size())}));
+  odsState.addAttribute("clockGatesPerRegister",
+                        odsBuilder.getI64ArrayAttr(clockGatesPerRegister));
+}
+
+ValueRange StageOp::getClockGatesForReg(unsigned regIdx) {
+  assert(regIdx < getRegisters().size() && "register index out of bounds.");
+
+  // This could be optimized quite a bit if we didn't store clock gates per
+  // register as an array of sizes... TODO: look into using properties and maybe
+  // attaching a more complex datastructure to reduce compute here.
+
+  unsigned clockGateStartIdx = 0;
+  for (auto [index, nClockGatesAttr] :
+       llvm::enumerate(getClockGatesPerRegister().getAsRange<IntegerAttr>())) {
+    int64_t nClockGates = nClockGatesAttr.getInt();
+    if (index == regIdx) {
+      // This is the register we are looking for.
+      return getClockGates().slice(clockGateStartIdx, nClockGates);
+    } else {
+      // Increment the start index by the number of clock gates for this
+      // register.
+      clockGateStartIdx += nClockGates;
+    }
+  }
+
+  llvm_unreachable("register index out of bounds.");
+}
+
 LogicalResult StageOp::verify() {
   // Verify that the target block has the correct arguments as this stage op.
   llvm::SmallVector<Type> expectedTargetArgTypes;
@@ -349,6 +498,12 @@ LogicalResult StageOp::verify() {
       return emitOpError("expected target stage argument ")
              << index << " to have type " << arg << ", got " << barg << ".";
   }
+
+  // Verify that the clock gate index list is equally sized to the # of
+  // registers.
+  if (getClockGatesPerRegister().size() != getRegisters().size())
+    return emitOpError("expected clockGatesPerRegister to be equally sized to "
+                       "the number of registers.");
 
   return success();
 }

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -422,41 +422,11 @@ void StageOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                         odsBuilder.getI64ArrayAttr(clockGatesPerRegister));
 }
 
-void StageOp::build(
-    OpBuilder &odsBuilder, OperationState &odsState, Block *dest,
-    ValueRange registers, ValueRange passthroughs,
-    const llvm::DenseMap<Value, llvm::SmallVector<Value>> &clockGates) {
-  odsState.addSuccessors(dest);
-  odsState.addOperands(registers);
-  odsState.addOperands(passthroughs);
-
-  // Get a sorted list of clock gates wrt. the registers.
-  llvm::SmallVector<int64_t> clockGatesPerRegister;
-  llvm::SmallVector<Value> sortedClockGates;
-  for (Value reg : registers) {
-    size_t nClockGates = 0;
-    if (auto it = clockGates.find(reg); it != clockGates.end()) {
-      llvm::append_range(sortedClockGates, it->second);
-      nClockGates = it->second.size();
-    }
-    clockGatesPerRegister.push_back(nClockGates);
-  }
-  odsState.addOperands(sortedClockGates);
-  odsState.addAttribute(
-      "operand_segment_sizes",
-      odsBuilder.getDenseI32ArrayAttr(
-          {static_cast<int32_t>(registers.size()),
-           static_cast<int32_t>(passthroughs.size()),
-           /*clock gates*/ static_cast<int32_t>(sortedClockGates.size())}));
-  odsState.addAttribute("clockGatesPerRegister",
-                        odsBuilder.getI64ArrayAttr(clockGatesPerRegister));
-}
-
 ValueRange StageOp::getClockGatesForReg(unsigned regIdx) {
   assert(regIdx < getRegisters().size() && "register index out of bounds.");
 
-  // This could be optimized quite a bit if we didn't store clock gates per
-  // register as an array of sizes... TODO: look into using properties and maybe
+  // TODO: This could be optimized quite a bit if we didn't store clock gates
+  // per register as an array of sizes... look into using properties and maybe
   // attaching a more complex datastructure to reduce compute here.
 
   unsigned clockGateStartIdx = 0;

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -167,8 +167,8 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
       // Create a StageOp in the new stage, and branch it to the newly created
       // stage.
       b.setInsertionPointToEnd(currentStage);
-      b.create<pipeline::StageOp>(pipeline.getLoc(), ValueRange{}, ValueRange{},
-                                  newStage);
+      b.create<pipeline::StageOp>(pipeline.getLoc(), newStage, ValueRange{},
+                                  ValueRange{});
       currentStage = newStage;
     }
   }

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -5,10 +5,10 @@
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -4,19 +4,20 @@
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -1,0 +1,50 @@
+// RUN: circt-opt --lower-pipeline-to-hw %s | FileCheck %s
+// RUN: circt-opt --lower-pipeline-to-hw="clock-gate-regs" %s | FileCheck %s --check-prefix=CGATE
+
+
+// CHECK-LABEL:   hw.module @testSingle(
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant false
+// CHECK:           %[[VAL_8:.*]] = comb.and %[[VAL_6]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_9:.*]] = comb.and %[[VAL_2]], %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]] = comb.mux %[[VAL_9]], %[[VAL_5]], %[[VAL_11:.*]] : i32
+// CHECK:           %[[VAL_11]] = seq.compreg %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_13:.*]] : i32
+// CHECK:           %[[VAL_13]] = seq.compreg %[[VAL_12]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_14:.*]] = hw.constant false
+// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_16:.*]] = comb.add %[[VAL_11]], %[[VAL_13]] : i32
+// CHECK:           hw.output %[[VAL_16]], %[[VAL_15]] : i32, i1
+// CHECK:         }
+
+// CGATE-LABEL:   hw.module @testSingle(
+// CGATE-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CGATE:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CGATE:           %[[VAL_6:.*]] = hw.constant true
+// CGATE:           %[[VAL_7:.*]] = hw.constant false
+// CGATE:           %[[VAL_8:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CGATE:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_8]], %[[VAL_6]]
+// CGATE:           %[[VAL_10:.*]] = seq.clock_gate %[[VAL_9]], %[[VAL_7]]
+// CGATE:           %[[VAL_11:.*]] = seq.compreg %[[VAL_5]], %[[VAL_10]] : i32
+// CGATE:           %[[VAL_12:.*]] = seq.compreg %[[VAL_0]], %[[VAL_8]] : i32
+// CGATE:           %[[VAL_13:.*]] = hw.constant false
+// CGATE:           %[[VAL_14:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CGATE:           %[[VAL_15:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
+// CGATE:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
+// CGATE:         }
+
+hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+  %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
+  ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
+    %1 = comb.sub %arg0_0, %arg1_1 : i32
+    %true = hw.constant true
+    %false = hw.constant false
+    pipeline.stage ^bb1 regs(%1 : i32 gated by [%true, %false], %arg0_0 : i32)
+  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+    %8 = comb.add %6, %7 : i32
+    pipeline.return %8 : i32
+  }
+  hw.output %0#0, %0#1 : i32, i1
+}

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -7,16 +7,12 @@
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = comb.and %[[VAL_6]], %[[VAL_7]] : i1
-// CHECK:           %[[VAL_9:.*]] = comb.and %[[VAL_2]], %[[VAL_8]] : i1
-// CHECK:           %[[VAL_10:.*]] = comb.mux %[[VAL_9]], %[[VAL_5]], %[[VAL_11:.*]] : i32
-// CHECK:           %[[VAL_11]] = seq.compreg %[[VAL_10]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_13:.*]] : i32
-// CHECK:           %[[VAL_13]] = seq.compreg %[[VAL_12]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           %[[VAL_16:.*]] = comb.add %[[VAL_11]], %[[VAL_13]] : i32
-// CHECK:           hw.output %[[VAL_16]], %[[VAL_15]] : i32, i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
 // CGATE-LABEL:   hw.module @testSingle(
@@ -27,10 +23,10 @@
 // CGATE:           %[[VAL_8:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
 // CGATE:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_8]], %[[VAL_6]]
 // CGATE:           %[[VAL_10:.*]] = seq.clock_gate %[[VAL_9]], %[[VAL_7]]
-// CGATE:           %[[VAL_11:.*]] = seq.compreg %[[VAL_5]], %[[VAL_10]] : i32
-// CGATE:           %[[VAL_12:.*]] = seq.compreg %[[VAL_0]], %[[VAL_8]] : i32
+// CGATE:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_10]] : i32
+// CGATE:           %[[VAL_12:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_8]] : i32
 // CGATE:           %[[VAL_13:.*]] = hw.constant false
-// CGATE:           %[[VAL_14:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CGATE:           %[[VAL_15:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
 // CGATE:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CGATE:         }

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -16,18 +16,16 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = comb.mux %[[VAL_9]], %[[VAL_5]], %[[VAL_11:.*]] : i32
-// CHECK:           %[[VAL_11]] = seq.compreg %[[VAL_10]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
-// CHECK:           %[[VAL_14:.*]] = comb.mux %[[VAL_13]], %[[VAL_11]], %[[VAL_15:.*]] : i32
-// CHECK:           %[[VAL_15]] = seq.compreg %[[VAL_14]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_16:.*]] = hw.constant false
-// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_13]], %[[VAL_3]], %[[VAL_4]], %[[VAL_16]]  : i1
-// CHECK:           hw.output %[[VAL_15]], %[[VAL_17]] : i32, i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @p0_s2_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = hw.constant false
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_s2_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg.ce sym @p0_s3_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_14:.*]] = hw.constant false
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_s3_valid %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled(%arg0) clock %clk reset %rst go %go : (i32) -> i32 {
@@ -52,14 +50,12 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -76,36 +72,28 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_13:.*]] = comb.mux %[[VAL_11]], %[[VAL_12]], %[[VAL_14:.*]] : i32
-// CHECK:           %[[VAL_14]] = seq.compreg %[[VAL_13]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_15:.*]] = comb.mux %[[VAL_11]], %[[VAL_7]], %[[VAL_16:.*]] : i32
-// CHECK:           %[[VAL_16]] = seq.compreg %[[VAL_15]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_17:.*]] = hw.constant false
-// CHECK:           %[[VAL_18:.*]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_17]]  : i1
-// CHECK:           %[[VAL_19:.*]] = comb.mul %[[VAL_14]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_20:.*]] = comb.sub %[[VAL_19]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_21:.*]] = comb.mux %[[VAL_2]], %[[VAL_20]], %[[VAL_22:.*]] : i32
-// CHECK:           %[[VAL_22]] = seq.compreg %[[VAL_21]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_23:.*]] = comb.mux %[[VAL_2]], %[[VAL_19]], %[[VAL_24:.*]] : i32
-// CHECK:           %[[VAL_24]] = seq.compreg %[[VAL_23]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_25:.*]] = hw.constant false
-// CHECK:           %[[VAL_26:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_25]]  : i1
-// CHECK:           %[[VAL_27:.*]] = comb.add %[[VAL_22]], %[[VAL_24]] : i32
-// CHECK:           %[[VAL_28:.*]] = comb.mux %[[VAL_26]], %[[VAL_27]], %[[VAL_29:.*]] : i32
-// CHECK:           %[[VAL_29]] = seq.compreg %[[VAL_28]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_30:.*]] = comb.mux %[[VAL_26]], %[[VAL_22]], %[[VAL_31:.*]] : i32
-// CHECK:           %[[VAL_31]] = seq.compreg %[[VAL_30]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_32:.*]] = hw.constant false
-// CHECK:           %[[VAL_33:.*]] = seq.compreg %[[VAL_26]], %[[VAL_3]], %[[VAL_4]], %[[VAL_32]]  : i1
-// CHECK:           %[[VAL_34:.*]] = comb.mul %[[VAL_29]], %[[VAL_31]] : i32
-// CHECK:           hw.output %[[VAL_19]], %[[VAL_18]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_s1_reg1 %[[VAL_6]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_13:.*]] = hw.constant false
+// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.compreg.ce sym @p1_s0_reg0 %[[VAL_16]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_18:.*]] = seq.compreg.ce sym @p1_s0_reg1 %[[VAL_15]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_19:.*]] = hw.constant false
+// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce sym @p1_s1_reg0 %[[VAL_21]], %[[VAL_3]], %[[VAL_20]] : i32
+// CHECK:           %[[VAL_23:.*]] = seq.compreg.ce sym @p1_s1_reg1 %[[VAL_17]], %[[VAL_3]], %[[VAL_20]] : i32
+// CHECK:           %[[VAL_24:.*]] = hw.constant false
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_s1_valid %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
+// CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
+// CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
@@ -139,16 +127,14 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = comb.mux %[[VAL_2]], %[[VAL_6]], %[[VAL_8:.*]] : i32
-// CHECK:           %[[VAL_8]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_12:.*]] = comb.mux %[[VAL_10]], %[[VAL_11]], %[[VAL_13:.*]] : i32
-// CHECK:           %[[VAL_13]] = seq.compreg %[[VAL_12]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
   %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
@@ -177,25 +163,23 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = comb.mux %[[VAL_1]], %[[VAL_8]], %[[VAL_10:.*]] : i32
-// CHECK:           %[[VAL_10]] = seq.compreg %[[VAL_9]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i32>
-// CHECK:           %[[VAL_15:.*]] = comb.add %[[VAL_14]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce %[[VAL_15]], %[[VAL_2]], %[[VAL_12]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_13]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_17:.*]] = comb.mux %[[VAL_12]], %[[VAL_16]], %[[VAL_18:.*]] : i32
-// CHECK:           %[[VAL_18]] = seq.compreg %[[VAL_17]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_12]], %[[VAL_2]], %[[VAL_3]], %[[VAL_19]]  : i1
-// CHECK:           %[[VAL_21:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_22:.*]] = sv.read_inout %[[VAL_21]] : !hw.inout<i32>
-// CHECK:           %[[VAL_23:.*]] = comb.add %[[VAL_22]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_24:.*]] = seq.compreg.ce %[[VAL_23]], %[[VAL_2]], %[[VAL_20]], %[[VAL_3]], %[[VAL_4]]  : i32
-// CHECK:           sv.assign %[[VAL_21]], %[[VAL_24]] : i32
-// CHECK:           hw.output %[[VAL_24]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_10:.*]] = hw.constant false
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
+// CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_15]], %[[VAL_2]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_17:.*]] = hw.constant false
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
+// CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
+// CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_2]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
+// CHECK:           hw.output %[[VAL_22]] : i32
 // CHECK:         }
 hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
   %0:2 = pipeline.scheduled(%arg0) ext (%clk, %rst : i1, i1) clock %clk reset %rst go %go : (i32) -> (i32) {
@@ -235,12 +219,10 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_2]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]] : i1
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_7]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_6]], %[[VAL_1]], %[[VAL_12:.*]] : i1
-// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_9]], %[[VAL_12]] : i32, i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @p0_s0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst go %go : (i32) -> (i32) {

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -65,7 +65,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
@@ -111,10 +111,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+    pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
   ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
@@ -123,10 +123,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %1:2 = pipeline.scheduled(%0#0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+    pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
   ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
@@ -148,7 +148,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK:           %[[VAL_13]] = seq.compreg %[[VAL_12]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
 // CHECK:           %[[VAL_15:.*]] = seq.compreg %[[VAL_10]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
-// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32, i32
+// CHECK:           hw.output %[[VAL_13]], %[[VAL_1]] : i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
   %0:3 = pipeline.scheduled(%arg0, %arg0) ext (%ext1 : i32) clock %clk reset %rst go %go : (i32, i32) -> (i32, i32) {
@@ -164,7 +164,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
   
   ^bb2(%9 : i32, %s2_valid: i1):
   // Use the external value in the exit stage.
-    pipeline.return %9, %ext0  : i32, i32
+    pipeline.return %9, %ext0 : i32, i32
   }
   hw.output %0#0, %0#1 : i32, i32
 }

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -31,33 +31,31 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1,  %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s1(
 // CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant false
-// CHECK:           %[[VAL_5:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]  : i1
+// CHECK:           %[[VAL_5:.*]] = seq.compreg sym @s1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]  : i1
 // CHECK:           hw.output %[[VAL_0]], %[[VAL_5]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
 // CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = comb.mux %[[VAL_1]], %[[VAL_0]], %[[VAL_5:.*]] : i32
-// CHECK:           %[[VAL_5]] = seq.compreg %[[VAL_4]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
-// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce sym @s2_reg0 %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s2_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = comb.mux %[[VAL_1]], %[[VAL_0]], %[[VAL_5:.*]] : i32
-// CHECK:           %[[VAL_5]] = seq.compreg %[[VAL_4]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_6]]  : i1
-// CHECK:           hw.output %[[VAL_5]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce sym @s3_reg0 %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s3_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1(
@@ -95,13 +93,11 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle(
@@ -132,25 +128,21 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s1_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1(
@@ -164,25 +156,21 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_2]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]], %[[VAL_11]] : i32, i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s1_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple(
@@ -230,21 +218,19 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = comb.mux %[[VAL_2]], %[[VAL_6]], %[[VAL_8:.*]] : i32
-// CHECK:           %[[VAL_8]] = seq.compreg %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
-// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
+// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = comb.mux %[[VAL_2]], %[[VAL_5]], %[[VAL_7:.*]] : i32
-// CHECK:           %[[VAL_7]] = seq.compreg %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant false
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
+// CHECK:           hw.output %[[VAL_6]], %[[VAL_8]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
@@ -292,11 +278,10 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_3]], %[[VAL_10]], %[[VAL_12:.*]] : i32
-// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
-// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @s0_valid %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage_p0_s1(
@@ -307,11 +292,10 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_9:.*]] = comb.add %[[VAL_8]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_10:.*]] = seq.compreg.ce %[[VAL_9]], %[[VAL_1]], %[[VAL_3]], %[[VAL_2]], %[[VAL_6]]  : i32
 // CHECK:           sv.assign %[[VAL_7]], %[[VAL_10]] : i32
-// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_3]], %[[VAL_10]], %[[VAL_12:.*]] : i32
-// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_13]]  : i1
-// CHECK:           hw.output %[[VAL_12]], %[[VAL_14]] : i32, i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_10]], %[[VAL_4]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = hw.constant false
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @s1_valid %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_12]]  : i1
+// CHECK:           hw.output %[[VAL_11]], %[[VAL_13]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage(
@@ -363,12 +347,10 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_2]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]] : i1
-// CHECK:           %[[VAL_8:.*]] = comb.mux %[[VAL_7]], %[[VAL_0]], %[[VAL_9:.*]] : i32
-// CHECK:           %[[VAL_9]] = seq.compreg %[[VAL_8]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = comb.mux %[[VAL_6]], %[[VAL_1]], %[[VAL_12:.*]] : i1
-// CHECK:           %[[VAL_12]] = seq.compreg %[[VAL_11]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
-// CHECK:           hw.output %[[VAL_9]], %[[VAL_12]] : i32, i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @s0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testWithStall(

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -113,7 +113,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid : i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
@@ -195,10 +195,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %0:2 = pipeline.scheduled(%arg0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+    pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
   ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
@@ -207,10 +207,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %1:2 = pipeline.scheduled(%0#0, %arg1) clock %clk reset %rst go %go : (i32, i32) -> (i32) {
   ^bb0(%arg0_0: i32, %arg1_1: i32, %s0_valid: i1):
     %1 = comb.sub %arg0_0, %arg1_1 : i32
-    pipeline.stage ^bb1 regs(%1, %arg0_0 : i32, i32)
+    pipeline.stage ^bb1 regs(%1 : i32, %arg0_0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
-    pipeline.stage ^bb2 regs(%5, %2 : i32, i32)
+    pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
   ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -5,10 +5,10 @@
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]], %[[VAL_1]]) clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32, i32) -> i32 {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i1):
 // CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]], %[[VAL_7]] : i32, i32)
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_10]] : i32, %[[VAL_7]] : i32)
 // CHECK:           ^bb1(%[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
 // CHECK:             %[[VAL_14:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
-// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_14]], %[[VAL_11]] : i32, i32)
+// CHECK:             pipeline.stage ^bb2 regs(%[[VAL_14]] : i32, %[[VAL_11]] : i32)
 // CHECK:           ^bb2(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i32, %[[VAL_17:.*]]: i1):
 // CHECK:             %[[VAL_18:.*]] = comb.add %[[VAL_15]], %[[VAL_16]] : i32
 // CHECK:             pipeline.return %[[VAL_18]] : i32

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -218,3 +218,18 @@ hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> (
   }
   hw.output
 }
+
+// -----
+
+hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () {
+  %done = pipeline.scheduled(%arg) clock %clk reset %rst go %go : (i32) -> () {
+   ^bb0(%a0 : i32, %s0_valid : i1):
+     // expected-note@+1 {{prior use here}}
+     %c0_i2 = hw.constant 0 : i2
+     // expected-error @+1 {{use of value '%c0_i2' expects different type than prior uses: 'i1' vs 'i2'}}
+     pipeline.stage ^bb1 regs(%a0 : i32 gated by [%c0_i2])
+   ^bb1(%0 : i32, %s1_valid : i1):
+      pipeline.return
+  }
+  hw.output
+}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -109,3 +109,52 @@ hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -
   }
   hw.output %0 : i32
 }
+
+// CHECK-LABEL:   hw.module @withMultipleRegs(
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) stall %[[VAL_1]] clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]] : i32, %[[VAL_7]] : i32)
+// CHECK:           ^bb1(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_12:.*]] : i32
+// CHECK:         }
+hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst go %go : (i32) -> (i32) {
+   ^bb0(%a0 : i32, %s0_valid : i1):
+    pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
+
+   ^bb1(%0 : i32, %1 : i32, %s1_valid : i1):
+    pipeline.return %0 : i32
+  }
+  hw.output %0 : i32
+}
+
+// CHECK-LABEL:   hw.module @withClockGates(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_0]]) stall %[[VAL_1]] clock %[[VAL_3]] reset %[[VAL_4]] go %[[VAL_2]] : (i32) -> i32 {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = hw.constant true
+// CHECK:             %[[VAL_10:.*]] = hw.constant true
+// CHECK:             %[[VAL_11:.*]] = hw.constant true
+// CHECK:             pipeline.stage ^bb1 regs(%[[VAL_7]] : i32 gated by {{\[}}%[[VAL_9]]], %[[VAL_7]] : i32, %[[VAL_7]] : i32 gated by {{\[}}%[[VAL_10]], %[[VAL_11]]])
+// CHECK:           ^bb1(%[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32, %[[VAL_15:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_12]] : i32
+// CHECK:           }
+// CHECK:           hw.output %[[VAL_16:.*]] : i32
+// CHECK:         }
+hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%arg0) stall %stall clock %clk reset %rst go %go : (i32) -> (i32) {
+   ^bb0(%a0 : i32, %s0_valid : i1):
+    %true1 = hw.constant true
+    %true2 = hw.constant true
+    %true3 = hw.constant true
+
+    pipeline.stage ^bb1 regs(%a0 : i32 gated by [%true1], %a0 : i32, %a0 : i32 gated by [%true2, %true3])
+
+   ^bb1(%0 : i32, %1 : i32, %2 : i32, %s1_valid : i1):
+    pipeline.return %0 : i32
+  }
+  hw.output %0 : i32
+}


### PR DESCRIPTION
Also changes to that the `clock-gate-regs` options actually implements clock gates instead of a `seq.comp_reg.ce` operation. To cover all cases, i think there needs to be three kinds of gating implementations - clock gate, clock enable (`seq.compreg.ce`) and input muxing. The first and last are what we have now.