### PR TITLE
[FIRRTL] Change emitter to v3.0.0

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIREmitter.h
+++ b/include/circt/Dialect/FIRRTL/FIREmitter.h
@@ -19,8 +19,11 @@
 namespace circt {
 namespace firrtl {
 
+struct FIRVersion;
+
 mlir::LogicalResult exportFIRFile(mlir::ModuleOp module, llvm::raw_ostream &os,
-                                  std::optional<size_t> targetLineLength);
+                                  std::optional<size_t> targetLineLength,
+                                  FIRVersion version);
 
 void registerToFIRFileTranslation();
 

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -76,6 +76,43 @@ maybeStringToLocation(llvm::StringRef spelling, bool skipParsing,
 
 void registerFromFIRFileTranslation();
 
+/// The FIRRTL specification version.
+struct FIRVersion {
+  uint32_t major, minor, patch;
+
+  /// Three way compare of one FIRRTL version with another FIRRTL version.
+  /// Return 1 if the first version is greater than the second version, -1 if
+  /// the first version is less than the second version, and 0 if the versions
+  /// are equal.
+  static int compare(const FIRVersion &a, const FIRVersion &b) {
+    if (a.major > b.major)
+      return 1;
+    if (a.major < b.major)
+      return -1;
+    if (a.minor > b.minor)
+      return 1;
+    if (a.minor < b.minor)
+      return -1;
+    if (a.patch > b.patch)
+      return 1;
+    if (a.patch < b.patch)
+      return -1;
+    return 0;
+  }
+
+  static FIRVersion minimumFIRVersion() { return {0, 2, 0}; }
+
+  static FIRVersion defaultFIRVersion() { return {1, 0, 0}; }
+
+}; // namespace firrtl
+
+/// Method to enable printing of FIRVersions
+template <typename T>
+static T &operator<<(T &os, const FIRVersion &version) {
+  os << version.major << "." << version.minor << "." << version.patch;
+  return os;
+}
+
 } // namespace firrtl
 } // namespace circt
 

--- a/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
+++ b/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
@@ -7,6 +7,7 @@
 #include "circt-c/ExportFIRRTL.h"
 
 #include "circt/Dialect/FIRRTL/FIREmitter.h"
+#include "circt/Dialect/FIRRTL/FIRParser.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 #include "mlir/CAPI/Utils.h"
@@ -16,8 +17,8 @@ using namespace circt;
 using namespace firrtl;
 
 MlirLogicalResult mlirExportFIRRTL(MlirModule module,
-                                   MlirStringCallback callback,
-                                   void *userData) {
+                                   MlirStringCallback callback, void *userData,
+                                   FIRVersion version) {
   mlir::detail::CallbackOstream stream(callback, userData);
-  return wrap(exportFIRFile(unwrap(module), stream, {}));
+  return wrap(exportFIRFile(unwrap(module), stream, {}, {3, 0, 0}));
 }

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/FIRRTL/FIREmitter.h"
 #include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
