### PR TITLE
[FIRRTL][LowerXMR] Include forceable + force/release ops in zero-width handling.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -224,14 +224,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             return success();
           })
           .Case<Forceable>([&](Forceable op) {
-            if (!op.isForceable())
+            if (!op.isForceable() || op.getDataRef().use_empty() ||
+                isZeroWidth(op.getDataType()))
               return success();
 
-            // Record this so can demote this to non-forceable.
-            forceableDecls.push_back(op);
-
-            if (op.getDataRef().use_empty() || isZeroWidth(op.getDataType()))
-              return success();
             addReachingSendsEntry(op.getDataRef(), getInnerRefTo(op));
             return success();
           })
@@ -307,7 +303,6 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     dataFlowClasses = nullptr;
     refPortsToRemoveMap.clear();
     opsToRemove.clear();
-    forceableDecls.clear();
     xmrPathSuffix.clear();
     circuitNamespace = nullptr;
     pathCache.clear();
@@ -676,8 +671,6 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     // the def is erased.
     for (Operation *op : llvm::reverse(opsToRemove))
       op->erase();
-    for (Forceable f : forceableDecls)
-      firrtl::detail::replaceWithNewForceability(f, false);
     for (auto iter : refPortsToRemoveMap)
       if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());
@@ -792,9 +785,6 @@ private:
 
   /// RefResolve, RefSend, and Connects involving them that will be removed.
   SmallVector<Operation *> opsToRemove;
