### PR TITLE
[PipelineToHW] Don't CE pipeline regs in non-stallable pipelines

### DIFF
--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -11,10 +11,10 @@
 // Test 2: Clock-gate implementation
 
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
-// RUN:     -o %t.mlir > %t.sv
+// RUN:     -o %t.mlir > %t_cg.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \
-// RUN:     --pythonModule=simple --pythonFolder="%S,%S/.." %t.sv 2>&1 | FileCheck %s
+// RUN:     --pythonModule=simple --pythonFolder="%S,%S/.." %t_cg.sv 2>&1 | FileCheck %s
 
 
 // CHECK: ** TEST

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -7,8 +7,8 @@
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -18,10 +18,10 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @p0_s2_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_s2_reg0 %[[VAL_5]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
 // CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_s2_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = seq.compreg.ce sym @p0_s3_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_12]] : i32
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_s3_reg0 %[[VAL_10]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
 // CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_s3_valid %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
 // CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
@@ -48,8 +48,8 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
@@ -69,24 +69,24 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_s1_reg1 %[[VAL_6]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_s1_reg1 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_13:.*]] = hw.constant false
 // CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.compreg.ce sym @p1_s0_reg0 %[[VAL_16]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_18:.*]] = seq.compreg.ce sym @p1_s0_reg1 %[[VAL_15]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_s0_reg0 %[[VAL_16]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_s0_reg1 %[[VAL_15]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
 // CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce sym @p1_s1_reg0 %[[VAL_21]], %[[VAL_3]], %[[VAL_20]] : i32
-// CHECK:           %[[VAL_23:.*]] = seq.compreg.ce sym @p1_s1_reg1 %[[VAL_17]], %[[VAL_3]], %[[VAL_20]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_s1_reg0 %[[VAL_21]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_s1_reg1 %[[VAL_17]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_24:.*]] = hw.constant false
 // CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_s1_valid %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
@@ -122,11 +122,11 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]], %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
 // CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
@@ -157,7 +157,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
@@ -165,7 +165,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
 // CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @p0_s1_reg0 %[[VAL_15]], %[[VAL_2]], %[[VAL_11]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_15]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_17:.*]] = hw.constant false
 // CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -43,7 +43,7 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
 // CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce sym @s2_reg0 %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @s2_reg0 %[[VAL_0]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
 // CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s2_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
@@ -51,7 +51,7 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg.ce sym @s3_reg0 %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @s3_reg0 %[[VAL_0]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
 // CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s3_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
@@ -91,8 +91,8 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
@@ -131,8 +131,8 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
@@ -141,8 +141,8 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s1_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
@@ -165,8 +165,8 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
@@ -175,8 +175,8 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple_p1_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s1_reg1 %[[VAL_0]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
@@ -231,7 +231,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_6]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
@@ -240,7 +240,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_5]], %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
 // CHECK:           %[[VAL_8:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_8]] : i32, i1
@@ -285,7 +285,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           hw.output %[[VAL_9]], %[[VAL_11]] : i32, i1
@@ -299,7 +299,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg.ce sym @s1_reg0 %[[VAL_8]], %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @s1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           hw.output %[[VAL_9]], %[[VAL_11]] : i32, i1
@@ -393,7 +393,7 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 
 // CHECK-LABEL:  hw.module @testNaming_MyPipeline_s0(%in0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out0: i1, valid: i1) {
 // CHECK-NEXT:    %0 = comb.add %in0, %in0 {sv.namehint = "myAdd"} : i1
-// CHECK-NEXT:    %s0_myAdd_reg = seq.compreg.ce sym @s0_myAdd_reg %0, %clk, %enable : i1
+// CHECK-NEXT:    %s0_myAdd_reg = seq.compreg sym @s0_myAdd_reg %0, %clk : i1
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    %s0_valid = seq.compreg sym @s0_valid %enable, %clk, %rst, %false  : i1
 // CHECK-NEXT:    hw.output %s0_myAdd_reg, %s0_valid : i1, i1


### PR DESCRIPTION
Will emit `CompRegOp` instead of `CompRegClockEnabledOp`s for pipelines without stall signals.

In cases where a register has hierarchical clock gates specified (as in `test_clockgates.mlir`) but the `"clock-gate-regs"` option for `lower-pipeline-to-hw` is **NOT** set, then these hierarchical clock gates will be ignored.