### PR TITLE
[NFC]  Move functions from HWMutableModuleLike to HWModuleLike

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -41,22 +41,8 @@ def HWModuleLike : OpInterface<"HWModuleLike"> {
     "size_t", "getNumPorts">,
 
     InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>
-  ];
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
 
-  let verify = [{
-    static_assert(
-        ConcreteOp::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
-        "expected operation to be a symbol");
-    return success();
-  }];
-}
-
-def HWMutableModuleLike : OpInterface<"HWMutableModuleLike", [HWModuleLike]> {
-  let cppNamespace = "circt::hw";
-  let description = "Provide methods to mutate a module.";
-
-  let methods = [
     InterfaceMethod<"Return the number of inputs to this module",
     "unsigned", "getNumInputs", (ins),
     /*methodBody=*/[{}],
@@ -72,32 +58,76 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike", [HWModuleLike]> {
     }]>,
 
     InterfaceMethod<"Return the names of the inputs to this module",
-    "mlir::ArrayAttr", "getArgNames", (ins),
+    "mlir::ArrayAttr", "getInputNames", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
       return $_op->template getAttrOfType<ArrayAttr>("argNames");
     }]>,
 
     InterfaceMethod<"Return the names of the outputs this module",
-    "mlir::ArrayAttr", "getResultNames", (ins),
+    "mlir::ArrayAttr", "getOutputNames", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
       return $_op->template getAttrOfType<ArrayAttr>("resultNames");
     }]>,
 
+    InterfaceMethod<"Return the name of an input.",
+    "mlir::StringRef", "getInputName", (ins "unsigned":$idx),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return getInputNameAttr(idx).getValue();
+    }]>,
+
+    InterfaceMethod<"Return the name of an output.",
+    "mlir::StringRef", "getOutputName", (ins "unsigned":$idx),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return getOutputNameAttr(idx).getValue();
+    }]>,
+
+    InterfaceMethod<"Return the name of an input to this module",
+    "mlir::StringAttr", "getInputNameAttr", (ins "unsigned":$idx),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return cast<StringAttr>($_op->template getAttrOfType<ArrayAttr>("argNames")[idx]);
+    }]>,
+
+    InterfaceMethod<"Return the name of an output to this module",
+    "mlir::StringAttr", "getOutputNameAttr", (ins "unsigned":$idx),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{
+      return cast<StringAttr>($_op->template getAttrOfType<ArrayAttr>("resultNames")[idx]);
+    }]>,
+
     InterfaceMethod<"Return the locations of the inputs to this module",
-    "mlir::ArrayAttr", "getArgLocs", (ins),
+    "mlir::ArrayAttr", "getInputLocs", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
       return $_op->template getAttrOfType<ArrayAttr>("argLocs");
     }]>,
 
     InterfaceMethod<"Return the locations of the outputs of this module",
-    "mlir::ArrayAttr", "getResultLocs", (ins),
+    "mlir::ArrayAttr", "getOutputLocs", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{
       return $_op->template getAttrOfType<ArrayAttr>("resultLocs");
     }]>,
+
+  ];
+
+  let verify = [{
+    static_assert(
+        ConcreteOp::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
+        "expected operation to be a symbol");
+    return success();
+  }];
+}
+
+def HWMutableModuleLike : OpInterface<"HWMutableModuleLike", [HWModuleLike]> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide methods to mutate a module.";
+
+  let methods = [
 
     InterfaceMethod<
     "Decode information about the input and output ports on this module.",

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -189,7 +189,7 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
 }
 
 def MSFTModuleExternOp : MSFTOp<"module.extern",
