### PR TITLE
[FIRRTL] Add GroupDeclOp and GroupOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -46,6 +46,18 @@ def Convention : I32EnumAttr<"Convention", "lowering convention", [
 def ConventionAttr : EnumAttr<FIRRTLDialect, Convention, "convention">;
 
 //===----------------------------------------------------------------------===//
+// Group Lowering Conventions
+//===----------------------------------------------------------------------===//
+
+def GroupConvention : I32EnumAttr<"GroupConvention", "group convention", [
+  I32EnumAttrCase<"Bind", 0, "bind">]> {
+
+  let genSpecializedAttr = 0;
+}
+
+def GroupConventionAttr : EnumAttr<FIRRTLDialect, GroupConvention, "groupconvention">;
+
+//===----------------------------------------------------------------------===//
 // Read Under Write Behaviour
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -17,6 +17,7 @@ include "FIRRTLDialect.td"
 include "FIRRTLEnums.td"
 include "FIRRTLOpInterfaces.td"
 include "FIRRTLTypes.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def AttachOp : FIRRTLOp<"attach"> {
@@ -374,5 +375,37 @@ class VerifIntrinsicOp<string mnemonic, list<Trait> traits = []> :
 def VerifAssertIntrinsicOp : VerifIntrinsicOp<"assert">;
 def VerifAssumeIntrinsicOp : VerifIntrinsicOp<"assume">;
 def VerifCoverIntrinsicOp : VerifIntrinsicOp<"cover">;
+
+//===----------------------------------------------------------------------===//
+// Group Op
+//===----------------------------------------------------------------------===//
+
+def GroupOp : FIRRTLOp<
+  "group",
+  [SingleBlock, NoTerminator, NoRegionArguments,
+   ParentOneOf<["firrtl::FModuleOp", "firrtl::GroupOp"]>,
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>]
+> {
+  let summary = "A definition of an optional group";
+  let description = [{
+    The `firrtl.group` operation defines optional code that is conditionally
+    part of a `firrtl.module`.  This is typically used to store verification or
+    debugging code that is lowered to a SystemVerilog `bind` instantiation.  An
+    optional group can read from (capture) values defined in parent group
+    definitions or in the parent module, but may not write to hardware declared
+    outside the group.
+
+    A `firrtl.group` must refer to an existing optional group declaration
+    (`firrtl.declgroup`) via a symbol reference.  A nested `firrtl.group` refers
+    to a nested group declaration via a nested symbol reference.
+  }];
+  let arguments = (ins SymbolRefAttr:$groupName);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$region);
+  let assemblyFormat = [{
+    $groupName $region attr-dict
+  }];
+  let hasVerifier = 1;
+}
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLSTATEMENTS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -253,4 +253,27 @@ def FMemModuleOp : FIRRTLModuleLike<"memmodule"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def GroupDeclOp : FIRRTLOp<
+  "declgroup",
+  [IsolatedFromAbove, Symbol, SymbolTable, SingleBlock, NoTerminator,
+   ParentOneOf<["firrtl::CircuitOp", "firrtl::GroupDeclOp"]>]
+> {
+  let summary = "A declaration of an optional group";
+  let description = [{
+    The `firrtl.declgroup` operation declares an optional group and a lowering
+    convetion for that group.  Optional groups are a feature of FIRRTL that add
+    verification or debugging code to an existing module at runtime.
+
+    A `firrtl.declgroup` operation only declares the group and any groups nested
+    under the current declaration.  Functionality is added to modules using the
+    `firrtl.group` operation.
+  }];
+  let arguments = (ins StrAttr:$sym_name, GroupConventionAttr:$convention);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $body attr-dict
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLSTRUCTURE_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -209,9 +209,10 @@ public:
                        AssumeOp, CoverOp, PropAssignOp, ProbeOp, RefForceOp,
                        RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
                        VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
-                       VerifCoverIntrinsicOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitStmt(opNode, args...);
-        })
+                       VerifCoverIntrinsicOp, GroupOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitStmt(opNode, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -255,6 +256,7 @@ public:
   HANDLE(VerifAssertIntrinsicOp);
   HANDLE(VerifAssumeIntrinsicOp);
   HANDLE(VerifCoverIntrinsicOp);
+  HANDLE(GroupOp);
 
 #undef HANDLE
 };

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1756,3 +1756,111 @@ firrtl.circuit "NonEquivalenctStrictConnect" {
     firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<2>>, !firrtl.uint<1>
   }
 }
