### PR TITLE
[SCFToCalyx] Use sequential memories

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -84,11 +84,13 @@ void buildAssignmentsForRegisterWrite(OpBuilder &builder,
 // A structure representing a set of ports which act as a memory interface for
 // external memories.
 struct MemoryPortsImpl {
-  Value readData;
-  Value done;
-  Value writeData;
+  std::optional<Value> readData;
+  std::optional<Value> readEn;
+  std::optional<Value> readDone;
+  std::optional<Value> writeData;
+  std::optional<Value> writeEn;
+  std::optional<Value> writeDone;
   SmallVector<Value> addrPorts;
-  Value writeEn;
 };
 
 // Represents the interface of memory in Calyx. The various lowering passes
@@ -98,16 +100,25 @@ struct MemoryInterface {
   MemoryInterface();
   explicit MemoryInterface(const MemoryPortsImpl &ports);
   explicit MemoryInterface(calyx::MemoryOp memOp);
+  explicit MemoryInterface(calyx::SeqMemoryOp memOp);
 
   // Getter methods for each memory interface port.
   Value readData();
-  Value done();
+  Value readEn();
+  Value readDone();
   Value writeData();
   Value writeEn();
+  Value writeDone();
+  std::optional<Value> readDataOpt();
+  std::optional<Value> readEnOpt();
+  std::optional<Value> readDoneOpt();
+  std::optional<Value> writeDataOpt();
+  std::optional<Value> writeEnOpt();
+  std::optional<Value> writeDoneOpt();
   ValueRange addrPorts();
 
 private:
-  std::variant<calyx::MemoryOp, MemoryPortsImpl> impl;
+  std::variant<calyx::MemoryOp, calyx::SeqMemoryOp, MemoryPortsImpl> impl;
 };
 
 // A common interface for loop operations that need to be lowered to Calyx.

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -475,7 +475,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   rewriter.create<calyx::AssignOp>(
       storeOp.getLoc(), memoryInterface.writeEn(),
       createConstant(storeOp.getLoc(), rewriter, getComponent(), 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.writeDone());
+  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(),
+                                      memoryInterface.writeDone());
 
   getState<ComponentLoweringState>().registerNonPipelineOperations(storeOp,
                                                                    group);

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -408,20 +408,41 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Value memref = loadOp.getMemref();
   auto memoryInterface =
       getState<ComponentLoweringState>().getMemoryInterface(memref);
-  auto group = createGroupForOp<calyx::GroupOp>(rewriter, loadOp);
-  assignAddressPorts(rewriter, loadOp.getLoc(), group, memoryInterface,
-                     loadOp.getIndices());
+  if (calyx::noStoresToMemory(memref) && calyx::singleLoadFromMemory(memref)) {
+    // Single load from memory; we do not need to write the
+    // output to a register. This is essentially a "combinational read" under
+    // current Calyx semantics with memory, and thus can be done in a
+    // combinational group. Note that if any stores are done to this memory,
+    // we require that the load and store be in separate non-combinational
+    // groups to avoid reading and writing to the same memory in the same group.
+    auto combGroup = createGroupForOp<calyx::CombGroupOp>(rewriter, loadOp);
+    assignAddressPorts(rewriter, loadOp.getLoc(), combGroup, memoryInterface,
+                       loadOp.getIndices());
 
-  rewriter.setInsertionPointToEnd(group.getBodyBlock());
-
-  Value res;
-  if (memoryInterface.readEnOpt().has_value()) {
-    auto oneI1 = 
-      calyx::createConstant(loadOp.getLoc(), rewriter, getComponent(), 1, 1);
-    rewriter.create<calyx::AssignOp>(loadOp.getLoc(), memoryInterface.readEn(), oneI1);
-    rewriter.create<calyx::GroupDoneOp>(loadOp.getLoc(), memoryInterface.readDone());
-    res = memoryInterface.readData();
+    // We refrain from replacing the loadOp result with
+    // memoryInterface.readData, since multiple loadOp's need to be converted
+    // to a single memory's ReadData. If this replacement is done now, we lose
+    // the link between which SSA memref::LoadOp values map to which groups for
+    // loading a value from the Calyx memory. At this point of lowering, we
+    // keep the memref::LoadOp SSA value, and do value replacement _after_
+    // control has been generated (see LateSSAReplacement). This is *vital* for
+    // things such as InlineCombGroups to be able to properly track which
+    // memory assignment groups belong to which accesses.
+    getState<ComponentLoweringState>().registerEvaluatingGroup(
+        loadOp.getResult(), combGroup);
   } else {
+    auto group = createGroupForOp<calyx::GroupOp>(rewriter, loadOp);
+    assignAddressPorts(rewriter, loadOp.getLoc(), group, memoryInterface,
+                       loadOp.getIndices());
+
+    // Multiple loads from the same memory; In this case, we _may_ have a
+    // structural hazard in the design we generate. To get around this, we
+    // conservatively place a register in front of each load operation, and
+    // replace all uses of the loaded value with the register output. Proper
+    // handling of this requires the combinational group inliner/scheduler to
+    // be aware of when a combinational expression references multiple loaded
+    // values from the same memory, and then schedule assignments to temporary
+    // registers to get around the structural hazard.
     auto reg = createRegister(
         loadOp.getLoc(), rewriter, getComponent(),
         loadOp.getMemRefType().getElementTypeBitWidth(),
@@ -432,12 +453,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     loadOp.getResult().replaceAllUsesWith(reg.getOut());
     getState<ComponentLoweringState>().addBlockScheduleable(loadOp->getBlock(),
                                                             group);
-    res = reg.getOut();
   }
-
-  loadOp.getResult().replaceAllUsesWith(memoryInterface.readData());
-  getState<ComponentLoweringState>().addBlockScheduleable(loadOp->getBlock(),
-                                                          group);
   return success();
 }
 

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -408,41 +408,20 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Value memref = loadOp.getMemref();
   auto memoryInterface =
       getState<ComponentLoweringState>().getMemoryInterface(memref);
-  if (calyx::noStoresToMemory(memref) && calyx::singleLoadFromMemory(memref)) {
-    // Single load from memory; we do not need to write the
-    // output to a register. This is essentially a "combinational read" under
-    // current Calyx semantics with memory, and thus can be done in a
-    // combinational group. Note that if any stores are done to this memory,
-    // we require that the load and store be in separate non-combinational
-    // groups to avoid reading and writing to the same memory in the same group.
-    auto combGroup = createGroupForOp<calyx::CombGroupOp>(rewriter, loadOp);
-    assignAddressPorts(rewriter, loadOp.getLoc(), combGroup, memoryInterface,
-                       loadOp.getIndices());
+  auto group = createGroupForOp<calyx::GroupOp>(rewriter, loadOp);
+  assignAddressPorts(rewriter, loadOp.getLoc(), group, memoryInterface,
+                     loadOp.getIndices());
 
-    // We refrain from replacing the loadOp result with
-    // memoryInterface.readData, since multiple loadOp's need to be converted
-    // to a single memory's ReadData. If this replacement is done now, we lose
-    // the link between which SSA memref::LoadOp values map to which groups for
-    // loading a value from the Calyx memory. At this point of lowering, we
-    // keep the memref::LoadOp SSA value, and do value replacement _after_
-    // control has been generated (see LateSSAReplacement). This is *vital* for
-    // things such as InlineCombGroups to be able to properly track which
-    // memory assignment groups belong to which accesses.
-    getState<ComponentLoweringState>().registerEvaluatingGroup(
-        loadOp.getResult(), combGroup);
+  rewriter.setInsertionPointToEnd(group.getBodyBlock());
+
+  Value res;
+  if (memoryInterface.readEnOpt().has_value()) {
+    auto oneI1 = 
+      calyx::createConstant(loadOp.getLoc(), rewriter, getComponent(), 1, 1);
+    rewriter.create<calyx::AssignOp>(loadOp.getLoc(), memoryInterface.readEn(), oneI1);
+    rewriter.create<calyx::GroupDoneOp>(loadOp.getLoc(), memoryInterface.readDone());
+    res = memoryInterface.readData();
   } else {
-    auto group = createGroupForOp<calyx::GroupOp>(rewriter, loadOp);
-    assignAddressPorts(rewriter, loadOp.getLoc(), group, memoryInterface,
-                       loadOp.getIndices());
-
-    // Multiple loads from the same memory; In this case, we _may_ have a
-    // structural hazard in the design we generate. To get around this, we
-    // conservatively place a register in front of each load operation, and
-    // replace all uses of the loaded value with the register output. Proper
-    // handling of this requires the combinational group inliner/scheduler to
-    // be aware of when a combinational expression references multiple loaded
-    // values from the same memory, and then schedule assignments to temporary
-    // registers to get around the structural hazard.
     auto reg = createRegister(
         loadOp.getLoc(), rewriter, getComponent(),
         loadOp.getMemRefType().getElementTypeBitWidth(),
@@ -453,7 +432,12 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     loadOp.getResult().replaceAllUsesWith(reg.getOut());
     getState<ComponentLoweringState>().addBlockScheduleable(loadOp->getBlock(),
                                                             group);
+    res = reg.getOut();
   }
+
+  loadOp.getResult().replaceAllUsesWith(memoryInterface.readData());
+  getState<ComponentLoweringState>().addBlockScheduleable(loadOp->getBlock(),
+                                                          group);
   return success();
 }
 
@@ -475,7 +459,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   rewriter.create<calyx::AssignOp>(
       storeOp.getLoc(), memoryInterface.writeEn(),
       createConstant(storeOp.getLoc(), rewriter, getComponent(), 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.done());
+  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.writeDone());
 
   getState<ComponentLoweringState>().registerNonPipelineOperations(storeOp,
                                                                    group);
@@ -827,7 +811,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
       unsigned outPortsIt = extMemPortIndices.getSecond().second +
                             compOp.getInputPortInfo().size();
       extMemPorts.readData = compOp.getArgument(inPortsIt++);
-      extMemPorts.done = compOp.getArgument(inPortsIt);
+      extMemPorts.writeDone = compOp.getArgument(inPortsIt);
       extMemPorts.writeData = compOp.getArgument(outPortsIt++);
       unsigned nAddresses = extMemPortIndices.getFirst()
                                 .getType()

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -369,7 +369,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   rewriter.create<calyx::AssignOp>(
       storeOp.getLoc(), memoryInterface.writeEn(),
       createConstant(storeOp.getLoc(), rewriter, getComponent(), 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.writeDone());
+  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(),
+                                      memoryInterface.writeDone());
 
   return success();
 }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -382,7 +382,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   rewriter.create<calyx::AssignOp>(
       storeOp.getLoc(), memoryInterface.writeEn(),
       createConstant(storeOp.getLoc(), rewriter, getComponent(), 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.done());
+  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryInterface.writeDone());
 
   return success();
 }
@@ -846,7 +846,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
       unsigned outPortsIt = extMemPortIndices.getSecond().second +
                             compOp.getInputPortInfo().size();
       extMemPorts.readData = compOp.getArgument(inPortsIt++);
-      extMemPorts.done = compOp.getArgument(inPortsIt);
+      extMemPorts.writeDone = compOp.getArgument(inPortsIt);
       extMemPorts.writeData = compOp.getArgument(outPortsIt++);
       unsigned nAddresses = extMemPortIndices.getFirst()
                                 .getType()

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -339,8 +339,6 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
         rewriter, group, getState<ComponentLoweringState>().getComponentOp(),
         reg, memoryInterface.readData());
     loadOp.getResult().replaceAllUsesWith(reg.getOut());
