### PR TITLE
[Seq] Add FIFO lowering

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -33,6 +33,7 @@ std::unique_ptr<mlir::Pass> createLowerSeqHLMemPass();
 std::unique_ptr<mlir::Pass>
 createExternalizeClockGatePass(const ExternalizeClockGateOptions &options = {});
 std::unique_ptr<mlir::Pass> createLowerFirMemPass();
+std::unique_ptr<mlir::Pass> createLowerSeqFIFOPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -47,6 +47,12 @@ def LowerSeqFIRRTLToSV: Pass<"lower-seq-firrtl-to-sv",  "hw::HWModuleOp"> {
   ];
 }
 
+def LowerSeqFIFO : Pass<"lower-seq-fifo", "hw::HWModuleOp"> {
+  let summary = "Lower seq.fifo ops";
+  let constructor = "circt::seq::createLowerSeqFIFOPass()";
+  let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect"];
+}
+
 def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {
   let summary = "Lowers seq.hlmem operations.";
   let constructor = "circt::seq::createLowerSeqHLMemPass()";

--- a/integration_test/Dialect/Seq/fifo/fifo.mlir
+++ b/integration_test/Dialect/Seq/fifo/fifo.mlir
@@ -1,0 +1,13 @@
+// REQUIRES: iverilog,cocotb
+
+// RUN: circt-opt %s --lower-seq-fifo --lower-seq-hlmem --lower-seq-to-sv --sv-trace-iverilog --export-verilog -o %t.mlir > %t.sv
+// RUN: circt-cocotb-driver.py --objdir=%T --topLevel=fifo \
+// RUN:     --pythonModule=fifo --pythonFolder="%S,%S/.." %t.sv 2>&1
+
+// CHECK: ** TEST
+// CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
+
+hw.module @fifo(%clk : i1, %rst : i1, %inp : i32, %rdEn : i1, %wrEn : i1) -> (out: i32, empty: i1, full: i1, almost_empty : i1, almost_full : i1) {
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 4 almost_full 2 almost_empty 1 in %inp rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  hw.output %out, %empty, %full, %almostEmpty, %almostFull : i32, i1, i1, i1, i1
+}

--- a/integration_test/Dialect/Seq/fifo/fifo.py
+++ b/integration_test/Dialect/Seq/fifo/fifo.py
@@ -1,0 +1,106 @@
+import cocotb
+from cocotb.triggers import Timer
+import cocotb.clock
+
+
+async def clock(dut):
+  dut.clk.value = 0
+  await Timer(1, units='ns')
+  dut.clk.value = 1
+  await Timer(1, units='ns')
+
+
+async def initDut(dut):
+  # Reset
+  dut.rst.value = 1
+  await clock(dut)
+  dut.rst.value = 0
+  await clock(dut)
+
+
+async def write(dut, value):
+  dut.inp.value = value
+  dut.wrEn.value = 1
+  await clock(dut)
+  dut.wrEn.value = 0
+  await clock(dut)
+
+
+async def combRead(dut, out):
+  dut.rdEn.value = 1
+  # Combinational reads, so let the model settle before reading
+  await Timer(1, units='ns')
+  return dut.out.value
+
+
+async def read(dut):
+  data = await combRead(dut, dut.out.value)
+  await clock(dut)
+  dut.rdEn.value = 0
+  await clock(dut)
+  return data
+
+
+async def readWrite(dut, value):
+  dut.inp.value = value
+  dut.wrEn.value = 1
+  data = await combRead(dut, dut.out.value)
+  await clock(dut)
+  dut.rdEn.value = 0
+  dut.wrEn.value = 0
+  await clock(dut)
+  return data
+
+
+FIFO_DEPTH = 4
+FIFO_ALMOST_FULL = 2
+FIFO_ALMOST_EMPTY = 1
+
+
+async def test_separate_read_write(dut):
+  # Run a test where we incrementally write and read values from 1 to FIFO_DEPTH values
+  for i in range(1, FIFO_DEPTH):
+    for j in range(i):
+      await write(dut, 42 + j)
+
+    if i >= FIFO_ALMOST_FULL:
+      assert dut.almost_full.value == 1
+
+    if i <= FIFO_ALMOST_EMPTY:
+      assert dut.almost_empty.value == 1
+
+    if i == FIFO_DEPTH:
+      assert dut.full.value == 1
+
+    for j in range(i):
+      assert await read(dut) == 42 + j
+
+    assert dut.empty.value == 1
+
+
+async def test_concurrent_read_write(dut):
+  # Fill up the FIFO halfway and concurrently read and write. Should be able
+  # to do this continuously.
+  counter = 0
+  for i in range(FIFO_DEPTH // 2):
+    await write(dut, counter)
+    counter += 1
+
+  for i in range(FIFO_DEPTH * 2):
+    expected_value = counter - FIFO_DEPTH // 2
+    print("expected_value: ", expected_value)
+    assert await readWrite(dut, counter) == expected_value
+    assert dut.full.value == 0
+    assert dut.empty.value == 0
+    counter += 1
+
+
+@cocotb.test()
+async def test1(dut):
+  dut.inp.value = 0
+  dut.rdEn.value = 0
+  dut.wrEn.value = 0
+  await initDut(dut)
+
+  await test_separate_read_write(dut)
+  await test_concurrent_read_write(dut)

--- a/integration_test/Dialect/Seq/lit.local.cfg.py
+++ b/integration_test/Dialect/Seq/lit.local.cfg.py
@@ -1,0 +1,6 @@
+import glob, os
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+for pyfile in glob.glob(os.path.join(dir_path, "**", "*.py")):
+  # remove dir from pyfile
+  config.excludes.add(os.path.basename(pyfile))

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTSeqTransforms
   LowerFirMem.cpp
   LowerSeqHLMem.cpp
   LowerSeqToSV.cpp
+  LowerSeqFIFO.cpp
 
   DEPENDS
   CIRCTSeqTransformsIncGen

--- a/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
@@ -1,0 +1,197 @@
+//===- LowerSeqFIFO.cpp - seq.fifo lowering -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "circt/Support/BackedgeBuilder.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace seq;
+
+namespace {
+
+struct FIFOLowering : public OpConversionPattern<seq::FIFOOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(seq::FIFOOp mem, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type eltType = adaptor.getInput().getType();
+    Value clk = adaptor.getClk();
+    Value rst = adaptor.getRst();
+    Location loc = mem.getLoc();
+    BackedgeBuilder bb(rewriter, loc);
+    size_t depth = mem.getDepth();
+    Type countType = rewriter.getIntegerType(llvm::Log2_64_Ceil(depth + 1));
+    Type ptrType = rewriter.getIntegerType(llvm::Log2_64_Ceil(depth));
+    Backedge rdAddrNext = bb.get(ptrType);
+    Backedge wrAddrNext = bb.get(ptrType);
+    Backedge nextCount = bb.get(countType);
+
+    // ====== Some constants ======
+    Value countTcFull =
+        rewriter.create<hw::ConstantOp>(loc, countType, depth - 1);
+    Value countTc1 = rewriter.create<hw::ConstantOp>(loc, countType, 1);
+    Value countTc0 = rewriter.create<hw::ConstantOp>(loc, countType, 0);
+    Value ptrTc1 = rewriter.create<hw::ConstantOp>(loc, ptrType, 1);
+
+    // ====== Hardware units ======
+    Value count = rewriter.create<seq::CompRegOp>(
+        loc, nextCount, clk, rst,
+        rewriter.create<hw::ConstantOp>(loc, countType, 0), "fifo_count");
+    seq::HLMemOp hlmem = rewriter.create<seq::HLMemOp>(
+        loc, clk, rst, "fifo_mem",
+        llvm::SmallVector<int64_t>{static_cast<int64_t>(depth)}, eltType);
+    Value rdAddr = rewriter.create<seq::CompRegOp>(
+        loc, rdAddrNext, clk, rst,
+        rewriter.create<hw::ConstantOp>(loc, ptrType, 0), "fifo_rd_addr");
+    Value wrAddr = rewriter.create<seq::CompRegOp>(
+        loc, wrAddrNext, clk, rst,
+        rewriter.create<hw::ConstantOp>(loc, ptrType, 0), "fifo_wr_addr");
+
+    Value readData = rewriter.create<seq::ReadPortOp>(
+        loc, hlmem, llvm::SmallVector<Value>{rdAddr}, adaptor.getRdEn(),
+        /*latency*/ 0);
+    rewriter.create<seq::WritePortOp>(loc, hlmem,
+                                      llvm::SmallVector<Value>{wrAddr},
+                                      adaptor.getInput(), adaptor.getWrEn(),
+                                      /*latency*/ 1);
+
+    // ====== some more constants =====
+    comb::ICmpOp fifoFull = rewriter.create<comb::ICmpOp>(
+        loc, comb::ICmpPredicate::eq, count, countTcFull);
+    fifoFull->setAttr("sv.namehint", rewriter.getStringAttr("fifo_full"));
+    comb::ICmpOp fifoEmpty = rewriter.create<comb::ICmpOp>(
+        loc, comb::ICmpPredicate::eq, count, countTc0);
+    fifoEmpty->setAttr("sv.namehint", rewriter.getStringAttr("fifo_empty"));
+
+    // ====== Next-state count ======
+    Value rdEnNandWrEn = rewriter.create<comb::AndOp>(
+        loc, comb::createOrFoldNot(loc, adaptor.getRdEn(), rewriter),
+        comb::createOrFoldNot(loc, adaptor.getWrEn(), rewriter));
+    Value rdEnAndNotWrEn = rewriter.create<comb::AndOp>(
+        loc, adaptor.getRdEn(),
+        comb::createOrFoldNot(loc, adaptor.getWrEn(), rewriter));
+    Value wrEnAndNotRdEn = rewriter.create<comb::AndOp>(
+        loc, adaptor.getWrEn(),
+        comb::createOrFoldNot(loc, adaptor.getRdEn(), rewriter));
+
+    Value wrEnNext = rewriter.create<comb::MuxOp>(
+        loc,
+        rewriter.create<comb::ICmpOp>(loc, comb::ICmpPredicate::eq, count,
+                                      countTcFull),
+        // keep value
+        count,
+        // increment
+        rewriter.create<comb::AddOp>(loc, count, countTc1));
+
+    Value rdEnNext = rewriter.create<comb::MuxOp>(
+        loc,
+        rewriter.create<comb::ICmpOp>(loc, comb::ICmpPredicate::eq, count,
+                                      countTc0),
+        // keep value
+        count,
+        // decrement
+        rewriter.create<comb::SubOp>(loc, count, countTc1));
+
+    nextCount.setValue(rewriter.create<comb::MuxOp>(
+        loc, rdEnNandWrEn, /*keep value*/ count,
+        rewriter.create<comb::MuxOp>(
+            loc, wrEnAndNotRdEn, wrEnNext,
+            rewriter.create<comb::MuxOp>(loc, rdEnAndNotWrEn, rdEnNext,
+                                         count))));
+    static_cast<Value>(nextCount).getDefiningOp()->setAttr(
+        "sv.namehint", rewriter.getStringAttr("fifo_count_next"));
+
+    // ====== Read/write pointers ======
+    Value wrAndNotFull = rewriter.create<comb::AndOp>(
+        loc, adaptor.getWrEn(), comb::createOrFoldNot(loc, fifoFull, rewriter));
+    wrAddrNext.setValue(rewriter.create<comb::MuxOp>(
+        loc, wrAndNotFull, rewriter.create<comb::AddOp>(loc, wrAddr, ptrTc1),
+        wrAddr));
+    static_cast<Value>(wrAddrNext)
+        .getDefiningOp()
+        ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_wr_addr_next"));
+
+    Value rdAndNotEmpty = rewriter.create<comb::AndOp>(
+        loc, adaptor.getRdEn(),
+        comb::createOrFoldNot(loc, fifoEmpty, rewriter));
+    rdAddrNext.setValue(rewriter.create<comb::MuxOp>(
+        loc, rdAndNotEmpty, rewriter.create<comb::AddOp>(loc, rdAddr, ptrTc1),
+        rdAddr));
+    static_cast<Value>(rdAddrNext)
+        .getDefiningOp()
+        ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_rd_addr_next"));
+
+    // ====== Result values ======
+    llvm::SmallVector<Value> results;
+
+    // Data
+    results.push_back(readData);
+    // Full
+    results.push_back(fifoFull);
+    // Empty
+    results.push_back(fifoEmpty);
+
+    if (auto almostFull = mem.getAlmostFullThreshold()) {
+      results.push_back(rewriter.create<comb::ICmpOp>(
+          loc, comb::ICmpPredicate::uge, count,
+          rewriter.create<hw::ConstantOp>(loc, countType, almostFull.value())));
+      static_cast<Value>(results.back())
+          .getDefiningOp()
+          ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_almost_full"));
+    }
+
+    if (auto almostEmpty = mem.getAlmostEmptyThreshold()) {
+      results.push_back(rewriter.create<comb::ICmpOp>(
+          loc, comb::ICmpPredicate::ule, count,
+          rewriter.create<hw::ConstantOp>(loc, countType,
+                                          almostEmpty.value())));
+      static_cast<Value>(results.back())
+          .getDefiningOp()
+          ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_almost_empty"));
+    }
+
+    rewriter.replaceOp(mem, results);
+    return success();
+  }
+};
+
+#define GEN_PASS_DEF_LOWERSEQFIFO
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+struct LowerSeqFIFOPass : public impl::LowerSeqFIFOBase<LowerSeqFIFOPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void LowerSeqFIFOPass::runOnOperation() {
+  MLIRContext &ctxt = getContext();
+  ConversionTarget target(ctxt);
+
+  // Lowering patterns must lower away all HLMem-related operations.
+  target.addIllegalOp<seq::FIFOOp>();
+  target.addLegalDialect<seq::SeqDialect, hw::HWDialect, comb::CombDialect>();
+  RewritePatternSet patterns(&ctxt);
+  patterns.add<FIFOLowering>(&ctxt);
+
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::seq::createLowerSeqFIFOPass() {
+  return std::make_unique<LowerSeqFIFOPass>();
+}

--- a/test/Dialect/Seq/lower-fifo.mlir
+++ b/test/Dialect/Seq/lower-fifo.mlir
@@ -1,0 +1,102 @@
+// This is such a large lowering that it doesn't really make that much sense to
+// inspect the test output. So this is mostly here for detecting regressions.
+// Canonicalize used to remove some of the constants introduced by the lowering.
+// RUN: circt-opt --lower-seq-fifo --canonicalize %s
+
+
+// CHECK-LABEL:   hw.module @fifo1(
+// CHECK-SAME:            %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
+// CHECK:           %[[VAL_6:.*]] = hw.constant -1 : i2
+// CHECK:           %[[VAL_7:.*]] = hw.constant -2 : i2
+// CHECK:           %[[VAL_8:.*]] = hw.constant 1 : i2
+// CHECK:           %[[VAL_9:.*]] = hw.constant 0 : i2
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @fifo_count %[[VAL_11:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_12:.*]] = seq.hlmem @fifo_mem %[[VAL_0]], %[[VAL_1]] : <3xi32>
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_rd_addr %[[VAL_14:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @fifo_wr_addr %[[VAL_16:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_17:.*]] = seq.read %[[VAL_12]]{{\[}}%[[VAL_13]]] rden %[[VAL_3]] {latency = 0 : i64} : !seq.hlmem<3xi32>
+// CHECK:           seq.write %[[VAL_12]]{{\[}}%[[VAL_15]]] %[[VAL_2]] wren %[[VAL_4]] {latency = 1 : i64} : !seq.hlmem<3xi32>
+// CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_4]], %[[VAL_5]] : i1
+// CHECK:           %[[VAL_19:.*]] = comb.and %[[VAL_3]], %[[VAL_18]] : i1
+// CHECK:           %[[VAL_20:.*]] = comb.xor %[[VAL_3]], %[[VAL_5]] : i1
+// CHECK:           %[[VAL_21:.*]] = comb.and %[[VAL_4]], %[[VAL_20]] : i1
+// CHECK:           %[[VAL_22:.*]] = comb.icmp eq %[[VAL_10]], %[[VAL_7]] : i2
+// CHECK:           %[[VAL_23:.*]] = comb.add %[[VAL_10]], %[[VAL_8]] : i2
+// CHECK:           %[[VAL_24:.*]] = comb.mux %[[VAL_22]], %[[VAL_10]], %[[VAL_23]] : i2
+// CHECK:           %[[VAL_25:.*]] = comb.icmp eq %[[VAL_10]], %[[VAL_9]] : i2
+// CHECK:           %[[VAL_26:.*]] = comb.add %[[VAL_10]], %[[VAL_6]] : i2
+// CHECK:           %[[VAL_27:.*]] = comb.xor %[[VAL_19]], %[[VAL_5]] : i1
+// CHECK:           %[[VAL_28:.*]] = comb.or %[[VAL_27]], %[[VAL_25]] : i1
+// CHECK:           %[[VAL_29:.*]] = comb.mux %[[VAL_28]], %[[VAL_10]], %[[VAL_26]] : i2
+// CHECK:           %[[VAL_30:.*]] = comb.mux %[[VAL_21]], %[[VAL_24]], %[[VAL_29]] : i2
+// CHECK:           %[[VAL_31:.*]] = comb.or %[[VAL_3]], %[[VAL_4]] : i1
+// CHECK:           %[[VAL_11]] = comb.mux %[[VAL_31]], %[[VAL_30]], %[[VAL_10]] {sv.namehint = "fifo_count_next"} : i2
+// CHECK:           %[[VAL_32:.*]] = comb.icmp ne %[[VAL_10]], %[[VAL_7]] : i2
+// CHECK:           %[[VAL_33:.*]] = comb.and %[[VAL_4]], %[[VAL_32]] : i1
+// CHECK:           %[[VAL_34:.*]] = comb.add %[[VAL_15]], %[[VAL_8]] : i2
+// CHECK:           %[[VAL_16]] = comb.mux %[[VAL_33]], %[[VAL_34]], %[[VAL_15]] {sv.namehint = "fifo_wr_addr_next"} : i2
+// CHECK:           %[[VAL_35:.*]] = comb.icmp ne %[[VAL_10]], %[[VAL_9]] : i2
+// CHECK:           %[[VAL_36:.*]] = comb.and %[[VAL_3]], %[[VAL_35]] : i1
+// CHECK:           %[[VAL_37:.*]] = comb.add %[[VAL_13]], %[[VAL_8]] : i2
+// CHECK:           %[[VAL_14]] = comb.mux %[[VAL_36]], %[[VAL_37]], %[[VAL_13]] {sv.namehint = "fifo_rd_addr_next"} : i2
+// CHECK:           hw.output %[[VAL_17]] : i32
+// CHECK:         }
+hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> (out: i32) {
+  // CHECK: %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  hw.output %out : i32
+}
+
+
+// CHECK-LABEL:   hw.module @fifo2(
+// CHECK-SAME:             %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, empty: i1, full: i1, almost_empty: i1, almost_full: i1) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant 2 : i3
+// CHECK:           %[[VAL_6:.*]] = hw.constant 0 : i2
+// CHECK:           %[[VAL_7:.*]] = hw.constant true
+// CHECK:           %[[VAL_8:.*]] = hw.constant -1 : i3
+// CHECK:           %[[VAL_9:.*]] = hw.constant 3 : i3
+// CHECK:           %[[VAL_10:.*]] = hw.constant 1 : i3
+// CHECK:           %[[VAL_11:.*]] = hw.constant 0 : i3
+// CHECK:           %[[VAL_12:.*]] = hw.constant 1 : i2
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_count %[[VAL_14:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_11]]  : i3
+// CHECK:           %[[VAL_15:.*]] = seq.hlmem @fifo_mem %[[VAL_0]], %[[VAL_1]] : <4xi32>
+// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @fifo_rd_addr %[[VAL_17:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_6]]  : i2
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @fifo_wr_addr %[[VAL_19:.*]], %[[VAL_0]], %[[VAL_1]], %[[VAL_6]]  : i2
+// CHECK:           %[[VAL_20:.*]] = seq.read %[[VAL_15]]{{\[}}%[[VAL_16]]] rden %[[VAL_3]] {latency = 0 : i64} : !seq.hlmem<4xi32>
+// CHECK:           seq.write %[[VAL_15]]{{\[}}%[[VAL_18]]] %[[VAL_2]] wren %[[VAL_4]] {latency = 1 : i64} : !seq.hlmem<4xi32>
+// CHECK:           %[[VAL_21:.*]] = comb.icmp eq %[[VAL_13]], %[[VAL_9]] {sv.namehint = "fifo_full"} : i3
+// CHECK:           %[[VAL_22:.*]] = comb.icmp eq %[[VAL_13]], %[[VAL_11]] {sv.namehint = "fifo_empty"} : i3
+// CHECK:           %[[VAL_23:.*]] = comb.xor %[[VAL_4]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_24:.*]] = comb.and %[[VAL_3]], %[[VAL_23]] : i1
+// CHECK:           %[[VAL_25:.*]] = comb.xor %[[VAL_3]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_26:.*]] = comb.and %[[VAL_4]], %[[VAL_25]] : i1
+// CHECK:           %[[VAL_27:.*]] = comb.icmp eq %[[VAL_13]], %[[VAL_9]] : i3
+// CHECK:           %[[VAL_28:.*]] = comb.add %[[VAL_13]], %[[VAL_10]] : i3
+// CHECK:           %[[VAL_29:.*]] = comb.mux %[[VAL_27]], %[[VAL_13]], %[[VAL_28]] : i3
+// CHECK:           %[[VAL_30:.*]] = comb.icmp eq %[[VAL_13]], %[[VAL_11]] : i3
+// CHECK:           %[[VAL_31:.*]] = comb.add %[[VAL_13]], %[[VAL_8]] : i3
+// CHECK:           %[[VAL_32:.*]] = comb.xor %[[VAL_24]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_33:.*]] = comb.or %[[VAL_32]], %[[VAL_30]] : i1
+// CHECK:           %[[VAL_34:.*]] = comb.mux %[[VAL_33]], %[[VAL_13]], %[[VAL_31]] : i3
+// CHECK:           %[[VAL_35:.*]] = comb.mux %[[VAL_26]], %[[VAL_29]], %[[VAL_34]] : i3
+// CHECK:           %[[VAL_36:.*]] = comb.or %[[VAL_3]], %[[VAL_4]] : i1
+// CHECK:           %[[VAL_14]] = comb.mux %[[VAL_36]], %[[VAL_35]], %[[VAL_13]] {sv.namehint = "fifo_count_next"} : i3
+// CHECK:           %[[VAL_37:.*]] = comb.xor %[[VAL_21]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_38:.*]] = comb.and %[[VAL_4]], %[[VAL_37]] : i1
+// CHECK:           %[[VAL_39:.*]] = comb.add %[[VAL_18]], %[[VAL_12]] : i2
+// CHECK:           %[[VAL_19]] = comb.mux %[[VAL_38]], %[[VAL_39]], %[[VAL_18]] {sv.namehint = "fifo_wr_addr_next"} : i2
+// CHECK:           %[[VAL_40:.*]] = comb.xor %[[VAL_22]], %[[VAL_7]] : i1
+// CHECK:           %[[VAL_41:.*]] = comb.and %[[VAL_3]], %[[VAL_40]] : i1
+// CHECK:           %[[VAL_42:.*]] = comb.add %[[VAL_16]], %[[VAL_12]] : i2
+// CHECK:           %[[VAL_17]] = comb.mux %[[VAL_41]], %[[VAL_42]], %[[VAL_16]] {sv.namehint = "fifo_rd_addr_next"} : i2
+// CHECK:           %[[VAL_43:.*]] = comb.extract %[[VAL_13]] from 1 : (i3) -> i2
+// CHECK:           %[[VAL_44:.*]] = comb.icmp ne %[[VAL_43]], %[[VAL_6]] {sv.namehint = "fifo_almost_full"} : i2
+// CHECK:           %[[VAL_45:.*]] = comb.icmp ult %[[VAL_13]], %[[VAL_5]] {sv.namehint = "fifo_almost_empty"} : i3
+// CHECK:           hw.output %[[VAL_20]], %[[VAL_22]], %[[VAL_21]], %[[VAL_45]], %[[VAL_44]] : i32, i1, i1, i1, i1
+// CHECK:         }
+hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> (out: i32, empty: i1, full: i1, almost_empty : i1, almost_full : i1) {
+  // CHECK: %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 2 almost_empty 1 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 4 almost_full 2 almost_empty 1 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  hw.output %out, %empty, %full, %almostEmpty, %almostFull : i32, i1, i1, i1, i1
+}


### PR DESCRIPTION
Lowers to a fairly standard fifo implementation. Will add more target-optimized implementations after this baseline is checked in.

For reference, the following:
```mlir
hw.module @fifo(%clk : i1, %rst : i1, %inp : i32, %rdEn : i1, %wrEn : i1) -> (out: i32, empty: i1, full: i1, almost_empty : i1, almost_full : i1) {
  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 4 almost_full 2 almost_empty 1 in %inp rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
  hw.output %out, %empty, %full, %almostEmpty, %almostFull : i32, i1, i1, i1, i1
}
```

exports as
```sv
module fifo(
  input         clk,
                rst,
  input  [31:0] inp,
  input         rdEn,
                wrEn,
  output [31:0] out,
  output        empty,
                full,
                almost_empty,
                almost_full
);

  wire [1:0]  fifo_rd_addr_next;
  wire [1:0]  fifo_wr_addr_next;
  wire [2:0]  fifo_count_next;
  reg  [1:0]  fifo_wr_addr;
  reg  [2:0]  fifo_count;
  always_ff @(posedge clk) begin
    if (rst)
      fifo_count <= 3'h0;
    else
      fifo_count <= fifo_count_next;
  end
  reg  [31:0] fifo_mem[0:3];
  always_ff @(posedge clk) begin
    if (rst) begin
    end
    else begin
      if (wrEn)
        fifo_mem[fifo_wr_addr] <= inp;
    end
  end
  reg  [1:0]  fifo_rd_addr;
  always_ff @(posedge clk) begin
    if (rst)
      fifo_rd_addr <= 2'h0;
    else
      fifo_rd_addr <= fifo_rd_addr_next;
  end
  always_ff @(posedge clk) begin
    if (rst)
      fifo_wr_addr <= 2'h0;
    else
      fifo_wr_addr <= fifo_wr_addr_next;
  end
  wire        fifo_full = fifo_count == 3'h3;
  wire        fifo_empty = fifo_count == 3'h0;
  assign fifo_count_next =
    ~rdEn & ~wrEn
      ? fifo_count
      : wrEn & ~rdEn
          ? (fifo_count == 3'h3 ? fifo_count : fifo_count + 3'h1)
          : rdEn & ~wrEn
              ? (fifo_count == 3'h0 ? fifo_count : fifo_count - 3'h1)
              : fifo_count;
  assign fifo_wr_addr_next = wrEn & ~fifo_full ? fifo_wr_addr + 2'h1 : fifo_wr_addr;
  assign fifo_rd_addr_next = rdEn & ~fifo_empty ? fifo_rd_addr + 2'h1 : fifo_rd_addr;
  assign out = fifo_mem[fifo_rd_addr];
  assign empty = fifo_empty;
  assign full = fifo_full;
  assign almost_empty = fifo_count <= 3'h1;
  assign almost_full = fifo_count >= 3'h2;
endmodule
```