### PR TITLE
[FIRRTL] Add LowerGroups pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -163,6 +163,8 @@ std::unique_ptr<mlir::Pass> createFinalizeIRPass();
 
 std::unique_ptr<mlir::Pass> createExtractClassesPass();
 
+std::unique_ptr<mlir::Pass> createLowerGroupsPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -97,8 +97,8 @@ def IMConstProp : Pass<"firrtl-imconstprop", "firrtl::CircuitOp"> {
 def RegisterOptimizer : Pass<"firrtl-register-optimizer", "firrtl::FModuleOp"> {
   let summary = "Optimizer Registers";
   let description = [{
-    This pass applies classic FIRRTL register optimizations.  These 
-    optimizations are isolated to this pass as they can change the visible 
+    This pass applies classic FIRRTL register optimizations.  These
+    optimizations are isolated to this pass as they can change the visible
     behavior of the register, especially before reset.
   }];
   let constructor = "circt::firrtl::createRegisterOptimizerPass()";
@@ -682,10 +682,10 @@ def VBToBV : Pass<"firrtl-vb-to-bv", "firrtl::CircuitOp"> {
 def DropConst : InterfacePass<"firrtl-drop-const", "firrtl::FModuleLike"> {
   let summary = "Drop 'const' modifier from types";
   let description = [{
-    This pass drops the 'const' modifier from all types and removes all 
-    const-cast ops. 
-    
-    This simplifies downstream passes and folds so that they do not need to 
+    This pass drops the 'const' modifier from all types and removes all
+    const-cast ops.
+
+    This simplifies downstream passes and folds so that they do not need to
     take 'const' into account.
   }];
   let constructor = "circt::firrtl::createDropConstPass()";
@@ -714,6 +714,17 @@ def ExtractClasses : Pass<"firrtl-extract-classes", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::firrtl::createExtractClassesPass()";
   let dependentDialects = ["om::OMDialect"];
+}
+
+def LowerGroups : Pass<"firrtl-lower-groups", "firrtl::CircuitOp"> {
+  let summary = "Lower optional groups to instances";
+  let description = [{
+    This pass converts FIRRTL optional gropus to new modules and instantiations.
+    Referenced SSA values captured by a group are converted to ports of the
+    created module.
+  }];
+  let constructor = "circt::firrtl::createLowerGroupsPass()";
+  let dependentDialects = ["sv::SVDialect"];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LegacyWiring.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
+  LowerGroups.cpp
   LowerIntrinsics.cpp
   LowerMatches.cpp
   LowerMemory.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerGroups.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerGroups.cpp
@@ -1,0 +1,375 @@
+//===- LowerGroups.cpp - Lower Optiona Groups to Instances ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// This pass lowers FIRRTL optional groups to modules and instances.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Mutex.h"
+#include "llvm/Support/RWMutex.h"
+
+#define DEBUG_TYPE "firrtl-lower-groups"
+
+using namespace circt;
+using namespace firrtl;
+
+class LowerGroupsPass : public LowerGroupsBase<LowerGroupsPass> {
+  /// Safely build a new module with a given namehint.  This handles geting a
+  /// lock to modify the top-level circuit.
+  FModuleOp buildNewModule(OpBuilder &builder, Location location,
+                           Twine namehint, SmallVectorImpl<PortInfo> &ports);
+
+  /// Function to process each module.
+  void runOnModule(FModuleOp moduleOp);
+
+  /// Entry point for the function.
+  void runOnOperation() override;
+
+  /// Indicates exclusive access to modify the circuitNamespace and the circuit.
+  llvm::sys::SmartMutex<true> *circuitMutex;
+
+  /// A circuit-level namespace.
+  CircuitNamespace *circuitNamespace;
+};
+
+/// Multi-process safe function to build a module in the circuit and return it.
+/// The name provided is only a namehint for the module---a unique name will be
+/// generated if there are conflicts with the namehint in the circuit-level
+/// namespace.
+FModuleOp LowerGroupsPass::buildNewModule(OpBuilder &builder, Location location,
+                                          Twine namehint,
+                                          SmallVectorImpl<PortInfo> &ports) {
+  llvm::sys::SmartScopedLock<true> instrumentationLock(*circuitMutex);
+  StringRef newModuleName = circuitNamespace->newName(namehint);
+  FModuleOp newModule = builder.create<FModuleOp>(
+      location, builder.getStringAttr(newModuleName),
+      ConventionAttr::get(builder.getContext(), Convention::Internal), ports,
+      ArrayAttr{});
+  SymbolTable::setSymbolVisibility(newModule, SymbolTable::Visibility::Private);
+  return newModule;
+};
+
+/// Process amodule to remove any groups it has.
+void LowerGroupsPass::runOnModule(FModuleOp moduleOp) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Module: " << moduleOp.getModuleName() << "\n";
+    llvm::dbgs() << "  Examining Groups:\n";
+  });
+
+  CircuitOp circuitOp = moduleOp->getParentOfType<CircuitOp>();
+  StringRef circuitName = circuitOp.getName();
+
+  // A set of ops that this pass creates.  This is used to check if certain
+  // operations should be handled specially, e.g., moved outside of their
+  // defining group.
+  DenseSet<Operation *> createdOps;
+
+  // Post-order traversal that expands a group into its parent. Foreach gorup
+  // found do the following:
+  //
+  // 1. Create and connect one ref-type output port for each value defined in
+  //    this group that drives an instance marked lowerToBind and move this
+  //    instance outside the group.
+  // 2. Create one input port for each value captured by this group.
+  // 3. Create a new module for this group and move the (mutated) body of this
+  //    group to the new module.
+  // 4. Instantiate the new module outside the group and hook it up.
+  // 5. Erase the group.
+  moduleOp.walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
+    auto group = dyn_cast<GroupOp>(op);
+    if (!group)
+      return WalkResult::advance();
+
+    // Compute the expanded group name.  For group @A::@B::@C, this is "A_B_C".
+    SmallString<32> groupName(group.getGroupName().getRootReference());
+    for (auto ref : group.getGroupName().getNestedReferences()) {
+      groupName.append("_");
+      groupName.append(ref.getValue());
+    }
+    LLVM_DEBUG(llvm::dbgs() << "    - Group: " << groupName << "\n");
+
+    Block *body = group.getBody(0);
+    OpBuilder builder(moduleOp);
+
+    // Ports that need to be created for the module derived from this group.
+    SmallVector<PortInfo> ports;
+
+    // Connectsion that need to be made to the instance of the derived module.
+    SmallVector<Value> connectValues;
+
+    // Create an input port for an operand that is captured from outside.
+    //
+    // TODO: If we allow capturing reference types, this will need to be
+    // updated.
+    auto createInputPort = [&](Value operand) {
+      auto portNum = ports.size();
+      auto operandName = getFieldName(FieldRef(operand, 0), true);
+
+      ports.push_back({builder.getStringAttr("_" + operandName.first),
+                       operand.getType(), Direction::In});
+      // Update the group's body with arguments as we will swap this body into
+      // the module when we create it.
+      body->addArgument(operand.getType(), builder.getUnknownLoc());
+      operand.replaceUsesWithIf(body->getArgument(portNum),
+                                [&](OpOperand &operand) {
+                                  return operand.getOwner()->getBlock() == body;
+                                });
+
+      connectValues.push_back(operand);
+    };
+
+    // Create an output probe port port and adds the ref.define/ref.send to
+    // drive the port.
+    auto createOutputPort = [&](Value dest, Value src) {
+      auto portNum = ports.size();
+      auto operandName = getFieldName(FieldRef(dest, 0), true);
+
+      auto refType = RefType::get(cast<FIRRTLBaseType>(dest.getType()),
+                                  /*forceable=*/false);
+
+      ports.push_back({builder.getStringAttr("_" + operandName.first), refType,
+                       Direction::Out});
+      body->addArgument(refType, builder.getUnknownLoc());
+      connectValues.push_back(dest);
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointAfterValue(src);
+      builder.create<RefDefineOp>(
+          builder.getUnknownLoc(), body->getArgument(portNum),
+          builder.create<RefSendOp>(builder.getUnknownLoc(), src)
+              ->getResult(0));
+    };
+
+    for (auto &op : llvm::make_early_inc_range(*body)) {
+      // Handle instance ops that were created from nested groups.  These ops
+      // need to be moved outside the group to avoid nested binds which are
+      // illegal in the SystemVerilog specification (and checked by FIRRTL
+      // verification).
+      //
+      // For each value defined in this group which drives a port of one of
+      // these instances, create an output reference type port on the
+      // to-be-created module and drive it with the value.  Move the instance
+      // outside the group. We will hook it up later once we replace the group
+      // with an instance.
+      if (auto instOp = dyn_cast<InstanceOp>(op)) {
+        // Ignore any instance which this pass did not create from a nested
+        // group. Instances which are not marked lowerToBind do not need to be
+        // split out.
+        if (!createdOps.contains(instOp))
+          continue;
+        LLVM_DEBUG({
+          llvm::dbgs() << "      Found instance created from nested group:\n"
+                       << "        module: " << instOp.getModuleName() << "\n"
+                       << "        instance: " << instOp.getName() << "\n";
+        });
+        instOp->moveBefore(group);
+        continue;
+      }
+
+      if (auto connect = dyn_cast<FConnectLike>(op)) {
+        auto srcInGroup = connect.getSrc().getParentBlock() == body;
+        auto destInGroup = connect.getDest().getParentBlock() == body;
+        if (!srcInGroup && !destInGroup) {
+          connect->moveBefore(group);
+          continue;
+        }
+        // Create an input port.
+        if (!srcInGroup) {
+          createInputPort(connect.getSrc());
+          continue;
+        }
+        // Create an output port.
+        if (!destInGroup) {
+          createOutputPort(connect.getDest(), connect.getSrc());
+          connect.erase();
+          continue;
+        }
+        // Source and destination in group.  Nothing to do.
+        continue;
+      }
+
+      // Pattern match the following structure.  Move the ref.resolve outside
+      // the group.  The strictconnect will be moved outside in the next loop
+      // iteration:
+      //     %0 = ...
+      //     %1 = ...
+      //     firrtl.group {
+      //       %2 = ref.resolve %0
+      //       firrtl.strictconnect %1, %2
+      //     }
+      if (auto refResolve = dyn_cast<RefResolveOp>(op))
+        if (refResolve.getResult().hasOneUse())
+          if (auto connect = dyn_cast<StrictConnectOp>(
+                  *refResolve.getResult().getUsers().begin()))
+            if (connect.getDest().getParentBlock() != body) {
+              refResolve->moveBefore(group);
+              continue;
+            }
+
+      // For any other ops, create input ports for any captured operands.
+      for (auto operand : op.getOperands())
+        if (operand.getParentBlock() != body)
+          createInputPort(operand);
+    }
+
+    // Create the new module.  This grabs a lock to modify the circuit.
+    SmallString<32> newModuleName(moduleOp.getName());
+    newModuleName.append("_");
+    newModuleName.append(groupName);
+    FModuleOp newModule =
+        buildNewModule(builder, group.getLoc(), newModuleName, ports);
+    SymbolTable::setSymbolVisibility(newModule,
+                                     SymbolTable::Visibility::Private);
+    newModule.getBody().takeBody(group.getRegion());
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "      New Module: " << newModuleName << "\n";
+      llvm::dbgs() << "        ports:\n";
+      for (size_t i = 0, e = ports.size(); i != e; ++i) {
+        auto port = ports[i];
+        auto value = connectValues[i];
+        llvm::dbgs() << "          - name: " << port.getName() << "\n"
+                     << "            type: " << port.type << "\n"
+                     << "            direction: " << port.direction << "\n"
+                     << "            value: " << value << "\n";
+      }
+    });
+
+    // Replace the original group with an instance.  Hook up the instance.
+    builder.setInsertionPointAfter(group);
+    auto moduleName = newModule.getModuleName();
+    auto instanceOp = builder.create<InstanceOp>(
+        group.getLoc(), /*moduleName=*/newModule,
+        /*name=*/
+        (Twine((char)tolower(moduleName[0])) + moduleName.drop_front()).str(),
+        NameKindEnum::DroppableName,
+        /*annotations=*/ArrayRef<Attribute>{},
+        /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/true);
+    instanceOp->setAttr("output_file",
+                        hw::OutputFileAttr::getFromFilename(
+                            builder.getContext(),
+                            "groups_" + circuitName + "_" + groupName + ".sv",
+                            /*excludeFromFileList=*/true));
+    createdOps.insert(instanceOp);
+
+    // Connect instance ports to values.
+    assert(ports.size() == connectValues.size() &&
+           "the number of instance ports and values to connect to them must be "
+           "equal");
+    for (unsigned portNum = 0, e = newModule.getNumPorts(); portNum < e;
+         ++portNum) {
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointAfterValue(instanceOp.getResult(portNum));
+      if (instanceOp.getPortDirection(portNum) == Direction::In)
+        builder.create<StrictConnectOp>(builder.getUnknownLoc(),
+                                        instanceOp.getResult(portNum),
+                                        connectValues[portNum]);
+      else
+        builder.create<StrictConnectOp>(
+            builder.getUnknownLoc(), connectValues[portNum],
+            builder.create<RefResolveOp>(builder.getUnknownLoc(),
+                                         instanceOp.getResult(portNum)));
+    }
+    group.erase();
+
+    return WalkResult::advance();
+  });
+}
+
+/// Process a circuit to remove all groups in each module and top-level group
+/// declarations.
+void LowerGroupsPass::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "==----- Running LowerGroups "
+                      "-------------------------------------------------===\n");
+  CircuitOp circuitOp = getOperation();
+
+  // Initialize members which cannot be initialized automatically.
+  llvm::sys::SmartMutex<true> mutex;
+  circuitMutex = &mutex;
+  CircuitNamespace ns(circuitOp);
+  circuitNamespace = &ns;
+
+  // Lower the groups of each module.
+  SmallVector<FModuleOp> modules(circuitOp.getBodyBlock()->getOps<FModuleOp>());
+  llvm::parallelForEach(modules,
+                        [&](FModuleOp moduleOp) { runOnModule(moduleOp); });
+
+  // Generate the header and footer of each bindings file.  The body will be
+  // populated later when binds are exported to Verilog.  This produces text
+  // like:
+  //
+  //     `include "groups_A.sv"
+  //     `include "groups_A_B.sv"
+  //     `ifnedf groups_A_B_C
+  //     `define groups_A_B_C
+  //     <body>
+  //     `endif // groups_A_B_C
+  //
+  // TODO: This would be better handled without the use of verbatim ops.
+  OpBuilder builder(circuitOp);
+  SmallVector<std::pair<GroupDeclOp, StringAttr>> groupDecls;
+  StringRef circuitName = circuitOp.getName();
+  circuitOp.walk<mlir::WalkOrder::PreOrder>([&](GroupDeclOp groupDeclOp) {
+    auto parentOp = groupDeclOp->getParentOfType<GroupDeclOp>();
+    while (parentOp && parentOp != groupDecls.back().first)
+      groupDecls.pop_back();
+    builder.setInsertionPointToStart(circuitOp.getBodyBlock());
+
+    SmallString<32> groupName;
+    for (auto [group, _] : groupDecls) {
+      groupName.append(group.getSymName());
+      groupName.append("_");
+    }
+    groupName.append(groupDeclOp.getSymName());
+
+    auto outputFileAttr = hw::OutputFileAttr::getFromFilename(
+        builder.getContext(), "groups_" + circuitName + "_" + groupName + ".sv",
+        /*excludeFromFileList=*/true);
+
+    SmallString<128> includes;
+    for (auto [_, strAttr] : groupDecls) {
+      includes.append(strAttr);
+      includes.append("\n");
+    }
+
+    // Write header to a verbatim.
+    builder
+        .create<sv::VerbatimOp>(groupDeclOp.getLoc(),
+                                includes + "`ifndef groups_" + circuitName +
+                                    "_" + groupName + "\n" + "`define groups_" +
+                                    circuitName + "_" + groupName)
+        ->setAttr("output_file", outputFileAttr);
+
+    // Write footer to a verbatim.
+    builder.setInsertionPointToEnd(circuitOp.getBodyBlock());
+    builder
+        .create<sv::VerbatimOp>(groupDeclOp.getLoc(), "`endif // groups_" +
+                                                          circuitName + "_" +
+                                                          groupName)
+        ->setAttr("output_file", outputFileAttr);
+
+    if (!groupDeclOp.getBody().getOps<GroupDeclOp>().empty())
+      groupDecls.push_back(
+          {groupDeclOp,
+           builder.getStringAttr("`include \"groups_" + circuitName + "_" +
+                                 groupName + ".sv\"")});
+  });
+
+  // All group declarations can now be deleted.
+  for (auto groupDeclOp : llvm::make_early_inc_range(
+           circuitOp.getBodyBlock()->getOps<GroupDeclOp>()))
+    groupDeclOp.erase();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerGroupsPass() {
+  return std::make_unique<LowerGroupsPass>();
+}

