### PR TITLE
[FIRRTL] Canonicalize reductions looking through casts of various forms

### DIFF
--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-sources: 
-    if: startsWith(github.ref, 'refs/tags/')
+  publish-sources:
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-20.04
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -27,10 +27,13 @@ jobs:
             --exclude=circt-full-sources.tar.gz \
             -czf \
             circt-full-sources.tar.gz .
+          shasum -a 256 circt-full-sources.tar.gz | cut -d ' ' -f1 > circt-full-sources.tar.gz.sha256
+
       - name: Upload Source Archive
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: circt-full-sources.tar.gz
+          # The * will grab the .sha256 as well
+          files: circt-full-sources.tar.gz*
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
@@ -41,25 +44,36 @@ jobs:
             assert: OFF
             shared: OFF
             stats: ON
-            cmake-args: ''
-        runner: [ubuntu-20.04, ubuntu-18.04, macos-11]
+        runner: [windows-2019, ubuntu-20.04, macos-11]
         include:
           - runner: ubuntu-20.04
             os: linux
-            tar: tar
+            arch: x64
+            tar: tar czf
+            archive: tar.gz
+            sha256: shasum -a 256
+            cont: "\\"
+            setup: ""
             # Default clang (11) is broken, see LLVM issue 59622.
-            cc: clang-12
-            cxx: clang++-12
-          - runner: ubuntu-18.04
-            os: linux
-            tar: tar
-            cc: clang
-            cxx: clang++
+            cmake-args: "-DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12"
           - runner: macos-11
             os: macos
-            tar: gtar
-            cc: clang
-            cxx: clang++
+            arch: x64
+            tar: gtar czf
+            archive: tar.gz
+            sha256: shasum -a 256
+            cont: "\\"
+            setup: ""
+            cmake-args: ""
+          - runner: windows-2019
+            os: windows
+            arch: x64
+            tar: tar czf # unused
+            archive: zip
+            sha256: sha256sum
+            cont: "`"
+            setup: ./utils/find-vs.ps1
+            cmake-args: ""
     runs-on: ${{ matrix.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -75,7 +89,7 @@ jobs:
         run: |
           git fetch --unshallow --no-recurse-submodules
 
-      - name: Setup Ninja Linux
+      - name: Setup Linux
         if: matrix.os == 'linux'
         run: sudo apt-get install ninja-build
 
@@ -85,30 +99,28 @@ jobs:
 
       - name: Build LLVM
         run: |
+          ${{ matrix.setup }}
           mkdir -p llvm/build
           cd llvm/build
-          cmake -G Ninja ../llvm \
-              ${{ matrix.build_config.cmake-args }} \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} \
-              -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
-              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} \
-              -DLLVM_BUILD_TOOLS=OFF \
-              -DLLVM_BUILD_EXAMPLES=OFF \
-              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} \
-              -DLLVM_ENABLE_BINDINGS=OFF \
-              -DLLVM_ENABLE_OCAMLDOC=OFF \
-              -DLLVM_ENABLE_PROJECTS='mlir' \
-              -DLLVM_OPTIMIZED_TABLEGEN=ON \
-              -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-              -DLLVM_ENABLE_TERMINFO=OFF \
-              -DLLVM_PARALLEL_LINK_JOBS=1 \
-              -DLLVM_TARGETS_TO_BUILD="host" \
-              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} \
+          cmake -G Ninja ../llvm ${{ matrix.cont }}
+              ${{ matrix.cmake-args }} ${{ matrix.cont }}
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
+              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
+              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.cont }}
+              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.cont }}
+              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
+              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.cont }}
+              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.cont }}
+              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.cont }}
+              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.cont }}
+              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
+              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
+              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
+              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.cont }}
+              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
               -DLLVM_ENABLE_ZSTD=OFF
           ninja
-          #Checks temporarily disabled because current LLVM commit (9305b63d6) fails checks
-          #ninja check-llvm check-mlir
+          ninja check-mlir
 
       # --------
       # Build and test CIRCT
@@ -116,26 +128,25 @@ jobs:
 
       - name: Build and Test CIRCT
         run: |
+          ${{ matrix.setup }}
           mkdir build
           cd build
