### PR TITLE
[PrettyPrinter] Add a callback token to record events

### DIFF
--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -72,6 +72,10 @@ public:
   struct EndInfo : public TokenInfo {
     // Nothing
   };
+  // This can be used to associate a callback with the print event on the
+  // tokens stream. Note that the lambda used to create the function object will
+  // be out of scope when it is evoked. So extra care is required to ensure the
+  // values captured by the function object are valid out of scope.
   struct CallbackInfo : public TokenInfo {
     using CallbackTy = std::function<void()>;
     CallbackTy *callback;
@@ -165,10 +169,8 @@ struct EndToken : public TokenBase<EndToken, Token::Kind::End> {};
 
 struct CallbackToken : public TokenBase<CallbackToken, Token::Kind::Callback> {
   CallbackToken(Token::CallbackInfo::CallbackTy *c) { initialize(c); }
-  void invoke() const {
-    if (auto *c = getInfo().callback)
-      std::invoke(*c);
-  }
+  bool isValid() { return getInfo().callback; }
+  void invoke() const { std::invoke(*getInfo().callback); }
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -76,7 +76,7 @@ public:
   // tokens stream. The id is used to uniquely identify an interesting event
   // on the token stream.
   struct CallbackInfo : public TokenInfo {
-    unsigned id;
+    uint32_t id;
   };
 
 private:
@@ -166,8 +166,8 @@ struct BeginToken : public TokenBase<BeginToken, Token::Kind::Begin> {
 struct EndToken : public TokenBase<EndToken, Token::Kind::End> {};
 
 struct CallbackToken : public TokenBase<CallbackToken, Token::Kind::Callback> {
-  CallbackToken(unsigned id) { initialize(id); }
-  unsigned id() const { return getInfo().id; }
+  CallbackToken(uint32_t id) { initialize(id); }
+  uint32_t id() const { return getInfo().id; }
 };
 
 //===----------------------------------------------------------------------===//
@@ -182,7 +182,7 @@ public:
     /// No tokens referencing external memory are present.
     virtual void clear(){};
     /// Listener for print event.
-    virtual void print(unsigned){};
+    virtual void print(uint32_t){};
   };
 
   /// PrettyPrinter for specified stream.

--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -166,6 +166,20 @@ public:
   void clear() override;
 };
 
+class TokenStringAndCallbackSaver : public TokenStringSaver {
+  llvm::SpecificBumpPtrAllocator<Token::CallbackInfo::CallbackTy> callbackAlloc;
+
+public:
+  Token::CallbackInfo::CallbackTy *
+  save(const Token::CallbackInfo::CallbackTy &c) {
+    return new (callbackAlloc.Allocate()) Token::CallbackInfo::CallbackTy(c);
+  }
+  void clear() override {
+    callbackAlloc.DestroyAll();
+    TokenStringSaver::clear();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Streaming support.
 //===----------------------------------------------------------------------===//

--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -173,7 +173,7 @@ class PrintEventListener : public PrettyPrinter::Listener {
   /// Note: Doesn't own Data !
   SmallVector<Data *> list;
   /// The storage for the callback, as a function object.
-  std::function<void(unsigned)> callbackObj;
+  std::function<void(uint32_t)> callbackObj;
 
   /// Note: Callable class must implement a callable with signature:
   /// void (Data*)
@@ -188,7 +188,7 @@ class PrintEventListener : public PrettyPrinter::Listener {
     // May result in heap allocation. Pointer to the callback object and data
     // vector is captured by value.
     callbackObj =
-        decltype(callbackObj)([c = &c, dataPtr = &this->list](unsigned id) {
+        decltype(callbackObj)([c = &c, dataPtr = &this->list](uint32_t id) {
           std::invoke(*c, (*dataPtr)[id]);
         });
   }
@@ -197,7 +197,7 @@ public:
   PrintEventListener(Callable &c) { init(c); }
 
   /// This is invoked when the CallbackToken is printed.
-  void print(unsigned id) override { std::invoke(callbackObj, id); }
+  void print(uint32_t id) override { std::invoke(callbackObj, id); }
 
   /// Insert data onto the list.
   void setData(Data *obj) { list.push_back(obj); }

--- a/include/circt/Support/PrettyPrinterHelpers.h
+++ b/include/circt/Support/PrettyPrinterHelpers.h
@@ -168,21 +168,20 @@ public:
 };
 
 /// Note: Callable class must implement a callable with signature:
-/// void (Data*)
-template <typename Callable, typename Data>
+/// void (Data)
+template <typename CallableTy, typename DataTy>
 class PrintEventAndStorageListener : public TokenStringSaver {
 
   /// List of all the unique data associated with each callback token.
   /// The fact that tokens on a stream can never be printed out of order,
   /// ensures that CallbackTokens are always added and invoked in FIFO order,
   /// hence no need to record an index into the Data list.
-  /// Note: Doesn't own Data !
-  std::queue<Data *> dataQ;
+  std::queue<DataTy> dataQ;
   /// The storage for the callback, as a function object.
-  Callable &callable;
+  CallableTy &callable;
 
 public:
-  PrintEventAndStorageListener(Callable &c) : callable(c) {}
+  PrintEventAndStorageListener(CallableTy &c) : callable(c) {}
 
   /// PrettyPrinter::Listener::print -- indicates all the preceding tokens on
   /// the stream have been printed.
@@ -192,7 +191,7 @@ public:
     dataQ.pop();
   }
   /// Get a token with the obj data.
-  CallbackToken getToken(Data *obj) {
+  CallbackToken getToken(DataTy obj) {
     // Insert data onto the list.
     dataQ.push(obj);
     return CallbackToken();

--- a/lib/Support/PrettyPrinter.cpp
+++ b/lib/Support/PrettyPrinter.cpp
@@ -116,8 +116,6 @@ void PrettyPrinter::add(Token t) {
         addScanToken(-1);
       })
       .Case([&](CallbackToken *c) {
-        if (!c->isValid())
-          return;
         if (scanStack.empty())
           return print({t, 0});
         tokens.push_back({t, 0});

--- a/lib/Support/PrettyPrinter.cpp
+++ b/lib/Support/PrettyPrinter.cpp
@@ -171,7 +171,7 @@ void PrettyPrinter::clear() {
   leftTotal = rightTotal = 1;
   tokens.clear();
   tokenOffset = 0;
-  if (listener && !listener->donotClear)
+  if (listener && !donotClear)
     listener->clear();
 }
 

--- a/lib/Support/PrettyPrinter.cpp
+++ b/lib/Support/PrettyPrinter.cpp
@@ -116,6 +116,8 @@ void PrettyPrinter::add(Token t) {
         addScanToken(-1);
       })
       .Case([&](CallbackToken *c) {
+        assert(printListener &&
+               "printListener must be set, before adding CallbackToken");
         if (scanStack.empty())
           return print({t, 0});
         tokens.push_back({t, 0});
@@ -306,7 +308,7 @@ void PrettyPrinter::print(const FormattedToken &f) {
           os.indent(pendingIndentation);
           pendingIndentation = 0;
         }
-        c->invoke();
+        printListener->print(c->id());
       });
 }
 } // end namespace pretty

--- a/lib/Support/PrettyPrinter.cpp
+++ b/lib/Support/PrettyPrinter.cpp
@@ -116,8 +116,9 @@ void PrettyPrinter::add(Token t) {
         addScanToken(-1);
       })
       .Case([&](CallbackToken *c) {
-        assert(printListener &&
-               "printListener must be set, before adding CallbackToken");
+        // Callbacktoken must be associated with a listener, it doesn't have any
+        // meaning without it.
+        assert(listener);
         if (scanStack.empty())
           return print({t, 0});
         tokens.push_back({t, 0});
@@ -170,7 +171,7 @@ void PrettyPrinter::clear() {
   leftTotal = rightTotal = 1;
   tokens.clear();
   tokenOffset = 0;
-  if (listener)
+  if (listener && !listener->donotClear)
     listener->clear();
 }
 
@@ -308,7 +309,7 @@ void PrettyPrinter::print(const FormattedToken &f) {
           os.indent(pendingIndentation);
           pendingIndentation = 0;
         }
-        printListener->print(c->id());
+        listener->print();
       });
 }
 } // end namespace pretty

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -21,7 +21,19 @@ using namespace pretty;
 
 namespace {
 
-using CallbackType = Token::CallbackInfo::CallbackTy;
+class RecordLocation {
+  formatted_raw_ostream *fStream;
+
+public:
+  void operator()(SmallString<128> *locationStr) {
+    locationStr->append(("line <" + Twine(fStream->getLine()) + "," +
+                         Twine(fStream->getColumn()) + ">,")
+                            .str());
+  }
+  void setStream(formatted_raw_ostream *&f) { fStream = f; }
+  RecordLocation(formatted_raw_ostream *f) : fStream(f) {}
+  RecordLocation() = default;
+};
 
 class FuncTest : public testing::Test {
 protected:
@@ -30,7 +42,8 @@ protected:
   SmallVector<Token> nestedTokens;
   SmallVector<Token> indentNestedTokens;
   formatted_raw_ostream *fStream = nullptr;
-  TokenStringAndCallbackSaver callbacks;
+  RecordLocation recordLoc;
+  CallbackSaver<RecordLocation, SmallString<128>> callbacks;
 
   /// Scratch buffer used by print.
   SmallString<256> out;
@@ -65,96 +78,82 @@ protected:
         });
   }
 
-  CallbackType *getCallback(SmallString<128> &str) {
-    // Note: The callback captures should be safe to access even out of scope of
-    // this function.
-    return callbacks.save([&formattedStream = this->fStream,
-                           locationStr = &str]() {
-      locationStr->append(("line <" + Twine((formattedStream)->getLine()) +
-                           "," + Twine((formattedStream)->getColumn()) + ">,")
-                              .str());
-    });
-  }
-
   void SetUp() override {
 
+    callbacks.init(recordLoc);
     buildArgs();
     {
       // foooooo(ARGS)
       // With ARGS in an ibox.
       funcTokens.append({StringToken("foooooo"), StringToken("("),
                          BeginToken(0, Breaks::Inconsistent), BreakToken(0)});
-      auto *callbackPtr = getCallback(locationOut1);
 
-      funcTokens.append({CallbackToken(*callbackPtr)});
+      funcTokens.append({callbacks.getToken(locationOut1)});
       funcTokens.append(argTokens);
-      funcTokens.append({CallbackToken(*callbackPtr)});
+      funcTokens.append({callbacks.getToken(locationOut1)});
       funcTokens.append({BreakToken(0), EndToken(), StringToken(");"),
                          BreakToken(PrettyPrinter::kInfinity)});
-      funcTokens.append({CallbackToken(*callbackPtr)});
+      funcTokens.append({callbacks.getToken(locationOut1)});
     }
     {
-      auto *callbackPtr = getCallback(locationOut2);
+      auto callbackToken = callbacks.getToken(locationOut2);
       // baroo(AR..  barooga(ARGS) .. GS)
       // Nested function call, nested method wrapped in cbox(0) w/breaks.
       nestedTokens.append({StringToken("baroo"), StringToken("("),
                            BeginToken(0, Breaks::Inconsistent), BreakToken(0)});
-      nestedTokens.append({CallbackToken(*callbackPtr)});
+      nestedTokens.append({callbackToken});
       SmallVectorImpl<Token>::iterator argMiddle =
           argTokens.begin() + argTokens.size() / 2;
       nestedTokens.append(argTokens.begin(), argMiddle);
-      nestedTokens.append({CallbackToken(*callbackPtr)});
+      nestedTokens.append({callbackToken});
 
       nestedTokens.append({
           BeginToken(0, Breaks::Consistent),
           StringToken("barooga"),
           StringToken("("),
-          CallbackToken(*callbackPtr),
+          callbackToken,
           BeginToken(0, Breaks::Inconsistent),
           BreakToken(0),
       });
-      nestedTokens.append({CallbackToken(*callbackPtr)});
+      nestedTokens.append({callbackToken});
       nestedTokens.append(argTokens);
-      nestedTokens.append({BreakToken(0), CallbackToken(*callbackPtr),
-                           EndToken(), StringToken("),"), BreakToken(),
-                           EndToken(),
+      nestedTokens.append({BreakToken(0), callbackToken, EndToken(),
+                           StringToken("),"), BreakToken(), EndToken(),
                            /* BreakToken(0), */});
       nestedTokens.append(argMiddle, argTokens.end());
       nestedTokens.append({BreakToken(0), EndToken(), StringToken(");"),
                            BreakToken(PrettyPrinter::kInfinity)});
     }
     {
-      auto *callbackPtr = getCallback(locationOut3);
+      auto callbackToken = callbacks.getToken(locationOut3);
       // wahoo(ARGS)
       // If wrap args, indent on next line
       indentNestedTokens.append(
-          {CallbackToken(*callbackPtr), BeginToken(2, Breaks::Consistent),
-           /*No change in location*/ CallbackToken(*callbackPtr),
-           StringToken("wahoo"), CallbackToken(*callbackPtr), StringToken("("),
-           BreakToken(0), CallbackToken(*callbackPtr),
+          {callbackToken, BeginToken(2, Breaks::Consistent),
+           /*No change in location*/ callbackToken, StringToken("wahoo"),
+           callbackToken, StringToken("("), BreakToken(0), callbackToken,
            BeginToken(0, Breaks::Inconsistent),
-           /*No change in location*/ CallbackToken(*callbackPtr)});
+           /*No change in location*/ callbackToken});
 
       SmallVectorImpl<Token>::iterator argMiddle =
           argTokens.begin() + argTokens.size() / 2;
       indentNestedTokens.append(argTokens.begin(), argMiddle);
 
       indentNestedTokens.append({
-          CallbackToken(*callbackPtr),
+          callbackToken,
           BeginToken(0, Breaks::Consistent),
-          CallbackToken(*callbackPtr),
+          callbackToken,
           StringToken("yahooooooo"),
           StringToken("("),
           BeginToken(0, Breaks::Inconsistent),
-          CallbackToken(*callbackPtr),
+          callbackToken,
           BreakToken(0),
       });
       indentNestedTokens.append(argTokens);
       indentNestedTokens.append({
-          CallbackToken(*callbackPtr), BreakToken(0), EndToken(),
-          CallbackToken(*callbackPtr), StringToken("),"), BreakToken(),
-          CallbackToken(*callbackPtr), EndToken(),
-          CallbackToken(*callbackPtr), /* BreakToken(0), */
+          callbackToken, BreakToken(0), EndToken(), callbackToken,
+          StringToken("),"), BreakToken(), callbackToken, EndToken(),
+          callbackToken, /* BreakToken(0), */
       });
       indentNestedTokens.append(argMiddle, argTokens.end());
       indentNestedTokens.append({EndToken(), BreakToken(0, -2),
@@ -168,6 +167,7 @@ protected:
     raw_svector_ostream os(out);
     formatted_raw_ostream formattedStream(os);
     fStream = &formattedStream;
+    recordLoc.setStream(fStream);
     locationOut1.clear();
     PrettyPrinter pp(formattedStream, margin);
     pp.addTokens(tokens);
@@ -577,27 +577,21 @@ TEST(PrettyPrinterTest, Expr) {
   raw_svector_ostream os(out);
   formatted_raw_ostream formattedStream(os);
   SmallString<128> locationOut;
-  auto callback = [&formattedStream, &locationOut]() {
-    locationOut.append(("line <" + Twine(formattedStream.getLine()) + "," +
-                        Twine(formattedStream.getColumn()) + ">,")
-                           .str());
-  };
-  TokenStringAndCallbackSaver callbacks;
-  CallbackType *callbackPtr = callbacks.save(callback);
+  RecordLocation recordLoc(&formattedStream);
+  CallbackSaver<RecordLocation, SmallString<128>> callbacks(recordLoc);
+  auto token = callbacks.getToken(locationOut);
 
-  auto sumExpr = [&callbackPtr](auto &ps) {
-    ps << CallbackToken(*callbackPtr) << "(";
+  auto sumExpr = [&token](auto &ps) {
+    ps << token << "(";
     {
       ps << PP::ibox0;
       auto vars = {"a", "b", "c", "d", "e", "f"};
       llvm::interleave(
           vars, [&](const char *each) { ps << each; },
-          [&]() {
-            ps << PP::space << "+" << CallbackToken(*callbackPtr) << PP::space;
-          });
-      ps << PP::end << CallbackToken(*callbackPtr);
+          [&]() { ps << PP::space << "+" << token << PP::space; });
+      ps << PP::end << token;
     }
-    ps << ")" << CallbackToken(*callbackPtr);
+    ps << ")" << token;
   };
 
   auto test = [&](const char *id, auto margin) {
@@ -606,7 +600,7 @@ TEST(PrettyPrinterTest, Expr) {
     TokenStream<> ps(pp, saver);
     out = "\n";
     ps.scopedBox(PP::ibox2, [&]() {
-      ps << CallbackToken(*callbackPtr);
+      ps << token;
       ps << "assign" << PP::nbsp << id << PP::nbsp << "=";
       ps << PP::space;
       ps.scopedBox(PP::ibox0, [&]() {
@@ -767,36 +761,32 @@ TEST(PrettyPrinterTest, NeverBreakGroup) {
   raw_svector_ostream os(out);
   formatted_raw_ostream formattedStream(os);
   SmallString<128> locationOut;
-  TokenStringAndCallbackSaver callbacks;
+  RecordLocation recordLoc(&formattedStream);
+  CallbackSaver<RecordLocation, SmallString<128>> callbacks(recordLoc);
   // Mostly checking location after break tokens.
-  CallbackType *callbackPtr =
-      callbacks.save([&formattedStream, &locationOut]() {
-        locationOut.append(("line <" + Twine(formattedStream.getLine()) + "," +
-                            Twine(formattedStream.getColumn()) + ">,")
-                               .str());
-      });
+  auto callbackToken = callbacks.getToken(locationOut);
 
   auto test = [&](Breaks breaks1, Breaks breaks2) {
     out = "\n";
     PrettyPrinter pp(formattedStream, 8);
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BeginToken(2, breaks1));
     pp.add(StringToken("test"));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BreakToken());
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(StringToken("test"));
     {
       pp.add(BeginToken(2, breaks2));
-      pp.add(CallbackToken(*callbackPtr));
+      pp.add(callbackToken);
       pp.add(BreakToken());
-      pp.add(CallbackToken(*callbackPtr));
+      pp.add(callbackToken);
       pp.add(StringToken("test"));
       pp.add(BreakToken());
-      pp.add(CallbackToken(*callbackPtr));
+      pp.add(callbackToken);
       pp.add(StringToken("test"));
       pp.add(EndToken());
-      pp.add(CallbackToken(*callbackPtr));
+      pp.add(callbackToken);
     }
     pp.add(BreakToken());
     pp.add(StringToken("test"));
@@ -841,35 +831,32 @@ TEST(PrettyPrinterTest, MaxStartingIndent) {
   formatted_raw_ostream formattedStream(os);
   SmallString<128> locationOut;
 
-  TokenStringAndCallbackSaver callbacks;
-  CallbackType *callbackPtr =
-      callbacks.save([&formattedStream, &locationOut]() {
-        locationOut.append(("line <" + Twine(formattedStream.getLine()) + "," +
-                            Twine(formattedStream.getColumn()) + ">,")
-                               .str());
-      });
+  // Mostly checking location after break tokens.
+  RecordLocation recordLoc(&formattedStream);
+  CallbackSaver<RecordLocation, SmallString<128>> callbacks(recordLoc);
+  auto callbackToken = callbacks.getToken(locationOut);
 
   auto test = [&](PrettyPrinter &pp) {
     out = "\n";
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BeginToken(2));
     pp.add(StringToken("test"));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BreakToken());
     pp.add(BeginToken(2));
     pp.add(StringToken("test"));
     pp.add(BreakToken());
     pp.add(BeginToken(2));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(StringToken("test"));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BreakToken());
     pp.add(BeginToken(2));
     pp.add(StringToken("test"));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(BreakToken());
     pp.add(StringToken("test"));
-    pp.add(CallbackToken(*callbackPtr));
+    pp.add(callbackToken);
     pp.add(EndToken());
     pp.add(EndToken());
     pp.add(EndToken());
@@ -940,22 +927,19 @@ protected:
   raw_svector_ostream ppOS = raw_svector_ostream(out);
   raw_svector_ostream os = raw_svector_ostream(compare);
 
-  TokenStringAndCallbackSaver callbacks;
+  formatted_raw_ostream formattedStream = formatted_raw_ostream(ppOS);
+  RecordLocation recordLoc = RecordLocation(&formattedStream);
+  CallbackSaver<RecordLocation, SmallString<128>> callbacks;
   TokenStringSaver saver;
-  CallbackType *callbackPtr = nullptr;
 
   template <typename Callable>
   void testStreams(Callable &&test,
                    std::optional<StringRef> data = std::nullopt,
                    unsigned margin = 10) {
-    formatted_raw_ostream formattedStream(ppOS);
     SmallString<128> locationOut;
-
-    callbackPtr = callbacks.save([&formattedStream, &locationOut]() {
-      locationOut.append(("line <" + Twine(formattedStream.getLine()) + "," +
-                          Twine(formattedStream.getColumn()) + ">,")
-                             .str());
-    });
+    callbacks.init(recordLoc);
+    callbacks.setData(locationOut);
+    // Mostly checking location after break tokens.
     out.clear();
     compare.clear();
     PrettyPrinter pp(formattedStream, margin);
@@ -1001,7 +985,7 @@ TEST_F(TokenStreamCompareTest, NBSPs) {
     testStreams([&](auto &ps, auto &os) {
       ps.nbsp(i);
       // This just checks there is no change in output stream.
-      ps << CallbackToken(*callbackPtr);
+      ps << callbacks.getToken();
       os.indent(i);
     });
 }

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -31,6 +31,7 @@ protected:
   SmallVector<Token> indentNestedTokens;
   formatted_raw_ostream *fStream = nullptr;
   llvm::BumpPtrAllocator allocator;
+  TokenCallbackSaver callbacks;
 
   /// Scratch buffer used by print.
   SmallString<256> out;
@@ -75,7 +76,8 @@ protected:
                              ">,")
                                 .str());
     };
-    return new (allocator.Allocate<CallbackType>()) CallbackType(callback);
+    return callbacks.get(callback);
+    // return new (allocator.Allocate<CallbackType>()) CallbackType(callback);
   }
   void SetUp() override {
 
@@ -573,9 +575,8 @@ TEST(PrettyPrinterTest, Expr) {
                         Twine(formattedStream.getColumn()) + ">,")
                            .str());
   };
-  llvm::BumpPtrAllocator allocator;
-  CallbackType *callbackPtr =
-      new (allocator.Allocate<CallbackType>()) CallbackType(callback);
+  TokenCallbackSaver callbacks;
+  CallbackType *callbackPtr = callbacks.get(callback);
 
   auto sumExpr = [&callbackPtr](auto &ps) {
     ps << CallbackToken(callbackPtr) << "(";
@@ -818,9 +819,8 @@ TEST(PrettyPrinterTest, MaxStartingIndent) {
                         Twine(formattedStream.getColumn()) + ">,")
                            .str());
   };
-  llvm::BumpPtrAllocator allocator;
-  CallbackType *callbackPtr =
-      new (allocator.Allocate<CallbackType>()) CallbackType(callback);
+  TokenCallbackSaver callbacks;
+  CallbackType *callbackPtr = callbacks.get(callback);
 
   auto test = [&](PrettyPrinter &pp) {
     out = "\n";

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -44,8 +44,10 @@ protected:
   SmallVector<Token> indentNestedTokens;
   formatted_raw_ostream *fStream = nullptr;
   RecordLocation recordLoc;
-  PrintEventAndStorageListener<RecordLocation, SmallString<128>> callbacks =
-      PrintEventAndStorageListener<RecordLocation, SmallString<128>>(recordLoc);
+  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>
+      callbacks =
+          PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>(
+              recordLoc);
 
   /// Scratch buffer used by print.
   SmallString<256> out;
@@ -581,8 +583,8 @@ TEST(PrettyPrinterTest, Expr) {
   formatted_raw_ostream formattedStream(os);
   SmallString<128> locationOut;
   RecordLocation recordLoc(&formattedStream);
-  PrintEventAndStorageListener<RecordLocation, SmallString<128>> callbacks(
-      recordLoc);
+  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>
+      callbacks(recordLoc);
 
   auto sumExpr = [&callbacks, &locationOut](auto &ps) {
     ps << callbacks.getToken(&locationOut) << "(";
@@ -769,8 +771,8 @@ TEST(PrettyPrinterTest, NeverBreakGroup) {
   formatted_raw_ostream formattedStream(os);
   SmallString<128> locationOut;
   RecordLocation recordLoc(&formattedStream);
-  PrintEventAndStorageListener<RecordLocation, SmallString<128>> callbacks(
-      recordLoc);
+  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>
+      callbacks(recordLoc);
   // Mostly checking location after break tokens.
   auto test = [&](Breaks breaks1, Breaks breaks2) {
     out = "\n";
@@ -840,8 +842,8 @@ TEST(PrettyPrinterTest, MaxStartingIndent) {
 
   // Mostly checking location after break tokens.
   RecordLocation recordLoc(&formattedStream);
-  PrintEventAndStorageListener<RecordLocation, SmallString<128>> callbacks(
-      recordLoc);
+  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>
+      callbacks(recordLoc);
 
   auto test = [&](PrettyPrinter &pp) {
     out = "\n";
@@ -938,9 +940,9 @@ protected:
 
   formatted_raw_ostream formattedStream = formatted_raw_ostream(ppOS);
   RecordLocation recordLoc = RecordLocation(&formattedStream);
-  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char>>
+  PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>
       callbacks =
-          PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char>>(
+          PrintEventAndStorageListener<RecordLocation, SmallVectorImpl<char> *>(
               recordLoc);
   TokenStringSaver saver;
   SmallString<128> locationOut;


### PR DESCRIPTION
This PR adds a `Callback` token to `PrettyPrinter`. It can be used to register a callback `std::function ` object, corresponding to any interesting event in the stream.
The `CallbackToken` is pushed along with the other tokens, and the `std::function` is invoked, only after the last token is printed to the stream. This enables the callback to record the location of the last printed token in the stream.
The callback is a `void()` function, it is the responsibility of the user, to capture the necessary data structures and manage the allocation. This enables the callback to be used for any generic purpose.
The unit tests demonstrate a use case of recording the stream location information for various tokens.