-    // getState<ComponentLoweringState>().addBlockScheduleable(loadOp->getBlock(),
-    //                                                         group);
     res = reg.getOut();
   }
 

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -126,13 +126,13 @@ private:
   /// Returns the library name for a given Operation Type.
   FailureOr<StringRef> getLibraryFor(Operation *op) {
     return TypeSwitch<Operation *, FailureOr<StringRef>>(op)
-        .Case<MemoryOp, SeqMemoryOp, RegisterOp, NotLibOp, AndLibOp, OrLibOp,
-              XorLibOp, AddLibOp, SubLibOp, GtLibOp, LtLibOp, EqLibOp, NeqLibOp,
-              GeLibOp, LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp,
-              WireLibOp>([&](auto op) -> FailureOr<StringRef> {
-          static constexpr std::string_view sCore = "core";
-          return {sCore};
-        })
+        .Case<MemoryOp, RegisterOp, NotLibOp, AndLibOp, OrLibOp, XorLibOp,
+              AddLibOp, SubLibOp, GtLibOp, LtLibOp, EqLibOp, NeqLibOp, GeLibOp,
+              LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp, WireLibOp>(
+            [&](auto op) -> FailureOr<StringRef> {
+              static constexpr std::string_view sCore = "core";
+              return {sCore};
+            })
         .Case<SgtLibOp, SltLibOp, SeqLibOp, SneqLibOp, SgeLibOp, SleLibOp,
               SrshLibOp, MultPipeLibOp, RemUPipeLibOp, RemSPipeLibOp,
               DivUPipeLibOp, DivSPipeLibOp>(
@@ -141,6 +141,10 @@ private:
                   "binary_operators";
               return {sBinaryOperators};
             })
