### PR TITLE
[FIRRTL][Properties] Add List<T>, Map<K, V> types.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -46,6 +46,8 @@ class RefType;
 class PropertyType;
 class StringType;
 class BigIntType;
+class ListType;
+class MapType;
 class BaseTypeAliasType;
 
 /// A collection of bits indicating the recursive properties of a type.
@@ -310,7 +312,7 @@ class PropertyType : public FIRRTLType {
 public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
-    return llvm::isa<StringType, BigIntType>(type);
+    return llvm::isa<StringType, BigIntType, ListType, MapType>(type);
   }
 
 protected:
@@ -333,6 +335,7 @@ std::optional<int64_t> getBitWidth(FIRRTLBaseType type,
 // Parse a FIRRTL type without a leading `!firrtl.` dialect tag.
 ParseResult parseNestedType(FIRRTLType &result, AsmParser &parser);
 ParseResult parseNestedBaseType(FIRRTLBaseType &result, AsmParser &parser);
+ParseResult parseNestedPropertyType(PropertyType &result, AsmParser &parser);
 
 // Print a FIRRTL type without a leading `!firrtl.` dialect tag.
 void printNestedType(Type type, AsmPrinter &os);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -198,4 +198,7 @@ def StringType : FIRRTLDialectTypeHelper<"StringType", "string type">,
 def BigIntType : FIRRTLDialectTypeHelper<"BigIntType", "big integer type">,
   BuildableType<"::circt::firrtl::BigIntType::get($_builder.getContext())">;
 
+def ListType : FIRRTLDialectTypeHelper<"ListType", "list type">;
+def MapType : FIRRTLDialectTypeHelper<"MapType", "map type">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -547,4 +547,23 @@ def BigIntImpl : FIRRTLImplType<"BigInt", [], "circt::firrtl::FIRRTLType"> {
   let genStorageClass = true;
 }
 
+def ListImpl : FIRRTLImplType<"List", [], "circt::firrtl::FIRRTLType"> {
+  let summary = [{
+    A typed property list of any length.  Not representable in hardware.
+  }];
+  let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "element type">:$elementType);
+  let genStorageClass = true;
+  let genAccessors = true;
+}
+
+def MapImpl : FIRRTLImplType<"Map", [], "circt::firrtl::FIRRTLType"> {
+  let summary = [{
+    A typed map of properties.  Not representable in hardware.
+  }];
+  let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "key type">:$keyType,
+                    TypeParameter<"circt::firrtl::PropertyType", "value type">:$valueType);
+  let genStorageClass = true;
+  let genAccessors = true;
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -37,6 +37,7 @@ using mlir::TypeStorageAllocator;
 // Type Printing
 //===----------------------------------------------------------------------===//
 
+// NOLINTBEGIN(misc-no-recursion)
 /// Print a type with a custom printer implementation.
 ///
 /// This only prints a subset of all types in the dialect. Use `printNestedType`
@@ -133,6 +134,7 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
       .Default([&](auto) { anyFailed = true; });
   return failure(anyFailed);
 }
