### PR TITLE
[FIRRTL][InferWidths] mux selelector back-prop >= 0, fixup if too narrow.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2115,7 +2115,12 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
           [&](auto muxOp) {
             auto bits = isa<Mux4CellIntrinsicOp>(op) ? 2 : 1;
             auto type = cast<FIRRTLBaseType>(muxOp.getSel().getType());
-            if (type.getBitWidthOrSentinel() == 0) {
+            auto width = type.getBitWidthOrSentinel();
+            assert(width >= 0 && "Unknown width after inference");
+            assert(isa<IntType>(type) && "Selector must be integer type");
+            assert(cast<IntType>(type).isUnsigned() &&
+                   "Selected must be unsigned");
+            if (width < bits) {
               ImplicitLocOpBuilder builder(muxOp.getSel().getLoc(), op);
               auto extend =
                   builder.createOrFold<PadPrimOp>(muxOp.getSel(), bits);

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2117,9 +2117,8 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
             auto type = cast<FIRRTLBaseType>(muxOp.getSel().getType());
             auto width = type.getBitWidthOrSentinel();
             assert(width >= 0 && "Unknown width after inference");
-            assert(isa<IntType>(type) && "Selector must be integer type");
-            assert(cast<IntType>(type).isUnsigned() &&
-                   "Selected must be unsigned");
+            assert(isa<IntType>(type) && cast<IntType>(type).isUnsigned() &&
+                   "Selector must be unsigned integer type");
             if (width < bits) {
               ImplicitLocOpBuilder builder(muxOp.getSel().getLoc(), op);
               auto extend =

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -983,4 +983,15 @@ firrtl.circuit "Foo" {
     %cast2 = firrtl.widthCast %1 : (!firrtl.uint) -> !firrtl.uint
     firrtl.strictconnect %out2, %cast2 : !firrtl.uint
   }
+
+  // CHECK-LABEL: module @Issue5444Reg(
+  // CHECK-SAME: %out: !firrtl.uint<0>
+  // CHECK-NEXT: firrtl.reg {{.+}} : !firrtl.clock, !firrtl.uint<0>
+  // CHECK-NEXT: firrtl.
+  firrtl.module @Issue5444Reg(in %clock: !firrtl.clock, out %out: !firrtl.uint) {
+    %r1 = firrtl.reg interesting_name %clock : !firrtl.clock, !firrtl.uint
+    %0 = firrtl.mux(%r1, %r1, %r1) : (!firrtl.uint, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %r1, %0 : !firrtl.uint, !firrtl.uint
+    firrtl.connect %out, %r1 : !firrtl.uint, !firrtl.uint
+  }
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -362,15 +362,16 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @MuxOp
   firrtl.module @MuxOp() {
-    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
-    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
-    // CHECK: %2 = firrtl.wire : !firrtl.uint<1>
-    // CHECK: %3 = firrtl.mux{{.*}} -> !firrtl.uint<3>
+    // CHECK-NEXT: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK-NEXT: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK-NEXT: %2 = firrtl.wire : !firrtl.uint<0>
+    // CHECK-NEXT: %3 = firrtl.pad %2
+    // CHECK-NEXT: %4 = firrtl.mux{{.*}} -> !firrtl.uint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
     %3 = firrtl.mux(%2, %0, %1) : (!firrtl.uint, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    // CHECK: %4 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %5 = firrtl.wire : !firrtl.uint<0>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %4 = firrtl.wire : !firrtl.uint
     %5 = firrtl.mux(%4, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -961,8 +962,8 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %out1, %2 : !firrtl.uint
   }
   // CHECK-LABEL: module @MuxIntrinsics
-  // CHECK-SAME: %sel: !firrtl.uint<1>
-  // CHECK-SAME: %sel2: !firrtl.uint<2>
+  // CHECK-SAME: %sel: !firrtl.uint<0>
+  // CHECK-SAME: %sel2: !firrtl.uint<0>
   firrtl.module @MuxIntrinsics(in %sel: !firrtl.uint, in %sel2: !firrtl.uint, in %high: !firrtl.uint<1>, in %low: !firrtl.uint<1>, out %out1: !firrtl.uint, out %out2: !firrtl.uint) {
     %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
     %c3_ui3 = firrtl.constant 3 : !firrtl.uint<3>


### PR DESCRIPTION
Instead of back-propagating required selector width,
add constraint to preserve (under test) behavior regarding
designs with otherwise unconstrained selector operands
("width >= 0") and fixup afterwards should the selector
be inferred too small.  This works here because the fixed up
operation does not impact any downstream users (terminates in the mux).

This is still "special" but avoids keeping around hardware that
should be deleted, such as in original examples in https://github.com/llvm/circt/issues/5444.

This differs from FIRRTL spec, which should be addressed (even if just tweaking that language).