### PR TITLE
[FIRRTL] Fix type cast to look through type alias for type interfaces

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -395,19 +395,26 @@ namespace firrtl {
 //===--------------------------------------------------------------------===//
 
 /// A struct to check if there is a type derived from FIRRTLBaseType.
-/// `ContainBaseSubTypes<BaseTy>::value` returns true if `BaseTy` is derived
-/// from `FIRRTLBaseType` and not `FIRRTLBaseType` itself.
+/// `ContainAliasableTypes<BaseTy>::value` returns true if `BaseTy` is derived
+/// from `FIRRTLBaseType` and not `FIRRTLBaseType` itself, or is not FIRRTL type
+/// to cover type interfaces.
 template <typename head, typename... tail>
-struct ContainBaseSubTypes {
-  static constexpr bool value =
-      ContainBaseSubTypes<head>::value || ContainBaseSubTypes<tail...>::value;
+class ContainAliasableTypes {
+public:
+  static constexpr bool value = ContainAliasableTypes<head>::value ||
+                                ContainAliasableTypes<tail...>::value;
 };
 
 template <typename BaseTy>
-struct ContainBaseSubTypes<BaseTy> {
-  static constexpr bool value =
+class ContainAliasableTypes<BaseTy> {
+  static constexpr bool isFIRRTLBaseType =
       std::is_base_of<FIRRTLBaseType, BaseTy>::value &&
       !std::is_same_v<FIRRTLBaseType, BaseTy>;
+  static constexpr bool isFIRRTLType =
+      std::is_base_of<FIRRTLType, BaseTy>::value;
+
+public:
+  static constexpr bool value = isFIRRTLBaseType || !isFIRRTLType;
 };
 
 template <typename... BaseTy>
@@ -418,7 +425,7 @@ bool type_isa(Type type) { // NOLINT(readability-identifier-naming)
 
   // If the requested type is a subtype of FIRRTLBaseType, then check if it is a
   // type alias wrapping the requested type.
-  if constexpr (ContainBaseSubTypes<BaseTy...>::value) {
+  if constexpr (ContainAliasableTypes<BaseTy...>::value) {
     if (auto alias = dyn_cast<BaseTypeAliasType>(type))
       return type_isa<BaseTy...>(alias.getInnerType());
   }
@@ -443,7 +450,7 @@ BaseTy type_cast(Type type) { // NOLINT(readability-identifier-naming)
     return cast<BaseTy>(type);
 
   // Otherwise, it must be a type alias wrapping the requested type.
-  if constexpr (ContainBaseSubTypes<BaseTy>::value) {
+  if constexpr (ContainAliasableTypes<BaseTy>::value) {
     if (auto alias = dyn_cast<BaseTypeAliasType>(type))
       return type_cast<BaseTy>(alias.getInnerType());
   }

--- a/unittests/Dialect/FIRRTL/TypesTest.cpp
+++ b/unittests/Dialect/FIRRTL/TypesTest.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/HW/HWTypeInterfaces.h"
 #include "gtest/gtest.h"
 
 using namespace mlir;
@@ -25,13 +26,14 @@ TEST(TypesTest, AnalogContainsAnalog) {
 TEST(TypesTest, TypeAliasCast) {
   MLIRContext context;
   context.loadDialect<FIRRTLDialect>();
-  // Check containBaseSubTypes.
-  static_assert(!ContainBaseSubTypes<FIRRTLType>::value);
+  // Check ContainAliasableTypes.
+  static_assert(!ContainAliasableTypes<FIRRTLType>::value);
   // Return false for FIRRTLBaseType.
-  static_assert(!ContainBaseSubTypes<FIRRTLBaseType>::value);
-  static_assert(!ContainBaseSubTypes<StringType>::value);
-  static_assert(ContainBaseSubTypes<FVectorType>::value);
-  static_assert(ContainBaseSubTypes<UIntType, StringType>::value);
+  static_assert(!ContainAliasableTypes<FIRRTLBaseType>::value);
+  static_assert(!ContainAliasableTypes<StringType>::value);
+  static_assert(ContainAliasableTypes<FVectorType>::value);
+  static_assert(ContainAliasableTypes<UIntType, StringType>::value);
+  static_assert(ContainAliasableTypes<hw::FieldIDTypeInterface>::value);
   AnalogType analog = AnalogType::get(&context);
   BaseTypeAliasType alias1 =
       BaseTypeAliasType::get(StringAttr::get(&context, "foo"), analog);


### PR DESCRIPTION
This fixes a bug that type_cast doesn't work well if a request type isTypeInterface.