+        .Case<SeqMemoryOp>([&](auto op) -> FailureOr<StringRef> {
+          static constexpr std::string_view sMemories = "memories";
+          return {sMemories};
+        })
         /*.Case<>([&](auto op) { library = "math"; })*/
         .Default([&](auto op) {
           auto diag = op->emitOpError() << "not supported for emission";

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -159,40 +159,118 @@ void buildAssignmentsForRegisterWrite(OpBuilder &builder,
 // MemoryInterface
 //===----------------------------------------------------------------------===//
 
-MemoryInterface::MemoryInterface() {}
+MemoryInterface::MemoryInterface() = default;
 MemoryInterface::MemoryInterface(const MemoryPortsImpl &ports) : impl(ports) {}
 MemoryInterface::MemoryInterface(calyx::MemoryOp memOp) : impl(memOp) {}
+MemoryInterface::MemoryInterface(calyx::SeqMemoryOp memOp) : impl(memOp) {}
 
 Value MemoryInterface::readData() {
+  auto readData = readDataOpt();
+  assert(readData.has_value() && "Memory does not have readData");
+  return readData.value();
+}
+
+Value MemoryInterface::readEn() {
+  auto readEn = readEnOpt();
+  assert(readEn.has_value() && "Memory does not have readEn");
+  return readEn.value();
+}
+
+Value MemoryInterface::readDone() {
+  auto readDone = readDoneOpt();
+  assert(readDone.has_value() && "Memory does not have readDone");
+  return readDone.value();
+}
+
+Value MemoryInterface::writeData() {
+  auto writeData = writeDataOpt();
+  assert(writeData.has_value() && "Memory does not have writeData");
+  return writeData.value();
+}
+
+Value MemoryInterface::writeEn() {
+  auto writeEn = writeEnOpt();
+  assert(writeEn.has_value() && "Memory does not have writeEn");
+  return writeEn.value();
+}
+
+Value MemoryInterface::writeDone() {
+  auto writeDone = writeDoneOpt();
+  assert(writeDone.has_value() && "Memory doe snot have writeDone");
+  return writeDone.value();
+}
+
+std::optional<Value> MemoryInterface::readDataOpt() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->readData();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
     return memOp->readData();
   }
   return std::get<MemoryPortsImpl>(impl).readData;
 }
 
-Value MemoryInterface::done() {
+std::optional<Value> MemoryInterface::readEnOpt() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
-    return memOp->done();
+    return std::nullopt;
   }
-  return std::get<MemoryPortsImpl>(impl).done;
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
+    return memOp->readEn();
+  }
+  return std::get<MemoryPortsImpl>(impl).readEn;
 }
 
