### PR TITLE
[FIRRTL] Remove UninferredWidthCastOp for now.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -979,19 +979,6 @@ def UninferredResetCastOp : FIRRTLOp<"resetCast", [HasCustomSSAName, Pure, SameG
     "$input attr-dict `:` functional-type($input, $result)";
 }
 
-def UninferredWidthCastOp : FIRRTLOp<"widthCast", [HasCustomSSAName, Pure, SameGroundTypeOperandConstness<"input", "result">]> {
-  let description = [{
-    Cast between sized and unsized integer types.  This is used to enable
-    strictconnects early in the pipeline by isolating all uninferred width
-    connections to a single op.
-  }];
-  let arguments = (ins IntType:$input);
-  let results = (outs IntType:$result);
-  let hasFolder = 1;
-  let assemblyFormat =
-    "$input attr-dict `:` functional-type($input, $result)";
-}
-
 def ConstCastOp : FIRRTLOp<"constCast", [HasCustomSSAName, Pure]> {
   let description = [{
     Cast from a 'const' to a non-'const' type.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -76,18 +76,22 @@ def AggregateType : FIRRTLDialectType<
   CPred<"isa<FVectorType, BundleType, FEnumType>($_self)">,
   "a aggregate type", "::circt::firrtl::FIRRTLBaseType">;
 
+def PassiveType : FIRRTLDialectType<
+  CPred<"isa<FIRRTLBaseType>($_self) && cast<FIRRTLBaseType>($_self).isPassive()">,
+  "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
+
 def SizedType : FIRRTLDialectType<CPred<"isa<FIRRTLBaseType>($_self) && "
     "!cast<FIRRTLBaseType>($_self).hasUninferredWidth()">,
     "a sized type (contains no uninferred widths)", "::circt::firrtl::FIRRTLType">;
 def SizedOrForeignType : AnyTypeOf<[SizedType, ForeignType]>;
+def SizedPassiveType : FIRRTLDialectType<And<[SizedType.predicate,PassiveType.predicate]>,
+    "a sized passive base type (contains no uninferred widths, or flips)", "::circt::firrtl::FIRRTLType">;
+def SizedPassiveOrForeignType : AnyTypeOf<[SizedPassiveType, ForeignType]>;
 
 def AsyncResetType : FIRRTLDialectTypeHelper<"AsyncResetType", "async reset type">;
 
 def ResetType : FIRRTLDialectTypeHelper<"ResetType", "reset type">;
 
-def PassiveType : FIRRTLDialectType<
-  CPred<"isa<FIRRTLBaseType>($_self) && cast<FIRRTLBaseType>($_self).isPassive()">,
-  "a passive base type (contain no flips)", "::circt::firrtl::FIRRTLBaseType">;
 
 def RefType : FIRRTLDialectTypeHelper<"RefType", "reference type">;
 
@@ -95,9 +99,8 @@ def RWProbe : FIRRTLDialectType<
   CPred<"isa<RefType>($_self) && cast<RefType>($_self).getForceable()">,
    "rwprobe type", "::circt::firrtl::RefType">;
 
-// TODO: When Refs can appear within Base, need to disallow that too.
 def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
-def StrictConnectableType : AnyTypeOf<[PassiveType, ForeignType]>;
+def StrictConnectableType : AnyTypeOf<[SizedPassiveType, ForeignType]>;
 
 //===----------------------------------------------------------------------===//
 // Sized and Unsized Integers

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -58,11 +58,10 @@ public:
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
             RefResolveOp, RefSubOp,
             // Casts to deal with weird stuff
-            UninferredResetCastOp, UninferredWidthCastOp, ConstCastOp,
-            RefCastOp, mlir::UnrealizedConversionCastOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitExpr(expr, args...);
-            })
+            UninferredResetCastOp, ConstCastOp, RefCastOp,
+            mlir::UnrealizedConversionCastOp>([&](auto expr) -> ResultType {
+          return thisCast->visitExpr(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidExpr(op, args...);
         });
@@ -190,7 +189,6 @@ public:
   // Conversions.
   HANDLE(HWStructCastOp, Unhandled);
   HANDLE(UninferredResetCastOp, Unhandled);
-  HANDLE(UninferredWidthCastOp, Unhandled);
   HANDLE(ConstCastOp, Unhandled);
   HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -103,7 +103,6 @@ struct Emitter {
   void emitExpression(RefSendOp op);
   void emitExpression(RefSubOp op);
   void emitExpression(UninferredResetCastOp op);
-  void emitExpression(UninferredWidthCastOp op);
   void emitExpression(ConstCastOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
@@ -932,7 +931,7 @@ void Emitter::emitExpression(Value value) {
           CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
-          ShrPrimOp, UninferredResetCastOp, UninferredWidthCastOp, ConstCastOp,
+          ShrPrimOp, UninferredResetCastOp, ConstCastOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp>([&](auto op) {
         ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
@@ -1034,10 +1033,6 @@ void Emitter::emitExpression(RefSubOp op) {
 }
 
 void Emitter::emitExpression(UninferredResetCastOp op) {
-  emitExpression(op.getInput());
-}
-
-void Emitter::emitExpression(UninferredWidthCastOp op) {
   emitExpression(op.getInput());
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1751,7 +1751,7 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
 
   // Ok, we know we are doing the transformation.
 
-  Value replacement = op.getSrc();
+  auto replacement = op.getSrc();
   if (srcValueOp) {
     // Replace with constant zero.
     if (isa<InvalidValueOp>(srcValueOp)) {
@@ -2121,12 +2121,6 @@ OpFoldResult VectorCreateOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult UninferredResetCastOp::fold(FoldAdaptor adaptor) {
   if (getOperand().getType() == getType())
-    return getOperand();
-  return {};
-}
-
-OpFoldResult UninferredWidthCastOp::fold(FoldAdaptor adaptor) {
-  if (getOperand().getType() == getType() && !getType().hasUninferredWidth())
     return getOperand();
   return {};
 }
@@ -3048,8 +3042,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   auto pt = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(con);
   auto v = constReg ? (Value)constOp.getResult() : (Value)mux.getLow();
-  replaceOpWithNewOpAndCopyName<StrictConnectOp>(rewriter, con, con.getDest(),
-                                                 v);
+  replaceOpWithNewOpAndCopyName<ConnectOp>(rewriter, con, con.getDest(), v);
   rewriter.restoreInsertionPoint(pt);
   return success();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4619,10 +4619,6 @@ void UninferredResetCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 
-void UninferredWidthCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  genericAsmResultNames(*this, setNameFn);
-}
-
 void ConstCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1535,7 +1535,7 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
   if (props.isPassive && !props.containsAnalog) {
     if (flow == Flow::Source)
       return;
-    builder.create<StrictConnectOp>(val, builder.create<InvalidValueOp>(tpe));
+    emitConnect(builder, val, builder.create<InvalidValueOp>(tpe));
     return;
   }
 

--- a/test/Dialect/FIRRTL/SFCTests/width-spec-errors.fir
+++ b/test/Dialect/FIRRTL/SFCTests/width-spec-errors.fir
@@ -55,12 +55,11 @@ circuit Unit :
   module Unit :
     input clock: Clock
     input reset: UInt<1>
-    ; expected-error @+1 {{is constrained to be wider than itself}}
+    ; expected-error @+1 {{'firrtl.regreset' op is constrained to be wider than itself}}
     reg r : UInt, clock with :
       reset => (reset, UInt(3))
     ; expected-note @+1 {{constrained width W >= W+1 here:}}
     node T_7 = add(r, r)
-    ; expected-error @+2 {{is constrained to be wider than itself}}
     ; expected-note @+1 {{constrained width W >= W+1 here:}}
     r <= T_7
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -122,13 +122,6 @@ firrtl.circuit "Foo" {
     %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.strictconnect %someOut, %invalid_ui2 : !firrtl.uint<1>
 
-    // CHECK: connect unknownWidth, knownWidth
-    %knownWidth = firrtl.wire : !firrtl.uint<1>
-    %unknownWidth = firrtl.wire : !firrtl.uint
-    %widthCast = firrtl.widthCast %knownWidth :
-      (!firrtl.uint<1>) -> !firrtl.uint
-    firrtl.strictconnect %unknownWidth, %widthCast : !firrtl.uint
-
     // CHECK: connect unknownReset, knownReset
     %knownReset = firrtl.wire : !firrtl.asyncreset
     %unknownReset = firrtl.wire : !firrtl.reset
@@ -532,12 +525,11 @@ firrtl.circuit "Foo" {
     %_17 = firrtl.node %_3 {name = "17"} : !firrtl.uint<1>
 
     // CHECK:      connect `9`.`1`, `9`.`0`
-    %2 = firrtl.widthCast %0 : (!firrtl.uint) -> !firrtl.uint
-    firrtl.strictconnect %1, %2 : !firrtl.uint
+    firrtl.connect %1, %0 : !firrtl.uint, !firrtl.uint
 
     // CHECK:      invalidate `11`
     %invalid_ui = firrtl.invalidvalue : !firrtl.uint
-    firrtl.strictconnect %_11, %invalid_ui : !firrtl.uint
+    firrtl.connect %_11, %invalid_ui : !firrtl.uint, !firrtl.uint
 
     // CHECK:      inst `0bar` of `0Bar`
     // CHECK-NEXT: connect `0bar`.`0`, `3`
@@ -587,8 +579,7 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %10, %_3 : !firrtl.uint<1>
     %12 = firrtl.pad %_3, 5 : (!firrtl.uint<1>) -> !firrtl.uint<5>
     firrtl.strictconnect %9, %12 : !firrtl.uint<5>
-    %13 = firrtl.widthCast %8 : (!firrtl.uint<8>) -> !firrtl.uint
-    firrtl.strictconnect %_11, %13 : !firrtl.uint
+    firrtl.connect %_11, %8 : !firrtl.uint, !firrtl.uint<8>
     firrtl.strictconnect %7, %_0 : !firrtl.clock
     firrtl.strictconnect %6, %_3 : !firrtl.uint<1>
     %14 = firrtl.pad %_3, 8 : (!firrtl.uint<1>) -> !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -876,6 +876,16 @@ firrtl.circuit "Top"   {
 
 // -----
 
+firrtl.circuit "Top" {
+  firrtl.module @Top (in %in : !firrtl.uint) {
+    %a = firrtl.wire : !firrtl.uint
+    // expected-error @+1 {{op operand #0 must be a sized passive base type}}
+    firrtl.strictconnect %a, %in : !firrtl.uint
+  }
+}
+
+// -----
+
 firrtl.circuit "AnalogRegister" {
   firrtl.module @AnalogRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive non-'const' base type that does not contain analog, but got '!firrtl.analog'}}
@@ -1109,7 +1119,7 @@ firrtl.circuit "Top" {
   firrtl.module @Foo (in %in: !firrtl.probe<uint<2>>) {}
   firrtl.module @Top (in %in: !firrtl.probe<uint<2>>) {
     %foo_in = firrtl.instance foo @Foo(in in: !firrtl.probe<uint<2>>)
-    // expected-error @below {{must be a passive base type}}
+    // expected-error @below {{must be a sized passive base type}}
     firrtl.strictconnect %foo_in, %in : !firrtl.probe<uint<2>>
   }
 }
@@ -1267,7 +1277,7 @@ firrtl.circuit "PropertyDoubleDrive" {
 firrtl.circuit "PropertyConnect" {
   firrtl.module @PropertyConnect(out %out: !firrtl.string) {
     %0 = firrtl.string "hello"
-    // expected-error @below {{must be a passive base type}}
+    // expected-error @below {{must be a sized passive base type}}
     firrtl.strictconnect %out, %0 : !firrtl.string
   }
 }
@@ -1614,16 +1624,6 @@ firrtl.circuit "BitcastNonConstToConstContaining" {
   firrtl.module @BitcastNonConstToConstContaining(in %a: !firrtl.bundle<a: uint<1>>) {
     // expected-error @+1 {{cannot cast non-'const' input type '!firrtl.bundle<a: uint<1>>' to 'const' result type '!firrtl.bundle<a: const.sint<1>>'}}
     %b = firrtl.bitcast %a : (!firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: const.sint<1>>
-  }
-}
-
-// -----
-
-// Uninferred width cast non-const to const
-firrtl.circuit "UninferredWidthCastNonConstToConst" {
-  firrtl.module @UninferredWidthCastNonConstToConst(in %a: !firrtl.uint) {
-    // expected-error @+1 {{operand constness must match}}
-    %b = firrtl.widthCast %a : (!firrtl.uint) -> !firrtl.const.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -343,10 +343,10 @@ firrtl.module @ShouldAdjustExtModule2() {
 firrtl.module @ForeignTypes(out %out: !firrtl.reset) {
   %0 = firrtl.wire : index
   %1 = firrtl.wire : index
-  firrtl.connect %0, %1 : index, index
+  firrtl.strictconnect %0, %1 : index
   // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
   // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
-  // CHECK-NEXT: firrtl.connect [[W0]], [[W1]] : index
+  // CHECK-NEXT: firrtl.strictconnect [[W0]], [[W1]] : index
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/legacy-wiring.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring.mlir
@@ -199,11 +199,10 @@ firrtl.circuit "IntWidths" attributes {
   }
   // CHECK-LABEL module @IntWidths
   firrtl.module @IntWidths() {
-    // CHECK:  firrtl.widthCast %bar_y__bore
-    // CHECK-NEXT: firrtl.strictconnect %x, %{{[^ ]*}} 
+    // CHECK: firrtl.connect %x, %{{[^ ]*}} : !firrtl.uint, !firrtl.uint<4>
     firrtl.instance bar interesting_name @Bar()
     %x = firrtl.wire interesting_name : !firrtl.uint
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint
-    firrtl.strictconnect %x, %invalid_ui1 : !firrtl.uint
+    firrtl.connect %x, %invalid_ui1 : !firrtl.uint, !firrtl.uint
   }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -8,8 +8,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in: UInt
     output out: UInt<8>
 
-    ; CHECK: %0 = firrtl.widthCast %in : (!firrtl.uint) -> !firrtl.uint<8>
-    ; CHECK: firrtl.strictconnect %out, %0 : !firrtl.uint<8>
+    ; CHECK: firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint
     out <= in
 
   ; CHECK: }
@@ -465,7 +464,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module expr_stmt_ambiguity :
     ; CHECK: %reg = firrtl.wire interesting_name : !firrtl.uint
     wire reg : UInt
-    ; CHECK: firrtl.strictconnect %reg,
+    ; CHECK: firrtl.connect %reg,
     reg <= UInt(42)
 
     ; CHECK: %write = firrtl.wire
@@ -478,7 +477,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module expr_stmt_ambiguity2 :
     ; CHECK: firrtl.instance write interesting_name @circuit
     inst write of circuit
-    ; CHECK: firrtl.strictconnect %write_in
+    ; CHECK: firrtl.connect %write_in
     write.in <= UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @oversize_shift(
@@ -1251,13 +1250,12 @@ circuit EnumTypes:
     ; CHECK-DAG: %[[AGG_B:.+]] = firrtl.subfield %[[AGG]][b]
     ; CHECK-DAG: %[[AGG_B_PROBE:.+]] = firrtl.ref.send %[[AGG_B]]
     ; CHECK-DAG: %[[READ_AGG_B_PROBE:.+]] = firrtl.ref.resolve %[[AGG_B_PROBE]]
-    ; CHECK-NEXT: %[[wfix:.*]] = firrtl.widthCast %[[READ_AGG_B_PROBE]]
-    ; CHECK-DAG: strictconnect %out2, %[[wfix]]
+    ; CHECK-DAG: connect %out2, %[[READ_AGG_B_PROBE]]
     out2 <= read(probe(agg.b))
     ; CHECK-DAG: %[[AGG2_PROBE:.+]] = firrtl.ref.send %[[AGG2]]
     ; CHECK-DAG: %[[READ_AGG2_PROBE:.+]] = firrtl.ref.resolve %[[AGG2_PROBE]]
     ; CHECK-DAG: %[[READ_AGG2_PROBE__B:.+]] = firrtl.subfield %[[READ_AGG2_PROBE]][b]
-    ; CHECK-DAG: strictconnect %out2, %[[READ_AGG2_PROBE__B]]
+    ; CHECK-DAG: connect %out2, %[[READ_AGG2_PROBE__B]]
     out2 <= read(probe(agg2)).b
 
     ; CHECK: %[[AGG3:.+]] = firrtl.wire
@@ -1271,7 +1269,7 @@ circuit EnumTypes:
     ; CHECK-NEXT: %[[REM_R2_1:.+]] = firrtl.ref.sub %[[REM_R2]][1]
     ; CHECK-NEXT: %[[REM_R2_1_A:.+]] = firrtl.ref.sub %[[REM_R2_1]][0]
     ; CHECK-NEXT: %[[READ_REM_R2_1_A:.+]] = firrtl.ref.resolve %[[REM_R2_1_A]]
-    ; CHECK-NEXT: strictconnect %out3, %[[READ_REM_R2_1_A]]
+    ; CHECK-NEXT: connect %out3, %[[READ_REM_R2_1_A]]
     inst rem of RefExtMore
     out3 <= read(rem.r2[1].a)
 
@@ -1519,63 +1517,53 @@ circuit RadixEncodedIntegerLiterals:
     output hs: SInt<8>
 
     ; CHECK:      %[[c42_ui7:[-a-zA-Z_0-9]+]] = firrtl.constant 42
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %bu, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c42_ui7]]
+    ; CHECK-NEXT: firrtl.connect %bu, %[[c_constCast]]
     bu <= UInt(0b101010)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %ou, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c42_ui7]]
+    ; CHECK-NEXT: firrtl.connect %ou, %[[c_constCast]]
     ou <= UInt(0o052)
 
     ; Note: this creates a second constant because the width of a parsed
     ; constant is dependent on the overestimation of LLVM::StringRef.
     ;
     ; CHECK:      %[[c42_ui8:[-a-zA-Z_0-9]+]] = firrtl.constant 42
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui8]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %du0, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c42_ui8]]
+    ; CHECK-NEXT: firrtl.connect %du0, %[[c_constCast]]
     du0 <= UInt(42)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui8]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %du1, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c42_ui8]]
+    ; CHECK-NEXT: firrtl.connect %du1, %[[c_constCast]]
     du1 <= UInt(0d42)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[c42_ui7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %hu, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c42_ui7]]
+    ; CHECK-NEXT: firrtl.connect %hu, %[[c_constCast]]
     hu <= UInt(0h2a)
 
     ; CHECK:      %[[cn42_si7:[-a-zA-Z_0-9]+]] = firrtl.constant -42
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %bs, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[cn42_si7]]
+    ; CHECK-NEXT: firrtl.connect %bs, %[[c_constCast]]
     bs <= SInt(-0b101010)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %os, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[cn42_si7]]
+    ; CHECK-NEXT: firrtl.connect %os, %[[c_constCast]]
     os <= SInt(-0o52)
 
     ; Note: this creates a second constant because the width of a parsed
     ; constant is dependent on the overestimation of LLVM::StringRef.
     ;
     ; CHECK:      %[[cn42_si8:[-a-zA-Z_0-9]+]] = firrtl.constant -42
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si8]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %dus0, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[cn42_si8]]
+    ; CHECK-NEXT: firrtl.connect %dus0, %[[c_constCast]]
     dus0 <= SInt(-42)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si8]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %dus1, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[cn42_si8]]
