### PR TITLE
[FIRRTL] Add RWProbeSSAOp.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1174,6 +1174,21 @@ def RWProbeOp : FIRRTLExprOp<"ref.rwprobe",
   let assemblyFormat = "$target attr-dict `:` $type";
 }
 
+def RWProbeSSAOp : FIRRTLExprOp<"ref.rwprobe.ssa"> {
+  let summary = "FIRRTL RWProbe";
+  let description = [{
+    Create a RWProbe for the op or port originating the target operand.
+    For temporary use, prefer `firrtl.ref.rwprobe`.
+    ```
+      %result = firrtl.ref.rwprobe.ssa %input : t
+    ```
+  }];
+
+  let arguments = (ins RWProbeTarget:$input);
+  let results = (outs RefType:$result);
+  let assemblyFormat = "$input attr-dict `:` type($input)";
+}
+
 //===----------------------------------------------------------------------===//
 // LTL Dialect Sequence and Property Intrinsics
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4667,6 +4667,10 @@ void RWProbeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 
+void RWProbeSSAOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
 FIRRTLType RefResolveOp::inferReturnType(ValueRange operands,
                                          ArrayRef<NamedAttribute> attrs,
                                          std::optional<Location> loc) {
@@ -4779,6 +4783,16 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
         .attachNote(symOp.getLoc())
         .append("target resolves here");
   return checkFinalType(symOp.getTargetResult().getType(), symOp.getLoc());
+}
+
+FIRRTLType RWProbeSSAOp::inferReturnType(ValueRange operands,
+                                         ArrayRef<NamedAttribute> attrs,
+                                         std::optional<Location> loc) {
+  auto type = operands[0].getType();
+  auto forceableType = firrtl::detail::getForceableResultType(true, type);
+  if (!forceableType)
+    return emitInferRetTypeError(loc, "cannot force type ", type);
+  return forceableType;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Directly model FIRRTL rwprobe using SSA operand, for use in parser especially when rwprobe'ing ports and instance results.