-Value MemoryInterface::writeData() {
+std::optional<Value> MemoryInterface::readDoneOpt() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return std::nullopt;
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
+    return memOp->readDone();
+  }
+  return std::get<MemoryPortsImpl>(impl).readDone;
+}
+std::optional<Value> MemoryInterface::writeDataOpt() {
+  if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->writeData();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
     return memOp->writeData();
   }
   return std::get<MemoryPortsImpl>(impl).writeData;
 }
 
-Value MemoryInterface::writeEn() {
+std::optional<Value> MemoryInterface::writeEnOpt() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->writeEn();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
     return memOp->writeEn();
   }
   return std::get<MemoryPortsImpl>(impl).writeEn;
 }
 
+std::optional<Value> MemoryInterface::writeDoneOpt() {
+  if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->done();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
+    return memOp->readDone();
+  }
+  return std::get<MemoryPortsImpl>(impl).writeDone;
+}
+
 ValueRange MemoryInterface::addrPorts() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->addrPorts();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
     return memOp->addrPorts();
   }
   return std::get<MemoryPortsImpl>(impl).addrPorts;

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -260,7 +260,7 @@ std::optional<Value> MemoryInterface::writeDoneOpt() {
   }
 
   if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
-    return memOp->readDone();
+    return memOp->writeDone();
   }
   return std::get<MemoryPortsImpl>(impl).writeDone;
 }
