### PR TITLE
[FIRRTL][Utils] Drop support for hinting at symbol names. 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -113,24 +113,24 @@ void walkGroundTypes(FIRRTLType firrtlType,
 /// Returns an operation's `inner_sym`, adding one if necessary.
 StringAttr
 getOrAddInnerSym(Operation *op, FModuleOp mod,
-                 std::function<ModuleNamespace &(FModuleOp)> getNamespace);
+                 llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace);
 
 /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
 /// to that operation.
 hw::InnerRefAttr
 getInnerRefTo(Operation *op,
-              std::function<ModuleNamespace &(FModuleOp)> getNamespace);
+              llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace);
 
 /// Returns a port's `inner_sym`, adding one if necessary.
-StringAttr
-getOrAddInnerSym(FModuleLike mod, size_t portIdx,
-                 std::function<ModuleNamespace &(FModuleLike)> getNamespace);
+StringAttr getOrAddInnerSym(
+    FModuleLike mod, size_t portIdx,
+    llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace);
 
 /// Obtain an inner reference to a port, possibly adding an `inner_sym`
 /// to the port.
 hw::InnerRefAttr
 getInnerRefTo(FModuleLike mod, size_t portIdx,
-              std::function<ModuleNamespace &(FModuleLike)> getNamespace);
+              llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace);
 
 //===----------------------------------------------------------------------===//
 // Type utilities

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -112,24 +112,24 @@ void walkGroundTypes(FIRRTLType firrtlType,
 
 /// Returns an operation's `inner_sym`, adding one if necessary.
 StringAttr
-getOrAddInnerSym(Operation *op, StringRef nameHint, FModuleOp mod,
+getOrAddInnerSym(Operation *op, FModuleOp mod,
                  std::function<ModuleNamespace &(FModuleOp)> getNamespace);
 
 /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
 /// to that operation.
 hw::InnerRefAttr
-getInnerRefTo(Operation *op, StringRef nameHint,
+getInnerRefTo(Operation *op,
               std::function<ModuleNamespace &(FModuleOp)> getNamespace);
 
 /// Returns a port's `inner_sym`, adding one if necessary.
 StringAttr
-getOrAddInnerSym(FModuleLike mod, size_t portIdx, StringRef nameHint,
+getOrAddInnerSym(FModuleLike mod, size_t portIdx,
                  std::function<ModuleNamespace &(FModuleLike)> getNamespace);
 
 /// Obtain an inner reference to a port, possibly adding an `inner_sym`
 /// to the port.
 hw::InnerRefAttr
-getInnerRefTo(FModuleLike mod, size_t portIdx, StringRef nameHint,
+getInnerRefTo(FModuleLike mod, size_t portIdx,
               std::function<ModuleNamespace &(FModuleLike)> getNamespace);
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -582,7 +582,7 @@ void OpAnnoTarget::setAnnotations(AnnotationSet annotations) const {
 }
 
 StringAttr OpAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
-  return ::getOrAddInnerSym(getOp(), "", getOp()->getParentOfType<FModuleOp>(),
+  return ::getOrAddInnerSym(getOp(), getOp()->getParentOfType<FModuleOp>(),
                             [&moduleNamespace](FModuleOp) -> ModuleNamespace & {
                               return moduleNamespace;
                             });
@@ -596,7 +596,7 @@ OpAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
     return FlatSymbolRefAttr::get(module.getModuleNameAttr());
   }
   // Return an inner-ref to the target.
-  return ::getInnerRefTo(getOp(), "",
+  return ::getInnerRefTo(getOp(),
                          [&moduleNamespace](FModuleOp) -> ModuleNamespace & {
                            return moduleNamespace;
                          });
@@ -646,11 +646,10 @@ StringAttr PortAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
   // itself.
   if (auto mod = ::llvm::dyn_cast<FModuleLike>(getOp()))
     return ::getOrAddInnerSym(
-        mod, getPortNo(), "",
-        [&moduleNamespace](FModuleLike) -> ModuleNamespace & {
+        mod, getPortNo(), [&moduleNamespace](FModuleLike) -> ModuleNamespace & {
           return moduleNamespace;
         });
-  return ::getOrAddInnerSym(getOp(), "", getOp()->getParentOfType<FModuleOp>(),
+  return ::getOrAddInnerSym(getOp(), getOp()->getParentOfType<FModuleOp>(),
                             [&moduleNamespace](FModuleOp) -> ModuleNamespace & {
                               return moduleNamespace;
                             });
@@ -660,12 +659,12 @@ Attribute
 PortAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
   auto module = llvm::dyn_cast<FModuleLike>(getOp());
   if (!module)
-    return ::getInnerRefTo(getOp(), "",
+    return ::getInnerRefTo(getOp(),
                            [&moduleNamespace](FModuleOp) -> ModuleNamespace & {
                              return moduleNamespace;
                            });
 
-  return ::getInnerRefTo(module, getPortNo(), "",
+  return ::getInnerRefTo(module, getPortNo(),
                          [&moduleNamespace](FModuleLike) -> ModuleNamespace & {
                            return moduleNamespace;
                          });

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -702,7 +702,7 @@ void circt::firrtl::walkGroundTypes(
 /// Returns an operation's `inner_sym`, adding one if necessary.
 StringAttr circt::firrtl::getOrAddInnerSym(
     Operation *op, FModuleOp mod,
-    std::function<ModuleNamespace &(FModuleOp)> getNamespace) {
+    llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace) {
   auto attr = getInnerSymName(op);
   if (attr)
     return attr;
@@ -716,7 +716,8 @@ StringAttr circt::firrtl::getOrAddInnerSym(
 /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
 /// to that operation.
 hw::InnerRefAttr circt::firrtl::getInnerRefTo(
-    Operation *op, std::function<ModuleNamespace &(FModuleOp)> getNamespace) {
+    Operation *op,
+    llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace) {
   auto mod = op->getParentOfType<FModuleOp>();
   assert(mod && "must be an operation inside an FModuleOp");
   return hw::InnerRefAttr::get(SymbolTable::getSymbolName(mod),
@@ -726,7 +727,7 @@ hw::InnerRefAttr circt::firrtl::getInnerRefTo(
 /// Returns a port's `inner_sym`, adding one if necessary.
 StringAttr circt::firrtl::getOrAddInnerSym(
     FModuleLike mod, size_t portIdx,
-    std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
+    llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace) {
 
   auto attr = cast<hw::HWModuleLike>(*mod).getPortSymbolAttr(portIdx);
   if (attr)
@@ -741,7 +742,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
 /// to the port.
 hw::InnerRefAttr circt::firrtl::getInnerRefTo(
     FModuleLike mod, size_t portIdx,
-    std::function<ModuleNamespace &(FModuleLike)> getNamespace) {
+    llvm::function_ref<ModuleNamespace &(FModuleLike)> getNamespace) {
   return hw::InnerRefAttr::get(SymbolTable::getSymbolName(mod),
                                getOrAddInnerSym(mod, portIdx, getNamespace));
 }

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -47,7 +47,7 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
   /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
   /// to that operation.
   hw::InnerRefAttr getInnerRefTo(Operation *op) {
-    return ::getInnerRefTo(op, "", [&](FModuleOp mod) -> ModuleNamespace & {
+    return ::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
       return getModuleNamespace(mod);
     });
   }

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -216,10 +216,10 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
     if (auto module = dyn_cast<FModuleLike>(op))
       symbol = FlatSymbolRefAttr::get(module);
     else
-      symbol = firrtl::getInnerRefTo(op, "",
-                                     [&](FModuleOp mod) -> ModuleNamespace & {
-                                       return getModuleNamespace(mod);
-                                     });
+      symbol =
+          firrtl::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
+            return getModuleNamespace(mod);
+          });
 
     auto [it, inserted] = symbolIndices.try_emplace(symbol, symbols.size());
     if (inserted)

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -1240,15 +1240,14 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
 }
 
 hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(Operation *op) {
-  return ::getInnerRefTo(op, "omir_sym",
-                         [&](FModuleOp module) -> ModuleNamespace & {
-                           return getModuleNamespace(module);
-                         });
+  return ::getInnerRefTo(op, [&](FModuleOp module) -> ModuleNamespace & {
+    return getModuleNamespace(module);
+  });
 }
 
 hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(FModuleLike module,
                                              size_t portIdx) {
-  return ::getInnerRefTo(module, portIdx, "omir_sym",
+  return ::getInnerRefTo(module, portIdx,
                          [&](FModuleLike mod) -> ModuleNamespace & {
                            return getModuleNamespace(mod);
                          });

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -77,10 +77,9 @@ struct ExtractInstancesPass
   /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
   /// to that operation.
   InnerRefAttr getInnerRefTo(Operation *op) {
-    return ::getInnerRefTo(op, "extraction_sym",
-                           [&](FModuleOp mod) -> ModuleNamespace & {
-                             return getModuleNamespace(mod);
-                           });
+    return ::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
+      return getModuleNamespace(mod);
+    });
   }
 
   /// Create a clone of a `HierPathOp` with a new uniquified name.

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -287,7 +287,7 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
       SmallVector<Attribute> newNamepath(namepath.begin(), namepath.end());
       if (!nla.isComponent())
         newNamepath.back() =
-            getInnerRefTo(inst, "", [&](FModuleOp mod) -> ModuleNamespace & {
+            getInnerRefTo(inst, [&](FModuleOp mod) -> ModuleNamespace & {
               return getModuleNamespace(mod);
             });
       newNamepath.push_back(leafAttr);

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -618,8 +618,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     if (auto arg = dyn_cast<BlockArgument>(val))
       return ::getInnerRefTo(
           cast<FModuleLike>(arg.getParentBlock()->getParentOp()),
-          arg.getArgNumber(), "xmr_sym",
-          [&](FModuleLike mod) -> ModuleNamespace & {
+          arg.getArgNumber(), [&](FModuleLike mod) -> ModuleNamespace & {
             return getModuleNamespace(mod);
           });
     else
@@ -627,10 +626,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   InnerRefAttr getInnerRefTo(Operation *op) {
-    return ::getInnerRefTo(op, "xmr_sym",
-                           [&](FModuleOp mod) -> ModuleNamespace & {
-                             return getModuleNamespace(mod);
-                           });
+    return ::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
+      return getModuleNamespace(mod);
+    });
   }
 
   void markForRemoval(Operation *op) { opsToRemove.push_back(op); }

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -621,8 +621,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
           arg.getArgNumber(), [&](FModuleLike mod) -> ModuleNamespace & {
             return getModuleNamespace(mod);
           });
-    else
-      return getInnerRefTo(val.getDefiningOp());
+    return getInnerRefTo(val.getDefiningOp());
   }
 
   InnerRefAttr getInnerRefTo(Operation *op) {

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -1182,11 +1182,10 @@ void Inliner::inlineInstances(FModuleOp parent) {
       for (auto sym : rootMap[target.getNameAttr()]) {
         auto &mnla = nlaMap[sym];
         sym = mnla.reTop(parent);
-        StringAttr instSym =
-            getOrAddInnerSym(instance, "inst_sym", parent,
-                             [&](FModuleOp mod) -> ModuleNamespace & {
-                               return moduleNamespace;
-                             });
+        StringAttr instSym = getOrAddInnerSym(
+            instance, parent, [&](FModuleOp mod) -> ModuleNamespace & {
+              return moduleNamespace;
+            });
         instOpHierPaths[InnerRefAttr::get(moduleName, instSym)].push_back(
             cast<StringAttr>(sym));
         // TODO: Update any symbol renames which need to be used by the next

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -250,8 +250,7 @@ void ResolveTracesPass::runOnOperation() {
           if (!updatePortTarget(moduleLike, anno, portIdx))
             return false;
 
-          getOrAddInnerSym(moduleLike, portIdx, moduleLike.getPortName(portIdx),
-                           getNamespace);
+          getOrAddInnerSym(moduleLike, portIdx, getNamespace);
           outputAnnotations.push_back(anno);
           return true;
         });
@@ -263,9 +262,7 @@ void ResolveTracesPass::runOnOperation() {
           return false;
 
         auto module = cast<FModuleOp>(moduleLike);
-        getOrAddInnerSym(
-            component, component->getAttrOfType<StringAttr>("name").getValue(),
-            module, getNamespace);
+        getOrAddInnerSym(component, module, getNamespace);
         outputAnnotations.push_back(anno);
         return true;
       });

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -152,15 +152,16 @@ firrtl.circuit "Complex" attributes {annotations = [
   }]} {
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   firrtl.module @Child() {
+    // CHECK: firrtl.instance MWrite_ext sym @[[CHILD_MWRITE_EXT:.+]] @MWrite_ext
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
   firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     // Double check that these instances now have symbols on them:
-    // CHECK: firrtl.instance MWrite_ext sym @MWrite_ext
+    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT:.+]] @MWrite_ext(
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-    // CHECK: firrtl.instance child sym @child  @Child
+    // CHECK: firrtl.instance child sym @[[CHILD:.+]] @Child(
     firrtl.instance child @Child()
-    // CHECK: firrtl.instance MWrite_ext sym @MWrite_ext_0  @MWrite_ext
+    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT_0:.+]] @MWrite_ext(
     %1:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
   firrtl.module @Complex() {
@@ -171,5 +172,5 @@ firrtl.circuit "Complex" attributes {annotations = [
   // CHECK-SAME{LITERAL}: 1 -> {{0}}.{{2}}.{{3}}
   // CHECK-SAME{LITERAL}: 2 -> {{0}}.{{4}}
   // CHECK-SAME: {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>,
-  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@MWrite_ext>, #hw.innerNameRef<@DUT::@child>, #hw.innerNameRef<@Child::@MWrite_ext>, #hw.innerNameRef<@DUT::@MWrite_ext_0>]
+  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@[[MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[CHILD]]>, #hw.innerNameRef<@Child::@[[CHILD_MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[MWRITE_EXT_0]]>]
 }

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -515,11 +515,11 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL:  firrtl.circuit "Foo"
-// CHECK:          hw.hierpath private @[[nla:[^ ]+]] [@Foo::@Foo, @Example]
+// CHECK:          hw.hierpath private @[[nla:[^ ]+]] [@Foo::@[[FOO_SYM:.+]], @Example]
 // CHECK:          firrtl.module @Example() attributes {
 // CHECK-SAME:       annotations = [{circt.nonlocal = @[[nla]], class = "circt.test"}]
 // CHECK:          firrtl.module @Foo()
-// CHECK:            firrtl.instance Foo sym @Foo @Example()
+// CHECK:            firrtl.instance Foo sym @[[FOO_SYM]] @Example()
 
 // -----
 
@@ -537,13 +537,13 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   }
 }
 // CHECK-LABEL: firrtl.circuit "Foo"
-// CHECK:         hw.hierpath private @[[nla:[^ ]+]] [@Foo::@bar, @Bar::@baz, @Baz]
+// CHECK:         hw.hierpath private @[[nla:[^ ]+]] [@Foo::@[[BAR_SYM:.+]], @Bar::@[[BAZ_SYM:.+]], @Baz]
 // CHECK:         firrtl.module @Baz
 // CHECK-SAME:      annotations = [{circt.nonlocal = @[[nla]], class = "circt.test", data = "a"}, {circt.nonlocal = @[[nla]], class = "circt.test", data = "b"}]
 // CHECK:         firrtl.module @Bar()
-// CHECK:           firrtl.instance baz sym @baz @Baz()
+// CHECK:           firrtl.instance baz sym @[[BAZ_SYM]] @Baz()
 // CHECK:           firrtl.module @Foo()
-// CHECK:           firrtl.instance bar sym @bar @Bar()
+// CHECK:           firrtl.instance bar sym @[[BAR_SYM]] @Bar()
 
 // -----
 
@@ -568,7 +568,8 @@ firrtl.circuit "memportAnno"  attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL: firrtl.circuit "memportAnno"  {
-// CHECK:        hw.hierpath private @nla [@memportAnno::@foo, @Foo]
+// CHECK:        hw.hierpath private @nla [@memportAnno::@[[FOO_SYM:.+]], @Foo]
+// CHECK: firrtl.instance foo sym @[[FOO_SYM]] @Foo
 // CHECK:        %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portAnnotations
 // CHECK-SAME:   [{circt.nonlocal = @nla, class = "circt.test"}]
 
@@ -595,9 +596,11 @@ firrtl.circuit "instportAnno" attributes {rawAnnotations = [
 }
 
 // CHECK-LABEL: firrtl.circuit "instportAnno"
-// CHECK:        hw.hierpath private @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz, @Baz]
+// CHECK:        hw.hierpath private @[[HIER:[^ ]+]] [@instportAnno::@[[BAR_SYM:.+]], @Bar::@[[BAZ_SYM:.+]], @Baz]
 // CHECK:        firrtl.module @Baz
 // CHECK-SAME:     {circt.nonlocal = @[[HIER]], class = "circt.test"}
+// CHECK: firrtl.instance baz sym @[[BAZ_SYM]] @Baz
+// CHECK: firrtl.instance bar sym @[[BAR_SYM]] @Bar
 
 // -----
 
@@ -654,13 +657,13 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: hw.hierpath private @nla [@MemPortsNL::@child, @Child]
+// CHECK: hw.hierpath private @nla [@MemPortsNL::@[[CHILD_SYM:.+]], @Child]
 // CHECK: firrtl.module @Child()
 // CHECK:   %bar_r = firrtl.mem
 // CHECK-NOT: sym
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
 // CHECK: firrtl.module @MemPortsNL()
-// CHECK:   firrtl.instance child sym @child
+// CHECK:   firrtl.instance child sym @[[CHILD_SYM]]
 firrtl.circuit "MemPortsNL" attributes {rawAnnotations = [
   {class = "circt.test", nl = "nl", target = "~MemPortsNL|MemPortsNL/child:Child>bar.r"}
   ]}  {
@@ -702,12 +705,12 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest"}
   ]} {
-  // CHECK: hw.hierpath private @nla [@Test::@exttest, @ExtTest]
+  // CHECK: hw.hierpath private @nla [@Test::@[[EXTTEST:.+]], @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest() attributes {annotations = [{circt.nonlocal = @nla, class = "circt.test"}]}
   firrtl.extmodule @ExtTest()
 
   firrtl.module @Test() {
-    // CHECK: firrtl.instance exttest sym @exttest @ExtTest()
+    // CHECK: firrtl.instance exttest sym @[[EXTTEST]] @ExtTest()
     firrtl.instance exttest @ExtTest()
   }
 }
@@ -718,12 +721,12 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: hw.hierpath private @nla [@Test::@exttest, @ExtTest]
+  // CHECK: hw.hierpath private @nla [@Test::@[[EXTTEST:.+]], @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
   firrtl.module @Test() {
-    // CHECK: %exttest_in = firrtl.instance exttest sym @exttest @ExtTest(in in: !firrtl.uint<1>)
+    // CHECK: %exttest_in = firrtl.instance exttest sym @[[EXTTEST]] @ExtTest(in in: !firrtl.uint<1>)
     firrtl.instance exttest @ExtTest(in in : !firrtl.uint<1>)
   }
 }
@@ -754,7 +757,7 @@ firrtl.circuit "Foo"  attributes {
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo>_T_9.a"},
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo>_T_10.a"},
     {class = "firrtl.transforms.DontTouchAnnotation", target = "~Foo|Foo/bar:Bar>_T.a"}]} {
-  // CHECK:      hw.hierpath private @nla [@Foo::@bar, @Bar]
+  // CHECK:      hw.hierpath private @nla [@Foo::@[[BAR_SYM:.+]], @Bar]
   // CHECK-NEXT: firrtl.module @Foo
   firrtl.module @Foo(in %reset: !firrtl.uint<1>, in %clock: !firrtl.clock) {
     // CHECK-NEXT: %_T_0 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
@@ -782,6 +785,7 @@ firrtl.circuit "Foo"  attributes {
     %aggregate = firrtl.wire  : !firrtl.bundle<a: uint<1>>
     // CHECK: %_T_9 = firrtl.node %aggregate {annotations = [{circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"}]}
     %_T_9 = firrtl.node %aggregate  : !firrtl.bundle<a: uint<1>>
+    // CHECK: instance bar sym @[[BAR_SYM]] @Bar()
     firrtl.instance bar @Bar()
 
     // CHECK: %_T_10, %_T_10_ref = firrtl.node %aggregate forceable {annotations = [{circt.fieldID = 1 : i32, class = "firrtl.transforms.DontTouchAnnotation"}]}

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -176,8 +176,8 @@ firrtl.module private @Baz(out %auto: !firrtl.bundle<a: uint<1>, b: uint<1>> sym
 // Check that module and memory port annotations are merged correctly.
 // CHECK-LABEL: firrtl.circuit "PortAnnotations"
 firrtl.circuit "PortAnnotations" {
-  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
-  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
+  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@PortAnnotations::@[[PORTANNOS_1:.+]], @PortAnnotations0]
+  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@PortAnnotations::@[[PORTANNOS_0:.+]], @PortAnnotations0]
   // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> [
   // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"},
   // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "port1"}]) {
@@ -194,7 +194,9 @@ firrtl.circuit "PortAnnotations" {
   }
   // CHECK: firrtl.module @PortAnnotations
   firrtl.module @PortAnnotations() {
+    // CHECK: firrtl.instance portannos0 sym @[[PORTANNOS_0]] @PortAnnotations
     %portannos0_in = firrtl.instance portannos0 @PortAnnotations0(in a: !firrtl.uint<1>)
+    // CHECK: firrtl.instance portannos1 sym @[[PORTANNOS_1]] @PortAnnotations
     %portannos1_in = firrtl.instance portannos1 @PortAnnotations1(in b: !firrtl.uint<1>)
   }
 }
@@ -241,10 +243,10 @@ firrtl.circuit "Breadcrumb" {
 // and the annotation should be cloned for each parent of the root module.
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
-  // CHECK: hw.hierpath private [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@in]
-  // CHECK: hw.hierpath private [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: hw.hierpath private [[NLA3:@nla.*]] [@Context::@[[CONTEXT1:.+]], @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@Context::@[[CONTEXT1]], @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: hw.hierpath private [[NLA2:@nla.*]] [@Context::@[[CONTEXT0:.+]], @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@Context::@[[CONTEXT0]], @Context0::@c0, @ContextLeaf::@in]
   // CHECK-NOT: @context_nla0
   // CHECK-NOT: @context_nla1
   // CHECK-NOT: @context_nla2
@@ -278,9 +280,9 @@ firrtl.circuit "Context" {
     %leaf_in = firrtl.instance leaf sym @c1 @ContextLeaf(in in : !firrtl.uint<1>)
   }
   firrtl.module @Context() {
-    // CHECK: firrtl.instance context0 sym @context0
+    // CHECK: firrtl.instance context0 sym @[[CONTEXT0]]
     firrtl.instance context0 @Context0()
-    // CHECK: firrtl.instance context1 sym @context1
+    // CHECK: firrtl.instance context1 sym @[[CONTEXT1]]
     firrtl.instance context1 @Context1()
   }
 }
@@ -298,8 +300,8 @@ firrtl.circuit "Context" {
   // CHECK-NOT: hw.hierpath private @nla1
   hw.hierpath private @nla1 [@Context1::@leaf1, @ContextLeaf1::@w1]
 
-  // CHECK: hw.hierpath private [[NLA0:@.+]] [@Context::@context1, @Context0::@leaf0, @ContextLeaf0::@w0]
-  // CHECK: hw.hierpath private [[NLA1:@.+]] [@Context::@context0, @Context0::@leaf0, @ContextLeaf0::@w0]
+  // CHECK: hw.hierpath private [[NLA0:@.+]] [@Context::@[[CONTEXT1:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
+  // CHECK: hw.hierpath private [[NLA1:@.+]] [@Context::@[[CONTEXT0:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
 
   // CHECK: firrtl.module @ContextLeaf0()
   firrtl.module @ContextLeaf0() {
@@ -324,7 +326,9 @@ firrtl.circuit "Context" {
   }
 
   firrtl.module @Context() {
+    // CHECK: firrtl.instance context0 sym @[[CONTEXT0]]
     firrtl.instance context0 @Context0()
+    // CHECK: firrtl.instance context1 sym @[[CONTEXT1]]
     firrtl.instance context1 @Context1()
   }
 }
@@ -438,10 +442,11 @@ firrtl.circuit "Foo"  {
 // As we dedup modules, the chain on NLAs should continuously grow.
 // CHECK-LABEL: firrtl.circuit "Chain"
 firrtl.circuit "Chain" {
-  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@Chain::@chainB1, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
-  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@Chain::@chainB0, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
+  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@Chain::@[[CHAINB1:.+]], @ChainB0::@[[CHAINA0:.+]], @ChainA0::@[[EXTCHAIN0:.+]], @ExtChain0]
+  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@Chain::@[[CHAINB0:.+]], @ChainB0::@[[CHAINA0:.+]], @ChainA0::@[[EXTCHAIN0:.+]], @ExtChain0]
   // CHECK: firrtl.module @ChainB0()
   firrtl.module @ChainB0() {
+    // CHECK: firrtl.instance chainA0 sym @[[CHAINA0]]
     firrtl.instance chainA0 @ChainA0()
   }
   // CHECK: firrtl.extmodule @ExtChain0() attributes {annotations = [
@@ -452,6 +457,7 @@ firrtl.circuit "Chain" {
   firrtl.extmodule @ExtChain1() attributes {annotations = [{class = "1"}], defname = "ExtChain"}
   // CHECK: firrtl.module @ChainA0()
   firrtl.module @ChainA0()  {
+    // CHECK: instance extchain0 sym @[[EXTCHAIN0]]
     firrtl.instance extchain0 @ExtChain0()
   }
   // CHECK-NOT: firrtl.module @ChainB1()
@@ -463,9 +469,9 @@ firrtl.circuit "Chain" {
     firrtl.instance extchain1 @ExtChain1()
   }
   firrtl.module @Chain() {
-    // CHECK: firrtl.instance chainB0 sym @chainB0 @ChainB0()
+    // CHECK: firrtl.instance chainB0 sym @[[CHAINB0]] @ChainB0()
     firrtl.instance chainB0 @ChainB0()
-    // CHECK: firrtl.instance chainB1 sym @chainB1 @ChainB0()
+    // CHECK: firrtl.instance chainB1 sym @[[CHAINB1]] @ChainB0()
     firrtl.instance chainB1 @ChainB1()
   }
 }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -195,6 +195,7 @@ firrtl.circuit "DualReadsSMem" {
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" {
     firrtl.module @top()  {
+      // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
       firrtl.instance dut @DUT()
       firrtl.instance mem1 @Mem1()
       firrtl.instance mem2 @Mem2()
@@ -207,6 +208,7 @@ firrtl.circuit "top" {
     }
     firrtl.module private @DUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+      // CHECK: firrtl.instance mem1 sym @[[MEM1_SYM:.+]] @Mem(
       firrtl.instance mem1 @Mem()
     }
     firrtl.module private @Mem() {
@@ -218,7 +220,7 @@ firrtl.circuit "top" {
     firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     // CHECK{LITERAL}: sv.verbatim "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 16,\0A \22width\22: 8,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 1,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.memory_ext\22\0A ]\0A },\0A {\0A \22module_name\22: \22{{5}}\22,\0A \22depth\22: 20,\0A \22width\22: 5,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.dumm_ext\22\0A ]\0A }\0A]"
-    // CHECK-SAME: symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@dut>, @DUT, #hw.innerNameRef<@DUT::@mem1>, @dumm_ext]
+    // CHECK-SAME: symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@[[DUT_SYM]]>, @DUT, #hw.innerNameRef<@DUT::@[[MEM1_SYM]]>, @dumm_ext]
     // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 20 width 5 ports write\0Aname {{1}} depth 20 width 5 ports write\0Aname {{2}} depth 16 width 8 ports read,rw\0Aname {{3}} depth 20 width 5 ports write,read\0A"
     // CHECK-SAME: {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList
     // CHECK-SAME: symbols = [@head_ext, @head_0_ext, @memory_ext, @dumm_ext]

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -662,11 +662,11 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
 // CHECK-LABEL: firrtl.circuit "SRAMPathsWithNLA"
 // CHECK:      symbols = [
 // CHECK-SAME:   @SRAMPathsWithNLA,
-// CHECK-SAME:   #hw.innerNameRef<@SRAMPathsWithNLA::@omir_sym>,
+// CHECK-SAME:   #hw.innerNameRef<@SRAMPathsWithNLA::@{{[^>]+}}>,
 // CHECK-SAME:   @SRAMPaths,
 // CHECK-SAME:   #hw.innerNameRef<@SRAMPaths::@sub>,
 // CHECK-SAME:   @Submodule,
-// CHECK-SAME:   #hw.innerNameRef<@Submodule::@omir_sym>,
+// CHECK-SAME:   #hw.innerNameRef<@Submodule::@{{[^>]+}}>,
 // CHECK-SAME:   @MySRAM
 // CHECK-SAME: ]
 

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -240,9 +240,9 @@ firrtl.module @Annotations() attributes {annotations = [{class = "sifive.enterpr
 // CHECK-LABEL: firrtl.circuit "NonLocalAnnotation"
 firrtl.circuit "NonLocalAnnotation" {
 
-// CHECK:  hw.hierpath private @[[nla_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem0, @mem0]
+// CHECK:  hw.hierpath private @[[nla_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM0:.+]], @mem0]
 hw.hierpath private @nla0 [@NonLocalAnnotation::@dut, @DUT::@mem0]
-// CHECK:  hw.hierpath private @[[nla_1:.+]] [@NonLocalAnnotation::@dut, @DUT::@mem1, @mem1]
+// CHECK:  hw.hierpath private @[[nla_1:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM1:.+]], @mem1]
 hw.hierpath private @nla1 [@NonLocalAnnotation::@dut, @DUT]
 
 // CHECK: firrtl.module @NonLocalAnnotation()
@@ -252,11 +252,11 @@ firrtl.module @NonLocalAnnotation()  {
 // CHECK: firrtl.module @DUT()
 firrtl.module @DUT() {
   // This memory has a symbol and an NLA directly targetting it.
-  // CHECK: firrtl.instance mem0 sym @mem0 @mem0
+  // CHECK: firrtl.instance mem0 sym @[[MEM0]] @mem0
   %mem0_write = firrtl.mem sym @mem0 Undefined {annotations = [{circt.nonlocal = @nla0, class = "test0"}], depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
   // This memory does not have a symbol already attached.
-  // CHECK: firrtl.instance mem1 sym @mem1 @mem1
+  // CHECK: firrtl.instance mem1 sym @[[MEM1]] @mem1
   %mem1_write = firrtl.mem Undefined {annotations = [{circt.nonlocal = @nla1, class = "test1"}], depth = 12 : i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
 // LowerMemory should ignore MemOps that are not seqmems. The following memory is a combmem with readLatency=0.

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -213,7 +213,7 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@bar, @Bar::@barXMR, @XmrSrcMod::@[[xmrSym:[a-zA-Z0-9_]+]]]
   firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1>, out %_a: !firrtl.probe<uint<1>>) {
-    // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @xmr_sym) {
+    // CHECK: firrtl.module @XmrSrcMod(in %pa: !firrtl.uint<1> sym @[[xmrSym]]) {
     %1 = firrtl.ref.send %pa : !firrtl.uint<1>
     firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
@@ -422,13 +422,13 @@ firrtl.circuit "Top" {
 // -----
 
 firrtl.circuit "Top"  {
-  // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
+  // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@[[TOP_XMR_SYM:.+]], @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK-LABEL: firrtl.module private @DUTModule
   // CHECK-SAME: (in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap: !firrtl.probe<vector<uint<8>, 8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 8 : i64, name = "rf", portNames = ["memTap", "read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 8 : i64, name = "rf", portNames = ["read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    // CHECK:  %rf_read, %rf_write = firrtl.mem sym @[[xmrSym]] Undefined  {depth = 8 : i64, name = "rf", portNames = ["read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %0 = firrtl.subfield %rf_read[addr] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
     %1 = firrtl.subfield %rf_read[en] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
     %2 = firrtl.subfield %rf_read[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -451,6 +451,7 @@ firrtl.circuit "Top"  {
   }
   // CHECK: firrtl.module @Top
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
+    // CHECK: firrtl.instance dut sym @[[TOP_XMR_SYM]] @DUTModule
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.probe<vector<uint<8>, 8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.probe<vector<uint<8>, 8>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory"
@@ -506,19 +507,20 @@ firrtl.circuit "Top"  {
 // -----
 
 firrtl.circuit "Top"  {
-  // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@xmr_sym, @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
+  // CHECK: hw.hierpath private @[[path:[a-zA-Z0-9_]+]] [@Top::@[[TOP_XMR_SYM:.+]], @DUTModule::@[[xmrSym:[a-zA-Z0-9_]+]]]
   // CHECK-LABEL:  firrtl.module private @DUTModule
   // CHECK-SAME: in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>)
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>, out %_gen_memTap_0: !firrtl.probe<uint<8>>, out %_gen_memTap_1: !firrtl.probe<uint<8>>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %rf_memTap, %rf_read, %rf_write = firrtl.mem  Undefined  {depth = 2 : i64, name = "rf", portNames = ["memTap", "read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    // CHECK:  %rf_read, %rf_write = firrtl.mem sym @xmr_sym  Undefined  {depth = 2 : i64, name = "rf", portNames = ["read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    // CHECK:  %rf_read, %rf_write = firrtl.mem sym @[[xmrSym]] Undefined  {depth = 2 : i64, name = "rf", portNames = ["read", "write"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %9 = firrtl.ref.sub %rf_memTap[0] : !firrtl.probe<vector<uint<8>, 2>>
     firrtl.ref.define %_gen_memTap_0, %9 : !firrtl.probe<uint<8>>
     %10 = firrtl.ref.sub %rf_memTap[1] : !firrtl.probe<vector<uint<8>, 2>>
     firrtl.ref.define %_gen_memTap_1, %10 : !firrtl.probe<uint<8>>
   }
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<3>, in %io_dataIn: !firrtl.uint<8>, in %io_wen: !firrtl.uint<1>, out %io_dataOut: !firrtl.uint<8>) {
+    // CHECK: firrtl.instance dut sym @[[TOP_XMR_SYM]] @DUTModule
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.probe<uint<8>>, out _gen_memTap_1: !firrtl.probe<uint<8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap_0 : !firrtl.probe<uint<8>>
     // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[0]"
@@ -575,7 +577,7 @@ firrtl.circuit "Top" {
   firrtl.module @XmrSrcMod(out %_a: !firrtl.probe<uint<1>>) {
     // CHECK: firrtl.module @XmrSrcMod() {
     // CHECK{LITERAL}:  firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
-    // CHECK:  = firrtl.node sym @xmr_sym  %[[internal:.+]]  : !firrtl.uint<1>
+    // CHECK:  = firrtl.node sym @[[xmrSym]] %[[internal:.+]]  : !firrtl.uint<1>
     %z = firrtl.verbatim.expr "internal.path" : () -> !firrtl.uint<1> {symbols = [@XmrSrcMod]}
     %1 = firrtl.ref.send %z : !firrtl.uint<1>
     firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
@@ -749,7 +751,7 @@ firrtl.circuit "Top" {
   // CHECK:        hw.hierpath private @[[XMR1]] [@Top::@w]
   // CHECK:        hw.hierpath private @[[XMR2]] [@Top::@foo, @Foo::@x]
   // CHECK:        hw.hierpath private @[[XMR3]] [@Top::@foo]
-  // CHECK:        hw.hierpath private @[[XMR4]] [@Top::@xmr_sym]
+  // CHECK:        hw.hierpath private @[[XMR4]] [@Top::@{{.+}}]
   
   // CHECK-LABEL: firrtl.module @Top()
   firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, 
@@ -791,10 +793,10 @@ firrtl.circuit "InternalPaths" {
                                        out r: !firrtl.probe<uint<1>>,
                                        out data: !firrtl.uint<3>,
                                        out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>, internalPaths = ["path.to.internal.signal", "in"]}
-  // CHECK: hw.hierpath private @xmrPath [@InternalPaths::@xmr_sym] 
+  // CHECK: hw.hierpath private @xmrPath [@InternalPaths::@[[EXT_SYM:.+]]] 
   // CHECK: module public @InternalPaths(
   firrtl.module public @InternalPaths(in %in: !firrtl.uint<1>) {
-    // CHECK: firrtl.instance ext sym @[[EXT_SYM:.+]] @RefExtMore
+    // CHECK: firrtl.instance ext sym @[[EXT_SYM]] @RefExtMore
     %ext_in, %ext_r, %ext_data, %ext_r2 =
       firrtl.instance ext @RefExtMore(in in: !firrtl.uint<1>,
                                       out r: !firrtl.probe<uint<1>>,
@@ -824,10 +826,11 @@ firrtl.circuit "RefABI" {
                                        out r: !firrtl.probe<uint<1>>,
                                        out data: !firrtl.uint<3>,
                                        out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>}
-  // CHECK:  hw.hierpath private @xmrPath [@RefABI::@xmr_sym] 
+  // CHECK:  hw.hierpath private @xmrPath [@RefABI::@[[XMR_SYM:.+]]] 
   // CHECK: module public @RefABI(
   firrtl.module public @RefABI(in %in: !firrtl.uint<1>) {
     %ext_in, %ext_r, %ext_data, %ext_r2 =
+      // CHECK: firrtl.instance ext sym @[[XMR_SYM]] @RefExtMore
       firrtl.instance ext @RefExtMore(in in: !firrtl.uint<1>,
                                       out r: !firrtl.probe<uint<1>>,
                                       out data: !firrtl.uint<3>,

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -36,8 +36,8 @@ circuit Foo : %[[
     input writeAddr : UInt<3>
     input writeData : UInt<32>
 
-    ; REPL-FIR:     firrtl.instance mem sym @mem @prefix1_mem
-    ; REPL-HW:      hw.instance "mem" sym @mem @prefix1_mem
+    ; REPL-FIR:     firrtl.instance mem sym @{{[^ ]+}} @prefix1_mem
+    ; REPL-HW:      hw.instance "mem" sym @{{[^ ]+}} @prefix1_mem
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix1_"
@@ -79,8 +79,8 @@ circuit Foo : %[[
     input writeAddr : UInt<3>
     input writeData : UInt<32>
 
-    ; REPL-FIR:     firrtl.instance mem sym @mem @prefix2_mem
-    ; REPL-HW:      hw.instance "mem" sym @mem @prefix2_mem
+    ; REPL-FIR:     firrtl.instance mem sym @{{[^ ]+}} @prefix2_mem
+    ; REPL-HW:      hw.instance "mem" sym @{{[^ ]+}} @prefix2_mem
     ; SIM-FIR:      firrtl.mem
     ; SIM-FIR-SAME:   name = "mem"
     ; SIM-FIR-SAME:   prefix = "prefix2_"


### PR DESCRIPTION
While they can be useful sometimes, as step towards making these
opaque handles instead of strings drop the notion of them
having "useful" names from API.

Still do the namespace bit to ensure unique, for now.