### PR TITLE
[LowerTypes] Replace isa with type_isa and type switch, NFC

### DIFF
--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1283,6 +1283,13 @@ firrtl.module private @is1436_FOO() {
       %a = firrtl.wire : !firrtl.bundle<b: uint<1>>
     }
   }
+
+  // CHECK-LABEL:  firrtl.module @Alias
+  // CHECK-NOT: alias
+  // AGGREGATE-LABEL: firrtl.module @Alias
+  // AGGREGATE-SAME: alias<FooBundle, bundle<x: uint<32>, y: uint<32>>>
+  firrtl.module @Alias(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %io: !firrtl.bundle<in flip: alias<FooBundle, bundle<x: uint<32>, y: uint<32>>>, out: alias<FooBundle, bundle<x: uint<32>, y: uint<32>>>>) {
+  }
 } // CIRCUIT
 
 // Check that we don't lose the DontTouchAnnotation when it is not the last


### PR DESCRIPTION
`isa<.*Type>` in LowerTypes seems to be not updated. This fixes LowerTypes to use type alias aware utils.