### PR TITLE
[Seq] Canonicalize transitive clock gates

### DIFF
--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -717,6 +717,15 @@ OpFoldResult ClockGateOp::fold(FoldAdaptor adaptor) {
   if (isConstantZero(adaptor.getInput()))
     return IntegerAttr::get(IntegerType::get(getContext(), 1), 0);
 
+  // Transitive clock gating - eliminate clock gates that are driven by an
+  // identical enable signal somewhere in a clock gate hierarchy.
+  auto clockGateInput = getInput().getDefiningOp<ClockGateOp>();
+  while (clockGateInput) {
+    if (clockGateInput.getEnable() == getEnable())
+      return getInput();
+    clockGateInput = clockGateInput.getInput().getDefiningOp<ClockGateOp>();
+  }
+
   return {};
 }
 

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -718,7 +718,7 @@ OpFoldResult ClockGateOp::fold(FoldAdaptor adaptor) {
     return IntegerAttr::get(IntegerType::get(getContext(), 1), 0);
 
   // Transitive clock gating - eliminate clock gates that are driven by an
-  // identical enable signal somewhere in a clock gate hierarchy.
+  // identical enable signal somewhere higher in the clock gate hierarchy.
   auto clockGateInputOp = getInput().getDefiningOp<ClockGateOp>();
   while (clockGateInputOp) {
     if (clockGateInputOp.getEnable() == getEnable() &&

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -719,11 +719,12 @@ OpFoldResult ClockGateOp::fold(FoldAdaptor adaptor) {
 
   // Transitive clock gating - eliminate clock gates that are driven by an
   // identical enable signal somewhere in a clock gate hierarchy.
-  auto clockGateInput = getInput().getDefiningOp<ClockGateOp>();
-  while (clockGateInput) {
-    if (clockGateInput.getEnable() == getEnable())
+  auto clockGateInputOp = getInput().getDefiningOp<ClockGateOp>();
+  while (clockGateInputOp) {
+    if (clockGateInputOp.getEnable() == getEnable() &&
+        clockGateInputOp.getTestEnable() == getTestEnable())
       return getInput();
-    clockGateInput = clockGateInput.getInput().getDefiningOp<ClockGateOp>();
+    clockGateInputOp = clockGateInputOp.getInput().getDefiningOp<ClockGateOp>();
   }
 
   return {};

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -89,7 +89,7 @@ hw.module @UninitializedArrayElement(%a: i1, %clock: i1) -> (b: !hw.array<2xi1>)
 }
 
 // CHECK-LABEL: hw.module @ClockGate
-hw.module @ClockGate(%clock: i1, %enable: i1, %testEnable: i1) {
+hw.module @ClockGate(%clock: i1, %enable: i1, %enable2 : i1, %testEnable: i1) {
   // CHECK-NEXT: hw.constant false
   %false = hw.constant false
   %true = hw.constant true
@@ -119,6 +119,18 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %testEnable: i1) {
   // CHECK-NEXT: %dropTestEnable = hw.wire [[TMP]] sym @dropTestEnable
   %6 = seq.clock_gate %clock, %enable, %false
   %dropTestEnable = hw.wire %6 sym @dropTestEnable : i1
+
+  // CHECK-NEXT: [[TCG1:%.+]] = seq.clock_gate %clock, %enable
+  // CHECK-NEXT: %transitiveClock1 = hw.wire [[TCG1]] sym @transitiveClock1  : i1
+  %7 = seq.clock_gate %clock, %enable
+  %8 = seq.clock_gate %clock, %enable
+  %transitiveClock1 = hw.wire %7 sym @transitiveClock1 : i1
+
+  // CHECK-NEXT: [[TCG2:%.+]] = seq.clock_gate [[TCG1]], %enable
+  // CHECK-NEXT: %transitiveClock2 = hw.wire [[TCG2]] sym @transitiveClock2  : i1
+  %9 = seq.clock_gate %7, %enable2
+  %10 = seq.clock_gate %9, %enable
+  %transitiveClock2 = hw.wire %10 sym @transitiveClock2 : i1
 }
 
 // CHECK-LABEL: @FirMem

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -126,11 +126,13 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %enable2 : i1, %testEnable: i1) {
   %8 = seq.clock_gate %clock, %enable
   %transitiveClock1 = hw.wire %7 sym @transitiveClock1 : i1
 
-  // CHECK-NEXT: [[TCG2:%.+]] = seq.clock_gate [[TCG1]], %enable
-  // CHECK-NEXT: %transitiveClock2 = hw.wire [[TCG2]] sym @transitiveClock2  : i1
-  %9 = seq.clock_gate %7, %enable2
-  %10 = seq.clock_gate %9, %enable
-  %transitiveClock2 = hw.wire %10 sym @transitiveClock2 : i1
+  // CHECK-NEXT: [[TCG2:%.+]] = seq.clock_gate %clock, %enable, %testEnable
+  // CHECK-NEXT: [[TCG3:%.+]] = seq.clock_gate [[TCG2]], %enable
+  // CHECK-NEXT: %transitiveClock2 = hw.wire [[TCG3]] sym @transitiveClock2  : i1
+  %9 = seq.clock_gate %clock, %enable, %testEnable
+  %10 = seq.clock_gate %9, %enable2 
+  %11 = seq.clock_gate %10, %enable, %testEnable
+  %transitiveClock2 = hw.wire %11 sym @transitiveClock2 : i1
 }
 
 // CHECK-LABEL: @FirMem


### PR DESCRIPTION
This adds a folder for clock gates which removes clock gates that are transitively enable'd by other clock gates in a clock gate hierarchy.