@@ -630,10 +630,10 @@ void InlineCombGroups::recurseInlineCombGroups(
     //   been rewritten to their register outputs, see comment in
     //   LateSSAReplacement)
     if (src.isa<BlockArgument>() ||
-        isa<calyx::RegisterOp, calyx::MemoryOp, hw::ConstantOp,
-            mlir::arith::ConstantOp, calyx::MultPipeLibOp, calyx::DivUPipeLibOp,
-            calyx::DivSPipeLibOp, calyx::RemSPipeLibOp, calyx::RemUPipeLibOp,
-            mlir::scf::WhileOp>(src.getDefiningOp()))
+        isa<calyx::RegisterOp, calyx::MemoryOp, calyx::SeqMemoryOp,
+            hw::ConstantOp, mlir::arith::ConstantOp, calyx::MultPipeLibOp,
+            calyx::DivUPipeLibOp, calyx::DivSPipeLibOp, calyx::RemSPipeLibOp,
+            calyx::RemUPipeLibOp, mlir::scf::WhileOp>(src.getDefiningOp()))
       continue;
 
     auto srcCombGroup = dyn_cast<calyx::CombGroupOp>(

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -390,74 +390,74 @@ module {
 // Test control flow order of While Loops w/ other operations in same basic block.
 // The ordering of the loops & operatioins should be maintained
 
-// CHECK: module attributes {calyx.entrypoint = "main"} {
-// CHECK-LABEL:   calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:      %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:      %c38_i32 = hw.constant 38 : i32
-// CHECK-DAG:      %std_slice_2.in, %std_slice_2.out = calyx.std_slice @std_slice_2 : i32, i6
-// CHECK-DAG:      %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:      %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt @std_slt_0 : i32, i32, i1
-// CHECK-DAG:      %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[38] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires {
-// CHECK-NEXT:       calyx.group @assign_while_0_init_0 {
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_0 {
-// CHECK-NEXT:         calyx.assign %std_slice_2.in = %c0_i32 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_2.out : i6
-// CHECK-NEXT:         calyx.assign %load_0_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %load_0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %load_0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.comb_group @bb0_1 {
-// CHECK-NEXT:         calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_slt_0.right = %c38_i32 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_2 {
-// CHECK-NEXT:         calyx.assign %std_slice_1.in = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
-// CHECK-NEXT:         calyx.assign %mem_0.write_data = %load_0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %mem_0.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @assign_while_0_latch {
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.in = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_4 {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %c1_i32 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.assign %mem_0.write_data = %load_0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %mem_0.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control {
-// CHECK-NEXT:       calyx.seq {
-// CHECK-NEXT:         calyx.enable @bb0_0
-// CHECK-NEXT:         calyx.enable @assign_while_0_init_0
-// CHECK-NEXT:         calyx.while %std_slt_0.out with @bb0_1 {
-// CHECK-NEXT:           calyx.seq {
-// CHECK-NEXT:             calyx.enable @bb0_2
-// CHECK-NEXT:             calyx.enable @assign_while_0_latch
-// CHECK-NEXT:           }
-// CHECK-NEXT:         }
-// CHECK-NEXT:         calyx.enable @bb0_4
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant 38 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_2 : i32, i6
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]] = calyx.seq_mem @mem_0 <[38] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @assign_while_0_init_0 {
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_5]] : i32
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_5]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_27]] : i1
+// CHECK:             }
+// CHECK:             calyx.comb_group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_7]] : i32
+// CHECK:             }
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_11]] : i6
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_25]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @assign_while_0_latch {
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_6]] : i32
+// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_4 {
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_6]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_13]] : i6
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_25]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @assign_while_0_init_0
+// CHECK:               calyx.while %[[VAL_19]] with @bb0_1 {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @bb0_2
+// CHECK:                   calyx.enable @assign_while_0_latch
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               calyx.enable @bb0_4
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main() {
     // declaring variables  

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -404,44 +404,47 @@ module {
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i6
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]] = calyx.seq_mem @mem_0 <[38] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
-// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.seq_mem @mem_0 <[38] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]] = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @assign_while_0_init_0 {
-// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_5]] : i32
-// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_4]] : i1
-// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_5]] : i32
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_39]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_5]] : i32
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_9]] : i6
-// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_4]] : i1
-// CHECK:               calyx.group_done %[[VAL_27]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_31]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_33]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
 // CHECK:             }
 // CHECK:             calyx.comb_group @bb0_1 {
-// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_38]] : i32
 // CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_7]] : i32
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
-// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_32]] : i32
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_11]] : i6
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_25]] : i32
-// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_38]] : i32
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_11]] : i6
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_24]] : i32
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_29]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @assign_while_0_latch {
-// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_16]] : i32
-// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_4]] : i1
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_38]] : i32
 // CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_6]] : i32
-// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:               calyx.group_done %[[VAL_39]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_4 {
 // CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_6]] : i32
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_13]] : i6
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_25]] : i32
-// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_13]] : i6
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_24]] : i32
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_29]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -218,30 +218,36 @@ module {
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i6
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i6
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_pad @std_pad_0 : i6, i32
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = calyx.std_pad @std_pad_0 : i6, i32
+// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_29]] : i32
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_41]] : i32
 // CHECK:             calyx.group @bb0_1 {
-// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_16]] : i32
-// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_9]] : i6
-// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_0]] : i6
-// CHECK:               calyx.group_done %[[VAL_24]] : i1
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_28]] : i32
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_34]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_36]] : i1
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_0]] : i6
+// CHECK:               calyx.group_done %[[VAL_26]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
 // CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_11]] : i6
-// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_24]] : i1
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_11]] : i6
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_34]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_36]] : i1
+// CHECK:               calyx.group_done %[[VAL_20]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_14]] : i32
-// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_22]] : i32
-// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_22]] : i32
-// CHECK:               calyx.group_done %[[VAL_30]] : i1
+// CHECK:               calyx.assign %[[VAL_37]] = %[[VAL_14]] : i32
+// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_25]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_19]] : i32
+// CHECK:               calyx.group_done %[[VAL_42]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -515,27 +521,30 @@ module {
 // CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i1
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i32, i1, i1, i1, i32, i1, i1
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_24]] : i32
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_30]] : i32
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_9]] : i1
-// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_23]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_25]] : i1
+// CHECK:               calyx.group_done %[[VAL_17]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_1 {
 // CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_11]] : i1
-// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_15]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_11]] : i1
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_21]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_17]] : i32
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_31]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -1,58 +1,65 @@
 // RUN: circt-opt %s --lower-scf-to-calyx -canonicalize -split-input-file | FileCheck %s
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK-LABEL:  calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
-// CHECK-DAG:      %c64_i32 = hw.constant 64 : i32
-// CHECK-DAG:      %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:      %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:      %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
-// CHECK-DAG:      %mem_1.addr0, %mem_1.write_data, %mem_1.write_en, %mem_1.clk, %mem_1.read_data, %mem_1.done = calyx.memory @mem_1 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.group @assign_while_0_init_0  {
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.comb_group @bb0_0  {
-// CHECK-NEXT:         calyx.assign %std_lt_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_lt_0.right = %c64_i32 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_2  {
-// CHECK-NEXT:         calyx.assign %std_slice_1.in = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %mem_1.addr0 = %std_slice_1.out : i6
-// CHECK-NEXT:         calyx.assign %mem_1.write_data = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %mem_1.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.group_done %mem_1.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @assign_while_0_latch  {
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.in = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @assign_while_0_init_0
-// CHECK-NEXT:         calyx.while %std_lt_0.out with @bb0_0  {
-// CHECK-NEXT:           calyx.seq  {
-// CHECK-NEXT:             calyx.enable @bb0_2
-// CHECK-NEXT:             calyx.enable @assign_while_0_latch
-// CHECK-NEXT:           }
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = hw.constant 64 : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_lt @std_lt_0 : i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @mem_1 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]] = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @assign_while_0_init_0 {
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_39]] : i1
+// CHECK:             }
+// CHECK:             calyx.comb_group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_38]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_5]] : i32
+// CHECK:             }
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_38]] : i32
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_38]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_11]] : i6
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_31]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_21]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @assign_while_0_latch {
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_14]] : i32
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_38]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_6]] : i32
+// CHECK:               calyx.group_done %[[VAL_39]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @assign_while_0_init_0
+// CHECK:               calyx.while %[[VAL_17]] with @bb0_0 {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @bb0_1
+// CHECK:                   calyx.enable @bb0_2
+// CHECK:                   calyx.enable @assign_while_0_latch
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main() {
     %c0 = arith.constant 0 : index
@@ -80,45 +87,49 @@ module {
 // that any referenced combinational assignments are re-applied in each
 // sequential group.
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK-LABEL:  calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:      %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:      %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
-// CHECK-DAG:      %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @bb0_1  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %c0_i32 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.assign %mem_0.write_data = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %in0 : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %mem_0.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %std_add_1.out : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_1.left = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %in0 : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.assign %std_add_1.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @bb0_1
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_29]] : i32
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_10]] : i6
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_7]] : i32
+// CHECK:               calyx.group_done %[[VAL_20]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_13]] : i32
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_7]] : i32
+// CHECK:               calyx.group_done %[[VAL_30]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%arg0 : i32) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
@@ -133,48 +144,52 @@ module {
 
 // -----
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK-LABEL:  calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:      %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:      %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %std_add_2.left, %std_add_2.right, %std_add_2.out = calyx.std_add @std_add_2 : i32, i32, i32
-// CHECK-DAG:      %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
-// CHECK-DAG:      %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @bb0_2  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %c0_i32 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.assign %mem_0.write_data = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %in0 : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %mem_0.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %std_add_2.out : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_2.left = %std_add_1.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_1.left = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %in0 : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.assign %std_add_1.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.assign %std_add_2.right = %c1_i32 : i32
-// CHECK-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @bb0_2
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_add @std_add_2 : i32, i32, i32
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_32]] : i32
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_10]] : i6
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_19]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_7]] : i32
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_13]] : i32
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_19]] : i32
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_7]] : i32
+// CHECK:               calyx.group_done %[[VAL_33]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_2
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%arg0 : i32) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
@@ -191,52 +206,52 @@ module {
 // -----
 // Test multiple reads from the same memory (structural hazard).
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK-LABEL:  calyx.component @main(%in0: i6, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:      %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:      %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %std_pad_0.in, %std_pad_0.out = calyx.std_pad @std_pad_0 : i6, i32
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @bb0_1  {
-// CHECK-NEXT:         calyx.assign %std_slice_1.in = %std_pad_0.out : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
-// CHECK-NEXT:         calyx.assign %load_0_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %load_0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_pad_0.in = %in0 : i6
-// CHECK-NEXT:         calyx.group_done %load_0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_2  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %c1_i32 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.assign %load_1_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %load_1_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %load_1_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %std_add_0.out : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %std_add_0.left = %load_0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %std_add_0.right = %load_1_reg.out : i32
-// CHECK-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @bb0_1
-// CHECK-NEXT:         calyx.enable @bb0_2
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i6,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.std_pad @std_pad_0 : i6, i32
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_29]] : i32
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_0]] : i6
+// CHECK:               calyx.group_done %[[VAL_24]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_11]] : i6
+// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_24]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_14]] : i32
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_22]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_22]] : i32
+// CHECK:               calyx.group_done %[[VAL_30]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.enable @bb0_2
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%arg0 : i6) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
@@ -253,29 +268,38 @@ module {
 
 // Test index types as inputs.
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK-NEXT:   calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:      %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %in0 : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_21]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i6
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_16]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_14]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_22]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%i : index) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
@@ -288,27 +312,31 @@ module {
 
 // Test index types as outputs.
 
-// CHECH:     module attributes {calyx.entrypoint = "main"} {
-// CHECH-NEXT:   calyx.component @main(%in0: i8, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECH-DAG:      %true = hw.constant true
-// CHECH-DAG:      %std_pad_0.in, %std_pad_0.out = calyx.std_pad @std_pad_0 : i8, i32
-// CHECH-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECH-NEXT:     calyx.wires  {
-// CHECH-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECH-NEXT:       calyx.group @ret_assign_0  {
-// CHECH-NEXT:         calyx.assign %ret_arg0_reg.in = %std_pad_0.out : i32
-// CHECH-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECH-NEXT:         calyx.assign %std_pad_0.in = %in0 : i8
-// CHECH-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECH-NEXT:       }
-// CHECH-NEXT:     }
-// CHECH-NEXT:     calyx.control  {
-// CHECH-NEXT:       calyx.seq  {
-// CHECH-NEXT:         calyx.enable @ret_assign_0
-// CHECH-NEXT:       }
-// CHECH-NEXT:     }
-// CHECH-NEXT:   } {toplevel}
-// CHECH-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_pad @std_pad_0 : i8, i32
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_13]] : i32
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_0]] : i8
+// CHECK:               calyx.group_done %[[VAL_14]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%i : i8) -> index {
     %0 = arith.index_cast %i : i8 to index