+// NOLINTEND(misc-no-recursion)
 
 /// Print a type defined by this dialect.
 void circt::firrtl::printNestedType(Type type, AsmPrinter &os) {
@@ -474,6 +476,7 @@ static ParseResult parseFIRRTLPropertyType(PropertyType &result, StringRef name,
   return failure();
 }
 
+// NOLINTBEGIN(misc-no-recursion)
 /// Parse a `FIRRTLType`.
 ///
 /// Note that only a subset of types defined in the FIRRTL dialect inherit from
@@ -485,7 +488,9 @@ ParseResult circt::firrtl::parseNestedType(FIRRTLType &result,
     return failure();
   return parseFIRRTLType(result, name, parser);
 }
+// NOLINTEND(misc-no-recursion)
 
+// NOLINTBEGIN(misc-no-recursion)
 ParseResult circt::firrtl::parseNestedBaseType(FIRRTLBaseType &result,
                                                AsmParser &parser) {
   StringRef name;
@@ -493,7 +498,9 @@ ParseResult circt::firrtl::parseNestedBaseType(FIRRTLBaseType &result,
     return failure();
   return parseFIRRTLBaseType(result, name, parser);
 }
+// NOLINTEND(misc-no-recursion)
 
+// NOLINTBEGIN(misc-no-recursion)
 ParseResult circt::firrtl::parseNestedPropertyType(PropertyType &result,
                                                    AsmParser &parser) {
   StringRef name;
@@ -501,6 +508,7 @@ ParseResult circt::firrtl::parseNestedPropertyType(PropertyType &result,
     return failure();
   return parseFIRRTLPropertyType(result, name, parser);
 }
+// NOLINTEND(misc-no-recursion)
 
 //===---------------------------------------------------------------------===//
 // Dialect Type Parsing and Printing

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1273,6 +1273,24 @@ firrtl.circuit "PropertyConnect" {
 }
 
 // -----
+// Property aggregates can only contain properties.
+// Check list.
+
+firrtl.circuit "ListOfHW" {
+  // expected-error @below {{expected property type, found '!firrtl.uint<2>'}}
+  firrtl.module @MapOfHW(in %in: !firrtl.list<uint<2>>) {}
+}
+
+// -----
+// Property aggregates can only contain properties.
+// Check map.
+
+firrtl.circuit "MapOfHW" {
+  // expected-error @below {{expected property type, found '!firrtl.uint<4>'}}
+  firrtl.module @MapOfHW(in %in: !firrtl.map<string,uint<4>>) {}
+}
+
+// -----
 // Issue 4174-- handle duplicate module names.
 
 firrtl.circuit "hi" {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -274,6 +274,12 @@ firrtl.module @MapTest(in %in: !firrtl.map<bigint, string>, out %out: !firrtl.ma
   firrtl.propassign %out, %in : !firrtl.map<bigint, string>
 }
 
+// CHECK-LABEL: PropertyNestedTest
+// CHECK-SAME:  (in %in: !firrtl.map<bigint, list<map<string, bigint>>>, out %out: !firrtl.map<bigint, list<map<string, bigint>>>)
+firrtl.module @PropertyNestedTest(in %in: !firrtl.map<bigint, list<map<string, bigint>>>, out %out: !firrtl.map<bigint, list<map<string, bigint>>>) {
+  firrtl.propassign %out, %in : !firrtl.map<bigint, list<map<string, bigint>>>
+}
+
 // CHECK-LABEL: TypeAlias
 // CHECK-SAME: %in: !firrtl.alias<bar, uint<1>>
 // CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -262,6 +262,18 @@ firrtl.module @BigIntTest(in %in: !firrtl.bigint, out %out: !firrtl.bigint) {
   %1 = firrtl.bigint -4
 }
 
+// CHECK-LABEL: ListTest
+// CHECK-SAME:  (in %in: !firrtl.list<string>, out %out: !firrtl.list<string>)
+firrtl.module @ListTest(in %in: !firrtl.list<string>, out %out: !firrtl.list<string>) {
+  firrtl.propassign %out, %in : !firrtl.list<string>
+}
+
+// CHECK-LABEL: MapTest
+// CHECK-SAME:  (in %in: !firrtl.map<bigint, string>, out %out: !firrtl.map<bigint, string>)
+firrtl.module @MapTest(in %in: !firrtl.map<bigint, string>, out %out: !firrtl.map<bigint, string>) {
+  firrtl.propassign %out, %in : !firrtl.map<bigint, string>
+}
+
 // CHECK-LABEL: TypeAlias
 // CHECK-SAME: %in: !firrtl.alias<bar, uint<1>>
 // CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>


### PR DESCRIPTION
Add two new property-aggregate types: `firrtl.list` and `firrtl.map`.

Ops to create values of these types and parser support will follow.