### PR TITLE
[FIRRTL] Fold cvt(x:signed) -> x, drop AndRCvtS.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -415,13 +415,6 @@ def AndRCvtU : Pat <
     (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), cast<IntType>($0.getType()), getIntZerosAttr($0.getType()))"> $old)),
   [(KnownWidth $x), (UIntTypes $x)]>;
 
-/// andr(cvt(x:signed)) -> andr(x)
-def AndRCvtS : Pat <
-  (AndRPrimOp:$old (CvtPrimOp $x)),
-  (MoveNameHint $old, (AndRPrimOp $x)),
-  [(KnownWidth $x), (SIntTypes $x)]>;
-
-
 // bits(bits(x, ...), ...) -> bits(x, ...)
 def BitsOfBits : Pat<
   (BitsPrimOp:$old (BitsPrimOp $x, I32Attr:$iHigh, I32Attr:$iLow), I32Attr:$oHigh, I32Attr:$oLow),

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1030,6 +1030,10 @@ OpFoldResult AsClockPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult CvtPrimOp::fold(FoldAdaptor adaptor) {
+  // No-op if signed-to-signed.  Result is always signed.
+  if (getOperand().getType() == getType())
+    return getOperand();
+
   if (!hasKnownWidthIntTypes(*this))
     return {};
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1095,8 +1095,9 @@ OpFoldResult AndRPrimOp::fold(FoldAdaptor adaptor) {
 
 void AndRPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::AndRasSInt, patterns::AndRasUInt, patterns::AndRCvtU,
-                 patterns::AndRCvtS>(context);
+  results
+      .insert<patterns::AndRasSInt, patterns::AndRasUInt, patterns::AndRCvtU>(
+          context);
 }
 
 OpFoldResult OrRPrimOp::fold(FoldAdaptor adaptor) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3035,4 +3035,11 @@ firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.pro
   firrtl.ref.define %out, %same_as_in : !firrtl.probe<uint<1>>
 }
 
+// CHECK-LABEL: @CvtS
+firrtl.module @CvtS(in %in: !firrtl.sint, out %out: !firrtl.sint) {
+  // CHECK-NOT: firrtl.cvt
+  %cvt = firrtl.cvt %in : (!firrtl.sint) -> !firrtl.sint
+  firrtl.connect %out, %cvt : !firrtl.sint, !firrtl.sint
+}
+
 }


### PR DESCRIPTION
We already did this for constant inputs of known width, but can do this for any Value if already signed.

Drop `AndRCvtS` pattern that's no longer needed.