### PR TITLE
[ExportVerilog] Use wire for inlined op operand

### DIFF
--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s -prepare-for-emission --split-input-file -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -export-verilog -split-input-file
 
 // CHECK: @namehint_variadic
 hw.module @namehint_variadic(%a: i3) -> (b: i3) {
@@ -241,5 +242,29 @@ hw.module @Issue5613(%a: i1, %b: i1) {
   %2 = ltl.and %b, %4 : i1, !ltl.sequence
   %3 = ltl.not %b : i1
   %4 = ltl.delay %a, 42 : i1
+  hw.output
+}
+
+// -----
+
+// If an operation is duplicated because it is always inline, make sure that the
+// recursive inlining of its operands (by splitting) may also duplicate an
+// operand which now needs to be spilled to a wire.
+//
+// See: https://github.com/llvm/circt/issues/5605
+// CHECK-LABEL: hw.module @Issue5605
+hw.module @Issue5605(%a: i1, %b: i1, %clock: i1, %reset: i1) {
+  %0 = comb.concat %a, %b : i1, i1
+  // CHECK:      %1 = sv.wire
+  // CHECK-NEXT: sv.assign %1, %0
+  %1 = sv.system.sampled %0 : i2
+  // CHECK-NEXT: %2 = sv.read_inout %1
+  // CHECK-NEXT: %3 = sv.system.sampled %2
+  // CHECK-NEXT: sv.assert.concurrent {{.*}}(%3)
+  sv.assert.concurrent posedge %clock, %reset label "assert_0" message "foo"(%1) : i2
+  // CHECK-NEXT: %4 = sv.read_inout %1
+  // CHECK-NEXT: %5 = sv.system.sampled %4
+  // CHECK-NEXT: sv.assert.concurrent {{.*}}(%5)
+  sv.assert.concurrent posedge %clock, %reset label "assert_1" message "bar"(%1) : i2
   hw.output
 }


### PR DESCRIPTION
Fix a bug where an assertion could fire in ExportVerilog due incomplete
wire creation in PrepareForEmission.  This bug occurss if an always inline
operation was duplicated, but its operand is not always inline.  This
creates a situation where, if you were to run PrepareForEmission _again_,
it would create a wire (and no assertion would fire).

Change the logic when recursing through operands of an always inline
operation to create this wire.

Fixes #5605.

This PR does some NFC monkeying with `PrepareForEmission`. The first two commits do this NFC monkeying. The third commit makes the change and adds tests. For the purposes of PR review, only the last commit matters.