+    ; CHECK-NEXT: firrtl.connect %dus1, %[[c_constCast]]
     dus1 <= SInt(-0d42)
 
-    ; CHECK-NEXT: %[[c_widthCast:[-a-zA-Z_0-9]+]] = firrtl.widthCast %[[cn42_si7]]
-    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[c_widthCast]]
-    ; CHECK-NEXT: firrtl.strictconnect %hs, %[[c_constCast]]
+    ; CHECK-NEXT: %[[c_constCast:[-a-zA-Z_0-9]+]] = firrtl.constCast %[[cn42_si7]]
+    ; CHECK-NEXT: firrtl.connect %hs, %[[c_constCast]]
     hs <= SInt(-0h2a)
 
 ;// -----

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -10,8 +10,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     input in: UInt      @[InputPort.scala 0:0]
     output out: UInt<8> @[OutputPort.scala 0:0]
 
-    ; CHECK: firrtl.widthCast %in : {{.*}} loc("Somewhere.galaxy":42:1)
-    ; CHECK-NEXT: firrtl.strictconnect {{.*}}loc("Somewhere.galaxy":42:1)
+    ; CHECK: firrtl.connect {{.*}}loc("Somewhere.galaxy":42:1)
     out <= in   @[Somewhere.galaxy 42:1]
 
     ; CHECK: firrtl.node {{.*}}loc("Somewhere.galaxy":42:2)

--- a/test/Dialect/FIRRTL/parse-version.fir
+++ b/test/Dialect/FIRRTL/parse-version.fir
@@ -7,8 +7,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in: UInt
     output out: UInt<8>
 
-    ; CHECK: %0 = firrtl.widthCast %in
-    ; CHECK: firrtl.strictconnect %out, %0 : !firrtl.uint<8>
+    ; CHECK: firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint
     out <= in
 
   ; CHECK: }


### PR DESCRIPTION
Unclear what this models/means, and instead of doubling down on workarounds lets drop this until we sort out
what this is and how it should work.

Fixes #5391.
(dropping the introduced back-propagation behavior)

This partially reverts commit 63d94ea003dcd0ed6c2f3da5580728569f2b346d.

Keep the parts of #5047 that aren't related to this op, such as use of emitConnect throughout code.

StrictConnect still keeps the restriction regarding passive types added in that commit, but now requires the operands to be sized as well.

We now need logic to emit ConstCast before a "connect", which is added (under existing/modified tests).