### PR TITLE
[Pipeline] Allow explicitly named registers and passthroughs

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -258,15 +258,19 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     Variadic<AnyType>:$registers,
     Variadic<AnyType>:$passthroughs,
     Variadic<I1>:$clockGates,
-    I64ArrayAttr:$clockGatesPerRegister);
+    I64ArrayAttr:$clockGatesPerRegister,
+    OptionalAttr<StrArrayAttr>:$registerNames,
+    OptionalAttr<StrArrayAttr>:$passthroughNames);
   let successors = (successor AnySuccessor:$nextStage);
   let results = (outs);
   let hasVerifier = 1;
   let skipDefaultBuilders = 1;
 
   let assemblyFormat = [{
-    $nextStage custom<StageRegisters>($registers, type($registers), $clockGates, $clockGatesPerRegister)
-      (`pass` `(` $passthroughs^ `:` type($passthroughs) `)` )? attr-dict
+    $nextStage
+    custom<StageRegisters>($registers, type($registers), $clockGates, $clockGatesPerRegister, $registerNames)
+    custom<Passthroughs>($passthroughs, type($passthroughs), $passthroughNames)  
+    attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -277,6 +281,30 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
 
     // Returns the list of clock gates for the given register.
     ValueRange getClockGatesForReg(unsigned regIdx);
+
+    // Returns the register name for a given register index.
+    StringAttr getRegisterName(unsigned regIdx) {
+      if(auto names = getOperation()->getAttrOfType<ArrayAttr>("registerNames")) {
+        auto name = names[regIdx].cast<StringAttr>();
+        if(!name.strref().empty())
+          return name;
+      }
+
+      return {};
+    }
+
+    // Returns the passthrough name for a given passthrough index.
+    StringAttr getPassthroughName(unsigned passthroughIdx) {
+      if(auto names = getOperation()->getAttrOfType<ArrayAttr>("passthroughNames")) {
+        auto name = names[passthroughIdx].cast<StringAttr>();
+        if(!name.strref().empty())
+          return name;
+      }
+
+      return {};
+    }
+
+
   }];
 
   let builders = [
@@ -284,7 +312,8 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
     // Clock gate builder, which takes a mapping between the registers and
     // and their clock gate hierarchy.
     OpBuilder<(ins "Block*":$dest, "ValueRange":$registers, "ValueRange":$passthroughs,
-      "const llvm::DenseMap<Value, llvm::SmallVector<Value>>&":$clockGates)>
+      "const llvm::DenseMap<Value, llvm::SmallVector<Value>>&":$clockGates,
+      CArg<"mlir::ArrayAttr", "{}">:$registerNames, CArg<"mlir::ArrayAttr", "{}">:$passthroughNames)>
   ];
 }
 

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -5,10 +5,10 @@
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -7,10 +7,10 @@
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
 // CHECK:         }
@@ -23,10 +23,10 @@
 // CGATE:           %[[VAL_8:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
 // CGATE:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_8]], %[[VAL_6]]
 // CGATE:           %[[VAL_10:.*]] = seq.clock_gate %[[VAL_9]], %[[VAL_7]]
-// CGATE:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_10]] : i32
-// CGATE:           %[[VAL_12:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_8]] : i32
+// CGATE:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_10]] : i32
+// CGATE:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_8]] : i32
 // CGATE:           %[[VAL_13:.*]] = hw.constant false
-// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CGATE:           %[[VAL_15:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
 // CGATE:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CGATE:         }

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -15,15 +15,15 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_s2_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_valid %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage2_reg0 %[[VAL_5]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_s2_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_s3_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage2_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage3_reg0 %[[VAL_10]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_s3_valid %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_stage3_valid %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
 // CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
@@ -48,10 +48,10 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-LABEL:   hw.module @testSingle(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
@@ -69,26 +69,26 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 // CHECK-LABEL:   hw.module @testMultiple(
 // CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_s1_reg1 %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage1_reg1 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_s0_reg0 %[[VAL_16]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_s0_reg1 %[[VAL_15]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_stage0_reg0 %[[VAL_16]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_stage0_reg1 %[[VAL_15]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_s1_reg0 %[[VAL_21]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_s1_reg1 %[[VAL_17]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_stage1_reg0 %[[VAL_21]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_stage1_reg1 %[[VAL_17]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_24:.*]] = hw.constant false
-// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_s1_valid %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_stage1_valid %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
 // CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
@@ -122,13 +122,13 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage1_valid %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
@@ -157,17 +157,17 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_s0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
 // CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
 // CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_s1_reg0 %[[VAL_15]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_15]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_17:.*]] = hw.constant false
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_s1_valid %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage1_valid %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
@@ -212,9 +212,9 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_2]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]] : i1
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_s0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_stage0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @p0_s0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @p0_stage0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -19,41 +19,41 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 
 // CHECK-LABEL:   hw.module @testLatency1_p0(
 // CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testLatency1_p0_s0" @testLatency1_p0_s0(in0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testLatency1_p0_s1" @testLatency1_p0_s1(in0: %[[VAL_4]]: i32, enable: %[[VAL_5]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testLatency1_p0_s2" @testLatency1_p0_s2(in0: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testLatency1_p0_s0" @testLatency1_p0_s0(a0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (pass0: i32, valid: i1)
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testLatency1_p0_s1" @testLatency1_p0_s1(pass0: %[[VAL_4]]: i32, enable: %[[VAL_5]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (pass0: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testLatency1_p0_s2" @testLatency1_p0_s2(pass0: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = hw.instance "testLatency1_p0_s3" @testLatency1_p0_s3(in0: %[[VAL_8]]: i32, enable: %[[VAL_9]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s0(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1,  %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1,  %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (pass0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s1(
-// CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (pass0: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant false
-// CHECK:           %[[VAL_5:.*]] = seq.compreg sym @s1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]  : i1
+// CHECK:           %[[VAL_5:.*]] = seq.compreg sym @stage1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]  : i1
 // CHECK:           hw.output %[[VAL_0]], %[[VAL_5]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s2(
 // CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @s2_reg0 %[[VAL_0]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @stage2_reg0 %[[VAL_0]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s2_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage2_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1_p0_s3(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @s3_reg0 %[[VAL_0]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_4:.*]] = seq.compreg sym @stage3_reg0 %[[VAL_0]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s3_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage3_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_5]]  : i1
 // CHECK:           hw.output %[[VAL_4]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
@@ -83,23 +83,23 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 
 // CHECK-LABEL:   hw.module @testSingle_p0(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingle_p0_s0" @testSingle_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testSingle_p0_s1" @testSingle_p0_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingle_p0_s0" @testSingle_p0_s0(a0: %[[VAL_0]]: i32, a1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testSingle_p0_s1" @testSingle_p0_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle_p0_s0(
 // CHECK-SAME:                                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingle_p0_s1(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_2]] : i32, i1
 // CHECK:         }
@@ -122,68 +122,68 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 
 // CHECK-LABEL:   hw.module @testMultiple_p0(
 // CHECK-SAME:                               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p0_s0" @testMultiple_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p0_s0" @testMultiple_p0_s0(a0: %[[VAL_0]]: i32, a1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = hw.instance "testMultiple_p0_s1" @testMultiple_p0_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
-// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = hw.instance "testMultiple_p0_s2" @testMultiple_p0_s2(in0: %[[VAL_8]]: i32, in1: %[[VAL_9]]: i32, enable: %[[VAL_10]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = hw.instance "testMultiple_p0_s2" @testMultiple_p0_s2(in0: %[[VAL_8]]: i32, in1: %[[VAL_9]]: i32, enable: %[[VAL_10]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_12]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p0_s2(
-// CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.mul %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_2]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1(
 // CHECK-SAME:                               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p1_s0" @testMultiple_p1_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testMultiple_p1_s0" @testMultiple_p1_s0(a0: %[[VAL_0]]: i32, a1: %[[VAL_1]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = hw.instance "testMultiple_p1_s1" @testMultiple_p1_s1(in0: %[[VAL_5]]: i32, in1: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, out1: i32, valid: i1)
-// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = hw.instance "testMultiple_p1_s2" @testMultiple_p1_s2(in0: %[[VAL_8]]: i32, in1: %[[VAL_9]]: i32, enable: %[[VAL_10]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = hw.instance "testMultiple_p1_s2" @testMultiple_p1_s2(in0: %[[VAL_8]]: i32, in1: %[[VAL_9]]: i32, enable: %[[VAL_10]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_12]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s0(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s1(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage1_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testMultiple_p1_s2(
-// CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:                %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.mul %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_2]] : i32, i1
 // CHECK:         }
@@ -222,7 +222,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1, %[[VAL_5:.*]]: i1) -> (out0: i32, out1: i32, valid: i1) {
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(in0: %[[VAL_0]]: i32, in1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testSingleWithExt_p0_s0" @testSingleWithExt_p0_s0(a0: %[[VAL_0]]: i32, a1: %[[VAL_1]]: i32, enable: %[[VAL_3]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testSingleWithExt_p0_s1" @testSingleWithExt_p0_s1(in0: %[[VAL_6]]: i32, e0: %[[VAL_2]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_4]]: i1, rst: %[[VAL_5]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_2]], %[[VAL_9]] : i32, i32, i1
 // CHECK:         }
@@ -231,18 +231,18 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @s0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage0_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           hw.output %[[VAL_7]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt_p0_s1(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, valid: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @s1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @stage1_reg0 %[[VAL_5]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @s1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @stage1_valid %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_7]]  : i1
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_8]] : i32, i1
 // CHECK:         }
 
@@ -271,9 +271,9 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 
 // CHECK-LABEL:   hw.module @testControlUsage_p0(
 // CHECK-SAME:               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testControlUsage_p0_s0" @testControlUsage_p0_s0(in0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = hw.instance "testControlUsage_p0_s0" @testControlUsage_p0_s0(a0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "testControlUsage_p0_s1" @testControlUsage_p0_s1(in0: %[[VAL_4]]: i32, enable: %[[VAL_5]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testControlUsage_p0_s2" @testControlUsage_p0_s2(in0: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = hw.instance "testControlUsage_p0_s2" @testControlUsage_p0_s2(in0: %[[VAL_6]]: i32, enable: %[[VAL_7]]: i1, clk: %[[VAL_2]]: i1, rst: %[[VAL_3]]: i1) -> (out: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
@@ -285,9 +285,9 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @s0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @stage0_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           hw.output %[[VAL_9]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
@@ -299,14 +299,14 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @s1_reg0 %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @stage1_reg0 %[[VAL_8]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @s1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @stage1_valid %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           hw.output %[[VAL_9]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testControlUsage_p0_s2(
-// CHECK-SAME:                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32, valid: i1) {
+// CHECK-SAME:                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out: i32, valid: i1) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant 0 : i32
 // CHECK:           %[[VAL_5:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !hw.inout<i32>
@@ -355,7 +355,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 
 // CHECK-LABEL:   hw.module @testWithStall_p0(
 // CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, valid: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testWithStall_p0_s0" @testWithStall_p0_s0(in0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, stall: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testWithStall_p0_s0" @testWithStall_p0_s0(a0: %[[VAL_0]]: i32, enable: %[[VAL_1]]: i1, stall: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out0: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
 
@@ -364,9 +364,9 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_2]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]] : i1
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @s0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @stage0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @s0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg.ce sym @stage0_valid %[[VAL_1]], %[[VAL_3]], %[[VAL_6]], %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
@@ -386,32 +386,44 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 
 // -----
 
-// CHECK-LABEL:  hw.module @testNaming_MyPipeline(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out: i1, valid: i1) {
-// CHECK-NEXT:    %testNaming_MyPipeline_s0.s0_myNamed_out, %testNaming_MyPipeline_s0.s0_out1, %testNaming_MyPipeline_s0.valid = hw.instance "testNaming_MyPipeline_s0" @testNaming_MyPipeline_s0(a0: %a0: i1, enable: %enable: i1, clk: %clk: i1, rst: %rst: i1) -> (s0_myNamed_out: i1, s0_out1: i1, valid: i1)
-// CHECK-NEXT:    hw.output %testNaming_MyPipeline_s0.s0_myNamed_out, %testNaming_MyPipeline_s0.s0_out1 : i1, i1
+// CHECK-LABEL:  hw.module @testNaming_MyPipeline(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (myOut: i1, valid: i1) {
+// CHECK-NEXT:    %testNaming_MyPipeline_s0.myReg_out, %testNaming_MyPipeline_s0.out1, %testNaming_MyPipeline_s0.myPass_out, %testNaming_MyPipeline_s0.valid = hw.instance "testNaming_MyPipeline_s0" @testNaming_MyPipeline_s0(a0: %a0: i1, enable: %enable: i1, clk: %clk: i1, rst: %rst: i1) -> (myReg_out: i1, out1: i1, myPass_out: i1, valid: i1)
+// CHECK-NEXT:    %testNaming_MyPipeline_s1.out0, %testNaming_MyPipeline_s1.out1, %testNaming_MyPipeline_s1.pass0, %testNaming_MyPipeline_s1.valid = hw.instance "testNaming_MyPipeline_s1" @testNaming_MyPipeline_s1(myReg_in: %testNaming_MyPipeline_s0.myReg_out: i1, in1: %testNaming_MyPipeline_s0.out1: i1, myPass_in: %testNaming_MyPipeline_s0.myPass_out: i1, enable: %testNaming_MyPipeline_s0.valid: i1, clk: %clk: i1, rst: %rst: i1) -> (out0: i1, out1: i1, pass0: i1, valid: i1)
+// CHECK-NEXT:    hw.output %testNaming_MyPipeline_s1.out0, %testNaming_MyPipeline_s1.out1 : i1, i1
 // CHECK-NEXT:  }
 
-// CHECK-LABEL:  hw.module @testNaming_MyPipeline_s0(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (s0_myNamed_out: i1, s0_out1: i1, valid: i1) {
+// CHECK-LABEL:  hw.module @testNaming_MyPipeline_s0(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (myReg_out: i1, out1: i1, myPass_out: i1, valid: i1) {
 // CHECK-NEXT:    %0 = comb.add %a0, %a0 : i1
-// CHECK-NEXT:    %s0_myNamed_reg = seq.compreg sym @s0_myNamed_reg %0, %clk : i1
-// CHECK-NEXT:    %s0_reg1 = seq.compreg sym @s0_reg1 %0, %clk : i1
+// CHECK-NEXT:    %myReg = seq.compreg sym @myReg %0, %clk : i1
+// CHECK-NEXT:    %stage0_reg1 = seq.compreg sym @stage0_reg1 %0, %clk : i1
 // CHECK-NEXT:    %false = hw.constant false
-// CHECK-NEXT:    %s0_valid = seq.compreg sym @s0_valid %enable, %clk, %rst, %false  : i1
-// CHECK-NEXT:    hw.output %s0_myNamed_reg, %s0_reg1, %s0_valid : i1, i1, i1
+// CHECK-NEXT:    %stage0_valid = seq.compreg sym @stage0_valid %enable, %clk, %rst, %false  : i1
+// CHECK-NEXT:    hw.output %myReg, %stage0_reg1, %0, %stage0_valid : i1, i1, i1, i1
+// CHECK-NEXT:  }
+
+// CHECK-LABEL:  hw.module @testNaming_MyPipeline_s1(%myReg_in: i1, %in1: i1, %myPass_in: i1, %enable: i1, %clk: i1, %rst: i1) -> (out0: i1, out1: i1, pass0: i1, valid: i1) {
+// CHECK-NEXT:    %stage1_reg0 = seq.compreg sym @stage1_reg0 %myReg_in, %clk : i1
+// CHECK-NEXT:    %stage1_reg1 = seq.compreg sym @stage1_reg1 %in1, %clk : i1
+// CHECK-NEXT:    %false = hw.constant false
+// CHECK-NEXT:    %stage1_valid = seq.compreg sym @stage1_valid %enable, %clk, %rst, %false  : i1
+// CHECK-NEXT:    hw.output %stage1_reg0, %stage1_reg1, %myPass_in, %stage1_valid : i1, i1, i1, i1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL:  hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
-// CHECK-NEXT:    %testNaming_MyPipeline.out, %testNaming_MyPipeline.valid = hw.instance "testNaming_MyPipeline" @testNaming_MyPipeline(a0: %go: i1, enable: %go: i1, clk: %clk: i1, rst: %rst: i1) -> (out: i1, valid: i1)
-// CHECK-NEXT:    hw.output %testNaming_MyPipeline.out : i1
+// CHECK-NEXT:    %testNaming_MyPipeline.myOut, %testNaming_MyPipeline.valid = hw.instance "testNaming_MyPipeline" @testNaming_MyPipeline(a0: %go: i1, enable: %go: i1, clk: %clk: i1, rst: %rst: i1) -> (myOut: i1, valid: i1)
+// CHECK-NEXT:    hw.output %testNaming_MyPipeline.myOut : i1
 // CHECK-NEXT:  }
 
 hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
-  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i1 = %go) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i1) {
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i1 = %go) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (myOut: i1) {
     %add = comb.add %a0, %a0 : i1
-    pipeline.stage ^bb1 regs("myNamed" = %add : i1, %add : i1)
+    pipeline.stage ^bb1 regs("myReg" = %add : i1, %add : i1) pass("myPass" = %add : i1)
   
-  ^bb1(%1 : i1, %2 : i1, %s1_valid: i1):
-    pipeline.return %1 : i1
+  ^bb1(%1 : i1, %2 : i1, %3 : i1, %s1_valid: i1):
+    pipeline.stage ^bb2 regs(%1 : i1, %2 : i1) pass(%3 : i1)
+
+  ^bb2(%4 : i1, %5 : i1, %6 : i1, %s2_valid: i1):
+    pipeline.return %4 : i1
   
   }
   hw.output %0#0 : i1

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -386,17 +386,18 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 
 // -----
 
-// CHECK-LABEL: hw.module @testNaming_MyPipeline(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out: i1, valid: i1) {
-// CHECK-NEXT:    %testNaming_MyPipeline_s0.out0, %testNaming_MyPipeline_s0.valid = hw.instance "testNaming_MyPipeline_s0" @testNaming_MyPipeline_s0(in0: %a0: i1, enable: %enable: i1, clk: %clk: i1, rst: %rst: i1) -> (out0: i1, valid: i1)
-// CHECK-NEXT:    hw.output %testNaming_MyPipeline_s0.out0, %testNaming_MyPipeline_s0.valid : i1, i1
+// CHECK-LABEL:  hw.module @testNaming_MyPipeline(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out: i1, valid: i1) {
+// CHECK-NEXT:    %testNaming_MyPipeline_s0.s0_myNamed_out, %testNaming_MyPipeline_s0.s0_out1, %testNaming_MyPipeline_s0.valid = hw.instance "testNaming_MyPipeline_s0" @testNaming_MyPipeline_s0(a0: %a0: i1, enable: %enable: i1, clk: %clk: i1, rst: %rst: i1) -> (s0_myNamed_out: i1, s0_out1: i1, valid: i1)
+// CHECK-NEXT:    hw.output %testNaming_MyPipeline_s0.s0_myNamed_out, %testNaming_MyPipeline_s0.s0_out1 : i1, i1
 // CHECK-NEXT:  }
 
-// CHECK-LABEL:  hw.module @testNaming_MyPipeline_s0(%in0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out0: i1, valid: i1) {
-// CHECK-NEXT:    %0 = comb.add %in0, %in0 {sv.namehint = "myAdd"} : i1
-// CHECK-NEXT:    %s0_myAdd_reg = seq.compreg sym @s0_myAdd_reg %0, %clk : i1
+// CHECK-LABEL:  hw.module @testNaming_MyPipeline_s0(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (s0_myNamed_out: i1, s0_out1: i1, valid: i1) {
+// CHECK-NEXT:    %0 = comb.add %a0, %a0 : i1
+// CHECK-NEXT:    %s0_myNamed_reg = seq.compreg sym @s0_myNamed_reg %0, %clk : i1
+// CHECK-NEXT:    %s0_reg1 = seq.compreg sym @s0_reg1 %0, %clk : i1
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    %s0_valid = seq.compreg sym @s0_valid %enable, %clk, %rst, %false  : i1
-// CHECK-NEXT:    hw.output %s0_myAdd_reg, %s0_valid : i1, i1
+// CHECK-NEXT:    hw.output %s0_myNamed_reg, %s0_reg1, %s0_valid : i1, i1, i1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL:  hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
@@ -406,11 +407,10 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 
 hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i1 = %go) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i1) {
-    // The register will be named after the namehint on the source operation.
-    %add = comb.add %a0, %a0 {sv.namehint = "myAdd"} : i1
-    pipeline.stage ^bb1 regs(%add : i1)
+    %add = comb.add %a0, %a0 : i1
+    pipeline.stage ^bb1 regs("myNamed" = %add : i1, %add : i1)
   
-  ^bb1(%1 : i1, %s1_valid: i1):
+  ^bb1(%1 : i1, %2 : i1, %s1_valid: i1):
     pipeline.return %1 : i1
   
   }

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -136,3 +136,23 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : 
   }
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-NEXT:     %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:       %0 = comb.add %a0, %a1 : i32
+// CHECK-NEXT:       pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
+// CHECK-NEXT:     ^bb1(%s1_arg0: i32, %s1_arg1: i32, %s1_arg2: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:       pipeline.return %s1_arg0 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     hw.output %out : i32
+// CHECK-NEXT:   }
+hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+    %0 = comb.add %a0, %a1 : i32
+    pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
+
+   ^bb1(%r1 : i32, %r2 : i32, %r3 : i32, %s1_valid : i1):
+    pipeline.return %r1 : i32
+  }
+  hw.output %0 : i32
+}


