### PR TITLE
[FIRRTL] Allow strictconnect to have different but structurally equivalent types

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -130,7 +130,6 @@ StrictConnectOp getSingleConnectUserOf(Value value);
 // functions commonly used among operations.
 namespace impl {
 LogicalResult verifySameOperandsIntTypeKind(Operation *op);
-LogicalResult verifySameAnonTypeOperands(Operation *op);
 
 // Type inference adaptor for FIRRTL operations.
 LogicalResult inferReturnTypes(
@@ -171,16 +170,6 @@ class SameOperandsIntTypeKind
 public:
   static LogicalResult verifyTrait(Operation *op) {
     return impl::verifySameOperandsIntTypeKind(op);
-  }
-};
-
-/// A binary operation where the operands have the anonymous types.
-template <typename ConcreteOp>
-class SameAnonTypeOperands
-    : public OpTrait::TraitBase<ConcreteOp, SameAnonTypeOperands> {
-public:
-  static LogicalResult verifyTrait(Operation *op) {
-    return impl::verifySameAnonTypeOperands(op);
   }
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -130,6 +130,7 @@ StrictConnectOp getSingleConnectUserOf(Value value);
 // functions commonly used among operations.
 namespace impl {
 LogicalResult verifySameOperandsIntTypeKind(Operation *op);
+LogicalResult verifySameAnnoTypeOperands(Operation *op);
 
 // Type inference adaptor for FIRRTL operations.
 LogicalResult inferReturnTypes(
@@ -170,6 +171,16 @@ class SameOperandsIntTypeKind
 public:
   static LogicalResult verifyTrait(Operation *op) {
     return impl::verifySameOperandsIntTypeKind(op);
+  }
+};
+
+/// A binary operation where the operands have the anonymous types..
+template <typename ConcreteOp>
+class SameAnnoTypeOperands
+    : public OpTrait::TraitBase<ConcreteOp, SameAnnoTypeOperands> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifySameAnnoTypeOperands(op);
   }
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -130,7 +130,7 @@ StrictConnectOp getSingleConnectUserOf(Value value);
 // functions commonly used among operations.
 namespace impl {
 LogicalResult verifySameOperandsIntTypeKind(Operation *op);
-LogicalResult verifySameAnnoTypeOperands(Operation *op);
+LogicalResult verifySameAnonTypeOperands(Operation *op);
 
 // Type inference adaptor for FIRRTL operations.
 LogicalResult inferReturnTypes(
@@ -176,11 +176,11 @@ public:
 
 /// A binary operation where the operands have the anonymous types..
 template <typename ConcreteOp>
-class SameAnnoTypeOperands
-    : public OpTrait::TraitBase<ConcreteOp, SameAnnoTypeOperands> {
+class SameAnonTypeOperands
+    : public OpTrait::TraitBase<ConcreteOp, SameAnonTypeOperands> {
 public:
   static LogicalResult verifyTrait(Operation *op) {
-    return impl::verifySameAnnoTypeOperands(op);
+    return impl::verifySameAnonTypeOperands(op);
   }
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -174,7 +174,7 @@ public:
   }
 };
 
-/// A binary operation where the operands have the anonymous types..
+/// A binary operation where the operands have the anonymous types.
 template <typename ConcreteOp>
 class SameAnonTypeOperands
     : public OpTrait::TraitBase<ConcreteOp, SameAnonTypeOperands> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -50,7 +50,12 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasCanonicalizer = true;
 }
 
-def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
+def SameAnnoTypeOperands : NativeOpTrait<"SameAnnoTypeOperands"> {
+  let cppNamespace = "::circt::firrtl";
+}
+
+def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
+                      SameAnnoTypeOperands]> {
   let summary = "Connect two signals";
   let description =  [{
     Connect two values with strict constraints:
@@ -66,8 +71,8 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
   let hasCanonicalizeMethod = true;
 
   let hasVerifier = 1;
-
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{$dest `,` $src  attr-dict `:`
+      custom<OptionalConnectOperandTypes>(type($dest), type($src))}];
 }
 
 def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -50,10 +50,9 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasCanonicalizer = true;
 }
 
-def SameAnonTypeOperands : NativeOpTrait<"SameAnonTypeOperands"> {
-  let cppNamespace = "::circt::firrtl";
-}
-
+def SameAnonTypeOperands: PredOpTrait<
+        "operands must be structurally equivalent",
+        CPred<[{areAnonymousTypesEquivalent(getOperand(0).getType(), getOperand(1).getType())}]>>;
 def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
                       SameAnonTypeOperands]> {
   let summary = "Connect two signals";
@@ -72,7 +71,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
 
   let hasVerifier = 1;
   let assemblyFormat = [{$dest `,` $src  attr-dict `:`
-      custom<OptionalConnectOperandTypes>(type($dest), type($src))}];
+      custom<OptionalBinaryOpTypes>(type($dest), type($src))}];
 }
 
 def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -50,12 +50,13 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasCanonicalizer = true;
 }
 
