### PR TITLE
[InstanceGraph] Speed up instance graph constructions, NFCI

### DIFF
--- a/lib/Dialect/HW/InstanceGraphBase.cpp
+++ b/lib/Dialect/HW/InstanceGraphBase.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/HW/InstanceGraphBase.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Threading.h"
 
 using namespace circt;
 using namespace hw;
@@ -51,18 +52,38 @@ InstanceGraphNode *InstanceGraphBase::getOrAddNode(StringAttr name) {
 }
 
 InstanceGraphBase::InstanceGraphBase(Operation *parent) : parent(parent) {
-  parent->walk([&](HWModuleLike module) {
+  SmallVector<std::pair<HWModuleLike, SmallVector<HWInstanceLike>>>
+      moduleToInstances;
+  // First accumulate modules inside the parent op. Use `PreOrder` to avoid
+  // visiting module bodies.
+  parent->walk<mlir::WalkOrder::PreOrder>([&](HWModuleLike module) {
+    moduleToInstances.push_back({module, {}});
+    // Skip.
+    return WalkResult::skip();
+  });
+
+  // Populate instances in the module parallelly.
+  mlir::parallelFor(parent->getContext(), 0, moduleToInstances.size(),
+                    [&](size_t idx) {
+                      auto module = moduleToInstances[idx].first;
+                      auto &instances = moduleToInstances[idx].second;
+                      // Find all instance operations in the module body.
+                      module.walk([&](HWInstanceLike instanceOp) {
+                        instances.push_back(instanceOp);
+                      });
+                    });
+
+  // Construct an instance graph sequentially.
+  for (auto &[module, instances] : moduleToInstances) {
     auto name = module.getModuleNameAttr();
     auto *currentNode = getOrAddNode(name);
     currentNode->module = module;
-
-    // Find all instance operations in the module body.
-    module.walk([&](HWInstanceLike instanceOp) {
+    for (auto instanceOp : instances) {
       // Add an edge to indicate that this module instantiates the target.
       auto *targetNode = getOrAddNode(instanceOp.getReferencedModuleNameAttr());
       currentNode->addInstance(instanceOp, targetNode);
-    });
-  });
+    }
+  }
 }
 
 InstanceGraphNode *InstanceGraphBase::addModule(HWModuleLike module) {


### PR DESCRIPTION
In large designs, it takes non-negligible amount of time to construct instance graphs (especially before dedup in firtool pipeline) since it was visiting entire circuits twice sequentially. This PR removes an unnecessary walk, and make instance operations accumlation parallel. It reduced graph construction time by 40% in large designs. (3~4% reduction in the entire execution time)

Before:
```
  50.1090 (  1.6%)   50.1090 (  6.1%)    LowerFIRRTLAnnotations
  17.6776 (  0.6%)   17.6776 (  2.2%)      (A) circt::firrtl::InstanceGraph
  16.6704 (  0.5%)   16.6704 (  2.0%)    LowerIntrinsics
  16.6657 (  0.5%)   16.6657 (  2.0%)      (A) circt::firrtl::InstanceGraph
```
After:
```
  38.6719 (  1.2%)   38.6719 (  5.1%)    LowerFIRRTLAnnotations
   9.4730 (  0.3%)    9.4730 (  1.2%)      (A) circt::firrtl::InstanceGraph
   9.7834 (  0.3%)    9.7834 (  1.3%)    LowerIntrinsics
   9.7817 (  0.3%)    9.7817 (  1.3%)      (A) circt::firrtl::InstanceGraph
```