### PR TITLE
[Python] Remove tablegen file that was deleted upstream.

### DIFF
--- a/lib/Bindings/Python/dialects/CombOps.td
+++ b/lib/Bindings/Python/dialects/CombOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_COMB_OPS
 #define BINDINGS_PYTHON_COMB_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/Comb/Comb.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/ESIOps.td
+++ b/lib/Bindings/Python/dialects/ESIOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_ESI_OPS
 #define BINDINGS_PYTHON_ESI_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/ESI/ESI.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/FSMOps.td
+++ b/lib/Bindings/Python/dialects/FSMOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_FSM_OPS
 #define BINDINGS_PYTHON_FSM_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/FSM/FSM.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/HWArithOps.td
+++ b/lib/Bindings/Python/dialects/HWArithOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_HWARITH_OPS
 #define BINDINGS_PYTHON_HWARITH_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/HWArith/HWArith.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/HWOps.td
+++ b/lib/Bindings/Python/dialects/HWOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_HW_OPS
 #define BINDINGS_PYTHON_HW_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/HW/HW.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/MSFTOps.td
+++ b/lib/Bindings/Python/dialects/MSFTOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_MSFT_OPS
 #define BINDINGS_PYTHON_MSFT_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/MSFT/MSFT.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/OMOps.td
+++ b/lib/Bindings/Python/dialects/OMOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_OM_OPS
 #define BINDINGS_PYTHON_OM_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/OM/OM.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/SVOps.td
+++ b/lib/Bindings/Python/dialects/SVOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_SV_OPS
 #define BINDINGS_PYTHON_SV_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/SV/SV.td"
 
 #endif

--- a/lib/Bindings/Python/dialects/SeqOps.td
+++ b/lib/Bindings/Python/dialects/SeqOps.td
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_SEQ_OPS
 #define BINDINGS_PYTHON_SEQ_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "circt/Dialect/Seq/Seq.td"
 
 #endif


### PR DESCRIPTION
Seems like this is just removed in https://reviews.llvm.org/D154469.

Doing the same here.