+
+// -----
+
+// A group definition, "@A::@B", is missing an outer nesting of a group
+// definition with symbol "@A".
+firrtl.circuit "GroupMissingNesting" {
+  firrtl.declgroup {
+    firrtl.declgroup {
+    } {sym_name = "B", convention = #firrtl<groupconvention bind>}
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  // expected-note @below {{illegal parent op defined here}}
+  firrtl.module @GroupMissingNesting() {
+    // expected-error @below {{'firrtl.group' op has a nested group symbol, but does not have a 'firrtl.group' op as a parent}}
+    firrtl.group @A::@B {}
+  }
+}
+
+// -----
+
+// A group definition with a legal symbol, "@B", is illegaly nested under
+// another group with a legal symbol, "@B".
+firrtl.circuit "UnnestedGroup" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.declgroup {
+  } {sym_name = "B", convention = #firrtl<groupconvention bind>}
+  firrtl.module @UnnestedGroup() {
+    // expected-note @below {{illegal parent op defined here}}
+    firrtl.group @A {
+      // expected-error @below {{'firrtl.group' op has an un-nested group symbol, but does not have a 'firrtl.module' op as a parent}}
+      firrtl.group @B {}
+    }
+  }
+}
+
+// -----
+
+// A group definition, "@B::@C", is nested under the wrong group, "@A".
+firrtl.circuit "WrongGroupNesting" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.declgroup {
+    firrtl.declgroup {
+    } {sym_name = "C", convention = #firrtl<groupconvention bind>}
+  } {sym_name = "B", convention = #firrtl<groupconvention bind>}
+  firrtl.module @WrongGroupNesting() {
+    // expected-note @below {{illegal parent group defined here}}
+    firrtl.group @A {
+      // expected-error @below {{'firrtl.group' op is nested under an illegal group}}
+      firrtl.group @B::@C {}
+    }
+  }
+}
+
+// -----
+
+// A group captures a type which is not a FIRRTL base type.
+firrtl.circuit "NonBaseTypeCapture" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  // expected-note @below {{operand is defined here}}
+  firrtl.module @NonBaseTypeCapture(in %a: !firrtl.probe<uint<1>>) {
+    // expected-error @below {{'firrtl.group' op captures an operand which is not a FIRRTL base type}}
+    firrtl.group @A {
+      // expected-note @below {{operand is used here}}
+      %b = firrtl.ref.resolve %a : !firrtl.probe<uint<1>>
+    }
+  }
+}
+
+// -----
+
+// A group captures a non-passive type.
+firrtl.circuit "NonPassiveCapture" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.module @NonPassiveCapture() {
+    // expected-note @below {{operand is defined here}}
+    %a = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
+    // expected-error @below {{'firrtl.group' op captures an operand which is not a passive type}}
+    firrtl.group @A {
+      %b = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
+      // expected-note @below {{operand is used here}}
+      firrtl.connect %b, %a : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
+    }
+  }
+}
+
+// -----
+
+// A group may not drive sinks outside the group.
+firrtl.circuit "GroupDrivesSinksOutside" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.module @GroupDrivesSinksOutside(in %cond : !firrtl.uint<1>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    // expected-note @below {{destination is defined here}}
+    %b = firrtl.wire : !firrtl.bundle<c: uint<1>>
+    // expected-note @below {{enclosing group is defined here}}
+    firrtl.group @A {
+      firrtl.when %cond : !firrtl.uint<1> {
+        %b_c = firrtl.subfield %b[c] : !firrtl.bundle<c: uint<1>>
+        // expected-error @below {{'firrtl.strictconnect' op connects to a destination which is defined outside its enclosing group}}
+        firrtl.strictconnect %b_c, %a : !firrtl.uint<1>
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add operations to represent FIRRTL optional groups. The FIRRTL spec discussion of this feature is here: https://github.com/chipsalliance/firrtl-spec/pull/108

This just adds the operations and nothing else. More will follow...