### PR TITLE
[FIRParser] Allocate subParser on heap

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2582,8 +2582,8 @@ ParseResult FIRStmtParser::parseWhen(unsigned whenIndent) {
   // This is a function to parse a suite body.
   auto parseSuite = [&](Block &blockToInsertInto) -> ParseResult {
     // Declarations within the suite are scoped to within the suite.
-    auto suiteScope = std::make_unique<FIRModuleContext::ContextScope> (moduleContext,
-                                              &blockToInsertInto);
+    auto suiteScope = std::make_unique<FIRModuleContext::ContextScope>(
+        moduleContext, &blockToInsertInto);
 
     // After parsing the when region, we can release any new entries in
     // unbundledValues since the symbol table entries that refer to them will be


### PR DESCRIPTION
This avoids stack overflow when parsing deeply nested whens. This PR creates a bump allocator in the module context and allocate subparser with it. 