### PR TITLE
[Verif] Add has_been_reset op

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -546,7 +546,8 @@ def LowerVerifToSV : Pass<"lower-verif-to-sv", "hw::HWModuleOp"> {
     This pass converts various Verif contructs to SV.
   }];
   let constructor = "circt::createLowerVerifToSVPass()";
-  let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
+  let dependentDialects = [
+    "sv::SVDialect", "hw::HWDialect", "comb::CombDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Verif/VerifDialect.td
+++ b/include/circt/Dialect/Verif/VerifDialect.td
@@ -16,6 +16,7 @@ def VerifDialect : Dialect {
   let summary = "Verification constructs and utilities.";
   // See `docs/Dialect/Verif.md` for detailed dialect documentation.
   let cppNamespace = "circt::verif";
+  let hasConstantMaterializer = 1;
 }
 
 #endif // CIRCT_DIALECT_VERIF_VERIFDIALECT_TD

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -42,6 +42,10 @@ def CoverOp : AssertLikeOp<"cover"> {
   let summary = "Ensure that a property can hold.";
 }
 
+//===----------------------------------------------------------------------===//
+// Printing Formatted Messages
+//===----------------------------------------------------------------------===//
+
 def FormatVerilogStringOp : VerifOp<"format_verilog_string", [
     Pure
   ]> {
@@ -70,6 +74,38 @@ def PrintOp : VerifOp<"print", []> {
   let assemblyFormat = [{
     $string attr-dict
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// Reset and Power-Cycling Detection
+//===----------------------------------------------------------------------===//
+
+def HasBeenResetOp : VerifOp<"has_been_reset", [Pure]> {
+  let summary = "Check that a proper reset has been seen.";
+  let description = [{
+    The result of `verif.has_been_reset` reads as 0 immediately after simulation
+    startup and after each power-cycle in a power-aware simulation. The result
+    remains 0 before and during reset and only switches to 1 after the reset is
+    deasserted again.
+
+    This is a useful utility to disable the evaluation of assertions and other
+    verification constructs in the IR before the circuit being tested has been
+    properly reset. Verification failures due to uninitialized or randomized
+    initial state can thus be prevented.
+
+    Using the result of `verif.has_been_reset` to enable verification is more
+    powerful and proper than just disabling verification during reset. The
+    latter does not properly handle the period of time between simulation
+    startup or power-cycling and the start of reset. `verif.has_been_reset` is
+    guaranteed to produce a 0 value in that period, as well as during the reset.
+  }];
+  let arguments = (ins I1:$clock, I1:$reset, BoolAttr:$async);
+  let results = (outs I1:$result);
+  let assemblyFormat = [{
+    $clock `,` custom<KeywordBool>($async, "\"async\"", "\"sync\"")
+    $reset attr-dict
+  }];
+  let hasFolder = true;
 }
 
 #endif // CIRCT_DIALECT_VERIF_VERIFOPS_TD

--- a/lib/Dialect/Verif/VerifDialect.cpp
+++ b/lib/Dialect/Verif/VerifDialect.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Verif/VerifDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Verif/VerifOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
 
 using namespace circt;
 using namespace verif;
@@ -17,6 +20,15 @@ void VerifDialect::initialize() {
 #define GET_OP_LIST
 #include "circt/Dialect/Verif/Verif.cpp.inc"
       >();
+}
+
+Operation *VerifDialect::materializeConstant(OpBuilder &builder,
+                                             Attribute value, Type type,
+                                             Location loc) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    if (auto attrValue = dyn_cast<IntegerAttr>(value))
+      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+  return nullptr;
 }
 
 #include "circt/Dialect/Verif/VerifDialect.cpp.inc"

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -8,6 +8,8 @@
 
 #include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Dialect/LTL/LTLTypes.h"
+#include "circt/Support/CustomDirectiveImpl.h"
+#include "circt/Support/FoldUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/OpImplementation.h"
@@ -18,6 +20,29 @@
 using namespace circt;
 using namespace verif;
 using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// HasBeenResetOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult HasBeenResetOp::fold(FoldAdaptor adaptor) {
+  // Fold to zero if the reset is a constant. In this case the op is either
+  // permanently in reset or never resets. Both mean that the reset never
+  // finishes, so this op never returns true.
+  if (adaptor.getReset())
+    return BoolAttr::get(getContext(), false);
+
+  // Fold to zero if the clock is a constant and the reset is synchronous. In
+  // that case the reset will never be started.
+  if (!adaptor.getAsync() && adaptor.getClock())
+    return BoolAttr::get(getContext(), false);
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// Generated code
+//===----------------------------------------------------------------------===//
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Verif/Verif.cpp.inc"

--- a/test/Conversion/VerifToSV/verif-to-sv.mlir
+++ b/test/Conversion/VerifToSV/verif-to-sv.mlir
@@ -1,0 +1,55 @@
+// RUN: circt-opt --lower-verif-to-sv %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @HasBeenResetAsync
+hw.module @HasBeenResetAsync(%clock: i1, %reset: i1) -> (out: i1) {
+  %0 = verif.has_been_reset %clock, async %reset
+  hw.output %0 : i1
+
+  // CHECK:      %hasBeenResetReg = sv.reg : !hw.inout<i1>
+
+  // CHECK-NEXT: sv.initial {
+  // CHECK-NEXT:   sv.if %reset {
+  // CHECK-NEXT:     sv.bpassign %hasBeenResetReg, %true : i1
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.bpassign %hasBeenResetReg, %x_i1 : i1
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: sv.always posedge %reset {
+  // CHECK-NEXT:   sv.passign %hasBeenResetReg, %true : i1
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: [[REG:%.+]] = sv.read_inout %hasBeenResetReg
+  // CHECK-NEXT: [[REG_HI:%.+]] = comb.icmp ceq [[REG]], %true
+  // CHECK-NEXT: [[RESET_LO:%.+]] = comb.icmp ceq %reset, %false
+  // CHECK-NEXT: [[DONE:%.+]] = comb.and bin [[REG_HI]], [[RESET_LO]]
+  // CHECK-NEXT: %hasBeenReset = hw.wire [[DONE]]
+
+  // CHECK-NEXT: hw.output %hasBeenReset
+}
+
+// CHECK-LABEL: hw.module @HasBeenResetSync
+hw.module @HasBeenResetSync(%clock: i1, %reset: i1) -> (out: i1) {
+  %0 = verif.has_been_reset %clock, sync %reset
+  hw.output %0 : i1
+
+  // CHECK:      %hasBeenResetReg = sv.reg : !hw.inout<i1>
+
+  // CHECK-NEXT: sv.initial {
+  // CHECK-NEXT:   sv.bpassign %hasBeenResetReg, %x_i1 : i1
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: sv.always posedge %clock {
+  // CHECK-NEXT:   sv.if %reset {
+  // CHECK-NEXT:     sv.passign %hasBeenResetReg, %true : i1
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: [[REG:%.+]] = sv.read_inout %hasBeenResetReg
+  // CHECK-NEXT: [[REG_HI:%.+]] = comb.icmp ceq [[REG]], %true
+  // CHECK-NEXT: [[RESET_LO:%.+]] = comb.icmp ceq %reset, %false
+  // CHECK-NEXT: [[DONE:%.+]] = comb.and bin [[REG_HI]], [[RESET_LO]]
+  // CHECK-NEXT: %hasBeenReset = hw.wire [[DONE]]
+
+  // CHECK-NEXT: hw.output %hasBeenReset
+}

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -49,3 +49,11 @@ hw.module @foo() {
   %fstr = verif.format_verilog_string "Hi %x\0A" (%false) : i1
   verif.print %fstr
 }
+
+// CHECK-LABEL: hw.module @HasBeenReset
+hw.module @HasBeenReset(%clock: i1, %reset: i1) {
+  // CHECK-NEXT: verif.has_been_reset %clock, async %reset
+  // CHECK-NEXT: verif.has_been_reset %clock, sync %reset
+  %hbr0 = verif.has_been_reset %clock, async %reset
+  %hbr1 = verif.has_been_reset %clock, sync %reset
+}

--- a/test/Dialect/Verif/canonicalization.mlir
+++ b/test/Dialect/Verif/canonicalization.mlir
@@ -1,0 +1,37 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @HasBeenReset
+hw.module @HasBeenReset(%clock: i1, %reset: i1) {
+  // CHECK-NEXT: %false = hw.constant false
+  // CHECK-NEXT: %true = hw.constant true
+  %false = hw.constant false
+  %true = hw.constant true
+
+  // CHECK-NEXT: %constResetA0 = hw.wire %false
+  // CHECK-NEXT: %constResetA1 = hw.wire %false
+  // CHECK-NEXT: %constResetS0 = hw.wire %false
+  // CHECK-NEXT: %constResetS1 = hw.wire %false
+  %r0 = verif.has_been_reset %clock, async %false
+  %r1 = verif.has_been_reset %clock, async %true
+  %r2 = verif.has_been_reset %clock, sync %false
+  %r3 = verif.has_been_reset %clock, sync %true
+  %constResetA0 = hw.wire %r0 sym @constResetA0 : i1
+  %constResetA1 = hw.wire %r1 sym @constResetA1 : i1
+  %constResetS0 = hw.wire %r2 sym @constResetS0 : i1
+  %constResetS1 = hw.wire %r3 sym @constResetS1 : i1
+
+  // CHECK-NEXT: [[TMP1:%.+]] = verif.has_been_reset %false, async %reset
+  // CHECK-NEXT: [[TMP2:%.+]] = verif.has_been_reset %true, async %reset
+  // CHECK-NEXT: %constClockA0 = hw.wire [[TMP1]]
+  // CHECK-NEXT: %constClockA1 = hw.wire [[TMP2]]
+  // CHECK-NEXT: %constClockS0 = hw.wire %false
+  // CHECK-NEXT: %constClockS1 = hw.wire %false
+  %c0 = verif.has_been_reset %false, async %reset
+  %c1 = verif.has_been_reset %true, async %reset
+  %c2 = verif.has_been_reset %false, sync %reset
+  %c3 = verif.has_been_reset %true, sync %reset
+  %constClockA0 = hw.wire %c0 sym @constClockA0 : i1
+  %constClockA1 = hw.wire %c1 sym @constClockA1 : i1
+  %constClockS0 = hw.wire %c2 sym @constClockS0 : i1
+  %constClockS1 = hw.wire %c3 sym @constClockS1 : i1
+}


### PR DESCRIPTION
Add the `verif.has_been_reset` operation to detect if a circuit has been properly reset. Useful to disable assertions before and during reset.

The result of `verif.has_been_reset` reads as 0 immediately after simulation startup and after each power-cycle in a power-aware simulation. The result remains 0 before and during reset and only switches to 1 after the reset is deasserted again.

This is a useful utility to disable the evaluation of assertions and other verification constructs in the IR before the circuit being tested has been properly reset. Verification failures due to uninitialized or randomized initial state can thus be prevented.

Using the result of `verif.has_been_reset` to enable verification is more powerful and proper than just disabling verification during reset. The latter does not properly handle the period of time between simulation startup or power-cycling and the start of reset. `verif.has_been_reset` is guaranteed to produce a 0 value in that period, as well as during the reset.

Example:
```
hw.module @HasBeenResetAsync(%clock: i1, %reset: i1) -> (out: i1) {
  %0 = verif.has_been_reset %clock, async %reset
  hw.output %0 : i1
}
```

The above produces the following Verilog:
```
module HasBeenResetAsync(input clock, reset, output out);
  reg hasBeenResetReg;
  initial begin
    if (reset)
      hasBeenResetReg = 1'h1;
    else
      hasBeenResetReg = 1'bx;
  end
  always @(posedge reset) hasBeenResetReg <= 1'h1;
  assign out = hasBeenResetReg === 1'h1 & reset === 1'h0;
endmodule
```

*Future work:* This is a verification-only construct. It lowers to a register that will not behave in the right way in actual silicon. Tools like `firtool` may need a linting pass that ensures the results of this op don't leak into synthesizable parts of the IR.