### PR TITLE
[HW][SV] Move string type from SV to HW

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -76,6 +76,13 @@ def HWAggregateType : DialectType<HWDialect,
 // Type Definitions
 //===----------------------------------------------------------------------===//
 
+def HWStringType : TypeDef<HWDialect, "String"> {
+  let summary = "String type";
+  let description = "Defines a string type for the hw-centric dialects";
+
+  let mnemonic = "string";
+}
+
 /// Points to a name within a module.
 def HWInnerRefAttr : Attr<
   CPred<"$_self.isa<::circt::hw::InnerRefAttr>()">,

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/SV/SVTypes.td"
 
 def HWValueOrInOutType : AnyTypeOf<[HWValueType, InOutType]>;
@@ -196,7 +197,7 @@ def ConstantStrOp : SVOp<"constantStr", [Pure]> {
     }];
 
   let arguments = (ins StrAttr:$str);
-  let results = (outs StringType:$result);
+  let results = (outs HWStringType:$result);
   let assemblyFormat = " $str attr-dict";
 }
 

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -20,13 +20,6 @@ include "circt/Dialect/SV/SVDialect.td"
 // includable for other dialects, without polluting their output with SV types.
 class SVType<string name> : TypeDef<SVDialect, name> { }
 
-def StringType : SVType<"String"> {
-  let summary = "SystemVerilog string type";
-  let description = "Defines the string type in verilog";
-
-  let mnemonic = "string";
-}
-
 //===----------------------------------------------------------------------===//
 // InOut type and related helpers.
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1691,12 +1691,12 @@ hw.module @intrinsic(%clk: i1) -> (io1: i1, io2: i1, io3: i1, io4: i5) {
   // CHECK: assign io1 = clk === 1'bx
 
   %1 = sv.constantStr "foo"
-  %2 = sv.system "test$plusargs"(%1) : (!sv.string) -> i1
+  %2 = sv.system "test$plusargs"(%1) : (!hw.string) -> i1
   // CHECK: assign io2 = $test$plusargs("foo")
 
   %_pargs = sv.wire  : !hw.inout<i5>
   %3 = sv.read_inout %_pargs : !hw.inout<i5>
-  %4 = sv.system "value$plusargs"(%1, %_pargs) : (!sv.string, !hw.inout<i5>) -> i1
+  %4 = sv.system "value$plusargs"(%1, %_pargs) : (!hw.string, !hw.inout<i5>) -> i1
   // CHECK: assign io3 = $value$plusargs("foo", [[tmp]])
   // CHECK: assign io4 = [[tmp]]
 


### PR DESCRIPTION
Closes #5576.

Moving this since in the (near) future the verif dialect and HW module parameterization will be using string types.