+#include "circt/Dialect/FIRRTL/FIRParser.h"
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
@@ -42,9 +43,9 @@ constexpr size_t defaultTargetLineLength = 80;
 
 /// An emitter for FIRRTL dialect operations to .fir output.
 struct Emitter {
-  Emitter(llvm::raw_ostream &os,
+  Emitter(llvm::raw_ostream &os, FIRVersion version,
           size_t targetLineLength = defaultTargetLineLength)
-      : pp(os, targetLineLength), ps(pp, saver) {
+      : pp(os, targetLineLength), ps(pp, saver), version(version) {
     pp.setListener(&saver);
   }
   LogicalResult finalize();
@@ -306,6 +307,9 @@ private:
 
   /// The current circuit namespace valid within the call to `emitCircuit`.
   CircuitNamespace circuitNamespace;
+
+  /// The version of the FIRRTL spec that should be emitted.
+  FIRVersion version;
 };
 } // namespace
 
@@ -315,6 +319,13 @@ LogicalResult Emitter::finalize() { return failure(encounteredError); }
 void Emitter::emitCircuit(CircuitOp op) {
   circuitNamespace.add(op);
   startStatement();
+  ps << "FIRRTL version ";
+  ps.addAsString(version.major);
+  ps << ".";
+  ps.addAsString(version.minor);
+  ps << ".";
+  ps.addAsString(version.patch);
+  ps << PP::newline;
   ps << "circuit " << PPExtString(legalize(op.getNameAttr())) << " :";
   setPendingNewline();
   ps.scopedBox(PP::bbox2, [&]() {
@@ -502,22 +513,35 @@ void Emitter::emitStatement(RegResetOp op) {
   auto legalName = legalize(op.getNameAttr());
   addValueName(op.getResult(), legalName);
   startStatement();
-  ps.scopedBox(PP::ibox2, [&]() {
-    ps << "reg " << legalName;
-    emitTypeWithColon(op.getResult().getType());
-    ps << "," << PP::space;
-    emitExpression(op.getClockVal());
-    ps << PP::space << "with :";
-    // Don't break this because of the newline.
-    ps << PP::neverbreak;
-    // No-paren version must be newline + indent.
-    ps << PP::newline; // ibox2 will indent.
-    ps << "reset => (" << PP::ibox0;
-    emitExpression(op.getResetSignal());
-    ps << "," << PP::space;
-    emitExpression(op.getResetValue());
-    ps << ")" << PP::end;
-  });
+  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+    ps.scopedBox(PP::ibox2, [&]() {
+      ps << "regreset " << legalName;
+      emitTypeWithColon(op.getResult().getType());
+      ps << "," << PP::space;
+      emitExpression(op.getClockVal());
+      ps << "," << PP::space;
+      emitExpression(op.getResetSignal());
+      ps << "," << PP::space;
+      emitExpression(op.getResetValue());
+    });
+  } else {
+    ps.scopedBox(PP::ibox2, [&]() {
+      ps << "reg " << legalName;
+      emitTypeWithColon(op.getResult().getType());
+      ps << "," << PP::space;
+      emitExpression(op.getClockVal());
+      ps << PP::space << "with :";
+      // Don't break this because of the newline.
+      ps << PP::neverbreak;
+      // No-paren version must be newline + indent.
+      ps << PP::newline; // ibox2 will indent.
+      ps << "reset => (" << PP::ibox0;
+      emitExpression(op.getResetSignal());
+      ps << "," << PP::space;
+      emitExpression(op.getResetValue());
+      ps << ")" << PP::end;
+    });
+  }
   emitLocationAndNewLine(op);
 }
 
@@ -596,26 +620,54 @@ void Emitter::emitVerifStatement(T op, StringRef mnemonic) {
 
 void Emitter::emitStatement(ConnectOp op) {
   startStatement();
-  auto emitLHS = [&]() { emitExpression(op.getDest()); };
-  if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
-    emitAssignLike(
-        emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+    ps.scopedBox(PP::ibox2, [&]() {
+      if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
+        ps << "invalidate" << PP::space;
+        emitExpression(op.getDest());
+      } else {
+        ps << "connect" << PP::space;
+        emitExpression(op.getDest());
+        ps << "," << PP::space;
+        emitExpression(op.getSrc());
+      }
+    });
   } else {
-    emitAssignLike(
-        emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
+    auto emitLHS = [&]() { emitExpression(op.getDest()); };
+    if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
+      emitAssignLike(
+          emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+    } else {
+      emitAssignLike(
+          emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
+    }
   }
   emitLocationAndNewLine(op);
 }
 
 void Emitter::emitStatement(StrictConnectOp op) {
   startStatement();
-  auto emitLHS = [&]() { emitExpression(op.getDest()); };
-  if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
-    emitAssignLike(
-        emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+    ps.scopedBox(PP::ibox2, [&]() {
+      if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
+        ps << "invalidate" << PP::space;
+        emitExpression(op.getDest());
+      } else {
+        ps << "connect" << PP::space;
+        emitExpression(op.getDest());
+        ps << "," << PP::space;
+        emitExpression(op.getSrc());
+      }
+    });
   } else {
-    emitAssignLike(
-        emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
+    auto emitLHS = [&]() { emitExpression(op.getDest()); };
+    if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
+      emitAssignLike(
+          emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+    } else {
+      emitAssignLike(
+          emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
+    }
   }
   emitLocationAndNewLine(op);
 }
@@ -848,7 +900,10 @@ void Emitter::emitStatement(InvalidValueOp op) {
   emitType(op.getType());
   emitLocationAndNewLine(op);
   startStatement();
-  ps << PPExtString(name) << " is invalid";
+  if (FIRVersion::compare(version, {3, 0, 0}) >= 0)
+    ps << "invalidate " << PPExtString(name);
+  else
+    ps << PPExtString(name) << " is invalid";
   emitLocationAndNewLine(op);
 }
 
@@ -1122,8 +1177,10 @@ void Emitter::emitLocation(Location loc) {
 // Emit the specified FIRRTL circuit into the given output stream.
 mlir::LogicalResult
 circt::firrtl::exportFIRFile(mlir::ModuleOp module, llvm::raw_ostream &os,
-                             std::optional<size_t> targetLineLength) {
-  Emitter emitter(os, targetLineLength.value_or(defaultTargetLineLength));
+                             std::optional<size_t> targetLineLength,
+                             FIRVersion version) {
+  Emitter emitter(os, version,
+                  targetLineLength.value_or(defaultTargetLineLength));
   for (auto &op : *module.getBody()) {
     if (auto circuitOp = dyn_cast<CircuitOp>(op))
       emitter.emitCircuit(circuitOp);
@@ -1140,7 +1197,7 @@ void circt::firrtl::registerToFIRFileTranslation() {
   static mlir::TranslateFromMLIRRegistration toFIR(
       "export-firrtl", "emit FIRRTL dialect operations to .fir output",
       [](ModuleOp module, llvm::raw_ostream &os) {
-        return exportFIRFile(module, os, targetLineLength);
+        return exportFIRFile(module, os, targetLineLength, {3, 0, 0});
       },
       [](mlir::DialectRegistry &registry) {
         registry.insert<chirrtl::CHIRRTLDialect>();

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -12,6 +12,7 @@
 // Check if printing with very short line length, removing info locators (@[...]), no line is longer than 5x line length.
 // RUN: circt-translate --export-firrtl %s --target-line-length=10 | sed -e 's/ @\[.*\]//' | FileCheck %s --implicit-check-not "{{^(.{50})}}" --check-prefix PRETTY
 
+// CHECK-LABEL: FIRRTL version 3.0.0
 // CHECK-LABEL: circuit Foo :
 // PRETTY-LABEL: circuit Foo :
 firrtl.circuit "Foo" {
@@ -88,8 +89,7 @@ firrtl.circuit "Foo" {
     %someWire = firrtl.wire : !firrtl.uint<1>
     // CHECK: reg someReg : UInt<1>, someClock
     %someReg = firrtl.reg %someClock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: reg someReg2 : UInt<1>, someClock with :
-    // CHECK:   reset => (someReset, ui1)
+    // CHECK: regreset someReg2 : UInt<1>, someClock, someReset, ui1
     %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: node someNode = ui1
     %someNode = firrtl.node %ui1 : !firrtl.uint<1>
@@ -105,31 +105,31 @@ firrtl.circuit "Foo" {
     firrtl.assert %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
     firrtl.assume %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
     firrtl.cover %someClock, %ui1, %ui1, "msg" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "foo"}
-    // CHECK: someOut <= ui1
+    // CHECK: connect someOut, ui1
     firrtl.connect %someOut, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: inst someInst of Simple
-    // CHECK: someInst.someIn <= ui1
-    // CHECK: someOut <= someInst.someOut
+    // CHECK: connect someInst.someIn, ui1
+    // CHECK: connect someOut, someInst.someOut
     %someInst_someIn, %someInst_someOut = firrtl.instance someInst @Simple(in someIn: !firrtl.uint<1>, out someOut: !firrtl.uint<1>)
     firrtl.connect %someInst_someIn, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %someOut, %someInst_someOut : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NOT: _invalid
-    // CHECK: someOut is invalid
+    // CHECK: invalidate someOut
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.connect %someOut, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NOT: _invalid
-    // CHECK: someOut is invalid
+    // CHECK: invalidate someOut
     %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.strictconnect %someOut, %invalid_ui2 : !firrtl.uint<1>
 
-    // CHECK: unknownWidth <= knownWidth
+    // CHECK: connect unknownWidth, knownWidth
     %knownWidth = firrtl.wire : !firrtl.uint<1>
     %unknownWidth = firrtl.wire : !firrtl.uint
     %widthCast = firrtl.widthCast %knownWidth :
       (!firrtl.uint<1>) -> !firrtl.uint
     firrtl.strictconnect %unknownWidth, %widthCast : !firrtl.uint
 
-    // CHECK: unknownReset <= knownReset
+    // CHECK: connect unknownReset, knownReset
     %knownReset = firrtl.wire : !firrtl.asyncreset
     %unknownReset = firrtl.wire : !firrtl.reset
     %resetCast = firrtl.resetCast %knownReset :
@@ -305,9 +305,9 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT:    writer => b
     // CHECK-NEXT:    readwriter => c
     // CHECK-NEXT:    read-under-write => undefined
-    // CHECK-NEXT:  MyMem.a.clk <= someClock
-    // CHECK-NEXT:  MyMem.b.clk <= someClock
-    // CHECK-NEXT:  MyMem.c.clk <= someClock
+    // CHECK-NEXT:  connect MyMem.a.clk, someClock
+    // CHECK-NEXT:  connect MyMem.b.clk, someClock
+    // CHECK-NEXT:  connect MyMem.c.clk, someClock
 
     %combmem = chirrtl.combmem : !chirrtl.cmemory<uint<3>, 256>
     %port0_data, %port0_port = chirrtl.memoryport Infer %combmem {name = "port0"} : (!chirrtl.cmemory<uint<3>, 256>) -> (!firrtl.uint<3>, !chirrtl.cmemoryport)
@@ -328,12 +328,12 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT:   infer mport port1 = seqmem[someAddr], someClock
 
     firrtl.connect %port0_data, %port1_data : !firrtl.uint<3>, !firrtl.uint<3>
-    // CHECK: port0 <= port1
+    // CHECK: connect port0, port1
 
     %invalid_clock = firrtl.invalidvalue : !firrtl.clock
     %dummyReg = firrtl.reg %invalid_clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: wire [[INV:_invalid.*]] : Clock
-    // CHECK-NEXT: [[INV]] is invalid
+    // CHECK-NEXT: invalidate [[INV]]
     // CHECK-NEXT: reg dummyReg : UInt<42>, [[INV]]
   }
 
@@ -473,7 +473,7 @@ firrtl.circuit "Foo" {
     out %b0: !firrtl.const.uint<42>
   ) {
     // Make sure literals strip the 'const' prefix
-    // CHECK: b0 <= UInt<42>(1)
+    // CHECK: connect b0, UInt<42>(1)
     %c = firrtl.constant 1 : !firrtl.const.uint<42>
     firrtl.strictconnect %b0, %c : !firrtl.const.uint<42>
   }
@@ -522,8 +522,7 @@ firrtl.circuit "Foo" {
 
     // CHECK:      wire `14` : UInt<1>
     // CHECK-NEXT: reg `15` : UInt<1>, `0`
-    // CHECK-NEXT: reg `16` : UInt<1>, `0` with :
-    // CHECK-NEXT:   reset => (`1`, `3`)
+    // CHECK-NEXT: regreset `16` : UInt<1>, `0`, `1`, `3`
     // CHECK-NEXT: node `17` = `3`
     %_14 = firrtl.wire interesting_name {name = "14"} : !firrtl.uint<1>
     %_15, %_15_ref = firrtl.reg %_0 forceable {name = "15"} :
@@ -532,16 +531,16 @@ firrtl.circuit "Foo" {
       !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
     %_17 = firrtl.node %_3 {name = "17"} : !firrtl.uint<1>
 
-    // CHECK:      `9`.`1` <= `9`.`0`
+    // CHECK:      connect `9`.`1`, `9`.`0`
     %2 = firrtl.widthCast %0 : (!firrtl.uint) -> !firrtl.uint
     firrtl.strictconnect %1, %2 : !firrtl.uint
 
-    // CHECK:      `11` is invalid
+    // CHECK:      invalidate `11`
     %invalid_ui = firrtl.invalidvalue : !firrtl.uint
     firrtl.strictconnect %_11, %invalid_ui : !firrtl.uint
 
     // CHECK:      inst `0bar` of `0Bar`
-    // CHECK-NEXT: `0bar`.`0` <= `3`
+    // CHECK-NEXT: connect `0bar`.`0`, `3`
     %_0bar_0 = firrtl.instance "0bar" @"0Bar"(in "0": !firrtl.uint<1>)
     firrtl.strictconnect %_0bar_0, %_3 : !firrtl.uint<1>
 
@@ -564,16 +563,16 @@ firrtl.circuit "Foo" {
         !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>,
         !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
 
-    // CHECK:      `18`.`0`.clk <= `0`
-    // CHECK-NEXT: `18`.`0`.en <= `3`
-    // CHECK-NEXT: `18`.`0`.addr <= pad(`3`, 5)
-    // CHECK-NEXT: `11` <= `18`.`0`.data
+    // CHECK:      connect `18`.`0`.clk, `0`
+    // CHECK-NEXT: connect `18`.`0`.en, `3`
+    // CHECK-NEXT: connect `18`.`0`.addr, pad(`3`, 5)
+    // CHECK-NEXT: connect `11`, `18`.`0`.data
 
-    // CHECK-NEXT: `18`.`1`.clk <= `0`
-    // CHECK-NEXT: `18`.`1`.en <= `3`
-    // CHECK-NEXT: `18`.`1`.data <= pad(`3`, 8)
-    // CHECK-NEXT: `18`.`1`.addr <= pad(`3`, 5)
-    // CHECK-NEXT: `18`.`1`.mask <= `3`
+    // CHECK-NEXT: connect `18`.`1`.clk, `0`
+    // CHECK-NEXT: connect `18`.`1`.en, `3`
+    // CHECK-NEXT: connect `18`.`1`.data, pad(`3`, 8)
+    // CHECK-NEXT: connect `18`.`1`.addr, pad(`3`, 5)
+    // CHECK-NEXT: connect `18`.`1`.mask, `3`
     %3 = firrtl.subfield %_18_1[mask] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %4 = firrtl.subfield %_18_1[addr] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %5 = firrtl.subfield %_18_1[data] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
@@ -602,7 +601,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: smem `20` : { `0` : UInt<8> }[32]
 
     // CHECK-NEXT: write mport `21` = `19`[UInt<5>(8)], `0`
-    // CHECK-NEXT: `21`.`0` <= UInt<8>(0)
+    // CHECK-NEXT: connect `21`.`0`, UInt<8>(0)
     %_19 = chirrtl.combmem {name = "19"} : !chirrtl.cmemory<bundle<"0": uint<8>>, 32>
     %_21_data, %_21_port = chirrtl.memoryport Write %_19 {name = "21"} : (!chirrtl.cmemory<bundle<"0": uint<8>>, 32>) -> (!firrtl.bundle<"0": uint<8>>, !chirrtl.cmemoryport)
     %16 = firrtl.subfield %_21_data["0"] : !firrtl.bundle<"0": uint<8>>


### PR DESCRIPTION
Change the FIRRTL emitter to use v3.0.0 of the FIRRTL specification.
Logic for emitting an older version of the spec is still preserved.  There
is no option for choosing the spec version from the command line right
now.