### PR TITLE
[RFC][HW] Type(s) for n-valued logic

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -18,7 +18,7 @@ namespace hw {
 class PEOAttr;
 class EnumType;
 enum class PEO : uint32_t;
-enum class LogicKind: uint32_t;
+enum class LogicKind : uint32_t;
 class LogicType;
 
 // Eventually move this to an op trait

--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -18,6 +18,8 @@ namespace hw {
 class PEOAttr;
 class EnumType;
 enum class PEO : uint32_t;
+enum class LogicKind: uint32_t;
+class LogicType;
 
 // Eventually move this to an op trait
 struct InnerName {

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -299,4 +299,23 @@ def EnumFieldAttr : AttrDef<HWDialect, "EnumField"> {
   }];
 }
 
+def LogicLiteralAttr : AttrDef<HWDialect, "LogicLiteral", [TypedAttrInterface]> {
+  let summary = "TODO";
+  let description = "TODO";
+
+  let parameters = (ins "circt::hw::LogicKind":$kind, "::mlir::StringAttr":$literal,  AttributeSelfTypeParameter<"">:$type);
+
+  let mnemonic = "loglit";
+  let assemblyFormat = " `<`$kind`:`$literal`>` ";
+
+  let genVerifyDecl = true;
+  let skipDefaultBuilders = true;
+
+  let builders = [
+    AttrBuilder<(ins "circt::hw::LogicKind":$kind, "::mlir::StringAttr":$literal, "::mlir::Type":$type)>
+  ];
+
+ 
+}
+
 #endif // CIRCT_DIALECT_HW_HWATTRIBUTES_TD

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -54,6 +54,32 @@ def ConstantOp
   let hasVerifier = 1;
 }
 
+def LogicConstantOp 
+ : HWOp<"logconst", [Pure, ConstantLike, FirstAttrDerivedResultType, InferTypeOpInterface]> {
+  let summary = "Produce a constant n-valued logic value";
+  let description = [{TODO
+      e.g.: hw.logconst <SV:"1X0ZX">
+  }];
+
+  let assemblyFormat = "$value attr-dict";
+
+  let arguments = (ins LogicLiteralAttr:$value);
+  let results = (outs HWIntegerType:$result);
+
+  let hasFolder = true;
+  let hasVerifier = true;
+
+  let extraClassDeclaration = [{
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          std::optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::OpaqueProperties properties,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+}
+
 def WireOp : HWOp<"wire", [
     SameOperandsAndResultType,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -80,6 +80,20 @@ def LogicConstantOp
   }];
 }
 
