### PR TITLE
[FIRRTL][LowerXMR] Support ref.sub. 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -49,10 +49,10 @@ using hw::InnerRefAttr;
 
 namespace {
 struct XMRNode {
-  using nextNodeOnPath = std::optional<size_t>;
-  using symOrIndexOp = PointerUnion<Attribute, Operation *>;
-  symOrIndexOp info;
-  nextNodeOnPath next;
+  using NextNodeOnPath = std::optional<size_t>;
+  using SymOrIndexOp = PointerUnion<Attribute, Operation *>;
+  SymOrIndexOp info;
+  NextNodeOnPath next;
 };
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const XMRNode &node) {
   os << "node(";
@@ -338,7 +338,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     while (remoteOpPath) {
       lastIndex = *remoteOpPath;
       auto entr = refSendPathList[*remoteOpPath];
-      TypeSwitch<XMRNode::symOrIndexOp>(entr.info)
+      TypeSwitch<XMRNode::SymOrIndexOp>(entr.info)
           .Case<Attribute>([&](auto attr) {
             // If the path is a singular verbatim expression, the attribute of
             // the send path list entry will be null.
@@ -637,7 +637,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   size_t
-  addReachingSendsEntry(Value atRefVal, XMRNode::symOrIndexOp info,
+  addReachingSendsEntry(Value atRefVal, XMRNode::SymOrIndexOp info,
                         std::optional<size_t> continueFrom = std::nullopt) {
     auto leader = dataFlowClasses->getOrInsertLeaderValue(atRefVal);
     auto indx = refSendPathList.size();

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -760,8 +760,8 @@ private:
   /// next node in the path. The InnerRefAttr can be to an InstanceOp or to the
   /// XMR defining op, the index op records narrowing along path. All the nodes
   /// representing an InstanceOp or indexing operation must have a valid
-  /// nextNodeOnPath. Only the node representing the final XMR defining op has
-  /// no nextNodeOnPath, which denotes a leaf node on the path.
+  /// NextNodeOnPath. Only the node representing the final XMR defining op has
+  /// no NextNodeOnPath, which denotes a leaf node on the path.
   SmallVector<XMRNode> refSendPathList;
 
   /// llvm::EquivalenceClasses wants comparable elements. This comparator uses

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -361,6 +361,18 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
 
     assert(!(refSendPath.empty() && stringLeaf.empty()) &&
            "nothing to index through");
+
+    // All indexing done as the ref is plumbed around indexes through
+    // the target/referent, not the current point of the path which
+    // describes how to access the referent we're indexing through.
+    // Above we gathered all indexing operations, so now append them
+    // to the path (after any relevant `xmrPathSuffix`) to reach
+    // the target element.
+    // Generating these strings here (especially if ref is sent
+    // out from a different design) is fragile but should get this
+    // working well enough while sorting out how to do this better.
+    // Some discussion of this can be found here:
+    // https://github.com/llvm/circt/pull/5551#discussion_r1258908834
     for (auto subOp : llvm::reverse(indexing)) {
       TypeSwitch<FIRRTLBaseType>(subOp.getInput().getType().getType())
           .Case<FVectorType, OpenVectorType>([&](auto vecType) {

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -59,25 +59,13 @@ firrtl.circuit "Top" {
 }
 
 // -----
-// Check handling of unexpected ref.sub.
-
-firrtl.circuit "RefSubNotFromMemory" {
-  firrtl.module @RefSubNotFromMemory(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>) {
-    // expected-note @below {{input here}}
-    %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    // expected-error @below {{can only lower RefSubOp of Memory}}
-    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
-    %res = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
-  }
-}
-
-// -----
-// Check handling of unexpected ref.sub, from port.
+// Check handling of unexpected ref.sub, from input port.
 
 firrtl.circuit "RefSubNotFromOp" {
-  // expected-note @below {{input here}}
+  // expected-error @below {{reference dataflow cannot be traced back to the remote read op for module port 'ref'}}
+  // expected-note @below {{indexing through this reference}}
   firrtl.module private @Child(in %ref : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>) {
-    // expected-error @below {{can only lower RefSubOp of Memory}}
+    // expected-error @below {{indexing through probe of unknown origin (input probe?)}}
     %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
     %res = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
   }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -846,3 +846,78 @@ firrtl.circuit "RefABI" {
    %node_r2 = firrtl.node %read_r2 : !firrtl.vector<bundle<a: uint<3>>, 3>
   }
 }
+
+// -----
+// Check handling of basic ref.sub.
+
+// CHECK-LABEL: circuit "BasicRefSub"
+firrtl.circuit "BasicRefSub" {
+  // CHECK:  hw.hierpath private @[[XMRPATH:.+]] [@BasicRefSub::@[[C_SYM:[^,]+]], @Child::@[[REF_SYM:[^,]+]]]
+  // CHECK-LABEL: firrtl.module private @Child
+  // CHECK-SAME: in %in: !firrtl.bundle<a: uint<1>, b: uint<2>> sym @[[REF_SYM]])
+  firrtl.module private @Child(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out : !firrtl.probe<uint<2>>) {
+    %ref = firrtl.ref.send %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    firrtl.ref.define %out, %sub : !firrtl.probe<uint<2>>
+  }
+  // CHECK-LABEL: module @BasicRefSub(
+  firrtl.module @BasicRefSub(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out : !firrtl.uint<2>) {
+    // CHECK: firrtl.instance c sym @[[C_SYM]]
+    %c_in, %c_out = firrtl.instance c @Child(in in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out out : !firrtl.probe<uint<2>>)
+    firrtl.strictconnect %c_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    // CHECK: sv.xmr.ref @[[XMRPATH]] ".b"
+    %res = firrtl.ref.resolve %c_out : !firrtl.probe<uint<2>>
+    firrtl.strictconnect %out, %res : !firrtl.uint<2>
+  }
+}
+
+// -----
+// Check rwprobe, forceable, ABI
+
+// CHECK-LABEL: circuit "RWProbe_field"
+firrtl.circuit "RWProbe_field" {
+  // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@RWProbe_field::@[[SYM:[^,]+]]]
+  // CHECK-NEXT: sv.macro.decl @ref_RWProbe_field_RWProbe_field_rw
+  // e.g., "n[0]"
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_RWProbe_field_RWProbe_field_rw "{{0}}[0]"
+  // CHECK-SAME: ([@[[XMRPATH]]])
+  // CHECK-NEXT: sv.macro.decl @ref_RWProbe_field_RWProbe_field_rw_narrow
+  // e.g., "n[0].a"
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_RWProbe_field_RWProbe_field_rw_narrow "{{0}}[0].a"
+  // CHECK-SAME: ([@[[XMRPATH]]])
+  firrtl.module @RWProbe_field(in %x: !firrtl.vector<bundle<a: uint<1>>, 2>, out %rw: !firrtl.rwprobe<bundle<a: uint<1>>>, out %rw_narrow : !firrtl.rwprobe<uint<1>>) {
+    %n, %n_ref = firrtl.node %x forceable : !firrtl.vector<bundle<a: uint<1>>, 2>
+    %0 = firrtl.ref.sub %n_ref[0] : !firrtl.rwprobe<vector<bundle<a: uint<1>>, 2>>
+    firrtl.ref.define %rw, %0 : !firrtl.rwprobe<bundle<a: uint<1>>>
+    %1 = firrtl.ref.sub %0[0] : !firrtl.rwprobe<bundle<a: uint<1>>>
+    firrtl.ref.define %rw_narrow, %1 : !firrtl.rwprobe<uint<1>>
+  }
+}
+
+// -----
+// Check ref.sub handling through layers, combining with import/export ABI (if aggs preserved?).
+
+// CHECK-LABEL: circuit "RefSubLayers"
+firrtl.circuit "RefSubLayers" {
+  // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@RefSubLayers::@[[TOP_SYM:[^,]+]], @Mid::@[[MID_SYM:[^,]+]], @Leaf::@[[LEAF_SYM:.+]]]
+  // CHECK-NEXT: sv.macro.decl @ref_RefSubLayers_RefSubLayers_rw
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_RefSubLayers_RefSubLayers_rw "{{0}}.`ref_ExtRef_ExtRef_out.b[1].a"
+  // CHECK-SAME ([@[[XMRPATH]]])
+   firrtl.extmodule @ExtRef(out out: !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<2>, b: uint<1>>, 2>>>)
+  firrtl.module @RefSubLayers(out %rw : !firrtl.probe<uint<2>>) {
+    %ref = firrtl.instance m @Mid(out rw: !firrtl.probe<bundle<a: uint<2>, b: uint<1>>>)
+    %sub = firrtl.ref.sub %ref[0] : !firrtl.probe<bundle<a: uint<2>, b: uint<1>>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<uint<2>>
+  }
+  firrtl.module private @Mid(out %rw : !firrtl.probe<bundle<a: uint<2>, b: uint<1>>>) {
+    %ref = firrtl.instance l @Leaf(out rw: !firrtl.probe<vector<bundle<a: uint<2>, b: uint<1>>, 2>>)
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<vector<bundle<a: uint<2>, b: uint<1>>, 2>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<bundle<a: uint<2>, b: uint<1>>>
+  }
+
+  firrtl.module private @Leaf(out %rw : !firrtl.probe<vector<bundle<a: uint<2>, b: uint<1>>, 2>>) {
+    %ref = firrtl.instance ext @ExtRef(out out: !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<2>, b: uint<1>>, 2>>>)
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<2>, b: uint<1>>, 2>>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<vector<bundle<a: uint<2>, b: uint<1>>, 2>>
+  }
+}


### PR DESCRIPTION
Implementation:

Extend the refSend list node to support recording indexing
along the resolution path, in addition to its current sole
use of tracking symbols of instances along the path.

When resolving, gather these indexing operations and generate
the appropriate string suffixes for each to narrow the origin
reference accordingly.

MemTap now use this for creating the right indexing suffix (under test).

Notes:

This is not the more general support needed once we support
input probes (and more complicated flow of probes through
the design) but build on existing requirements/assumptions
here and throughout compiler to get this working for the
more straightforward cases.

Known limitations:

Indexing through an input probe will cause resolution error.
  * Given input probes are rejected during parsing, and our avoidance
    of input probes in wiring, this should not be user-reachable.
  * Longer-term input probes can be rewritten to not exist,
    and "de-squiggling" the dataflow generally so that LowerXMR
    and other passes don't have to accomodate input probes.

Forcing part of an aggregate (continues to) cause entire aggregate
to be preserved.

Expects names/sizes of aggregates to be preserved through the end of the pipeline,
as they're hardcoded into the XMR strings + ABI contents.
This is fragile and should be replaced with placeholders so they can be substituted
after ExportVerilog.  Plan is to use per-field HW inner symbols for that portion,
once they're supported in HW and onward.