### PR TITLE
[DC] Add cast to/from ESI ops

### DIFF
--- a/docs/Dialects/DC/RationaleDC.md
+++ b/docs/Dialects/DC/RationaleDC.md
@@ -46,6 +46,29 @@ IR which already contains fork and sink operations, one may use the
 the `--dc-materialize-forks-sinks` pass.
 
 
+## Value (channel) semantics
+
+1. **Latency insensitive**:
+    * Any DC-typed value (`dc.token/dc.value<T...>`) has latency insensitive
+semantics.
+    * DC does **not** specify the implementation of this latency
+insensitivity, given that it strictly pertains to the **control** of latency
+insensitive values. This should reinforce the mental model that DC isn't
+strictly a hardware construct - that is, DC values could be implemented in
+hardware by e.g ready/valid semantics or by FIFO interfaces (read/write, full, empty, ...)
+or in software by e.g. message queues, RPC, or other streaming protocols.
+    * In the current state of the world (CIRCT), DC uses ESI to implement its
+latency insensitive hardware protocol. By doing so, we let DC do what DC does
+best (control language) and likewise with ESI (silicon interconnect).
+2. **Values are channels**:
+    * Given the above latency insensitivity, it is useful to think of DC values
+as channels, wherein a channel can be arbitrarily buffered without changing the
+semantics of the program.
+2. **FIFO semantics**:
+    * DC-typed values have FIFO semantics, meaning that the order of values in
+the 'channel' is preserved (i.e. the order of values written to the channel is
+the same as the order of values read from the channel).
+
 ## Canonicalization
 By explicitly separating data and control parts of a program, we allow for
 control-only canonicalization to take place.

