### PR TITLE
[FIRRTL] Add ClassOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -277,8 +277,8 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
   }];
 }
 
-def PropAssignOp : FIRRTLOp<"propassign", [FConnectLike, SameTypeOperands,
-                                           HasParent<"FModuleOp">]> {
+def PropAssignOp : FIRRTLOp<"propassign",
+  [FConnectLike, SameTypeOperands, ParentOneOf<["FModuleOp", "ClassOp"]>]> {
   let summary = "Assign to a sink property value.";
   let description = [{
     Assign an output property value. The types must match exactly.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -253,6 +253,62 @@ def FMemModuleOp : FIRRTLModuleLike<"memmodule"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def ClassOp : FIRRTLModuleLike<"class", [
+  SingleBlock, NoTerminator,
+  DeclareOpInterfaceMethods<FModuleLike, [
+    // Class Ops do not support port annotations.
+    // Override this method to return an empty array attr.
+    "getPortAnnotationsAttr"]>
+]> {
+  let summary = "FIRRTL Class";
+  let description = [{
+    The "firrtl.class" operation defines a class of property-only objects,
+    including a given name, a list of ports, and a body that represents the
+    connections within the class.
+
+    A class may only have property ports, and its body may only be ops that act
+    on properties, such as propassign ops.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name, APIntAttr:$portDirections,
+                       ArrayRefAttr:$portNames, ArrayRefAttr:$portTypes,
+                       ArrayRefAttr:$portSyms, ArrayRefAttr:$portLocations);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+
+  let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+  let builders = [
+    OpBuilder<(ins
+      "StringAttr":$name,
+      "ArrayRef<PortInfo>":$ports)>];
+
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &getBody().front(); }
+
+    using iterator = Block::iterator;
+    iterator begin() { return getBodyBlock()->begin(); }
+    iterator end() { return getBodyBlock()->end(); }
+
+    Block::BlockArgListType getArguments() {
+      return getBodyBlock()->getArguments();
+    }
+
+    // Return the block argument for the port with the specified index.
+    BlockArgument getArgument(size_t portNumber);
+
+    OpBuilder getBodyBuilder() {
+      assert(!getBody().empty() && "Unexpected empty 'body' region.");
+      Block &bodyBlock = getBody().front();
+      return OpBuilder::atBlockEnd(&bodyBlock);
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                  mlir::OpAsmSetValueNameFn setNameFn);
+    ArrayAttr getParameters();
+  }];
+}
+
 def GroupDeclOp : FIRRTLOp<
   "declgroup",
   [IsolatedFromAbove, Symbol, SymbolTable, SingleBlock, NoTerminator,

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -199,6 +199,14 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
         << "module doesn't exist '" << path.module << '\'';
     return {};
   }
+
+  // ClassOps may not participate in annotation targeting. Neither the class
+  // itself, nor any "named thing" defined under it, may be targeted by an anno.
+  if (isa<ClassOp>(mod)) {
+    mlir::emitError(mod.getLoc()) << "annotations cannot target classes";
+    return {};
+  }
+
   AnnoTarget ref;
   if (path.name.empty()) {
     assert(path.component.empty());

--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -234,8 +234,8 @@ void ExtractClassesPass::extractClass(FModuleOp moduleOp) {
     formalParamNames.push_back(inputProperty.name);
 
   // Construct the ClassOp with the FModuleOp name and parameter names.
-  auto classOp = builder.create<ClassOp>(moduleOp.getLoc(), moduleOp.getName(),
-                                         formalParamNames);
+  auto classOp = builder.create<om::ClassOp>(
+      moduleOp.getLoc(), moduleOp.getName(), formalParamNames);
 
   // Construct the ClassOp body with block arguments for each input property,
   // updating the mapping to map from the input property to the block argument.

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -313,3 +313,39 @@ firrtl.circuit "Anno" attributes {rawAnnotations = [{
   firrtl.extmodule @Ext()
   firrtl.module @Anno(in %in : !firrtl.uint<1>) {}
 }
+
+// -----
+// Reject annotation on a class.
+
+// expected-error @+1 {{Unable to resolve target of annotation: {class = "circt.test", target = "~Component|Class"}}}
+firrtl.circuit "Component"
+  attributes {
+    rawAnnotations = [
+      {
+        class = "circt.test",
+        target = "~Component|Class"
+      }
+    ]
+} {
+  firrtl.module @Component() {}
+  // expected-error @+1 {{annotations cannot target classes}}
+  firrtl.class @Class() {}
+}
+
+// -----
+// Reject annotation on a class's port.
+
+// expected-error @+1 {{Unable to resolve target of annotation: {class = "circt.test", target = "~Component|Class>port"}}}
+firrtl.circuit "Component"
+  attributes {
+    rawAnnotations = [
+      {
+        class = "circt.test",
+        target = "~Component|Class>port"
+      }
+    ]
+} {
+  firrtl.module @Component() {}
+  // expected-error @+1 {{annotations cannot target classes}}
+  firrtl.class @Class(in %port: !firrtl.string) {}
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1758,6 +1758,34 @@ firrtl.circuit "NonEquivalenctStrictConnect" {
 }
 
 // -----
+// Classes cannot be the top module.
+
+// expected-error @below {{'firrtl.circuit' op must have a non-class top module}}
+firrtl.circuit "TopModuleIsClass" {
+  firrtl.class @TopModuleIsClass() {}
+}
+
+// -----
+// Classes cannot have hardware ports.
+
+firrtl.circuit "ClassCannotHaveHardwarePorts" {
+  firrtl.module @ClassCannotHaveHardwarePorts() {}
+  // expected-error @below {{'firrtl.class' op ports on a class must be properties}}
+  firrtl.class @ClassWithHardwarePort(in %in: !firrtl.uint<8>) {}
+}
+
+// -----
+// Classes cannot hold hardware things.
+
+firrtl.circuit "ClassCannotHaveWires" {
+  firrtl.module @ClassCannotHaveWires() {}
+  firrtl.class @ClassWithWire() {
+    // expected-error @below {{'firrtl.wire' op expects parent op to be one of 'firrtl.module, firrtl.group, firrtl.when, firrtl.match'}}
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+}
+
+// -----
 
 // A group definition, "@A::@B", is missing an outer nesting of a group
 // definition with symbol "@A".


### PR DESCRIPTION
Add a class op to the FIRRTL dialect. Classes are a properties-only module-like thing. Classes can have input and output port, like a module, but these ports can only hold properties.