### PR TITLE
[Python] Fix wheel publishing

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Unshallow CIRCT
         run: |
-          git fetch --unshallow --tags --no-recurse-submodules
+          git fetch --force --unshallow --tags --no-recurse-submodules
 
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
Proposed workaround for `git fetch` unshallowing not working on a tag.

I'm attempting to test this on a fork.

h/t @richardxia for the suggested fix.