### PR TITLE
[Comb][Canonicalize] keep attributes during op width narrowing

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -221,6 +221,7 @@ static bool narrowOperationWidth(OpTy op, bool narrowTrailingBits,
                                                       inop, range.first));
   }
   Value newop = rewriter.createOrFold<OpTy>(op.getLoc(), newType, args);
+  newop.getDefiningOp()->setDialectAttrs(op->getDialectAttrs());
   if (range.first)
     newop = rewriter.createOrFold<ConcatOp>(
         op.getLoc(), newop,
@@ -232,7 +233,7 @@ static bool narrowOperationWidth(OpTy op, bool narrowTrailingBits,
         rewriter.create<hw::ConstantOp>(
             op.getLoc(), APInt::getZero(opType.getWidth() - range.second - 1)),
         newop);
-  replaceOpAndCopyName(rewriter, op, newop);
+  rewriter.replaceOp(op, newop);
   return true;
 }
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1508,3 +1508,12 @@ hw.module @twoStateICmp(%arg: i4) -> (cond: i1) {
   %0 = comb.icmp bin eq %c-1_i4, %arg : i4
   hw.output %0 : i1
 }
+
+// https://github.com/llvm/circt/issues/5531
+// CHECK-LABEL: @Issue5531
+hw.module @Issue5531(%arg0: i64, %arg1: i64) -> (out: i32) {
+  // CHECK:  %2 = comb.mul %0, %1 {sv.namehint = "hint"} : i32
+  %2 = comb.mul %arg0, %arg1 {sv.namehint = "hint"} : i64
+  %3 = comb.extract %2 from 0 : (i64) -> i32
+  hw.output %3 : i32
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/circt/issues/5531.
TLDR: `narrowOperationWidth()` copies attributes to a `comb.concat` operation, which is optimized away in a later step.
The fix is simple: do not copy the attributes to the intermediate `comb.concat` op but instead to the width narrowed operation.