--- a/test/Dialect/FIRRTL/lower-groups.mlir
+++ b/test/Dialect/FIRRTL/lower-groups.mlir
@@ -1,0 +1,120 @@
+// RUN: circt-opt -firrtl-lower-groups -split-input-file %s | FileCheck %s
+
+firrtl.circuit "Simple" {
+  firrtl.declgroup {
+    firrtl.declgroup {
+      firrtl.declgroup {
+      } {sym_name = "C", convention = #firrtl<groupconvention bind>}
+    } {sym_name = "B", convention = #firrtl<groupconvention bind>}
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.module @Simple() {
+    %a = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.wire : !firrtl.uint<2>
+    firrtl.group @A {
+      %aa = firrtl.node %a: !firrtl.uint<1>
+      %c = firrtl.wire : !firrtl.uint<3>
+      firrtl.group @A::@B {
+        %bb = firrtl.node %b: !firrtl.uint<2>
+        %cc = firrtl.node %c: !firrtl.uint<3>
+        firrtl.group @A::@B::@C {
+          %ccc = firrtl.node %cc: !firrtl.uint<3>
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "Simple"
+//
+// CHECK:      sv.verbatim "`include \22groups_Simple_A.sv\22\0A
+// CHECK-SAME:   `include \22groups_Simple_A_B.sv\22\0A
+// CHECK-SAME:   `ifndef groups_Simple_A_B_C\0A
+// CHECK-SAME:   define groups_Simple_A_B_C"
+// CHECK-SAME:   output_file = #hw.output_file<"groups_Simple_A_B_C.sv", excludeFromFileList>
+// CHECK:      sv.verbatim "`include \22groups_Simple_A.sv\22\0A
+// CHECK-SAME:   `ifndef groups_Simple_A_B\0A
+// CHECK-SAME:   define groups_Simple_A_B"
+// CHECK-SAME:   output_file = #hw.output_file<"groups_Simple_A_B.sv", excludeFromFileList>
+// CHECK:      sv.verbatim "`ifndef groups_Simple_A\0A
+// CHECK-SAME:   define groups_Simple_A"
+// CHECK-SAME:   output_file = #hw.output_file<"groups_Simple_A.sv", excludeFromFileList>
+//
+// CHECK:      firrtl.module private @Simple_A_B_C(
+// CHECK-NOT:  firrtl.module
+// CHECK-SAME:   in %[[cc_port:[_a-zA-Z0-9]+]]: !firrtl.uint<3>
+// CHECK-NEXT:   %ccc = firrtl.node %[[cc_port]]
+// CHECK-NEXT: }
+//
+// CHECK:      firrtl.module private @Simple_A_B(
+// CHECK-NOT:  firrtl.module
+// CHECK-SAME:   in %[[b_port:[_a-zA-Z0-9]+]]: !firrtl.uint<2>
+// CHECK-SAME:   in %[[c_port:[_a-zA-Z0-9]+]]: !firrtl.uint<3>
+// CHECK-SAME:   out %[[cc_port:[_a-zA-Z0-9]+]]: !firrtl.probe<uint<3>>
+// CHECK-NEXT:   %bb = firrtl.node %[[b_port]]
+// CHECK-NEXT:   %cc = firrtl.node %[[c_port]]
+// CHECK-NEXT:   %0 = firrtl.ref.send %cc
+// CHECK-NEXT:   firrtl.ref.define %[[cc_port]], %0
+// CHECK-NEXT: }
+//
+// CHECK:      firrtl.module private @Simple_A(
+// CHECK-NOT:  firrtl.module
+// CHECK-SAME:   in %[[a_port:[_a-zA-Z0-9]+]]: !firrtl.uint<1>
+// CHECK-SAME:   out %[[c_port:[_a-zA-Z0-9]+]]: !firrtl.probe<uint<3>>
+// CHECK-NEXT:   %aa = firrtl.node %[[a_port]]
+// CHECK:        %[[c_ref:[_a-zA-Z0-9]+]] = firrtl.ref.send %c
+// CHECK-NEXT:   firrtl.ref.define %[[c_port]], %[[c_ref]]
+// CHECK-NEXT: }
+//
+// CHECK:      firrtl.module @Simple() {
+// CHECK-NOT:  firrtl.module
+// CHECK-NOT:    firrtl.group
+// CHECK:        %[[A_B_C_cc:[_a-zA-Z0-9]+]] = firrtl.instance simple_A_B_C {
+// CHECK-SAME:     lowerToBind
+// CHECK-SAME:     output_file = #hw.output_file<"groups_Simple_A_B_C.sv"
+// CHECK-SAME:     excludeFromFileList
+// CHECK-SAME:     @Simple_A_B_C(
+// CHECK-NEXT:   %[[A_B_b:[_a-zA-Z0-9]+]], %[[A_B_c:[_a-zA-Z0-9]+]], %[[A_B_cc:[_a-zA-Z0-9]+]] = firrtl.instance simple_A_B {
+// CHECK-SAME:     lowerToBind
+// CHECK-SAME:     output_file = #hw.output_file<"groups_Simple_A_B.sv", excludeFromFileList>
+// CHECK-SAME:     @Simple_A_B(
+// CHECK-NEXT:   %[[A_B_cc_resolve:[_a-zA-Z0-9]+]] = firrtl.ref.resolve %[[A_B_cc]]
+// CHECK-NEXT:   firrtl.strictconnect %[[A_B_C_cc]], %[[A_B_cc_resolve]]
+// CHECK-NEXT:   firrtl.strictconnect %[[A_B_b]], %b
+// CHECK-NEXT:   %[[A_a:[_a-zA-Z0-9]+]], %[[A_c:[_a-zA-Z0-9]+]] = firrtl.instance simple_A {
+// CHECK-SAME:     lowerToBind
+// CHECK-SAME:     output_file = #hw.output_file<"groups_Simple_A.sv", excludeFromFileList>
+// CHECK-SAME:     @Simple_A(
+// CHECK-NEXT:   %[[A_c_resolve:[_a-zA-Z0-9]+]] = firrtl.ref.resolve %[[A_c]]
+// CHECK-NEXT:   firrtl.strictconnect %[[A_B_c]], %[[A_c_resolve]]
+// CHECK-NEXT:   firrtl.strictconnect %[[A_a]], %a
+// CHECK:      }
+//
+// CHECK-DAG:  sv.verbatim "`endif // groups_Simple_A"
+// CHECK-SAME:   output_file = #hw.output_file<"groups_Simple_A.sv", excludeFromFileList>
+// CHECK-DAG:  sv.verbatim "`endif // groups_Simple_A_B"
+// CHECK-SAME:   output_file = #hw.output_file<"groups_Simple_A_B.sv", excludeFromFileList>
+
+// -----
+
+firrtl.circuit "ModuleNameConflict" {
+  firrtl.declgroup {
+  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
+  firrtl.module private @ModuleNameConflict_A() {}
+  firrtl.module @ModuleNameConflict() {
+    %a = firrtl.wire : !firrtl.uint<1>
+    firrtl.instance foo @ModuleNameConflict_A()
+    firrtl.group @A {
+      %b = firrtl.node %a : !firrtl.uint<1>
+    }
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "ModuleNameConflict"
+//
+// CHECK:       firrtl.module private @[[groupModule:[_a-zA-Z0-9]+]](in
+//
+// CHECK:       firrtl.module @ModuleNameConflict()
+// CHECK-NOT:   firrtl.module
+// CHECK:         firrtl.instance foo @ModuleNameConflict_A()
+// CHECK-NEXT:    firrtl.instance {{[_a-zA-Z0-9]+}} {lowerToBind,
+// CHECK-SAME:      @[[groupModule]](


### PR DESCRIPTION
Add the LowerGroups pass that converts FIRRTL optional groups to bound modules.

#### Example

The following MLIR contains two gropus, `A` and `B`. `B` is a nested group of `A`. This can be represented in the following FIRRTL (this does not work) or in the following MLIR (this does work):

```
FIRRTL version 3.0.0
circuit Foo: %[[
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>aa"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>bb"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>cc"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>ccc"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>dd"}
]]
  declgroup A:
    declgroup B:
      declgroup C:

  module Foo:
    input a: UInt<1>
    input b: UInt<2>
    input c: UInt<3>
    input d: UInt<4>

    group A:
      node aa = a
      node cc = c
      group B:
        node bb = b
        node ccc = cc
        group C:
          node dd = d
```

```mlir
firrtl.circuit "Foo" {
  firrtl.declgroup {
    firrtl.declgroup {
      firrtl.declgroup {
      } {sym_name = "C", convention = #firrtl<groupconvention bind>}
    } {sym_name = "B", convention = #firrtl<groupconvention bind>}
  } {sym_name = "A", convention = #firrtl<groupconvention bind>}
  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, in %c: !firrtl.uint<3>, in %d: !firrtl.uint<4>) {
    firrtl.group @A {
      %aa = firrtl.node %a {annotations=[{class="firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
      %cc = firrtl.node %c {annotations=[{class="firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<3>
      firrtl.group @A::@B {
        %bb = firrtl.node %b {annotations=[{class="firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
        %ccc = firrtl.node %cc {annotations=[{class="firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<3>
        firrtl.group @A::@B::@C {
          %dd = firrtl.node %d {annotations=[{class="firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
        }
      }
    }
  }
}
```

This produces the following Verilog using `circt-opt groups/Foo.mlir -firrtl-lower-groups | firtool -format=mlir -strip-debug-info`:

```verilog
// Generated by CIRCT unknown git version
module Foo_A_B_C(
  input [3:0] _d
);

  wire [3:0] dd = _d;
endmodule

module Foo_A_B(
  input [1:0] _b,
  input [2:0] _cc
);

  wire [1:0] bb = _b;
  wire [2:0] ccc = _cc;
endmodule

module Foo_A(
  input       _a,
  input [2:0] _c
);

  wire       aa = _a;
  wire [2:0] cc = _c;
endmodule

module Foo(
  input       a,
  input [1:0] b,
  input [2:0] c,
  input [3:0] d
);

endmodule

// ----- 8< ----- FILE "groups_Foo_A_B_C.sv" ----- 8< -----

// Generated by CIRCT unknown git version
`include "groups_Foo_A.sv"
`include "groups_Foo_A_B.sv"
`ifndef groups_Foo_A_B_C
`define groups_Foo_A_B_C
bind Foo Foo_A_B_C foo_A_B_C (
  ._d (d)
);
`endif // groups_Foo_A_B_C

// ----- 8< ----- FILE "groups_Foo_A_B.sv" ----- 8< -----

// Generated by CIRCT unknown git version
`include "groups_Foo_A.sv"
`ifndef groups_Foo_A_B
`define groups_Foo_A_B
bind Foo Foo_A_B foo_A_B (
  ._b  (b),
  ._cc (Foo.foo_A.cc)
);
`endif // groups_Foo_A_B

// ----- 8< ----- FILE "groups_Foo_A.sv" ----- 8< -----

// Generated by CIRCT unknown git version
`ifndef groups_Foo_A
`define groups_Foo_A
bind Foo Foo_A foo_A (
  ._a (a),
  ._c (c)
);
`endif // groups_Foo_A
```