### PR TITLE
[HW][ESI][MSFT][NFCI] HWInnerRefAttr -> InnerRefAttr.

### DIFF
--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Dialect/HW/HWAttributesNaming.td"
 include "circt/Dialect/HW/HWTypes.td"
 include "mlir/IR/RegionKindInterface.td"
 
@@ -132,7 +133,7 @@ def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
         ServiceReqOpInterface]> {
   let summary = "Request a connection to send data";
 
-  let arguments = (ins HWInnerRefAttr:$servicePort,
+  let arguments = (ins InnerRefAttr:$servicePort,
                        ChannelType:$toServer, StrArrayAttr:$clientNamePath);
   let assemblyFormat = [{
     $toServer `->` $servicePort `(` $clientNamePath `)`
@@ -153,7 +154,7 @@ def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
         ServiceReqOpInterface]> {
   let summary = "Request a connection to receive data";
 
-  let arguments = (ins HWInnerRefAttr:$servicePort,
+  let arguments = (ins InnerRefAttr:$servicePort,
                        StrArrayAttr:$clientNamePath);
   let results = (outs ChannelType:$toClient);
   let assemblyFormat = [{
@@ -167,7 +168,7 @@ def RequestInOutChannelOp : ESI_Op<"service.req.inout", [
         ServiceReqOpInterface]> {
   let summary = "Request a bidirectional channel";
 
-  let arguments = (ins HWInnerRefAttr:$servicePort,
+  let arguments = (ins InnerRefAttr:$servicePort,
                        ChannelType:$toServer,
                        StrArrayAttr:$clientNamePath);
   let results = (outs ChannelType:$toClient);

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -83,15 +83,6 @@ def HWStringType : TypeDef<HWDialect, "String"> {
   let mnemonic = "string";
 }
 
-/// Points to a name within a module.
-def HWInnerRefAttr : Attr<
-  CPred<"$_self.isa<::circt::hw::InnerRefAttr>()">,
-        "name reference attribute"> {
-  let returnType = "::circt::hw::InnerRefAttr";
-  let storageType = "::circt::hw::InnerRefAttr";
-  let convertFromStorage = "$_self";
-}
-
 /// A flat symbol reference or a reference to a name within a module.
 def NameRefAttr : Attr<
   CPred<"$_self.isa<::mlir::FlatSymbolRefAttr, ::circt::hw::InnerRefAttr>()">,

--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Dialect/HW/HWAttributesNaming.td"
 include "circt/Dialect/HW/HWTypes.td"
 
 def DeclPhysicalRegionOp : MSFTOp<"physical_region",
@@ -119,7 +120,7 @@ def DynamicInstanceOp : MSFTOp<"instance.dynamic",
     gives them the symbol of the globalref which was created to replace the
     dynamic instance.
   }];
-  let arguments = (ins HWInnerRefAttr:$instanceRef);
+  let arguments = (ins InnerRefAttr:$instanceRef);
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{


### PR DESCRIPTION
Drop the HWInnerRefAttr wrapper, use InnerRefAttr directly.

Bit of source code archaeology suggests this was added to workaround build problems re:ODS[1], which no longer appears to be the case.

[1] https://github.com/llvm/circt/pull/3005#discussion_r862374300