-
-  /// Forceable declarations, these should all be demoted after dropping uses.
-  SmallVector<Forceable> forceableDecls;
 
   /// Record the internal path to an external module or a memory.
   DenseMap<size_t, SmallString<128>> xmrPathSuffix;

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -434,7 +434,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     return TypeSwitch<Operation *, LogicalResult>(op)
         .Case<RefForceOp, RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp>(
             [&](auto op) {
-              // LowerXMR removes zero-width refs and their users, so drop these too.
+              // Drop if zero-width target.
               if (isZeroWidth(op.getDest().getType().getType())) {
                 op.erase();
                 return success();

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -650,7 +650,7 @@ firrtl.circuit "ReadForceable" {
     %x = firrtl.ref.resolve %w_ref : !firrtl.rwprobe<uint<2>>
     // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
-    // CHECK:      %w = firrtl.wire sym @[[wSym]] : !firrtl.uint<2>
+    // CHECK:      %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
     // CHECK:      firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
@@ -669,7 +669,7 @@ firrtl.circuit "RefCast" {
     %w_ro = firrtl.ref.cast %w_ref : (!firrtl.rwprobe<uint<2>>) -> !firrtl.probe<uint<2>>
     %x = firrtl.ref.resolve %w_ro : !firrtl.probe<uint<2>>
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
-    // CHECK-NEXT: %w = firrtl.wire sym @[[wSym]] : !firrtl.uint<2>
+    // CHECK-NEXT: %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
     // CHECK-NEXT: firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
@@ -683,7 +683,7 @@ firrtl.circuit "ForceRelease" {
   // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@ForceRelease::@[[INST_SYM:.+]], @RefMe::@[[TARGET_SYM:.+]]]
   // CHECK: firrtl.module private @RefMe() {
   firrtl.module private @RefMe(out %p: !firrtl.rwprobe<uint<4>>) {
-    // CHECK-NEXT: %x = firrtl.wire sym @[[TARGET_SYM]] : !firrtl.uint<4>
+    // CHECK-NEXT: %x, %x_ref = firrtl.wire sym @[[TARGET_SYM]] forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     %x, %x_ref = firrtl.wire forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     // CHECK-NEXT: }
     firrtl.ref.define %p, %x_ref : !firrtl.rwprobe<uint<4>>
@@ -924,11 +924,14 @@ firrtl.circuit "RefSubLayers" {
 
 // -----
 // Check dropping force/etc. ops that target zero-width references.
+// Ensure no symbol added, so can be dropped in LowerToHW.
 
 // CHECK-LABEL: circuit "DropForceOp"
-// CHECK-NOT: force
 firrtl.circuit "DropForceOp" {
   firrtl.module @DropForceOp() {
+    // CHECK: firrtl.wire
+    // CHECK-NOT: sym
+    // CHECK-NEXT: }
     %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %x, %x_ref = firrtl.wire forceable : !firrtl.uint<0>, !firrtl.rwprobe<uint<0>>

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -921,3 +921,42 @@ firrtl.circuit "RefSubLayers" {
     firrtl.ref.define %rw, %sub : !firrtl.probe<vector<bundle<a: uint<2>, b: uint<1>>, 2>>
   }
 }
+
+// -----
+// Check dropping force/etc. ops that target zero-width references.
+
+// CHECK-LABEL: circuit "DropForceOp"
+// CHECK-NOT: force
+firrtl.circuit "DropForceOp" {
+  firrtl.module @DropForceOp() {
+    %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %x, %x_ref = firrtl.wire forceable : !firrtl.uint<0>, !firrtl.rwprobe<uint<0>>
+    firrtl.ref.force_initial %c1_ui1, %x_ref, %c0_ui0 : !firrtl.uint<1>, !firrtl.uint<0>
+  }
+}
+
+// -----
+// Check dropping zero-width and interaction with ABI/across layers.
+
+// CHECK-LABEL: circuit "RefSubZeroWidth"
+firrtl.circuit "RefSubZeroWidth" {
+   // CHECK-NOT: probe<
+   firrtl.extmodule @ExtRef(out out: !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<0>, b: uint<1>>, 2>>>)
+  firrtl.module @RefSubZeroWidth(out %rw : !firrtl.probe<uint<0>>) {
+    %ref = firrtl.instance m @Mid(out rw: !firrtl.probe<bundle<a: uint<0>, b: uint<1>>>)
+    %sub = firrtl.ref.sub %ref[0] : !firrtl.probe<bundle<a: uint<0>, b: uint<1>>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<uint<0>>
+  }
+  firrtl.module private @Mid(out %rw : !firrtl.probe<bundle<a: uint<0>, b: uint<1>>>) {
+    %ref = firrtl.instance l @Leaf(out rw: !firrtl.probe<vector<bundle<a: uint<0>, b: uint<1>>, 2>>)
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<vector<bundle<a: uint<0>, b: uint<1>>, 2>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<bundle<a: uint<0>, b: uint<1>>>
+  }
+
+  firrtl.module private @Leaf(out %rw : !firrtl.probe<vector<bundle<a: uint<0>, b: uint<1>>, 2>>) {
+    %ref = firrtl.instance ext @ExtRef(out out: !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<0>, b: uint<1>>, 2>>>)
+    %sub = firrtl.ref.sub %ref[1] : !firrtl.probe<bundle<a: uint<1>, b: vector<bundle<a: uint<0>, b: uint<1>>, 2>>>
+    firrtl.ref.define %rw, %sub : !firrtl.probe<vector<bundle<a: uint<0>, b: uint<1>>, 2>>
+  }
+}

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -650,7 +650,7 @@ firrtl.circuit "ReadForceable" {
     %x = firrtl.ref.resolve %w_ref : !firrtl.rwprobe<uint<2>>
     // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
-    // CHECK:      %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    // CHECK:      %w = firrtl.wire sym @[[wSym]] : !firrtl.uint<2>
     // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
     // CHECK:      firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
@@ -669,7 +669,7 @@ firrtl.circuit "RefCast" {
     %w_ro = firrtl.ref.cast %w_ref : (!firrtl.rwprobe<uint<2>>) -> !firrtl.probe<uint<2>>
     %x = firrtl.ref.resolve %w_ro : !firrtl.probe<uint<2>>
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
-    // CHECK-NEXT: %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    // CHECK-NEXT: %w = firrtl.wire sym @[[wSym]] : !firrtl.uint<2>
     // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
     // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
     // CHECK-NEXT: firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
@@ -683,7 +683,7 @@ firrtl.circuit "ForceRelease" {
   // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@ForceRelease::@[[INST_SYM:.+]], @RefMe::@[[TARGET_SYM:.+]]]
   // CHECK: firrtl.module private @RefMe() {
   firrtl.module private @RefMe(out %p: !firrtl.rwprobe<uint<4>>) {
-    // CHECK-NEXT: %x, %x_ref = firrtl.wire sym @[[TARGET_SYM]] forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
+    // CHECK-NEXT: %x = firrtl.wire sym @[[TARGET_SYM]] : !firrtl.uint<4>
     %x, %x_ref = firrtl.wire forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     // CHECK-NEXT: }
     firrtl.ref.define %p, %x_ref : !firrtl.rwprobe<uint<4>>


### PR DESCRIPTION
Extend zero-width-ref pruning to handle Forceable  + force/release ops,
and test nothing breaks if ref.sub to a zero-width value.

Fixes #5552 .