### PR TITLE
[LowerFIRRTLToHW] Use backedges over temporary wires, NFC

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3274,12 +3274,6 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
     auto portResult = oldInstance.getResult(portIndex);
     assert(portResult && "invalid IR, couldn't find port");
 
-    // Directly materialize foreign types.
-    if (!isa<FIRRTLType>(port.type)) {
-      operands.push_back(createBackedge(portResult, portType));
-      continue;
-    }
-
     // Replace the input port with a backedge.  If it turns out that this port
     // is never driven, an uninitialized wire will be materialized at the end.
     if (port.isInput()) {


### PR DESCRIPTION
This changes LowerFIRRTLToHW to use backedges instead of temporary wire operations.  The temporary wires were guaranteed to be optimized away. Now we slightly more gracefully handle the, technically illegal, cases of these wires having no value driven to them.  This change is NFC in the FIRRTL pipeline where these invariants have already been verified. We can remove the infrastructure for creating these temporary wires, as it is not used anymore.