### PR TITLE
[Calyx] Fix flat symbol reference for WhileOp.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -89,7 +89,10 @@ def IfOp : CalyxContainer<"if", [
       CArg<"bool", "false">:$initializeElseBody), [{
         $_state.addOperands(cond);
         if (groupName)
-          $_state.addAttribute("groupName", groupName);
+          $_state.addAttribute(
+            "groupName",
+            FlatSymbolRefAttr::get($_builder.getContext(), groupName)
+          );
 
         Region *thenRegion = $_state.addRegion();
         Region *elseRegion = $_state.addRegion();


### PR DESCRIPTION
This should fix the compiler bug mentioned in https://github.com/llvm/circt/pull/5635/files#r1269649717.