+def LogicCastOp
+  : HWOp<"logcast", [Pure]> {
+
+  let summary = "TODO";
+  let description = "TODO";
+
+  let arguments = (ins HWIntegerType:$input);
+  let results = (outs HWIntegerType:$result);
+  let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";
+
+  let hasFolder = true;
+  let hasVerifier = true;  
+}
+
 def WireOp : HWOp<"wire", [
     SameOperandsAndResultType,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -76,7 +76,6 @@ int64_t getBitWidth(mlir::Type type);
 /// false on known InOut types, rather than any unknown types.
 bool hasHWInOutType(mlir::Type type);
 
-
 bool isNBitWideLogicType(mlir::Type type, std::optional<unsigned> width);
 
 bool isTwoStateLogicType(Type type);

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -76,6 +76,13 @@ int64_t getBitWidth(mlir::Type type);
 /// false on known InOut types, rather than any unknown types.
 bool hasHWInOutType(mlir::Type type);
 
+
+bool isNBitWideLogicType(mlir::Type type, std::optional<unsigned> width);
+
+bool isTwoStateLogicType(Type type);
+
+std::optional<unsigned> getLogicBitWidth(mlir::Type type);
+
 template <typename... BaseTy>
 bool type_isa(Type type) {
   // First check if the type is the requested type.

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -24,8 +24,8 @@ include "mlir/IR/AttrTypeBase.td"
 // known, non-directional type.
 def HWIntegerType : DialectType<HWDialect,
     CPred<"::circt::hw::isHWIntegerType($_self)">,
-    "a signless integer bitvector",
-    "::circt::hw::TypeVariant<::mlir::IntegerType, ::circt::hw::IntType>">;
+    "a signless integer or logic bitvector",
+    "::circt::hw::TypeVariant<::mlir::IntegerType, ::circt::hw::IntType, ::circt::hw::LogicType>">;
 
 // Type constraint that indicates that an operand/result may only be a valid,
 // known, non-directional type.

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -15,6 +15,7 @@
 
 include "circt/Dialect/HW/HWDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
 
 // Base class for other typedefs. Provides dialact-specific defaults.
 class HWType<string name> : TypeDef<HWDialect, name> { }
@@ -44,6 +45,74 @@ def IntTypeImpl : HWType<"Int"> {
     /// a builtin integer type if the width is a known-constant value.
     static Type get(::mlir::TypedAttr width);
   }];
+}
+
+// N-Valued Logic
+
+class LogicKindAttrCase<string sym, int val, string str, string lits>
+    : I32EnumAttrCase<sym, val, str> {
+  string atomicLitsStr = "\"" # lits # "\""; 
+}
+    
+
+defset list<LogicKindAttrCase> LogicKinds = {
+  def LogicKindTwo     : LogicKindAttrCase<"Two",   0, "B",  "01">;
+  def LogicKindThree   : LogicKindAttrCase<"Three", 1, "T",  "01X">;
+  def LogicKindSV      : LogicKindAttrCase<"SV",    2, "SV", "01XZ">;
+  def LogicKindVHDL    : LogicKindAttrCase<"VHDL",  3, "VH", "01XZULHW-">;
+}
+
+def LogicKindAttr : I32EnumAttr<
+    "LogicKind",
+    "Logic kind for HW logic type",
+    LogicKinds> {
+
+    let cppNamespace = "circt::hw";
+    let convertFromStorage = "$_self";
+
+    list<string> atomicLitsList = !foreach(kind, LogicKinds, kind.atomicLitsStr);
+}
+
+
+def LogicTypeImpl : HWType<"Logic"> {
+
+  let summary = "n-valued logic vector of fixed or parameterized length";
+  let description = [{
+    TODO
+  }];
+
+  let mnemonic = "log";
+   
+  let parameters = (ins LogicKindAttr:$kind,  "::mlir::TypedAttr":$widthAttr);
+
+  let hasCustomAssemblyFormat = true;
+  let skipDefaultBuilders = true;
+
+  let extraClassDeclaration = [{
+    constexpr const static std::array<::llvm::StringLiteral, }] # !size(LogicKindAttr.atomicLitsList) # [{> kindAtomicValues = { }]
+     # !interleave(LogicKindAttr.atomicLitsList, ", ") # [{ }; 
+    static size_t checkLiteral (const std::string &lit, circt::hw::LogicKind kind);
+    static Type get(::circt::hw::LogicKind kind, ::mlir::TypedAttr widthAttr);
+    static Type get(::circt::hw::LogicKindAttr kind, ::mlir::TypedAttr widthAttr) {
+      return get(kind.getValue(), widthAttr);
+    }
+    static Type get(::mlir::MLIRContext *context, ::circt::hw::LogicKind kind, unsigned width) {
+      auto int32Type = mlir::IntegerType::get(context, 32);
+      return get(kind, mlir::IntegerAttr::get(int32Type, (int32_t)width)); 
+    }
+    static Type get(::circt::hw::LogicKindAttr kind, unsigned width) {
+      auto int32Type = mlir::IntegerType::get(kind.getContext(), 32);
+      return get(kind, mlir::IntegerAttr::get(int32Type, (int32_t)width)); 
+    }
+    std::optional<unsigned> getWidth() const {
+      if (auto cstWidth = getWidthAttr().dyn_cast<IntegerAttr>()) {
+        auto cstAttrVal = cstWidth.getValue().getZExtValue();
+        return (unsigned) cstAttrVal;
+      }
+      return {};
+    };
+  }];
+
 }
 
 // A simple fixed size array. Declares the hw::ArrayType in C++.

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -1004,7 +1004,7 @@ FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
             evaluateParametricAttr(loc, parameters, t.getWidthAttr());
         if (failed(evaluatedWidth))
           return {failure()};