-      [Symbol, FunctionOpInterface, HasParent<"mlir::ModuleOp">]> {
+      [Symbol, FunctionOpInterface, HasParent<"mlir::ModuleOp">, DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "MSFT external Module";
   let description = [{
     Identical to `hw.module.extern`, and trivially lowers to that. This op

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -481,8 +481,8 @@ public:
   }
 };
 
-static hw::ModulePortInfo getModulePortInfo(TypeConverter &tc,
-                                            handshake::FuncOp funcOp) {
+static hw::ModulePortInfo getModulePortInfoHS(TypeConverter &tc,
+                                              handshake::FuncOp funcOp) {
   hw::ModulePortInfo ports({}, {});
   auto *ctx = funcOp->getContext();
   auto ft = funcOp.getFunctionType();
@@ -519,7 +519,7 @@ public:
   LogicalResult
   matchAndRewrite(handshake::FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    ModulePortInfo ports = getModulePortInfo(*getTypeConverter(), op);
+    ModulePortInfo ports = getModulePortInfoHS(*getTypeConverter(), op);
 
     if (op.isExternal()) {
       rewriter.create<hw::HWModuleExternOp>(

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -608,10 +608,10 @@ ESIConnectServicesPass::surfaceReqs(hw::HWMutableModuleLike mod,
     SmallVector<NamedAttribute> newAttrs;
     for (auto attr : inst->getAttrs()) {
       if (attr.getName() == argsAttrName)
-        newAttrs.push_back(b.getNamedAttr(argsAttrName, mod.getArgNames()));
+        newAttrs.push_back(b.getNamedAttr(argsAttrName, mod.getInputNames()));
       else if (attr.getName() == resultsAttrName)
         newAttrs.push_back(
-            b.getNamedAttr(resultsAttrName, mod.getResultNames()));
+            b.getNamedAttr(resultsAttrName, mod.getOutputNames()));
       else
         newAttrs.push_back(attr);
     }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -691,9 +691,10 @@ LogicalResult MSFTModuleOp::verify() {
 /// dialect.
 ///
 /// If `disallowParamRefs` is true, then parameter references are not allowed.
-static LogicalResult checkParameterInContext(Attribute value, Operation *module,
-                                             Operation *usingOp,
-                                             bool disallowParamRefs) {
+static LogicalResult checkParameterInContextMSFT(Attribute value,
+                                                 Operation *module,
+                                                 Operation *usingOp,
+                                                 bool disallowParamRefs) {
   // Literals are always ok.  Their types are already known to match
   // expectations.
   if (value.isa<IntegerAttr>() || value.isa<FloatAttr>() ||
@@ -703,8 +704,8 @@ static LogicalResult checkParameterInContext(Attribute value, Operation *module,
   // Check both subexpressions of an expression.
   if (auto expr = value.dyn_cast<hw::ParamExprAttr>()) {
     for (auto op : expr.getOperands())
-      if (failed(
-              checkParameterInContext(op, module, usingOp, disallowParamRefs)))
+      if (failed(checkParameterInContextMSFT(op, module, usingOp,
+                                             disallowParamRefs)))
         return failure();
     return success();
   }
@@ -898,8 +899,8 @@ LogicalResult MSFTModuleExternOp::verify() {
     // Verify that this is a valid parameter value, disallowing parameter
     // references.  We could allow parameters to refer to each other in the
     // future with lexical ordering if there is a need.
-    if (failed(checkParameterInContext(value, *this, *this,
-                                       /*disallowParamRefs=*/true)))
+    if (failed(checkParameterInContextMSFT(value, *this, *this,
+                                           /*disallowParamRefs=*/true)))
       return failure();
   }
   return success();
@@ -945,6 +946,14 @@ hw::ModulePortInfo MSFTModuleExternOp::getPorts() {
   }
 
   return hw::ModulePortInfo(inputs, outputs);
+}
+
+size_t MSFTModuleExternOp::getNumPorts() {
+  return getArgNames().size() + getResultNames().size();
+}
+
+hw::InnerSymAttr MSFTModuleExternOp::getPortSymbolAttr(unsigned long) {
+  return {};
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
@@ -304,14 +304,14 @@ static StringRef getOperandName(OpOperand &oper, const SymbolCache &syms,
     Operation *modOp = syms.getDefinition(inst.getModuleNameAttr());
     if (modOp) { // If modOp isn't in the cache, it's probably a new module;
       assert(isAnyModule(modOp) && "Instance must point to a module");
-      hw::ModulePortInfo ports = getModulePortInfo(modOp);
-      return ports.inputs[oper.getOperandNumber()].name;
+      auto mod = cast<hw::HWModuleLike>(modOp);
+      return mod.getInputName(oper.getOperandNumber());
     }
   }
   if (auto blockArg = oper.get().dyn_cast<BlockArgument>()) {
-    auto portInfo =
-        getModulePortInfo(blockArg.getOwner()->getParent()->getParentOp());
-    return portInfo.inputs[blockArg.getArgNumber()].getName();
+    auto mod =
+        cast<hw::HWModuleLike>(blockArg.getOwner()->getParent()->getParentOp());
+    return mod.getInputName(blockArg.getArgNumber());
   }
 
   if (oper.getOwner()->getNumOperands() == 1)

--- a/lib/Dialect/MSFT/Transforms/PassCommon.cpp
+++ b/lib/Dialect/MSFT/Transforms/PassCommon.cpp
@@ -41,11 +41,11 @@ StringRef circt::msft::getValueName(Value v, const SymbolCache &syms,
     if (modOp) { // If modOp isn't in the cache, it's probably a new module;
       assert(isAnyModule(modOp) && "Instance must point to a module");
       OpResult instResult = v.cast<OpResult>();
-      hw::ModulePortInfo ports = getModulePortInfo(modOp);
+      auto mod = cast<hw::HWModuleLike>(modOp);
       buff.clear();
       llvm::raw_string_ostream os(buff);
       os << inst.getSymName() << ".";
-      StringAttr name = ports.outputs[instResult.getResultNumber()].name;
+      StringAttr name = mod.getOutputNameAttr(instResult.getResultNumber());
       if (name)
         os << name.getValue();
       return buff;


### PR DESCRIPTION
HWMutableModuleLike inherits from HWModuleLike now, so non-mutating functions can move back.  Also make MSFTExternalModuleOp HWModuleLike.  It was very close before.