### PR TITLE
[HW][Support][NFC] Move generic module parsing func into support

### DIFF
--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -23,9 +23,6 @@ namespace circt {
 namespace hw {
 
 namespace module_like_impl {
-/// Get the portname from an SSA value string, if said value name is not a
-/// number.
-StringAttr getPortNameAttr(MLIRContext *context, StringRef name);
 
 /// This is a variant of mlir::parseFunctionSignature that allows names on
 /// result arguments.

--- a/include/circt/Support/ParsingUtils.h
+++ b/include/circt/Support/ParsingUtils.h
@@ -1,0 +1,40 @@
+//===- ParsingUtils.h - CIRCT parsing common functions ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities to help with parsing.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PARSINGUTILS_H
+#define CIRCT_SUPPORT_PARSINGUTILS_H
+
+#include "mlir/IR/BuiltinAttributes.h"
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+namespace parsing_util {
+
+/// Get a name from an SSA value string, if said value name is not a
+/// number.
+static StringAttr getNameFromSSA(MLIRContext *context, StringRef name) {
+  if (!name.empty()) {
+    // Ignore numeric names like %42
+    assert(name.size() > 1 && name[0] == '%' && "Unknown MLIR name");
+    if (isdigit(name[1]))
+      name = StringRef();
+    else
+      name = name.drop_front();
+  }
+  return StringAttr::get(context, name);
+}
+
+} // namespace parsing_util
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_PARSINGUTILS_H

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -9,29 +9,14 @@
 #include "circt/Dialect/HW/ModuleImplementation.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/LLVM.h"
+#include "circt/Support/ParsingUtils.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
-#include <mlir/IR/BuiltinAttributes.h>
 
 using namespace circt;
 using namespace circt::hw;
-
-/// Get the portname from an SSA value string, if said value name is not a
-/// number
-StringAttr module_like_impl::getPortNameAttr(MLIRContext *context,
-                                             StringRef name) {
-  if (!name.empty()) {
-    // Ignore numeric names like %42
-    assert(name.size() > 1 && name[0] == '%' && "Unknown MLIR name");
-    if (isdigit(name[1]))
-      name = StringRef();
-    else
-      name = name.drop_front();
-  }
-  return StringAttr::get(context, name);
-}
 
 /// Parse a function result list.
 ///
@@ -109,7 +94,7 @@ ParseResult module_like_impl::parseModuleFunctionSignature(
   // Process the ssa args for the information we're looking for.
   SmallVector<Type> argTypes;
   for (auto &arg : args) {
-    argNames.push_back(getPortNameAttr(context, arg.ssaName.name));
+    argNames.push_back(parsing_util::getNameFromSSA(context, arg.ssaName.name));
     argTypes.push_back(arg.type);
     if (!arg.sourceLoc)
       arg.sourceLoc = parser.getEncodedSourceLoc(arg.ssaName.location);


### PR DESCRIPTION
The 'getPortNameAttr' functionality is generic. Move it into a new support header and rename it.