### PR TITLE
[Arc] Fix dominance issue in GroupResetsAndEnables

### DIFF
--- a/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
+++ b/lib/Dialect/Arc/Transforms/GroupResetsAndEnables.cpp
@@ -165,8 +165,7 @@ struct GroupAssignmentsInIfPattern : public OpRewritePattern<scf::IfOp> {
     // Skip anything not in a ClockTreeOp
     auto clockTreeOp = ifOp->getParentOfType<ClockTreeOp>();
     if (!clockTreeOp)
-      // This probably means the design uses a derived clock (warning).
-      return success(false);
+      return failure();
     // Group assignments in each region and keep track of whether either
     // grouping made changes
     bool changed = groupInRegion(ifOp.thenBlock(), clockTreeOp, &rewriter) ||


### PR DESCRIPTION
This fixes a dominance issue that can occur in GroupResetsAndEnables. Unfortunately I haven't been able to reduce the test case from a larger design (tried using circt-reduce).

There are two fixes:

* It should not fail if it can't get a ClockTreeOp, but instead should just return that nothing was changed.
* It should use `definition->getUsers()` to check for dominance, since `definition` is the operation that will actually be moved. If it generates multiple results, the place it is being moved to must dominate all those results, not just the operand used in the block.