### PR TITLE
[FIRRTL][LowerTypes] Don't silently drop symbols on type-lowered mem's.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -225,6 +225,7 @@ static SmallVector<Operation *> getSAWritePath(Operation *op) {
   return retval;
 }
 
+/// Clone memory for the specified field.  Returns null op on error.
 static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
                                  FlatBundleFieldEntry field) {
   SmallVector<Type, 8> ports;
@@ -246,8 +247,10 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
       op.getNameKind(), op.getAnnotations().getValue(),
       op.getPortAnnotations().getValue(), op.getInnerSymAttr());
 
-  assert(!op.getInnerSym() &&
-         "should already have produced error if sym present");
+  if (op.getInnerSym()) {
+    op.emitError("cannot split memory with symbol present");
+    return {};
+  }
 
   SmallVector<Attribute> newAnnotations;
   for (size_t portIdx = 0, e = newMem.getNumResults(); portIdx < e; ++portIdx) {
@@ -879,8 +882,15 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
   // Do not overwrite the pass flag!
 
   // Memory for each field
-  for (const auto &field : fields)
-    newMemories.push_back(cloneMemWithNewType(builder, op, field));
+  for (const auto &field : fields) {
+    auto newMemForField = cloneMemWithNewType(builder, op, field);
+    if (!newMemForField) {
+      op.emitError("failed cloning memory for field");
+      encounteredError = true;
+      return false;
+    }
+    newMemories.push_back(newMemForField);
+  }
   // Hook up the new memories to the wires the old memory was replaced with.
   for (size_t index = 0, rend = op.getNumResults(); index < rend; ++index) {
     auto result = oldPorts[index].getResult();

--- a/test/Dialect/FIRRTL/lower-types-issue-5592.mlir
+++ b/test/Dialect/FIRRTL/lower-types-issue-5592.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt %s --verify-diagnostics -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types{preserve-aggregate=none}))'
+
+// Don't silently drop symbols from memories.
+
+// https://github.com/llvm/circt/issues/5592
+firrtl.circuit "Issue5592" {
+  firrtl.module @Issue5592(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.vector<uint<8>, 4>, in %wMask: !firrtl.vector<uint<1>, 4>, in %wData: !firrtl.vector<uint<8>, 4>) attributes {convention = #firrtl<convention scalarized>} {
+    // expected-error @below {{has a symbol, but no symbols may exist on aggregates passed through LowerTypes}}
+    %memory_r, %memory_w = firrtl.mem sym @X interesting_name Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %0 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %1 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %2 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %3 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
+    %5 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
+    %6 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
+    %7 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
+    %8 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
+    firrtl.strictconnect %8, %clock : !firrtl.clock
+    firrtl.strictconnect %7, %rEn : !firrtl.uint<1>
+    firrtl.strictconnect %6, %rAddr : !firrtl.uint<4>
+    firrtl.strictconnect %rData, %5 : !firrtl.vector<uint<8>, 4>
+    firrtl.strictconnect %4, %clock : !firrtl.clock
+    firrtl.strictconnect %3, %rEn : !firrtl.uint<1>
+    firrtl.strictconnect %2, %rAddr : !firrtl.uint<4>
+    firrtl.strictconnect %1, %wMask : !firrtl.vector<uint<1>, 4>
+    firrtl.strictconnect %0, %wData : !firrtl.vector<uint<8>, 4>
+  }
+  sv.verbatim "Testing {{0}}" {symbols = [#hw.innerNameRef<@Issue5592::@X>]}
+}

--- a/test/Dialect/FIRRTL/lower-types-issue-5592.mlir
+++ b/test/Dialect/FIRRTL/lower-types-issue-5592.mlir
@@ -7,24 +7,6 @@ firrtl.circuit "Issue5592" {
   firrtl.module @Issue5592(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.vector<uint<8>, 4>, in %wMask: !firrtl.vector<uint<1>, 4>, in %wData: !firrtl.vector<uint<8>, 4>) attributes {convention = #firrtl<convention scalarized>} {
     // expected-error @below {{has a symbol, but no symbols may exist on aggregates passed through LowerTypes}}
     %memory_r, %memory_w = firrtl.mem sym @X interesting_name Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %0 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %1 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %2 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %3 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
-    %5 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
-    %6 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
-    %7 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
-    %8 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>
-    firrtl.strictconnect %8, %clock : !firrtl.clock
-    firrtl.strictconnect %7, %rEn : !firrtl.uint<1>
-    firrtl.strictconnect %6, %rAddr : !firrtl.uint<4>
-    firrtl.strictconnect %rData, %5 : !firrtl.vector<uint<8>, 4>
-    firrtl.strictconnect %4, %clock : !firrtl.clock
-    firrtl.strictconnect %3, %rEn : !firrtl.uint<1>
-    firrtl.strictconnect %2, %rAddr : !firrtl.uint<4>
-    firrtl.strictconnect %1, %wMask : !firrtl.vector<uint<1>, 4>
-    firrtl.strictconnect %0, %wData : !firrtl.vector<uint<8>, 4>
   }
   sv.verbatim "Testing {{0}}" {symbols = [#hw.innerNameRef<@Issue5592::@X>]}
 }


### PR DESCRIPTION
Fixes #5592.