### PR TITLE
[FIRRTL][LowerTypes] Consistently use 64bit for fieldID attr.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -267,7 +267,7 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
         if (annoFieldID == oldPortType.getFieldID(targetIndex)) {
           anno.setMember(
               "circt.fieldID",
-              b->getI32IntegerAttr(portType.getFieldID(targetIndex)));
+              b->getI64IntegerAttr(portType.getFieldID(targetIndex)));
           portAnno.push_back(anno.getDict());
           continue;
         }
@@ -284,7 +284,7 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
             // Set the field ID of the new annotation.
             auto newFieldID =
                 annoFieldID - fieldID + portType.getFieldID(targetIndex);
-            anno.setMember("circt.fieldID", b->getI32IntegerAttr(newFieldID));
+            anno.setMember("circt.fieldID", b->getI64IntegerAttr(newFieldID));
             portAnno.push_back(anno.getDict());
           }
         }
@@ -530,7 +530,7 @@ ArrayAttr TypeLoweringVisitor::filterAnnotations(MLIRContext *ctxt,
     if (auto newFieldID = fieldID - field.fieldID) {
       // If the target is a subfield/subindex of the current field, create a
       // new annotation with the correct circt.fieldID.
-      anno.setMember("circt.fieldID", builder->getI32IntegerAttr(newFieldID));
+      anno.setMember("circt.fieldID", builder->getI64IntegerAttr(newFieldID));
     }
 
     retval.push_back(anno.getAttr());

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -933,15 +933,15 @@ firrtl.circuit "TopLevel" {
   firrtl.module private @Foo4() {
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i32}],
-    // CHECK-SAME: [{c, circt.fieldID = 2 : i32}]
-    // CHECK-SAME: [{circt.fieldID = 4 : i32, e}, {circt.fieldID = 7 : i32, f}]
+    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i64}],
+    // CHECK-SAME: [{c, circt.fieldID = 2 : i64}]
+    // CHECK-SAME: [{circt.fieldID = 4 : i64, e}, {circt.fieldID = 7 : i64, f}]
 
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i32}],
-    // CHECK-SAME: [{c, circt.fieldID = 2 : i32}, {circt.fieldID = 4 : i32, d}]
-    // CHECK-SAME: [{circt.fieldID = 4 : i32, e}]
+    // CHECK-SAME: [{a}, {b, circt.fieldID = 4 : i64}],
+    // CHECK-SAME: [{c, circt.fieldID = 2 : i64}, {circt.fieldID = 4 : i64, d}]
+    // CHECK-SAME: [{circt.fieldID = 4 : i64, e}]
 
     %bar_r, %bar_w, %bar_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
         portAnnotations = [


### PR DESCRIPTION
FieldID's can be 64bit, don't truncate to 32bits here.

Presently this is unlikely to be reachable as parser truncates them to 32bit presently.