-          cmake -G Ninja .. \
-            ${{ matrix.build_config.cmake-args }} \
-            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} \
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} \
-            -DMLIR_DIR=`pwd`/../llvm/build/lib/cmake/mlir \
-            -DLLVM_DIR=`pwd`/../llvm/build/lib/cmake/llvm \
-            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
-            -DVERILATOR_DISABLE=ON \
-            -DLLVM_ENABLE_TERMINFO=OFF \
-            -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-            -DLLVM_PARALLEL_LINK_JOBS=1 \
-            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} \
-            -DCIRCT_RELEASE_TAG_ENABLED=ON \
-            -DCIRCT_RELEASE_TAG=firtool \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF \
-            -DCMAKE_INSTALL_PREFIX=`pwd`/../install
+          cmake -G Ninja .. ${{ matrix.cont }}
+            ${{ matrix.cmake-args }} ${{ matrix.cont }}
+            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
+            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
+            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.cont }}
+            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.cont }}
+            -DVERILATOR_DISABLE=ON ${{ matrix.cont }}
+            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
+            -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
+            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
+            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
+            -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.cont }}
+            -DCIRCT_RELEASE_TAG=firtool ${{ matrix.cont }}
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.cont }}
+            -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
           ninja
           ninja check-circt check-circt-unit
           ninja install-firtool
