### PR TITLE
[FIRRTL] Relax ODS defined FIRRTL base subtypes to allow type aliases

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -85,6 +85,18 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
         return {};
       return inferReturnType(operands, attrs, loc);
     }
+
+    // Returns when two result types are compatible for this op; method used by
+    // InferTypeOpInterface.
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+      if (l.size () != r.size())
+        return false;
+      for (auto [l, r] : llvm::zip(l, r)) {
+        if (!areAnonymousTypesEquivalent(l, r))
+          return false;
+      }
+      return true;
+    }
   }];
 }
 
@@ -221,7 +233,7 @@ def FEnumCreateOp : FIRRTLOp<"enumcreate"> {
   let extraClassDeclaration = [{
     /// Return the name attribute of the accessed field.
     StringAttr getFieldNameAttr() {
-      return getResult().getType().getElementNameAttr(getFieldIndex());
+      return getResult().getType().get().getElementNameAttr(getFieldIndex());
     }
 
     /// Return the name of the accessed field.
@@ -285,13 +297,13 @@ class BaseSubfieldOp<string name, Type btype, Type rtype> : FIRRTLExprOp<name> {
 
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType()
+      return FieldRef(getInput(), firrtl::type_cast<InputType>(getInput().getType())
                                             .getFieldID(getFieldIndex()));
     }
 
     /// Return the name of the accessed field.
     StringRef getFieldName() {
-      return getInput().getType().getElementName(getFieldIndex());
+      return firrtl::type_cast<InputType>(getInput().getType()).getElementName(getFieldIndex());
     }
   }];
 }
@@ -325,8 +337,9 @@ def SubindexOp : FIRRTLExprOp<"subindex"> {
   let firrtlExtraClassDeclaration = [{
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType().getFieldID(getIndex()));
+      return FieldRef(getInput(), getInput().getType().get().getFieldID(getIndex()));
     }
+    using InputType = FVectorType;
   }];
 }
 
@@ -353,6 +366,8 @@ def OpenSubindexOp : FIRRTLExprOp<"opensubindex"> {
     FieldRef getAccessedField() {
       return FieldRef(getInput(), getInput().getType().getFieldID(getIndex()));
     }
+
+    using InputType = OpenVectorType;
   }];
 }
 