--- a/include/circt/Dialect/DC/DCDialect.td
+++ b/include/circt/Dialect/DC/DCDialect.td
@@ -21,6 +21,7 @@ def DCDialect : Dialect {
   let cppNamespace = "circt::dc";
 
   let useDefaultTypePrinterParser = 1;
+  let dependentDialects = ["circt::esi::ESIDialect"];
 
   let extraClassDeclaration = [{
     void registerTypes();

--- a/include/circt/Dialect/DC/DCOps.h
+++ b/include/circt/Dialect/DC/DCOps.h
@@ -19,6 +19,8 @@
 
 #include "circt/Dialect/DC/DCDialect.h"
 #include "circt/Dialect/DC/DCTypes.h"
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "circt/Dialect/ESI/ESITypes.h"
 
 namespace circt {
 namespace dc {

--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -21,6 +21,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/FunctionInterfaces.td"
+include "circt/Dialect/ESI/ESITypes.td"
 
 class DCOp<string mnemonic, list<Trait> traits = []> :
   Op<DCDialect, mnemonic, !listconcat(traits, [
@@ -173,7 +174,9 @@ def SourceOp : DCOp<"source"> {
         }]>];
 }
 
-def PackOp : DCOp<"pack", [InferTypeOpInterface]> {
+def PackOp : DCOp<"pack", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+]> {
     let summary = "Pack operation";
     let description = [{
         An operation which packs together a !dc.token value with some other
@@ -188,20 +191,11 @@ def PackOp : DCOp<"pack", [InferTypeOpInterface]> {
     let results = (outs ValueType:$output);
     let assemblyFormat = "$token `,` $input attr-dict `:` type($input)";
     let hasFolder = 1;
-
-    let extraClassDeclaration = [{
-      /// Infer the return types of this operation.
-      static LogicalResult inferReturnTypes(MLIRContext *context,
-                                            std::optional<Location> loc,
-                                            ValueRange operands,
-                                            DictionaryAttr attrs,
-                                            mlir::OpaqueProperties properties,
-                                            mlir::RegionRange regions,
-                                            SmallVectorImpl<Type> &results);
-    }];
 }
 
-def UnpackOp : DCOp<"unpack", [InferTypeOpInterface]> {
+def UnpackOp : DCOp<"unpack", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+]> {
     let summary = "Unpack operation";
     let description = [{
         An operation which unpacks a !dc.value value into a !dc.token value
@@ -213,17 +207,6 @@ def UnpackOp : DCOp<"unpack", [InferTypeOpInterface]> {
     let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
     let hasCanonicalizer = 1;
     let hasFolder = 1;
-  
-    let extraClassDeclaration = [{
-      /// Infer the return types of this operation.
-      static LogicalResult inferReturnTypes(MLIRContext *context,
-                                            std::optional<Location> loc,
-                                            ValueRange operands,
-                                            DictionaryAttr attrs,
-                                            mlir::OpaqueProperties properties,
-                                            mlir::RegionRange regions,
-                                            SmallVectorImpl<Type> &results);
-    }];
 }
 
 def MergeOp : DCOp<"merge"> {
@@ -238,6 +221,34 @@ def MergeOp : DCOp<"merge"> {
   let arguments = (ins TokenType:$first, TokenType:$second);
   let results = (outs I1ValueType:$output);
   let assemblyFormat = "$first `,` $second attr-dict";
+}
+
+def ToESIOp : DCOp<"to_esi", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+]> {
+  let summary = "Convert a DC-typed value to an ESI-typed value";
+  let description = [{
+    Convert a `dc.token/dc.value` to an ESI channel.
+  }];
+
+  let arguments = (ins
+    ValueOrTokenType:$input
+  );
+  let results = (outs ChannelType:$output);
+  let assemblyFormat = "$input attr-dict `:` type($input)";
+}
+
+def FromESIOp : DCOp<"from_esi", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+]> {
+  let summary = "Convert an ESI-typed value to a DC-typed value";
+  let description = [{
+    Convert an ESI channel to a `dc.token/dc.value`.
+  }];
+
+  let arguments = (ins ChannelType:$input);
+  let results = (outs ValueOrTokenType:$output);
+  let assemblyFormat = "$input attr-dict `:` type($input)";
 }
 
 #endif // CIRCT_DIALECT_DC_OPS_TD

--- a/lib/Dialect/DC/CMakeLists.txt
+++ b/lib/Dialect/DC/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTDC
 
   LINK_LIBS PUBLIC
   MLIRIR
+  CIRCTESI
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces
 )

--- a/test/Conversion/DCToHW/basic.mlir
+++ b/test/Conversion/DCToHW/basic.mlir
@@ -140,3 +140,16 @@ hw.module @select(%sel : !dc.value<i1>, %true : !dc.token, %false : !dc.token) -
     %0 = dc.select %sel, %true, %false
     hw.output %0 : !dc.token
 }
+
+// CHECK-LABEL:   hw.module @to_from_esi_noop(
+// CHECK-SAME:               %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i1>) -> (token: !esi.channel<i0>, value: !esi.channel<i1>) {
+// CHECK-NEXT:           hw.output %[[VAL_0]], %[[VAL_1]] : !esi.channel<i0>, !esi.channel<i1>
+// CHECK-NEXT:         }
+hw.module @to_from_esi_noop(%token : !esi.channel<i0>, %value : !esi.channel<i1>) ->
+    (token : !esi.channel<i0>, value : !esi.channel<i1>) {
+    %token_dc = dc.from_esi %token : !esi.channel<i0>
+    %value_dc = dc.from_esi %value : !esi.channel<i1>
+    %token_esi = dc.to_esi %token_dc : !dc.token
+    %value_esi = dc.to_esi %value_dc : !dc.value<i1>
+    hw.output %token_esi, %value_esi : !esi.channel<i0>, !esi.channel<i1>
+}

--- a/test/Dialect/DC/roundtrip.mlir
+++ b/test/Dialect/DC/roundtrip.mlir
@@ -7,6 +7,10 @@
 // CHECK-NEXT:    %3 = dc.pack %arg0, %arg2 : i32
 // CHECK-NEXT:    %4 = dc.merge %0, %arg0
 // CHECK-NEXT:    %token, %output = dc.unpack %arg1 : !dc.value<i1>
+// CHECK-NEXT:    %5 = dc.to_esi %arg0 : !dc.token
+// CHECK-NEXT:    %6 = dc.to_esi %arg1 : !dc.value<i1>
+// CHECK-NEXT:    %7 = dc.from_esi %5 : <i0>
+// CHECK-NEXT:    %8 = dc.from_esi %6 : <i1>
 // CHECK-NEXT:    hw.output
 // CHECK-NEXT:  }
 
@@ -17,4 +21,8 @@ hw.module @foo(%0 : !dc.token, %1 : !dc.value<i1>, %2 : i32) {
   %pack = dc.pack %0, %2 : i32
   %merge = dc.merge %buffer, %0
   %unpack_token, %unpack_value = dc.unpack %1 : !dc.value<i1>
+  %esi_token = dc.to_esi %0 : !dc.token
+  %esi_value = dc.to_esi %1 : !dc.value<i1>
+  %from_esi_token = dc.from_esi %esi_token : !esi.channel<i0>
+  %from_esi_value = dc.from_esi %esi_value : !esi.channel<i1>
 }


### PR DESCRIPTION
Much needed cast operations to/from ESI.
Given that `dc.value`s have unnamed fields (which i think is a good descision) `dc.value`s with multiple types will be converted to a `hw.struct` with an inferred name, in this case `field#`. In most cases, this won't be compatible with the structs used in an input/output ESI channel. To address this, source materializations (esi -> dc) are automatically handled by an inserted `hw.bitcast`. Target materializations (and result type inference, dc -> esi) can be directed by specifying a forced type in the `dc.to_esi` op.