### PR TITLE
[OM] Add external class declaration.

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -90,6 +90,28 @@ def ClassFieldOp : OMClassFieldLike<"class.field",
 }
 
 //===----------------------------------------------------------------------===//
+// External class definitions
+//===----------------------------------------------------------------------===//
+
+def ClassExternOp : OMClassLike<"class.extern"> {
+  let extraClassDeclaration = [{
+    mlir::Block *getBodyBlock() { return &getBody().front(); }
+  }];
+}
+
+def ClassExternFieldOp : OMClassFieldLike<"class.extern.field",
+    [HasParent<"ClassExternOp">]> {
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttr:$type
+  );
+
+  let assemblyFormat = [{
+    $sym_name `:` $type attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Object instantiations and fields
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -176,6 +176,50 @@ void circt::om::ClassOp::getAsmBlockArgumentNames(
 Type circt::om::ClassFieldOp::getType() { return getValue().getType(); }
 
 //===----------------------------------------------------------------------===//
+// ClassExternOp
+//===----------------------------------------------------------------------===//
+
+ParseResult circt::om::ClassExternOp::parse(OpAsmParser &parser,
+                                            OperationState &state) {
+  return parseClassLike(parser, state);
+}
+
+void circt::om::ClassExternOp::build(OpBuilder &odsBuilder,
+                                     OperationState &odsState, Twine name) {
+  return build(odsBuilder, odsState, odsBuilder.getStringAttr(name),
+               odsBuilder.getStrArrayAttr({}));
+}
+
+void circt::om::ClassExternOp::build(OpBuilder &odsBuilder,
+                                     OperationState &odsState, Twine name,
+                                     ArrayRef<StringRef> formalParamNames) {
+  return build(odsBuilder, odsState, odsBuilder.getStringAttr(name),
+               odsBuilder.getStrArrayAttr(formalParamNames));
+}
+
+void circt::om::ClassExternOp::print(OpAsmPrinter &printer) {
+  printClassLike(*this, printer);
+}
+
+LogicalResult circt::om::ClassExternOp::verify() {
+  if (failed(verifyClassLike(*this))) {
+    return failure();
+  }
+
+  // Verify that only external class field declarations are present in the body.
+  for (auto &op : getOps())
+    if (!isa<ClassExternFieldOp>(op))
+      return op.emitOpError("not allowed in external class");
+
+  return success();
+}
+
+void circt::om::ClassExternOp::getAsmBlockArgumentNames(
+    Region &region, OpAsmSetValueNameFn setNameFn) {
+  getClassLikeAsmBlockArgumentNames(*this, region, setNameFn);
+}
+
+//===----------------------------------------------------------------------===//
 // ObjectOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -71,6 +71,14 @@ om.class @Class2(%arg0: i1) {
 
 // -----
 
+om.class.extern @Extern(%param1: i1) {
+  // expected-error @+1 {{'om.constant' op not allowed in external class}}
+  %0 = om.constant 0 : i1
+  om.class.extern.field @field1 : i1
+}
+
+// -----
+
 // CHECK-LABEL: @List
 om.class @List() {
   // expected-error @+1 {{an element of a list attribute must have a type 'i32' but got 'i64'}}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -55,6 +55,26 @@ om.class @Empty() {}
 // CHECK-SAME: attributes {foo.bar = "baz"}
 om.class @DiscardableAttrs() attributes {foo.bar="baz"} {}
 
+// CHECK-LABEL: om.class.extern @Extern
+// CHECK-SAME: (%param1: i1, %param2: i2)
+om.class.extern @Extern(%param1: i1, %param2: i2) {
+  // CHECK: om.class.extern.field @field1 : i3
+  om.class.extern.field @field1 : i3
+
+  // CHECK: om.class.extern.field @field2 : i4
+  om.class.extern.field @field2 : i4
+}
+
+// CHECK-LABEL: om.class @ExternObject
+// CHECK-SAME: (%[[P0:.+]]: i1, %[[P1:.+]]: i2)
+om.class @ExternObject(%param1: i1, %param2: i2) {
+  // CHECK: %[[O0:.+]] = om.object @Extern(%[[P0]], %[[P1]])
+  %0 = om.object @Extern(%param1, %param2) : (i1, i2) -> !om.class.type<@Extern>
+
+  // CHECK: om.object.field %[[O0]], [@field1]
+  %1 = om.object.field %0, [@field1] : (!om.class.type<@Extern>) -> i3
+}
+
 om.class @NestedField1() {
   %0 = om.constant 1 : i1
   om.class.field @baz, %0 : i1


### PR DESCRIPTION
An external class is to a class what an external module is to a module. It captures just the types of the external class parameters, and fields, but no computation. This will be useful for linking together OM dialect IR.