### PR TITLE
[Python] Ensure attribute_to_var only accesses value when legal.

### DIFF
--- a/integration_test/Bindings/Python/support/conversion.py
+++ b/integration_test/Bindings/Python/support/conversion.py
@@ -1,0 +1,12 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+from circt.ir import ArrayAttr, Context, StringAttr
+from circt.support import attribute_to_var
+
+with Context():
+  string_attr = StringAttr.get("foo")
+  array_attr = ArrayAttr.get([string_attr])
+  array = attribute_to_var(array_attr)
+  # CHECK: ['foo']
+  print(array)

--- a/lib/Bindings/Python/support.py
+++ b/lib/Bindings/Python/support.py
@@ -131,7 +131,7 @@ def attribute_to_var(attr):
 
   # If it's not the root type, assume it's already been downcasted and don't do
   # the expensive probing below.
-  if attr.__class__ != ir.Attribute:
+  if attr.__class__ != ir.Attribute and hasattr(attr, "value"):
     return attr.value
 
   from .dialects import hw, om


### PR DESCRIPTION
This codepath assumes when the input attribute is not an Attribute, it has a value member. This is the case for things like StringAttr, but not for ArrayAttr. This popped up because upstream MLIR has been working to return downcasted concrete Attribute subclasses in more situations, so APIs that previously returned an Attribute might now return an ArrayAttr. A simpler testcase also reveals the issue. I've updated this path to also ensure that a value member exists before using it, and otherwise fall back to the generic code path.