### PR TITLE
[Arc] Fix header generation when depth is -1

### DIFF
--- a/tools/arcilator/arcilator-header-cpp.py
+++ b/tools/arcilator/arcilator-header-cpp.py
@@ -194,7 +194,7 @@ def format_view_hierarchy(hierarchy: StateHierarchy, depth: int) -> str:
   lines = []
   for state in hierarchy.states:
     lines.append(f"{state_cpp_type(state)} &{clean_name(state.name)};")
-  if depth > 0:
+  if depth != 0:
     for child in hierarchy.children:
       lines.append(
           f"{indent(format_view_hierarchy(child, depth-1))} {clean_name(child.name)};"
@@ -213,7 +213,7 @@ def format_view_constructor(hierarchy: StateHierarchy, depth: int) -> str:
   lines = []
   for state in hierarchy.states:
     lines.append(f".{clean_name(state.name)} = {state_cpp_ref(state)}")
-  if depth > 0:
+  if depth != 0:
     for child in hierarchy.children:
       lines.append(
           f".{clean_name(child.name)} = {indent(format_view_constructor(child, depth-1))}"


### PR DESCRIPTION
Since the default depth is -1 and the script checks `depth > 0`, currently the header generator does not generate any values below the top-level hierarchy by default. This update allows arbitrarily deep hierarchy generation when the depth is -1 (I think this was probably the intended behavior). Alternatively, we could set the default depth to some large value.

cc @fabianschuiki 