### PR TITLE
Add codeowners for Calyx

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,13 @@
 **/Dialect/Arc @fabianschuiki @maerhart
 tools/arcilator @fabianschuiki @maerhart
 
+# Calyx
+**/Dialect/Calyx @rachitnigam @mortbopet @cgyurgyik @mikeurbach @andrewb1999
+**/Conversion/CalyxToFSM @mortbopet
+**/Conversion/CalyxToHW @mortbopet
+**/Conversion/SCFToCalyx @mikeurbach
+**/Conversion/LoopScheduleToCalyx @andrewb1999
+
 # DC
 **/Dialect/DC @mortbopet
 


### PR DESCRIPTION
Fixes #5543.

Attempt to allocate the owners based on previous file commit histories for now. My suggestion is that we keep it pretty liberal going forward so that people can take ownership of various passes as they evolve.