### PR TITLE
[FIRRTL] -emit-asserts-as-sva changes all asserts

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4194,7 +4194,7 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
 
   auto emit = [&]() {
     // Handle the purely procedural flavor of the operation.
-    if (!isConcurrent) {
+    if (!isConcurrent && !circuitState.emitChiselAssertsAsSVA) {
       auto deferImmediate = circt::sv::DeferAssertAttr::get(
           builder.getContext(), circt::sv::DeferAssert::Immediate);
       addToAlwaysBlock(clock, [&]() {

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -15,5 +15,18 @@ firrtl.circuit "ifElseFatalToSVA" {
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
     // CHECK-NEXT: }
-}
+  }
+
+  // Test that an immediate assertion is always converted to a concurrent
+  // assertion if the "emit-chisel-asserts-as-sva" option is enabled.
+  //
+  // CHECK-LABEL: hw.module @immediateToConcurrent
+  firrtl.module @immediateToConcurrent(
+    in %clock: !firrtl.clock,
+    in %cond: !firrtl.uint<1>,
+    in %enable: !firrtl.uint<1>
+  ) {
+    firrtl.assert %clock, %cond, %enable, "assert1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: sv.assert.concurrent
+  }
 }


### PR DESCRIPTION
Modify the behavior of the firtool/lower-to-hw flag "emit-asserts-as-svas" and "emit-chisel-asserts-as-sva", respectively, to lower all Chisel immediate assertions to concurrent assertions and an "`ifdef"-guarded assumption.  This may cause problems for Verilator as it has been known to segfault if there are too many concurrent assertions.