@@ -320,26 +348,35 @@ module {
 
 // External memory store.
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK:      calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %done: i1 {done}) {
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.group @bb0_0  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %in2 : i32
-// CHECK-NEXT:         calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i3
-// CHECK-NEXT:         calyx.assign %ext_mem0_write_data = %in0 : i32
-// CHECK-NEXT:         calyx.assign %ext_mem0_write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %ext_mem0_done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @bb0_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
+// CHECK-SAME:                          %[[VAL_3:in2]]: i32,
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_6:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_7:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
+// CHECK-SAME:                          %[[VAL_8:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
+// CHECK-SAME:                          %[[VAL_9:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
+// CHECK-SAME:                          %[[VAL_10:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_11:.*]] = hw.constant true
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_3]] : i32
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_13]] : i3
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_11]] : i1
+// CHECK:               calyx.group_done %[[VAL_2]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
     memref.store %arg0, %mem0[%i] : memref<8xi32>
@@ -351,28 +388,44 @@ module {
 
 // External memory load.
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK:      calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %done: i1 {done}) {
-// CHECK:          %true = hw.constant true
-// CHECK:          %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:          %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %in0 : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %ext_mem0_read_data : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i3
-// CHECK-NEXT:         calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_6:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
+// CHECK-SAME:                          %[[VAL_7:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
+// CHECK-SAME:                          %[[VAL_8:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
+// CHECK-SAME:                          %[[VAL_9:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_10:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_11:.*]] = hw.constant true
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_9]] = %[[VAL_24]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_13]] : i3
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_11]] : i1
+// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_18]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_11]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
     %0 = memref.load %mem0[%i] : memref<8xi32>
@@ -384,50 +437,61 @@ module {
 
 // External memory hazard.
 
-// CHECK:     module attributes {calyx.entrypoint = "main"} {
-// CHECK:      calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %out1: i32, %done: i1 {done}) {
-// CHECK-DAG:      %true = hw.constant true
-// CHECK-DAG:      %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i3
-// CHECK-DAG:      %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK-DAG:      %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:      %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:     calyx.wires  {
-// CHECK-NEXT:       calyx.assign %out1 = %ret_arg1_reg.out : i32
-// CHECK-NEXT:       calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.group @bb0_0  {
-// CHECK-NEXT:         calyx.assign %std_slice_1.in = %in0 : i32
-// CHECK-NEXT:         calyx.assign %ext_mem0_addr0 = %std_slice_1.out : i3
-// CHECK-NEXT:         calyx.assign %load_0_reg.in = %ext_mem0_read_data : i32
-// CHECK-NEXT:         calyx.assign %load_0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %load_0_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @bb0_1  {
-// CHECK-NEXT:         calyx.assign %std_slice_0.in = %in1 : i32
-// CHECK-NEXT:         calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i3
-// CHECK-NEXT:         calyx.assign %load_1_reg.in = %ext_mem0_read_data : i32
-// CHECK-NEXT:         calyx.assign %load_1_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %load_1_reg.done : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:       calyx.group @ret_assign_0  {
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.in = %load_0_reg.out : i32
-// CHECK-NEXT:         calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.assign %ret_arg1_reg.in = %load_1_reg.out : i32
-// CHECK-NEXT:         calyx.assign %ret_arg1_reg.write_en = %true : i1
-// CHECK-NEXT:         %0 = comb.and %ret_arg1_reg.done, %ret_arg0_reg.done : i1
-// CHECK-NEXT:         calyx.group_done %0 ? %true : i1
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.control  {
-// CHECK-NEXT:       calyx.seq  {
-// CHECK-NEXT:         calyx.enable @bb0_0
-// CHECK-NEXT:         calyx.enable @bb0_1
-// CHECK-NEXT:         calyx.enable @ret_assign_0
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   } {toplevel}
-// CHECK-NEXT: }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:in1]]: i32,
+// CHECK-SAME:                          %[[VAL_2:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_6:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_7:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
+// CHECK-SAME:                          %[[VAL_8:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
+// CHECK-SAME:                          %[[VAL_9:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
+// CHECK-SAME:                          %[[VAL_10:out0]]: i32,
+// CHECK-SAME:                          %[[VAL_11:out1]]: i32,
+// CHECK-SAME:                          %[[VAL_12:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_13:.*]] = hw.constant true
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.std_slice @std_slice_1 : i32, i3
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_11]] = %[[VAL_34]] : i32
+// CHECK:             calyx.assign %[[VAL_10]] = %[[VAL_40]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_15]] : i3
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_2]] : i32
+// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_13]] : i1
+// CHECK:               calyx.group_done %[[VAL_29]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_17]] : i3
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_2]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_13]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_36]] = %[[VAL_28]] : i32
+// CHECK:               calyx.assign %[[VAL_37]] = %[[VAL_13]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_22]] : i32
+// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_13]] : i1
+// CHECK:               %[[VAL_42:.*]] = comb.and %[[VAL_35]], %[[VAL_41]] : i1
+// CHECK:               calyx.group_done %[[VAL_42]] ? %[[VAL_13]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
     %0 = memref.load %mem0[%i0] : memref<8xi32>