@@ -449,13 +464,13 @@ def SubtagOp : FIRRTLExprOp<"subtag"> {
   let firrtlExtraClassDeclaration = [{
     /// Return a `FieldRef` to the accessed field.
     FieldRef getAccessedField() {
-      return FieldRef(getInput(), getInput().getType()
+      return FieldRef(getInput(), getInput().getType().get()
                                             .getFieldID(getFieldIndex()));
     }
 
     /// Return the name of the accessed field.
     StringAttr getFieldNameAttr() {
-      return getInput().getType().getElementNameAttr(getFieldIndex());
+      return getInput().getType().get().getElementNameAttr(getFieldIndex());
     }
 
     /// Return the name of the accessed field.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -620,6 +620,24 @@ private:
   bool foundMatch = false;
 };
 
+template <typename BaseTy>
+class BaseTypeAliasOr
+    : public ::mlir::Type::TypeBase<BaseTypeAliasOr<BaseTy>,
+                                    firrtl::FIRRTLBaseType,
+                                    detail::FIRRTLBaseTypeStorage> {
+
+public:
+  using mlir::Type::TypeBase<BaseTypeAliasOr<BaseTy>, firrtl::FIRRTLBaseType,
+                             detail::FIRRTLBaseTypeStorage>::Base::Base;
+  // Support LLVM isa/cast/dyn_cast to BaseTy.
+  static bool classof(Type other) { return type_isa<BaseTy>(other); }
+
+  // Support C++ implicit conversions to BaseTy.
+  operator BaseTy() const { return circt::firrtl::type_cast<BaseTy>(*this); }
+
+  BaseTy get() const { return circt::firrtl::type_cast<BaseTy>(*this); }
+};
+
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -29,6 +29,11 @@ class FIRRTLDialectTypeHelper<string typeName, string summary, string desc = "">
   : FIRRTLDialectType<CPred<"isa<" # typeName # ">($_self)">, summary,
                       "::circt::firrtl::" # typeName, desc>;
 
+// Helper class to define firrtl types which allows alias types to be used as well.
+class FIRRTLDialectAliasTypeHelper<string typeName, string summary, string desc = "">
+  : FIRRTLDialectType<CPred<"type_isa<" # typeName # ">($_self)">, summary,
+                      "::circt::firrtl::BaseTypeAliasOr<::circt::firrtl::" # typeName #">", desc>;
+
 def FIRRTLType : FIRRTLDialectTypeHelper<"FIRRTLType", "FIRRTLType", [{
     Any FIRRTL dialect type, represented by FIRRTLType.
   }]>;
@@ -48,29 +53,29 @@ def FIRRTLBaseType : FIRRTLDialectType<
 def ForeignType : FIRRTLDialectType<CPred<"!isa<FIRRTLType>($_self)">,
                                     "foreign type", "::mlir::Type">;
 
-def ClockType : FIRRTLDialectTypeHelper<"ClockType", "clock">;
+def ClockType : FIRRTLDialectAliasTypeHelper<"ClockType", "clock">;
 
 def NonConstClockType :
-  FIRRTLDialectTypeHelper<"ClockType", "clock">,
+  FIRRTLDialectAliasTypeHelper<"ClockType", "clock">,
   BuildableType<"::circt::firrtl::ClockType::get($_builder.getContext())">;
 
-def IntType : FIRRTLDialectTypeHelper<"IntType", "sint or uint type">;
+def IntType : FIRRTLDialectAliasTypeHelper<"IntType", "sint or uint type">;
 
-def SIntType : FIRRTLDialectTypeHelper<"SIntType", "sint type">;
+def SIntType : FIRRTLDialectAliasTypeHelper<"SIntType", "sint type">;
 
-def UIntType : FIRRTLDialectTypeHelper<"UIntType", "uint type">;
+def UIntType : FIRRTLDialectAliasTypeHelper<"UIntType", "uint type">;
 
-def AnalogType : FIRRTLDialectTypeHelper<"AnalogType", "analog type">;
+def AnalogType : FIRRTLDialectAliasTypeHelper<"AnalogType", "analog type">;
 
-def BundleType : FIRRTLDialectTypeHelper<"BundleType", "bundle type">;
+def BundleType : FIRRTLDialectAliasTypeHelper<"BundleType", "bundle type">;
 
 def OpenBundleType : FIRRTLDialectTypeHelper<"OpenBundleType", "open bundle type">;
 
-def FVectorType : FIRRTLDialectTypeHelper<"FVectorType", "vector type">;
+def FVectorType : FIRRTLDialectAliasTypeHelper<"FVectorType", "vector type">;
 
 def OpenVectorType : FIRRTLDialectTypeHelper<"OpenVectorType", "open vector type">;
 
-def FEnumType : FIRRTLDialectTypeHelper<"FEnumType", "enum type">;
+def FEnumType : FIRRTLDialectAliasTypeHelper<"FEnumType", "enum type">;
 
 def AggregateType : FIRRTLDialectType<
   CPred<"type_isa<FVectorType, BundleType, FEnumType>($_self)">,
@@ -88,9 +93,9 @@ def SizedPassiveType : FIRRTLDialectType<And<[SizedType.predicate,PassiveType.pr
     "a sized passive base type (contains no uninferred widths, or flips)", "::circt::firrtl::FIRRTLType">;
 def SizedPassiveOrForeignType : AnyTypeOf<[SizedPassiveType, ForeignType]>;
 
-def AsyncResetType : FIRRTLDialectTypeHelper<"AsyncResetType", "async reset type">;
+def AsyncResetType : FIRRTLDialectAliasTypeHelper<"AsyncResetType", "async reset type">;
 
-def ResetType : FIRRTLDialectTypeHelper<"ResetType", "reset type">;
+def ResetType : FIRRTLDialectAliasTypeHelper<"ResetType", "reset type">;
 
 
 def RefType : FIRRTLDialectTypeHelper<"RefType", "reference type">;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1287,7 +1287,8 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
   for (auto *op : structValue.getUsers()) {
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
-    auto elemIndex = fieldAccess.getInput().getType().getElementIndex(field);
+    auto elemIndex =
+        fieldAccess.getInput().getType().get().getElementIndex(field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
   }

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1056,7 +1056,7 @@ void Emitter::emitExpression(SpecialConstantOp op) {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void Emitter::emitExpression(SubfieldOp op) {
-  auto type = op.getInput().getType();
+  BundleType type = op.getInput().getType();
   emitExpression(op.getInput());
   ps << "." << legalize(type.getElementNameAttr(op.getFieldIndex()));
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -462,7 +462,7 @@ OpFoldResult DivPrimOp::fold(FoldAdaptor adaptor) {
   /// supersede any division with invalid or zero.  Division of invalid by
   /// invalid should be one.
   if (getLhs() == getRhs()) {
-    auto width = getType().getWidthOrSentinel();
+    auto width = getType().get().getWidthOrSentinel();
     if (width == -1)
       width = 2;
     // Only fold if we have at least 1 bit of width to represent the `1` value.
@@ -541,8 +541,8 @@ OpFoldResult DShrPrimOp::fold(FoldAdaptor adaptor) {
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::DivideOrShift,
       [=](const APSInt &a, const APSInt &b) -> APInt {
-        return getType().isUnsigned() || !a.getBitWidth() ? a.lshr(b)
-                                                          : a.ashr(b);
+        return getType().get().isUnsigned() || !a.getBitWidth() ? a.lshr(b)
+                                                                : a.ashr(b);
       });
 }
 
@@ -629,18 +629,20 @@ void OrPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult XorPrimOp::fold(FoldAdaptor adaptor) {
   /// xor(x, 0) -> x
   if (auto rhsCst = getConstant(adaptor.getRhs()))
-    if (rhsCst->isZero() && getLhs().getType() == getType())
+    if (rhsCst->isZero() &&
+        firrtl::areAnonymousTypesEquivalent(getLhs().getType(), getType()))
       return getLhs();
 
   /// xor(x, 0) -> x
   if (auto lhsCst = getConstant(adaptor.getLhs()))
-    if (lhsCst->isZero() && getRhs().getType() == getType())
+    if (lhsCst->isZero() &&
+        firrtl::areAnonymousTypesEquivalent(getRhs().getType(), getType()))
       return getRhs();
 
   /// xor(x, x) -> 0
   if (getLhs() == getRhs())
-    return getIntAttr(getType(),
-                      APInt(std::max(getType().getWidthOrSentinel(), 0), 0));
+    return getIntAttr(
+        getType(), APInt(std::max(getType().get().getWidthOrSentinel(), 0), 0));
 
   return constFoldFIRRTLBinaryOp(
       *this, adaptor.getOperands(), BinOpKind::Normal,
@@ -660,14 +662,14 @@ void LEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult LEQPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isUnsigned();
+  bool isUnsigned = getLhs().getType().get().isUnsigned();
 
   // leq(x, x) -> 1
   if (getLhs() == getRhs())
     return getIntAttr(getType(), APInt(1, 1));
 
   // Comparison against constant outside type bounds.
-  if (auto width = getLhs().getType().getWidth()) {
+  if (auto width = getLhs().getType().get().getWidth()) {
     if (auto rhsCst = getConstant(adaptor.getRhs())) {
       auto commonWidth = std::max<int32_t>(*width, rhsCst->getBitWidth());
       commonWidth = std::max(commonWidth, 1);
@@ -705,7 +707,8 @@ void LTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isUnsigned();
+  IntType lhsType = getLhs().getType();
+  bool isUnsigned = lhsType.isUnsigned();
 
   // lt(x, x) -> 0
   if (getLhs() == getRhs())
@@ -713,12 +716,12 @@ OpFoldResult LTPrimOp::fold(FoldAdaptor adaptor) {
 
   // lt(x, 0) -> 0 when x is unsigned
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
-    if (rhsCst->isZero() && getLhs().getType().isUnsigned())
+    if (rhsCst->isZero() && lhsType.isUnsigned())
       return getIntAttr(getType(), APInt(1, 0));
   }
 
   // Comparison against constant outside type bounds.
-  if (auto width = getLhs().getType().getWidth()) {
+  if (auto width = lhsType.getWidth()) {
     if (auto rhsCst = getConstant(adaptor.getRhs())) {
       auto commonWidth = std::max<int32_t>(*width, rhsCst->getBitWidth());
       commonWidth = std::max(commonWidth, 1);
@@ -756,7 +759,8 @@ void GEQPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isUnsigned();
+  IntType lhsType = getLhs().getType();
+  bool isUnsigned = lhsType.isUnsigned();
 
   // geq(x, x) -> 1
   if (getLhs() == getRhs())
@@ -769,7 +773,7 @@ OpFoldResult GEQPrimOp::fold(FoldAdaptor adaptor) {
   }
 
   // Comparison against constant outside type bounds.
-  if (auto width = getLhs().getType().getWidth()) {
+  if (auto width = lhsType.getWidth()) {
     if (auto rhsCst = getConstant(adaptor.getRhs())) {
       auto commonWidth = std::max<int32_t>(*width, rhsCst->getBitWidth());
       commonWidth = std::max(commonWidth, 1);
@@ -807,14 +811,15 @@ void GTPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult GTPrimOp::fold(FoldAdaptor adaptor) {
-  bool isUnsigned = getLhs().getType().isUnsigned();
+  IntType lhsType = getLhs().getType();
+  bool isUnsigned = lhsType.isUnsigned();
 
   // gt(x, x) -> 0
   if (getLhs() == getRhs())
     return getIntAttr(getType(), APInt(1, 0));
 
   // Comparison against constant outside type bounds.
-  if (auto width = getLhs().getType().getWidth()) {
+  if (auto width = lhsType.getWidth()) {
     if (auto rhsCst = getConstant(adaptor.getRhs())) {
       auto commonWidth = std::max<int32_t>(*width, rhsCst->getBitWidth());
       commonWidth = std::max(commonWidth, 1);
@@ -969,13 +974,13 @@ OpFoldResult IsXIntrinsicOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult AsSIntPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
+  if (areAnonymousTypesEquivalent(getInput().getType(), getType()))
     return getInput();
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
-  if (getType().hasWidth())
+  if (getType().get().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
       return getIntAttr(getType(), *cst);
 
@@ -989,13 +994,13 @@ void AsSIntPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 OpFoldResult AsUIntPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
-  if (getInput().getType() == getType())
+  if (areAnonymousTypesEquivalent(getInput().getType(), getType()))
     return getInput();
 
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
-  if (getType().hasWidth())
+  if (getType().get().hasWidth())
     if (auto cst = getConstant(adaptor.getInput()))
       return getIntAttr(getType(), *cst);
 
@@ -1037,7 +1042,7 @@ OpFoldResult CvtPrimOp::fold(FoldAdaptor adaptor) {
 
   // Signed to signed is a noop, unsigned operands prepend a zero bit.
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
-                                     getType().getWidthOrSentinel()))
+                                     getType().get().getWidthOrSentinel()))
     return getIntAttr(getType(), *cst);
 
   return {};
@@ -1055,7 +1060,7 @@ OpFoldResult NegPrimOp::fold(FoldAdaptor adaptor) {
   // FIRRTL negate always adds a bit.
   // -x ---> 0-sext(x) or 0-zext(x)
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
-                                     getType().getWidthOrSentinel()))
+                                     getType().get().getWidthOrSentinel()))
     return getIntAttr(getType(), APInt((*cst).getBitWidth(), 0) - *cst);
 
   return {};
@@ -1066,7 +1071,7 @@ OpFoldResult NotPrimOp::fold(FoldAdaptor adaptor) {
     return {};
 
   if (auto cst = getExtendedConstant(getOperand(), adaptor.getInput(),
-                                     getType().getWidthOrSentinel()))
+                                     getType().get().getWidthOrSentinel()))
     return getIntAttr(getType(), ~*cst);
 
   return {};
@@ -1161,11 +1166,11 @@ OpFoldResult CatPrimOp::fold(FoldAdaptor adaptor) {
   // cat(x, 0-width) -> x
   // cat(0-width, x) -> x
   // Limit to unsigned (result type), as cannot insert cast here.
-  if (getLhs().getType().getBitWidthOrSentinel() == 0 &&
-      getRhs().getType().isUnsigned())
+  IntType lhsType = getLhs().getType();
+  IntType rhsType = getRhs().getType();
+  if (lhsType.getBitWidthOrSentinel() == 0 && rhsType.isUnsigned())
     return getRhs();
-  if (getRhs().getType().getBitWidthOrSentinel() == 0 &&
-      getLhs().getType().isUnsigned())
+  if (rhsType.getBitWidthOrSentinel() == 0 && rhsType.isUnsigned())
     return getLhs();
 
   if (!hasKnownWidthIntTypes(*this))
@@ -1237,15 +1242,16 @@ OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult BitsPrimOp::fold(FoldAdaptor adaptor) {
-  auto inputType = getInput().getType();
+  IntType inputType = getInput().getType();
+  IntType resultType = getType();
   // If we are extracting the entire input, then return it.
-  if (inputType == getType() && getType().hasWidth())
+  if (inputType == getType() && resultType.hasWidth())
     return getInput();
 
   // Constant fold.
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(),
+      return getIntAttr(resultType,
                         cst->extractBits(getHi() - getLo() + 1, getLo()));
 
   return {};
@@ -1483,14 +1489,14 @@ OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
     return input;
 
   // Need to know the input width.
-  auto inputType = input.getType();
+  auto inputType = input.getType().get();
   int32_t width = inputType.getWidthOrSentinel();
   if (width == -1)
     return {};
 
   // Constant fold.
   if (auto cst = getConstant(adaptor.getInput())) {
-    auto destWidth = getType().getWidthOrSentinel();
+    auto destWidth = getType().get().getWidthOrSentinel();
     if (destWidth == -1)
       return {};
 
@@ -1504,7 +1510,7 @@ OpFoldResult PadPrimOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
   auto input = this->getInput();
-  auto inputType = input.getType();
+  IntType inputType = input.getType();
   int shiftAmount = getAmount();
 
   // shl(x, 0) -> x
@@ -1525,7 +1531,7 @@ OpFoldResult ShlPrimOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
   auto input = this->getInput();
-  auto inputType = input.getType();
+  IntType inputType = input.getType();
   int shiftAmount = getAmount();
 
   // shr(x, 0) -> x
@@ -1557,7 +1563,7 @@ OpFoldResult ShrPrimOp::fold(FoldAdaptor adaptor) {
 }
 
 LogicalResult ShrPrimOp::canonicalize(ShrPrimOp op, PatternRewriter &rewriter) {
-  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().get().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 
@@ -1565,7 +1571,7 @@ LogicalResult ShrPrimOp::canonicalize(ShrPrimOp op, PatternRewriter &rewriter) {
   unsigned shiftAmount = op.getAmount();
   if (int(shiftAmount) >= inputWidth) {
     // shift(x, 32) => 0 when x has 32 bits.  This is handled by fold().
-    if (op.getType().isUnsigned())
+    if (op.getType().get().isUnsigned())
       return failure();
 
     // Shifting a signed value by the full width is actually taking the
@@ -1580,7 +1586,7 @@ LogicalResult ShrPrimOp::canonicalize(ShrPrimOp op, PatternRewriter &rewriter) {
 
 LogicalResult HeadPrimOp::canonicalize(HeadPrimOp op,
                                        PatternRewriter &rewriter) {
-  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().get().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 
@@ -1595,7 +1601,8 @@ LogicalResult HeadPrimOp::canonicalize(HeadPrimOp op,
 OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput())) {
-      int shiftAmount = getInput().getType().getWidthOrSentinel() - getAmount();
+      int shiftAmount =
+          getInput().getType().get().getWidthOrSentinel() - getAmount();
       return getIntAttr(getType(), cst->lshr(shiftAmount).trunc(getAmount()));
     }
 
@@ -1605,13 +1612,14 @@ OpFoldResult HeadPrimOp::fold(FoldAdaptor adaptor) {
 OpFoldResult TailPrimOp::fold(FoldAdaptor adaptor) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(adaptor.getInput()))
-      return getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel()));
+      return getIntAttr(getType(),
+                        cst->trunc(getType().get().getWidthOrSentinel()));
   return {};
 }
 
 LogicalResult TailPrimOp::canonicalize(TailPrimOp op,
                                        PatternRewriter &rewriter) {
-  auto inputWidth = op.getInput().getType().getWidthOrSentinel();
+  auto inputWidth = op.getInput().getType().get().getWidthOrSentinel();
   if (inputWidth <= 0)
     return failure();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2750,6 +2750,7 @@ static LogicalResult checkConnectConditionality(FConnectLike connect) {
           .Case<SubaccessOp>([&](SubaccessOp op) {
             if (op.getInput()
                     .getType()
+                    .get()
                     .getElementTypePreservingConst()
                     .isConst())
               originalFieldType = originalFieldType.getConstType(true);
@@ -2955,7 +2956,7 @@ void WhenOp::build(OpBuilder &builder, OperationState &result, Value condition,
 //===----------------------------------------------------------------------===//
 
 LogicalResult MatchOp::verify() {
-  auto type = getInput().getType();
+  FEnumType type = getInput().getType();
 
   // Make sure that the number of tags matches the number of regions.
   auto numCases = getTags().size();
@@ -3004,7 +3005,7 @@ LogicalResult MatchOp::verify() {
 
 void MatchOp::print(OpAsmPrinter &p) {
   auto input = getInput();
-  auto type = input.getType();
+  FEnumType type = input.getType();
   auto regions = getRegions();
   p << " " << input << " : " << type;
   SmallVector<StringRef> elided = {"tags"};
@@ -3216,7 +3217,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 
 LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  auto intType = getType();
+  IntType intType = getType();
   auto width = intType.getWidthOrSentinel();
   if (width != -1 && (int)getValue().getBitWidth() != width)
     return emitError(
@@ -3224,7 +3225,7 @@ LogicalResult ConstantOp::verify() {
 
   // The sign of the attribute's integer type must match our integer type sign.
   auto attrType = type_cast<IntegerType>(getValueAttr().getType());
-  if (attrType.isSignless() || attrType.isSigned() != getType().isSigned())
+  if (attrType.isSignless() || attrType.isSigned() != intType.isSigned())
     return emitError("firrtl.constant attribute has wrong sign");
 
   return success();
@@ -3257,7 +3258,7 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
 void ConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // For constants in particular, propagate the value into the result name to
   // make it easier to read the IR.
-  auto intTy = getType();
+  IntType intTy = getType();
   assert(intTy);
 
   // Otherwise, build a complex name with the value and type.
@@ -3421,23 +3422,25 @@ ParseResult FIntegerConstantOp::parse(OpAsmParser &parser,
 }
 
 LogicalResult BundleCreateOp::verify() {
-  if (getType().getNumElements() != getFields().size())
+  BundleType resultType = getType();
+  if (resultType.getNumElements() != getFields().size())
     return emitOpError("number of fields doesn't match type");
-  for (size_t i = 0; i < getType().getNumElements(); ++i)
+  for (size_t i = 0; i < resultType.getNumElements(); ++i)
     if (!areTypesConstCastable(
-            getType().getElementTypePreservingConst(i),
+            resultType.getElementTypePreservingConst(i),
             type_cast<FIRRTLBaseType>(getOperand(i).getType())))
       return emitOpError("type of element doesn't match bundle for field ")
-             << getType().getElement(i).name;
+             << resultType.getElement(i).name;
   // TODO: check flow
   return success();
 }
 
 LogicalResult VectorCreateOp::verify() {
-  if (getType().getNumElements() != getFields().size())
+  FVectorType resultType = getType();
+  if (resultType.getNumElements() != getFields().size())
     return emitOpError("number of fields doesn't match type");
-  auto elemTy = getType().getElementTypePreservingConst();
-  for (size_t i = 0; i < getType().getNumElements(); ++i)
+  auto elemTy = resultType.getElementTypePreservingConst();
+  for (size_t i = 0; i < resultType.getNumElements(); ++i)
     if (!areTypesConstCastable(
             elemTy, type_cast<FIRRTLBaseType>(getOperand(i).getType())))
       return emitOpError("type of element doesn't match vector element");
@@ -3450,13 +3453,14 @@ LogicalResult VectorCreateOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult FEnumCreateOp::verify() {
-  auto elementIndex = getResult().getType().getElementIndex(getFieldName());
+  FEnumType resultType = getResult().getType();
+  auto elementIndex = resultType.getElementIndex(getFieldName());
   if (!elementIndex)
     return emitOpError("label ")
            << getFieldName() << " is not a member of the enumeration type "
-           << getResult().getType();
+           << resultType;
   if (!areTypesConstCastable(
-          getResult().getType().getElementTypePreservingConst(*elementIndex),
+          resultType.getElementTypePreservingConst(*elementIndex),
           getInput().getType()))
     return emitOpError("type of element doesn't match enum element");
   return success();
@@ -3520,7 +3524,7 @@ ParseResult FEnumCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult IsTagOp::verify() {
-  if (getFieldIndex() >= getInput().getType().getNumElements())
+  if (getFieldIndex() >= getInput().getType().get().getNumElements())
     return emitOpError("element index is greater than the number of fields in "
                        "the bundle type");
   return success();
@@ -3591,7 +3595,7 @@ ParseResult parseSubfieldLikeOp(OpAsmParser &parser, OperationState &result) {
   if (parser.resolveOperand(input, inputType, result.operands))
     return failure();
 
-  auto bundleType = dyn_cast<typename OpTy::InputType>(inputType);
+  auto bundleType = type_dyn_cast<typename OpTy::InputType>(inputType);
   if (!bundleType)
     return parser.emitError(parser.getNameLoc(),
                             "input must be bundle type, got ")
@@ -3694,7 +3698,9 @@ void SubtagOp::print(::mlir::OpAsmPrinter &printer) {
 
 template <typename OpTy>
 static LogicalResult verifySubfieldLike(OpTy op) {
-  if (op.getFieldIndex() >= op.getInput().getType().getNumElements())
+  if (op.getFieldIndex() >=
+      firrtl::type_cast<typename OpTy::InputType>(op.getInput().getType())
+          .getNumElements())
     return op.emitOpError("subfield element index is greater than the number "
                           "of fields in the bundle type");
   return success();
@@ -3707,7 +3713,7 @@ LogicalResult OpenSubfieldOp::verify() {
 }
 
 LogicalResult SubtagOp::verify() {
-  if (getFieldIndex() >= getInput().getType().getNumElements())
+  if (getFieldIndex() >= getInput().getType().get().getNumElements())
     return emitOpError("subfield element index is greater than the number "
                        "of fields in the bundle type");
   return success();
@@ -3798,7 +3804,7 @@ FIRRTLType OpenSubfieldOp::inferReturnType(ValueRange operands,
 }
 
 bool SubfieldOp::isFieldFlipped() {
-  auto bundle = getInput().getType();
+  BundleType bundle = getInput().getType();
   return bundle.getElement(getFieldIndex()).isFlip;
 }
 bool OpenSubfieldOp::isFieldFlipped() {

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -35,7 +35,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   // Special Connects (non-base, foreign):
   if (!dstType) {
     // References use ref.define.  Add cast if types don't match.
-    if (isa<RefType>(dstFType)) {
+    if (type_isa<RefType>(dstFType)) {
       if (dstFType != srcFType)
         src = builder.create<RefCastOp>(dstFType, src);
       builder.create<RefDefineOp>(dst, src);
@@ -433,7 +433,7 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
       auto fieldID = back.fieldID;
 
       if (auto subfield = dyn_cast<SubfieldOp>(user)) {
-        auto bundleType = subfield.getInput().getType();
+        BundleType bundleType = subfield.getInput().getType();
         auto index = subfield.getFieldIndex();
         auto subID = bundleType.getFieldID(index);
         // If the index of this operation doesn't match the target, skip it.
@@ -444,7 +444,7 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
         auto value = subfield.getResult();
         workStack.emplace_back(subOriginal, subRef, value, fieldID - subID);
       } else if (auto subindex = dyn_cast<SubindexOp>(user)) {
-        auto vectorType = subindex.getInput().getType();
+        FVectorType vectorType = subindex.getInput().getType();
         auto index = subindex.getIndex();
         auto subID = vectorType.getFieldID(index);
         // If the index of this operation doesn't match the target, skip it.
@@ -488,7 +488,8 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
         TypeSwitch<Operation *, bool>(op)
             .Case<SubfieldOp, OpenSubfieldOp>([&](auto subfieldOp) {
               value = subfieldOp.getInput();
-              auto bundleType = subfieldOp.getInput().getType();
+              typename decltype(subfieldOp)::InputType bundleType =
+                  subfieldOp.getInput().getType();
               // Rebase the current index on the parent field's
               // index.
               id += bundleType.getFieldID(subfieldOp.getFieldIndex());
@@ -496,7 +497,8 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
             })
             .Case<SubindexOp, OpenSubindexOp>([&](auto subindexOp) {
               value = subindexOp.getInput();
-              auto vecType = subindexOp.getInput().getType();
+              typename decltype(subindexOp)::InputType vecType =
+                  subindexOp.getInput().getType();
               // Rebase the current index on the parent field's
               // index.
               id += vecType.getFieldID(subindexOp.getIndex());

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -274,7 +274,7 @@ public:
             auto fieldIndex = sub.getAccessedField().getFieldID();
             if (memPorts.contains(sub.getInput())) {
               auto memPort = sub.getInput();
-              auto type = memPort.getType();
+              BundleType type = memPort.getType();
               auto enableFieldId =
                   type.getFieldID((unsigned)ReadPortSubfield::en);
               auto dataFieldId =
@@ -320,7 +320,7 @@ public:
             }
           })
           .Case<SubaccessOp>([&](SubaccessOp sub) {
-            auto vecType = sub.getInput().getType();
+            FVectorType vecType = sub.getInput().getType();
             auto res = sub.getResult();
             bool isValid = false;
             SmallVector<FieldRef, 4> fields;

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -80,8 +80,8 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
         for (Operation *u : portVal.getUsers())
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
             // Get the field name.
-            auto fName =
-                sf.getInput().getType().getElementName(sf.getFieldIndex());
+            auto fName = sf.getInput().getType().get().getElementName(
+                sf.getFieldIndex());
             // If this is the enable field, record the product terms(the And
             // expression tree).
             if (fName.equals("en"))
@@ -188,8 +188,8 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
         // replace them.
         for (Operation *u : portVal.getUsers())
           if (auto sf = dyn_cast<SubfieldOp>(u)) {
-            StringRef fName =
-                sf.getInput().getType().getElementName(sf.getFieldIndex());
+            StringRef fName = sf.getInput().getType().get().getElementName(
+                sf.getFieldIndex());
             Value repl;
             if (isReadPort)
               repl = llvm::StringSwitch<Value>(fName)
@@ -328,7 +328,7 @@ private:
         if (auto sf = dyn_cast<SubfieldOp>(u)) {
           // Get the field name.
           auto fName =
-              sf.getInput().getType().getElementName(sf.getFieldIndex());
+              sf.getInput().getType().get().getElementName(sf.getFieldIndex());
           // Check if this is the mask field.
           if (fName.contains("mask")) {
             // Already 1 bit, nothing to do.
@@ -379,7 +379,7 @@ private:
           auto sf =
               builder.create<SubfieldOp>(newPortVal, oldRes.getFieldIndex());
           auto fName =
-              sf.getInput().getType().getElementName(sf.getFieldIndex());
+              sf.getInput().getType().get().getElementName(sf.getFieldIndex());
           // Replace all mask fields with a one bit constant 1.
           // Replace all other fields with the new port.
           if (fName.contains("mask")) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -814,7 +814,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
           .Case<SubfieldOp>([&](auto op) {
             // Associate the input bundle's resets with the output field's
             // resets.
-            auto bundleType = op.getInput().getType();
+            BundleType bundleType = op.getInput().getType();
             auto index = op.getFieldIndex();
             traceResets(op.getType(), op.getResult(), 0,
                         bundleType.getElements()[index].type, op.getInput(),
@@ -834,7 +834,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
             // were connected. However for the sake of type inference, this
             // is indistinguishable from them having to share the same type
             // (namely the vector element type).
-            auto vectorType = op.getInput().getType();
+            FVectorType vectorType = op.getInput().getType();
             traceResets(op.getType(), op.getResult(), 0,
                         vectorType.getElementType(), op.getInput(),
                         getFieldID(vectorType), op.getLoc());

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1341,7 +1341,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         // If the constant has a known width, use that. Otherwise pick the
         // smallest number of bits necessary to represent the constant.
         Expr *e;
-        if (auto width = op.getType().getWidth())
+        if (auto width = op.getType().get().getWidth())
           e = solver.known(*width);
         else {
           auto v = op.getValue();
@@ -1398,7 +1398,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
 
       // Aggregate Values
       .Case<SubfieldOp>([&](auto op) {
-        auto bundleType = op.getInput().getType();
+        BundleType bundleType = op.getInput().getType();
         auto fieldID = bundleType.getFieldID(op.getFieldIndex());
         unifyTypes(FieldRef(op.getResult(), 0),
                    FieldRef(op.getInput(), fieldID), op.getType());
@@ -1410,7 +1410,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
                    op.getType());
       })
       .Case<SubtagOp>([&](auto op) {
-        auto enumType = op.getInput().getType();
+        FEnumType enumType = op.getInput().getType();
         auto fieldID = enumType.getFieldID(op.getFieldIndex());
         unifyTypes(FieldRef(op.getResult(), 0),
                    FieldRef(op.getInput(), fieldID), op.getType());
@@ -1443,7 +1443,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       .Case<DivPrimOp>([&](auto op) {
         auto lhs = getExpr(op.getLhs());
         Expr *e;
-        if (op.getType().isSigned()) {
+        if (op.getType().get().isSigned()) {
           e = solver.add(lhs, solver.known(1));
         } else {
           e = lhs;
@@ -1489,7 +1489,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
       .Case<CvtPrimOp>([&](auto op) {
         auto input = getExpr(op.getInput());
-        auto e = op.getInput().getType().isSigned()
+        auto e = op.getInput().getType().get().isSigned()
                      ? input
                      : solver.add(input, solver.known(1));
         setExpr(op.getResult(), e);

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -322,7 +322,8 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
   for (auto *op : structValue.getUsers()) {
     assert(isa<SubfieldOp>(op));
     auto fieldAccess = cast<SubfieldOp>(op);
-    auto elemIndex = fieldAccess.getInput().getType().getElementIndex(field);
+    auto elemIndex =
+        fieldAccess.getInput().getType().get().getElementIndex(field);
     if (elemIndex && *elemIndex == fieldAccess.getFieldIndex())
       accesses.push_back(fieldAccess);
   }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -208,7 +208,7 @@ static bool isNotSubAccess(Operation *op) {
     return true;
   ConstantOp arg =
       llvm::dyn_cast_or_null<ConstantOp>(sao.getIndex().getDefiningOp());
-  return arg && sao.getInput().getType().getNumElements() != 0;
+  return arg && sao.getInput().getType().get().getNumElements() != 0;
 }
 
 /// Look through and collect subfields leading to a subaccess.
@@ -827,7 +827,7 @@ static Value cloneAccess(ImplicitLocOpBuilder *builder, Operation *op,
 void TypeLoweringVisitor::lowerSAWritePath(Operation *op,
                                            ArrayRef<Operation *> writePath) {
   SubaccessOp sao = cast<SubaccessOp>(writePath.back());
-  auto saoType = sao.getInput().getType();
+  FVectorType saoType = sao.getInput().getType();
   auto selectWidth = llvm::Log2_64_Ceil(saoType.getNumElements());
 
   for (size_t index = 0, e = saoType.getNumElements(); index < e; ++index) {
@@ -1465,7 +1465,7 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
 
 bool TypeLoweringVisitor::visitExpr(SubaccessOp op) {
   auto input = op.getInput();
-  auto vType = input.getType();
+  FVectorType vType = input.getType();
 
   // Check for empty vectors
   if (vType.getNumElements() == 0) {

--- a/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
@@ -845,7 +845,7 @@ LogicalResult Visitor::visitExpr(VectorCreateOp op) {
   }
 
   auto value = sinkVecDimIntoOperands(
-      builder, convertType(oldType.getElementType()), convertedOldFields);
+      builder, convertType(oldType.get().getElementType()), convertedOldFields);
   valueMap[op.getResult()] = value;
   toDelete.push_back(op);
   return success();

--- a/lib/Dialect/FIRRTL/Transforms/Vectorization.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Vectorization.cpp
@@ -43,8 +43,8 @@ public:
   matchAndRewrite(Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
     auto vectorCreateOp = cast<VectorCreateOp>(op);
-    auto type = vectorCreateOp.getType();
-    if (type.hasUninferredWidth() || !isa<UIntType>(type.getElementType()))
+    FVectorType type = vectorCreateOp.getType();
+    if (type.hasUninferredWidth() || !type_isa<UIntType>(type.getElementType()))
       return failure();
 
     SmallVector<Value> lhs, rhs;

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1586,12 +1586,18 @@ circuit Top:
   ; CHECK-SAME:                                         valid: alias<ValidType, uint<1>>, ready flip: uint<1>>>,
   ; CHECK-SAME: in %in_complex: !firrtl.alias<Complex, bundle<real: sint<10>, imag: sint<10>>>
   ; CHECK-SAME: out %out: !firrtl.probe<alias<Complex, bundle<real: sint<10>, imag: sint<10>>>>
+  ; CHECK-SAME: out %out_valid: !firrtl.alias<ValidType, uint<1>>
+
+  ; CHECK-NEXT: %[[RESULT:.+]] = firrtl.subfield %in_data[valid] : !firrtl.alias<Data, bundle<w: const.vector<const.alias<WordType, const.uint<32>>, 2>, valid: alias<ValidType, uint<1>>, ready flip: uint<1>>>
   ; CHECK-NEXT: %c = firrtl.wire interesting_name : !firrtl.alias<Complex_id, alias<Complex, bundle<real: sint<10>, imag: sint<10>>>>
+  ; CHECK-NEXT: firrtl.strictconnect %out_valid, %[[RESULT]] : !firrtl.alias<ValidType, uint<1>>
   module Top:
     input in_data: Data
     input in_complex: Complex
     output out: ProbeComplex
+    output out_valid: ValidType
     wire c: Complex_id
+    out_valid <= in_data.valid
 
   ; CHECK-LABEL: firrtl.module private @Const
   ; CHECK-SAME: (in %a: !firrtl.const.alias<ConstI1, const.uint<1>>)

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -46,17 +46,19 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 
 ; VERILOG-IR: sv.verbatim{{.*}}Standard header to adapt well known macros to our needs
 ; VERILOG-IR: sv.macro.def @INIT_RANDOM_PROLOG_
+  type V3 = UInt<1>[3]
+  type V2 = UInt<1>[2]
 
   module test_mod :
     input clock : Clock
     input a: UInt<1>
     input b: UInt<2>
     output c: UInt<1>
-    input vec: UInt<1>[3]
+    input vec: V3
     output out_implicitTrunc: UInt<1>
     output out_prettifyExample: UInt<1>
     output out_multibitMux: UInt<1>
-    output out_mux2cell: UInt<1>[2]
+    output out_mux2cell: V2
 
     inst cat of Cat
     cat.a <= b


### PR DESCRIPTION
This PR introduces `BaseTypeAliasOr` helper struct to create a type which accepts both type aliases and a specified type. 
Unfortunately this PR makes it hard to use `TypedValue<Foo>` which is returned by standard ODS generated getters since now the type will become `TypedValue<BaseTypeAliasOr<Foo>>`. 