-        
+
         return LogicType::get(t.getKind(), *evaluatedWidth);
       })
       .Case<hw::ArrayType>([&](hw::ArrayType arrayType) -> FailureOr<Type> {
@@ -1057,21 +1057,26 @@ bool hw::isParametricType(mlir::Type t) {
 // LogicLiteralAttr
 // -----------------
 
-LogicLiteralAttr LogicLiteralAttr::get(MLIRContext *context, LogicKind kind, StringAttr literal, Type type) {
+LogicLiteralAttr LogicLiteralAttr::get(MLIRContext *context, LogicKind kind,
+                                       StringAttr literal, Type type) {
   if (type == NoneType::get(context)) {
     type = LogicType::get(literal.getContext(), kind, literal.size());
   }
   return Base::get(context, kind, literal, type);
 }
 
-LogicLiteralAttr LogicLiteralAttr::getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, MLIRContext *context, LogicKind kind, StringAttr literal, Type type) {
+LogicLiteralAttr LogicLiteralAttr::getChecked(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    MLIRContext *context, LogicKind kind, StringAttr literal, Type type) {
   if (type == NoneType::get(context)) {
     type = LogicType::get(literal.getContext(), kind, literal.size());
   }
   return Base::getChecked(emitError, context, kind, literal, type);
 }
 
-LogicalResult LogicLiteralAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, circt::hw::LogicKind kind, ::mlir::StringAttr literal, ::mlir::Type type) {
+LogicalResult LogicLiteralAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    circt::hw::LogicKind kind, ::mlir::StringAttr literal, ::mlir::Type type) {
   auto width = literal.size();
 
   if (width == 0) {
@@ -1081,14 +1086,16 @@ LogicalResult LogicLiteralAttr::verify(::llvm::function_ref<::mlir::InFlightDiag
 
   if (auto logType = hw::type_dyn_cast<LogicType>(type)) {
     if (logType.getKind() != kind) {
-      emitError() << "logic kind of specified type (" << stringifyLogicKind(logType.getKind()) 
-      << ") does not match kind of literal (" << stringifyLogicKind(kind) << ")";
+      emitError() << "logic kind of specified type ("
+                  << stringifyLogicKind(logType.getKind())
+                  << ") does not match kind of literal ("
+                  << stringifyLogicKind(kind) << ")";
       return failure();
     }
     if (auto fixedWidth = logType.getWidth()) {
       if (*fixedWidth != width) {
-        emitError() << "width of specified type (" << *fixedWidth 
-          << ") does not match width of literal (" << width << ")";
+        emitError() << "width of specified type (" << *fixedWidth
+                    << ") does not match width of literal (" << width << ")";
         return failure();
       }
     } else {
@@ -1105,7 +1112,8 @@ LogicalResult LogicLiteralAttr::verify(::llvm::function_ref<::mlir::InFlightDiag
 
   auto matchLen = LogicType::checkLiteral(literal.str(), kind);
   if (matchLen != width) {
-    emitError() << "logic literal contains invalid character at index " << matchLen;
+    emitError() << "logic literal contains invalid character at index "
+                << matchLen;
     return failure();
   }
 

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -13,6 +13,7 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -1042,4 +1043,63 @@ bool hw::isParametricType(mlir::Type t) {
                isParamAttrWithParamRef(arrayType.getSizeAttr());
       })
       .Default([](auto) { return false; });
+}
+
+// -----------------
+// LogicLiteralAttr
+// -----------------
+
+LogicLiteralAttr LogicLiteralAttr::get(MLIRContext *context, LogicKind kind, StringAttr literal, Type type) {
+  if (type == NoneType::get(context)) {
+    type = LogicType::get(literal.getContext(), kind, literal.size());
+  }
+  return Base::get(context, kind, literal, type);
+}
+
+LogicLiteralAttr LogicLiteralAttr::getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, MLIRContext *context, LogicKind kind, StringAttr literal, Type type) {
+  if (type == NoneType::get(context)) {
+    type = LogicType::get(literal.getContext(), kind, literal.size());
+  }
+  return Base::getChecked(emitError, context, kind, literal, type);
+}
+
+LogicalResult LogicLiteralAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, circt::hw::LogicKind kind, ::mlir::StringAttr literal, ::mlir::Type type) {
+  auto width = literal.size();
+
+  if (width == 0) {
+    emitError() << "zero width logic literals not allowed";
+    return failure();
+  }
+
+  if (auto logType = hw::type_dyn_cast<LogicType>(type)) {
+    if (logType.getKind() != kind) {
+      emitError() << "logic kind of specified type (" << stringifyLogicKind(logType.getKind()) 
+      << ") does not match kind of literal (" << stringifyLogicKind(kind) << ")";
+      return failure();
+    }
+    if (auto fixedWidth = logType.getWidth()) {
+      if (*fixedWidth != width) {
+        emitError() << "width of specified type (" << *fixedWidth 
+          << ") does not match width of literal (" << width << ")";
+        return failure();
+      }
+    } else {
+      emitError() << "width of logic literal self-type must be a known integer";
+      return failure();
+    }
+  } else {
+    // Binary literals fall back to IntegerType
+    if (!hw::type_isa<IntegerType>(type)) {
+      emitError() << "speciifed type of logic literal must be LogicType";
+      return failure();
+    }
+  }
+
+  auto matchLen = LogicType::checkLiteral(literal.str(), kind);
+  if (matchLen != width) {
+    emitError() << "logic literal contains invalid character at index " << matchLen;
+    return failure();
+  }
+
+  return success();
 }

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -999,6 +999,14 @@ FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
         // Otherwise parameter references are still involved
         return hw::IntType::get(evaluatedWidth->cast<TypedAttr>());
       })
+      .Case<hw::LogicType>([&](hw::LogicType t) -> FailureOr<Type> {
+        auto evaluatedWidth =
+            evaluateParametricAttr(loc, parameters, t.getWidthAttr());
+        if (failed(evaluatedWidth))
+          return {failure()};
+        
+        return LogicType::get(t.getKind(), *evaluatedWidth);
+      })
       .Case<hw::ArrayType>([&](hw::ArrayType arrayType) -> FailureOr<Type> {
         auto size =
             evaluateParametricAttr(loc, parameters, arrayType.getSizeAttr());

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -372,34 +372,28 @@ OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
 // LogicConstantOp
 //===----------------------------------------------------------------------===//
 
-
 LogicalResult LogicConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
   if (getValue().getType() != getType())
-    return emitError(
-        "hw.constant attribute type doesn't match return type");
+    return emitError("hw.constant attribute type doesn't match return type");
 
   return success();
 }
-
 
 OpFoldResult LogicConstantOp::fold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getValueAttr();
 }
 
-LogicalResult LogicConstantOp::inferReturnTypes(MLIRContext *context,
-                                          std::optional<Location> loc,
-                                          ValueRange operands,
-                                          DictionaryAttr attrs,
-                                          mlir::OpaqueProperties properties,
-                                          mlir::RegionRange regions,
-                                          SmallVectorImpl<Type> &results) {
-     auto valueAttr = attrs.getAs<LogicLiteralAttr>("value");
-     if (!hw::type_isa<LogicType,IntegerType>(valueAttr.getType()))
-      return failure();
-    results.push_back(valueAttr.getType());
-    return success();
+LogicalResult LogicConstantOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
+  auto valueAttr = attrs.getAs<LogicLiteralAttr>("value");
+  if (!hw::type_isa<LogicType, IntegerType>(valueAttr.getType()))
+    return failure();
+  results.push_back(valueAttr.getType());
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -416,18 +410,19 @@ LogicalResult LogicCastOp::verify() {
   else if (!resultWidth && !inputWidth) {
     // Input and result are parameterized-width logic type
     auto logResult = hw::type_cast<LogicType>(getResult().getType());
-    auto logInput  = hw::type_cast<LogicType>(getInput().getType());
+    auto logInput = hw::type_cast<LogicType>(getInput().getType());
     if (logResult.getWidthAttr() == logInput.getWidthAttr())
       return success();
   }
-  
+
   emitError("width of cast input and result must be equal");
   return failure();
 }
 
 OpFoldResult LogicCastOp::fold(FoldAdaptor adaptor) {
   // Remove casts to same type
-  if (getCanonicalType(getInput().getType()) == getCanonicalType(getResult().getType()))
+  if (getCanonicalType(getInput().getType()) ==
+      getCanonicalType(getResult().getType()))
     return getInput();
   return {};
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -369,6 +369,40 @@ OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// LogicConstantOp
+//===----------------------------------------------------------------------===//
+
+
+LogicalResult LogicConstantOp::verify() {
+  // If the result type has a bitwidth, then the attribute must match its width.
+  if (getValue().getType() != getType())
+    return emitError(
+        "hw.constant attribute type doesn't match return type");
+
+  return success();
+}
+
+
+OpFoldResult LogicConstantOp::fold(FoldAdaptor adaptor) {
+  assert(adaptor.getOperands().empty() && "constant has no operands");
+  return getValueAttr();
+}
+
+LogicalResult LogicConstantOp::inferReturnTypes(MLIRContext *context,
+                                          std::optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::OpaqueProperties properties,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results) {
+     auto valueAttr = attrs.getAs<LogicLiteralAttr>("value");
+     if (!hw::type_isa<LogicType,IntegerType>(valueAttr.getType()))
+      return failure();
+    results.push_back(valueAttr.getType());
+    return success();
+}
+
+//===----------------------------------------------------------------------===//
 // WireOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/StorageUniquerSupport.h"
 #include "mlir/IR/Types.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -47,17 +48,15 @@ mlir::Type circt::hw::getCanonicalType(mlir::Type type) {
 
 /// Return true if the specified type is a value HW Integer type.  This checks
 /// that it is a signless standard dialect type or a hw::IntType.
+//  HACK: Also LogicType
 bool circt::hw::isHWIntegerType(mlir::Type type) {
   Type canonicalType = getCanonicalType(type);
 
-  if (canonicalType.isa<hw::IntType>())
+  if (canonicalType.isa<hw::IntType, hw::LogicType>())
     return true;
 
   auto intType = canonicalType.dyn_cast<IntegerType>();
-  if (!intType || !intType.isSignless())
-    return false;
-
-  return true;
+  return intType && intType.isSignless();
 }
 
 bool circt::hw::isHWEnumType(mlir::Type type) {
@@ -69,7 +68,7 @@ bool circt::hw::isHWEnumType(mlir::Type type) {
 /// hardware but not marker types like InOutType.
 bool circt::hw::isHWValueType(Type type) {
   // Signless and signed integer types are both valid.
-  if (type.isa<IntegerType, IntType, EnumType>())
+  if (type.isa<IntegerType, IntType, EnumType, LogicType>())
     return true;
 
   if (auto array = type.dyn_cast<ArrayType>())
@@ -101,6 +100,11 @@ int64_t circt::hw::getBitWidth(mlir::Type type) {
   return llvm::TypeSwitch<::mlir::Type, size_t>(type)
       .Case<IntegerType>(
           [](IntegerType t) { return t.getIntOrFloatBitWidth(); })
+      .Case<LogicType>([](LogicType t) {
+        if (auto width = t.getWidth())
+          return static_cast<int64_t>(*width);
+        return static_cast<int64_t>(-1L);
+      })
       .Case<ArrayType, UnpackedArrayType>([](auto a) {
         int64_t elementBitWidth = getBitWidth(a.getElementType());
         if (elementBitWidth < 0)
@@ -170,7 +174,7 @@ static ParseResult parseHWElementType(Type &result, AsmParser &p) {
   if (typeString.startswith("array<") || typeString.startswith("inout<") ||
       typeString.startswith("uarray<") || typeString.startswith("struct<") ||
       typeString.startswith("typealias<") || typeString.startswith("int<") ||
-      typeString.startswith("enum<")) {
+      typeString.startswith("log<") || typeString.startswith("enum<")) {
     llvm::StringRef mnemonic;
     auto parseResult = generatedTypeParser(p, &mnemonic, result);
     return parseResult.has_value() ? success() : failure();
@@ -183,6 +187,53 @@ static void printHWElementType(Type element, AsmPrinter &p) {
   if (succeeded(generatedTypePrinter(element, p)))
     return;
   p.printType(element);
+}
+
+size_t LogicType::checkLiteral(const std::string &lit, circt::hw::LogicKind kind) {
+
+  // Construct set of valid atomic literals for logic kind
+  std::string atomicVals = LogicType::kindAtomicValues[static_cast<int64_t>(kind)].str();
+  llvm::SmallSet<char, 9> atomicsSet;
+  atomicsSet.insert(atomicVals.begin(), atomicVals.end());
+
+  for(size_t i = 0; i < lit.size(); i++) {
+    if (!atomicsSet.contains(lit[i]))
+      return i;
+  }
+
+  return lit.size();
+}
+
+bool circt::hw::isNBitWideLogicType(mlir::Type type, std::optional<unsigned> width) {
+  auto canonicalType = getCanonicalType(type);
+  if (auto baseInt = llvm::dyn_cast<IntegerType>(canonicalType)) {
+    return (!width) || (baseInt.getIntOrFloatBitWidth() == *width);
+  }
+
+  if (auto logType = llvm::dyn_cast<LogicType>(canonicalType)) {
+    if (auto typeWidth = logType.getWidth())
+      return (!width) || (*typeWidth == *width);
+  }
+
+  return false;
+}
+
+bool circt::hw::isTwoStateLogicType(Type type) {
+  auto canonicalType = getCanonicalType(type);
+  if (llvm::isa<IntegerType>(canonicalType)) 
+    return true;
+  if (auto logType = llvm::dyn_cast<LogicType>(canonicalType))
+    return logType.getKind() == LogicKind::Two;
+  return false;
+}
+
+std::optional<unsigned> circt::hw::getLogicBitWidth(mlir::Type type) {
+  auto canonicalType = getCanonicalType(type);
+  if (auto intType = llvm::dyn_cast<IntegerType>(canonicalType))
+    return intType.getIntOrFloatBitWidth();
+  if (auto logType = llvm::dyn_cast<LogicType>(canonicalType))
+    return logType.getWidth();
+  return {};
 }
 
 //===----------------------------------------------------------------------===//
@@ -217,6 +268,76 @@ void IntType::print(AsmPrinter &p) const {
   p << "<";
   p.printAttributeWithoutType(getWidth());
   p << '>';
+}
+
+//===----------------------------------------------------------------------===//
+// Logic Type
+//===----------------------------------------------------------------------===//
+
+Type LogicType::get(::circt::hw::LogicKind kind, ::mlir::TypedAttr widthAttr) {
+  if (auto cstWidth = widthAttr.dyn_cast<IntegerAttr>()) {
+    // Construct an integer type for fixed-width logic of kind 2
+      if (kind == LogicKind::Two)
+        return IntegerType::get(widthAttr.getContext(),
+                                cstWidth.getValue().getZExtValue());
+  } else {
+      auto widthWidth = widthAttr.getType().dyn_cast<IntegerType>();
+      assert(widthWidth && widthWidth.getWidth() == 32 &&
+          "!hw.log width must be 32-bits");
+      (void)widthWidth;
+  }
+
+  return Base::get(widthAttr.getContext(), kind, widthAttr);
+}
+
+
+// Examples:
+// !hw.log<SV:8>          8 digit SystemVerilog four valued logic
+// !hw.log<T>             Single digit three valued logic
+// !hw.log<B:3>           3 bit binary logic, will yield 'i3' type
+//
+// !hw.log<B:#hw.param.decl.ref<"p">>    Binary logic of parameterized width 'p'
+// !hw.log<VH:#hw.param.decl.ref<"p">>   9-valued VHDL logic of parameterized width 'p'
+
+Type LogicType::parse(::mlir::AsmParser &odsParser) {
+  if (odsParser.parseLess())
+    return Type();
+  
+  // Parse logic kind
+  auto kindParse = mlir::FieldParser<LogicKind>::parse(odsParser);
+  if (failed(kindParse))
+    return Type();
+
+  // Optionally parse width from integer literal or attribute, defaults to 1 if missing.
+  bool hasFixedWidth = true;
+  unsigned fixedWidth = 1;
+  TypedAttr widthAttr;
+
+  if (odsParser.parseOptionalColon().succeeded()) {
+    auto widthIntParse = odsParser.parseOptionalInteger(fixedWidth);
+    if(widthIntParse.has_value() && failed(*widthIntParse))
+      return Type();
+    if (!widthIntParse.has_value()) {
+      // Try to parse width from attribute
+      hasFixedWidth = false;
+      auto int32Type = odsParser.getBuilder().getIntegerType(32);
+      if (odsParser.parseAttribute(widthAttr, int32Type))
+        return Type();
+    }
+  }
+
+  if (odsParser.parseGreater())
+    return Type();
+
+  if (hasFixedWidth)
+    return LogicType::get(odsParser.getContext(), *kindParse, fixedWidth);
+  return LogicType::get(*kindParse, widthAttr);
+}
+
+void LogicType::print(::mlir::AsmPrinter &odsPrinter) const {
+  odsPrinter << "<" << stringifyLogicKind(getKind()) << ":";
+  odsPrinter.printAttributeWithoutType(getWidthAttr());
+  odsPrinter << ">";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Note: This PR is primarily intended to collect opinions and suggestions outside of the weekly Zoom calls. The attached code is merely an initial prototype. 

**Motivation**
Use of logic types encoding more than two states per "bit" is common practice in both SystemVerilog and VHDL. These can have major implications on what optimizations are valid, especially in Comb. E.g.:

- `comb.mul(a, 0) -> 0` is invalid for both SV `logic` and VHDL `numeric_std` since `X * 0`  evaluates to `X`
- `comb.and(a,~a) -> 0`  is invalid for both SV `logic` and VHDL `std_logic` since `X & ~X` evaluates to `X`
- `comb.mux(s, a, a) -> a` is invalid for SV `logic` since `X ? Z : Z` evaluates to `X`. For VHDL a multiplexer is technically not defined on non-boolean conditions and has to be constructed with an `if`-like statement and an explicit comparison.

To accurately model this behavior in circt, the respective semantics need to be encoded _somehow_ in the IR. Currently, HW only operates on two-state primitive types (builtin Integer for fixed-width and HWIntegerType for parameterized-width types). The `twoState` attribute was added to operations in Comb to circumvent these issues, indicating that an operation should either ignore n-state behavior or strictly adhere to both SystemVerilog _and_ VHDL semantics. However, the current approach has several drawbacks:

- SystemVerilog and VHDL interpretations of non two-state operations are not necessarily compatible, primarily for the `comb.mux` and `comb.icmp` ops, making it hard to reason about the intended behavior.
- For multiplexers there is a major difference between having n-state values on the condition vs. having n-state input values.
-  The newly added `comb.truthtable` op requires semantics that are, strictly speaking, incompatible with all other current interpretations.
- Having to select between the two extremes can be impractical in many cases. X-propagation issues are an unfortunate reality in simulations, but strictly retaining Z behavior is frequently unnecessary.
- Intentional selection of two-state vs. n-state types (e.g. `bit` vs. `logic` in SV) for specific variables is not possible.

While it would be possible to implement the n-state semantics entirely in the respective language backends, this would likely lead to a lot of duplicated implementations and reduce the usefulness of HW as a common abstraction. Based on the discussions with @darthscsi, @fabianschuiki, @seldridge and @teqdruid  (thank you all) the consensus appears to be that the best solution is to add one or several types to HW to encode n-state logic.

**Summary**

This PR adds four elements to the HW dialect:

-  LogicType (`!hw.log`) : A type representing an arbitrary (positive) length one-dimensional vector of logic "digits" with a specific logic _kind_. The width can be fixed or depend on a parameter. Possible kinds are Binary (`B`), Three-valued logic (`T`), 4-state SystemVerilog (`SV`) and 9-state VHDL (`VH`). Binary-kind LogicType of fixed width is identical to the built-in integer type. The precise semantics of the different logic kinds are beyond the scope of this PR. 
The printer/parser encoding is < _kind_ : _width_ >, e.g. `!hw.log<T:5>` for five digits of  `[0,1,X]`. 
- LogicLiteralAttr (`#hw.loglit`) : An attribute encapsulating a known constant LogicType value of a specific kind and fixed width. Legal "atomic" literals are a subset of `[0,1,X,Z,U,W,L,H,-]`, depending on the specified kind.
- LogicConstantOp (`hw.logconst`): An operation producing a constant LogicType value based on a LogicLiterallAttr.
- LogicCastOp (`hw.logcast`): An operation converting between LogicType values of different kind and same width.

**LogicType**

One of the major design questions is how to "box" the different aspects (logic kind and fixed vs. parameterized width) of logic variables into type(s). The one extreme case would be to have six separate type classes for T, SV and VH kind and fixed/parameterized width respectively, plus HWIntegerType and builtin integer for the binary kind. 
The approach I have taken so far is the other extreme, i.e. encapsulating everything in one single type class. Up to this point this has worked out relatively well, but I know (looking @darthscsi) there are opponents to this approach and I'm not saying it has to be done this way. 

One aspect of the current implementation is that LogicType is a superset of HWIntegerType, effectively making HWIntegerType redundant. Overall support for parameterized-width integers appears to be shaky in HW and I considered making LogicType fixed width only. But I feel supporting (however badly) parameterized width for two-state but not for n-state types would be an odd decision. By effectively moving HWIntegerType into LogicType , the problem gets kicked further down the road but at least it should not become harder. 

The builder for LogicType also mimics HWIntegerType in returning a builtin integer for fixed-width types of binary kind. This is an annoying source for mistakes as I have experienced myself. But I think it is preferable over having to deal with two different types for binary fixed-width logic. And replacing the builtin integer as "default" type does not seem reasonable to me.

**LogicLiteralAttr**

LogicLiteralAttributes are used to represent constants of LogicType in the IR. Currently, they are simply a wrapper for the specified logic kind and the string constant representing the value. This is neither efficient nor practical to work with when performing operations on these constants.
After last week's discussion I have started experimenting with more compact encodings.  I have not included it in this PR because I have not yet actually integrated it. But you can take a look at what I have come up with so far on a different branch: 
https://github.com/fzi-hielscher/circt/blob/hwlogic-code-github/include/circt/Dialect/HW/HWLogicCode.h

The basic idea is to "stripe" the binary encoding bit-per-bit over one, two, or four "fields" of an underlying integer type depending on the required number of distinct logic values. This way, n-valued logic operations can be realized by a sequence of binary bit-wise operations on those fields (I suppose this is what you had in mind last Wednesday, @fabianschuiki?) 

This kind of encoding would allow us to dynamically pick the required number of fields for a given constant. An open question for me is, whether this should be tied to the constant's logic kind or it's concrete value. E.g., does a 
`#hw.loglit < VH: "11001101"> : !hw.log<VH:8>` 
take four fields because it is 9-valued logic or only two fields because it actually is an integer?

**LogicConstantOp**

Used to "materialize" LogicLiteralAttributes as constant LogicType values. Since the LogicLiteralAttribute already fully encodes the type, it does not need to be specified. E.g.: `%cx = hw.logconst <SV:"001XZ">`  is sufficient to produce a value of type `!hw.log<SV:5>`. However, it should probably be extended to also parse integer literals, since the vast majority of constants of any kind will effectively be binary.

**LogicCastOp**

Used to convert between logic kinds. This will change the semantics of the converted values. How precisely remains to be specified. Also, should the conversion function be fixed or should we allow customization?  It probably needs at least an attribute to control how unknown values are treated when casting to binary logic.

 

So.... this has gotten quite a bit longer than I had anticipated. Sorry for the wall of text. If you just want to try out the code, I'll attach a toy MLIR snippet:
[sandbox.txt](https://github.com/llvm/circt/files/12086774/sandbox.txt)
But expect it to crash and burn when doing any more than parsing and printing.

Looking forward to your comments.
