### PR TITLE
[FIRRTLFolds] Fix `andr(pad(x:sint, n)) -> andr(x)` canonicalization

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -473,9 +473,8 @@ def AndRPadU : Pat <
 /// andr(pad(x:S,n)) -> andr(x)
 def AndRPadS : Pat <
   (AndRPrimOp:$old (PadPrimOp:$pad $x, $n)),
-  (NativeCodeCall<"$_builder.create<ConstantOp>($0.getLoc(), cast<IntType>($0.getType()), getIntZerosAttr($0.getType()))"> $old),
+  (MoveNameHint $old, (AndRPrimOp $x)),
   [(KnownWidth $x), (SIntTypes $x)]>;
-
 
 // bits(bits(x, ...), ...) -> bits(x, ...)
 def BitsOfBits : Pat<

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -682,7 +682,8 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>, in %in1 : !firrtl.sint<2>,
                     out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
                     out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>,
                     out %e: !firrtl.uint<1>, out %f: !firrtl.uint<1>, 
-                    out %g: !firrtl.uint<1>, in %h : !firrtl.uint<64>) {
+                    out %g: !firrtl.uint<1>, in %h : !firrtl.uint<64>,
+                    out %i: !firrtl.uint<1>) {
   %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
@@ -723,7 +724,13 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>, in %in1 : !firrtl.sint<2>,
   %9 = firrtl.cvt %6 : (!firrtl.uint<64>) -> !firrtl.sint<65>
   %10 = firrtl.andr %9 : (!firrtl.sint<65>) -> !firrtl.uint<1>
   firrtl.strictconnect %g, %10 : !firrtl.uint<1>
-  }
+
+  // CHECK: %[[andr:.*]] = firrtl.andr %in1
+  // CHECK-NEXT: firrtl.strictconnect %i, %[[andr]]
+  %11 = firrtl.pad %in1, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
+  %12 = firrtl.andr %11 : (!firrtl.sint<3>) -> !firrtl.uint<1>
+  firrtl.strictconnect %i, %12 : !firrtl.uint<1>
+}
 
 // CHECK-LABEL: firrtl.module @Orr
 firrtl.module @Orr(in %in0 : !firrtl.uint<0>,


### PR DESCRIPTION
This fixes a bug that `andr(pad(x:sint, n))` is canonicalized into `0`. 