@@ -146,31 +157,62 @@ jobs:
           file install/*
           file install/bin/*
 
+      # Specify bash for the Windows runner to work
       - name: Name Install Directory
         id: name_dir
+        shell: bash
         run: |
           BASE=$(git describe --tag)
           SANITIZED=$(echo -n $BASE | tr '/' '-')
           echo "value=$SANITIZED" >> "$GITHUB_OUTPUT"
 
-      - name: Package Binaries
+      - name: Name Archive
+        id: name_archive
+        shell: bash
+        run: |
+          NAME=firrtl-bin-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.archive }}
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Package Binaries Linux and MacOS
+        if: matrix.os == 'macos' || matrix.os == 'linux'
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
-          ${{ matrix.tar }} czf firrtl-bin-${{ matrix.runner }}.tar.gz ${{ steps.name_dir.outputs.value }}
-      - name: Show Tarball
+          ${{ matrix.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
+
+      # Not sure how to create a zip in bash on Windows so using powershell
+      - name: Package Binaries Windows
+        if: matrix.os == 'windows'
+        shell: pwsh
         run: |
-          ls -l firrtl-bin-${{ matrix.runner }}.tar.gz
-          shasum -a 256 firrtl-bin-${{ matrix.runner }}.tar.gz
-      - name: Upload Binaries (Non-Tag)
+          mv install ${{ steps.name_dir.outputs.value }}
+          Compress-Archive -Path ${{ steps.name_dir.outputs.value }} -DestinationPath ${{ steps.name_archive.outputs.name }}
+
+      # Specify bash for the Windows runner to work
+      - name: Show Tarball
+        shell: bash
+        run: |
+          ls -l ${{ steps.name_archive.outputs.name }}
+          ${{ matrix.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256
+
+      - name: Upload Binary (Non-Tag)
         uses: actions/upload-artifact@v3
         if: github.ref_type != 'tag'
         with:
-          name: firrtl-bin-${{ matrix.runner }}.tar.gz
-          path: firrtl-bin-${{ matrix.runner }}.tar.gz
+          name: ${{ steps.name_archive.outputs.name }}
+          path: ${{ steps.name_archive.outputs.name }}
           retention-days: 7
+      - name: Upload SHA256 (Non-Tag)
+        uses: actions/upload-artifact@v3
+        if: github.ref_type != 'tag'
+        with:
+          name: ${{ steps.name_archive.outputs.name }}.sha256
+          path: ${{ steps.name_archive.outputs.name }}.sha256
+          retention-days: 7
+
       - name: Upload Binaries (Tag)
         uses: AButler/upload-release-assets@v2.0
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
-          files: firrtl-bin-${{ matrix.runner }}.tar.gz
+          # The * will grab the .sha256 as well
+          files: ${{ steps.name_archive.outputs.name }}*
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -282,6 +282,16 @@ def AndOfPad : Pat <
   (MoveNameHint $old, (PadPrimOp (AndPrimOp (TailPrimOp $x, (TypeWidthAdjust32 $x, $y)), $y), $n)),
   [(KnownWidth $x), (UIntType $x), (EqualTypes $x, $pad)]>;
 
+/// cvt is adding a 0, which will pass through the and
+/// and(cvt(x:U), const) -> cat(0, and(x,trunc(const))
+def AndCvtU : Pat <
+  (AndPrimOp:$old (CvtPrimOp $x), (ConstantOp:$ocst $cst)),
+  (MoveNameHint $old, (CatPrimOp 
+    (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), APSInt(APInt()))"> $ocst),
+    (AndPrimOp $x, (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), cast<IntType>($0.getType()), $1.getValue().trunc($1.getValue().getBitWidth()-1).zext(*cast<IntType>($0.getType()).getWidth()))"> $x, $cst))
+  )),
+  [(KnownWidth $x), (UIntType $x)]>;
+
 // or(x, 0) -> x, fold can't handle all cases
 def OrOfZero : Pat <
   (OrPrimOp:$old $x, (ConstantOp:$zcst $cst)),
@@ -338,6 +348,24 @@ def OrRasUInt : Pat <
   (MoveNameHint $old, (OrRPrimOp $x)),
   [(KnownWidth $x), (IntTypes $x)]>;
 
+/// orr(cvt(x)) -> orr(x)
+def OrRCvt : Pat <
+  (OrRPrimOp:$old (CvtPrimOp $x)),
+  (MoveNameHint $old, (OrRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// orr(cat(0,x)) -> orr(x)
+def OrRCatZeroH : Pat <
+  (OrRPrimOp:$old (CatPrimOp $c, $x)),
+  (MoveNameHint $old, (OrRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x), (ZeroConstantOp $c)]>;
+
+/// orr(cat(x,0)) -> orr(x)
+def OrRCatZeroL : Pat <
+  (OrRPrimOp:$old (CatPrimOp $x, $c)),
+  (MoveNameHint $old, (OrRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x), (ZeroConstantOp $c)]>;
+
 /// xorr(asSInt(x)) -> xorr(x)
 def XorRasSInt : Pat <
   (XorRPrimOp:$old (AsSIntPrimOp $x)),
@@ -347,6 +375,12 @@ def XorRasSInt : Pat <
 /// xorr(asUInt(x)) -> xorr(x)
 def XorRasUInt : Pat <
   (XorRPrimOp:$old (AsUIntPrimOp $x)),
+  (MoveNameHint $old, (XorRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// xorr(cvt(x)) -> xorr(x)
+def XorRCvt : Pat <
+  (XorRPrimOp:$old (CvtPrimOp $x)),
   (MoveNameHint $old, (XorRPrimOp $x)),
   [(KnownWidth $x), (IntTypes $x)]>;
 
@@ -361,6 +395,19 @@ def AndRasUInt : Pat <
   (AndRPrimOp:$old (AsUIntPrimOp $x)),
   (MoveNameHint $old, (AndRPrimOp $x)),
   [(KnownWidth $x), (IntTypes $x)]>;
+
+/// andr(cvt(x:unsigned)) -> 0
+def AndRCvtU : Pat <
+  (AndRPrimOp:$old (CvtPrimOp $x)),
+  (MoveNameHint $old,
+    (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), cast<IntType>($0.getType()), getIntZerosAttr($0.getType()))"> $old)),
+  [(KnownWidth $x), (UIntTypes $x)]>;
+
+/// andr(cvt(x:signed)) -> andr(x)
+def AndRCvtS : Pat <
+  (AndRPrimOp:$old (CvtPrimOp $x)),
+  (MoveNameHint $old, (AndRPrimOp $x)),
+  [(KnownWidth $x), (SIntTypes $x)]>;
 
 
 // bits(bits(x, ...), ...) -> bits(x, ...)

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -434,6 +434,12 @@ def BitsOfMux : Pat<
   (MoveNameHint $old, (MuxPrimOp $c, (BitsPrimOp $x, $oHigh, $oLow), (BitsPrimOp $y, $oHigh, $oLow))),
   [(AnyConstantOp $x), (AnyConstantOp $y)]>;
 
+// bits(asUInt) -> bits
+def BitsOfAsUInt : Pat<
+  (BitsPrimOp:$old (AsUIntPrimOp $x), I32Attr:$oHigh, I32Attr:$oLow),
+  (MoveNameHint $old, (BitsPrimOp $x, $oHigh, $oLow)),
+  [(KnownWidth $x)]>;
+
 // subaccess a, cst -> subindex a, cst
 // TODO: only enable if cst is inside a.  Subaccess and subindex behave differently for out-of-bounds indexes.
 def SubaccessOfConstant : Pat<

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -117,15 +117,6 @@ def GTWithConstLHS : Pat<
   (MoveNameHint $old, (LTPrimOp $rhs, $lhs)),
   [(AnyConstantOp $lhs), (NonConstantOp $rhs)]>;
 
-////////////////////////////////////////////////////////////////////////////////
-// Width Narrow
-////////////////////////////////////////////////////////////////////////////////
-
-// leq(shl(x, c), const) -> leq(x, const >> c) if lowest c bits of const are zero
-
-
-
-
 // not(not(x)) -> x
 def NotNot : Pat <
   (NotPrimOp:$old (NotPrimOp $x)),
@@ -393,6 +384,18 @@ def XorRCvt : Pat <
   (MoveNameHint $old, (XorRPrimOp $x)),
   [(KnownWidth $x), (IntTypes $x)]>;
 
+/// xorr(cat(0,x)) -> xorr(x)
+def XorRCatZeroH : Pat <
+  (XorRPrimOp:$old (CatPrimOp $c, $x)),
+  (MoveNameHint $old, (XorRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x), (ZeroConstantOp $c)]>;
+
+/// xorr(cat(x,0)) -> xorr(x)
+def XorRCatZeroL : Pat <
+  (XorRPrimOp:$old (CatPrimOp $x, $c)),
+  (MoveNameHint $old, (XorRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x), (ZeroConstantOp $c)]>;
+
 /// andr(asSInt(x)) -> andr(x)
 def AndRasSInt : Pat <
   (AndRPrimOp:$old (AsSIntPrimOp $x)),
@@ -496,7 +499,7 @@ def RefResolveOfRefSend : Pat<
 >;
 
 def UtoStoU : Pat<
-  (AsUIntPrimOp (AsSIntPrimOp $x)),
+  (AsSIntPrimOp (AsUIntPrimOp $x)),
   (replaceWithValue $x),
   []>;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -45,13 +45,13 @@ def NullAttr : Constraint<CPred<"!$0">>;
 def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
 
 // Constraint that enforces int types
-def IntTypes : Constraint<CPred<"isa<IntType>($0)">>;
+def IntTypes : Constraint<CPred<"isa<IntType>($0.getType())">>;
 
 // Constraint that enforces sint types
-def SIntTypes : Constraint<CPred<"isa<SIntType>($0)">>;
+def SIntTypes : Constraint<CPred<"isa<SIntType>($0.getType())">>;
 
 // Constraint that enforces uint types
-def UIntTypes : Constraint<CPred<"isa<UIntType>($0)">>;
+def UIntTypes : Constraint<CPred<"isa<UIntType>($0.getType())">>;
 
 // Constraint that enforces types mismatches
 def mismatchTypes : Constraint<CPred<"$0.getType() != $1.getType()">>;
@@ -325,6 +325,43 @@ def XorOfPad : Pat <
   (MoveNameHint $old, (CatPrimOp (HeadPrimOp $x, (TypeWidthAdjust32 $x, $y)),
                                  (XorPrimOp (TailPrimOp $x, (TypeWidthAdjust32 $x, $y)), $y))),
   [(KnownWidth $x), (UIntType $x), (EqualTypes $x, $pad)]>;
+
+/// orr(asSInt(x)) -> orr(x)
+def OrRasSInt : Pat <
+  (OrRPrimOp:$old (AsSIntPrimOp $x)),
+  (MoveNameHint $old, (OrRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// orr(asUInt(x)) -> orr(x)
+def OrRasUInt : Pat <
+  (OrRPrimOp:$old (AsUIntPrimOp $x)),
+  (MoveNameHint $old, (OrRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// xorr(asSInt(x)) -> xorr(x)
+def XorRasSInt : Pat <
+  (XorRPrimOp:$old (AsSIntPrimOp $x)),
+  (MoveNameHint $old, (XorRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// xorr(asUInt(x)) -> xorr(x)
+def XorRasUInt : Pat <
+  (XorRPrimOp:$old (AsUIntPrimOp $x)),
+  (MoveNameHint $old, (XorRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// andr(asSInt(x)) -> andr(x)
+def AndRasSInt : Pat <
+  (AndRPrimOp:$old (AsSIntPrimOp $x)),
+  (MoveNameHint $old, (AndRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
+/// andr(asUInt(x)) -> andr(x)
+def AndRasUInt : Pat <
+  (AndRPrimOp:$old (AsUIntPrimOp $x)),
+  (MoveNameHint $old, (AndRPrimOp $x)),
+  [(KnownWidth $x), (IntTypes $x)]>;
+
 
 // bits(bits(x, ...), ...) -> bits(x, ...)
 def BitsOfBits : Pat<

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -117,6 +117,15 @@ def GTWithConstLHS : Pat<
   (MoveNameHint $old, (LTPrimOp $rhs, $lhs)),
   [(AnyConstantOp $lhs), (NonConstantOp $rhs)]>;
 
+////////////////////////////////////////////////////////////////////////////////
+// Width Narrow
+////////////////////////////////////////////////////////////////////////////////
+
+// leq(shl(x, c), const) -> leq(x, const >> c) if lowest c bits of const are zero
+
+
+
+
 // not(not(x)) -> x
 def NotNot : Pat <
   (NotPrimOp:$old (NotPrimOp $x)),
@@ -418,6 +427,13 @@ def BitsOfBits : Pat<
     (NativeCodeCall<"$_builder.getI32IntegerAttr($0.getValue().getZExtValue() + $1.getValue().getZExtValue())"> $oLow, $iLow))),
   []>;
 
+// bits(mux(c,x,y)) -> mux(c, bits(x), bits(y))
+// This isn't obviously good if the mux has multiple uses, so limit it to constants.
+def BitsOfMux : Pat<
+  (BitsPrimOp:$old (MuxPrimOp $c, $x, $y), I32Attr:$oHigh, I32Attr:$oLow),
+  (MoveNameHint $old, (MuxPrimOp $c, (BitsPrimOp $x, $oHigh, $oLow), (BitsPrimOp $y, $oHigh, $oLow))),
+  [(AnyConstantOp $x), (AnyConstantOp $y)]>;
+
 // subaccess a, cst -> subindex a, cst
 // TODO: only enable if cst is inside a.  Subaccess and subindex behave differently for out-of-bounds indexes.
 def SubaccessOfConstant : Pat<
@@ -472,5 +488,16 @@ def RefResolveOfRefSend : Pat<
   (RefResolveOp:$resolve (RefSendOp $base)),
   (replaceWithValue $base), [(EqualTypes $base, $resolve)]
 >;
+
+def UtoStoU : Pat<
+  (AsUIntPrimOp (AsSIntPrimOp $x)),
+  (replaceWithValue $x),
+  []>;
+
+def StoUtoS : Pat<
+  (AsUIntPrimOp (AsSIntPrimOp $x)),
+  (replaceWithValue $x),
+  []>;
+
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -674,26 +674,28 @@ let hasCanonicalizer = true in
 def NotPrimOp : UnaryPrimOp<"not", IntType, UIntType>;
 
 let inferType = "impl::inferReductionResult" in {
-  def AndRPrimOp : UnaryPrimOp<"andr", IntType, UInt1Type> {
-    let description = [{
-      Horizontally reduce a value to one bit, using the 'and' operation to merge
-      bits.  `andr(x)` is equivalent to `concat(x, 1b1) == ~0`.  As such, it
-      returns 1 for zero-bit-wide operands.
-    }];
-  }
-  def OrRPrimOp : UnaryPrimOp<"orr", IntType, UInt1Type> {
-    let description = [{
-      Horizontally reduce a value to one bit, using the 'or' operation to merge
-      bits.  `orr(x)` is equivalent to `concat(x, 1b0) != 0`.  As such, it
-      returns 0 for zero-bit-wide operands.
-    }];
-  }
-  def XorRPrimOp : UnaryPrimOp<"xorr", IntType, UInt1Type> {
-    let description = [{
-      Horizontally reduce a value to one bit, using the 'xor' operation to merge
-      bits.  `xorr(x)` is equivalent to `popcount(concat(x, 1b0)) & 1`.  As
-      such, it returns 0 for zero-bit-wide operands.
-    }];
+  let hasCanonicalizer =1 in {
+    def AndRPrimOp : UnaryPrimOp<"andr", IntType, UInt1Type> {
+      let description = [{
+        Horizontally reduce a value to one bit, using the 'and' operation to merge
+        bits.  `andr(x)` is equivalent to `concat(x, 1b1) == ~0`.  As such, it
+        returns 1 for zero-bit-wide operands.
+      }];
+    }
+    def OrRPrimOp : UnaryPrimOp<"orr", IntType, UInt1Type> {
+      let description = [{
+        Horizontally reduce a value to one bit, using the 'or' operation to merge
+        bits.  `orr(x)` is equivalent to `concat(x, 1b0) != 0`.  As such, it
+        returns 0 for zero-bit-wide operands.
+      }];
+    }
+    def XorRPrimOp : UnaryPrimOp<"xorr", IntType, UInt1Type> {
+      let description = [{
+        Horizontally reduce a value to one bit, using the 'xor' operation to merge
+        bits.  `xorr(x)` is equivalent to `popcount(concat(x, 1b0)) & 1`.  As
+        such, it returns 0 for zero-bit-wide operands.
+      }];
+    }
   }
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -663,8 +663,10 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
 
 def SizeOfIntrinsicOp : UnaryPrimOp<"int.sizeof", FIRRTLBaseType, UInt32Type>;
 
-def AsSIntPrimOp : UnaryPrimOp<"asSInt", FIRRTLBaseType, SIntType>;
-def AsUIntPrimOp : UnaryPrimOp<"asUInt", FIRRTLBaseType, UIntType>;
+let hasCanonicalizer=1 in {
+  def AsSIntPrimOp : UnaryPrimOp<"asSInt", FIRRTLBaseType, SIntType>;
+  def AsUIntPrimOp : UnaryPrimOp<"asUInt", FIRRTLBaseType, UIntType>;
+}
 def AsAsyncResetPrimOp
   : UnaryPrimOp<"asAsyncReset", OneBitCastableType, AsyncResetType>;
 def AsClockPrimOp : UnaryPrimOp<"asClock", OneBitCastableType, ClockType>;

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -579,10 +579,10 @@ OpFoldResult AndPrimOp::fold(FoldAdaptor adaptor) {
 
 void AndPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
-  results
-      .insert<patterns::extendAnd, patterns::moveConstAnd, patterns::AndOfZero,
-              patterns::AndOfAllOne, patterns::AndOfSelf, patterns::AndOfPad>(
-          context);
+  results.insert<patterns::extendAnd, patterns::moveConstAnd,
+                 patterns::AndOfZero, patterns::AndOfAllOne,
+                 patterns::AndOfSelf, patterns::AndOfPad, patterns::AndCvtU>(
+      context);
 }
 
 OpFoldResult OrPrimOp::fold(FoldAdaptor adaptor) {
@@ -1080,8 +1080,9 @@ OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 void AndRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                            MLIRContext *context) {
-  results.insert<patterns::AndRasSInt, patterns::AndRasUInt>(context);
+                                             MLIRContext *context) {
+  results.insert<patterns::AndRasSInt, patterns::AndRasUInt, patterns::AndRCvtU,
+                 patterns::AndRCvtS>(context);
 }
 
 OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
@@ -1105,7 +1106,8 @@ OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
 
 void OrRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
-  results.insert<patterns::OrRasSInt, patterns::OrRasUInt>(context);
+  results.insert<patterns::OrRasSInt, patterns::OrRasUInt, patterns::OrRCvt,
+                 patterns::OrRCatZeroH, patterns::OrRCatZeroL>(context);
 }
 
 OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
@@ -1127,10 +1129,10 @@ OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 void XorRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                            MLIRContext *context) {
-  results.insert<patterns::XorRasSInt, patterns::XorRasUInt>(context);
+                                             MLIRContext *context) {
+  results.insert<patterns::XorRasSInt, patterns::XorRasUInt, patterns::XorRCvt>(
+      context);
 }
-
 
 //===----------------------------------------------------------------------===//
 // Other Operators

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1140,8 +1140,8 @@ OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
 
 void XorRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::XorRasSInt, patterns::XorRasUInt, patterns::XorRCvt>(
-      context);
+  results.insert<patterns::XorRasSInt, patterns::XorRasUInt, patterns::XorRCvt,
+                 patterns::XorRCatZeroH, patterns::XorRCatZeroL>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -980,6 +980,11 @@ OpFoldResult AsSIntPrimOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+void AsSIntPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                               MLIRContext *context) {
+  results.insert<patterns::StoUtoS>(context);
+}
+
 OpFoldResult AsUIntPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
   if (getInput().getType() == getType())
@@ -993,6 +998,11 @@ OpFoldResult AsUIntPrimOp::fold(FoldAdaptor adaptor) {
       return getIntAttr(getType(), *cst);
 
   return {};
+}
+
+void AsUIntPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                               MLIRContext *context) {
+  results.insert<patterns::UtoStoU>(context);
 }
 
 OpFoldResult AsAsyncResetPrimOp::fold(FoldAdaptor adaptor) {
@@ -1234,7 +1244,7 @@ OpFoldResult BitsPrimOp::fold(FoldAdaptor adaptor) {
 
 void BitsPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::BitsOfBits>(context);
+  results.insert<patterns::BitsOfBits, patterns::BitsOfMux>(context);
 }
 
 /// Replace the specified operation with a 'bits' op from the specified hi/lo

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1079,6 +1079,11 @@ OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+void AndRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::AndRasSInt, patterns::AndRasUInt>(context);
+}
+
 OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
@@ -1098,6 +1103,11 @@ OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+void OrRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::OrRasSInt, patterns::OrRasUInt>(context);
+}
+
 OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
   if (!hasKnownWidthIntTypes(*this))
     return {};
@@ -1115,6 +1125,12 @@ OpFoldResult XorRPrimOp::fold(FoldAdaptor adaptor) {
 
   return {};
 }
+
+void XorRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::XorRasSInt, patterns::XorRasUInt>(context);
+}
+
 
 //===----------------------------------------------------------------------===//
 // Other Operators

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1244,7 +1244,8 @@ OpFoldResult BitsPrimOp::fold(FoldAdaptor adaptor) {
 
 void BitsPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::BitsOfBits, patterns::BitsOfMux>(context);
+  results.insert<patterns::BitsOfBits, patterns::BitsOfMux,
+                 patterns::BitsOfAsUInt>(context);
 }
 
 /// Replace the specified operation with a 'bits' op from the specified hi/lo

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -7,7 +7,8 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
     in %clock : !firrtl.clock, in %asyncreset : !firrtl.asyncreset,
     in %inreset : !firrtl.reset, out %outreset : !firrtl.reset,
     out %out_ui1 : !firrtl.uint<1>, out %out_si1 : !firrtl.sint<1>,
-    out %out_clock : !firrtl.clock, out %out_asyncreset : !firrtl.asyncreset) {
+    out %out_clock : !firrtl.clock, out %out_asyncreset : !firrtl.asyncreset,
+    out %out2_si1 : !firrtl.sint<1>, out %out2_ui1 : !firrtl.uint<1>) {
 
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %c1_si1 = firrtl.constant 1 : !firrtl.sint<1>
@@ -46,6 +47,16 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
   // CHECK: firrtl.strictconnect %outreset, %inreset : !firrtl.reset
   %8 = firrtl.resetCast %inreset : (!firrtl.reset) -> !firrtl.reset
   firrtl.strictconnect %outreset, %8 : !firrtl.reset
+
+  // Transparent
+  // CHECK: firrtl.strictconnect %out2_si1, %si1
+  %9 = firrtl.asUInt %si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.asSInt %9 : (!firrtl.uint<1>) -> !firrtl.sint<1>
+  firrtl.strictconnect %out2_si1, %10 : !firrtl.sint<1>
+  // CHECK: firrtl.strictconnect %out2_ui1, %ui1
+  %11 = firrtl.asSInt %ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
+  %12 = firrtl.asUInt %11 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out2_ui1, %12 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Div
@@ -105,10 +116,13 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
                    in %zin2: !firrtl.uint<0>,
                    out %out: !firrtl.uint<4>,
                    out %out6: !firrtl.uint<6>,
+                   out %out5: !firrtl.uint<5>,
                    out %outz: !firrtl.uint<0>) {
   // CHECK: firrtl.strictconnect %out, %c1_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
+  %c3_si5 = firrtl.constant 3 : !firrtl.sint<5>
+
   %0 = firrtl.and %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -162,7 +176,7 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // CHECK: firrtl.strictconnect %out, %c0_ui4
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
   %7 = firrtl.and %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
-  firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
+  firrtl.strictconnect %out, %7 : !firrtl.uint<4>
 
   // CHECK: %[[trunc:.*]] = firrtl.bits %in6
   // CHECK: %[[ANDPAD:.*]] = firrtl.and %[[trunc]], %in
@@ -170,7 +184,13 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // CHECK: firrtl.strictconnect %out6, %[[POST]]
   %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %9 = firrtl.and %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-  firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
+  firrtl.strictconnect %out6, %9 : !firrtl.uint<6>
+
+  // CHECK: %[[AND:.*]] = firrtl.and %in, %c3_ui4
+  // CHECK: firrtl.cat %c0_ui1, %[[AND]]
+  %10 = firrtl.cvt %in : (!firrtl.uint<4>) -> !firrtl.sint<5>
+  %11 = firrtl.and %10, %c3_si5 : (!firrtl.sint<5>, !firrtl.sint<5>) -> !firrtl.uint<5>
+  firrtl.strictconnect %out5, %11 : !firrtl.uint<5>
 }
 
 // CHECK-LABEL: firrtl.module @Or
@@ -420,7 +440,8 @@ firrtl.module @Bits(in %in1: !firrtl.uint<1>,
                     in %in4: !firrtl.uint<4>,
                     out %out1: !firrtl.uint<1>,
                     out %out2: !firrtl.uint<2>,
-                    out %out4: !firrtl.uint<4>) {
+                    out %out4: !firrtl.uint<4>,
+                    out %out2b: !firrtl.uint<2>) {
   // CHECK: firrtl.strictconnect %out1, %in1
   %0 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -444,6 +465,12 @@ firrtl.module @Bits(in %in1: !firrtl.uint<1>,
   // CHECK: firrtl.strictconnect %out1, %in1
   %5 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.strictconnect %out2b, %c1_ui2
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
+  %6 = firrtl.mux( %in1, %c10_ui4, %c11_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %7 = firrtl.bits %6 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  firrtl.strictconnect %out2b, %7 : !firrtl.uint<2>
 }
 
 // CHECK-LABEL: firrtl.module @Head
@@ -651,7 +678,8 @@ firrtl.module @Tail(in %in4u: !firrtl.uint<4>,
 firrtl.module @Andr(in %in0 : !firrtl.uint<0>,
                     out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
                     out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>,
-                    out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>) {
+                    out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>, 
+                    out %g: !firrtl.uint<1>, in %h : !firrtl.uint<64>) {
   %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
@@ -662,8 +690,8 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>,
   %2 = firrtl.andr %cn2_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
   %3 = firrtl.andr %cn1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
   %4 = firrtl.andr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
-  // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
+  // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %b, %[[ONE]]
@@ -674,13 +702,21 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>,
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %e, %[[ONE]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
-}
+
+  // CHECK: firrtl.strictconnect %g, %[[ZERO]]
+  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
+  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
+  %9 = firrtl.cvt %6 : (!firrtl.uint<64>) -> !firrtl.sint<65>
+  %10 = firrtl.andr %9 : (!firrtl.sint<65>) -> !firrtl.uint<1>
+  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
+  }
 
 // CHECK-LABEL: firrtl.module @Orr
 firrtl.module @Orr(in %in0 : !firrtl.uint<0>,
                    out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
                    out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>,
-                   out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>) {
+                   out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>, 
+                   out %g: !firrtl.uint<1>, in %h : !firrtl.uint<64>) {
   %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
@@ -703,16 +739,28 @@ firrtl.module @Orr(in %in0 : !firrtl.uint<0>,
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: %[[OR:.*]] = firrtl.orr %h
+  // CHECK: firrtl.strictconnect %g, %[[OR]]
+  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
+  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
+  %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
+  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
+  %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>  
+  %10 = firrtl.orr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
+  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Xorr
 firrtl.module @Xorr(in %in0 : !firrtl.uint<0>,
                     out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
                     out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>,
-                    out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>) {
+                    out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>, 
+                    out %g: !firrtl.uint<1>, in %h : !firrtl.uint<64>) {
   %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
+  %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %cn1_si2 = firrtl.constant -1 : !firrtl.sint<2>
   %cn2_si2 = firrtl.constant -2 : !firrtl.sint<2>
   %0 = firrtl.xorr %c3_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
@@ -732,6 +780,16 @@ firrtl.module @Xorr(in %in0 : !firrtl.uint<0>,
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: %[[XOR:.*]] = firrtl.xorr %h
+  // CHECK: firrtl.strictconnect %g, %[[OR]]
+  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
+  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
+  %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
+  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
+  %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>  
+  %10 = firrtl.xorr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
+  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Reduce


### PR DESCRIPTION
Greatly reduces the number of ops in real designs
```
wc -l foo.mlir foo5.mlir 
  2247057 foo.mlir
  2057784 foo5.mlir
```
