### PR TITLE
[FIRRTL] Add Groups to LowerTypes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -380,6 +380,7 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitStmt(StrictConnectOp op);
   bool visitStmt(RefDefineOp op);
   bool visitStmt(WhenOp op);
+  bool visitStmt(GroupOp op);
 
   bool isFailed() const { return encounteredError; }
 
@@ -927,6 +928,12 @@ bool TypeLoweringVisitor::visitStmt(WhenOp op) {
   if (op.hasElseRegion())
     lowerBlock(&op.getElseBlock());
   return false; // don't delete the when!
+}
+
+/// Lower any types declared in the group definition.
+bool TypeLoweringVisitor::visitStmt(GroupOp op) {
+  lowerBlock(op.getBody());
+  return false;
 }
 
 /// Lower memory operations. A new memory is created for every leaf

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1273,6 +1273,16 @@ firrtl.module private @is1436_FOO() {
     %1 = firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
     firrtl.strictconnect %out2, %0 : !firrtl.bundle<a: uint<5>>
   }
+
+  // CHECK-LABEL: firrtl.module @Groups
+  firrtl.declgroup @GroupFoo bind {}
+  firrtl.module @Groups() {
+    // CHECK-NEXT: firrtl.group @GroupFoo
+    firrtl.group @GroupFoo {
+      // CHECK-NEXT: %a_b = firrtl.wire : !firrtl.uint<1>
+      %a = firrtl.wire : !firrtl.bundle<b: uint<1>>
+    }
+  }
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last


### PR DESCRIPTION
Update the LowerTypes pass to support lowering aggregate declarations inside group definitions.