### PR TITLE
[Pipeline] Improve pipeline naming

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -45,14 +45,15 @@ def UnscheduledPipelineOp : Op<Pipeline_Dialect, "unscheduled", [
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs, I1:$go, I1:$clock, I1:$reset, Optional<I1>:$stall
+    OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs,
+    Variadic<AnyType>:$extInputs, I1:$go, I1:$clock, I1:$reset, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let regions = (region SizedRegion<1>: $body);
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
+    ($name^)? `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
       `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $dataOutputs) $body
   }];
 
@@ -98,7 +99,8 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   }];
 
   let arguments = (ins
-    Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, I1:$go, Optional<I1>:$stall
+    OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs,
+    Variadic<AnyType>:$extInputs,  I1:$clock, I1:$reset, I1:$go, Optional<I1>:$stall
   );
   let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let regions = (region AnyRegion:$body);
@@ -111,7 +113,7 @@ def ScheduledPipelineOp : Op<Pipeline_Dialect, "scheduled", [
   ];
 
   let assemblyFormat = [{
-    `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
+    ($name^)? `(` $inputs `)` (`stall` $stall^)? (`ext` `(` $extInputs^ `:` type($extInputs) `)`)? 
       `clock` $clock `reset` $reset `go` $go attr-dict `:`functional-type($inputs, $dataOutputs) $body
   }];
 


### PR DESCRIPTION
* Adds an optional name parameter to the pipeline
* Stage registers will look at their source values and, if provided a `sv.namehint`, will take its name from that.

There's still more naming work to be done here (naming pipeline in/outputs, explicit stage reg names, ...) - starting with these two since they're super low hanging fruit.

Example verilog output:

```mlir

hw.module @testNaming(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
  %0:2 = pipeline.scheduled "MyPipeline"(%arg0) clock %clk reset %rst go %arg0 : (i1) -> (i1) {
  ^bb0(%a0: i1, %s0_valid: i1):
    // The register will be named after the namehint on the source operation.
    %add = comb.add %a0, %a0 {sv.namehint = "myAdd"} : i1
    pipeline.stage ^bb1 regs(%add : i1)

  ^bb1(%1 : i1, %s1_valid: i1):
    pipeline.return %1 : i1

  }
  hw.output %0#0 : i1
}
```
exports as

```sv
module testNaming_MyPipeline(
  input  in0,
         enable,
         clk,
         rst,
  output out0,
         valid
);

  testNaming_MyPipeline_s0 testNaming_MyPipeline_s0 (
    .in0    (in0),
    .enable (enable),
    .clk    (clk),
    .rst    (rst),
    .out0   (out0),
    .valid  (valid)
  );
endmodule

module testNaming_MyPipeline_s0(
  input  in0,
         enable,
         clk,
         rst,
  output out0,
         valid
);

  reg s0_myAdd_reg;
  always_ff @(posedge clk) begin
    if (enable)
      s0_myAdd_reg <= in0 + in0;
  end
  reg s0_valid;
  always_ff @(posedge clk) begin
    if (rst)
      s0_valid <= 1'h0;
    else
      s0_valid <= enable;
  end
  assign out0 = s0_myAdd_reg;
  assign valid = s0_valid;
endmodule

module testNaming(
  input  arg0,
         clk,
         rst,
  output out
);

  testNaming_MyPipeline testNaming_MyPipeline (
    .in0    (arg0),
    .enable (arg0),
    .clk    (clk),
    .rst    (rst),
    .out0   (out),
    .valid  (/* unused */)
  );
endmodule
```