@@ -440,20 +504,48 @@ module {
 
 // Load followed by store to the same memory should be placed in separate groups.
 
-// CHECK:         calyx.group @bb0_0  {
-// CHECK-NEXT:         calyx.assign %std_slice_1.in = %in0 : i32
-// CHECK-NEXT:         calyx.assign %mem_0.addr0 = %std_slice_1.out : i1
-// CHECK-NEXT:         calyx.assign %load_0_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:         calyx.assign %load_0_reg.write_en = %true : i1
-// CHECK-NEXT:         calyx.group_done %load_0_reg.done : i1
-// CHECK-NEXT:      }
-// CHECK-NEXT:      calyx.group @bb0_1  {
-// CHECK-NEXT:        calyx.assign %std_slice_0.in = %in0 : i32
-// CHECK-NEXT:        calyx.assign %mem_0.addr0 = %std_slice_0.out : i1
-// CHECK-NEXT:        calyx.assign %mem_0.write_data = %c1_i32 : i32
-// CHECK-NEXT:        calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:        calyx.group_done %mem_0.done : i1
-// CHECK-NEXT:      }
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i32, i1, i1, i1, i32, i1, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_24]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_11]] : i1
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_15]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_17]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
 module {
   func.func @main(%i : index) -> i32 {
     %c1_32 = arith.constant 1 : i32

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -593,13 +593,13 @@ module {
 // Convert memrefs w/o shape (e.g., memref<i32>) to 1 dimensional Calyx memories 
 // of size 1
 
-// CHECK-DAG: %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[1] x 32> [1] {external = true} : i1, i32, i1, i1, i32, i1
+// CHECK-DAG: %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.write_done, %mem_0.clk, %mem_0.read_data, %mem_0.read_en, %mem_0.read_done = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i32, i1, i1, i1, i32, i1, i1
 //CHECK-NEXT: calyx.wires {
 //CHECK-NEXT:   calyx.group @bb0_0 {
 //CHECK-NEXT:     calyx.assign %mem_0.addr0 = %false : i1
 //CHECK-NEXT:     calyx.assign %mem_0.write_data = %c1_i32 : i32
 //CHECK-NEXT:     calyx.assign %mem_0.write_en = %true : i1
-//CHECK-NEXT:     calyx.group_done %mem_0.done : i1
+//CHECK-NEXT:     calyx.group_done %mem_0.write_done : i1
 //CHECK-NEXT:   }
 //CHECK-NEXT: }
 module {

--- a/test/Dialect/Calyx/emit-seq-memory.mlir
+++ b/test/Dialect/Calyx/emit-seq-memory.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-translate --export-calyx --split-input-file --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
 module attributes {calyx.entrypoint = "main"} {
+  // CHECK: import "primitives/memories.futil";
   // CHECK-LABEL: component main<"static"=1>(in: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
   calyx.component @main(%in: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i32, %done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1


### PR DESCRIPTION
Switches SCFToCalyx from using combinational read memories to sequential read memories. Sequential reads are much more realistic for hardware, so the plan is to eventually deprecate combinational read memories in the native Calyx compiler. Unfortunately, the same change cannot be made in LoopScheduleToCalyx yet as it requires further changes to how we build the pipeline. A PR for those fixed to LoopScheduleToCalyx is in the works.