### PR TITLE
[Pipeline] Fix `ScheduledPipelineOp` builder

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -47,13 +47,13 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
   let arguments = (ins
     Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs, I1:$go, I1:$clock, I1:$reset, Optional<I1>:$stall
   );
-  let results = (outs Variadic<AnyType>:$results, I1:$done);
+  let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let regions = (region SizedRegion<1>: $body);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
-      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $results) $body
+      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $dataOutputs) $body
   }];
 
   let extraClassDeclaration = [{
@@ -100,19 +100,19 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   let arguments = (ins
     Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, I1:$go, Optional<I1>:$stall
   );
-  let results = (outs Variadic<AnyType>:$results, I1:$done);
+  let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let regions = (region AnyRegion:$body);
   let hasVerifier = 1;
   let skipDefaultBuilders = 1;
 
   let builders = [
-    OpBuilder<(ins "TypeRange":$results, "ValueRange":$inputs, "ValueRange":$extInputs,
+    OpBuilder<(ins "TypeRange":$dataOutputs, "ValueRange":$inputs, "ValueRange":$extInputs,
       "Value":$clock, "Value":$reset, "Value":$go, CArg<"Value", "{}">:$stall)>
   ];
 
   let assemblyFormat = [{
     `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
-      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $results) $body
+      `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $dataOutputs) $body
   }];
 
   let extraClassDeclaration = [{

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -315,7 +315,7 @@ public:
     pipelineMod =
         buildPipelineLike(pipelineName, pipeline.getInputs().getTypes(),
                           pipeline.getExtInputs().getTypes(),
-                          pipeline.getResults().getTypes(), withStall);
+                          pipeline.getDataOutputs().getTypes(), withStall);
     auto portLookup = pipelineMod.getPortLookupInfo();
     pipelineClk = pipelineMod.getBody().front().getArgument(
         *portLookup.getInputPortIndex("clk"));

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -109,7 +109,7 @@ LogicalResult UnscheduledPipelineOp::verify() { return verifyPipeline(*this); }
 //===----------------------------------------------------------------------===//
 
 void ScheduledPipelineOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                                TypeRange results, ValueRange inputs,
+                                TypeRange dataOutputs, ValueRange inputs,
                                 ValueRange extInputs, Value clock, Value reset,
                                 Value go, Value stall) {
   odsState.addOperands(inputs);
@@ -129,7 +129,10 @@ void ScheduledPipelineOp::build(OpBuilder &odsBuilder, OperationState &odsState,
            static_cast<int32_t>(stall ? 1 : 0)}));
 
   auto *region = odsState.addRegion();
-  odsState.addTypes(results);
+  odsState.addTypes(dataOutputs);
+
+  // Add the implicit done output signal.
+  odsState.addTypes({odsBuilder.getIntegerType(1)});
 
   // Add the entry stage
   auto &entryBlock = region->emplaceBlock();

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -137,9 +137,9 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
   // Create the scheduled pipeline.
   b.setInsertionPoint(pipeline);
   auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
-      pipeline.getLoc(), pipeline->getResultTypes(), pipeline.getInputs(),
-      pipeline.getExtInputs(), pipeline.getClock(), pipeline.getReset(),
-      pipeline.getGo(), pipeline.getStall());
+      pipeline.getLoc(), pipeline.getDataOutputs().getTypes(),
+      pipeline.getInputs(), pipeline.getExtInputs(), pipeline.getClock(),
+      pipeline.getReset(), pipeline.getGo(), pipeline.getStall());
 
   Block *currentStage = schedPipeline.getStage(0);
 


### PR DESCRIPTION
Also renames the data output field of the op to avoid aliasing with the built-in `getResultTypes()` that is the reason this bug went unnoticed.