### PR DESCRIPTION
Reflected in HW lowering, and used by e.g. the register materialization pass to carry register names through multiple stages.

Still a draft since i want to get peoples opinion on the HW lowering before i change tests, e.g. things like whether there should be a `_reg` suffix on stage module outputs which are driven by registers (and likewise e.g. `_reg_in` for stage inputs that arrive from a prior stage that was a registered output).

Example lowering:

```mlir
hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i1 = %go) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i1) {
    // The register will be named after the namehint on the source operation.
    %add = comb.add %a0, %a0 : i1
    pipeline.stage ^bb1 regs("myNamed" = %add : i1, %add : i1) pass("myNamed" = %add : i1, %add : i1)

  ^bb1(%reg0 : i1, %reg1 : i1, %pass0 : i1, %pass1 : i1, %s1_valid: i1):
    pipeline.stage ^bb2 regs(%reg0 : i1, %reg1 : i1) pass(%pass0 : i1, %pass1 : i1)
  ^bb2(%reg01 : i1, %reg11 : i1, %pass01 : i1, %pass11 : i1, %s2_valid: i1):

    pipeline.return %reg01 : i1

  }
  hw.output %0#0 : i1
}

// Becomes
  hw.module @testNaming_MyPipeline(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (out: i1, valid: i1) {
    %testNaming_MyPipeline_s0.myNamed, %testNaming_MyPipeline_s0.out1, %testNaming_MyPipeline_s0.myNamed_pass, %testNaming_MyPipeline_s0.pass1, %testNaming_MyPipeline_s0.valid = hw.instance "testNaming_MyPipeline_s0" @testNaming_MyPipeline_s0(a0: %a0: i1, enable: %enable: i1, clk: %clk: i1, rst: %rst: i1) -> (myNamed: i1, out1: i1, myNamed_pass: i1, pass1: i1, valid: i1)
    %testNaming_MyPipeline_s1.out0, %testNaming_MyPipeline_s1.out1, %testNaming_MyPipeline_s1.pass0, %testNaming_MyPipeline_s1.pass1, %testNaming_MyPipeline_s1.valid = hw.instance "testNaming_MyPipeline_s1" @testNaming_MyPipeline_s1(myNamed: %testNaming_MyPipeline_s0.myNamed: i1, out1: %testNaming_MyPipeline_s0.out1: i1, myNamed_pass: %testNaming_MyPipeline_s0.myNamed_pass: i1, pass1: %testNaming_MyPipeline_s0.pass1: i1, enable: %testNaming_MyPipeline_s0.valid: i1, clk: %clk: i1, rst: %rst: i1) -> (out0: i1, out1: i1, pass0: i1, pass1: i1, valid: i1)
    hw.output %testNaming_MyPipeline_s1.out0, %testNaming_MyPipeline_s1.out1 : i1, i1
  }
  hw.module @testNaming_MyPipeline_s0(%a0: i1, %enable: i1, %clk: i1, %rst: i1) -> (myNamed: i1, out1: i1, myNamed_pass: i1, pass1: i1, valid: i1) {
    %0 = comb.add %a0, %a0 : i1
    %s0_myNamed_reg = seq.compreg sym @s0_myNamed_reg %0, %clk : i1
    %s0_reg1 = seq.compreg sym @s0_reg1 %0, %clk : i1
    %false = hw.constant false
    %s0_valid = seq.compreg sym @s0_valid %enable, %clk, %rst, %false  : i1
    hw.output %s0_myNamed_reg, %s0_reg1, %0, %0, %s0_valid : i1, i1, i1, i1, i1
  }
  hw.module @testNaming_MyPipeline_s1(%myNamed: i1, %out1: i1, %myNamed_pass: i1, %pass1: i1, %enable: i1, %clk: i1, %rst: i1) -> (out0: i1, out1: i1, pass0: i1, pass1: i1, valid: i1) {
    %s1_reg0 = seq.compreg sym @s1_reg0 %myNamed, %clk : i1
    %s1_reg1 = seq.compreg sym @s1_reg1 %out1, %clk : i1
    %false = hw.constant false
    %s1_valid = seq.compreg sym @s1_valid %enable, %clk, %rst, %false  : i1
    hw.output %s1_reg0, %s1_reg1, %myNamed_pass, %pass1, %s1_valid : i1, i1, i1, i1, i1
  }
  hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
    %testNaming_MyPipeline.out, %testNaming_MyPipeline.valid = hw.instance "testNaming_MyPipeline" @testNaming_MyPipeline(a0: %go: i1, enable: %go: i1, clk: %clk: i1, rst: %rst: i1) -> (out: i1, valid: i1)
    hw.output %testNaming_MyPipeline.out : i1
  }
```
Exports as
```sv
module testNaming_MyPipeline(
  input  a0,
         enable,
         clk,
         rst,
  output out,
         valid
);

  wire _testNaming_MyPipeline_s0_myNamed;
  wire _testNaming_MyPipeline_s0_out1;
  wire _testNaming_MyPipeline_s0_myNamed_pass;
  wire _testNaming_MyPipeline_s0_pass1;
  wire _testNaming_MyPipeline_s0_valid;
  testNaming_MyPipeline_s0 testNaming_MyPipeline_s0 (
    .a0           (a0),
    .enable       (enable),
    .clk          (clk),
    .rst          (rst),
    .myNamed      (_testNaming_MyPipeline_s0_myNamed),
    .out1         (_testNaming_MyPipeline_s0_out1),
    .myNamed_pass (_testNaming_MyPipeline_s0_myNamed_pass),
    .pass1        (_testNaming_MyPipeline_s0_pass1),
    .valid        (_testNaming_MyPipeline_s0_valid)
  );
  testNaming_MyPipeline_s1 testNaming_MyPipeline_s1 (
    .myNamed      (_testNaming_MyPipeline_s0_myNamed),
    .out1         (_testNaming_MyPipeline_s0_out1),
    .myNamed_pass (_testNaming_MyPipeline_s0_myNamed_pass),
    .pass1        (_testNaming_MyPipeline_s0_pass1),
    .enable       (_testNaming_MyPipeline_s0_valid),
    .clk          (clk),
    .rst          (rst),
    .out0         (out),
    .out1_0       (valid),
    .pass0        (/* unused */),
    .pass1_0      (/* unused */),
    .valid        (/* unused */)
  );
endmodule

module testNaming_MyPipeline_s0(
  input  a0,
         enable,
         clk,
         rst,
  output myNamed,
         out1,
         myNamed_pass,
         pass1,
         valid
);

  reg s0_myNamed_reg;
  reg s0_reg1;
  always_ff @(posedge clk) begin
    s0_myNamed_reg <= 1'h0;
    s0_reg1 <= 1'h0;
  end
  reg s0_valid;
  always_ff @(posedge clk) begin
    if (rst)
      s0_valid <= 1'h0;
    else
      s0_valid <= enable;
  end
  assign myNamed = s0_myNamed_reg;
  assign out1 = s0_reg1;
  assign myNamed_pass = 1'h0;
  assign pass1 = 1'h0;
  assign valid = s0_valid;
endmodule

module testNaming_MyPipeline_s1(
  input  myNamed,
         out1,
         myNamed_pass,
         pass1,
         enable,
         clk,
         rst,
  output out0,
         out1_0,
         pass0,
         pass1_0,
         valid
);

  reg s1_reg0;
  reg s1_reg1;
  always_ff @(posedge clk) begin
    s1_reg0 <= myNamed;
    s1_reg1 <= out1;
  end
  reg s1_valid;
  always_ff @(posedge clk) begin
    if (rst)
      s1_valid <= 1'h0;
    else
      s1_valid <= enable;
  end
  assign out0 = s1_reg0;
  assign out1_0 = s1_reg1;
  assign pass0 = myNamed_pass;
  assign pass1_0 = pass1;
  assign valid = s1_valid;
endmodule

module testNaming(
  input  go,
         clk,
         rst,
  output out
);

  testNaming_MyPipeline testNaming_MyPipeline (
    .a0     (go),
    .enable (go),
    .clk    (clk),
    .rst    (rst),
    .out    (out),
    .valid  (/* unused */)
  );
endmodule
```