-def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]> {
+def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike]> {
   let summary = "Connect two signals";
   let description =  [{
     Connect two values with strict constraints:
     ```
       firrtl.strictconnect %dest, %src : t1
+      firrtl.strictconnect %dest, %src : t1, !firrtl.alias<foo, t1>
     ```
     }];
 
@@ -66,8 +67,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
 
   let hasVerifier = 1;
 
-  let assemblyFormat =
-    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+  let hasCustomAssemblyFormat = 1;
 }
 
 def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -52,7 +52,7 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
 
 def SameAnonTypeOperands: PredOpTrait<
         "operands must be structurally equivalent",
-        CPred<[{areAnonymousTypesEquivalent(getOperand(0).getType(), getOperand(1).getType())}]>>;
+        CPred<"areAnonymousTypesEquivalent(getOperand(0).getType(), getOperand(1).getType())">>;
 def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
                       SameAnonTypeOperands]> {
   let summary = "Connect two signals";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -50,12 +50,12 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasCanonicalizer = true;
 }
 
-def SameAnnoTypeOperands : NativeOpTrait<"SameAnnoTypeOperands"> {
+def SameAnonTypeOperands : NativeOpTrait<"SameAnonTypeOperands"> {
   let cppNamespace = "::circt::firrtl";
 }
 
 def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
-                      SameAnnoTypeOperands]> {
+                      SameAnonTypeOperands]> {
   let summary = "Connect two signals";
   let description =  [{
     Connect two values with strict constraints:

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -256,6 +256,11 @@ bool areTypesRefCastable(Type dstType, Type srcType);
 /// hold their counterparts.
 bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
+/// Return true if anonymous types of given arguments are equivalent by pointer
+/// comparison.
+bool areAnonymousTypesEquivalent(FIRRTLBaseType destType,
+                                 FIRRTLBaseType srcType);
+
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -258,9 +258,9 @@ bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
 /// Return true if anonymous types of given arguments are equivalent by pointer
 /// comparison.
-bool areAnonymousTypesEquivalent(FIRRTLBaseType destType,
-                                 FIRRTLBaseType srcType);
-bool areAnonymousTypesEquivalent(mlir::Type destType, mlir::Type srcType);
+bool areAnonymousTypesEquivalent(FIRRTLBaseType lhs,
+                                 FIRRTLBaseType rhs);
+bool areAnonymousTypesEquivalent(mlir::Type lhs, mlir::Type rhs);
 
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -258,8 +258,7 @@ bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 
 /// Return true if anonymous types of given arguments are equivalent by pointer
 /// comparison.
-bool areAnonymousTypesEquivalent(FIRRTLBaseType lhs,
-                                 FIRRTLBaseType rhs);
+bool areAnonymousTypesEquivalent(FIRRTLBaseType lhs, FIRRTLBaseType rhs);
 bool areAnonymousTypesEquivalent(mlir::Type lhs, mlir::Type rhs);
 
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -260,6 +260,7 @@ bool isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType);
 /// comparison.
 bool areAnonymousTypesEquivalent(FIRRTLBaseType destType,
                                  FIRRTLBaseType srcType);
+bool areAnonymousTypesEquivalent(mlir::Type destType, mlir::Type srcType);
 
 mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 

--- a/include/circt/Support/CustomDirectiveImpl.h
+++ b/include/circt/Support/CustomDirectiveImpl.h
@@ -61,6 +61,13 @@ void elideImplicitSSAName(OpAsmPrinter &printer, Operation *op,
                           DictionaryAttr attrs,
                           SmallVectorImpl<StringRef> &elides);
 
+/// Print/parse binary operands type only when types are different.
+/// optional-bin-op-types := type($lhs) (, type($rhs))?
+void printOptionalBinaryOpTypes(OpAsmPrinter &p, Operation *op, Type lhs,
+                                Type rhs);
+ParseResult parseOptionalBinaryOpTypes(OpAsmParser &parser, Type &lhs,
+                                       Type &rhs);
+
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_CUSTOMDIRECTIVEIMPL_H

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2478,8 +2478,6 @@ LogicalResult ConnectOp::verify() {
   return success();
 }
 
-// type(%dest) ^(, type(%src))
-// ParseResult circt::parseOptionalBinaryOpTypes(OpAsmParser &parser,
 LogicalResult StrictConnectOp::verify() {
   if (auto type = dyn_cast<FIRRTLType>(getDest().getType())) {
     auto baseType = cast<FIRRTLBaseType>(type);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2479,30 +2479,7 @@ LogicalResult ConnectOp::verify() {
 }
 
 // type(%dest) ^(, type(%src))
-static ParseResult parseOptionalConnectOperandTypes(OpAsmParser &parser,
-                                                    mlir::Type &dest,
-                                                    mlir::Type &src) {
-  if (parser.parseType(dest))
-    return failure();
-
-  // Parse an optional src type.
-  if (parser.parseOptionalComma()) {
-    src = dest;
-  } else {
-    if (parser.parseType(src))
-      return failure();
-  }
-  return success();
-}
-
-static void printOptionalConnectOperandTypes(OpAsmPrinter &p, Operation *op,
-                                             mlir::Type dest, mlir::Type src) {
-  p << dest;
-  // If operand types are not same, print a src type.
-  if (dest != src)
-    p << ", " << src;
-}
-
+// ParseResult circt::parseOptionalBinaryOpTypes(OpAsmParser &parser,
 LogicalResult StrictConnectOp::verify() {
   if (auto type = dyn_cast<FIRRTLType>(getDest().getType())) {
     auto baseType = cast<FIRRTLBaseType>(type);
@@ -3625,17 +3602,6 @@ LogicalResult impl::verifySameOperandsIntTypeKind(Operation *op) {
   return success(isSameIntTypeKind(op->getOperand(0).getType(),
                                    op->getOperand(1).getType(), lhsWidth,
                                    rhsWidth, isConstResult, op->getLoc()));
-}
-
-LogicalResult impl::verifySameAnonTypeOperands(Operation *op) {
-  assert(op->getNumOperands() == 2 && "SameAnnoTypeOperand on non-binary op");
-  if (!circt::firrtl::areAnonymousTypesEquivalent(op->getOperand(0).getType(),
-                                                  op->getOperand(1).getType()))
-    return mlir::emitError(op->getLoc(), "operand types must be structually "
-                                         "equivalent but a dest type is ")
-           << op->getOperand(0).getType() << ", and a src type is "
-           << op->getOperand(1).getType();
-  return success();
 }
 
 LogicalResult impl::validateBinaryOpArguments(ValueRange operands,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2514,7 +2514,7 @@ LogicalResult StrictConnectOp::verify() {
     // The anonymous types of operands must be equivalent.
     assert(areAnonymousTypesEquivalent(cast<FIRRTLBaseType>(getSrc().getType()),
                                        baseType) &&
-           "`SameAnnoTypeOperands` trait should have already rejected "
+           "`SameAnonTypeOperands` trait should have already rejected "
            "structurally non-equivalent types");
   }
 
@@ -3627,7 +3627,7 @@ LogicalResult impl::verifySameOperandsIntTypeKind(Operation *op) {
                                    rhsWidth, isConstResult, op->getLoc()));
 }
 
-LogicalResult impl::verifySameAnnoTypeOperands(Operation *op) {
+LogicalResult impl::verifySameAnonTypeOperands(Operation *op) {
   assert(op->getNumOperands() == 2 && "SameAnnoTypeOperand on non-binary op");
   if (!circt::firrtl::areAnonymousTypesEquivalent(op->getOperand(0).getType(),
                                                   op->getOperand(1).getType()))

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1211,23 +1211,22 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
 }
 // NOLINTEND(misc-no-recursion)
 
-bool firrtl::areAnonymousTypesEquivalent(FIRRTLBaseType destType,
-                                         FIRRTLBaseType srcType) {
-  return destType.getAnonymousType() == srcType.getAnonymousType();
+bool firrtl::areAnonymousTypesEquivalent(FIRRTLBaseType lhs,
+                                         FIRRTLBaseType rhs) {
+  return lhs.getAnonymousType() == rhs.getAnonymousType();
 }
 
-bool firrtl::areAnonymousTypesEquivalent(mlir::Type destType,
-                                         mlir::Type srcType) {
-  if (auto destBaseType = type_dyn_cast<FIRRTLBaseType>(destType))
-    if (auto srcBaseType = type_dyn_cast<FIRRTLBaseType>(srcType))
+bool firrtl::areAnonymousTypesEquivalent(mlir::Type lhs, mlir::Type rhs) {
+  if (auto destBaseType = type_dyn_cast<FIRRTLBaseType>(lhs))
+    if (auto srcBaseType = type_dyn_cast<FIRRTLBaseType>(rhs))
       return areAnonymousTypesEquivalent(destBaseType, srcBaseType);
 
-  if (auto destRefType = type_dyn_cast<RefType>(destType))
-    if (auto srcRefType = type_dyn_cast<RefType>(srcType))
+  if (auto destRefType = type_dyn_cast<RefType>(lhs))
+    if (auto srcRefType = type_dyn_cast<RefType>(rhs))
       return areAnonymousTypesEquivalent(destRefType.getType(),
                                          srcRefType.getType());
 
-  return destType == srcType;
+  return lhs == rhs;
 }
 
 /// Return the passive version of a firrtl type

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1211,6 +1211,11 @@ bool firrtl::isTypeLarger(FIRRTLBaseType dstType, FIRRTLBaseType srcType) {
 }
 // NOLINTEND(misc-no-recursion)
 
+bool firrtl::areAnonymousTypesEquivalent(FIRRTLBaseType destType,
+                                         FIRRTLBaseType srcType) {
+  return destType.getAnonymousType() == srcType.getAnonymousType();
+}
+
 /// Return the passive version of a firrtl type
 /// top level for ODS constraint usage
 Type firrtl::getPassiveType(Type anyBaseFIRRTLType) {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1216,6 +1216,20 @@ bool firrtl::areAnonymousTypesEquivalent(FIRRTLBaseType destType,
   return destType.getAnonymousType() == srcType.getAnonymousType();
 }
 
+bool firrtl::areAnonymousTypesEquivalent(mlir::Type destType,
+                                         mlir::Type srcType) {
+  if (auto destBaseType = type_dyn_cast<FIRRTLBaseType>(destType))
+    if (auto srcBaseType = type_dyn_cast<FIRRTLBaseType>(srcType))
+      return areAnonymousTypesEquivalent(destBaseType, srcBaseType);
+
+  if (auto destRefType = type_dyn_cast<RefType>(destType))
+    if (auto srcRefType = type_dyn_cast<RefType>(srcType))
+      return areAnonymousTypesEquivalent(destRefType.getType(),
+                                         srcRefType.getType());
+
+  return destType == srcType;
+}
+
 /// Return the passive version of a firrtl type
 /// top level for ODS constraint usage
 Type firrtl::getPassiveType(Type anyBaseFIRRTLType) {

--- a/lib/Support/CustomDirectiveImpl.cpp
+++ b/lib/Support/CustomDirectiveImpl.cpp
@@ -88,3 +88,27 @@ void circt::elideImplicitSSAName(OpAsmPrinter &printer, Operation *op,
       (expectedName.empty() && isdigit(actualName[0])))
     elides.push_back("name");
 }
+
+ParseResult circt::parseOptionalBinaryOpTypes(OpAsmParser &parser,
+                                                    mlir::Type &dest,
+                                                    mlir::Type &src) {
+  if (parser.parseType(dest))
+    return failure();
+
+  // Parse an optional src type.
+  if (parser.parseOptionalComma()) {
+    src = dest;
+  } else {
+    if (parser.parseType(src))
+      return failure();
+  }
+  return success();
+}
+
+void circt::printOptionalBinaryOpTypes(OpAsmPrinter &p, Operation *op,
+                                             mlir::Type dest, mlir::Type src) {
+  p << dest;
+  // If operand types are not same, print a src type.
+  if (dest != src)
+    p << ", " << src;
+}

--- a/lib/Support/CustomDirectiveImpl.cpp
+++ b/lib/Support/CustomDirectiveImpl.cpp
@@ -89,26 +89,25 @@ void circt::elideImplicitSSAName(OpAsmPrinter &printer, Operation *op,
     elides.push_back("name");
 }
 
-ParseResult circt::parseOptionalBinaryOpTypes(OpAsmParser &parser,
-                                                    mlir::Type &dest,
-                                                    mlir::Type &src) {
-  if (parser.parseType(dest))
+ParseResult circt::parseOptionalBinaryOpTypes(OpAsmParser &parser, Type &lhs,
+                                              Type &rhs) {
+  if (parser.parseType(lhs))
     return failure();
 
-  // Parse an optional src type.
+  // Parse an optional rhs type.
   if (parser.parseOptionalComma()) {
-    src = dest;
+    rhs = lhs;
   } else {
-    if (parser.parseType(src))
+    if (parser.parseType(rhs))
       return failure();
   }
   return success();
 }
 
-void circt::printOptionalBinaryOpTypes(OpAsmPrinter &p, Operation *op,
-                                             mlir::Type dest, mlir::Type src) {
-  p << dest;
-  // If operand types are not same, print a src type.
-  if (dest != src)
-    p << ", " << src;
+void circt::printOptionalBinaryOpTypes(OpAsmPrinter &p, Operation *op, Type lhs,
+                                       Type rhs) {
+  p << lhs;
+  // If operand types are not same, print a rhs type.
+  if (lhs != rhs)
+    p << ", " << rhs;
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1746,3 +1746,13 @@ firrtl.circuit "OpenBundleNotFieldID" {
   // expected-error @below {{bundle element "a" has unsupported type that does not support fieldID's: '!firrtl.string'}}
   firrtl.extmodule @OpenBundleNotFieldID(out out : !firrtl.openbundle<a: string>)
 }
+
+// -----
+// Strict connet between non-equivalent anonymous type operands.
+
+firrtl.circuit "NonEquivalenctStrictConnect" {
+  firrtl.module @NonEquivalenctStrictConnect(in %in: !firrtl.uint<1>, out %out: !firrtl.alias<foo, uint<2>>) {
+    // expected-error @below {{operand types must be structually equivalent but a dest type is '!firrtl.alias<foo, uint<2>>', and a src type is '!firrtl.uint<1>'}}
+    firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<2>>, !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1752,7 +1752,7 @@ firrtl.circuit "OpenBundleNotFieldID" {
 
 firrtl.circuit "NonEquivalenctStrictConnect" {
   firrtl.module @NonEquivalenctStrictConnect(in %in: !firrtl.uint<1>, out %out: !firrtl.alias<foo, uint<2>>) {
-    // expected-error @below {{operand types must be structually equivalent but a dest type is '!firrtl.alias<foo, uint<2>>', and a src type is '!firrtl.uint<1>'}}
+    // expected-error @below {{op failed to verify that operands must be structurally equivalent}}
     firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<2>>, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1748,7 +1748,7 @@ firrtl.circuit "OpenBundleNotFieldID" {
 }
 
 // -----
-// Strict connet between non-equivalent anonymous type operands.
+// Strict connect between non-equivalent anonymous type operands.
 
 firrtl.circuit "NonEquivalenctStrictConnect" {
   firrtl.module @NonEquivalenctStrictConnect(in %in: !firrtl.uint<1>, out %out: !firrtl.alias<foo, uint<2>>) {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -284,9 +284,14 @@ firrtl.module @PropertyNestedTest(in %in: !firrtl.map<bigint, list<map<string, b
 // CHECK-SAME: %in: !firrtl.alias<bar, uint<1>>
 // CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>
 // CHECK-SAME: %r: !firrtl.openbundle<a: alias<baz, uint<1>>>
+// CHECK-SAME: %out: !firrtl.alias<foo, uint<1>>
+// CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
+
 firrtl.module @TypeAlias(in %in: !firrtl.alias<bar, uint<1>>,
                          in %const: !firrtl.const.alias<baz, const.uint<1>>,
-                         out %r : !firrtl.openbundle<a: alias<baz, uint<1>>>) {
+                         out %r : !firrtl.openbundle<a: alias<baz, uint<1>>>,
+                         out %out: !firrtl.alias<foo, uint<1>>) {
+  firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
 }
 
 }


### PR DESCRIPTION
This PR modifies strictconnect's verifier/parser/printer to allow different (but structurally equivalent) types as operands. In mlir textual format, print src type only when dest type != src type so there is no change in tests.